### PR TITLE
🐛 users: skip /etc/passwd entries with unparseable uid/gid

### DIFF
--- a/providers/os/resources/users/etcpasswd.go
+++ b/providers/os/resources/users/etcpasswd.go
@@ -32,11 +32,15 @@ func ParseEtcPasswd(input io.Reader) ([]*User, error) {
 			// parse uid
 			uid, err := strconv.ParseInt(m[2], 10, 0)
 			if err != nil {
-				log.Error().Err(err).Str("user", m[0]).Msg("could not parse uid")
+				// Skip the entry rather than fall through with uid 0: a
+				// malformed line must not surface as a phantom root account.
+				log.Error().Err(err).Str("user", m[0]).Msg("could not parse uid, skipping user")
+				continue
 			}
 			gid, err := strconv.ParseInt(m[3], 10, 0)
 			if err != nil {
-				log.Error().Err(err).Str("user", m[0]).Msg("could not parse gid")
+				log.Error().Err(err).Str("user", m[0]).Msg("could not parse gid, skipping user")
+				continue
 			}
 
 			// bin:x:1:1:bin:/bin:/sbin/nologin

--- a/providers/os/resources/users/etcpasswd_test.go
+++ b/providers/os/resources/users/etcpasswd_test.go
@@ -4,6 +4,7 @@
 package users_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,26 @@ import (
 	"go.mondoo.com/mql/providers/os/connection/mock"
 	"go.mondoo.com/mql/providers/os/resources/users"
 )
+
+func TestParseEtcPasswdSkipsMalformedUidGid(t *testing.T) {
+	// A line with a non-numeric uid/gid must be skipped, not surfaced as a
+	// phantom uid 0 (root) account.
+	const passwd = `root:x:0:0:root:/root:/bin/bash
+broken:x:notanumber:1:broken uid:/home/broken:/bin/sh
+brokengid:x:1001:notanumber:broken gid:/home/brokengid:/bin/sh
+alice:x:1000:1000:Alice:/home/alice:/bin/bash
+`
+
+	m, err := users.ParseEtcPasswd(strings.NewReader(passwd))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(m), "malformed uid/gid lines should be skipped")
+
+	assert.Equal(t, "root", m[0].Name)
+	assert.Equal(t, int64(0), m[0].Uid)
+	assert.Equal(t, "alice", m[1].Name)
+	assert.Equal(t, int64(1000), m[1].Uid)
+	assert.Equal(t, int64(1000), m[1].Gid)
+}
 
 func TestParseLinuxEtcPasswd(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/debian.toml"))


### PR DESCRIPTION
## Bug

`ParseEtcPasswd` in `users/etcpasswd.go`:

```go
uid, err := strconv.ParseInt(m[2], 10, 0)
if err != nil {
    log.Error().Err(err).Str("user", m[0]).Msg("could not parse uid")
}
gid, err := strconv.ParseInt(m[3], 10, 0)
if err != nil {
    log.Error().Err(err).Str("user", m[0]).Msg("could not parse gid")
}
users = append(users, &User{ ... Uid: uid, Gid: gid, ... })
```

The error is logged but not acted on: on a parse failure `uid`/`gid` keep their zero value and the user is still appended. A malformed `/etc/passwd` line therefore surfaces as a **uid 0 / gid 0 (root)** account — the worst possible sentinel for an inventory/security tool (the sibling `shadow.go` parser correctly returns an error in the same situation).

## Fix

Skip the entry (with a warning log) when uid or gid can't be parsed, so a corrupt line is dropped rather than fabricating root. Added a regression test with malformed uid and gid lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_