### PR TITLE
Elasticsearch -> OpenSearch

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -954,21 +954,21 @@ private aws.sns.subscription @defaults("arn") {
   protocol string
 }
 
-// AWS Elasticsearch service
+// AWS OpenSearch (formerly Elasticsearch) service
 aws.es {
-  // List of Elasticsearch domains
+  // List of OpenSearch (formerly Elasticsearch) domains
   domains() []aws.es.domain
 }
 
-// Amazon Elasticsearch service domain
+// Amazon OpenSearch (formerly Elasticsearch) service domain
 private aws.es.domain @defaults("arn name") {
-  // ARN for the Elasticsearch domain
+  // ARN for the OpenSearch domain
   arn string
   // Whether encryption at rest is enabled
   encryptionAtRestEnabled bool
   // Denoted whether node to node encryption is enabled
   nodeToNodeEncryptionEnabled bool
-  // Name of the Elasticsearch domain
+  // Name of the OpenSearch domain
   name string
   // Endpoint used to submit index and search requests
   endpoint string
@@ -976,11 +976,11 @@ private aws.es.domain @defaults("arn name") {
   region string
   // Tags for the domain
   tags map[string]string
-  // The version of Elasticsearch running
+  // The version of OpenSearch running
   elasticsearchVersion string
-  // The Elasticsearch domain ID
+  // The OpenSearch domain ID
   domainId string
-  // The Elasticsearch domain name
+  // The OpenSearch domain name
   domainName string
 }
 

--- a/providers/aws/resources/aws.lr.manifest.yaml
+++ b/providers/aws/resources/aws.lr.manifest.yaml
@@ -1602,7 +1602,7 @@ resources:
   aws.es:
     docs:
       desc: |
-        Use the `aws.es` resource to assess the configuration of Amazon Elasticsearch domains. This resource provides a list of `aws.es.domain` resources representing Elasticsearch domains deployed across all enabled regions.
+        Use the `aws.es` resource to assess the configuration of Amazon OpenSearch (formerly Elasticsearch) domains. This resource provides a list of `aws.es.domain` resources representing OpenSearch domains deployed across all enabled regions.
     fields:
       domains: {}
     min_mondoo_version: 5.15.0
@@ -1610,12 +1610,12 @@ resources:
       name:
       - aws
     refs:
-    - title: Amazon Security Blog on Elasticsearch
+    - title: Amazon Security Blog posts on Elasticsearch
       url: https://aws.amazon.com/blogs/security/tag/amazon-elasticsearch-service/
   aws.es.domain:
     docs:
       desc: |
-        The `aws.es.domain` provides fields for assessing the configuration of individual Amazon Elasticsearch domains. For usage, read the `aws.es` resource documentation
+        The `aws.es.domain` provides fields for assessing the configuration of individual Amazon OpenSearch (formerly Elasticsearch) domains. For usage, read the `aws.es` resource documentation
     fields:
       arn: {}
       domainId:


### PR DESCRIPTION
With Amazon's rebranding, updates "Elasticsearch" to "OpenSearch"