### PR TITLE
⚡ os: resolve rpm %{_dbpath} once instead of per package

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.mondoo.com/mql/providers/core/resources/versions/semver"
@@ -259,6 +260,13 @@ type RpmPkgManager struct {
 	platform      *inventory.Platform
 	staticChecked bool
 	static        bool
+
+	// The rpm database path (`%{_dbpath}`) is a system-wide constant, so it is
+	// resolved once via `rpm -E` and reused for every package that asks for its
+	// files instead of spawning one identical command per package.
+	dbPathMu       sync.Mutex
+	dbPathResolved bool
+	dbPathFiles    []FileRecord
 }
 
 func (rpm *RpmPkgManager) Name() string {
@@ -514,22 +522,52 @@ func (rpm *RpmPkgManager) Files(name string, version string, arch string) ([]Fil
 	if rpm.isStaticAnalysis() {
 		// nothing to do since the data is already attached to the package
 		return nil, nil
-	} else {
-		// This returns the path to the RPM database
-		cmd, err := rpm.conn.RunCommand("rpm -E '%{_dbpath}'")
-		if err != nil {
-			return nil, errors.Wrap(err, "could not rpm database path")
-		}
-		fileRecords := []FileRecord{}
-		scanner := bufio.NewScanner(cmd.Stdout)
-		for scanner.Scan() {
-			line := scanner.Text()
-			fileRecords = append(fileRecords, FileRecord{
-				Path: line,
-			})
-		}
-		return fileRecords, nil
 	}
+
+	// `%{_dbpath}` is the same for every package on the system, so we resolve it
+	// once and hand the cached result to every package that asks for its files.
+	// This avoids running one `rpm -E '%{_dbpath}'` command per package (an N+1
+	// on hosts with hundreds of packages).
+	records, err := rpm.dbPathFileRecords()
+	if err != nil {
+		return nil, err
+	}
+
+	// Return a copy so callers can't mutate the cached slice.
+	out := make([]FileRecord, len(records))
+	copy(out, records)
+	return out, nil
+}
+
+// dbPathFileRecords resolves the rpm database path (`%{_dbpath}`) once and caches
+// the resulting file records on the manager, so repeated calls reuse the cached
+// value instead of re-running the `rpm -E` command. A failed resolution is not
+// cached, so a transient error can be retried on the next call.
+func (rpm *RpmPkgManager) dbPathFileRecords() ([]FileRecord, error) {
+	rpm.dbPathMu.Lock()
+	defer rpm.dbPathMu.Unlock()
+
+	if rpm.dbPathResolved {
+		return rpm.dbPathFiles, nil
+	}
+
+	// This returns the path to the RPM database
+	cmd, err := rpm.conn.RunCommand("rpm -E '%{_dbpath}'")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not rpm database path")
+	}
+	fileRecords := []FileRecord{}
+	scanner := bufio.NewScanner(cmd.Stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fileRecords = append(fileRecords, FileRecord{
+			Path: line,
+		})
+	}
+
+	rpm.dbPathFiles = fileRecords
+	rpm.dbPathResolved = true
+	return fileRecords, nil
 }
 
 // SusePkgManager overwrites the normal RPM handler

--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -533,7 +533,11 @@ func (rpm *RpmPkgManager) Files(name string, version string, arch string) ([]Fil
 		return nil, err
 	}
 
-	// Return a copy so callers can't mutate the cached slice.
+	// Return a copy so callers can't mutate the cached slice. A shallow copy is
+	// enough because FileRecord is transitively value-typed: Path is a string,
+	// and PkgDigest and PkgFileInfo hold only strings and fixed-width integers.
+	// Adding a pointer, slice, or map to any of the three would make the copy
+	// share state with the cache again, and this would need to deep copy.
 	out := make([]FileRecord, len(records))
 	copy(out, records)
 	return out, nil

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
 func TestRedhat8Parser(t *testing.T) {
@@ -179,6 +181,61 @@ func TestRedhat8Parser(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(pkgFiles), "detected the right amount of package files")
 	assert.Contains(t, pkgFiles, FileRecord{Path: "/var/lib/rpm/rpmdb.sqlite"})
+}
+
+// countingConnection wraps a shared.Connection and counts how often each
+// command string is executed, so a test can assert that a command is issued
+// exactly once regardless of how many callers request it.
+type countingConnection struct {
+	shared.Connection
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func (c *countingConnection) RunCommand(command string) (*shared.Command, error) {
+	c.mu.Lock()
+	if c.counts == nil {
+		c.counts = map[string]int{}
+	}
+	c.counts[command]++
+	c.mu.Unlock()
+	return c.Connection.RunCommand(command)
+}
+
+func (c *countingConnection) count(command string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.counts[command]
+}
+
+// TestRpmFilesResolvesDBPathOnce guards the N+1 fix: `rpm -E '%{_dbpath}'`
+// returns the same system-wide constant for every package, so the manager must
+// resolve it once and reuse it, no matter how many packages ask for their files.
+func TestRpmFilesResolvesDBPathOnce(t *testing.T) {
+	base, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_redhat8.toml"))
+	require.NoError(t, err)
+
+	conn := &countingConnection{Connection: base}
+
+	pf := &inventory.Platform{
+		Name:    "redhat",
+		Version: "8.4",
+		Arch:    "x86_64",
+		Family:  []string{"redhat", "linux", "unix", "os"},
+		Labels:  map[string]string{"distro-id": "rhel"},
+	}
+
+	mgr := &RpmPkgManager{conn: conn, platform: pf}
+
+	const pkgCount = 500
+	for i := 0; i < pkgCount; i++ {
+		files, err := mgr.Files("which", "2.21-12.el8", "x86_64")
+		require.NoError(t, err)
+		require.Equal(t, []FileRecord{{Path: "/var/lib/rpm/rpmdb.sqlite"}}, files)
+	}
+
+	assert.Equal(t, 1, conn.count("rpm -E '%{_dbpath}'"),
+		"rpm database path must be resolved once and reused for every package")
 }
 
 func TestPhoton4ImageParser(t *testing.T) {


### PR DESCRIPTION
## Problem

On RPM-based hosts, package listing marks every package `FilesAvailable = PkgFilesAsync`, so each `mqlPackage.files()` access calls `RpmPkgManager.Files()`. In runtime mode (the `rpm` CLI is available), `Files()` ran `rpm -E '%{_dbpath}'` to discover the RPM database path — once per package.

The `%{_dbpath}` value is a system-wide constant (e.g. `/var/lib/rpm/rpmdb.sqlite`); it never varies between packages.

## Impact

`packages { files }` on a host with N installed packages spawned N identical `rpm -E '%{_dbpath}'` commands. On a typical 500-package host that is 500 process launches, all returning the same string.

## Fix

Resolve `%{_dbpath}` once and cache the resulting file records on the package manager behind a `sync.Mutex`-guarded field, reusing them for every package. `Files()` now returns a copy of the cached records, so callers can't mutate shared state.

- The returned value is unchanged.
- The runtime-vs-static-image code paths are preserved (static analysis still short-circuits, since the data is already attached to the package).
- A failed resolution is not cached, so a transient error can be retried on the next call.
- `SusePkgManager` embeds `RpmPkgManager`, so it inherits the same caching.

## Verification

- Added `TestRpmFilesResolvesDBPathOnce`, which wraps the mock connection in a counting connection, calls `Files()` 500 times on one manager, and asserts `rpm -E '%{_dbpath}'` is issued exactly once while every call still returns the correct file record.
- `go test ./providers/os/resources/packages/...` passes (existing RPM parser/files tests included).
