### PR TITLE
try large runners for providers build

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -89,13 +89,13 @@ jobs:
 
   provider-build:
     name: "${{ matrix.provider }}"
-    runs-on: self-hosted
+    runs-on: ubuntu-latest-m
     timeout-minutes: 120
     needs: scoping
     if: ${{ needs.scoping.outputs.build_list != '[]' }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 12
       matrix:
         provider: ${{ fromJSON(needs.scoping.outputs.build_list) }}
     steps:
@@ -111,7 +111,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ">=${{ env.golang-version }}"
-          cache: false
+          cache: true
+
+      ## Install Build Tools, for Github Hosted Runners only
+      - name: Install Build Tools
+        if: contains( ${{ runner.name }}, 'Github Actions')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xz-utils make protobuf-compiler curl zip unzip jq
+          make prep/tools
 
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v2'


### PR DESCRIPTION
- user larger runners
- enable Go cache

https://github.com/mondoohq/cnquery/actions/runs/8047544409
https://github.com/mondoohq/cnquery/actions/runs/8048639872