### PR TITLE
⭐ Azure auto discovery should include all resources

### DIFF
--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -48,7 +48,21 @@ var All = []string{
 	DiscoveryInstances,
 }
 
-var Auto = []string{DiscoverySubscriptions}
+var Auto = []string{
+	DiscoverySubscriptions,
+	DiscoveryInstances,
+	//DiscoveryInstancesApi,
+	DiscoverySqlServers,
+	DiscoveryPostgresServers,
+	DiscoveryPostgresFlexibleServers,
+	DiscoveryMySqlServers,
+	DiscoveryMySqlFlexibleServers,
+	DiscoveryMariaDbServers,
+	DiscoveryStorageAccounts,
+	DiscoveryStorageContainers,
+	DiscoveryKeyVaults,
+	DiscoverySecurityGroups,
+}
 
 func allDiscovery() []string {
 	return append(All, AllAPIResources...)

--- a/providers/azure/resources/discovery_test.go
+++ b/providers/azure/resources/discovery_test.go
@@ -40,4 +40,8 @@ func TestGetDiscoveryTargets(t *testing.T) {
 	// test random
 	config.Discover.Targets = []string{"postgres-servers", "keyvaults-vaults", "instances"}
 	require.Equal(t, []string{DiscoveryPostgresServers, DiscoveryKeyVaults, DiscoveryInstances}, getDiscoveryTargets(config))
+
+	// test standard cli run without options
+	config.Discover.Targets = []string{}
+	require.Equal(t, Auto, getDiscoveryTargets(config))
 }


### PR DESCRIPTION
As done for AWS and GCP now also for Azure as i am now using Azure Integration as well.

I have one question:
For AWS and GCP as i sticked to the AWS changes you did. And therfore not added certain resources to auto.

From my understanding it is crucial to make auto == all. As on the integrations used on the mondoo plattform we cant define any options as input for the scans right ?

When i look at `gcp` and `aws` there are some things excluded.
I had this problem just today wanted to check ec2 instances but `ec2-instance-api` was not included into auto behaviour and also not included in `all` but worked perfectly fine on the shell on my laptop.

I also dont understand the difference between `instances` and `ec2-instance-api`

Could we align why this is the case and if it does not has any reasons also include it into the scans?

[AWS PR](https://github.com/mondoohq/cnquery/pull/6397/changes)
[GCP PR](https://github.com/mondoohq/cnquery/pull/6451/changes)