### PR TITLE
:bug: (os): skip unresolved users in group.members

### DIFF
--- a/providers/os/resources/group.go
+++ b/providers/os/resources/group.go
@@ -89,13 +89,16 @@ func (x *mqlGroup) members() ([]any, error) {
 		return nil, err
 	}
 
-	res := make([]any, len(x.membersArr))
-	for i, name := range x.membersArr {
+	res := make([]any, 0, len(x.membersArr))
+	for _, name := range x.membersArr {
+		if name == "" {
+			continue
+		}
 		user, ok := users.usersByName[name]
 		if !ok {
-			return nil, errors.New("cannot find user with name '" + name + "'")
+			continue
 		}
-		res[i] = user
+		res = append(res, user)
 	}
 
 	return res, nil


### PR DESCRIPTION
## Summary
- make `group.members` tolerate usernames that are not present in the resolved `users` cache
- skip unresolved or empty member entries instead of failing the whole field evaluation
- keeps group queries usable on systems where group member names are not resolvable via `getent passwd`

## Testing
- `go test ./providers/os/resources/...`

## Related
- Fixes #6355
