### PR TITLE
Azure: Add data security export settings (MCAS)

### DIFF
--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -81,7 +81,7 @@ func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssi
 
 // the armsecurity.NewListPager is broken, see https://github.com/Azure/azure-sdk-for-go/issues/19740.
 // until it's fixed, we can fetch them manually
-func getSecurityContacts(ctx context.Context, conn armSecurityConn) ([]security.Contact, error) {
+func getSecurityContacts(ctx context.Context, conn armSecurityConn) ([], error) {
 	token, err := conn.GetToken()
 	if err != nil {
 		return []security.Contact{}, err
@@ -119,6 +119,58 @@ func getSecurityContacts(ctx context.Context, conn armSecurityConn) ([]security.
 	if err != nil {
 		// fallback, try to unmarshal to ContactList
 		contactList := &security.ContactList{}
+		err = json.Unmarshal(raw, contactList)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range contactList.Value {
+			if c != nil {
+				result = append(result, *c)
+			}
+		}
+	}
+
+	return result, err
+}
+
+func getSettingsClient(ctx context.Context, conn armSecurityConn) ([]security.SettingsClient, error) {
+	token, err := conn.GetToken()
+	if err != nil {
+		return []security.SettingsClient{}, err
+	}
+	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Security/settings"
+	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(conn.subscriptionId))
+	urlPath = runtime.JoinPaths(conn.host, urlPath)
+	client := http.Client{}
+	req, err := http.NewRequest("GET", urlPath, nil)
+	if err != nil {
+		return []security.SettingsClient{}, err
+	}
+	q := req.URL.Query()
+	q.Set("api-version", "2021-06-01")
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return []security.SettingsClient{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return [][]security.SettingsClient{}, errors.New("failed to fetch security contacts from " + urlPath + ": " + resp.Status)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return [][]security.SettingsClient{}, err
+	}
+	result := [][]security.SettingsClient{}
+	err = json.Unmarshal(raw, &result)
+	if err != nil {
+		// fallback, try to unmarshal to ContactList
+		contactList := &security.SettingsList{}
 		err = json.Unmarshal(raw, contactList)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Replaces: https://github.com/mondoohq/cnquery/pull/5091

Adding this:


```
 /home/manuel/azure-tests $ az account get-access-token --query "{subscription:subscription,accessToken:accessToken}" --out tsv | xargs -L1 bash -c 'curl -X GET -H "Authorization: Bearer $1" -H "Content-Type:application/json" https://management.azure.com/subscriptions/<subscription>/providers/Microsoft.Security/settings?api-version=2021-06-01' | jq '.|.value[] '

{
  "id": "/subscriptions/<subscription>/providers/Microsoft.Security/settings/MCAS",
  "name": "MCAS",
  "type": "Microsoft.Security/settings",
  "kind": "DataExportSettings",
  "properties": {
    "enabled": true
  }
}
{
  "id": "/subscriptions/<subscription>/providers/Microsoft.Security/settings/WDATP",
  "name": "WDATP",
  "type": "Microsoft.Security/settings",
  "kind": "DataExportSettings",
  "properties": {
    "enabled": false
  }
}
{
  "id": "/subscriptions/<subscription>/providers/Microsoft.Security/settings/Sentinel",
  "name": "Sentinel",
  "type": "Microsoft.Security/settings",
  "kind": "AlertSyncSettings",
  "properties": {
    "enabled": false
  }
}
```