### PR TITLE
✨ providers: add --schema-only flag to providers install

### DIFF
--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -42,6 +42,7 @@ func init() {
 	resourcesProviderCmd.Flags().Bool("json", false, "Output in JSON format")
 	installProviderCmd.Flags().StringP("file", "f", "", "Install a provider via a file")
 	installProviderCmd.Flags().String("url", "", "Install a provider via a URL")
+	installProviderCmd.Flags().Bool("schema-only", false, "Install only the provider's config and resource schema, without its binary")
 	deleteProviderCmd.Flags().Bool("yes", false, "Confirm removal of all providers when using the 'all' target")
 }
 
@@ -66,21 +67,34 @@ var listProvidersCmd = &cobra.Command{
 }
 
 var installProviderCmd = &cobra.Command{
-	Use:    "install <NAME[@VERSION]>",
-	Short:  "Install or update a provider",
-	Long:   "",
+	Use:   "install <NAME[@VERSION]>",
+	Short: "Install or update a provider",
+	Long: `Install or update a provider.
+
+With --schema-only, only the provider's config and resource schema are
+installed, skipping the (much larger) binary download. That is enough to
+compile queries against the provider's resources; the binary is fetched
+automatically the first time the provider connects to an asset.`,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
+		schemaOnly, _ := cmd.Flags().GetBool("schema-only")
+
 		// Explicit installs of files will ignore version recommendations.
 		// So we just take them and roll with it.
 		path, _ := cmd.Flags().GetString("file")
 		if path != "" {
+			if schemaOnly {
+				log.Fatal().Msg("--schema-only is not supported together with --file")
+			}
 			installProviderFile(path)
 			return
 		}
 
 		url, _ := cmd.Flags().GetString("url")
 		if url != "" {
+			if schemaOnly {
+				log.Fatal().Msg("--schema-only is not supported together with --url")
+			}
 			installProviderUrl(url)
 			return
 		}
@@ -90,7 +104,7 @@ var installProviderCmd = &cobra.Command{
 		}
 
 		// if no url or file is specified, we default to installing by name from the default upstream
-		installProviderByName(args[0])
+		installProviderByName(args[0], schemaOnly)
 	},
 }
 
@@ -686,7 +700,13 @@ func updateProviders(binary string, names []string) error {
 			continue
 		}
 
-		installed, err := providers.Install(p.Name, latest)
+		// Schema-only installs stay schema-only when updated; their binary
+		// is only fetched when the provider actually connects to an asset.
+		install := providers.Install
+		if !p.HasBinary {
+			install = providers.InstallSchemaOnly
+		}
+		installed, err := install(p.Name, latest)
 		if err != nil {
 			log.Warn().Err(err).Str("provider", p.Name).Msg("failed to update provider")
 			failed++
@@ -708,7 +728,7 @@ func updateProviders(binary string, names []string) error {
 
 // --- existing functions ---
 
-func installProviderByName(name string) {
+func installProviderByName(name string, schemaOnly bool) {
 	parts := strings.Split(name, "@")
 	if len(parts) > 2 {
 		log.Fatal().Msg("invalid provider name")
@@ -719,7 +739,11 @@ func installProviderByName(name string) {
 		// trim the v prefix, allowing users to specify both 9.0.0 and v9.0.0
 		version = strings.TrimPrefix(parts[1], "v")
 	}
-	installed, err := providers.Install(name, version)
+	install := providers.Install
+	if schemaOnly {
+		install = providers.InstallSchemaOnly
+	}
+	installed, err := install(name, version)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to install")
 	}
@@ -845,6 +869,10 @@ func printProvider(p *providers.Provider) {
 		}
 		maturity = " " + termenv.String("["+strings.ToLower(label)+"]").Foreground(color).String()
 	}
+	schemaOnly := ""
+	if p.Path != "" && !p.HasBinary {
+		schemaOnly = " " + theme.DefaultTheme.Disabled("(schema-only)")
+	}
 
-	fmt.Println("  " + name + " " + p.Version + supports + maturity)
+	fmt.Println("  " + name + " " + p.Version + supports + maturity + schemaOnly)
 }

--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -74,8 +74,7 @@ var installProviderCmd = &cobra.Command{
 With --schema-only, only the provider's config and resource schema are
 installed, skipping the (much larger) binary download. That is enough to
 compile queries against the provider's resources; the binary is fetched
-automatically the first time the provider connects to an asset. If the
-provider is already fully installed, it is kept as-is.`,
+automatically the first time the provider connects to an asset.`,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
 		schemaOnly, _ := cmd.Flags().GetBool("schema-only")

--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -73,8 +73,8 @@ var installProviderCmd = &cobra.Command{
 
 With --schema-only, only the provider's config and resource schema are
 installed, skipping the (much larger) binary download. That is enough to
-compile queries against the provider's resources; the binary is fetched
-automatically the first time the provider connects to an asset.`,
+compile queries against the provider's resources, but not to connect to
+assets; for that, install the provider fully.`,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
 		schemaOnly, _ := cmd.Flags().GetBool("schema-only")

--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -74,7 +74,8 @@ var installProviderCmd = &cobra.Command{
 With --schema-only, only the provider's config and resource schema are
 installed, skipping the (much larger) binary download. That is enough to
 compile queries against the provider's resources; the binary is fetched
-automatically the first time the provider connects to an asset.`,
+automatically the first time the provider connects to an asset. If the
+provider is already fully installed, it is kept as-is.`,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
 		schemaOnly, _ := cmd.Flags().GetBool("schema-only")

--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -700,13 +700,7 @@ func updateProviders(binary string, names []string) error {
 			continue
 		}
 
-		// Schema-only installs stay schema-only when updated; their binary
-		// is only fetched when the provider actually connects to an asset.
-		install := providers.Install
-		if !p.HasBinary {
-			install = providers.InstallSchemaOnly
-		}
-		installed, err := install(p.Name, latest)
+		installed, err := providers.Install(p.Name, latest)
 		if err != nil {
 			log.Warn().Err(err).Str("provider", p.Name).Msg("failed to update provider")
 			failed++

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -4,7 +4,6 @@
 package providers
 
 import (
-	"context"
 	"math"
 	"os/exec"
 	"strconv"
@@ -293,22 +292,6 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	provider, ok := c.providers[id]
 	if !ok {
 		return nil, errors.New("cannot find provider " + id)
-	}
-
-	// Schema-only installs have no binary to launch. Fetch the full provider
-	// package at the installed schema's version before starting the plugin.
-	if provider.Path != "" && !provider.HasBinary {
-		if !update.Enabled {
-			return nil, errors.New("provider '" + provider.Name + "' is installed schema-only and updates are disabled; install the provider fully to connect with it")
-		}
-		log.Info().Str("provider", provider.Name).Msg("provider is installed schema-only, downloading its binary")
-		nu, err := installVersion(context.Background(), provider.Name, provider.Version)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to install binary for schema-only provider "+provider.Name)
-		}
-		PrintInstallResults([]*Provider{nu})
-		c.providers.Add(nu)
-		provider = nu
 	}
 
 	if update.Enabled {

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -4,6 +4,7 @@
 package providers
 
 import (
+	"context"
 	"math"
 	"os/exec"
 	"strconv"
@@ -292,6 +293,22 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	provider, ok := c.providers[id]
 	if !ok {
 		return nil, errors.New("cannot find provider " + id)
+	}
+
+	// Schema-only installs have no binary to launch. Fetch the full provider
+	// package at the installed schema's version before starting the plugin.
+	if provider.Path != "" && !provider.HasBinary {
+		if !update.Enabled {
+			return nil, errors.New("provider '" + provider.Name + "' is installed schema-only and updates are disabled; install the provider fully to connect with it")
+		}
+		log.Info().Str("provider", provider.Name).Msg("provider is installed schema-only, downloading its binary")
+		nu, err := installVersion(context.Background(), provider.Name, provider.Version)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to install binary for schema-only provider "+provider.Name)
+		}
+		PrintInstallResults([]*Provider{nu})
+		c.providers.Add(nu)
+		provider = nu
 	}
 
 	if update.Enabled {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -532,6 +532,108 @@ func installVersion(ctx context.Context, name string, version string) (*Provider
 	return installed[0], nil
 }
 
+// InstallSchemaOnly installs only a provider's config and resource schema,
+// without downloading the provider binary. The result is enough to compile
+// queries against the provider's resources; the binary is fetched on demand
+// the first time the provider is actually connected (see
+// (*coordinator).unsafeStartProvider).
+func InstallSchemaOnly(name string, version string) (*Provider, error) {
+	ctx := context.Background()
+	if version == "" {
+		// if no version is specified, we default to installing the latest one
+		latestVersion, err := registry.GetLatestVersion(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		version = latestVersion
+	}
+
+	log.Info().
+		Str("version", version).
+		Msg("installing schema for provider '" + name + "'")
+	return installSchemaVersion(ctx, name, version, DefaultPath)
+}
+
+func installSchemaVersion(ctx context.Context, name string, version string, dst string) (*Provider, error) {
+	dstPath := filepath.Join(dst, name)
+
+	// Writing a new schema over a full install would leave a binary from a
+	// different version behind. Keep schema-only installs to schema-only
+	// (or fresh) provider directories.
+	bin := filepath.Join(dstPath, name)
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	if config.ProbeFile(bin) {
+		return nil, errors.New("provider '" + name + "' is already installed with its binary; update it with a regular install or delete it first")
+	}
+
+	confJSON, schemaJSON, err := registry.DownloadProviderMetadata(ctx, name, version)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to install schema for "+name+"-"+version)
+	}
+
+	if err := os.MkdirAll(dstPath, 0o755); err != nil {
+		return nil, err
+	}
+	if err := writeProviderFile(filepath.Join(dstPath, name+".json"), confJSON); err != nil {
+		return nil, err
+	}
+	if err := writeProviderFile(filepath.Join(dstPath, name+".resources.json"), schemaJSON); err != nil {
+		return nil, err
+	}
+	syncDir(dstPath)
+
+	provider, err := readProviderDir(dstPath)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return nil, errors.New("failed to read provider from " + dstPath + " after installing its schema")
+	}
+	if err := provider.LoadJSON(); err != nil {
+		return nil, err
+	}
+	if err := provider.LoadResources(); err != nil {
+		return nil, err
+	}
+	if provider.Version != version {
+		return nil, errors.New("version for provider didn't match expected install version: expected " + version + ", installed: " + provider.Version)
+	}
+
+	// we need to clear out the cache now, because we installed something new,
+	// otherwise it will load old data
+	CachedProviders = nil
+	LastProviderInstall = time.Now().Unix()
+
+	return provider, nil
+}
+
+// writeProviderFile writes data to path via a temporary file, fsync, and
+// rename, so a crash can't leave a half-written (or zeroed, see InstallIO)
+// provider file behind.
+func writeProviderFile(path string, data []byte) error {
+	tmp := path + ".tmp"
+	writer, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.Write(data); err != nil {
+		writer.Close()
+		return err
+	}
+	if err := writer.Sync(); err != nil {
+		writer.Close()
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	return osRetry(func() error {
+		return os.Rename(tmp, path)
+	}, maxInstallConfRetries)
+}
+
 // installDependencies ensures all dependencies of a provider are installed
 func installDependencies(provider *Provider, existing Providers) error {
 	// Builtins have no file-backed schema; their Schema is set at init time

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -641,6 +641,9 @@ func writeProviderFile(path string, data []byte) error {
 	if err != nil {
 		return err
 	}
+	// don't leave the temp file behind on any failure below; after a
+	// successful rename the file is gone and this is a no-op
+	defer os.Remove(tmp)
 	if _, err := writer.Write(data); err != nil {
 		writer.Close()
 		return err

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -558,14 +558,37 @@ func installSchemaVersion(ctx context.Context, name string, version string, dst 
 	dstPath := filepath.Join(dst, name)
 
 	// Writing a new schema over a full install would leave a binary from a
-	// different version behind. Keep schema-only installs to schema-only
-	// (or fresh) provider directories.
+	// different version behind. A full install already ships its schema, so
+	// keep it as-is and return it.
 	bin := filepath.Join(dstPath, name)
 	if runtime.GOOS == "windows" {
 		bin += ".exe"
 	}
 	if config.ProbeFile(bin) {
-		return nil, errors.New("provider '" + name + "' is already installed with its binary; update it with a regular install or delete it first")
+		provider, err := readProviderDir(dstPath)
+		if err != nil {
+			return nil, err
+		}
+		if provider == nil {
+			return nil, errors.New("provider '" + name + "' has a binary but a broken config or schema in " + dstPath + "; reinstall it fully or delete it first")
+		}
+		if err := provider.LoadJSON(); err != nil {
+			return nil, err
+		}
+		if err := provider.LoadResources(); err != nil {
+			return nil, err
+		}
+		if provider.Version != version {
+			log.Warn().
+				Str("installed", provider.Version).
+				Str("requested", version).
+				Msg("provider '" + name + "' is already fully installed, keeping it at its current version")
+		} else {
+			log.Info().
+				Str("version", provider.Version).
+				Msg("provider '" + name + "' is already fully installed, keeping it")
+		}
+		return provider, nil
 	}
 
 	confJSON, schemaJSON, err := registry.DownloadProviderMetadata(ctx, name, version)

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -557,40 +557,6 @@ func InstallSchemaOnly(name string, version string) (*Provider, error) {
 func installSchemaVersion(ctx context.Context, name string, version string, dst string) (*Provider, error) {
 	dstPath := filepath.Join(dst, name)
 
-	// Writing a new schema over a full install would leave a binary from a
-	// different version behind. A full install already ships its schema, so
-	// keep it as-is and return it.
-	bin := filepath.Join(dstPath, name)
-	if runtime.GOOS == "windows" {
-		bin += ".exe"
-	}
-	if config.ProbeFile(bin) {
-		provider, err := readProviderDir(dstPath)
-		if err != nil {
-			return nil, err
-		}
-		if provider == nil {
-			return nil, errors.New("provider '" + name + "' has a binary but a broken config or schema in " + dstPath + "; reinstall it fully or delete it first")
-		}
-		if err := provider.LoadJSON(); err != nil {
-			return nil, err
-		}
-		if err := provider.LoadResources(); err != nil {
-			return nil, err
-		}
-		if provider.Version != version {
-			log.Warn().
-				Str("installed", provider.Version).
-				Str("requested", version).
-				Msg("provider '" + name + "' is already fully installed, keeping it at its current version")
-		} else {
-			log.Info().
-				Str("version", provider.Version).
-				Msg("provider '" + name + "' is already fully installed, keeping it")
-		}
-		return provider, nil
-	}
-
 	confJSON, schemaJSON, err := registry.DownloadProviderMetadata(ctx, name, version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to install schema for "+name+"-"+version)

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -534,9 +534,8 @@ func installVersion(ctx context.Context, name string, version string) (*Provider
 
 // InstallSchemaOnly installs only a provider's config and resource schema,
 // without downloading the provider binary. The result is enough to compile
-// queries against the provider's resources; the binary is fetched on demand
-// the first time the provider is actually connected (see
-// (*coordinator).unsafeStartProvider).
+// queries against the provider's resources. It is meant for workflows that
+// never start the provider; connecting to an asset requires a full install.
 func InstallSchemaOnly(name string, version string) (*Provider, error) {
 	ctx := context.Background()
 	if version == "" {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -564,13 +564,12 @@ func installSchemaVersion(ctx context.Context, name string, version string, dst 
 	if err := os.MkdirAll(dstPath, 0o755); err != nil {
 		return nil, err
 	}
-	if err := writeProviderFile(filepath.Join(dstPath, name+".json"), confJSON); err != nil {
+	if err := os.WriteFile(filepath.Join(dstPath, name+".json"), confJSON, 0o644); err != nil {
 		return nil, err
 	}
-	if err := writeProviderFile(filepath.Join(dstPath, name+".resources.json"), schemaJSON); err != nil {
+	if err := os.WriteFile(filepath.Join(dstPath, name+".resources.json"), schemaJSON, 0o644); err != nil {
 		return nil, err
 	}
-	syncDir(dstPath)
 
 	provider, err := readProviderDir(dstPath)
 	if err != nil {
@@ -595,34 +594,6 @@ func installSchemaVersion(ctx context.Context, name string, version string, dst 
 	LastProviderInstall = time.Now().Unix()
 
 	return provider, nil
-}
-
-// writeProviderFile writes data to path via a temporary file, fsync, and
-// rename, so a crash can't leave a half-written (or zeroed, see InstallIO)
-// provider file behind.
-func writeProviderFile(path string, data []byte) error {
-	tmp := path + ".tmp"
-	writer, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-	// don't leave the temp file behind on any failure below; after a
-	// successful rename the file is gone and this is a no-op
-	defer os.Remove(tmp)
-	if _, err := writer.Write(data); err != nil {
-		writer.Close()
-		return err
-	}
-	if err := writer.Sync(); err != nil {
-		writer.Close()
-		return err
-	}
-	if err := writer.Close(); err != nil {
-		return err
-	}
-	return osRetry(func() error {
-		return os.Rename(tmp, path)
-	}, maxInstallConfRetries)
 }
 
 // installDependencies ensures all dependencies of a provider are installed

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -591,7 +591,13 @@ func buildTarXz(files map[string][]byte) ([]byte, error) {
 		return nil, err
 	}
 	tarWriter := tar.NewWriter(xzWriter)
-	for name, data := range files {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		data := files[name]
 		header := &tar.Header{
 			Name: name,
 			Mode: 0o644,

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -554,46 +554,63 @@ func InstallSchemaOnly(name string, version string) (*Provider, error) {
 }
 
 func installSchemaVersion(ctx context.Context, name string, version string, dst string) (*Provider, error) {
-	dstPath := filepath.Join(dst, name)
-
 	confJSON, schemaJSON, err := registry.DownloadProviderMetadata(ctx, name, version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to install schema for "+name+"-"+version)
 	}
 
-	if err := os.MkdirAll(dstPath, 0o755); err != nil {
-		return nil, err
-	}
-	if err := os.WriteFile(filepath.Join(dstPath, name+".json"), confJSON, 0o644); err != nil {
-		return nil, err
-	}
-	if err := os.WriteFile(filepath.Join(dstPath, name+".resources.json"), schemaJSON, 0o644); err != nil {
-		return nil, err
-	}
-
-	provider, err := readProviderDir(dstPath)
+	// Pack the two files into an in-memory tar.xz so the install goes
+	// through the same path as a full provider archive.
+	archive, err := buildTarXz(map[string][]byte{
+		name + ".json":           confJSON,
+		name + ".resources.json": schemaJSON,
+	})
 	if err != nil {
 		return nil, err
 	}
-	if provider == nil {
-		return nil, errors.New("failed to read provider from " + dstPath + " after installing its schema")
-	}
-	if err := provider.LoadJSON(); err != nil {
+
+	installed, err := InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: dst})
+	if err != nil {
 		return nil, err
 	}
-	if err := provider.LoadResources(); err != nil {
-		return nil, err
+	if len(installed) != 1 {
+		return nil, errors.New("failed to install schema for provider " + name)
 	}
+	provider := installed[0]
 	if provider.Version != version {
 		return nil, errors.New("version for provider didn't match expected install version: expected " + version + ", installed: " + provider.Version)
 	}
-
-	// we need to clear out the cache now, because we installed something new,
-	// otherwise it will load old data
-	CachedProviders = nil
-	LastProviderInstall = time.Now().Unix()
-
 	return provider, nil
+}
+
+// buildTarXz packs the given files into an in-memory tar.xz archive.
+func buildTarXz(files map[string][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	xzWriter, err := xz.NewWriter(&buf)
+	if err != nil {
+		return nil, err
+	}
+	tarWriter := tar.NewWriter(xzWriter)
+	for name, data := range files {
+		header := &tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(data)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return nil, err
+		}
+		if _, err := tarWriter.Write(data); err != nil {
+			return nil, err
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		return nil, err
+	}
+	if err := xzWriter.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // installDependencies ensures all dependencies of a provider are installed
@@ -776,22 +793,23 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 	log.Debug().Msg("move provider to destination")
 	providerDirs := []string{}
 	for name := range files {
-		// we only want to identify the binary and then all associated files from it
-		// NOTE: we need special handling for windows since binaries have the .exe extension
-		if !strings.HasSuffix(name, ".exe") && strings.Contains(name, ".") {
+		// Providers are identified by their schema file: every package has
+		// one, with or without a binary (schema-only installs have none).
+		if !strings.HasSuffix(name, ".resources.json") {
 			continue
 		}
-
-		providerName := name
-		if strings.HasSuffix(name, ".exe") {
-			providerName = strings.TrimSuffix(name, ".exe")
-		}
+		providerName := strings.TrimSuffix(name, ".resources.json")
 
 		if _, ok := files[providerName+".json"]; !ok {
 			return nil, errors.New("cannot find " + providerName + ".json in the archive")
 		}
-		if _, ok := files[providerName+".resources.json"]; !ok {
-			return nil, errors.New("cannot find " + providerName + ".resources.json in the archive")
+
+		// NOTE: we need special handling for windows since binaries have the .exe extension
+		binName := ""
+		if _, ok := files[providerName]; ok {
+			binName = providerName
+		} else if _, ok := files[providerName+".exe"]; ok {
+			binName = providerName + ".exe"
 		}
 
 		dstPath := filepath.Join(conf.Dst, providerName)
@@ -799,17 +817,19 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 			return nil, err
 		}
 
-		// move the binary and the associated files
-		srcBin := filepath.Join(tmpdir, name)
-		dstBin := filepath.Join(dstPath, name)
-		log.Debug().Str("src", srcBin).Str("dst", dstBin).Msg("move provider binary")
-		if err = osRetry(func() error {
-			return os.Rename(srcBin, dstBin)
-		}, maxInstallBinaryRetries); err != nil {
-			return nil, err
-		}
-		if err = os.Chmod(dstBin, 0o755); err != nil {
-			return nil, err
+		// move the binary (if any) and the associated files
+		if binName != "" {
+			srcBin := filepath.Join(tmpdir, binName)
+			dstBin := filepath.Join(dstPath, binName)
+			log.Debug().Str("src", srcBin).Str("dst", dstBin).Msg("move provider binary")
+			if err = osRetry(func() error {
+				return os.Rename(srcBin, dstBin)
+			}, maxInstallBinaryRetries); err != nil {
+				return nil, err
+			}
+			if err = os.Chmod(dstBin, 0o755); err != nil {
+				return nil, err
+			}
 		}
 
 		srcMeta := filepath.Join(tmpdir, providerName)

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -162,6 +162,21 @@ func TestInstallSchemaVersion_ExistingFullInstall(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "1.2.3", provider.Version)
 		assert.True(t, provider.HasBinary)
+
+		// the existing install must be byte-for-byte untouched: nothing
+		// new written, nothing rewritten at the requested version
+		infos, err := afero.ReadDir(config.AppFs, pdir)
+		require.NoError(t, err)
+		names := make([]string, 0, len(infos))
+		for _, fi := range infos {
+			names = append(names, fi.Name())
+		}
+		assert.ElementsMatch(t, []string{"testp", "testp.json", "testp.resources.json"}, names)
+		for name, content := range files {
+			data, err := afero.ReadFile(config.AppFs, filepath.Join(pdir, name))
+			require.NoError(t, err)
+			assert.Equal(t, content, string(data), name)
+		}
 	})
 
 	t.Run("binary with broken config errors", func(t *testing.T) {

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -4,7 +4,9 @@
 package providers
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -128,4 +130,50 @@ func TestOsRetry_RetryableError(t *testing.T) {
 	}
 	assert.NoError(t, osRetry(testFunc, 2))
 	assert.Equal(t, 2, funcCounter)
+}
+
+func TestInstallIO(t *testing.T) {
+	confJSON := []byte(`{"Name":"testp","Version":"1.2.3"}`)
+	schemaJSON := []byte(`{"resources":{}}`)
+
+	t.Run("schema-only archive", func(t *testing.T) {
+		archive, err := buildTarXz(map[string][]byte{
+			"testp.json":           confJSON,
+			"testp.resources.json": schemaJSON,
+		})
+		require.NoError(t, err)
+
+		installed, err := InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: t.TempDir()})
+		require.NoError(t, err)
+		require.Len(t, installed, 1)
+		assert.Equal(t, "testp", installed[0].Name)
+		assert.Equal(t, "1.2.3", installed[0].Version)
+		assert.False(t, installed[0].HasBinary)
+	})
+
+	t.Run("archive with binary", func(t *testing.T) {
+		archive, err := buildTarXz(map[string][]byte{
+			"testp":                []byte(`fake-binary`),
+			"testp.json":           confJSON,
+			"testp.resources.json": schemaJSON,
+		})
+		require.NoError(t, err)
+
+		installed, err := InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: t.TempDir()})
+		require.NoError(t, err)
+		require.Len(t, installed, 1)
+		assert.Equal(t, "testp", installed[0].Name)
+		assert.True(t, installed[0].HasBinary)
+	})
+
+	t.Run("archive without config errors", func(t *testing.T) {
+		archive, err := buildTarXz(map[string][]byte{
+			"testp.resources.json": schemaJSON,
+		})
+		require.NoError(t, err)
+
+		_, err = InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: t.TempDir()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot find testp.json")
+	})
 }

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -5,6 +5,7 @@ package providers
 
 import (
 	"context"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -128,4 +129,48 @@ func TestOsRetry_RetryableError(t *testing.T) {
 	}
 	assert.NoError(t, osRetry(testFunc, 2))
 	assert.Equal(t, 2, funcCounter)
+}
+
+func TestInstallSchemaVersion_ExistingFullInstall(t *testing.T) {
+	origFs := config.AppFs
+	config.AppFs = afero.NewMemMapFs()
+	t.Cleanup(func() { config.AppFs = origFs })
+
+	dst := "providers"
+	pdir := filepath.Join(dst, "testp")
+	require.NoError(t, config.AppFs.MkdirAll(pdir, 0o755))
+	files := map[string]string{
+		"testp":                `fake-binary`,
+		"testp.json":           `{"Name":"testp","Version":"1.2.3"}`,
+		"testp.resources.json": `{"resources":{}}`,
+	}
+	for name, content := range files {
+		require.NoError(t, afero.WriteFile(config.AppFs, filepath.Join(pdir, name), []byte(content), 0o644))
+	}
+
+	ctx := context.Background()
+
+	t.Run("same version is kept as-is", func(t *testing.T) {
+		provider, err := installSchemaVersion(ctx, "testp", "1.2.3", dst)
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3", provider.Version)
+		assert.True(t, provider.HasBinary)
+	})
+
+	t.Run("different version is kept as-is", func(t *testing.T) {
+		provider, err := installSchemaVersion(ctx, "testp", "9.9.9", dst)
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3", provider.Version)
+		assert.True(t, provider.HasBinary)
+	})
+
+	t.Run("binary with broken config errors", func(t *testing.T) {
+		brokenDir := filepath.Join(dst, "broken")
+		require.NoError(t, config.AppFs.MkdirAll(brokenDir, 0o755))
+		require.NoError(t, afero.WriteFile(config.AppFs, filepath.Join(brokenDir, "broken"), []byte(`fake-binary`), 0o644))
+
+		_, err := installSchemaVersion(ctx, "broken", "1.2.3", dst)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "broken config or schema")
+	})
 }

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -5,7 +5,6 @@ package providers
 
 import (
 	"context"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -129,63 +128,4 @@ func TestOsRetry_RetryableError(t *testing.T) {
 	}
 	assert.NoError(t, osRetry(testFunc, 2))
 	assert.Equal(t, 2, funcCounter)
-}
-
-func TestInstallSchemaVersion_ExistingFullInstall(t *testing.T) {
-	origFs := config.AppFs
-	config.AppFs = afero.NewMemMapFs()
-	t.Cleanup(func() { config.AppFs = origFs })
-
-	dst := "providers"
-	pdir := filepath.Join(dst, "testp")
-	require.NoError(t, config.AppFs.MkdirAll(pdir, 0o755))
-	files := map[string]string{
-		"testp":                `fake-binary`,
-		"testp.json":           `{"Name":"testp","Version":"1.2.3"}`,
-		"testp.resources.json": `{"resources":{}}`,
-	}
-	for name, content := range files {
-		require.NoError(t, afero.WriteFile(config.AppFs, filepath.Join(pdir, name), []byte(content), 0o644))
-	}
-
-	ctx := context.Background()
-
-	t.Run("same version is kept as-is", func(t *testing.T) {
-		provider, err := installSchemaVersion(ctx, "testp", "1.2.3", dst)
-		require.NoError(t, err)
-		assert.Equal(t, "1.2.3", provider.Version)
-		assert.True(t, provider.HasBinary)
-	})
-
-	t.Run("different version is kept as-is", func(t *testing.T) {
-		provider, err := installSchemaVersion(ctx, "testp", "9.9.9", dst)
-		require.NoError(t, err)
-		assert.Equal(t, "1.2.3", provider.Version)
-		assert.True(t, provider.HasBinary)
-
-		// the existing install must be byte-for-byte untouched: nothing
-		// new written, nothing rewritten at the requested version
-		infos, err := afero.ReadDir(config.AppFs, pdir)
-		require.NoError(t, err)
-		names := make([]string, 0, len(infos))
-		for _, fi := range infos {
-			names = append(names, fi.Name())
-		}
-		assert.ElementsMatch(t, []string{"testp", "testp.json", "testp.resources.json"}, names)
-		for name, content := range files {
-			data, err := afero.ReadFile(config.AppFs, filepath.Join(pdir, name))
-			require.NoError(t, err)
-			assert.Equal(t, content, string(data), name)
-		}
-	})
-
-	t.Run("binary with broken config errors", func(t *testing.T) {
-		brokenDir := filepath.Join(dst, "broken")
-		require.NoError(t, config.AppFs.MkdirAll(brokenDir, 0o755))
-		require.NoError(t, afero.WriteFile(config.AppFs, filepath.Join(brokenDir, "broken"), []byte(`fake-binary`), 0o644))
-
-		_, err := installSchemaVersion(ctx, "broken", "1.2.3", dst)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "broken config or schema")
-	})
 }

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -35,6 +35,11 @@ type ProviderRegistry interface {
 
 	// DownloadProvider downloads a provider package and returns a ReadCloser for the content
 	DownloadProvider(ctx context.Context, name, version, os, arch string) (io.ReadCloser, error)
+
+	// DownloadProviderMetadata downloads only a provider's config (the
+	// contents of <name>.json) and resource schema (the contents of
+	// <name>.resources.json), without the provider binary.
+	DownloadProviderMetadata(ctx context.Context, name, version string) (confJSON []byte, schemaJSON []byte, err error)
 }
 
 // MondooProviderRegistry implements ProviderRegistry for Mondoo's provider registry
@@ -154,4 +159,62 @@ func (r *MondooProviderRegistry) DownloadProvider(ctx context.Context, name, ver
 	// Wrap with idle timeout so slow-but-active downloads succeed while
 	// truly stalled transfers are detected. Callers just read and close.
 	return httpx.NewIdleTimeoutReader(res.Body, httpx.DownloadTimeout()), nil
+}
+
+// DownloadProviderMetadata downloads only a provider's config and resource
+// schema. The registry publishes these alongside the binary archives as
+// provider.json and schema.json, so schema-only installs don't have to pull
+// the (much larger) provider binary down.
+func (r *MondooProviderRegistry) DownloadProviderMetadata(ctx context.Context, name, version string) ([]byte, []byte, error) {
+	confJSON, err := r.downloadReleaseFile(ctx, name, version, "provider.json")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	schemaJSON, err := r.downloadReleaseFile(ctx, name, version, "schema.json")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return confJSON, schemaJSON, nil
+}
+
+// downloadReleaseFile fetches a single file from a provider's release
+// directory, e.g. <base>/<name>/<version>/schema.json.
+func (r *MondooProviderRegistry) downloadReleaseFile(ctx context.Context, name, version, filename string) ([]byte, error) {
+	downloadURL, err := url.JoinPath(r.BaseURL, name, version, filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct download URL")
+	}
+
+	log.Debug().Str("url", downloadURL).Msg("downloading provider file from URL")
+
+	client, err := httpClientWithRetry()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build download request")
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to download "+filename+" for "+name+"-"+version)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		return nil, errors.New("cannot find " + filename + " for provider " + name + "-" + version + " under url " + downloadURL)
+	} else if res.StatusCode != http.StatusOK {
+		log.Debug().Str("url", downloadURL).Int("status", res.StatusCode).Msg("failed to download from URL (status code)")
+		return nil, errors.New("failed to download " + filename + " for " + name + "-" + version + ", received status code: " + res.Status)
+	}
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read "+filename+" for "+name+"-"+version)
+	}
+	return data, nil
 }

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -166,3 +166,39 @@ func TestMondooProviderRegistry_DownloadProvider(t *testing.T) {
 		assert.Contains(t, err.Error(), "cannot find provider")
 	})
 }
+
+func TestMondooProviderRegistry_DownloadProviderMetadata(t *testing.T) {
+	expectedConf := `{"Name":"aws","Version":"1.2.3"}`
+	expectedSchema := `{"resources":{}}`
+
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/aws/1.2.3/provider.json":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(expectedConf)) // nolint:errcheck
+		case "/aws/1.2.3/schema.json":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(expectedSchema)) // nolint:errcheck
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	registry := NewMondooProviderRegistry(WithBaseURL(server.URL))
+	ctx := context.Background()
+
+	t.Run("successful download", func(t *testing.T) {
+		conf, schema, err := registry.DownloadProviderMetadata(ctx, "aws", "1.2.3")
+		require.NoError(t, err)
+		assert.Equal(t, expectedConf, string(conf))
+		assert.Equal(t, expectedSchema, string(schema))
+	})
+
+	t.Run("provider not found", func(t *testing.T) {
+		_, _, err := registry.DownloadProviderMetadata(ctx, "nonexistent", "1.0.0")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot find provider.json")
+	})
+}


### PR DESCRIPTION
## Summary

Adds `mql providers install <name> --schema-only`, which installs only a provider's config and resource schema without pulling the binary down.

The key enabler: releases.mondoo.com already publishes `provider.json` and `schema.json` standalone next to each release archive (they're listed in the SHA256SUMS), so a schema-only install fetches just those two files — for aws that's **~2.6MB instead of the ~90MB tar.xz**. Streaming the archive and stopping early wouldn't have worked anyway: the binary is the first entry in the tar.

## Changes

- **`providers/registry.go`** — new `DownloadProviderMetadata(ctx, name, version)` on the `ProviderRegistry` interface, fetching `<base>/<name>/<version>/provider.json` + `schema.json`.
- **`providers/providers.go`** — `InstallSchemaOnly(name, version)`: downloads the two JSONs, packs them into an in-memory tar.xz, and installs through `InstallIO` — the schema-only path shares the exact staging/fsync/rename/load machinery of a full install. To support this, `InstallIO` now identifies providers by their `.resources.json` entry instead of the binary, making the binary optional; archives with binaries behave exactly as before. Schema-only deliberately doesn't care what's already installed — an existing binary is left in place and only the schema files are refreshed. A full install over a schema-only one upgrades it.
- **`apps/mql/cmd/providers.go`** — the flag itself (rejected alongside `--file`/`--url`); `providers list` marks schema-only installs with a dim `(schema-only)`. `providers update` always does a full install; `--schema-only` is an install-time option only.
- **`providers/registry_test.go`** — httptest coverage for the new registry method.
- **`providers/providers_test.go`** — `InstallIO` coverage: schema-only archive, archive with binary, and missing-config error.

## Verification

Against the real registry (with `PROVIDERS_PATH` pointing at a scratch dir):

- `mql providers install shodan --schema-only` → wrote only the two JSONs (25KB vs 22MB binary)
- `mql providers list` → `shodan 13.2.5 with connectors: shodan (schema-only)`
- `mql providers install shodan` over schema-only → clean upgrade to a full install
- `--schema-only` over a full install → schema files rewritten, binary left in place
- `gofmt` clean; `./providers` and `./apps/mql/cmd` test suites pass

Schema-only installs are meant for workflows that never start the provider (e.g. compiling queries against its schema); connecting to an asset requires a full install.

Caveat: very old pinned versions predating the standalone `schema.json` publication will 404 with a clear "cannot find schema.json" error; the fallback is a regular install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

