### PR TITLE
🐛 device/windows: restore disk read-only state, not online state

### DIFF
--- a/providers/os/connection/device/windows/device_manager.go
+++ b/providers/os/connection/device/windows/device_manager.go
@@ -63,7 +63,7 @@ func (d *WindowsDeviceManager) IdentifyMountTargets(opts map[string]string) ([]*
 		if err != nil {
 			return nil, err
 		}
-		d.diskSetToOnline = true
+		d.diskSetToReadonly = true
 		d.diskIndex = targetDrive.Index
 	}
 	if diskStatus.Offline {


### PR DESCRIPTION
## Bug

`connection/device/windows/device_manager.go`:

```go
if diskStatus.Readonly {
    err = d.setDiskReadonlyState(targetDrive.Index, false)
    if err != nil {
        return nil, err
    }
    d.diskSetToOnline = true   // BUG: should be d.diskSetToReadonly = true
    d.diskIndex = targetDrive.Index
}
```

The read-only branch records its action in `diskSetToOnline` instead of `diskSetToReadonly`. `diskSetToReadonly` is therefore never set to `true` anywhere, so `UnmountAndClose` never restores the disk's read-only protection — **the disk is left writable after the scan**. Worse, the spurious `diskSetToOnline = true` makes cleanup flip the online/offline state that was never changed.

## Fix

Record the read-only change in `diskSetToReadonly` so cleanup re-applies it. (Windows-only code path; verified by build — no mock harness exists for the disk-management PowerShell calls.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_