### PR TITLE
✨ os: expose Dockerfile provenance on docker.file (sha256 + source repository)

### DIFF
--- a/providers/os/connection/docker/docker_file_connection.go
+++ b/providers/os/connection/docker/docker_file_connection.go
@@ -29,8 +29,15 @@ type DockerfileConnection struct {
 	// FileAbsSrc must be the absolute path of the Dockerfile so
 	// that we find the file downstream
 	FileAbsSrc string
-	osFamily   shared.OSFamily
-	closer     func()
+	// RepositoryURL is the HTTPS URL of the source repository the Dockerfile
+	// was discovered in. Empty when the Dockerfile has no repository context.
+	RepositoryURL string
+	// RepositoryOrg and RepositoryName identify the source repository, parsed
+	// from the git ssh-url. Empty when the Dockerfile has no repository context.
+	RepositoryOrg  string
+	RepositoryName string
+	osFamily       shared.OSFamily
+	closer         func()
 }
 
 func NewDockerfileConnection(_ uint32,
@@ -94,6 +101,7 @@ func NewDockerfileConnection(_ uint32,
 		TechnologyUrlSegments: []string{"iac", "dockerfile"},
 	}
 
+	var repoURL, repoOrg, repoName string
 	if url, ok := conf.Options["ssh-url"]; ok {
 		domain, org, repo, err := urlx.ParseGitSshUrl(url)
 		if err != nil {
@@ -111,6 +119,15 @@ func NewDockerfileConnection(_ uint32,
 		asset.PlatformIds = []string{platformID}
 		asset.Name = "Dockerfile " + name
 
+		repoOrg = org
+		repoName = repo
+		// prefer the explicit http-url for the clickable repository link;
+		// fall back to reconstructing an https URL from the ssh-url parts
+		if httpURL := conf.Options["http-url"]; httpURL != "" {
+			repoURL = httpURL
+		} else {
+			repoURL = "https://" + domain + "/" + org + "/" + repo
+		}
 	} else {
 		h := sha256.New()
 		h.Write([]byte(absSrc))
@@ -126,8 +143,11 @@ func NewDockerfileConnection(_ uint32,
 		LocalConnection: localConn,
 		// here we must use the absolute path of the Dockerfile so
 		// that we find the file downstream
-		FileAbsSrc: absSrc,
-		closer:     closer,
+		FileAbsSrc:     absSrc,
+		RepositoryURL:  repoURL,
+		RepositoryOrg:  repoOrg,
+		RepositoryName: repoName,
+		closer:         closer,
 	}
 	// the connection now owns the clone directory and cleans it up via Close()
 	cleanup = false

--- a/providers/os/connection/docker/docker_file_connection_test.go
+++ b/providers/os/connection/docker/docker_file_connection_test.go
@@ -61,5 +61,49 @@ func TestNewDockerfileConnection(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, subject)
 		require.Equal(t, dockerfile.Name(), subject.FileAbsSrc)
+		// no repository context when scanned from a plain path
+		require.Empty(t, subject.RepositoryURL)
+		require.Empty(t, subject.RepositoryOrg)
+		require.Empty(t, subject.RepositoryName)
+	})
+	t.Run("repository context from ssh-url", func(t *testing.T) {
+		dockerfile, err := os.CreateTemp("", "Dockerfile")
+		require.Nil(t, err)
+		defer os.Remove(dockerfile.Name())
+		_, err = dockerfile.WriteString("FROM debian:stable")
+		require.Nil(t, err)
+		conf := &inventory.Config{
+			Path:    dockerfile.Name(),
+			Options: map[string]string{"ssh-url": "git@github.com:mondoohq/lunalectric.git"},
+		}
+		asset := &inventory.Asset{Connections: []*inventory.Config{{}}}
+		local := local.NewConnection(0, conf, asset)
+		subject, err := NewDockerfileConnection(0, conf, asset, local, []string{})
+		require.Nil(t, err)
+		require.NotNil(t, subject)
+		require.Equal(t, "mondoohq", subject.RepositoryOrg)
+		require.Equal(t, "lunalectric", subject.RepositoryName)
+		// reconstructed from the ssh-url when no http-url is provided
+		require.Equal(t, "https://github.com/mondoohq/lunalectric", subject.RepositoryURL)
+	})
+	t.Run("repository url prefers explicit http-url", func(t *testing.T) {
+		dockerfile, err := os.CreateTemp("", "Dockerfile")
+		require.Nil(t, err)
+		defer os.Remove(dockerfile.Name())
+		_, err = dockerfile.WriteString("FROM debian:stable")
+		require.Nil(t, err)
+		conf := &inventory.Config{
+			Path: dockerfile.Name(),
+			Options: map[string]string{
+				"ssh-url":  "git@github.com:mondoohq/lunalectric.git",
+				"http-url": "https://github.com/mondoohq/lunalectric.git",
+			},
+		}
+		asset := &inventory.Asset{Connections: []*inventory.Config{{}}}
+		local := local.NewConnection(0, conf, asset)
+		subject, err := NewDockerfileConnection(0, conf, asset, local, []string{})
+		require.Nil(t, err)
+		require.NotNil(t, subject)
+		require.Equal(t, "https://github.com/mondoohq/lunalectric.git", subject.RepositoryURL)
 	})
 }

--- a/providers/os/resources/docker_file.go
+++ b/providers/os/resources/docker_file.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"slices"
 	"strconv"
@@ -82,6 +84,39 @@ func (p *mqlDockerFile) id() (string, error) {
 
 func (p *mqlDockerFile) file() (*mqlFile, error) {
 	return nil, errors.New("missing underlying file, please specify a path of file")
+}
+
+func (p *mqlDockerFile) sha256(file *mqlFile) (string, error) {
+	content := file.GetContent()
+	if content.Error != nil {
+		return "", content.Error
+	}
+	sum := sha256.Sum256([]byte(content.Data))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (p *mqlDockerFile) repositoryUrl() (string, error) {
+	if dfc, ok := p.MqlRuntime.Connection.(*docker.DockerfileConnection); ok && dfc.RepositoryURL != "" {
+		return dfc.RepositoryURL, nil
+	}
+	p.RepositoryUrl.State = plugin.StateIsSet | plugin.StateIsNull
+	return "", nil
+}
+
+func (p *mqlDockerFile) repositoryOrganization() (string, error) {
+	if dfc, ok := p.MqlRuntime.Connection.(*docker.DockerfileConnection); ok && dfc.RepositoryOrg != "" {
+		return dfc.RepositoryOrg, nil
+	}
+	p.RepositoryOrganization.State = plugin.StateIsSet | plugin.StateIsNull
+	return "", nil
+}
+
+func (p *mqlDockerFile) repositoryName() (string, error) {
+	if dfc, ok := p.MqlRuntime.Connection.(*docker.DockerfileConnection); ok && dfc.RepositoryName != "" {
+		return dfc.RepositoryName, nil
+	}
+	p.RepositoryName.State = plugin.StateIsSet | plugin.StateIsNull
+	return "", nil
 }
 
 func (p *mqlDockerFile) parse(file *mqlFile) error {

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -4360,6 +4360,29 @@ docker.file @defaults("file.path instructions.length stages.length") {
   // Shortcut to the last `docker.file.stage`, which is the one that produces
   // the image when the build runs without `--target`. Null for an empty file.
   finalStage(file) docker.file.stage
+  // SHA256 of the Dockerfile contents
+  //
+  // Hex-encoded SHA256 digest of the raw file bytes. Provides a stable
+  // fingerprint for identifying or comparing Dockerfiles independent of the
+  // path or repository they were scanned from.
+  sha256(file) string
+  // HTTPS URL of the source code repository
+  //
+  // Set when the Dockerfile was discovered through a source-control
+  // integration, such as a GitHub or GitLab scan, that records the origin
+  // repository. Null when the Dockerfile was scanned from a path with no
+  // repository context.
+  repositoryUrl() string
+  // Organization or owner of the source code repository
+  //
+  // Null when the Dockerfile was scanned from a path with no repository
+  // context.
+  repositoryOrganization() string
+  // Name of the source code repository
+  //
+  // Null when the Dockerfile was scanned from a path with no repository
+  // context.
+  repositoryName() string
 }
 
 // Build stage in a Dockerfile

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -6360,6 +6360,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"docker.file.finalStage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFile).GetFinalStage()).ToDataRes(types.Resource("docker.file.stage"))
 	},
+	"docker.file.sha256": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetSha256()).ToDataRes(types.String)
+	},
+	"docker.file.repositoryUrl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetRepositoryUrl()).ToDataRes(types.String)
+	},
+	"docker.file.repositoryOrganization": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetRepositoryOrganization()).ToDataRes(types.String)
+	},
+	"docker.file.repositoryName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDockerFile).GetRepositoryName()).ToDataRes(types.String)
+	},
 	"docker.file.stage.from": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDockerFileStage).GetFrom()).ToDataRes(types.Resource("docker.file.from"))
 	},
@@ -19335,6 +19347,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"docker.file.finalStage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDockerFile).FinalStage, ok = plugin.RawToTValue[*mqlDockerFileStage](v.Value, v.Error)
+		return
+	},
+	"docker.file.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.repositoryUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).RepositoryUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.repositoryOrganization": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).RepositoryOrganization, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"docker.file.repositoryName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDockerFile).RepositoryName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"docker.file.stage.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47848,13 +47876,17 @@ type mqlDockerFile struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlDockerFileInternal
-	File               plugin.TValue[*mqlFile]
-	Instructions       plugin.TValue[any]
-	Stages             plugin.TValue[[]any]
-	Directives         plugin.TValue[map[string]any]
-	MultiStage         plugin.TValue[bool]
-	HasSyntaxDirective plugin.TValue[bool]
-	FinalStage         plugin.TValue[*mqlDockerFileStage]
+	File                   plugin.TValue[*mqlFile]
+	Instructions           plugin.TValue[any]
+	Stages                 plugin.TValue[[]any]
+	Directives             plugin.TValue[map[string]any]
+	MultiStage             plugin.TValue[bool]
+	HasSyntaxDirective     plugin.TValue[bool]
+	FinalStage             plugin.TValue[*mqlDockerFileStage]
+	Sha256                 plugin.TValue[string]
+	RepositoryUrl          plugin.TValue[string]
+	RepositoryOrganization plugin.TValue[string]
+	RepositoryName         plugin.TValue[string]
 }
 
 // createDockerFile creates a new instance of this resource
@@ -47993,6 +48025,35 @@ func (c *mqlDockerFile) GetFinalStage() *plugin.TValue[*mqlDockerFileStage] {
 		}
 
 		return c.finalStage(vargFile.Data)
+	})
+}
+
+func (c *mqlDockerFile) GetSha256() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return "", vargFile.Error
+		}
+
+		return c.sha256(vargFile.Data)
+	})
+}
+
+func (c *mqlDockerFile) GetRepositoryUrl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.RepositoryUrl, func() (string, error) {
+		return c.repositoryUrl()
+	})
+}
+
+func (c *mqlDockerFile) GetRepositoryOrganization() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.RepositoryOrganization, func() (string, error) {
+		return c.repositoryOrganization()
+	})
+}
+
+func (c *mqlDockerFile) GetRepositoryName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.RepositoryName, func() (string, error) {
+		return c.repositoryName()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -676,6 +676,9 @@ docker.file.oci.version 13.25.1
 docker.file.onbuild 13.16.10
 docker.file.onbuild.context 13.30.2
 docker.file.onbuild.expression 13.16.10
+docker.file.repositoryName 13.26.1
+docker.file.repositoryOrganization 13.26.1
+docker.file.repositoryUrl 13.26.1
 docker.file.run 11.0.2
 docker.file.run.command 13.25.1
 docker.file.run.command.args 13.25.1
@@ -706,6 +709,7 @@ docker.file.run.mountsSsh 13.21.1
 docker.file.run.network 13.16.10
 docker.file.run.script 11.0.2
 docker.file.run.security 13.16.10
+docker.file.sha256 13.26.1
 docker.file.shell 11.8.15
 docker.file.shell.command 11.8.15
 docker.file.shell.context 13.30.2


### PR DESCRIPTION
## What

Adds four provenance fields to the `docker.file` resource so a user viewing a scanned Dockerfile in the Mondoo console can tell **where it came from** — and so policies can query it:

| Field | Description |
|---|---|
| `sha256` | Hex-encoded SHA256 of the raw Dockerfile contents — a stable fingerprint independent of path or repository. |
| `repositoryUrl` | HTTPS URL of the source repository. |
| `repositoryOrganization` | Organization / owner of the source repository. |
| `repositoryName` | Name of the source repository. |

## Why

Until now the only "where did this come from" signal on `docker.file` was `file.path` — the **absolute path on whatever machine ran the scan** (`/home/runner/work/.../Dockerfile` in CI, `/Users/.../Dockerfile` locally). That's close to useless in the console.

Meanwhile the dockerfile connection *already* parsed the git `ssh-url` to build the asset platform ID, then discarded the parsed host/org/repo. This PR plumbs that data onto the connection and surfaces it on the resource.

## Behavior

- `sha256` is always available (computed from file content).
- The `repository*` fields are populated when the Dockerfile is discovered through a source-control integration — the `ssh-url` / `http-url` connection options that GitHub and GitLab discovery already attach to IaC assets. They are **null** when the Dockerfile is scanned from a plain path with no repository context.
- `repositoryUrl` prefers an explicit `http-url`; otherwise it reconstructs `https://<host>/<org>/<repo>` from the `ssh-url`.

## Scope note (Tier 1)

This is the self-contained, high-value slice. A meaningful **repo-relative path**, **branch**, and **commit SHA** were deliberately left out: they require the scanning integration to pass the checkout root / ref, which it does not today. Those belong in a follow-up once that context is plumbed through.

## Testing

- `make providers/build/os` + interactive verification:
  - `docker.file { sha256 ... }` against a local Dockerfile → `sha256` matches `shasum -a 256`, repository fields `null`.
- Unit tests added to `docker_file_connection_test.go` covering the `ssh-url` → org/repo/URL parsing and the `http-url` preference. All pass.
- Generated code (`os.lr.go`, `os.lr.versions`) regenerated; new `.lr.versions` entries at `13.26.1`.