### PR TITLE
🐛 powershell: write stderr read error to the stderr field

### DIFF
--- a/providers/os/resources/powershell.go
+++ b/providers/os/resources/powershell.go
@@ -62,7 +62,7 @@ func (c *mqlPowershell) execute() error {
 
 	stderr, err := io.ReadAll(x.Stderr)
 	if err != nil {
-		c.Stdout = plugin.TValue[string]{Error: err, State: plugin.StateIsSet}
+		c.Stderr = plugin.TValue[string]{Error: err, State: plugin.StateIsSet}
 	} else {
 		serr, err := convertToUtf8Encoding(stderr)
 		c.Stderr = plugin.TValue[string]{Data: string(serr), Error: err, State: plugin.StateIsSet}


### PR DESCRIPTION
## Bug

In `powershell.go`, the branch that handles a failed `io.ReadAll(x.Stderr)` assigned the error to `c.Stdout` instead of `c.Stderr`:

```go
stderr, err := io.ReadAll(x.Stderr)
if err != nil {
    c.Stdout = plugin.TValue[string]{Error: err, State: plugin.StateIsSet}  // wrong field
} else {
    ...
    c.Stderr = plugin.TValue[string]{...}
}
```

This is a copy-paste slip from the stdout block above it. When reading stderr fails, it clobbers the stdout value that was just populated correctly and leaves `c.Stderr` in its zero/unset state — so `powershell { stdout, stderr }` reports a bogus error on `.stdout` while `.stderr` is silently never set.

The `powershell` resource underlies `auditpol` and `secpol`, so those inherit the corruption on this error path.

## Fix

Assign the stderr read error to `c.Stderr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_