### PR TITLE
:star: gcp: support cross-zone instance scanning via snapshot bridge

### DIFF
--- a/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
@@ -279,6 +279,13 @@ func (sc *SnapshotCreator) createSnapshotDisk(snapshotUrl, projectID, zone, disk
 
 // cloneDisk clones a provided disk
 func (sc *SnapshotCreator) cloneDisk(sourceDisk, projectID, zone, diskName string) (string, error) {
+	// A zonal disk can only be cloned directly within the same zone. If the
+	// source disk lives in a different zone than the target, bridge through a
+	// temporary snapshot (snapshots are global) so cross-zone scanning works.
+	if _, srcZone, _, err := parseDiskUrl(sourceDisk); err == nil && srcZone != "" && srcZone != zone {
+		return sc.cloneDiskViaSnapshot(sourceDisk, projectID, zone, diskName)
+	}
+
 	// create a new disk clone
 	disk := &compute.Disk{
 		Name:       diskName,
@@ -286,6 +293,90 @@ func (sc *SnapshotCreator) cloneDisk(sourceDisk, projectID, zone, diskName strin
 		Labels:     sc.labels,
 	}
 	return sc.createDisk(disk, projectID, zone, diskName)
+}
+
+// cloneDiskViaSnapshot clones a disk across zones by bridging through a
+// temporary global snapshot. GCP requires the source disk and the target disk
+// to be in the same zone for a direct disk clone, so when the scanner zone
+// differs from the source disk's zone we first snapshot the source disk
+// (snapshots are a global resource), create the scanner disk from that
+// snapshot, and best-effort delete the temporary snapshot afterwards.
+func (sc *SnapshotCreator) cloneDiskViaSnapshot(sourceDisk, projectID, zone, diskName string) (string, error) {
+	ctx := context.Background()
+
+	computeService, err := sc.computeServiceClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	srcProject, srcZone, srcDiskName, err := parseDiskUrl(sourceDisk)
+	if err != nil {
+		return "", err
+	}
+
+	// build a valid temporary snapshot name. GCP requires names to match
+	// [a-z]([-a-z0-9]{0,61}[a-z0-9])? and be at most 63 characters. The disk
+	// name we are handed already follows this convention, so derive from it and
+	// truncate to stay within the limit.
+	snapName := diskName
+	if len(snapName) > 63 {
+		snapName = snapName[:63]
+	}
+	// avoid a trailing hyphen after truncation, which is invalid
+	snapName = strings.TrimRight(snapName, "-")
+
+	// create a snapshot from the source disk in the source project/zone
+	op, err := computeService.Disks.CreateSnapshot(srcProject, srcZone, srcDiskName, &compute.Snapshot{
+		Name:   snapName,
+		Labels: sc.labels,
+	}).Context(ctx).Do()
+	if err != nil {
+		return "", err
+	}
+
+	if err := sc.waitForZoneOperation(ctx, computeService, srcProject, srcZone, op.Name, "create snapshot"); err != nil {
+		return "", err
+	}
+
+	// fetch the snapshot to get its SelfLink, which is required to create a disk
+	snap, err := computeService.Snapshots.Get(srcProject, snapName).Context(ctx).Do()
+	if err != nil {
+		return "", err
+	}
+
+	// create the scanner disk from the snapshot in the target project/zone
+	clonedDiskUrl, err := sc.createSnapshotDisk(snap.SelfLink, projectID, zone, diskName)
+
+	// best-effort cleanup: the scanner disk no longer needs the snapshot once it
+	// has been created, so delete the temporary snapshot. Do not fail the clone
+	// if cleanup fails.
+	if _, delErr := computeService.Snapshots.Delete(srcProject, snapName).Context(ctx).Do(); delErr != nil {
+		log.Warn().Err(delErr).Str("snapshot", snapName).Msg("could not delete temporary snapshot created for cross-zone clone")
+	}
+
+	return clonedDiskUrl, err
+}
+
+// waitForZoneOperation blocks until the given zonal operation reaches the DONE
+// state, returning an error if the operation reported one.
+func (sc *SnapshotCreator) waitForZoneOperation(ctx context.Context, computeService *compute.Service, projectID, zone, opName, action string) error {
+	for {
+		operation, err := computeService.ZoneOperations.Get(projectID, zone, opName).Context(ctx).Do()
+		if err != nil {
+			return err
+		}
+		if operation.Status == "DONE" {
+			if operation.Error != nil {
+				errMessage, _ := operation.Error.MarshalJSON()
+				log.Debug().Str("error", string(errMessage)).Msg("operation failed")
+				if len(operation.Error.Errors) > 0 {
+					errMessage = []byte(operation.Error.Errors[0].Message)
+				}
+				return fmt.Errorf("%s failed: %s", action, errMessage)
+			}
+			return nil
+		}
+	}
 }
 
 // attachDisk attaches a disk to an instance

--- a/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/snapshot.go
@@ -26,6 +26,11 @@ import (
 const (
 	createdByLabel = "created-by"
 	createdValue   = "cnspec"
+
+	// zoneOperationTimeout caps how long we wait for a single zonal operation.
+	// Snapshotting a large disk is slow, so this is a backstop against an
+	// operation that never reaches DONE, not a target duration.
+	zoneOperationTimeout = 30 * time.Minute
 )
 
 // invalidDiskNameChars matches any character that is not allowed in a GCP disk
@@ -244,26 +249,12 @@ func (sc *SnapshotCreator) createDisk(disk *compute.Disk, projectID, zone, diskN
 	}
 
 	// wait for the disk creation operation to complete
-	for {
-		operation, err := computeService.ZoneOperations.Get(projectID, zone, op.Name).Context(ctx).Do()
-		if err != nil {
-			return clonedDiskUrl, err
-		}
-		if operation.Status == "DONE" {
-			if operation.Error != nil {
-				errMessage, _ := operation.Error.MarshalJSON()
-				log.Debug().Str("error", string(errMessage)).Msg("operation failed")
-				if len(operation.Error.Errors) > 0 {
-					errMessage = []byte(operation.Error.Errors[0].Message)
-				}
-				return clonedDiskUrl, fmt.Errorf("create disk failed: %s", errMessage)
-			}
-			clonedDiskUrl = operation.TargetLink
-			break
-		}
+	operation, err := sc.waitForZoneOperation(ctx, computeService, projectID, zone, op.Name, "create disk")
+	if err != nil {
+		return clonedDiskUrl, err
 	}
 
-	return clonedDiskUrl, nil
+	return operation.TargetLink, nil
 }
 
 // createSnapshotDisk creates a new disk from a snapshot
@@ -277,12 +268,20 @@ func (sc *SnapshotCreator) createSnapshotDisk(snapshotUrl, projectID, zone, disk
 	return sc.createDisk(disk, projectID, zone, diskName)
 }
 
+// isCrossZoneClone reports whether the source disk lives in a different zone
+// than the target. A zonal disk can only be cloned directly within its own
+// zone, so a cross-zone clone has to be bridged through a snapshot.
+func isCrossZoneClone(sourceDisk, targetZone string) bool {
+	_, srcZone, _, err := parseDiskUrl(sourceDisk)
+	return err == nil && srcZone != "" && srcZone != targetZone
+}
+
 // cloneDisk clones a provided disk
 func (sc *SnapshotCreator) cloneDisk(sourceDisk, projectID, zone, diskName string) (string, error) {
 	// A zonal disk can only be cloned directly within the same zone. If the
 	// source disk lives in a different zone than the target, bridge through a
 	// temporary snapshot (snapshots are global) so cross-zone scanning works.
-	if _, srcZone, _, err := parseDiskUrl(sourceDisk); err == nil && srcZone != "" && srcZone != zone {
+	if isCrossZoneClone(sourceDisk, zone) {
 		return sc.cloneDiskViaSnapshot(sourceDisk, projectID, zone, diskName)
 	}
 
@@ -334,7 +333,22 @@ func (sc *SnapshotCreator) cloneDiskViaSnapshot(sourceDisk, projectID, zone, dis
 		return "", err
 	}
 
-	if err := sc.waitForZoneOperation(ctx, computeService, srcProject, srcZone, op.Name, "create snapshot"); err != nil {
+	// From here the snapshot may exist, so clean it up on every exit path, not
+	// just the successful one. The scanner disk is independent of the snapshot
+	// once created: GCP guarantees that deleting a snapshot does not affect
+	// disks already created from it.
+	defer func() {
+		delOp, delErr := computeService.Snapshots.Delete(srcProject, snapName).Context(ctx).Do()
+		if delErr != nil {
+			log.Warn().Err(delErr).Str("snapshot", snapName).Msg("could not delete temporary snapshot created for cross-zone clone")
+			return
+		}
+		// the API has accepted the delete; we deliberately do not wait for the
+		// operation to finish, so log its name to keep it traceable.
+		log.Debug().Str("snapshot", snapName).Str("operation", delOp.Name).Msg("deleting temporary snapshot created for cross-zone clone")
+	}()
+
+	if _, err := sc.waitForZoneOperation(ctx, computeService, srcProject, srcZone, op.Name, "create snapshot"); err != nil {
 		return "", err
 	}
 
@@ -345,25 +359,23 @@ func (sc *SnapshotCreator) cloneDiskViaSnapshot(sourceDisk, projectID, zone, dis
 	}
 
 	// create the scanner disk from the snapshot in the target project/zone
-	clonedDiskUrl, err := sc.createSnapshotDisk(snap.SelfLink, projectID, zone, diskName)
-
-	// best-effort cleanup: the scanner disk no longer needs the snapshot once it
-	// has been created, so delete the temporary snapshot. Do not fail the clone
-	// if cleanup fails.
-	if _, delErr := computeService.Snapshots.Delete(srcProject, snapName).Context(ctx).Do(); delErr != nil {
-		log.Warn().Err(delErr).Str("snapshot", snapName).Msg("could not delete temporary snapshot created for cross-zone clone")
-	}
-
-	return clonedDiskUrl, err
+	return sc.createSnapshotDisk(snap.SelfLink, projectID, zone, diskName)
 }
 
 // waitForZoneOperation blocks until the given zonal operation reaches the DONE
-// state, returning an error if the operation reported one.
-func (sc *SnapshotCreator) waitForZoneOperation(ctx context.Context, computeService *compute.Service, projectID, zone, opName, action string) error {
+// state and returns it, or returns an error if the operation reported one or
+// did not finish within zoneOperationTimeout.
+func (sc *SnapshotCreator) waitForZoneOperation(ctx context.Context, computeService *compute.Service, projectID, zone, opName, action string) (*compute.Operation, error) {
+	ctx, cancel := context.WithTimeout(ctx, zoneOperationTimeout)
+	defer cancel()
+
 	for {
-		operation, err := computeService.ZoneOperations.Get(projectID, zone, opName).Context(ctx).Do()
+		// Wait blocks server-side for up to two minutes, so a slow operation
+		// costs a couple of requests instead of thousands of polls. It is
+		// best-effort and may return before the operation is DONE, hence the loop.
+		operation, err := computeService.ZoneOperations.Wait(projectID, zone, opName).Context(ctx).Do()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if operation.Status == "DONE" {
 			if operation.Error != nil {
@@ -372,9 +384,12 @@ func (sc *SnapshotCreator) waitForZoneOperation(ctx context.Context, computeServ
 				if len(operation.Error.Errors) > 0 {
 					errMessage = []byte(operation.Error.Errors[0].Message)
 				}
-				return fmt.Errorf("%s failed: %s", action, errMessage)
+				return nil, fmt.Errorf("%s failed: %s", action, errMessage)
 			}
-			return nil
+			return operation, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("%s did not complete: %w", action, err)
 		}
 	}
 }
@@ -400,22 +415,8 @@ func (sc *SnapshotCreator) attachDisk(projectID, zone, instanceName, sourceDiskU
 		return err
 	}
 	// wait for the operation to complete
-	for {
-		operation, err := computeService.ZoneOperations.Get(projectID, zone, op.Name).Context(ctx).Do()
-		if err != nil {
-			return err
-		}
-		if operation.Status == "DONE" {
-			if operation.Error != nil {
-				errMessage, _ := operation.Error.MarshalJSON()
-				log.Debug().Str("error", string(errMessage)).Msg("operation failed")
-				if len(operation.Error.Errors) > 0 {
-					errMessage = []byte(operation.Error.Errors[0].Message)
-				}
-				return fmt.Errorf("attach disk failed: %s", errMessage)
-			}
-			break
-		}
+	if _, err := sc.waitForZoneOperation(ctx, computeService, projectID, zone, op.Name, "attach disk"); err != nil {
+		return err
 	}
 
 	return nil
@@ -436,22 +437,8 @@ func (sc *SnapshotCreator) detachDisk(projectID, zone, instanceName, deviceName 
 	}
 
 	// wait for the operation to complete
-	for {
-		operation, err := computeService.ZoneOperations.Get(projectID, zone, op.Name).Context(ctx).Do()
-		if err != nil {
-			return err
-		}
-		if operation.Status == "DONE" {
-			if operation.Error != nil {
-				errMessage, _ := operation.Error.MarshalJSON()
-				log.Debug().Str("error", string(errMessage)).Msg("operation failed")
-				if len(operation.Error.Errors) > 0 {
-					errMessage = []byte(operation.Error.Errors[0].Message)
-				}
-				return fmt.Errorf("detach disk failed: %s", errMessage)
-			}
-			break
-		}
+	if _, err := sc.waitForZoneOperation(ctx, computeService, projectID, zone, op.Name, "detach disk"); err != nil {
+		return err
 	}
 
 	return nil
@@ -466,6 +453,14 @@ func parseDiskUrl(diskURL string) (string, string, string, error) {
 
 	// extract the path and split it into components
 	pathComponents := strings.Split(url.Path, "/")
+
+	// the path we expect is
+	// /compute/v1/projects/<project>/zones/<zone>/disks/<disk>. url.Parse
+	// accepts almost anything, so guard the indexes here: without this a disk
+	// url in an unexpected shape panics and takes the whole scan down.
+	if len(pathComponents) < 9 {
+		return "", "", "", fmt.Errorf("unexpected gcp disk url: %q", diskURL)
+	}
 
 	// extract project, zone, and disk names
 	projectId := pathComponents[4]

--- a/providers/gcp/connection/gcpinstancesnapshot/snapshot_test.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/snapshot_test.go
@@ -18,3 +18,22 @@ func TestParseDiskUrl(t *testing.T) {
 	assert.Equal(t, "us-central1-a", zone)
 	assert.Equal(t, "super-dupa-disk", disk)
 }
+
+// isCrossZoneClone mirrors the decision cloneDisk makes: a source disk whose
+// zone differs from the target zone must be bridged through a snapshot.
+func isCrossZoneClone(sourceDisk, targetZone string) bool {
+	_, srcZone, _, err := parseDiskUrl(sourceDisk)
+	return err == nil && srcZone != "" && srcZone != targetZone
+}
+
+func TestCloneDiskCrossZoneDecision(t *testing.T) {
+	sourceDisk := "https://www.googleapis.com/compute/v1/projects/my-project-1234/zones/us-central1-a/disks/super-dupa-disk"
+
+	// different zones -> must bridge through a snapshot
+	assert.True(t, isCrossZoneClone(sourceDisk, "us-west1-a"),
+		"a source disk in us-central1-a with target us-west1-a should be detected as cross-zone")
+
+	// same zone -> direct clone, no snapshot bridge
+	assert.False(t, isCrossZoneClone(sourceDisk, "us-central1-a"),
+		"a source disk and target in the same zone should not be detected as cross-zone")
+}

--- a/providers/gcp/connection/gcpinstancesnapshot/snapshot_test.go
+++ b/providers/gcp/connection/gcpinstancesnapshot/snapshot_test.go
@@ -19,21 +19,70 @@ func TestParseDiskUrl(t *testing.T) {
 	assert.Equal(t, "super-dupa-disk", disk)
 }
 
-// isCrossZoneClone mirrors the decision cloneDisk makes: a source disk whose
-// zone differs from the target zone must be bridged through a snapshot.
-func isCrossZoneClone(sourceDisk, targetZone string) bool {
-	_, srcZone, _, err := parseDiskUrl(sourceDisk)
-	return err == nil && srcZone != "" && srcZone != targetZone
+func TestParseDiskUrlMalformed(t *testing.T) {
+	// url.Parse accepts nearly anything, so these reach the path-component
+	// indexing. They must return an error rather than panic.
+	for _, diskUrl := range []string{
+		"",
+		"not-a-disk-url",
+		"https://www.googleapis.com/compute/v1/projects/my-project-1234",
+		"projects/my-project-1234/zones/us-central1-a/disks/super-dupa-disk",
+	} {
+		t.Run(diskUrl, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, _, _, err := parseDiskUrl(diskUrl)
+				assert.Error(t, err)
+			})
+		})
+	}
 }
 
-func TestCloneDiskCrossZoneDecision(t *testing.T) {
-	sourceDisk := "https://www.googleapis.com/compute/v1/projects/my-project-1234/zones/us-central1-a/disks/super-dupa-disk"
+func TestIsCrossZoneClone(t *testing.T) {
+	const diskUrl = "https://www.googleapis.com/compute/v1/projects/my-project-1234/zones/us-central1-a/disks/super-dupa-disk"
 
-	// different zones -> must bridge through a snapshot
-	assert.True(t, isCrossZoneClone(sourceDisk, "us-west1-a"),
-		"a source disk in us-central1-a with target us-west1-a should be detected as cross-zone")
+	tests := []struct {
+		name       string
+		sourceDisk string
+		targetZone string
+		expected   bool
+	}{
+		{
+			name:       "different zone bridges through a snapshot",
+			sourceDisk: diskUrl,
+			targetZone: "us-west1-a",
+			expected:   true,
+		},
+		{
+			name:       "same zone clones directly",
+			sourceDisk: diskUrl,
+			targetZone: "us-central1-a",
+			expected:   false,
+		},
+		{
+			name:       "same region but a different zone still bridges",
+			sourceDisk: diskUrl,
+			targetZone: "us-central1-b",
+			expected:   true,
+		},
+		{
+			// an unparseable url must fall back to the direct clone rather than
+			// bridging on a zone we never actually determined
+			name:       "unparseable source disk does not bridge",
+			sourceDisk: "not-a-disk-url",
+			targetZone: "us-west1-a",
+			expected:   false,
+		},
+		{
+			name:       "empty source disk does not bridge",
+			sourceDisk: "",
+			targetZone: "us-west1-a",
+			expected:   false,
+		},
+	}
 
-	// same zone -> direct clone, no snapshot bridge
-	assert.False(t, isCrossZoneClone(sourceDisk, "us-central1-a"),
-		"a source disk and target in the same zone should not be detected as cross-zone")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isCrossZoneClone(test.sourceDisk, test.targetZone))
+		})
+	}
 }


### PR DESCRIPTION
## Problem

GCP cross-zone instance scanning fails in the no-snapshot clone path. When the scanner runs in one zone (e.g. `us-west1-a`) but the target instance's boot disk lives in another (e.g. `--zone us-central1-a`), `cloneDisk` builds a `compute.Disk{SourceDisk: ...}` and calls `Disks.Insert(projectID, zone, disk)`. GCP requires `SourceDisk` and the target disk to be in the **same zone**, so a direct cross-zone disk clone returns a 400. A zonal disk cannot be cloned directly across zones.

## Fix — snapshot bridge

Snapshots are a **global** GCP resource, so a cross-zone clone can be bridged through one. `cloneDisk` now detects the zone mismatch (via `parseDiskUrl` on the source disk) and, when the source zone differs from the target zone, routes through a new `cloneDiskViaSnapshot` helper. The same-zone path is preserved exactly.

`cloneDiskViaSnapshot` does:

1. Parse the source disk URL → `srcProject`, `srcZone`, `srcDiskName`.
2. Derive a valid temporary snapshot name from the disk name (GCP rule `[a-z]([-a-z0-9]{0,61}[a-z0-9])?`, ≤63 chars; truncate + trim trailing hyphen). Apply `sc.labels`.
3. `Disks.CreateSnapshot(srcProject, srcZone, srcDiskName, &compute.Snapshot{...})` from the **source** disk, then wait on `ZoneOperations.Get(srcProject, srcZone, op.Name)` until `DONE` (mirrors the existing wait-loop + `Operation.Error` handling, factored into a shared `waitForZoneOperation` helper).
4. `Snapshots.Get(srcProject, snapName)` → `snap.SelfLink`.
5. Create the scanner disk from that snapshot in the target project/zone by reusing the existing `createSnapshotDisk(snap.SelfLink, projectID, zone, diskName)`.
6. Best-effort cleanup: `Snapshots.Delete(srcProject, snapName)` — logs a warning on failure, does **not** fail the clone (the scanner disk no longer needs the snapshot once created).
7. Return the created disk URL and any error from `createSnapshotDisk`.

## ✅ Verified live (2026-08-20)

Verified against real cross-zone GCP infrastructure: a scanner VM in `us-west1-a`
scanning a target instance whose boot disk lives in `us-central1-a`, running a
build of this branch (`mql` + the `gcp` and `os` providers, cross-compiled
linux/amd64 and installed on the scanner).

| Test | Result |
|---|---|
| Cross-zone scan, clone path forced (`--create-snapshot`) | ✅ bridged through a snapshot, mounted the disk, detected `debian 12.15` |
| Same-zone scan (control VM in the scanner's zone) | ✅ unchanged — direct clone, disk insert in 3s, **zero** `createSnapshot` operations |
| Cross-zone scan without `--create-snapshot` (snapshot-reuse branch) | ✅ falls back to the clone path and bridges correctly |
| Negative control: same scan on the **released** provider | ✅ reproduces the `Error 400 ... must be in the same zone` from #8416 |
| Temporary snapshot cleanup | ✅ no snapshots or cnspec disks left behind after any run |

The negative control is the one that matters: the released provider fails on
exactly the same infrastructure, so the passing runs are attributable to this
change rather than to anything about the test environment.

`gcloud compute operations list` is what proves which branch ran — the debug log
never names it:

```
us-central1-a  createSnapshot  <target>            12:18:47 → 12:20:07   cross-zone, bridged
us-west1-a     insert  cnspec-<control>-<ts>       12:21:57 → 12:22:00   same-zone, direct clone (3s, no snapshot)
```

Two notes for anyone reproducing this:

- `--create-snapshot` does not create a snapshot; it **skips the
  reuse-latest-snapshot branch**, which is the only way to force the `cloneDisk`
  path under test. Without it, any snapshot under 8 hours old routes the scan
  down a path that already worked cross-zone.
- Pass `--auto-update=false`, and install the built providers into
  `/opt/mondoo/providers`. A snapshot scan runs as root, and
  `providers/providers.go:52` only consults the home provider directory when
  `euid != 0`, so `make providers/install` is invisible to it.

The IAM permission set below was **not** verified least-privilege — the scanner
ran with a broadly-scoped service account. See the review comment for details.

The unit test only covers the pure decision logic — that a source disk in `zones/us-central1-a/...` with target zone `us-west1-a` is detected as cross-zone, and same-zone is not. The live API calls are not mocked.

## New runtime IAM permissions

The scanner service account now additionally needs, at runtime:

- `compute.disks.createSnapshot`
- `compute.snapshots.create`
- `compute.snapshots.delete`

(plus the existing `compute.snapshots.get` already used elsewhere)

Fixes #8416
