### PR TITLE
🐛 platformid: error on non-zero ioreg exit instead of returning empty id

### DIFF
--- a/providers/os/id/platformid/osx.go
+++ b/providers/os/id/platformid/osx.go
@@ -27,8 +27,11 @@ var MACOS_ID_REGEX = regexp.MustCompile(`\"IOPlatformUUID\"\s*=\s*\"(.*)\"`)
 
 func (p *MacOSIdProvider) ID() (string, error) {
 	c, err := p.connection.RunCommand("ioreg -rd1 -c IOPlatformExpertDevice")
-	if err != nil || c.ExitStatus != 0 {
+	if err != nil {
 		return "", err
+	}
+	if c.ExitStatus != 0 {
+		return "", errors.New("could not detect the machine id: ioreg exited with a non-zero status")
 	}
 
 	// parse string with regex with \"IOPlatformUUID\"\s*=\s*\"(.*)\"

--- a/providers/os/id/platformid/osx_test.go
+++ b/providers/os/id/platformid/osx_test.go
@@ -24,3 +24,17 @@ func TestMacOSMachineId(t *testing.T) {
 
 	assert.Equal(t, "5c09e2c7-07f2-5bee-be82-7cb70688e55c", id, "machine id is properly detected")
 }
+
+func TestMacOSMachineIdNonZeroExit(t *testing.T) {
+	filepath, _ := filepath.Abs("./testdata/osx_nonzero_exit.toml")
+	provider, err := mock.New(0, &inventory.Asset{}, mock.WithPath(filepath))
+	require.NoError(t, err)
+
+	lid := MacOSIdProvider{connection: provider}
+	id, err := lid.ID()
+
+	// a non-zero ioreg exit must surface as an error, not a silent empty id
+	// that callers would mistake for a valid (blank) machine id
+	require.Error(t, err)
+	assert.Empty(t, id)
+}

--- a/providers/os/id/platformid/testdata/osx_nonzero_exit.toml
+++ b/providers/os/id/platformid/testdata/osx_nonzero_exit.toml
@@ -1,0 +1,3 @@
+[commands."ioreg -rd1 -c IOPlatformExpertDevice"]
+stdout = ""
+exit_status = 1


### PR DESCRIPTION
## Bug

`id/platformid/osx.go`:

```go
c, err := p.connection.RunCommand("ioreg -rd1 -c IOPlatformExpertDevice")
if err != nil || c.ExitStatus != 0 {
    return "", err   // err is nil when only ExitStatus != 0
}
```

If `ioreg` exits non-zero with `err == nil`, this returns `("", nil)`. Callers check only the error, so a blank platform UUID propagates as success — risking blank/duplicated asset identifiers.

## Fix

Split the checks and return an explicit error when `ExitStatus != 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015U1ocAxfcBhVYi3f9JnyZZ)_