### PR TITLE
Migrate mql workflows to arc runners and add PR concurrency

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -52,7 +52,7 @@ jobs:
       id-token: "write"
 
     runs-on:
-      group: Default
+      group: arc-runners
     environment: prod
     timeout-minutes: 120
     steps:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -204,6 +204,11 @@ jobs:
           TSIGN_ACCESS_TOKEN: ${{ steps.get_token.outputs.TSIGN_ACCESS_TOKEN }}
           MAKE_LATEST: ${{ inputs.make-latest == false && 'false' || 'true' }}
 
+      - name: Install rpm tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+
       - name: Check RPMs
         run: |
           rpm -qpi dist/*.rpm

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -22,7 +22,7 @@ jobs:
   # Check if there is any dirty change for generated files
   generated-files:
     runs-on:
-      group: Default
+      group: arc-runners
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -7,6 +7,7 @@ on:
       - "**.proto"
       - "**.lr"
       - "**.go"
+  workflow_dispatch:
 
 env:
   PROTO_VERSION: "21.7"

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -98,7 +98,7 @@ jobs:
 
   go-test:
     runs-on:
-      group: Default
+      group: arc-runners
     timeout-minutes: 120
     steps:
       - name: Checkout code
@@ -136,7 +136,7 @@ jobs:
 
   go-test-integration:
     runs-on:
-      group: Default
+      group: arc-runners
     timeout-minutes: 120
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-test-windows.yml
+++ b/.github/workflows/pr-test-windows.yml
@@ -6,6 +6,10 @@ on:
       - "providers/os/**"
       - ".github/workflows/pr-test-windows.yml"
 
+concurrency:
+  group: pr-test-windows-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -2,6 +2,11 @@ name: Spell Check
 permissions:
   contents: read
 on: [pull_request]
+
+concurrency:
+  group: spell-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   spelling:
     name: Spell Check with Typos

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: xgrep-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

This updates the `mql` workflows to continue the runner migration away from the old `Default` pool and adds concurrency protection to a few PR-oriented workflows that were missing it.

## Changes

- move `goreleaser.yml` from `group: Default` to `group: arc-runners`
- move `pr-test-generated-files.yaml` from `group: Default` to `group: arc-runners`
- move the `go-test` and `go-test-integration` jobs in `pr-test-lint.yml` from `group: Default` to `group: arc-runners`
- add concurrency to:
  - `pr-test-windows.yml`
  - `spell-check.yaml`
  - `xgrep.yaml`

## Notes

- existing `ubuntu-latest` jobs were left unchanged
- `actions/setup-go` cache settings were already `cache: false` where relevant
- `cla.yaml` was intentionally left untouched for now because it uses `pull_request_target` / `issue_comment` and should be handled separately