### PR TITLE
🐛 MQL: fix empty-left array concat losing element type (#5803)

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -1132,33 +1132,23 @@ func tarrayConcatTarrayV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uin
 		return nil, rref, err
 	}
 
-	if items.Value == nil {
-		return &RawData{Type: items.Type}, 0, nil
-	}
+	left, _ := bind.Value.([]any)
+	right, _ := items.Value.([]any)
 
-	v, _ := bind.Value.([]any)
-	if v == nil {
-		if items.Value == nil {
-			return &RawData{Type: bind.Type}, 0, nil
-		}
-		return nil, 0, errors.New("cannot add arrays to null")
-	}
-
-	list := items.Value.([]any)
-	if len(list) == 0 {
+	// Concatenating an empty array is a no-op, and the result must not depend on
+	// operand order. Returning the non-empty side as-is also lets it supply the
+	// element type: an empty literal `[]` carries no element type, so deriving
+	// the result type from it would render the other side's items as unknown.
+	if len(right) == 0 {
 		return bind, 0, nil
 	}
+	if len(left) == 0 {
+		return items, 0, nil
+	}
 
-	res := make([]any, len(v)+len(list))
-	var idx int
-	for i := range v {
-		res[idx] = v[i]
-		idx++
-	}
-	for i := range list {
-		res[idx] = list[i]
-		idx++
-	}
+	res := make([]any, len(left)+len(right))
+	copy(res, left)
+	copy(res[len(left):], right)
 
 	return &RawData{
 		Type:  bind.Type,

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/mqlc"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+	"go.mondoo.com/mql/v13/types"
 )
 
 // Core Language constructs
@@ -793,6 +794,45 @@ func TestArray(t *testing.T) {
 			Code:        "[].flat + [9]",
 			Expectation: []any{int64(9)},
 		},
+		// Regression for #5803: concatenating an empty array must be a no-op and
+		// must not depend on operand order. An empty literal `[]` carries no
+		// element type, so the non-empty side has to supply both the values and
+		// the result type (otherwise its items render as unknown).
+		{
+			Code:        "[1,2,3] + []",
+			Expectation: []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			Code:        "[] + [1,2,3]",
+			Expectation: []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			Code:        "[1,2] + [] + [3]",
+			Expectation: []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			Code:        "[] + []",
+			Expectation: []any{},
+		},
+		{
+			Code:        `["a"] + ["b"] + ["c"] + []`,
+			Expectation: []any{"a", "b", "c"},
+		},
+		{
+			Code:        `[] + ["a"] + ["b"] + ["c"]`,
+			Expectation: []any{"a", "b", "c"},
+		},
+	})
+
+	// Regression for #5803: when the left operand is an empty (untyped) literal,
+	// the result must inherit the element type from the non-empty right operand.
+	// Otherwise the type stays `[]unset` and the reporter renders every element
+	// as unknown ("🤷") even though the values are correct.
+	t.Run("empty-array concat preserves element type", func(t *testing.T) {
+		res := x.TestQuery(t, `[] + ["a","b"]`)
+		require.NotEmpty(t, res)
+		assert.Equal(t, types.Array(types.String), res[0].Data.Type)
+		assert.Equal(t, []any{"a", "b"}, res[0].Data.Value)
 	})
 
 	t.Run("join()", func(t *testing.T) {


### PR DESCRIPTION
## What

Fixes the remaining half of #5803. Concatenating an empty array on the **left** rendered every element as `🤷`:

```
cnspec> [] + ["a"] + ["b"] + ["c"]
+.+.+: [
  0:   🤷 "a"
  1:   🤷 "b"
  2:   🤷 "c"
]
```

## Root cause

This was a **type** bug, not a value bug — the values were always correct, which is why it slipped past existing value-only tests. In `tarrayConcatTarrayV2` (`llx/builtin_array.go`) the result always took its element type from the left (`bind`) operand. An empty literal `[]` carries no element type (`[]unset`), so the concatenated result was typed `[]unset` even though it held strings, and the reporter renders untyped elements as `🤷`. The function also still carried a dead `"cannot add arrays to null"` error branch for a nil left operand.

The earlier fix (#7196) only covered empty arrays on the **right** (`["a"] + []`), by making builtin-produced empties non-nil. This handles the left side.

## Fix

Coalesce both operands and treat an empty side as a no-op that returns the *other* side untouched, so the non-empty operand supplies both the values and the element type — and order no longer matters:

```go
if len(right) == 0 { return bind, 0, nil }
if len(left)  == 0 { return items, 0, nil }
// else copy left ++ right
```

## Verification

- Built from source and confirmed all five repro lines from the issue now behave correctly; `🤷` is gone.
- Added a **type-asserting** regression test (`[] + ["a","b"]` must be typed `Array(String)`) — it fails without the fix (`Array(unset)` vs `Array(String)`) and passes with it. A value-only test would not have caught this.
- Added value-level regression cases for both operand orders and chained `+`.
- `llx` and `providers/core/resources` suites pass; `gofmt` clean.