### PR TITLE
🐛 awsssmsession: return the process-kill error, not nil

### DIFF
--- a/providers/os/connection/ssh/awsssmsession/session_manager.go
+++ b/providers/os/connection/ssh/awsssmsession/session_manager.go
@@ -144,7 +144,7 @@ func (a *AwsSsmSessionConnection) Close() error {
 			return err
 		}
 		if processerr != nil {
-			return err
+			return processerr
 		}
 	}
 	return nil


### PR DESCRIPTION
## Bug

`connection/ssh/awsssmsession/session_manager.go`, on session close:

```go
if err != nil {
    return err
}
if processerr != nil {
    return err   // err is nil here — should be `return processerr`
}
```

When `TerminateSession` succeeds (`err == nil`) but the earlier `a.process.Kill()` failed, the function returns the nil `err`, hiding the kill failure. A leaked `session-manager-plugin` subprocess is reported as a clean close.

## Fix

`return processerr`. (Verified by build; this close path has no mock harness.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_