### PR TITLE
🧹 inventory: keep relative private key paths within the inventory dir

### DIFF
--- a/providers-sdk/v1/inventory/inventory.go
+++ b/providers-sdk/v1/inventory/inventory.go
@@ -196,7 +196,16 @@ func (p *Inventory) PreProcess() error {
 				// we handle credentials relative to the inventory file
 				fileLoc, ok := p.Metadata.Labels[InventoryFilePath]
 				if ok {
-					path = filepath.Join(filepath.Dir(fileLoc), path)
+					baseDir := filepath.Dir(fileLoc)
+					resolved := filepath.Join(baseDir, path)
+					// a relative key path is meant to sit alongside the
+					// inventory; keep it within that directory rather than
+					// letting ".." segments resolve elsewhere on disk
+					rel, err := filepath.Rel(baseDir, resolved)
+					if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+						return errors.New("private key path is outside the inventory directory: " + cred.PrivateKeyPath)
+					}
+					path = resolved
 				} else {
 					absPath, err := filepath.Abs(path)
 					if err != nil {

--- a/providers-sdk/v1/inventory/inventory_test.go
+++ b/providers-sdk/v1/inventory/inventory_test.go
@@ -243,6 +243,65 @@ func TestPreprocess(t *testing.T) {
 		assert.Equal(t, vault.CredentialType_password, v1inventory.Spec.Credentials[secretid].Type)
 		assert.Equal(t, secret, string(v1inventory.Spec.Credentials[secretid].Secret))
 	})
+
+	t.Run("relative private key path resolves within the inventory directory", func(t *testing.T) {
+		v1inventory := &Inventory{
+			Metadata: &ObjectMeta{
+				Labels: map[string]string{InventoryFilePath: "./testdata/inventory.yaml"},
+			},
+			Spec: &InventorySpec{
+				Assets: []*Asset{
+					{
+						Name: "test",
+						Connections: []*Config{
+							{
+								Type: "ssh",
+								Credentials: []*vault.Credential{
+									{
+										Type:           vault.CredentialType_private_key,
+										PrivateKeyPath: "private_key_01",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := v1inventory.PreProcess()
+		require.NoError(t, err)
+		secretid := v1inventory.Spec.Assets[0].Connections[0].Credentials[0].SecretId
+		assert.NotEmpty(t, v1inventory.Spec.Credentials[secretid].Secret)
+	})
+
+	t.Run("relative private key path may not escape the inventory directory", func(t *testing.T) {
+		v1inventory := &Inventory{
+			Metadata: &ObjectMeta{
+				Labels: map[string]string{InventoryFilePath: "./testdata/inventory.yaml"},
+			},
+			Spec: &InventorySpec{
+				Assets: []*Asset{
+					{
+						Name: "test",
+						Connections: []*Config{
+							{
+								Type: "ssh",
+								Credentials: []*vault.Credential{
+									{
+										Type:           vault.CredentialType_private_key,
+										PrivateKeyPath: "../../etc/hostname",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := v1inventory.PreProcess()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the inventory directory")
+	})
 }
 
 func TestParseGCPInventory(t *testing.T) {


### PR DESCRIPTION
## What

When a credential's `privateKeyPath` is relative, `Inventory.PreProcess` resolves it relative to the source inventory file. The documented intent (see the existing comment) is that the key sits alongside the inventory:

```go
// special handling for relative filenames, instead of loading
// private keys from relative to the work directory, we want to
// load the files relative to the source inventory
```

The join was unguarded, so `..` segments in a relative path resolved to a file elsewhere on disk instead of staying within the inventory directory — contrary to that intent.

## Change

- Resolve the relative path and confirm it stays under the inventory directory with `filepath.Rel`; return a clear error if it escapes.
- Absolute paths and `~/`-prefixed paths are unchanged.
- Adds `TestPreprocess` subtests for the in-bounds case (loads the key) and the escaping case (returns an error).

## Test

```
go test ./providers-sdk/v1/inventory/ -run TestPreprocess -v
```

All subtests pass.