### PR TITLE
🧹  Draft: Enhancing the Retrieval and Handling of AccessKey Information in aws.iam.users (aws)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -776,7 +776,7 @@ private aws.iam.user @defaults("arn name") {
   // List of group ARNs that the user belongs to
   groups() []string
   // List of access keys metadata associated with the user
-  accessKeys() []dict
+  accessKeys() aws.iam.accesskey
   // Login profile for the user
   loginProfile() aws.iam.loginProfile
 }


### PR DESCRIPTION
It needs to be fixed, something is still wrong!

The issue is related to accessing the Status field in:

``` 
 aws.iam.users {accessKeys}
``` 

As mentioned here: https://github.com/mondoohq/cnspec-enterprise-policies/pull/712
