### PR TITLE
🐛 fix service socket being filtered

### DIFF
--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -95,7 +95,7 @@ func SystemDExtractDescription(systemctlOutput string) string {
 // List returns a slice of Service structs representing the state of all services
 func (s *SystemDServiceManager) List() ([]*Service, error) {
 	var services []*Service
-	cmdList, err := s.conn.RunCommand("systemctl list-unit-files --type service --all")
+	cmdList, err := s.conn.RunCommand("systemctl list-unit-files --all")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/services/systemd_test.go
+++ b/providers/os/resources/services/systemd_test.go
@@ -54,7 +54,7 @@ func TestParseServiceSystemDUnitFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := mock.RunCommand("systemctl list-unit-files --type service --all")
+	c, err := mock.RunCommand("systemctl list-unit-files --all")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestParseServiceSystemDUnitFilesPhoton(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := mock.RunCommand("systemctl list-unit-files --type service --all")
+	c, err := mock.RunCommand("systemctl list-unit-files --all")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/providers/os/resources/services/testdata/photon.toml
+++ b/providers/os/resources/services/testdata/photon.toml
@@ -1,4 +1,4 @@
-[commands."systemctl list-unit-files --type service --all"]
+[commands."systemctl list-unit-files --all"]
 stdout = """
 UNIT FILE                              STATE           PRESET
 autovt@.service                        alias           -

--- a/providers/os/resources/services/testdata/ubuntu2204.toml
+++ b/providers/os/resources/services/testdata/ubuntu2204.toml
@@ -1,4 +1,4 @@
-[commands."systemctl list-unit-files --type service --all"]
+[commands."systemctl list-unit-files --all"]
 stdout = """
 UNIT FILE                                  STATE           VENDOR PRESET
 accounts-daemon.service                    enabled         enabled


### PR DESCRIPTION
#1606 

```
cnquery> services.where(name == /remote/)
services.where.list: [
  0: service name="systemd-journal-remote" running=false enabled=false type="systemd"
  1: service name="systemd-journal-remote.socket" running=false enabled=false type="systemd"
  2: service name="remote-cryptsetup.target" running=false enabled=false type="systemd"
  3: service name="remote-fs-pre.target" running=false enabled=false type="systemd"
  4: service name="remote-fs.target" running=true enabled=true type="systemd"
  5: service name="remote-veritysetup.target" running=false enabled=false type="systemd"
]
```

- [ ] adjust tests