### PR TITLE
🐛 llx: guard Type.Underlying against empty type

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -216,6 +216,9 @@ func (typ Type) IsFunction() bool {
 
 // Underlying returns the basic type, e.g. types.MapLike instead of types.Map(..)
 func (typ Type) Underlying() Type {
+	if len(typ) == 0 {
+		return typ
+	}
 	return Type(typ[0])
 }
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -69,3 +69,15 @@ func TestEqual_NilOperands(t *testing.T) {
 		assert.True(t, eq(nil, nil), "%s: nil == nil", c.typ.Label())
 	}
 }
+
+func TestUnderlying_EmptyType(t *testing.T) {
+	// An empty Type with a non-nil RawData value reaches Underlying via
+	// isSuccess. Underlying must not index into the empty slice and panic,
+	// which would crash the whole scan. It returns the empty type, so callers
+	// fall through to their undetermined branch.
+	var got Type
+	assert.NotPanics(t, func() {
+		got = Type("").Underlying()
+	})
+	assert.Equal(t, Type(""), got)
+}


### PR DESCRIPTION
## The crash

A full scan can be killed by an unrecoverable panic:

```
index out of range [0] with length 0
```

The panic originates in `types.Type.Underlying()` (`types/types.go`) and is reached via `llx.isSuccess` → `arrayBlockCallResult.isSuccess`.

## Root cause

`Underlying()` indexes the first byte of the type slice with no length guard:

```go
func (typ Type) Underlying() Type {
	return Type(typ[0]) // panics when typ == ""
}
```

The guard at `llx/rawdata.go:387-390` only protects the `data == nil` case. A `RawData` with a **non-nil value but an empty `Type`** slips past that guard and reaches `Underlying()`, which then panics on `typ[0]`. Because the executor runs blocks in goroutines, this panic is unrecoverable and takes down the whole scan.

## The fix

Guard the empty case and return the empty type:

```go
func (typ Type) Underlying() Type {
	if len(typ) == 0 {
		return typ
	}
	return Type(typ[0])
}
```

Returning the empty type is the correct, safe behavior: callers such as `isSuccess`/`isTruthy` switch on `Underlying()`, and an empty value falls through to their `default` branch, which returns `(false, false)` — "undetermined". No panic, no crash.

## Test

Added `TestUnderlying_EmptyType` in `types/types_test.go`, which asserts that `Type("").Underlying()` does not panic and returns `Type("")`.

Verified locally: `gofmt -l` clean, `go test ./types/` passes, `go build ./types/... ./llx/...` succeeds.

Fixes #8432