### PR TITLE
Add workflow to auto-approve bot workflow runs

### DIFF
--- a/.github/workflows/auto-approve-bot-runs.yml
+++ b/.github/workflows/auto-approve-bot-runs.yml
@@ -1,9 +1,11 @@
 name: Auto-approve bot workflow runs
 
 on:
-  # workflow_run runs in the context of the default branch,
-  # so it is not itself subject to the approval gate.
+  # Scoped to CodeQL only — the workflow that requires approval on bot PRs.
+  # workflow_run runs in the default-branch context, so it is not itself
+  # subject to the approval gate.
   workflow_run:
+    workflows: ["CodeQL Advanced"]
     types: [requested]
 
 permissions:
@@ -13,15 +15,26 @@ jobs:
   approve:
     runs-on: ubuntu-latest
     if: >-
-      github.event.workflow_run.conclusion == 'action_required' &&
-      contains(fromJSON('["github-actions[bot]","dependabot[bot]"]'), github.event.workflow_run.actor.login)
+      contains(fromJSON('["github-actions[bot]","dependabot[bot]"]'), github.event.workflow_run.actor.login) &&
+      startsWith(github.event.workflow_run.head_branch, 'version/')
     steps:
-      - name: Approve workflow run
+      - name: Approve workflow run if pending
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           ACTOR: ${{ github.event.workflow_run.actor.login }}
           REPO: ${{ github.repository }}
         run: |
-          echo "Approving run $RUN_ID triggered by $ACTOR"
-          gh run approve "$RUN_ID" --repo "$REPO"
+          # The 'requested' event fires before the conclusion is set.
+          # Poll briefly for GitHub to settle the run into action_required.
+          for i in 1 2 3; do
+            STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status')
+            if [ "$STATUS" = "action_required" ]; then
+              echo "Approving run $RUN_ID triggered by $ACTOR"
+              gh run approve "$RUN_ID" --repo "$REPO"
+              exit 0
+            fi
+            echo "Run status is '$STATUS', waiting…"
+            sleep 10
+          done
+          echo "Run $RUN_ID never entered action_required state — skipping"

--- a/.github/workflows/auto-approve-bot-runs.yml
+++ b/.github/workflows/auto-approve-bot-runs.yml
@@ -1,0 +1,24 @@
+name: Auto-approve bot workflow runs
+
+on:
+  # workflow_run runs in the context of the default branch,
+  # so it is not itself subject to the approval gate.
+  workflow_run:
+    types: [requested]
+
+permissions:
+  actions: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'action_required' &&
+      contains(fromJSON('["github-actions[bot]","dependabot[bot]"]'), github.event.workflow_run.actor.login)
+    steps:
+      - name: Approve workflow run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Approving run ${{ github.event.workflow_run.id }} triggered by ${{ github.event.workflow_run.actor.login }}"
+          gh run approve ${{ github.event.workflow_run.id }} --repo ${{ github.repository }}

--- a/.github/workflows/auto-approve-bot-runs.yml
+++ b/.github/workflows/auto-approve-bot-runs.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Approve workflow run
         env:
           GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "Approving run ${{ github.event.workflow_run.id }} triggered by ${{ github.event.workflow_run.actor.login }}"
-          gh run approve ${{ github.event.workflow_run.id }} --repo ${{ github.repository }}
+          echo "Approving run $RUN_ID triggered by $ACTOR"
+          gh run approve "$RUN_ID" --repo "$REPO"

--- a/.github/workflows/auto-approve-bot-runs.yml
+++ b/.github/workflows/auto-approve-bot-runs.yml
@@ -15,7 +15,9 @@ jobs:
     # GitHub's approval gate checks the *commit* author, not the workflow
     # actor.  When a bot-authored PR is merged by a human the run's actor
     # is the human, but head_commit.author.name is still the bot.
+    # The head_repository check prevents fork PRs with spoofed author names.
     if: >-
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       contains(fromJSON('["github-actions[bot]","dependabot[bot]"]'),
         github.event.workflow_run.head_commit.author.name)
     steps:
@@ -28,7 +30,7 @@ jobs:
         run: |
           # The 'requested' event fires before the status settles.
           # Poll briefly for GitHub to move the run into action_required.
-          for i in 1 2 3; do
+          for i in 1 2 3 4 5; do
             STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status')
             if [ "$STATUS" = "action_required" ]; then
               echo "Approving run $RUN_ID (commit authored by $AUTHOR)"
@@ -38,4 +40,4 @@ jobs:
             echo "Run status is '$STATUS', waiting…"
             sleep 10
           done
-          echo "Run $RUN_ID never entered action_required state — skipping"
+          echo "::warning::Run $RUN_ID never entered action_required state after 50s — skipping"

--- a/.github/workflows/auto-approve-bot-runs.yml
+++ b/.github/workflows/auto-approve-bot-runs.yml
@@ -1,11 +1,9 @@
 name: Auto-approve bot workflow runs
 
 on:
-  # Scoped to CodeQL only — the workflow that requires approval on bot PRs.
   # workflow_run runs in the default-branch context, so it is not itself
   # subject to the approval gate.
   workflow_run:
-    workflows: ["CodeQL Advanced"]
     types: [requested]
 
 permissions:
@@ -14,23 +12,26 @@ permissions:
 jobs:
   approve:
     runs-on: ubuntu-latest
+    # GitHub's approval gate checks the *commit* author, not the workflow
+    # actor.  When a bot-authored PR is merged by a human the run's actor
+    # is the human, but head_commit.author.name is still the bot.
     if: >-
-      contains(fromJSON('["github-actions[bot]","dependabot[bot]"]'), github.event.workflow_run.actor.login) &&
-      startsWith(github.event.workflow_run.head_branch, 'version/')
+      contains(fromJSON('["github-actions[bot]","dependabot[bot]"]'),
+        github.event.workflow_run.head_commit.author.name)
     steps:
       - name: Approve workflow run if pending
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
-          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
           REPO: ${{ github.repository }}
         run: |
-          # The 'requested' event fires before the conclusion is set.
-          # Poll briefly for GitHub to settle the run into action_required.
+          # The 'requested' event fires before the status settles.
+          # Poll briefly for GitHub to move the run into action_required.
           for i in 1 2 3; do
             STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status --jq '.status')
             if [ "$STATUS" = "action_required" ]; then
-              echo "Approving run $RUN_ID triggered by $ACTOR"
+              echo "Approving run $RUN_ID (commit authored by $AUTHOR)"
               gh run approve "$RUN_ID" --repo "$REPO"
               exit 0
             fi


### PR DESCRIPTION
## Summary
- GitHub now requires maintainer approval for workflows triggered by bot-authored events ([changelog](https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/))
- This adds a companion workflow that auto-approves `action_required` runs from `github-actions[bot]` and `dependabot[bot]`
- Uses `workflow_run` trigger which runs in the default branch context, so it is not itself subject to the approval gate

## Test plan
- [ ] Merge this PR
- [ ] Wait for the next bot-authored PR (e.g. providers update or Dependabot bump)
- [ ] Verify the CodeQL / other workflows no longer sit in `action_required` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)