### PR TITLE
⭐   Draft: Enhancing Users Key Metadata retrieval (aws)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -699,8 +699,6 @@ aws.iam {
   virtualMfaDevices() []aws.iam.virtualmfadevice
   // List of server certificates stored in IAM
   serverCertificates() []dict
-  // Retrieves metadata for IAM access keys
-   accessKeyMetadata() []aws.iam.accessKey
 }
 
 // Entry in AWS IAM credential report
@@ -782,9 +780,19 @@ private aws.iam.user @defaults("arn name") {
   // List of group ARNs that the user belongs to
   groups() []string
   // List of access keys metadata associated with the user
-  accessKeys() []dict
+  accessKeys() []aws.iam.accessKey
   // Login profile for the user
   loginProfile() aws.iam.loginProfile
+}
+
+// AWS IAM accessKey definition
+private aws.iam.accessKey @defaults("accessKeyId status") {
+  // Access Key ID
+  accessKeyId string
+  // Status of the access key (Active/Inactive)
+  status string
+  // Time when the access key was created
+  createDate time
 }
 
 // AWS IAM login profile for a user
@@ -2591,12 +2599,3 @@ private aws.eks.cluster @defaults("arn version status") {
   createdAt time
 }
 
-// AWS IAM accessKey definition
-private aws.iam.accessKey {"accessKeyId status"
-  // Access Key ID
-  accessKeyId string
-  // Status of the access key (Active/Inactive)
-  status string
-  // Time when the access key was created
-  createDate time
-}

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -699,6 +699,8 @@ aws.iam {
   virtualMfaDevices() []aws.iam.virtualmfadevice
   // List of server certificates stored in IAM
   serverCertificates() []dict
+  // Retrieves metadata for IAM access keys
+   accessKeyMetadata() []aws.iam.accessKey
 }
 
 // Entry in AWS IAM credential report
@@ -2587,4 +2589,14 @@ private aws.eks.cluster @defaults("arn version status") {
   resourcesVpcConfig dict
   // Cluster creation timestamp
   createdAt time
+}
+
+// AWS IAM accessKey definition
+private aws.iam.accessKey {"accessKeyId status"
+  // Access Key ID
+  accessKeyId string
+  // Status of the access key (Active/Inactive)
+  status string
+  // Time when the access key was created
+  createDate time
 }

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1835,6 +1835,19 @@ resources:
     platform:
       name:
       - aws
+  aws.iam.accessKey:
+  docs:
+    desc: |
+      The `aws.iam.accessKey` provides fields for assessing the configuration of individual IAM Access Keys. For usage, read the `aws.iam` resource documentation. This resource helps in identifying and analyzing the state and configurations of access keys, allowing for better security and management of AWS IAM credentials.
+  fields:
+    accessKeyId: {}
+    createDate: {}
+    status: {}
+  is_private: true
+  min_mondoo_version: 9.0.0
+  platform:
+    name:
+    - aws
   aws.iam.virtualmfadevice:
     docs:
       desc: |

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1662,6 +1662,10 @@ resources:
       desc: |
         Use the `aws.iam` resource to assess the configuration of the AWS IAM service. The resource provides a list of `aws.iam.user` resources representing GuardDuty Detectors deployed across all enabled regions.
     fields:
+      accessKeyMetadata:
+        min_mondoo_version: latest
+      accessKeys:
+        min_mondoo_version: latest
       accountPasswordPolicy: {}
       accountSummary: {}
       attachedPolicies: {}
@@ -1702,6 +1706,28 @@ resources:
         != null\n  ) \n"
       title: Do not setup access keys during initial user setup for all IAM users
         that have a console password
+  aws.iam.accessKey:
+    docs:
+      desc: |
+        The `aws.iam.accessKey` provides fields for assessing the configuration of individual IAM Access Keys. For usage, read the `aws.iam` resource documentation. This resource helps in identifying and analyzing the state and configurations of access keys, allowing for better security and management of AWS IAM credentials.
+    fields:
+      accessKeyId: {}
+      createDate: {}
+      status: {}
+    is_private: true
+    min_mondoo_version: 9.0.0
+    platform:
+      name:
+      - aws
+  aws.iam.accessKeys:
+    fields:
+      accessKeyId: {}
+      createDate: {}
+      status: {}
+    min_mondoo_version: latest
+    platform:
+      name:
+      - aws
   aws.iam.group:
     docs:
       desc: |
@@ -1817,6 +1843,9 @@ resources:
       accessKey2LastUsedDate: {}
       accessKey2LastUsedRegion: {}
       accessKey2LastUsedService: {}
+      accessKeyMetadata:
+        min_mondoo_version: latest
+      accessKeys: {}
       arn: {}
       cert1Active: {}
       cert1LastRotated: {}
@@ -1835,19 +1864,6 @@ resources:
     platform:
       name:
       - aws
-  aws.iam.accessKey:
-  docs:
-    desc: |
-      The `aws.iam.accessKey` provides fields for assessing the configuration of individual IAM Access Keys. For usage, read the `aws.iam` resource documentation. This resource helps in identifying and analyzing the state and configurations of access keys, allowing for better security and management of AWS IAM credentials.
-  fields:
-    accessKeyId: {}
-    createDate: {}
-    status: {}
-  is_private: true
-  min_mondoo_version: 9.0.0
-  platform:
-    name:
-    - aws
   aws.iam.virtualmfadevice:
     docs:
       desc: |


### PR DESCRIPTION
Problems:


1. it seems it  fetch access keys for one specific IAM user, not for all users

2. need to check if a.Name.Data returns all usernames, or there is another mechanism in place that calls accessKeys() multiple times


The modified function, by explicitly handling each relevant field of the access key metadata, might offer better clarity and maintainability, especially in contexts where specific data handling or additional processing is required for each field.

![Screenshot from 2024-03-01 13-46-32](https://github.com/mondoohq/cnquery/assets/56231339/272c757b-b94e-4aa8-a4a4-fab3870d5486)


**Goals:**

    Initially, the task was to develop a function to fetch the access dates for each key. However, it became apparent that such a function already existed. Consequently, the focus shifted to enhancing the quality of data returned by this function. The aim was to refine the output, ensuring it provides detailed and well-organized information, thereby augmenting the function's effectiveness and its applicability in scenarios requiring comprehensive and structured data insights.

    The second objective was to integrate key metadata information within the context of aws.iam.usercredentialreportentry. Despite various attempts, successfully embedding this data proved challenging. The idea was to include an access key retrieval method within the aws.iam.usercredentialreportentry structure, as shown below:

```
// Entry in AWS IAM credential report
private aws.iam.usercredentialreportentry @defaults("arn") {
  ...
  ...
  // List of access keys metadata associated with the user
  accessKeys() []aws.iam.accessKey
}
```

The motivation behind this approach was to enable a direct comparison between data obtained from **aws.iam.usercredentialreportentry** and **aws.iam.accessKey** through an MQL query, thereby facilitating a more comprehensive data analysis and correlation within the AWS IAM framework.