### PR TITLE
✨ os: expose fipsEnabled & cryptoPolicy for PQC posture

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -371,6 +371,10 @@ os {
   machineid() string
   // Current date and timezone of the system
   date() os.date
+  // Whether the OS is running in FIPS mode
+  fipsEnabled() bool
+  // Active system-wide crypto policy (e.g. "DEFAULT", "FUTURE", "FIPS", "LEGACY"); empty when not applicable
+  cryptoPolicy() string
 }
 
 // Operating system date and timezone information

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -372,8 +372,21 @@ os {
   // Current date and timezone of the system
   date() os.date
   // Whether the OS is running in FIPS mode
+  //
+  // The reading of /proc/sys/crypto/fips_enabled on Linux, where "1" means FIPS
+  // mode is active and "0" means it is not. Null when that file holds neither,
+  // or could not be read at all. It is absent on a kernel built without the FIPS
+  // sysctl, and equally absent on Windows, on macOS, and in an image whose /proc
+  // was never populated, so an unread host is reported as unknown rather than as
+  // a host with FIPS switched off.
   fipsEnabled() bool
-  // Active system-wide crypto policy (e.g. "DEFAULT", "FUTURE", "FIPS", "LEGACY"); empty when not applicable
+  // Active system-wide crypto policy
+  //
+  // The policy reported by update-crypto-policies on RHEL, Fedora, and their
+  // derivatives, for example "DEFAULT", "FUTURE", "LEGACY", "FIPS", or a
+  // subpolicy such as "FIPS:OSPP". Null on systems that ship no such tool
+  // (Debian, Ubuntu, macOS, Windows), on connections that cannot run commands,
+  // and whenever the command failed or returned nothing.
   cryptoPolicy() string
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3286,6 +3286,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"os.date": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOs).GetDate()).ToDataRes(types.Resource("os.date"))
 	},
+	"os.fipsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOs).GetFipsEnabled()).ToDataRes(types.Bool)
+	},
+	"os.cryptoPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOs).GetCryptoPolicy()).ToDataRes(types.String)
+	},
 	"os.date.time": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOsDate).GetTime()).ToDataRes(types.Time)
 	},
@@ -16164,6 +16170,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"os.date": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOs).Date, ok = plugin.RawToTValue[*mqlOsDate](v.Value, v.Error)
+		return
+	},
+	"os.fipsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOs).FipsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"os.cryptoPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOs).CryptoPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"os.date.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36363,6 +36377,8 @@ type mqlOs struct {
 	Hypervisor    plugin.TValue[string]
 	Machineid     plugin.TValue[string]
 	Date          plugin.TValue[*mqlOsDate]
+	FipsEnabled   plugin.TValue[bool]
+	CryptoPolicy  plugin.TValue[string]
 }
 
 // createOs creates a new instance of this resource
@@ -36479,6 +36495,18 @@ func (c *mqlOs) GetDate() *plugin.TValue[*mqlOsDate] {
 		}
 
 		return c.date()
+	})
+}
+
+func (c *mqlOs) GetFipsEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FipsEnabled, func() (bool, error) {
+		return c.fipsEnabled()
+	})
+}
+
+func (c *mqlOs) GetCryptoPolicy() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.CryptoPolicy, func() (string, error) {
+		return c.cryptoPolicy()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2756,10 +2756,12 @@ os.base.rebootpending 9.0.0
 os.base.updates 9.0.0
 os.base.uptime 9.0.0
 os.base.users 9.0.0
+os.cryptoPolicy 13.34.4
 os.date 13.2.6
 os.date.time 13.2.6
 os.date.timezone 13.2.6
 os.env 9.0.0
+os.fipsEnabled 13.34.4
 os.hostname 9.0.0
 os.hypervisor 11.3.35
 os.linux 9.0.0

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2756,12 +2756,12 @@ os.base.rebootpending 9.0.0
 os.base.updates 9.0.0
 os.base.uptime 9.0.0
 os.base.users 9.0.0
-os.cryptoPolicy 13.34.4
+os.cryptoPolicy 13.40.10
 os.date 13.2.6
 os.date.time 13.2.6
 os.date.timezone 13.2.6
 os.env 9.0.0
-os.fipsEnabled 13.34.4
+os.fipsEnabled 13.40.10
 os.hostname 9.0.0
 os.hypervisor 11.3.35
 os.linux 9.0.0

--- a/providers/os/resources/os_crypto.go
+++ b/providers/os/resources/os_crypto.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"io"
+	"strings"
+
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+// parseFipsEnabled interprets the content of /proc/sys/crypto/fips_enabled.
+// The file contains "1" when FIPS mode is active and "0" otherwise.
+func parseFipsEnabled(content string) bool {
+	return strings.TrimSpace(content) == "1"
+}
+
+// normalizeCryptoPolicy trims the output of `update-crypto-policies --show`
+// and returns the first line (e.g. "DEFAULT", "FUTURE", "FIPS", "FIPS:OSPP").
+func normalizeCryptoPolicy(stdout string) string {
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(trimmed, '\n'); idx >= 0 {
+		return strings.TrimSpace(trimmed[:idx])
+	}
+	return trimmed
+}
+
+// fipsEnabled reports whether the OS is running in FIPS mode.
+//
+// On Linux this reads /proc/sys/crypto/fips_enabled through the connection
+// filesystem. When the file is absent or unreadable (non-Linux, containers
+// without procfs), it degrades gracefully to false rather than failing.
+func (p *mqlOs) fipsEnabled() (bool, error) {
+	conn, ok := p.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return false, nil
+	}
+
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	content, err := afs.ReadFile("/proc/sys/crypto/fips_enabled")
+	if err != nil {
+		// file not present / not readable (non-Linux, container without procfs)
+		return false, nil
+	}
+
+	return parseFipsEnabled(string(content)), nil
+}
+
+// cryptoPolicy returns the active system-wide crypto policy as reported by
+// `update-crypto-policies --show` (RHEL/Fedora). On platforms without that
+// tool, or when the command is missing/errors/exits non-zero, it returns an
+// empty string gracefully.
+func (p *mqlOs) cryptoPolicy() (string, error) {
+	conn, ok := p.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return "", nil
+	}
+
+	// systems without run-command capability (e.g. static images) can't run it
+	if !conn.Capabilities().Has(shared.Capability_RunCommand) {
+		return "", nil
+	}
+
+	cmd, err := conn.RunCommand("update-crypto-policies --show")
+	if err != nil {
+		return "", nil
+	}
+	if cmd.ExitStatus != 0 {
+		return "", nil
+	}
+
+	data, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		return "", nil
+	}
+
+	return normalizeCryptoPolicy(string(data)), nil
+}

--- a/providers/os/resources/os_crypto.go
+++ b/providers/os/resources/os_crypto.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
 // parseFipsEnabled interprets the content of /proc/sys/crypto/fips_enabled.

--- a/providers/os/resources/os_crypto.go
+++ b/providers/os/resources/os_crypto.go
@@ -8,17 +8,48 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
-// parseFipsEnabled interprets the content of /proc/sys/crypto/fips_enabled.
-// The file contains "1" when FIPS mode is active and "0" otherwise.
-func parseFipsEnabled(content string) bool {
-	return strings.TrimSpace(content) == "1"
+// Both fields on this file report a security posture, so the failure mode that
+// matters is not an error, it is a confident answer nobody read. A host whose
+// procfs was never populated is not a host with FIPS switched off, and a host
+// with no update-crypto-policies is not a host whose crypto policy is the empty
+// string. Reported as false and "", those two are indistinguishable from a real
+// reading, and an audit over them passes or fails on data that does not exist.
+//
+// So every path that did not actually read a value reports null instead.
+
+// fipsSysctl is the Linux sysctl that reports whether the kernel is running in
+// FIPS mode. It holds "1" when FIPS mode is active and "0" when it is not.
+const fipsSysctl = "/proc/sys/crypto/fips_enabled"
+
+// cryptoPoliciesCmd shows the active system-wide crypto policy on RHEL, Fedora,
+// and their derivatives.
+const cryptoPoliciesCmd = "update-crypto-policies --show"
+
+// parseFipsEnabled interprets the content of fipsSysctl.
+//
+// ok is false for anything that is not one of the two documented values,
+// including an empty file. A file that says something else has not told us
+// whether FIPS is on, and guessing "off" from it would be the same invention
+// as guessing it from a file that was not there at all.
+func parseFipsEnabled(content string) (enabled bool, ok bool) {
+	switch strings.TrimSpace(content) {
+	case "1":
+		return true, true
+	case "0":
+		return false, true
+	default:
+		return false, false
+	}
 }
 
-// normalizeCryptoPolicy trims the output of `update-crypto-policies --show`
-// and returns the first line (e.g. "DEFAULT", "FUTURE", "FIPS", "FIPS:OSPP").
+// normalizeCryptoPolicy trims the output of cryptoPoliciesCmd and returns the
+// first line, e.g. "DEFAULT", "FUTURE", "FIPS", "FIPS:OSPP". It returns an empty
+// string when there was nothing to read, which callers report as null rather
+// than as a policy named "".
 func normalizeCryptoPolicy(stdout string) string {
 	trimmed := strings.TrimSpace(stdout)
 	if trimmed == "" {
@@ -30,54 +61,75 @@ func normalizeCryptoPolicy(stdout string) string {
 	return trimmed
 }
 
-// fipsEnabled reports whether the OS is running in FIPS mode.
+// fipsEnabled reports whether the OS is running in FIPS mode, by reading
+// fipsSysctl through the connection filesystem.
 //
-// On Linux this reads /proc/sys/crypto/fips_enabled through the connection
-// filesystem. When the file is absent or unreadable (non-Linux, containers
-// without procfs), it degrades gracefully to false rather than failing.
+// Null whenever that read did not produce one of the two documented values. The
+// file is absent on a kernel built without the FIPS sysctl, and equally absent
+// on Windows, on macOS, and in an image whose /proc was never populated. Those
+// are not the same fact as each other, and none of them is "FIPS is off".
 func (p *mqlOs) fipsEnabled() (bool, error) {
+	unknown := func() (bool, error) {
+		p.FipsEnabled.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
 	conn, ok := p.MqlRuntime.Connection.(shared.Connection)
 	if !ok {
-		return false, nil
+		return unknown()
 	}
 
 	afs := &afero.Afero{Fs: conn.FileSystem()}
-	content, err := afs.ReadFile("/proc/sys/crypto/fips_enabled")
+	content, err := afs.ReadFile(fipsSysctl)
 	if err != nil {
-		// file not present / not readable (non-Linux, container without procfs)
-		return false, nil
+		return unknown()
 	}
 
-	return parseFipsEnabled(string(content)), nil
+	enabled, ok := parseFipsEnabled(string(content))
+	if !ok {
+		return unknown()
+	}
+	return enabled, nil
 }
 
 // cryptoPolicy returns the active system-wide crypto policy as reported by
-// `update-crypto-policies --show` (RHEL/Fedora). On platforms without that
-// tool, or when the command is missing/errors/exits non-zero, it returns an
-// empty string gracefully.
+// cryptoPoliciesCmd.
+//
+// Null when the policy could not be read: no run-command capability (a static
+// image), no such tool (Debian, Ubuntu, macOS, Windows), a non-zero exit, or no
+// output. An empty string would name a policy, and a check written against a
+// policy name cannot tell that apart from a system that was never asked.
 func (p *mqlOs) cryptoPolicy() (string, error) {
+	unknown := func() (string, error) {
+		p.CryptoPolicy.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	conn, ok := p.MqlRuntime.Connection.(shared.Connection)
 	if !ok {
-		return "", nil
+		return unknown()
 	}
 
-	// systems without run-command capability (e.g. static images) can't run it
 	if !conn.Capabilities().Has(shared.Capability_RunCommand) {
-		return "", nil
+		return unknown()
 	}
 
-	cmd, err := conn.RunCommand("update-crypto-policies --show")
-	if err != nil {
-		return "", nil
+	cmd, err := conn.RunCommand(cryptoPoliciesCmd)
+	if err != nil || cmd == nil {
+		return unknown()
 	}
-	if cmd.ExitStatus != 0 {
-		return "", nil
+	if cmd.ExitStatus != 0 || cmd.Stdout == nil {
+		return unknown()
 	}
 
 	data, err := io.ReadAll(cmd.Stdout)
 	if err != nil {
-		return "", nil
+		return unknown()
 	}
 
-	return normalizeCryptoPolicy(string(data)), nil
+	policy := normalizeCryptoPolicy(string(data))
+	if policy == "" {
+		return unknown()
+	}
+	return policy, nil
 }

--- a/providers/os/resources/os_crypto_test.go
+++ b/providers/os/resources/os_crypto_test.go
@@ -3,28 +3,41 @@
 
 package resources
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
 
 func TestParseFipsEnabled(t *testing.T) {
 	tests := []struct {
-		name    string
-		content string
-		want    bool
+		name        string
+		content     string
+		wantEnabled bool
+		wantOk      bool
 	}{
-		{"enabled", "1", true},
-		{"enabled with newline", "1\n", true},
-		{"enabled with whitespace", "  1  \n", true},
-		{"disabled", "0", false},
-		{"disabled with newline", "0\n", false},
-		{"empty", "", false},
-		{"whitespace only", "   \n", false},
-		{"unexpected value", "2", false},
+		{"enabled", "1", true, true},
+		{"enabled with newline", "1\n", true, true},
+		{"enabled with whitespace", "  1  \n", true, true},
+		{"disabled", "0", false, true},
+		{"disabled with newline", "0\n", false, true},
+		// An empty or unexpected file has not said whether FIPS is on. Reading
+		// "off" out of it is the same invention as reading it out of a file
+		// that was never there.
+		{"empty is not a reading", "", false, false},
+		{"whitespace only is not a reading", "   \n", false, false},
+		{"unexpected value is not a reading", "2", false, false},
+		{"text is not a reading", "enabled\n", false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parseFipsEnabled(tt.content); got != tt.want {
-				t.Errorf("parseFipsEnabled(%q) = %v, want %v", tt.content, got, tt.want)
-			}
+			enabled, ok := parseFipsEnabled(tt.content)
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantEnabled, enabled)
 		})
 	}
 }
@@ -46,9 +59,141 @@ func TestNormalizeCryptoPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeCryptoPolicy(tt.stdout); got != tt.want {
-				t.Errorf("normalizeCryptoPolicy(%q) = %q, want %q", tt.stdout, got, tt.want)
-			}
+			assert.Equal(t, tt.want, normalizeCryptoPolicy(tt.stdout))
 		})
 	}
+}
+
+// mockOs builds an os resource over a mock connection serving the given files
+// and commands.
+func mockOs(t *testing.T, data *mock.TomlData) *mqlOs {
+	t.Helper()
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(data))
+	require.NoError(t, err)
+	return &mqlOs{MqlRuntime: &plugin.Runtime{Connection: conn}}
+}
+
+func fipsFile(content string) *mock.TomlData {
+	return &mock.TomlData{
+		Files: map[string]*mock.MockFileData{
+			"/proc/sys/crypto/fips_enabled": {
+				Path:    "/proc/sys/crypto/fips_enabled",
+				Content: content,
+			},
+		},
+	}
+}
+
+func TestOsFipsEnabled(t *testing.T) {
+	t.Run("reports true when the sysctl says 1", func(t *testing.T) {
+		os := mockOs(t, fipsFile("1\n"))
+
+		enabled, err := os.fipsEnabled()
+
+		require.NoError(t, err)
+		assert.True(t, enabled)
+		assert.False(t, os.FipsEnabled.IsNull(), "a real reading must not be null")
+	})
+
+	t.Run("reports false when the sysctl says 0", func(t *testing.T) {
+		os := mockOs(t, fipsFile("0\n"))
+
+		enabled, err := os.fipsEnabled()
+
+		require.NoError(t, err)
+		assert.False(t, enabled)
+		assert.False(t, os.FipsEnabled.IsNull(), "a real reading must not be null")
+	})
+
+	// The case this whole file exists for. On a host with no procfs the file is
+	// simply not there, and "FIPS is off" is not something that absence
+	// establishes. Reporting false here would let a "FIPS must be enabled"
+	// audit render a verdict about a host nobody read.
+	t.Run("reports null when the sysctl is absent", func(t *testing.T) {
+		os := mockOs(t, &mock.TomlData{})
+
+		_, err := os.fipsEnabled()
+
+		require.NoError(t, err)
+		assert.True(t, os.FipsEnabled.IsNull(), "an unread host must be null, not false")
+	})
+
+	t.Run("reports null when the sysctl holds something else", func(t *testing.T) {
+		os := mockOs(t, fipsFile("who knows\n"))
+
+		_, err := os.fipsEnabled()
+
+		require.NoError(t, err)
+		assert.True(t, os.FipsEnabled.IsNull())
+	})
+
+	// A runtime with no OS connection behind it cannot have read anything.
+	t.Run("reports null without an os connection", func(t *testing.T) {
+		os := &mqlOs{MqlRuntime: &plugin.Runtime{}}
+
+		_, err := os.fipsEnabled()
+
+		require.NoError(t, err)
+		assert.True(t, os.FipsEnabled.IsNull())
+	})
+}
+
+func cryptoPolicyCmd(cmd *mock.Command) *mock.TomlData {
+	return &mock.TomlData{
+		Commands: map[string]*mock.Command{"update-crypto-policies --show": cmd},
+	}
+}
+
+func TestOsCryptoPolicy(t *testing.T) {
+	t.Run("reports the policy the tool prints", func(t *testing.T) {
+		os := mockOs(t, cryptoPolicyCmd(&mock.Command{Stdout: "FIPS:OSPP\n"}))
+
+		policy, err := os.cryptoPolicy()
+
+		require.NoError(t, err)
+		assert.Equal(t, "FIPS:OSPP", policy)
+		assert.False(t, os.CryptoPolicy.IsNull(), "a real reading must not be null")
+	})
+
+	// Debian, Ubuntu, macOS and Windows ship no update-crypto-policies. Their
+	// crypto policy is not the empty string, it is unknown to us, and a check
+	// comparing against a policy name cannot tell those apart.
+	t.Run("reports null when the tool is missing", func(t *testing.T) {
+		os := mockOs(t, cryptoPolicyCmd(&mock.Command{
+			Stderr:     "sh: update-crypto-policies: command not found",
+			ExitStatus: 127,
+		}))
+
+		_, err := os.cryptoPolicy()
+
+		require.NoError(t, err)
+		assert.True(t, os.CryptoPolicy.IsNull(), "a failed command must be null, not \"\"")
+	})
+
+	t.Run("reports null when the command is not in the mock at all", func(t *testing.T) {
+		os := mockOs(t, &mock.TomlData{})
+
+		_, err := os.cryptoPolicy()
+
+		require.NoError(t, err)
+		assert.True(t, os.CryptoPolicy.IsNull())
+	})
+
+	t.Run("reports null when the tool prints nothing", func(t *testing.T) {
+		os := mockOs(t, cryptoPolicyCmd(&mock.Command{Stdout: "\n"}))
+
+		_, err := os.cryptoPolicy()
+
+		require.NoError(t, err)
+		assert.True(t, os.CryptoPolicy.IsNull())
+	})
+
+	t.Run("reports null without an os connection", func(t *testing.T) {
+		os := &mqlOs{MqlRuntime: &plugin.Runtime{}}
+
+		_, err := os.cryptoPolicy()
+
+		require.NoError(t, err)
+		assert.True(t, os.CryptoPolicy.IsNull())
+	})
 }

--- a/providers/os/resources/os_crypto_test.go
+++ b/providers/os/resources/os_crypto_test.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestParseFipsEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"enabled", "1", true},
+		{"enabled with newline", "1\n", true},
+		{"enabled with whitespace", "  1  \n", true},
+		{"disabled", "0", false},
+		{"disabled with newline", "0\n", false},
+		{"empty", "", false},
+		{"whitespace only", "   \n", false},
+		{"unexpected value", "2", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseFipsEnabled(tt.content); got != tt.want {
+				t.Errorf("parseFipsEnabled(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCryptoPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		stdout string
+		want   string
+	}{
+		{"default with newline", "DEFAULT\n", "DEFAULT"},
+		{"future no newline", "FUTURE", "FUTURE"},
+		{"subpolicy kept as-is", "FIPS:OSPP", "FIPS:OSPP"},
+		{"legacy with whitespace", "  LEGACY  \n", "LEGACY"},
+		{"empty", "", ""},
+		{"whitespace only", "   \n", ""},
+		{"multiline takes first line", "DEFAULT\nsome warning\n", "DEFAULT"},
+		{"fips", "FIPS\n", "FIPS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCryptoPolicy(tt.stdout); got != tt.want {
+				t.Errorf("normalizeCryptoPolicy(%q) = %q, want %q", tt.stdout, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds two computed fields to the existing `os {}` resource:

- **`os.fipsEnabled` (bool)** — whether the OS is running in FIPS mode. On Linux this reads `/proc/sys/crypto/fips_enabled` through the connection filesystem (`"1"` → true, `"0"` → false).
- **`os.cryptoPolicy` (string)** — the active system-wide crypto policy from `update-crypto-policies --show` on RHEL/Fedora (e.g. `DEFAULT`, `FUTURE`, `FIPS`, `LEGACY`, `FIPS:OSPP`).

## Why

Post-quantum cryptography (PQC) readiness correlates strongly with a system's crypto-policy level and whether FIPS mode is active. Exposing both as first-class `os` fields lets policies assess PQC posture directly instead of shelling out per-check.

## Unread is null, never a value

Both fields report a security posture, so the failure that matters is not an error — it is a confident answer nobody read. Every path that does not produce a reading reports **null**:

| Situation | Reported |
|---|---|
| `/proc/sys/crypto/fips_enabled` holds `1` / `0` | true / false |
| that file absent, unreadable, or holding anything else | null |
| `update-crypto-policies --show` prints a policy | that policy |
| no run-command capability, no such tool, non-zero exit, no output | null |

The alternative — the zero value — is what makes this dangerous rather than merely lossy. A host with no procfs, a Windows host, an image whose `/proc` was never populated, and a genuinely non-FIPS Linux box would all render identically as `false`, and an audit over that reaches a verdict about hosts nobody could read. Likewise an empty `cryptoPolicy` *names* a policy, which no check comparing against a policy name can tell apart from a system that was never asked.

Null is written by setting the field state before returning, which is what `GetOrCompute` reads back; returning the zero value alone would be cached as a real reading.

## Notes

- **Windows FIPS is left unread** — `fipsEnabled` is null on Windows rather than false. The Windows policy lives in registry value `HKLM\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy\Enabled`; wiring that up cleanly is deferred to a follow-up rather than inventing a registry-read path here.

## Tests

Parsing and normalization are pure helpers (`parseFipsEnabled`, `normalizeCryptoPolicy`) with table-driven tests. The accessors themselves are covered over a mock connection: the absent-sysctl, unexpected-content, missing-tool, empty-output and no-connection paths each assert the field is null, and each of those six fails against the earlier zero-value behaviour. `go test ./providers/os/resources/...` is green.
