### PR TITLE
🧹 providers: keep unpacked archive entries within the temp dir

### DIFF
--- a/providers/install_test.go
+++ b/providers/install_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ulikunitz/xz"
+)
+
+// tarXz builds an in-memory .tar.xz containing a single regular-file entry
+// with the given name and contents.
+func tarXz(t *testing.T, name, content string) io.ReadCloser {
+	t.Helper()
+	var buf bytes.Buffer
+	xzw, err := xz.NewWriter(&buf)
+	require.NoError(t, err)
+	tw := tar.NewWriter(xzw)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     name,
+		Mode:     0o644,
+		Size:     int64(len(content)),
+	}))
+	_, err = tw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, xzw.Close())
+	return io.NopCloser(&buf)
+}
+
+func TestInstallIO_RejectsPathTraversal(t *testing.T) {
+	dst := t.TempDir()
+	// InstallIO unpacks into a temp dir created *inside* dst, so an entry of
+	// "../escapee.txt" resolves to dst/escapee.txt — outside the unpack dir.
+	escapee := filepath.Join(dst, "escapee.txt")
+	require.NoFileExists(t, escapee)
+
+	_, err := InstallIO(tarXz(t, "../escapee.txt", "pwned"), InstallConf{Dst: dst})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid path in provider archive")
+
+	// Nothing was written outside the unpack directory.
+	assert.NoFileExists(t, escapee)
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -681,8 +681,19 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 	log.Debug().Str("path", tmpdir).Msg("unpacking providers")
 	files := map[string]struct{}{}
 	err = walkTarXz(reader, func(reader *tar.Reader, header *tar.Header) error {
-		files[header.Name] = struct{}{}
 		dst := filepath.Join(tmpdir, header.Name)
+
+		// Keep every entry within tmpdir. filepath.Join cleans the path, so an
+		// entry whose name contains ".." segments would otherwise resolve to a
+		// location outside the unpack directory; reject those instead. This
+		// also keeps the names recorded in `files` safe for the rename loop
+		// below, which joins them onto conf.Dst.
+		rel, err := filepath.Rel(tmpdir, dst)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return errors.New("invalid path in provider archive: " + header.Name)
+		}
+
+		files[header.Name] = struct{}{}
 		log.Debug().Str("name", header.Name).Str("dest", dst).Msg("unpacking file")
 		writer, err := os.Create(dst)
 		if err != nil {


### PR DESCRIPTION
## What

`InstallIO` unpacks a provider's `tar.xz` into a temp directory:

```go
dst := filepath.Join(tmpdir, header.Name)
writer, err := os.Create(dst)
```

There was no check that an entry stays inside `tmpdir`. Because `filepath.Join` cleans the path, an archive whose entry name contains `..` segments resolves to a location outside the unpack directory. The recorded name is also reused later in the rename loop, where it is joined onto `conf.Dst`.

## Change

- Before creating the file or recording its name, verify the resolved path stays within `tmpdir` (via `filepath.Rel`); return a clear error otherwise.
- Recording the name into `files` now happens after that check, so the subsequent rename loop only ever sees in-bounds names too.
- `walkTarXz` already skips non-regular entries, so symlink entries aren't a concern here.

Uses the same `filepath.Rel` confinement idiom as the inventory key-path change (#8205).

## Test

Adds `TestInstallIO_RejectsPathTraversal`, which feeds an in-memory `.tar.xz` with a `../escapee.txt` entry and asserts the install errors and nothing is written outside the unpack directory.

```
go test ./providers/ -run TestInstallIO_RejectsPathTraversal -v
```

Passes.
