### PR TITLE
🎉 os-13.30.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.29.0",
+	Version: "13.30.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.30.0)
- 🐛 fix lsof TCP state keys and guard malformed T-fields (#8632)
- 🐛 fix kubelet manifest-url-header reading a stray tab key (#8636)
- 🐛 fix panic on malformed key=value kubelet flag lists (#8637)
- 🐛 fix sshd time-value conversion ignoring keyword case (#8617)
- 🐛 fix panic parsing malformed auditd `-a` syscall rules (#8614)
- 🐛 fix sudoers user specs dropped when `=` is attached to the host (#8618)
- 🐛 fix iptables ParseStat error messages dropping context (#8621)
- 🐛 fix out-of-range index in AIX ps uid parse error path (#8633)
- ✨ os/kubelet: typed fields + version, defaults refresh to k8s 1.34, flag-merge fixes (#8612)
- 🐛 fix grub.cfg parser flushing entries before the opening brace (#8623)
- 🐛 fix fstab parser aborting on indented comments and blank lines (#8616)
- 🐛 fix nil-pointer panic in macOS dscl user enumeration (#8619)
- 🐛 normalize systemd timer Persistent and socket Accept booleans (#8626)
- 🐛 resolve systemd-resolved cache state from resolved.conf (#8627)
- 🐛 fix dscacheutil group parser logging and bogus gid handling (#8628)
- 🐛 fix initKubelet returning a nil error on failure paths (#8640)
- 🐛 fix unbounded recursion on apache Include cycles (#8641)
- 🐛 fix panic parsing /proc/cpuinfo cache size without a unit (#8642)
- 🐛 fix panic on short lines in iptables ParseStat (#8615)
- 🐛 fix auditd config error reporting empty field name (#8620)
- 🐛 fix rsyslog content() swallowing non-NotFound read errors (#8625)
- 🐛 fix /proc status parser writing PPid into the Pid field (#8631)
- 🐛 fix files.find -maxdepth rendered in octal instead of decimal (#8635)
- 🐛 fix authorized_keys line number counting only key entries (#8639)
- 🐛 fix panic parsing PAM bracketed control with no module (#8630)
- 🌟 Add windows.powershell resource for PowerShell logging policy (#8566)
- 🧹 windows: model binary registry settings as bool instead of int (#8583)
- Add windows.rdp endSessionWhenTimeLimitReached and cloudClipboardIntegrationDisabled (#8570)
- 🌟 Add windows.telemetry resource for diagnostic-data and consumer cloud-content policy (#8565)
- 🌟 Add windows.smartScreen resource for Microsoft Defender SmartScreen (#8557)
- Add windows.bitlocker.policy resource for BitLocker (FVE) Group Policy settings (#8564)
- Add windows.spooler resource for Print Spooler hardening (#8563)
- Extend windows.rdp to cover all CIS Remote Desktop / Terminal Services checks (#8558)
- Add windows.update.policy resource for Windows Update for Business GPO settings (#8556)
- 🌟 Add windows.exploitProtection resource for system-wide exploit mitigations (#8559)
- Extend windows.smb with server and client SMB configuration (#8561)
- 🌟 Add windows.lsa resource for LSA / NTLM / secure-channel security settings (#8569)
- Harden windows.defender availability detection for non-English systems (#8562)
- Add windows.deviceGuard resource for VBS, HVCI, and Credential Guard policy (#8568)
- 🌟 Add windows.winrm resource for WinRM client and service policy (#8560)
- 🌟 Add windows.defender resources for Microsoft Defender status and settings (#8555)
- 🐛 os: file.user/file.group fail gracefully on an unknown owner uid/gid (#8524)
- :star: add network.neighbors and windows.smb resources (#8444)
- 🐛 os: registrykey.property fails gracefully on a missing property (#8522)
- 🐛 llx: array/map all/any/none/one fail gracefully on a null receiver (#8520)