### PR TITLE
⭐ show assessments inside of blocks

### DIFF
--- a/apps/cnquery/cmd/plugin.go
+++ b/apps/cnquery/cmd/plugin.go
@@ -81,7 +81,7 @@ func (c *cnqueryPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Ru
 			return errors.Wrap(err, "failed to compile command")
 		}
 
-		out.WriteString(logger.PrettyJSON((b)) + "\n" + printer.DefaultPrinter.CodeBundle(b))
+		out.WriteString(logger.PrettyJSON((b)) + "\n" + printer.DefaultPrinter.CodeBundle(b.Expand()))
 		return nil
 	}
 

--- a/llx/code.go
+++ b/llx/code.go
@@ -307,7 +307,7 @@ func (l *CodeV2) returnValues(bundle *CodeBundle, lookup func(s string) (*RawRes
 	return res
 }
 
-func (l *CodeV2) entrypoint2assessment(bundle *CodeBundle, ref uint64, lookup func(s string) (*RawResult, bool)) *AssessmentItem {
+func (l *CodeV2) Entrypoint2Assessment(bundle *CodeBundle, ref uint64, lookup func(s string) (*RawResult, bool)) *AssessmentItem {
 	code := bundle.CodeV2
 	checksum := code.Checksums[ref]
 

--- a/llx/code_bundle.go
+++ b/llx/code_bundle.go
@@ -29,14 +29,6 @@ func ReturnValuesV2(bundle *CodeBundle, f func(s string) (*RawResult, bool)) []*
 	return bundle.CodeV2.returnValues(bundle, f)
 }
 
-// Results2Assessment converts a list of raw results into an assessment for the query
-func Results2AssessmentV2(bundle *CodeBundle, results map[string]*RawResult) *Assessment {
-	return Results2AssessmentLookupV2(bundle, func(s string) (*RawResult, bool) {
-		r := results[s]
-		return r, r != nil
-	})
-}
-
 // Results2AssessmentLookup creates an assessment for a bundle using a lookup hook to get all results
 func Results2AssessmentLookupV2(bundle *CodeBundle, f func(s string) (*RawResult, bool)) *Assessment {
 	code := bundle.CodeV2
@@ -54,7 +46,7 @@ func Results2AssessmentLookupV2(bundle *CodeBundle, f func(s string) (*RawResult
 	entrypoints := code.Entrypoints()
 	for i := range entrypoints {
 		ep := entrypoints[i]
-		cur := code.entrypoint2assessment(bundle, ep, f)
+		cur := code.Entrypoint2Assessment(bundle, ep, f)
 		if cur == nil {
 			continue
 		}
@@ -97,4 +89,22 @@ func (x *CodeBundle) DatapointChecksums() []string {
 		checksums[i] = x.CodeV2.Checksums[ref]
 	}
 	return checksums
+}
+
+type ExpandedCodeBundle struct {
+	*CodeBundle
+	Ref2CodeID map[string]uint64
+}
+
+func (x *CodeBundle) Expand() *ExpandedCodeBundle {
+	res := ExpandedCodeBundle{
+		CodeBundle: x,
+		Ref2CodeID: make(map[string]uint64, len(x.CodeV2.Checksums)),
+	}
+
+	for ref, csum := range x.CodeV2.Checksums {
+		res.Ref2CodeID[csum] = ref
+	}
+
+	return &res
 }

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -383,7 +383,7 @@ func (c *compiler) compileIfBlock(expressions []*parser.Expression, chunk *llx.C
 	if err != nil {
 		return types.Nil, err
 	}
-	blockCompiler.updateEntrypoints(false)
+	blockCompiler.updateEntrypoints()
 
 	block := blockCompiler.block
 
@@ -536,7 +536,7 @@ func (c *compiler) compileSwitchBlock(expressions []*parser.Expression, chunk *l
 		if err != nil {
 			return types.Nil, err
 		}
-		blockCompiler.updateEntrypoints(false)
+		blockCompiler.updateEntrypoints()
 
 		// TODO(jaym): Discuss with dom: v1 seems to hardcore this as
 		// single valued
@@ -626,7 +626,7 @@ func (c *compiler) blockcompileOnResource(expressions []*parser.Expression, typ 
 		return &blockCompiler, err
 	}
 
-	blockCompiler.updateEntrypoints(false)
+	blockCompiler.updateEntrypoints()
 	blockCompiler.updateLabels()
 
 	return &blockCompiler, nil
@@ -1989,14 +1989,7 @@ func (c *compiler) updateLabels() {
 	}
 }
 
-func (c *compiler) updateEntrypoints(collectRefDatapoints bool) {
-	// BUG (jaym): collectRefDatapoints prevents us from collecting datapoints.
-	// Collecting datapoints for blocks didn't work correctly until 6.7.0.
-	// See https://gitlab.com/mondoolabs/mondoo/-/merge_requests/2639
-	// We can fix this after some time has passed. If we fix it too soon
-	// people will start having their queries fail if a falsy datapoint
-	// is collected.
-
+func (c *compiler) updateEntrypoints() {
 	code := c.Result.CodeV2
 
 	// 1. efficiently remove variable definitions from entrypoints
@@ -2034,10 +2027,6 @@ func (c *compiler) updateEntrypoints(collectRefDatapoints bool) {
 		if chunk.Function != nil {
 			delete(entrypoints, chunk.Function.Binding)
 		}
-	}
-
-	if !collectRefDatapoints {
-		return
 	}
 
 	datapoints := map[uint64]struct{}{}
@@ -2096,7 +2085,7 @@ func (c *compiler) CompileParsed(ast *parser.AST) error {
 
 	c.postCompile()
 	c.Result.CodeV2.UpdateID()
-	c.updateEntrypoints(true)
+	c.updateEntrypoints()
 	c.updateLabels()
 
 	return nil

--- a/providers/extensible_schema_test.go
+++ b/providers/extensible_schema_test.go
@@ -55,6 +55,6 @@ func TestExtensibleSchema(t *testing.T) {
 	assert.ElementsMatch(t, []string{"first", "second"}, providers)
 
 	_, finfo = s.LookupField("eternity", "v")
-	require.NotNil(t, info)
+	require.NotNil(t, finfo)
 	assert.Equal(t, "first", finfo.Provider)
 }


### PR DESCRIPTION
This has been a very long time coming. Despite being an important step forward, it's also only just the first step in terms of the code changes that will be necessary to clean this up long-term.

So, ...

## What is this?

Currently if we run this:

```coffee
> [1,2,3].containsOnly([1,2])
[failed] [].containsOnly()
  expected: == []
  actual:   [
    0: 3
  ]
```

It shows us what's up. 

But what if we put it inside a block?

```coffee
> mondoo { [1,2,3].containsOnly([1,2]) }
mondoo: {
  [].containsOnly(): false
}
```

Darn, all the useful output just disappeared.

This PR make it so that instead we get:

```coffee
> mondoo { [1,2,3].containsOnly([1,2]) }
mondoo: {
  [failed] [].containsOnly()
    expected: == []
    actual:   [
      0: 3
    ]
}
```

This example is a bit constructed, but works just as well with naturally occurring blocks like:

**TODO**

Fixes https://github.com/mondoohq/cnquery/issues/5246

## How does it work?

This is where things get a bit tricky, because this PR is only a first step to solve the problem, but ultimately needs follow-ups to increase clarity.

**1: Expand Code Bundles**

By default, code bundles don't need to translate from CodeIDs into refs. This only ever becomes useful when we print things and deal with CodeIDs and try to go back to the compiled code (CodeBundle) and figure out how best to render it. We add a type that is only used for printing so we don't need to extend the CodeBundle for this task (no foreseeable future where we'd ever want to transmit this data, ie not part of proto).

**2: Start to building assessments inside the data printer**

Printing is currently split up in an assessment and a data-printing phase. If something is handled in the assessment phase it will be printed as an assessment and that's it. If not, it will be printed as data. 

When we receive an outer block, it switches into data mode. However, the block may contain assertions, that are then ignored and never collected nor printed. This PR changes this behavior and starts to look for assertions inside of blocks.

**3. Start to collect datapoints inside of blocks**

An old piece of code had previously removed this:

```
	// BUG (jaym): collectRefDatapoints prevents us from collecting datapoints.
	// Collecting datapoints for blocks didn't work correctly until 6.7.0.
	// See https://gitlab.com/mondoolabs/mondoo/-/merge_requests/2639
	// We can fix this after some time has passed. If we fix it too soon
	// people will start having their queries fail if a falsy datapoint
	// is collected.
```

Looks like we are far past that point, so let's start collecting.
