### PR TITLE
🧹 Protect resource init from wrong ARN service.

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -318,6 +319,74 @@ func getAssetIdentifier(runtime *plugin.Runtime) string {
 	}
 
 	return arnStr
+}
+
+// getAssetIdentifierForService returns the discovered asset's ARN, but only when
+// its service matches one of wantServices. Resource init functions adopt the
+// current asset's ARN (via getAssetIdentifier) when invoked with no arguments so
+// that a bare singular query like `aws.msk.cluster` resolves to the asset being
+// scanned. Without a service check, an asset from an unrelated service (e.g. a
+// Route53 hosted zone being synchronized while a policy references
+// aws.msk.cluster) would be adopted as this resource's own ARN, fabricating a
+// bogus husk resource keyed on the wrong ARN. Returning "" on a service mismatch
+// leaves args["arn"] unset so the caller falls through to its "arn required"
+// path instead.
+func getAssetIdentifierForService(runtime *plugin.Runtime, wantServices ...string) string {
+	assetArn := getAssetIdentifier(runtime)
+	if assetArn == "" {
+		return ""
+	}
+	parsed, err := arn.Parse(assetArn)
+	if err != nil {
+		return ""
+	}
+	for _, svc := range wantServices {
+		if parsed.Service == svc {
+			return assetArn
+		}
+	}
+	return ""
+}
+
+// resolveArnArg resolves and validates the args["arn"] an init function needs,
+// adopting the scanned asset's ARN when args is empty. It returns that ARN, and
+// on a nil error guarantees it is well-formed and belongs to one of
+// wantServices; everything else is an error, named after resource ("arn
+// required to fetch aws msk cluster"). Validating here also catches the ARN a
+// caller supplied explicitly, which getAssetIdentifierForService never sees.
+//
+// Use it only where an ARN is mandatory. Resources that accept an alternative
+// key -- a name, an id, or the bare key ID and "alias/..." forms aws.kms.key
+// takes -- must call getAssetIdentifierForService directly instead, since every
+// one of those is rejected here.
+func resolveArnArg(runtime *plugin.Runtime, args map[string]*llx.RawData, resource string, wantServices ...string) (string, error) {
+	// Adopt the scanned asset's ARN for a bare singular query like
+	// `aws.msk.cluster`, so it resolves to the asset being scanned.
+	if len(args) == 0 {
+		if assetArn := getAssetIdentifierForService(runtime, wantServices...); assetArn != "" {
+			args["arn"] = llx.StringData(assetArn)
+		}
+	}
+
+	if args["arn"] == nil {
+		return "", fmt.Errorf("arn required to fetch %s", resource)
+	}
+	arnVal, ok := args["arn"].Value.(string)
+	if !ok {
+		// Returning the ARN spares callers a bare args["arn"].Value.(string),
+		// which panics on a null or non-string argument -- and a panic in an
+		// init takes down the whole scan, not just this query.
+		return "", fmt.Errorf("arn for %s must be a string, got %T", resource, args["arn"].Value)
+	}
+
+	parsed, err := arn.Parse(arnVal)
+	if err != nil {
+		return "", fmt.Errorf("invalid arn %q for %s: %w", arnVal, resource, err)
+	}
+	if slices.Contains(wantServices, parsed.Service) {
+		return arnVal, nil
+	}
+	return "", fmt.Errorf("arn %q is not a %s arn: service is %q, expected %s", arnVal, resource, parsed.Service, strings.Join(wantServices, " or "))
 }
 
 // getAssetName returns the discovered asset's name, or "" when the connection

--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -319,74 +318,6 @@ func getAssetIdentifier(runtime *plugin.Runtime) string {
 	}
 
 	return arnStr
-}
-
-// getAssetIdentifierForService returns the discovered asset's ARN, but only when
-// its service matches one of wantServices. Resource init functions adopt the
-// current asset's ARN (via getAssetIdentifier) when invoked with no arguments so
-// that a bare singular query like `aws.msk.cluster` resolves to the asset being
-// scanned. Without a service check, an asset from an unrelated service (e.g. a
-// Route53 hosted zone being synchronized while a policy references
-// aws.msk.cluster) would be adopted as this resource's own ARN, fabricating a
-// bogus husk resource keyed on the wrong ARN. Returning "" on a service mismatch
-// leaves args["arn"] unset so the caller falls through to its "arn required"
-// path instead.
-func getAssetIdentifierForService(runtime *plugin.Runtime, wantServices ...string) string {
-	assetArn := getAssetIdentifier(runtime)
-	if assetArn == "" {
-		return ""
-	}
-	parsed, err := arn.Parse(assetArn)
-	if err != nil {
-		return ""
-	}
-	for _, svc := range wantServices {
-		if parsed.Service == svc {
-			return assetArn
-		}
-	}
-	return ""
-}
-
-// resolveArnArg resolves and validates the args["arn"] an init function needs,
-// adopting the scanned asset's ARN when args is empty. It returns that ARN, and
-// on a nil error guarantees it is well-formed and belongs to one of
-// wantServices; everything else is an error, named after resource ("arn
-// required to fetch aws msk cluster"). Validating here also catches the ARN a
-// caller supplied explicitly, which getAssetIdentifierForService never sees.
-//
-// Use it only where an ARN is mandatory. Resources that accept an alternative
-// key -- a name, an id, or the bare key ID and "alias/..." forms aws.kms.key
-// takes -- must call getAssetIdentifierForService directly instead, since every
-// one of those is rejected here.
-func resolveArnArg(runtime *plugin.Runtime, args map[string]*llx.RawData, resource string, wantServices ...string) (string, error) {
-	// Adopt the scanned asset's ARN for a bare singular query like
-	// `aws.msk.cluster`, so it resolves to the asset being scanned.
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, wantServices...); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return "", fmt.Errorf("arn required to fetch %s", resource)
-	}
-	arnVal, ok := args["arn"].Value.(string)
-	if !ok {
-		// Returning the ARN spares callers a bare args["arn"].Value.(string),
-		// which panics on a null or non-string argument -- and a panic in an
-		// init takes down the whole scan, not just this query.
-		return "", fmt.Errorf("arn for %s must be a string, got %T", resource, args["arn"].Value)
-	}
-
-	parsed, err := arn.Parse(arnVal)
-	if err != nil {
-		return "", fmt.Errorf("invalid arn %q for %s: %w", arnVal, resource, err)
-	}
-	if slices.Contains(wantServices, parsed.Service) {
-		return arnVal, nil
-	}
-	return "", fmt.Errorf("arn %q is not a %s arn: service is %q, expected %s", arnVal, resource, parsed.Service, strings.Join(wantServices, " or "))
 }
 
 // getAssetName returns the discovered asset's name, or "" when the connection

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -128,14 +128,9 @@ func initAwsApigatewayRestapi(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch gateway restapi")
+	arnVal, err := resolveArnArg(runtime, args, "gateway restapi", "apigateway")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, ResourceAwsApigateway, map[string]*llx.RawData{})
@@ -149,7 +144,6 @@ func initAwsApigatewayRestapi(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		restApi := rawResource.(*mqlAwsApigatewayRestapi)
 		if restApi.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -123,12 +123,17 @@ func (a *mqlAwsApigateway) getRestApis(conn *connection.AwsConnection) []*jobpoo
 	return tasks
 }
 
+var apigatewayRestapiArnSpec = arnSpec{
+	resource: ResourceAwsApigatewayRestapi,
+	services: []string{"apigateway"},
+}
+
 func initAwsApigatewayRestapi(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "gateway restapi", "apigateway")
+	ref, err := apigatewayRestapiArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,7 +151,7 @@ func initAwsApigatewayRestapi(runtime *plugin.Runtime, args map[string]*llx.RawD
 
 	for _, rawResource := range rawResources.Data {
 		restApi := rawResource.(*mqlAwsApigatewayRestapi)
-		if restApi.Arn.Data == arnVal {
+		if restApi.Arn.Data == ref.RawArn {
 			return args, restApi, nil
 		}
 	}

--- a/providers/aws/resources/aws_apigatewayv2.go
+++ b/providers/aws/resources/aws_apigatewayv2.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -142,6 +141,12 @@ func (a *mqlAwsApigatewayv2Api) id() (string, error) {
 	return apigatewayv2ApiArn(a.Region.Data, &a.ApiId.Data), nil
 }
 
+var apigatewayv2ApiArnSpec = arnSpec{
+	resource: ResourceAwsApigatewayv2Api,
+	services: []string{"apigateway"},
+	altKeys:  []string{"apiId"},
+}
+
 // initAwsApigatewayv2Api lets typed back-references like
 // aws.apigatewayv2.stage.api() resolve a previously-fetched api by apiId.
 // Without this init, NewResource would create an empty resource keyed on a
@@ -151,13 +156,9 @@ func initAwsApigatewayv2Api(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 	// Resolve a discovered asset (aws-apigatewayv2-api platform) by its ARN.
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "apigateway"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["apiId"] == nil && args["arn"] == nil {
-		return args, nil, errors.New("apiId or arn required to fetch aws.apigatewayv2.api")
+	ref, err := apigatewayv2ApiArnSpec.resolve(runtime, args)
+	if err != nil {
+		return args, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.apigatewayv2", map[string]*llx.RawData{})
@@ -169,13 +170,11 @@ func initAwsApigatewayv2Api(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return nil, nil, apis.Error
 	}
 
-	var wantApiId, wantArn string
+	var wantApiId string
 	if args["apiId"] != nil {
 		wantApiId = args["apiId"].Value.(string)
 	}
-	if args["arn"] != nil {
-		wantArn = args["arn"].Value.(string)
-	}
+	wantArn := ref.RawArn
 	for _, r := range apis.Data {
 		api := r.(*mqlAwsApigatewayv2Api)
 		if (wantApiId != "" && api.ApiId.Data == wantApiId) || (wantArn != "" && api.Arn.Data == wantArn) {

--- a/providers/aws/resources/aws_apigatewayv2.go
+++ b/providers/aws/resources/aws_apigatewayv2.go
@@ -152,7 +152,7 @@ func initAwsApigatewayv2Api(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 	// Resolve a discovered asset (aws-apigatewayv2-api platform) by its ARN.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "apigateway"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_appstream.go
+++ b/providers/aws/resources/aws_appstream.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/appstream"
 	appstreamtypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
 	"github.com/rs/zerolog/log"
@@ -203,17 +201,23 @@ func (a *mqlAwsAppstreamFleet) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+var appstreamFleetArnSpec = arnSpec{
+	resource: ResourceAwsAppstreamFleet,
+	services: []string{"appstream"},
+	prefix:   "fleet/",
+	altKeys:  []string{"name", "region"},
+}
+
 func initAwsAppstreamFleet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 	// Resolve a discovered asset (aws-appstream-fleet platform) by its ARN.
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "appstream"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	ref, err := appstreamFleetArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
-	region, name, err := parseAppstreamRef(args, "fleet/")
+	region, name, err := parseAppstreamRef(args, ref)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -461,11 +465,22 @@ func (a *mqlAwsAppstreamStack) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+var appstreamStackArnSpec = arnSpec{
+	resource: ResourceAwsAppstreamStack,
+	services: []string{"appstream"},
+	prefix:   "stack/",
+	altKeys:  []string{"name", "region"},
+}
+
 func initAwsAppstreamStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	region, name, err := parseAppstreamRef(args, "stack/")
+	ref, err := appstreamStackArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
+	}
+	region, name, err := parseAppstreamRef(args, ref)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -496,20 +511,11 @@ func initAwsAppstreamStack(runtime *plugin.Runtime, args map[string]*llx.RawData
 
 // parseAppstreamRef extracts region + resource name from init args. Supports
 // {arn}, {name + region}, or both. resourcePrefix is "fleet/" or "stack/".
-func parseAppstreamRef(args map[string]*llx.RawData, resourcePrefix string) (string, string, error) {
-	var region, name string
-	if a := args["arn"]; a != nil {
-		s, ok := a.Value.(string)
-		if !ok {
-			return "", "", errors.New("aws appstream init: arn must be a string")
-		}
-		parsed, err := arn.Parse(s)
-		if err != nil {
-			return "", "", err
-		}
-		region = parsed.Region
-		name = strings.TrimPrefix(parsed.Resource, resourcePrefix)
-	}
+// parseAppstreamRef resolves the region and resource name to describe, taking
+// them from the already-validated ARN and letting explicit region/name args
+// override.
+func parseAppstreamRef(args map[string]*llx.RawData, ref arnRef) (string, string, error) {
+	region, name := ref.Region, ref.ResourceID
 	if r := args["region"]; r != nil {
 		if s, ok := r.Value.(string); ok {
 			region = s
@@ -863,6 +869,13 @@ func (a *mqlAwsAppstream) getImages(conn *connection.AwsConnection) []*jobpool.J
 	return tasks
 }
 
+var appstreamImageArnSpec = arnSpec{
+	resource: ResourceAwsAppstreamImage,
+	services: []string{"appstream"},
+	prefix:   "image/",
+	altKeys:  []string{"name", "region"},
+}
+
 // initAwsAppstreamImage resolves a single AppStream image by ARN (or name +
 // region), enabling typed references such as aws.appstream.fleet.image to
 // return a populated image rather than an empty husk.
@@ -873,7 +886,11 @@ func initAwsAppstreamImage(runtime *plugin.Runtime, args map[string]*llx.RawData
 	if args["arn"] == nil && args["name"] == nil {
 		return args, nil, nil
 	}
-	region, name, err := parseAppstreamRef(args, "image/")
+	ref, err := appstreamImageArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
+	}
+	region, name, err := parseAppstreamRef(args, ref)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/aws/resources/aws_appstream.go
+++ b/providers/aws/resources/aws_appstream.go
@@ -209,7 +209,7 @@ func initAwsAppstreamFleet(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 	// Resolve a discovered asset (aws-appstream-fleet platform) by its ARN.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "appstream"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_arn.go
+++ b/providers/aws/resources/aws_arn.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// arnSpec declares how one MQL resource resolves the ARN that identifies it.
+//
+// Resource init functions adopt the scanned asset's ARN when invoked with no
+// arguments, so that a bare singular query like `aws.msk.cluster` resolves to
+// the asset being scanned. Without a service check, an asset from an unrelated
+// service (e.g. a Route53 hosted zone being synchronized while a policy
+// references aws.msk.cluster) would be adopted as this resource's own ARN,
+// fabricating a bogus husk resource keyed on the wrong ARN. Declaring the
+// accepted services once, next to the init that uses them, applies the same
+// check to the asset ARN and to an ARN the caller supplied explicitly.
+//
+// Declare one as a package-level var next to the init function it serves.
+type arnSpec struct {
+	// resource is the MQL resource name, given as the generated constant for
+	// it (ResourceAwsMskCluster) so a typo cannot compile. It names the
+	// resource in every error message.
+	resource string
+
+	// services lists the ARN service tokens this resource accepts ("kafka").
+	// Leaving it empty rejects every ARN, making the resource unresolvable.
+	services []string
+
+	// prefix optionally requires the ARN's resource segment to start with a
+	// given string ("cluster/"), and is trimmed off arnRef.ResourceID.
+	//
+	// Set it only where a mismatched segment is already an error today. Inits
+	// that treat the segment as a hint and fall back to scanning the parent
+	// collection (aws.vpc, aws.ec2.snapshot, aws.ecr.repository) must leave it
+	// empty and keep testing arnRef.Resource themselves, so a soft fallback
+	// does not turn into a hard failure.
+	prefix string
+
+	// altKeys lists the other init args that can identify this resource
+	// ("name", "id"). When it is empty the ARN is mandatory; otherwise resolve
+	// succeeds with a zero arnRef as long as one of these args is present, and
+	// the init resolves by that key instead.
+	altKeys []string
+
+	// allowRef permits the "arn" arg to carry a non-ARN reference. Only
+	// aws.kms.key needs this: it accepts a bare key ID or an "alias/..." name
+	// in the same arg, and normalizes them itself.
+	allowRef bool
+}
+
+// arnRef is an ARN that satisfied its arnSpec. Raw is "" when the spec allowed
+// the ARN to be absent because an altKey was supplied instead.
+type arnRef struct {
+	// ARN is the parsed form, for Region, AccountID and Resource. It is the
+	// zero value when Raw is empty or held a non-ARN reference (see allowRef).
+	arn.ARN
+
+	// RawArn is the ARN exactly as supplied, never reconstructed from ARN.
+	RawArn string
+
+	// ResourceID is ARN.Resource with the spec's prefix trimmed off, so
+	// "cluster/my-cluster" reads back as "my-cluster".
+	ResourceID string
+}
+
+// String returns the ARN as supplied, shadowing arn.ARN.String so a ref never
+// stringifies to a reconstruction of itself.
+func (r arnRef) String() string { return r.RawArn }
+
+// resolve produces the ARN identifying this resource, adopting the scanned
+// asset's ARN when args is empty. On a nil error the returned ref is either
+// well-formed and belongs to one of the spec's services, or empty because the
+// spec accepts an altKey that args supplied instead.
+//
+// It writes an adopted ARN back into args["arn"], so callers that pass args on
+// to CreateResource see it.
+func (s arnSpec) resolve(runtime *plugin.Runtime, args map[string]*llx.RawData) (arnRef, error) {
+	if len(args) == 0 {
+		if ref := s.assetRef(runtime); ref.RawArn != "" {
+			args["arn"] = llx.StringData(ref.RawArn)
+		}
+	}
+
+	raw := args["arn"]
+	if raw == nil {
+		if s.hasAltKey(args) {
+			return arnRef{}, nil
+		}
+		return arnRef{}, fmt.Errorf("%s required to fetch %s", s.keyList(), s.resource)
+	}
+
+	// Nothing can reach this today: the schema types arn as a string, so mqlc
+	// rejects anything else before the provider runs, and every NewResource
+	// caller that builds an arn from a *string nil-checks it first (a nil one
+	// would arrive as llx.NilData, whose Value is nil). Reading it with
+	// comma-ok keeps that true without depending on the convention holding:
+	// the alternative, a bare args["arn"].Value.(string), turns a future
+	// unguarded caller into an interface-conversion panic that GetData's
+	// recover reports as an Internal error naming no resource or field.
+	val, ok := raw.Value.(string)
+	if !ok {
+		return arnRef{}, fmt.Errorf("arn for %s must be a string, got %T", s.resource, raw.Value)
+	}
+	return s.parse(val)
+}
+
+// assetRef returns the scanned asset's ARN when it satisfies the spec, and the
+// zero arnRef otherwise. A zero ref leaves args["arn"] unset so resolve falls
+// through to its "arn required" path instead of adopting a foreign ARN.
+//
+// Call it directly instead of resolve in inits that identify the resource by
+// args derived from the asset ARN rather than by the ARN itself (region+name
+// for aws.codebuild.project, directoryId for aws.directoryservice.directory),
+// so that args does not gain an "arn" key those inits never read.
+func (s arnSpec) assetRef(runtime *plugin.Runtime) arnRef {
+	assetArn := getAssetIdentifier(runtime)
+	if assetArn == "" {
+		return arnRef{}
+	}
+	ref, err := s.parse(assetArn)
+	if err != nil {
+		return arnRef{}
+	}
+	return ref
+}
+
+// parse validates a single ARN string against the spec.
+func (s arnSpec) parse(val string) (arnRef, error) {
+	if s.allowRef && !strings.HasPrefix(val, "arn:") {
+		return arnRef{RawArn: val}, nil
+	}
+
+	parsed, err := arn.Parse(val)
+	if err != nil {
+		return arnRef{}, fmt.Errorf("invalid arn %q for %s: %w", val, s.resource, err)
+	}
+	if !slices.Contains(s.services, parsed.Service) {
+		return arnRef{}, fmt.Errorf("arn %q is not an %s arn: service is %q, expected %s",
+			val, s.resource, parsed.Service, strings.Join(s.services, " or "))
+	}
+	if s.prefix != "" && !strings.HasPrefix(parsed.Resource, s.prefix) {
+		return arnRef{}, fmt.Errorf("arn %q is not an %s arn: resource is %q, expected it to start with %q",
+			val, s.resource, parsed.Resource, s.prefix)
+	}
+
+	return arnRef{
+		ARN:        parsed,
+		RawArn:     val,
+		ResourceID: strings.TrimPrefix(parsed.Resource, s.prefix),
+	}, nil
+}
+
+// hasAltKey reports whether args carries one of the alternative identifying
+// keys this resource accepts in place of an ARN.
+func (s arnSpec) hasAltKey(args map[string]*llx.RawData) bool {
+	for _, key := range s.altKeys {
+		if args[key] != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// keyList renders the accepted identifying args for an error message, as
+// "arn", "arn or name", or "arn, id, or name".
+func (s arnSpec) keyList() string {
+	keys := append([]string{"arn"}, s.altKeys...)
+	switch len(keys) {
+	case 1:
+		return keys[0]
+	case 2:
+		return keys[0] + " or " + keys[1]
+	default:
+		return strings.Join(keys[:len(keys)-1], ", ") + ", or " + keys[len(keys)-1]
+	}
+}

--- a/providers/aws/resources/aws_arn_init_test.go
+++ b/providers/aws/resources/aws_arn_init_test.go
@@ -15,11 +15,11 @@ import (
 type arnInitFunc func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 
 // TestInitsRejectForeignArns covers every init that resolves strictly by ARN.
-// Both paths it exercises fail inside resolveArnArg, before the init builds an
+// Both paths it exercises fail inside arnSpec.resolve, before the init builds an
 // AWS client or issues a request, so the whole table runs offline with no
 // credentials.
 //
-// What it protects: an init that drops the resolveArnArg call (or reverts to
+// What it protects: an init that drops the arnSpec.resolve call (or reverts to
 // adopting the asset ARN unchecked) starts resolving a foreign ARN into a husk
 // resource whose fields are never set -- which surfaces to users as "provider
 // returned no data and no error for a field" and "llx: encountered a primitive
@@ -29,52 +29,53 @@ func TestInitsRejectForeignArns(t *testing.T) {
 	// some other service" for all of them.
 	const foreignArn = "arn:aws:iam::012345678910:role/some-role"
 
+	// Pairing each init with its spec keeps the expected resource name in the
+	// error messages tied to the single place that declares it.
 	cases := []struct {
 		init arnInitFunc
-		// resource is the name resolveArnArg puts in its error messages.
-		resource string
+		spec arnSpec
 	}{
-		{initAwsApigatewayRestapi, "gateway restapi"},
-		{initAwsBatchJobDefinition, "batch job definition"},
-		{initAwsCloudfrontDistribution, "cloudfront distribution"},
-		{initAwsCloudwatchLoggroup, "cloudwatch log group"},
-		{initAwsCognitoUserPool, "cognito user pool"},
-		{initAwsDocumentdbCluster, "documentdb cluster"},
-		{initAwsDocumentdbInstance, "documentdb instance"},
-		{initAwsDynamodbGlobaltable, "dynamodb global table"},
-		{initAwsDynamodbTable, "dynamodb table"},
-		{initAwsEc2Instance, "ec2 instance"},
-		{initAwsEc2Volume, "aws volume"},
-		{initAwsEcrImage, "ecr image"},
-		{initAwsEcsCluster, "ecs cluster"},
-		{initAwsEcsService, "ecs service"},
-		{initAwsEcsTask, "ecs task"},
-		{initAwsEcsTaskDefinition, "aws ecs task definition"},
-		{initAwsEfsFilesystem, "efs filesystem"},
-		{initAwsEksCluster, "eks cluster"},
-		{initAwsElasticacheCluster, "elasticache cluster"},
-		{initAwsElbLoadbalancer, "elb loadbalancer"},
-		{initAwsEmrCluster, "emr cluster"},
-		{initAwsFsxBackup, "fsx backup"},
-		{initAwsFsxCache, "fsx cache"},
-		{initAwsFsxFilesystem, "fsx filesystem"},
-		{initAwsMemorydbCluster, "memorydb cluster"},
-		{initAwsMskCluster, "aws msk cluster"},
-		{initAwsNeptuneCluster, "neptune cluster"},
-		{initAwsRdsDbcluster, "rds db cluster"},
-		{initAwsRdsDbinstance, "rds db instance"},
-		{initAwsRedshiftCluster, "redshift cluster"},
-		{initAwsSagemakerDomain, "sagemaker domain"},
-		{initAwsSagemakerModel, "sagemaker model"},
-		{initAwsSagemakerNotebookinstance, "sagemaker notebookinstance"},
-		{initAwsSecretsmanagerSecret, "secretsmanager secret"},
-		{initAwsSsmInstance, "ssm instance"},
-		{initAwsStoragegatewayGateway, "storage gateway"},
-		{initAwsTransferServer, "transfer server"},
+		{initAwsApigatewayRestapi, apigatewayRestapiArnSpec},
+		{initAwsBatchJobDefinition, batchJobDefinitionArnSpec},
+		{initAwsCloudfrontDistribution, cloudfrontDistributionArnSpec},
+		{initAwsCloudwatchLoggroup, cloudwatchLoggroupArnSpec},
+		{initAwsCognitoUserPool, cognitoUserPoolArnSpec},
+		{initAwsDocumentdbCluster, documentdbClusterArnSpec},
+		{initAwsDocumentdbInstance, documentdbInstanceArnSpec},
+		{initAwsDynamodbGlobaltable, dynamodbGlobaltableArnSpec},
+		{initAwsDynamodbTable, dynamodbTableArnSpec},
+		{initAwsEc2Instance, ec2InstanceArnSpec},
+		{initAwsEc2Volume, ec2VolumeArnSpec},
+		{initAwsEcrImage, ecrImageArnSpec},
+		{initAwsEcsCluster, ecsClusterArnSpec},
+		{initAwsEcsService, ecsServiceArnSpec},
+		{initAwsEcsTask, ecsTaskArnSpec},
+		{initAwsEcsTaskDefinition, ecsTaskDefinitionArnSpec},
+		{initAwsEfsFilesystem, efsFilesystemArnSpec},
+		{initAwsEksCluster, eksClusterArnSpec},
+		{initAwsElasticacheCluster, elasticacheClusterArnSpec},
+		{initAwsElbLoadbalancer, elbLoadbalancerArnSpec},
+		{initAwsEmrCluster, emrClusterArnSpec},
+		{initAwsFsxBackup, fsxBackupArnSpec},
+		{initAwsFsxCache, fsxCacheArnSpec},
+		{initAwsFsxFilesystem, fsxFilesystemArnSpec},
+		{initAwsMemorydbCluster, memorydbClusterArnSpec},
+		{initAwsMskCluster, mskClusterArnSpec},
+		{initAwsNeptuneCluster, neptuneClusterArnSpec},
+		{initAwsRdsDbcluster, rdsDbclusterArnSpec},
+		{initAwsRdsDbinstance, rdsDbinstanceArnSpec},
+		{initAwsRedshiftCluster, redshiftClusterArnSpec},
+		{initAwsSagemakerDomain, sagemakerDomainArnSpec},
+		{initAwsSagemakerModel, sagemakerModelArnSpec},
+		{initAwsSagemakerNotebookinstance, sagemakerNotebookinstanceArnSpec},
+		{initAwsSecretsmanagerSecret, secretsmanagerSecretArnSpec},
+		{initAwsSsmInstance, ssmInstanceArnSpec},
+		{initAwsStoragegatewayGateway, storagegatewayGatewayArnSpec},
+		{initAwsTransferServer, transferServerArnSpec},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.resource, func(t *testing.T) {
+		t.Run(tc.spec.resource, func(t *testing.T) {
 			t.Run("rejects an explicitly passed foreign arn", func(t *testing.T) {
 				runtime := testAwsIdentifierRuntime("irrelevant", nil)
 				args := map[string]*llx.RawData{"arn": llx.StringData(foreignArn)}
@@ -82,7 +83,7 @@ func TestInitsRejectForeignArns(t *testing.T) {
 				_, res, err := tc.init(runtime, args)
 
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "is not a "+tc.resource+" arn")
+				assert.Contains(t, err.Error(), "is not an "+tc.spec.resource+" arn")
 				assert.Nil(t, res, "must not build a resource from a foreign arn")
 			})
 
@@ -95,7 +96,7 @@ func TestInitsRejectForeignArns(t *testing.T) {
 				_, res, err := tc.init(runtime, args)
 
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "arn required to fetch "+tc.resource)
+				assert.Contains(t, err.Error(), "arn required to fetch "+tc.spec.resource)
 				assert.Nil(t, res, "must not build a resource from an unrelated asset")
 				assert.Nil(t, args["arn"], "must not leave a foreign arn in args")
 			})

--- a/providers/aws/resources/aws_arn_init_test.go
+++ b/providers/aws/resources/aws_arn_init_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+type arnInitFunc func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+
+// TestInitsRejectForeignArns covers every init that resolves strictly by ARN.
+// Both paths it exercises fail inside resolveArnArg, before the init builds an
+// AWS client or issues a request, so the whole table runs offline with no
+// credentials.
+//
+// What it protects: an init that drops the resolveArnArg call (or reverts to
+// adopting the asset ARN unchecked) starts resolving a foreign ARN into a husk
+// resource whose fields are never set -- which surfaces to users as "provider
+// returned no data and no error for a field" and "llx: encountered a primitive
+// with no type information", with no attribution back to the init at fault.
+func TestInitsRejectForeignArns(t *testing.T) {
+	// No resource in the table accepts iam, so this stands in for "an ARN from
+	// some other service" for all of them.
+	const foreignArn = "arn:aws:iam::012345678910:role/some-role"
+
+	cases := []struct {
+		init arnInitFunc
+		// resource is the name resolveArnArg puts in its error messages.
+		resource string
+	}{
+		{initAwsApigatewayRestapi, "gateway restapi"},
+		{initAwsBatchJobDefinition, "batch job definition"},
+		{initAwsCloudfrontDistribution, "cloudfront distribution"},
+		{initAwsCloudwatchLoggroup, "cloudwatch log group"},
+		{initAwsCognitoUserPool, "cognito user pool"},
+		{initAwsDocumentdbCluster, "documentdb cluster"},
+		{initAwsDocumentdbInstance, "documentdb instance"},
+		{initAwsDynamodbGlobaltable, "dynamodb global table"},
+		{initAwsDynamodbTable, "dynamodb table"},
+		{initAwsEc2Instance, "ec2 instance"},
+		{initAwsEc2Volume, "aws volume"},
+		{initAwsEcrImage, "ecr image"},
+		{initAwsEcsCluster, "ecs cluster"},
+		{initAwsEcsService, "ecs service"},
+		{initAwsEcsTask, "ecs task"},
+		{initAwsEcsTaskDefinition, "aws ecs task definition"},
+		{initAwsEfsFilesystem, "efs filesystem"},
+		{initAwsEksCluster, "eks cluster"},
+		{initAwsElasticacheCluster, "elasticache cluster"},
+		{initAwsElbLoadbalancer, "elb loadbalancer"},
+		{initAwsEmrCluster, "emr cluster"},
+		{initAwsFsxBackup, "fsx backup"},
+		{initAwsFsxCache, "fsx cache"},
+		{initAwsFsxFilesystem, "fsx filesystem"},
+		{initAwsMemorydbCluster, "memorydb cluster"},
+		{initAwsMskCluster, "aws msk cluster"},
+		{initAwsNeptuneCluster, "neptune cluster"},
+		{initAwsRdsDbcluster, "rds db cluster"},
+		{initAwsRdsDbinstance, "rds db instance"},
+		{initAwsRedshiftCluster, "redshift cluster"},
+		{initAwsSagemakerDomain, "sagemaker domain"},
+		{initAwsSagemakerModel, "sagemaker model"},
+		{initAwsSagemakerNotebookinstance, "sagemaker notebookinstance"},
+		{initAwsSecretsmanagerSecret, "secretsmanager secret"},
+		{initAwsSsmInstance, "ssm instance"},
+		{initAwsStoragegatewayGateway, "storage gateway"},
+		{initAwsTransferServer, "transfer server"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.resource, func(t *testing.T) {
+			t.Run("rejects an explicitly passed foreign arn", func(t *testing.T) {
+				runtime := testAwsIdentifierRuntime("irrelevant", nil)
+				args := map[string]*llx.RawData{"arn": llx.StringData(foreignArn)}
+
+				_, res, err := tc.init(runtime, args)
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "is not a "+tc.resource+" arn")
+				assert.Nil(t, res, "must not build a resource from a foreign arn")
+			})
+
+			t.Run("does not adopt an asset arn from another service", func(t *testing.T) {
+				// A bare singular query (`aws.msk.cluster` with no args) while an
+				// unrelated asset is being scanned must not adopt that asset's ARN.
+				runtime := testAwsIdentifierRuntime("irrelevant", []string{foreignArn})
+				args := map[string]*llx.RawData{}
+
+				_, res, err := tc.init(runtime, args)
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "arn required to fetch "+tc.resource)
+				assert.Nil(t, res, "must not build a resource from an unrelated asset")
+				assert.Nil(t, args["arn"], "must not leave a foreign arn in args")
+			})
+		})
+	}
+}

--- a/providers/aws/resources/aws_asset_identifier_test.go
+++ b/providers/aws/resources/aws_asset_identifier_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
@@ -74,6 +76,211 @@ func TestGetAssetIdentifier(t *testing.T) {
 		first := "arn:aws:s3:::first-bucket"
 		second := "arn:aws:s3:::second-bucket"
 		assert.Equal(t, second, getAssetIdentifier(testAwsIdentifierRuntime("my-bucket", []string{first, second})))
+	})
+}
+
+func TestGetAssetIdentifierForService(t *testing.T) {
+	const (
+		s3Arn  = "arn:aws:s3:::my-bucket"
+		mskArn = "arn:aws:kafka:us-east-1:012345678910:cluster/my-cluster/abc-123"
+	)
+
+	t.Run("returns the arn when the service matches", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
+		assert.Equal(t, mskArn, getAssetIdentifierForService(runtime, "kafka"))
+	})
+
+	t.Run("returns the arn when the service matches any of several", func(t *testing.T) {
+		// Some resources legitimately accept more than one service token, e.g.
+		// DocumentDB and Neptune assets both carry rds ARNs.
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
+		assert.Equal(t, mskArn, getAssetIdentifierForService(runtime, "rds", "kafka", "dynamodb"))
+	})
+
+	t.Run("returns empty when the service does not match", func(t *testing.T) {
+		// The regression this function exists for: a Route53 hosted zone asset
+		// must not be adopted as, say, an aws.msk.cluster ARN just because the
+		// init ran with no args.
+		runtime := testAwsIdentifierRuntime("example.com.", []string{"arn:aws:route53:::hostedzone/Z123456"})
+		assert.Empty(t, getAssetIdentifierForService(runtime, "kafka"))
+	})
+
+	t.Run("returns empty when none of several services match", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
+		assert.Empty(t, getAssetIdentifierForService(runtime, "kafka", "rds", "dynamodb"))
+	})
+
+	t.Run("returns empty when no service is requested", func(t *testing.T) {
+		// A caller that forgets its service token gets no ARN, not every ARN.
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
+		assert.Empty(t, getAssetIdentifierForService(runtime))
+	})
+
+	t.Run("matches the service exactly, not by prefix or substring", func(t *testing.T) {
+		// "ec2" must not be satisfied by "ec2messages" or vice versa, and a
+		// truncated token must not match a longer real one.
+		runtime := testAwsIdentifierRuntime("i-abc", []string{"arn:aws:ec2:us-east-1:012345678910:instance/i-abc"})
+		assert.Equal(t, "arn:aws:ec2:us-east-1:012345678910:instance/i-abc", getAssetIdentifierForService(runtime, "ec2"))
+		assert.Empty(t, getAssetIdentifierForService(runtime, "ec"))
+		assert.Empty(t, getAssetIdentifierForService(runtime, "ec2messages"))
+	})
+
+	t.Run("matches the service case-sensitively", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
+		assert.Empty(t, getAssetIdentifierForService(runtime, "S3"))
+	})
+
+	t.Run("matches global arns that carry no region or account", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
+		assert.Equal(t, s3Arn, getAssetIdentifierForService(runtime, "s3"))
+	})
+
+	t.Run("returns empty when the connection is not an AwsConnection", func(t *testing.T) {
+		assert.Empty(t, getAssetIdentifierForService(&plugin.Runtime{}, "s3"))
+	})
+
+	t.Run("returns empty when the asset has no arn", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("some-asset", []string{"not-an-arn"})
+		assert.Empty(t, getAssetIdentifierForService(runtime, "s3"))
+	})
+
+	t.Run("returns empty when the only arn fails to parse", func(t *testing.T) {
+		// An unparseable ARN is dropped by getAssetIdentifier, so there is
+		// nothing to service-match against.
+		runtime := testAwsIdentifierRuntime("AWS Account 010438491650", []string{"arn:aws:sts::010438491650"})
+		assert.Empty(t, getAssetIdentifierForService(runtime, "sts"))
+	})
+}
+
+func TestResolveArnArg(t *testing.T) {
+	const (
+		mskArn = "arn:aws:kafka:us-east-1:012345678910:cluster/my-cluster/abc-123"
+		s3Arn  = "arn:aws:s3:::my-bucket"
+	)
+
+	// --- adoption path: args empty, ARN comes from the scanned asset ---
+
+	t.Run("adopts the asset arn when the service matches", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
+		args := map[string]*llx.RawData{}
+		got, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+		require.NoError(t, err)
+		assert.Equal(t, mskArn, got)
+		assert.Equal(t, mskArn, args["arn"].Value.(string))
+	})
+
+	t.Run("errors when the asset belongs to another service", func(t *testing.T) {
+		// A Route53 hosted zone asset must not be adopted as an MSK cluster ARN
+		// just because the init ran with no args.
+		runtime := testAwsIdentifierRuntime("example.com.", []string{"arn:aws:route53:::hostedzone/Z123456"})
+		args := map[string]*llx.RawData{}
+		_, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+		require.ErrorContains(t, err, "arn required to fetch aws msk cluster")
+		assert.Nil(t, args["arn"])
+	})
+
+	t.Run("errors when there is no asset arn", func(t *testing.T) {
+		args := map[string]*llx.RawData{}
+		_, err := resolveArnArg(&plugin.Runtime{}, args, "aws msk cluster", "kafka")
+		require.ErrorContains(t, err, "arn required to fetch aws msk cluster")
+	})
+
+	t.Run("does not adopt the asset arn when args are already populated", func(t *testing.T) {
+		// Only the no-args form adopts; an explicit lookup must not be silently
+		// retargeted at the scanned asset.
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
+		args := map[string]*llx.RawData{"name": llx.StringData("other-cluster")}
+		_, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+		require.ErrorContains(t, err, "arn required to fetch aws msk cluster")
+		assert.Nil(t, args["arn"])
+	})
+
+	// --- validation path: ARN supplied explicitly by the caller ---
+
+	t.Run("accepts an explicit arn of the wanted service", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.StringData(mskArn)}
+		got, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+		require.NoError(t, err)
+		assert.Equal(t, mskArn, got)
+		assert.Equal(t, mskArn, args["arn"].Value.(string))
+	})
+
+	t.Run("returns an empty arn alongside every error", func(t *testing.T) {
+		// Callers use the returned ARN directly, so a failed call must not hand
+		// back a usable-looking value.
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		for _, bad := range []*llx.RawData{
+			llx.StringData(s3Arn),        // wrong service
+			llx.StringData("not-an-arn"), // not an arn at all
+			llx.IntData(42),              // not a string
+		} {
+			args := map[string]*llx.RawData{"arn": bad}
+			got, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+			require.Error(t, err)
+			assert.Empty(t, got)
+		}
+	})
+
+	t.Run("accepts an explicit arn matching any of several services", func(t *testing.T) {
+		// e.g. documentdb and neptune assets both carry rds ARNs.
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.StringData(mskArn)}
+		_, err := resolveArnArg(runtime, args, "documentdb cluster", "rds", "kafka")
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects an explicit arn from another service", func(t *testing.T) {
+		// The case the len(args)==0 gate structurally cannot see.
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.StringData("arn:aws:lambda:us-east-1:012345678910:function:my-fn:PROD")}
+		_, err := resolveArnArg(runtime, args, "cloudwatch log group", "logs")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not a cloudwatch log group arn")
+		assert.Contains(t, err.Error(), `service is "lambda"`)
+		assert.Contains(t, err.Error(), "expected logs")
+	})
+
+	t.Run("names every wanted service in the mismatch error", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.StringData(s3Arn)}
+		_, err := resolveArnArg(runtime, args, "documentdb cluster", "rds", "kafka")
+		require.ErrorContains(t, err, "expected rds or kafka")
+	})
+
+	t.Run("rejects a malformed arn", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.StringData("arn:aws:sts::010438491650")}
+		_, err := resolveArnArg(runtime, args, "ec2 instance", "sts")
+		require.ErrorContains(t, err, "invalid arn")
+	})
+
+	t.Run("rejects a reference that is not an arn", func(t *testing.T) {
+		// The hardened contract: resources that accept a non-ARN reference (a
+		// bare KMS key ID, an "alias/..." name, a bare resource name) must not
+		// use resolveArnArg at all -- here every one of them is an error.
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		for _, ref := range []string{"1234abcd-12ab-34cd-56ef-1234567890ab", "alias/my-key", "my-bucket", ""} {
+			args := map[string]*llx.RawData{"arn": llx.StringData(ref)}
+			_, err := resolveArnArg(runtime, args, "kms key", "kms")
+			require.Error(t, err, "ref %q", ref)
+		}
+	})
+
+	t.Run("rejects every arn when no service is wanted", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.StringData(s3Arn)}
+		_, err := resolveArnArg(runtime, args, "s3 bucket")
+		require.Error(t, err)
+	})
+
+	t.Run("errors instead of panicking on a non-string arn", func(t *testing.T) {
+		// Most inits go on to assert args["arn"].Value.(string) bare; a panic
+		// there would take down the whole scan.
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.IntData(42)}
+		_, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+		require.ErrorContains(t, err, "arn for aws msk cluster must be a string")
 	})
 }
 

--- a/providers/aws/resources/aws_asset_identifier_test.go
+++ b/providers/aws/resources/aws_asset_identifier_test.go
@@ -79,94 +79,111 @@ func TestGetAssetIdentifier(t *testing.T) {
 	})
 }
 
-func TestGetAssetIdentifierForService(t *testing.T) {
-	const (
-		s3Arn  = "arn:aws:s3:::my-bucket"
-		mskArn = "arn:aws:kafka:us-east-1:012345678910:cluster/my-cluster/abc-123"
-	)
+const (
+	testMskArn = "arn:aws:kafka:us-east-1:012345678910:cluster/my-cluster/abc-123"
+	testS3Arn  = "arn:aws:s3:::my-bucket"
+)
 
+var testMskSpec = arnSpec{resource: ResourceAwsMskCluster, services: []string{"kafka"}}
+
+func TestArnSpecAssetRef(t *testing.T) {
 	t.Run("returns the arn when the service matches", func(t *testing.T) {
-		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
-		assert.Equal(t, mskArn, getAssetIdentifierForService(runtime, "kafka"))
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{testMskArn})
+		assert.Equal(t, testMskArn, testMskSpec.assetRef(runtime).RawArn)
 	})
 
 	t.Run("returns the arn when the service matches any of several", func(t *testing.T) {
 		// Some resources legitimately accept more than one service token, e.g.
-		// DocumentDB and Neptune assets both carry rds ARNs.
-		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
-		assert.Equal(t, mskArn, getAssetIdentifierForService(runtime, "rds", "kafka", "dynamodb"))
+		// ecr repositories carry either an ecr or an ecr-public ARN.
+		spec := arnSpec{resource: ResourceAwsMskCluster, services: []string{"rds", "kafka", "dynamodb"}}
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{testMskArn})
+		assert.Equal(t, testMskArn, spec.assetRef(runtime).RawArn)
 	})
 
 	t.Run("returns empty when the service does not match", func(t *testing.T) {
-		// The regression this function exists for: a Route53 hosted zone asset
-		// must not be adopted as, say, an aws.msk.cluster ARN just because the
-		// init ran with no args.
+		// The regression the service gate exists for: a Route53 hosted zone
+		// asset must not be adopted as, say, an aws.msk.cluster ARN just because
+		// the init ran with no args.
 		runtime := testAwsIdentifierRuntime("example.com.", []string{"arn:aws:route53:::hostedzone/Z123456"})
-		assert.Empty(t, getAssetIdentifierForService(runtime, "kafka"))
+		assert.Empty(t, testMskSpec.assetRef(runtime).RawArn)
 	})
 
 	t.Run("returns empty when none of several services match", func(t *testing.T) {
-		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
-		assert.Empty(t, getAssetIdentifierForService(runtime, "kafka", "rds", "dynamodb"))
+		spec := arnSpec{resource: ResourceAwsMskCluster, services: []string{"kafka", "rds", "dynamodb"}}
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{testS3Arn})
+		assert.Empty(t, spec.assetRef(runtime).RawArn)
 	})
 
-	t.Run("returns empty when no service is requested", func(t *testing.T) {
-		// A caller that forgets its service token gets no ARN, not every ARN.
-		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
-		assert.Empty(t, getAssetIdentifierForService(runtime))
+	t.Run("returns empty when the spec wants no service", func(t *testing.T) {
+		// A spec that forgets its service token gets no ARN, not every ARN.
+		spec := arnSpec{resource: ResourceAwsS3Bucket}
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{testS3Arn})
+		assert.Empty(t, spec.assetRef(runtime).RawArn)
 	})
 
 	t.Run("matches the service exactly, not by prefix or substring", func(t *testing.T) {
 		// "ec2" must not be satisfied by "ec2messages" or vice versa, and a
 		// truncated token must not match a longer real one.
-		runtime := testAwsIdentifierRuntime("i-abc", []string{"arn:aws:ec2:us-east-1:012345678910:instance/i-abc"})
-		assert.Equal(t, "arn:aws:ec2:us-east-1:012345678910:instance/i-abc", getAssetIdentifierForService(runtime, "ec2"))
-		assert.Empty(t, getAssetIdentifierForService(runtime, "ec"))
-		assert.Empty(t, getAssetIdentifierForService(runtime, "ec2messages"))
+		const ec2Arn = "arn:aws:ec2:us-east-1:012345678910:instance/i-abc"
+		runtime := testAwsIdentifierRuntime("i-abc", []string{ec2Arn})
+		assert.Equal(t, ec2Arn, arnSpec{resource: ResourceAwsEc2Instance, services: []string{"ec2"}}.assetRef(runtime).RawArn)
+		assert.Empty(t, arnSpec{resource: ResourceAwsEc2Instance, services: []string{"ec"}}.assetRef(runtime).RawArn)
+		assert.Empty(t, arnSpec{resource: ResourceAwsEc2Instance, services: []string{"ec2messages"}}.assetRef(runtime).RawArn)
 	})
 
 	t.Run("matches the service case-sensitively", func(t *testing.T) {
-		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
-		assert.Empty(t, getAssetIdentifierForService(runtime, "S3"))
+		spec := arnSpec{resource: ResourceAwsS3Bucket, services: []string{"S3"}}
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{testS3Arn})
+		assert.Empty(t, spec.assetRef(runtime).RawArn)
 	})
 
 	t.Run("matches global arns that carry no region or account", func(t *testing.T) {
-		runtime := testAwsIdentifierRuntime("my-bucket", []string{s3Arn})
-		assert.Equal(t, s3Arn, getAssetIdentifierForService(runtime, "s3"))
+		runtime := testAwsIdentifierRuntime("my-bucket", []string{testS3Arn})
+		assert.Equal(t, testS3Arn, s3BucketArnSpec.assetRef(runtime).RawArn)
 	})
 
 	t.Run("returns empty when the connection is not an AwsConnection", func(t *testing.T) {
-		assert.Empty(t, getAssetIdentifierForService(&plugin.Runtime{}, "s3"))
+		assert.Empty(t, s3BucketArnSpec.assetRef(&plugin.Runtime{}).RawArn)
 	})
 
 	t.Run("returns empty when the asset has no arn", func(t *testing.T) {
 		runtime := testAwsIdentifierRuntime("some-asset", []string{"not-an-arn"})
-		assert.Empty(t, getAssetIdentifierForService(runtime, "s3"))
+		assert.Empty(t, s3BucketArnSpec.assetRef(runtime).RawArn)
 	})
 
 	t.Run("returns empty when the only arn fails to parse", func(t *testing.T) {
 		// An unparseable ARN is dropped by getAssetIdentifier, so there is
 		// nothing to service-match against.
+		spec := arnSpec{resource: ResourceAwsEc2Instance, services: []string{"sts"}}
 		runtime := testAwsIdentifierRuntime("AWS Account 010438491650", []string{"arn:aws:sts::010438491650"})
-		assert.Empty(t, getAssetIdentifierForService(runtime, "sts"))
+		assert.Empty(t, spec.assetRef(runtime).RawArn)
+	})
+
+	t.Run("rejects an asset arn whose resource segment fails the prefix", func(t *testing.T) {
+		// aws.codebuild.project only ever wants a project ARN; a codebuild
+		// report-group asset must not be adopted in its place.
+		runtime := testAwsIdentifierRuntime("my-reports", []string{"arn:aws:codebuild:us-east-1:012345678910:report-group/my-reports"})
+		assert.Empty(t, codebuildProjectArnSpec.assetRef(runtime).RawArn)
+	})
+
+	t.Run("trims the prefix off ResourceID", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("my-project", []string{"arn:aws:codebuild:us-east-1:012345678910:project/my-project"})
+		ref := codebuildProjectArnSpec.assetRef(runtime)
+		assert.Equal(t, "my-project", ref.ResourceID)
+		assert.Equal(t, "us-east-1", ref.Region)
 	})
 }
 
-func TestResolveArnArg(t *testing.T) {
-	const (
-		mskArn = "arn:aws:kafka:us-east-1:012345678910:cluster/my-cluster/abc-123"
-		s3Arn  = "arn:aws:s3:::my-bucket"
-	)
-
+func TestArnSpecResolve(t *testing.T) {
 	// --- adoption path: args empty, ARN comes from the scanned asset ---
 
 	t.Run("adopts the asset arn when the service matches", func(t *testing.T) {
-		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{testMskArn})
 		args := map[string]*llx.RawData{}
-		got, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+		got, err := testMskSpec.resolve(runtime, args)
 		require.NoError(t, err)
-		assert.Equal(t, mskArn, got)
-		assert.Equal(t, mskArn, args["arn"].Value.(string))
+		assert.Equal(t, testMskArn, got.RawArn)
+		assert.Equal(t, testMskArn, args["arn"].Value.(string))
 	})
 
 	t.Run("errors when the asset belongs to another service", func(t *testing.T) {
@@ -174,24 +191,24 @@ func TestResolveArnArg(t *testing.T) {
 		// just because the init ran with no args.
 		runtime := testAwsIdentifierRuntime("example.com.", []string{"arn:aws:route53:::hostedzone/Z123456"})
 		args := map[string]*llx.RawData{}
-		_, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
-		require.ErrorContains(t, err, "arn required to fetch aws msk cluster")
+		_, err := testMskSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "arn required to fetch aws.msk.cluster")
 		assert.Nil(t, args["arn"])
 	})
 
 	t.Run("errors when there is no asset arn", func(t *testing.T) {
 		args := map[string]*llx.RawData{}
-		_, err := resolveArnArg(&plugin.Runtime{}, args, "aws msk cluster", "kafka")
-		require.ErrorContains(t, err, "arn required to fetch aws msk cluster")
+		_, err := testMskSpec.resolve(&plugin.Runtime{}, args)
+		require.ErrorContains(t, err, "arn required to fetch aws.msk.cluster")
 	})
 
 	t.Run("does not adopt the asset arn when args are already populated", func(t *testing.T) {
 		// Only the no-args form adopts; an explicit lookup must not be silently
 		// retargeted at the scanned asset.
-		runtime := testAwsIdentifierRuntime("my-cluster", []string{mskArn})
+		runtime := testAwsIdentifierRuntime("my-cluster", []string{testMskArn})
 		args := map[string]*llx.RawData{"name": llx.StringData("other-cluster")}
-		_, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
-		require.ErrorContains(t, err, "arn required to fetch aws msk cluster")
+		_, err := testMskSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "arn required to fetch aws.msk.cluster")
 		assert.Nil(t, args["arn"])
 	})
 
@@ -199,34 +216,36 @@ func TestResolveArnArg(t *testing.T) {
 
 	t.Run("accepts an explicit arn of the wanted service", func(t *testing.T) {
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
-		args := map[string]*llx.RawData{"arn": llx.StringData(mskArn)}
-		got, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+		args := map[string]*llx.RawData{"arn": llx.StringData(testMskArn)}
+		got, err := testMskSpec.resolve(runtime, args)
 		require.NoError(t, err)
-		assert.Equal(t, mskArn, got)
-		assert.Equal(t, mskArn, args["arn"].Value.(string))
+		assert.Equal(t, testMskArn, got.RawArn)
+		assert.Equal(t, "us-east-1", got.Region)
+		assert.Equal(t, testMskArn, args["arn"].Value.(string))
 	})
 
-	t.Run("returns an empty arn alongside every error", func(t *testing.T) {
+	t.Run("returns an empty ref alongside every error", func(t *testing.T) {
 		// Callers use the returned ARN directly, so a failed call must not hand
 		// back a usable-looking value.
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
 		for _, bad := range []*llx.RawData{
-			llx.StringData(s3Arn),        // wrong service
+			llx.StringData(testS3Arn),    // wrong service
 			llx.StringData("not-an-arn"), // not an arn at all
 			llx.IntData(42),              // not a string
 		} {
 			args := map[string]*llx.RawData{"arn": bad}
-			got, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+			got, err := testMskSpec.resolve(runtime, args)
 			require.Error(t, err)
-			assert.Empty(t, got)
+			assert.Empty(t, got.RawArn)
+			assert.Empty(t, got.Region)
 		}
 	})
 
 	t.Run("accepts an explicit arn matching any of several services", func(t *testing.T) {
-		// e.g. documentdb and neptune assets both carry rds ARNs.
+		// e.g. an ecr repository ARN may be ecr or ecr-public.
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
-		args := map[string]*llx.RawData{"arn": llx.StringData(mskArn)}
-		_, err := resolveArnArg(runtime, args, "documentdb cluster", "rds", "kafka")
+		args := map[string]*llx.RawData{"arn": llx.StringData("arn:aws:ecr-public::012345678910:repository/my-repo")}
+		_, err := ecrRepositoryArnSpec.resolve(runtime, args)
 		require.NoError(t, err)
 	})
 
@@ -234,53 +253,103 @@ func TestResolveArnArg(t *testing.T) {
 		// The case the len(args)==0 gate structurally cannot see.
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
 		args := map[string]*llx.RawData{"arn": llx.StringData("arn:aws:lambda:us-east-1:012345678910:function:my-fn:PROD")}
-		_, err := resolveArnArg(runtime, args, "cloudwatch log group", "logs")
+		_, err := cloudwatchLoggroupArnSpec.resolve(runtime, args)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "is not a cloudwatch log group arn")
+		assert.Contains(t, err.Error(), "is not an aws.cloudwatch.loggroup arn")
 		assert.Contains(t, err.Error(), `service is "lambda"`)
 		assert.Contains(t, err.Error(), "expected logs")
 	})
 
 	t.Run("names every wanted service in the mismatch error", func(t *testing.T) {
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
-		args := map[string]*llx.RawData{"arn": llx.StringData(s3Arn)}
-		_, err := resolveArnArg(runtime, args, "documentdb cluster", "rds", "kafka")
-		require.ErrorContains(t, err, "expected rds or kafka")
+		args := map[string]*llx.RawData{"arn": llx.StringData(testS3Arn)}
+		_, err := ecrRepositoryArnSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "expected ecr or ecr-public")
 	})
 
 	t.Run("rejects a malformed arn", func(t *testing.T) {
+		spec := arnSpec{resource: ResourceAwsEc2Instance, services: []string{"sts"}}
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
 		args := map[string]*llx.RawData{"arn": llx.StringData("arn:aws:sts::010438491650")}
-		_, err := resolveArnArg(runtime, args, "ec2 instance", "sts")
+		_, err := spec.resolve(runtime, args)
 		require.ErrorContains(t, err, "invalid arn")
 	})
 
-	t.Run("rejects a reference that is not an arn", func(t *testing.T) {
-		// The hardened contract: resources that accept a non-ARN reference (a
-		// bare KMS key ID, an "alias/..." name, a bare resource name) must not
-		// use resolveArnArg at all -- here every one of them is an error.
+	t.Run("rejects a reference that is not an arn unless allowRef is set", func(t *testing.T) {
+		// Bare KMS key IDs, "alias/..." names and bare resource names are only
+		// legal in the arn arg of a spec that opts into them.
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		strict := arnSpec{resource: ResourceAwsKmsKey, services: []string{"kms"}}
 		for _, ref := range []string{"1234abcd-12ab-34cd-56ef-1234567890ab", "alias/my-key", "my-bucket", ""} {
 			args := map[string]*llx.RawData{"arn": llx.StringData(ref)}
-			_, err := resolveArnArg(runtime, args, "kms key", "kms")
+			_, err := strict.resolve(runtime, args)
 			require.Error(t, err, "ref %q", ref)
+
+			args = map[string]*llx.RawData{"arn": llx.StringData(ref)}
+			got, err := kmsKeyArnSpec.resolve(runtime, args)
+			require.NoError(t, err, "ref %q", ref)
+			assert.Equal(t, ref, got.RawArn)
 		}
 	})
 
-	t.Run("rejects every arn when no service is wanted", func(t *testing.T) {
+	t.Run("still validates an arn-shaped value when allowRef is set", func(t *testing.T) {
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
-		args := map[string]*llx.RawData{"arn": llx.StringData(s3Arn)}
-		_, err := resolveArnArg(runtime, args, "s3 bucket")
+		args := map[string]*llx.RawData{"arn": llx.StringData(testS3Arn)}
+		_, err := kmsKeyArnSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "is not an aws.kms.key arn")
+	})
+
+	t.Run("rejects every arn when the spec wants no service", func(t *testing.T) {
+		spec := arnSpec{resource: ResourceAwsS3Bucket}
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"arn": llx.StringData(testS3Arn)}
+		_, err := spec.resolve(runtime, args)
 		require.Error(t, err)
 	})
 
 	t.Run("errors instead of panicking on a non-string arn", func(t *testing.T) {
-		// Most inits go on to assert args["arn"].Value.(string) bare; a panic
-		// there would take down the whole scan.
+		// Unreachable in practice: the schema types arn as a string, and every
+		// caller building one from a *string nil-checks first. This pins the
+		// total behaviour so the guarantee survives a caller that does not.
 		runtime := testAwsIdentifierRuntime("irrelevant", nil)
 		args := map[string]*llx.RawData{"arn": llx.IntData(42)}
-		_, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
-		require.ErrorContains(t, err, "arn for aws msk cluster must be a string")
+		_, err := testMskSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "arn for aws.msk.cluster must be a string")
+	})
+
+	// --- altKeys: resources that accept an identifier other than an ARN ---
+
+	t.Run("succeeds with an empty ref when an altKey is supplied", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"name": llx.StringData("my-broker")}
+		got, err := mqBrokerArnSpec.resolve(runtime, args)
+		require.NoError(t, err)
+		assert.Empty(t, got.RawArn)
+	})
+
+	t.Run("errors when neither the arn nor any altKey is supplied", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"region": llx.StringData("us-east-1")}
+		_, err := mqBrokerArnSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "arn or name required to fetch aws.mq.broker")
+	})
+
+	t.Run("lists every accepted key in the missing-key error", func(t *testing.T) {
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{"region": llx.StringData("us-east-1")}
+		_, err := route53HostedZoneArnSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "arn, id, or name required to fetch aws.route53.hostedZone")
+	})
+
+	t.Run("still validates the arn when an altKey is also supplied", func(t *testing.T) {
+		// A wrong-service ARN is an error even though "name" alone would do.
+		runtime := testAwsIdentifierRuntime("irrelevant", nil)
+		args := map[string]*llx.RawData{
+			"arn":  llx.StringData(testS3Arn),
+			"name": llx.StringData("my-broker"),
+		}
+		_, err := mqBrokerArnSpec.resolve(runtime, args)
+		require.ErrorContains(t, err, "is not an aws.mq.broker arn")
 	})
 }
 

--- a/providers/aws/resources/aws_athena.go
+++ b/providers/aws/resources/aws_athena.go
@@ -91,7 +91,7 @@ func initAwsAthenaWorkgroup(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "athena"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_athena.go
+++ b/providers/aws/resources/aws_athena.go
@@ -82,6 +82,12 @@ func (a *mqlAwsAthena) getWorkgroups(conn *connection.AwsConnection) []*jobpool.
 	return tasks
 }
 
+var athenaWorkgroupArnSpec = arnSpec{
+	resource: ResourceAwsAthenaWorkgroup,
+	services: []string{"athena"},
+	altKeys:  []string{"name"},
+}
+
 // initAwsAthenaWorkgroup resolves a single Athena workgroup. When invoked
 // for a discovered asset (aws-athena-workgroup platform), no args are passed,
 // so the workgroup ARN is read from the connection's asset identifier and used
@@ -90,13 +96,8 @@ func initAwsAthenaWorkgroup(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "athena"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil && args["name"] == nil {
-		return args, nil, fmt.Errorf("arn or name required to fetch athena workgroup")
+	if _, err := athenaWorkgroupArnSpec.resolve(runtime, args); err != nil {
+		return args, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.athena", map[string]*llx.RawData{})

--- a/providers/aws/resources/aws_batch.go
+++ b/providers/aws/resources/aws_batch.go
@@ -604,6 +604,11 @@ func (a *mqlAwsBatch) jobDefinitions() ([]any, error) {
 	return res, nil
 }
 
+var batchJobDefinitionArnSpec = arnSpec{
+	resource: ResourceAwsBatchJobDefinition,
+	services: []string{"batch"},
+}
+
 // initAwsBatchJobDefinition resolves a single Batch job definition. When
 // invoked for a discovered asset (aws-batch-jobdefinition platform), no args
 // are passed, so the job definition ARN is read from the connection's asset
@@ -613,7 +618,7 @@ func initAwsBatchJobDefinition(runtime *plugin.Runtime, args map[string]*llx.Raw
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	wantArn, err := resolveArnArg(runtime, args, "batch job definition", "batch")
+	ref, err := batchJobDefinitionArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -629,14 +634,14 @@ func initAwsBatchJobDefinition(runtime *plugin.Runtime, args map[string]*llx.Raw
 
 	for _, r := range jds.Data {
 		jd := r.(*mqlAwsBatchJobDefinition)
-		if jd.Arn.Data == wantArn {
+		if jd.Arn.Data == ref.RawArn {
 			return args, jd, nil
 		}
 	}
 	// Returning (args, nil, nil) here would let the runtime create a resource
 	// whose fields are all unset, which surfaces as malformed nil data when
 	// those fields are queried.
-	return nil, nil, fmt.Errorf("aws.batch.jobDefinition with arn %q not found", wantArn)
+	return nil, nil, fmt.Errorf("aws.batch.jobDefinition with arn %q not found", ref.RawArn)
 }
 
 func (a *mqlAwsBatch) getJobDefinitions(conn *connection.AwsConnection) []*jobpool.Job {

--- a/providers/aws/resources/aws_batch.go
+++ b/providers/aws/resources/aws_batch.go
@@ -613,13 +613,9 @@ func initAwsBatchJobDefinition(runtime *plugin.Runtime, args map[string]*llx.Raw
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil {
-		return args, nil, fmt.Errorf("arn required to fetch batch job definition")
+	wantArn, err := resolveArnArg(runtime, args, "batch job definition", "batch")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.batch", map[string]*llx.RawData{})
@@ -631,7 +627,6 @@ func initAwsBatchJobDefinition(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return nil, nil, jds.Error
 	}
 
-	wantArn := args["arn"].Value.(string)
 	for _, r := range jds.Data {
 		jd := r.(*mqlAwsBatchJobDefinition)
 		if jd.Arn.Data == wantArn {

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -573,14 +573,9 @@ func initAwsCloudfrontDistribution(runtime *plugin.Runtime, args map[string]*llx
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch cloudfront distribution")
+	arnVal, err := resolveArnArg(runtime, args, "cloudfront distribution", "cloudfront")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.cloudfront", map[string]*llx.RawData{})
@@ -594,10 +589,6 @@ func initAwsCloudfrontDistribution(runtime *plugin.Runtime, args map[string]*llx
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal, ok := args["arn"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("arn must be a string")
-	}
 	for _, rawResource := range rawResources.Data {
 		distribution := rawResource.(*mqlAwsCloudfrontDistribution)
 		if distribution.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -568,12 +568,17 @@ func (a *mqlAwsCloudfrontAnycastIpList) tags() (map[string]any, error) {
 	return tags, nil
 }
 
+var cloudfrontDistributionArnSpec = arnSpec{
+	resource: ResourceAwsCloudfrontDistribution,
+	services: []string{"cloudfront"},
+}
+
 func initAwsCloudfrontDistribution(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "cloudfront distribution", "cloudfront")
+	ref, err := cloudfrontDistributionArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -591,7 +596,7 @@ func initAwsCloudfrontDistribution(runtime *plugin.Runtime, args map[string]*llx
 
 	for _, rawResource := range rawResources.Data {
 		distribution := rawResource.(*mqlAwsCloudfrontDistribution)
-		if distribution.Arn.Data == arnVal {
+		if distribution.Arn.Data == ref.RawArn {
 			return args, distribution, nil
 		}
 	}

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -46,17 +46,18 @@ func (a *mqlAwsCloudtrail) trails() ([]any, error) {
 	return res, nil
 }
 
+var cloudtrailTrailArnSpec = arnSpec{
+	resource: ResourceAwsCloudtrailTrail,
+	services: []string{"cloudtrail"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsCloudtrailTrail(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) >= 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "cloudtrail"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch aws cloudtrail trail")
+	if _, err := cloudtrailTrailArnSpec.resolve(runtime, args); err != nil {
+		return nil, nil, err
 	}
 
 	// We match the requested trail by ARN when supplied, otherwise by name.

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -51,7 +51,7 @@ func initAwsCloudtrailTrail(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "cloudtrail"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -702,17 +702,12 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch cloudwatch log group")
+	arnVal, err := resolveArnArg(runtime, args, "cloudwatch log group", "logs")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	conn := runtime.Connection.(*connection.AwsConnection)
-	arnVal := args["arn"].Value.(string)
 
 	// Targeted lookup: derive the region + group name from the ARN and fetch
 	// just this one log group (by name prefix) instead of describing every log

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -697,12 +697,17 @@ func buildLogGroupResource(runtime *plugin.Runtime, region string, loggroup clou
 	return mqlLogGroup.(*mqlAwsCloudwatchLoggroup), nil
 }
 
+var cloudwatchLoggroupArnSpec = arnSpec{
+	resource: ResourceAwsCloudwatchLoggroup,
+	services: []string{"logs"},
+}
+
 func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "cloudwatch log group", "logs")
+	ref, err := cloudwatchLoggroupArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -717,7 +722,7 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	region := ""
 	name := ""
 	sameAccount := true
-	if parsed, parseErr := arn.Parse(arnVal); parseErr == nil {
+	if parsed, parseErr := arn.Parse(ref.RawArn); parseErr == nil {
 		region = parsed.Region
 		name = strings.TrimSuffix(strings.TrimPrefix(parsed.Resource, "log-group:"), ":*")
 		sameAccount = parsed.AccountID == "" || parsed.AccountID == conn.AccountId()
@@ -772,12 +777,12 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	// other AWS services (e.g. EventBridge Pipes LogConfiguration) return the
 	// bare ARN without it. Compare both with and without the suffix so init
 	// resolves correctly regardless of which form the caller passes.
-	arnNoStar := strings.TrimSuffix(arnVal, ":*")
+	arnNoStar := strings.TrimSuffix(ref.RawArn, ":*")
 	for _, rawResource := range rawResources.Data {
 		logGroup := rawResource.(*mqlAwsCloudwatchLoggroup)
 		mqlLgArn := logGroup.Arn.Data
 
-		if mqlLgArn == arnVal || strings.TrimSuffix(mqlLgArn, ":*") == arnNoStar {
+		if mqlLgArn == ref.RawArn || strings.TrimSuffix(mqlLgArn, ":*") == arnNoStar {
 			return args, logGroup, nil
 		}
 	}
@@ -785,9 +790,9 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	// If the log group is in a different account (e.g., organizational trail referencing
 	// a log group in the management account), create a placeholder resource with basic
 	// info extracted from the ARN instead of failing.
-	if parsedArn, parseErr := arn.Parse(arnVal); parseErr == nil && parsedArn.AccountID != conn.AccountId() {
-		log.Warn().Str("arn", arnVal).Str("currentAccount", conn.AccountId()).Str("logGroupAccount", parsedArn.AccountID).Msg("cross-account CloudWatch log group reference")
-		grpRegion, groupName := parseLogGroupArn(arnVal)
+	if parsedArn, parseErr := arn.Parse(ref.RawArn); parseErr == nil && parsedArn.AccountID != conn.AccountId() {
+		log.Warn().Str("arn", ref.RawArn).Str("currentAccount", conn.AccountId()).Str("logGroupAccount", parsedArn.AccountID).Msg("cross-account CloudWatch log group reference")
+		grpRegion, groupName := parseLogGroupArn(ref.RawArn)
 		if grpRegion == "" || groupName == "" {
 			return nil, nil, errors.New("cloudwatch log group does not exist")
 		}

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -113,7 +113,7 @@ func initAwsCodebuildProject(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the project's region and name from the ARN carried on the asset.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "codebuild"); assetArn != "" {
 			parsed, err := arn.Parse(assetArn)
 			if err != nil {
 				return nil, nil, err

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
 	cbtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 	"github.com/rs/zerolog/log"
@@ -105,6 +104,15 @@ func (a *mqlAwsCodebuildProject) id() (string, error) {
 	return a.Name.Data, nil
 }
 
+// aws.codebuild.project is identified by name + region rather than by ARN, so
+// the init reads the asset ARN through assetRef and never keeps it in args.
+var codebuildProjectArnSpec = arnSpec{
+	resource: ResourceAwsCodebuildProject,
+	services: []string{"codebuild"},
+	prefix:   "project/",
+	altKeys:  []string{"name", "region"},
+}
+
 func initAwsCodebuildProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -113,13 +121,9 @@ func initAwsCodebuildProject(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the project's region and name from the ARN carried on the asset.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "codebuild"); assetArn != "" {
-			parsed, err := arn.Parse(assetArn)
-			if err != nil {
-				return nil, nil, err
-			}
-			args["region"] = llx.StringData(parsed.Region)
-			args["name"] = llx.StringData(strings.TrimPrefix(parsed.Resource, "project/"))
+		if ref := codebuildProjectArnSpec.assetRef(runtime); ref.RawArn != "" {
+			args["region"] = llx.StringData(ref.Region)
+			args["name"] = llx.StringData(ref.ResourceID)
 		}
 	}
 

--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -118,16 +118,11 @@ func initAwsCognitoUserPool(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the pool's region and id from the ARN carried on the asset.
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch cognito user pool")
+	arnVal, err := resolveArnArg(runtime, args, "cognito user pool", "cognito-idp")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	arnVal := args["arn"].Value.(string)
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -111,6 +111,11 @@ func (a *mqlAwsCognito) getUserPools(conn *connection.AwsConnection) []*jobpool.
 	return tasks
 }
 
+var cognitoUserPoolArnSpec = arnSpec{
+	resource: ResourceAwsCognitoUserPool,
+	services: []string{"cognito-idp"},
+}
+
 func initAwsCognitoUserPool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -118,12 +123,12 @@ func initAwsCognitoUserPool(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the pool's region and id from the ARN carried on the asset.
-	arnVal, err := resolveArnArg(runtime, args, "cognito user pool", "cognito-idp")
+	ref, err := cognitoUserPoolArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	parsed, err := arn.Parse(arnVal)
+	parsed, err := arn.Parse(ref.RawArn)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,8 +151,8 @@ func initAwsCognitoUserPool(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	up := resp.UserPool
 	mqlPool, err := CreateResource(runtime, "aws.cognito.userPool",
 		map[string]*llx.RawData{
-			"__id":      llx.StringData(arnVal),
-			"arn":       llx.StringData(arnVal),
+			"__id":      llx.StringData(ref.RawArn),
+			"arn":       llx.StringData(ref.RawArn),
 			"id":        llx.StringData(poolId),
 			"name":      llx.StringDataPtr(up.Name),
 			"region":    llx.StringData(region),

--- a/providers/aws/resources/aws_directoryservice.go
+++ b/providers/aws/resources/aws_directoryservice.go
@@ -53,7 +53,7 @@ func initAwsDirectoryserviceDirectory(runtime *plugin.Runtime, args map[string]*
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "ds"); assetArn != "" {
 			if parsed, err := arn.Parse(assetArn); err == nil {
 				args["directoryId"] = llx.StringData(strings.TrimPrefix(parsed.Resource, "directory/"))
 			}

--- a/providers/aws/resources/aws_directoryservice.go
+++ b/providers/aws/resources/aws_directoryservice.go
@@ -6,10 +6,8 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
 	dstypes "github.com/aws/aws-sdk-go-v2/service/directoryservice/types"
 	"github.com/rs/zerolog/log"
@@ -42,6 +40,16 @@ func (a *mqlAwsDirectoryservice) directories() ([]any, error) {
 	return res, nil
 }
 
+// aws.directoryservice.directory is identified by directoryId rather than by
+// ARN, so the init reads the asset ARN through assetRef and never keeps it in
+// args.
+var directoryserviceDirectoryArnSpec = arnSpec{
+	resource: ResourceAwsDirectoryserviceDirectory,
+	services: []string{"ds"},
+	prefix:   "directory/",
+	altKeys:  []string{"directoryId"},
+}
+
 // initAwsDirectoryserviceDirectory resolves a single Directory Service
 // directory. When invoked for a discovered asset
 // (aws-directoryservice-directory platform), no args are passed, so the
@@ -53,10 +61,8 @@ func initAwsDirectoryserviceDirectory(runtime *plugin.Runtime, args map[string]*
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "ds"); assetArn != "" {
-			if parsed, err := arn.Parse(assetArn); err == nil {
-				args["directoryId"] = llx.StringData(strings.TrimPrefix(parsed.Resource, "directory/"))
-			}
+		if ref := directoryserviceDirectoryArnSpec.assetRef(runtime); ref.RawArn != "" {
+			args["directoryId"] = llx.StringData(ref.ResourceID)
 		}
 	}
 	if args["directoryId"] == nil {

--- a/providers/aws/resources/aws_documentdb.go
+++ b/providers/aws/resources/aws_documentdb.go
@@ -254,11 +254,16 @@ type mqlAwsDocumentdbClusterInternal struct {
 	cacheSubnetGroupName             *string
 }
 
+var documentdbClusterArnSpec = arnSpec{
+	resource: ResourceAwsDocumentdbCluster,
+	services: []string{"rds"},
+}
+
 func initAwsDocumentdbCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	arnVal, err := resolveArnArg(runtime, args, "documentdb cluster", "rds")
+	ref, err := documentdbClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -272,14 +277,14 @@ func initAwsDocumentdbCluster(runtime *plugin.Runtime, args map[string]*llx.RawD
 	}
 	for _, raw := range rawResources.Data {
 		c := raw.(*mqlAwsDocumentdbCluster)
-		if c.Arn.Data == arnVal {
+		if c.Arn.Data == ref.RawArn {
 			return args, c, nil
 		}
 	}
 	// Returning (args, nil, nil) here would let the runtime create a resource
 	// whose fields are all unset, which surfaces as malformed nil data when
 	// those fields are queried.
-	return nil, nil, fmt.Errorf("aws.documentdb.cluster with arn %q not found", arnVal)
+	return nil, nil, fmt.Errorf("aws.documentdb.cluster with arn %q not found", ref.RawArn)
 }
 
 func (a *mqlAwsDocumentdbCluster) kmsKey() (*mqlAwsKmsKey, error) {
@@ -726,11 +731,16 @@ type mqlAwsDocumentdbInstanceInternal struct {
 	cacheClusterIdentifier           *string
 }
 
+var documentdbInstanceArnSpec = arnSpec{
+	resource: ResourceAwsDocumentdbInstance,
+	services: []string{"rds"},
+}
+
 func initAwsDocumentdbInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	arnVal, err := resolveArnArg(runtime, args, "documentdb instance", "rds")
+	ref, err := documentdbInstanceArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -744,14 +754,14 @@ func initAwsDocumentdbInstance(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 	for _, raw := range rawResources.Data {
 		i := raw.(*mqlAwsDocumentdbInstance)
-		if i.Arn.Data == arnVal {
+		if i.Arn.Data == ref.RawArn {
 			return args, i, nil
 		}
 	}
 	// Returning (args, nil, nil) here would let the runtime create a resource
 	// whose fields are all unset, which surfaces as malformed nil data when
 	// those fields are queried.
-	return nil, nil, fmt.Errorf("aws.documentdb.instance with arn %q not found", arnVal)
+	return nil, nil, fmt.Errorf("aws.documentdb.instance with arn %q not found", ref.RawArn)
 }
 
 func docdbInstancePendingModifiedValues(p *docdb_types.PendingModifiedValues) map[string]any {

--- a/providers/aws/resources/aws_documentdb.go
+++ b/providers/aws/resources/aws_documentdb.go
@@ -258,13 +258,9 @@ func initAwsDocumentdbCluster(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch documentdb cluster")
+	arnVal, err := resolveArnArg(runtime, args, "documentdb cluster", "rds")
+	if err != nil {
+		return nil, nil, err
 	}
 	d, err := docdbGetParent(runtime)
 	if err != nil {
@@ -274,7 +270,6 @@ func initAwsDocumentdbCluster(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if rawResources.Error != nil {
 		return nil, nil, rawResources.Error
 	}
-	arnVal := args["arn"].Value.(string)
 	for _, raw := range rawResources.Data {
 		c := raw.(*mqlAwsDocumentdbCluster)
 		if c.Arn.Data == arnVal {
@@ -735,13 +730,9 @@ func initAwsDocumentdbInstance(runtime *plugin.Runtime, args map[string]*llx.Raw
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch documentdb instance")
+	arnVal, err := resolveArnArg(runtime, args, "documentdb instance", "rds")
+	if err != nil {
+		return nil, nil, err
 	}
 	d, err := docdbGetParent(runtime)
 	if err != nil {
@@ -751,7 +742,6 @@ func initAwsDocumentdbInstance(runtime *plugin.Runtime, args map[string]*llx.Raw
 	if rawResources.Error != nil {
 		return nil, nil, rawResources.Error
 	}
-	arnVal := args["arn"].Value.(string)
 	for _, raw := range rawResources.Data {
 		i := raw.(*mqlAwsDocumentdbInstance)
 		if i.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -333,17 +333,10 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	arnVal, err := resolveArnArg(runtime, args, "dynamodb table", "dynamodb")
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch dynamodb table")
-	}
-
-	arnVal := args["arn"].Value.(string)
 
 	// No API call is required: the DynamoDB table ARN
 	// (arn:aws:dynamodb:<region>:<acct>:table/<name>) carries both the region
@@ -928,14 +921,9 @@ func initAwsDynamodbGlobaltable(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch dynamodb table")
+	arnVal, err := resolveArnArg(runtime, args, "dynamodb global table", "dynamodb")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.dynamodb", map[string]*llx.RawData{})
@@ -949,7 +937,6 @@ func initAwsDynamodbGlobaltable(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsDynamodbGlobaltable)
 		if dbInstance.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
 	aatypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -328,12 +327,17 @@ func (a *mqlAwsDynamodb) getBackups(conn *connection.AwsConnection) []*jobpool.J
 	return tasks
 }
 
+var dynamodbTableArnSpec = arnSpec{
+	resource: ResourceAwsDynamodbTable,
+	services: []string{"dynamodb"},
+}
+
 func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "dynamodb table", "dynamodb")
+	ref, err := dynamodbTableArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -345,9 +349,9 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	// So derive region + name from the ARN and build the shell directly instead
 	// of fanning ListTables across every region and scanning in memory.
 	var region, tableName string
-	if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "table/") {
-		region = parsed.Region
-		tableName = strings.TrimPrefix(parsed.Resource, "table/")
+	if strings.HasPrefix(ref.Resource, "table/") {
+		region = ref.Region
+		tableName = strings.TrimPrefix(ref.Resource, "table/")
 	}
 	if args["region"] != nil {
 		if r, ok := args["region"].Value.(string); ok && r != "" {
@@ -363,7 +367,7 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	if region != "" && tableName != "" {
 		table, err := CreateResource(runtime, "aws.dynamodb.table",
 			map[string]*llx.RawData{
-				"arn":    llx.StringData(arnVal),
+				"arn":    llx.StringData(ref.RawArn),
 				"name":   llx.StringData(tableName),
 				"region": llx.StringData(region),
 				"id":     llx.StringData(""),
@@ -389,7 +393,7 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsDynamodbTable)
-		if dbInstance.Arn.Data == arnVal {
+		if dbInstance.Arn.Data == ref.RawArn {
 			return args, dbInstance, nil
 		}
 	}
@@ -916,12 +920,17 @@ func (a *mqlAwsDynamodbGlobaltable) replicaSettings() ([]any, error) {
 	return convert.JsonToDictSlice(tableSettingsResp.ReplicaSettings)
 }
 
+var dynamodbGlobaltableArnSpec = arnSpec{
+	resource: ResourceAwsDynamodbGlobaltable,
+	services: []string{"dynamodb"},
+}
+
 func initAwsDynamodbGlobaltable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "dynamodb global table", "dynamodb")
+	ref, err := dynamodbGlobaltableArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -939,7 +948,7 @@ func initAwsDynamodbGlobaltable(runtime *plugin.Runtime, args map[string]*llx.Ra
 
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsDynamodbGlobaltable)
-		if dbInstance.Arn.Data == arnVal {
+		if dbInstance.Arn.Data == ref.RawArn {
 			return args, dbInstance, nil
 		}
 	}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2138,7 +2138,7 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "ec2"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -2506,16 +2506,10 @@ func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	arnVal, err := resolveArnArg(runtime, args, "aws volume", "ec2")
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch aws volume")
-	}
-	arnVal := args["arn"].Value.(string)
 
 	parsed, err := arn.Parse(arnVal)
 	if err == nil && parsed.Region != "" && strings.HasPrefix(parsed.Resource, "volume/") {
@@ -2655,16 +2649,10 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 
 	log.Debug().Msg("init an ec2 instance")
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	arnVal, err := resolveArnArg(runtime, args, "ec2 instance", "ec2")
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch ec2 instance")
-	}
-	arnVal := args["arn"].Value.(string)
 
 	// Parse the ARN to extract region + instance id and target a single
 	// DescribeInstances call. Fall back to the cross-region list path only
@@ -2756,7 +2744,7 @@ func initAwsEc2Snapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "ec2"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2132,30 +2132,31 @@ func buildSecurityGroupResource(runtime *plugin.Runtime, region, accountID strin
 	return sg, nil
 }
 
+// The spec declares no prefix: an ec2 ARN for some other resource type is not
+// an error here, it just means the targeted lookup below is skipped in favour
+// of scanning the cached list.
+var ec2SecuritygroupArnSpec = arnSpec{
+	resource: ResourceAwsEc2Securitygroup,
+	services: []string{"ec2"},
+	altKeys:  []string{"id"},
+}
+
 func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "ec2"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil && args["id"] == nil {
-		return nil, nil, errors.New("arn or id required to fetch aws security group")
+	ref, err := ec2SecuritygroupArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Derive region + groupId for a single targeted DescribeSecurityGroups
 	// call instead of listing every SG in every region.
 	var region, groupId string
-	if args["arn"] != nil {
-		arnVal := args["arn"].Value.(string)
-		if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "security-group/") {
-			region = parsed.Region
-			groupId = strings.TrimPrefix(parsed.Resource, "security-group/")
-		}
+	if strings.HasPrefix(ref.Resource, "security-group/") {
+		region = ref.Region
+		groupId = strings.TrimPrefix(ref.Resource, "security-group/")
 	}
 	if args["id"] != nil && groupId == "" {
 		groupId = args["id"].Value.(string)
@@ -2501,21 +2502,25 @@ func (a *mqlAwsEc2) getVolumes(conn *connection.AwsConnection) []*jobpool.Job {
 	return tasks
 }
 
+var ec2VolumeArnSpec = arnSpec{
+	resource: ResourceAwsEc2Volume,
+	services: []string{"ec2"},
+}
+
 func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "aws volume", "ec2")
+	ref, err := ec2VolumeArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	parsed, err := arn.Parse(arnVal)
-	if err == nil && parsed.Region != "" && strings.HasPrefix(parsed.Resource, "volume/") {
-		volumeId := strings.TrimPrefix(parsed.Resource, "volume/")
+	if ref.Region != "" && strings.HasPrefix(ref.Resource, "volume/") {
+		volumeId := strings.TrimPrefix(ref.Resource, "volume/")
 		conn := runtime.Connection.(*connection.AwsConnection)
-		svc := conn.Ec2(parsed.Region)
+		svc := conn.Ec2(ref.Region)
 		resp, err := svc.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
 			VolumeIds: []string{volumeId},
 		})
@@ -2523,7 +2528,7 @@ func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 			return nil, nil, err
 		}
 		if len(resp.Volumes) > 0 {
-			mqlVol, err := buildVolumeResource(runtime, parsed.Region, conn.AccountId(), resp.Volumes[0])
+			mqlVol, err := buildVolumeResource(runtime, ref.Region, conn.AccountId(), resp.Volumes[0])
 			if err != nil {
 				return nil, nil, err
 			}
@@ -2544,7 +2549,7 @@ func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	}
 	for _, rawResource := range rawResources.Data {
 		volume := rawResource.(*mqlAwsEc2Volume)
-		if volume.Arn.Data == arnVal {
+		if volume.Arn.Data == ref.RawArn {
 			return args, volume, nil
 		}
 	}
@@ -2643,13 +2648,18 @@ func (a *mqlAwsEc2Volume) kmsKey() (*mqlAwsKmsKey, error) {
 	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
+var ec2InstanceArnSpec = arnSpec{
+	resource: ResourceAwsEc2Instance,
+	services: []string{"ec2"},
+}
+
 func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
 	log.Debug().Msg("init an ec2 instance")
-	arnVal, err := resolveArnArg(runtime, args, "ec2 instance", "ec2")
+	ref, err := ec2InstanceArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2657,9 +2667,8 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	// Parse the ARN to extract region + instance id and target a single
 	// DescribeInstances call. Fall back to the cross-region list path only
 	// when the ARN is malformed.
-	parsed, err := arn.Parse(arnVal)
-	if err == nil && parsed.Region != "" && strings.HasPrefix(parsed.Resource, "instance/") {
-		instanceId := strings.TrimPrefix(parsed.Resource, "instance/")
+	if ref.Region != "" && strings.HasPrefix(ref.Resource, "instance/") {
+		instanceId := strings.TrimPrefix(ref.Resource, "instance/")
 		obj, err := CreateResource(runtime, ResourceAwsEc2, map[string]*llx.RawData{})
 		if err != nil {
 			return nil, nil, err
@@ -2667,7 +2676,7 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		mqlEc2 := obj.(*mqlAwsEc2)
 
 		conn := runtime.Connection.(*connection.AwsConnection)
-		svc := conn.Ec2(parsed.Region)
+		svc := conn.Ec2(ref.Region)
 		resp, err := svc.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{
 			InstanceIds: []string{instanceId},
 		})
@@ -2678,7 +2687,7 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 			if len(reservation.Instances) == 0 {
 				continue
 			}
-			res, err := mqlEc2.gatherInstanceInfo(reservation.Instances[:1], parsed.Region)
+			res, err := mqlEc2.gatherInstanceInfo(reservation.Instances[:1], ref.Region)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -2701,7 +2710,7 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 	for _, rawResource := range rawResources.Data {
 		instance := rawResource.(*mqlAwsEc2Instance)
-		if instance.Arn.Data == arnVal {
+		if instance.Arn.Data == ref.RawArn {
 			return args, instance, nil
 		}
 	}
@@ -2738,43 +2747,44 @@ func buildSnapshotResource(runtime *plugin.Runtime, region, accountID string, sn
 	return s, nil
 }
 
+// The spec declares no prefix: an ec2 ARN for some other resource type is not
+// an error here, it just means the targeted lookup below is skipped in favour
+// of scanning the cached list.
+var ec2SnapshotArnSpec = arnSpec{
+	resource: ResourceAwsEc2Snapshot,
+	services: []string{"ec2"},
+	altKeys:  []string{"id"},
+}
+
 func initAwsEc2Snapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "ec2"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil && args["id"] == nil {
-		return nil, nil, errors.New("arn or id required to fetch aws snapshot")
+	ref, err := ec2SnapshotArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Targeted path: arn carries the region and snapshot id.
-	if args["arn"] != nil {
-		arnVal := args["arn"].Value.(string)
-		if parsed, err := arn.Parse(arnVal); err == nil && parsed.Region != "" && strings.HasPrefix(parsed.Resource, "snapshot/") {
-			snapshotId := strings.TrimPrefix(parsed.Resource, "snapshot/")
-			conn := runtime.Connection.(*connection.AwsConnection)
-			svc := conn.Ec2(parsed.Region)
-			resp, err := svc.DescribeSnapshots(context.Background(), &ec2.DescribeSnapshotsInput{
-				SnapshotIds: []string{snapshotId},
-			})
+	if ref.Region != "" && strings.HasPrefix(ref.Resource, "snapshot/") {
+		snapshotId := strings.TrimPrefix(ref.Resource, "snapshot/")
+		conn := runtime.Connection.(*connection.AwsConnection)
+		svc := conn.Ec2(ref.Region)
+		resp, err := svc.DescribeSnapshots(context.Background(), &ec2.DescribeSnapshotsInput{
+			SnapshotIds: []string{snapshotId},
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(resp.Snapshots) > 0 {
+			mqlSnap, err := buildSnapshotResource(runtime, ref.Region, conn.AccountId(), resp.Snapshots[0])
 			if err != nil {
 				return nil, nil, err
 			}
-			if len(resp.Snapshots) > 0 {
-				mqlSnap, err := buildSnapshotResource(runtime, parsed.Region, conn.AccountId(), resp.Snapshots[0])
-				if err != nil {
-					return nil, nil, err
-				}
-				return args, mqlSnap, nil
-			}
-			return nil, nil, errors.New("snapshot does not exist")
+			return args, mqlSnap, nil
 		}
+		return nil, nil, errors.New("snapshot does not exist")
 	}
 
 	// Fallback: scan the cached list when only an opaque id was supplied or
@@ -3621,8 +3631,10 @@ func (a *mqlAwsEc2Vpnconnection) customerGateway() (*mqlAwsEc2CustomerGateway, e
 
 // Customer gateway (#4)
 
-const customerGatewayArnPattern = "arn:aws:ec2:%s:%s:customer-gateway/%s"
-const egressOnlyIgwArnPattern = "arn:aws:ec2:%s:%s:egress-only-internet-gateway/%s"
+const (
+	customerGatewayArnPattern = "arn:aws:ec2:%s:%s:customer-gateway/%s"
+	egressOnlyIgwArnPattern   = "arn:aws:ec2:%s:%s:egress-only-internet-gateway/%s"
+)
 
 func (a *mqlAwsEc2CustomerGateway) id() (string, error) {
 	return a.Arn.Data, nil

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
@@ -502,12 +501,17 @@ func (a *mqlAwsEcrImage) repository() (*mqlAwsEcrRepository, error) {
 	return res.(*mqlAwsEcrRepository), nil
 }
 
+var ecrImageArnSpec = arnSpec{
+	resource: ResourceAwsEcrImage,
+	services: []string{"ecr", "ecr-public"},
+}
+
 func initAwsEcrImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "ecr image", "ecr")
+	ref, err := ecrImageArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -524,7 +528,7 @@ func initAwsEcrImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 	for _, rawResource := range rawResources.Data {
 		image := rawResource.(*mqlAwsEcrImage)
-		if image.Arn.Data == arnVal {
+		if image.Arn.Data == ref.RawArn {
 			return args, image, nil
 		}
 	}
@@ -953,28 +957,29 @@ func (a *mqlAwsEcrScanningConfigurationRule) id() (string, error) {
 	return a.__id, nil
 }
 
+var ecrRepositoryArnSpec = arnSpec{
+	resource: ResourceAwsEcrRepository,
+	services: []string{"ecr", "ecr-public"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsEcrRepository(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "ecr"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch ecr repository")
+	ref, err := ecrRepositoryArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// When an ARN is supplied, the registry kind (private vs public), region,
 	// and repository name are all encoded in it, so we can issue a single
 	// targeted DescribeRepositories call instead of listing every repository in
 	// every region (plus all public repos).
-	if args["arn"] != nil {
-		arnVal, _ := args["arn"].Value.(string)
-		if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "repository/") {
+	if ref.RawArn != "" {
+		parsed := ref.ARN
+		if strings.HasPrefix(parsed.Resource, "repository/") {
 			name := strings.TrimPrefix(parsed.Resource, "repository/")
 			conn := runtime.Connection.(*connection.AwsConnection)
 			switch parsed.Service {

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -507,14 +507,9 @@ func initAwsEcrImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch ecr image")
+	arnVal, err := resolveArnArg(runtime, args, "ecr image", "ecr")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.ecr", map[string]*llx.RawData{})
@@ -527,7 +522,6 @@ func initAwsEcrImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	if rawResources.Error != nil {
 		return nil, nil, rawResources.Error
 	}
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		image := rawResource.(*mqlAwsEcrImage)
 		if image.Arn.Data == arnVal {
@@ -965,7 +959,7 @@ func initAwsEcrRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "ecr"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -157,16 +157,10 @@ func initAwsEcsCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	a, err := resolveArnArg(runtime, args, "ecs cluster", "ecs")
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch ecs cluster")
-	}
-	a := args["arn"].Value.(string)
 	conn := runtime.Connection.(*connection.AwsConnection)
 
 	// Validate and parse ARN if provided
@@ -428,16 +422,10 @@ func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	a, err := resolveArnArg(runtime, args, "ecs task", "ecs")
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch ecs task")
-	}
-	a := args["arn"].Value.(string)
 	conn := runtime.Connection.(*connection.AwsConnection)
 
 	parsedARN, err := validateAndParseARN(a, "ecs")
@@ -2085,16 +2073,10 @@ func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	a, err := resolveArnArg(runtime, args, "ecs service", "ecs")
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch ecs service")
-	}
-	a := args["arn"].Value.(string)
 	conn := runtime.Connection.(*connection.AwsConnection)
 
 	// Validate and parse ARN if provided
@@ -2596,14 +2578,9 @@ func initAwsEcsTaskDefinition(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch aws ecs task definition")
+	arnVal, err := resolveArnArg(runtime, args, "aws ecs task definition", "ecs")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.ecs", map[string]*llx.RawData{})
@@ -2617,7 +2594,6 @@ func initAwsEcsTaskDefinition(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal, _ := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		td := rawResource.(*mqlAwsEcsTaskDefinition)
 		if td.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -152,28 +152,27 @@ func (a *mqlAwsEcs) getECSClusters(conn *connection.AwsConnection) []*jobpool.Jo
 	return tasks
 }
 
+var ecsClusterArnSpec = arnSpec{
+	resource: ResourceAwsEcsCluster,
+	services: []string{"ecs"},
+}
+
 func initAwsEcsCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	a, err := resolveArnArg(runtime, args, "ecs cluster", "ecs")
+	ref, err := ecsClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 	conn := runtime.Connection.(*connection.AwsConnection)
 
-	// Validate and parse ARN if provided
-	parsedARN, err := validateAndParseARN(a, "ecs")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	region := parsedARN.Region
+	region := ref.Region
 
 	svc := conn.Ecs(region)
 	ctx := context.Background()
-	clusterDetails, err := svc.DescribeClusters(ctx, &ecs.DescribeClustersInput{Clusters: []string{a}, Include: []ecstypes.ClusterField{ecstypes.ClusterFieldConfigurations, ecstypes.ClusterFieldSettings, ecstypes.ClusterFieldStatistics, ecstypes.ClusterFieldTags}})
+	clusterDetails, err := svc.DescribeClusters(ctx, &ecs.DescribeClustersInput{Clusters: []string{ref.RawArn}, Include: []ecstypes.ClusterField{ecstypes.ClusterFieldConfigurations, ecstypes.ClusterFieldSettings, ecstypes.ClusterFieldStatistics, ecstypes.ClusterFieldTags}})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -216,7 +215,7 @@ func initAwsEcsCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	}
 	args["statistics"] = llx.MapData(statisticsMap, types.String)
 
-	clusterArn := a
+	clusterArn := ref.RawArn
 	strategyItems := make([]any, 0, len(c.DefaultCapacityProviderStrategy))
 	for _, item := range c.DefaultCapacityProviderStrategy {
 		cpName := ""
@@ -417,31 +416,31 @@ func (s *mqlAwsEcsTask) id() (string, error) {
 	return s.Arn.Data, nil
 }
 
+var ecsTaskArnSpec = arnSpec{
+	resource: ResourceAwsEcsTask,
+	services: []string{"ecs"},
+}
+
 func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	a, err := resolveArnArg(runtime, args, "ecs task", "ecs")
+	ref, err := ecsTaskArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 	conn := runtime.Connection.(*connection.AwsConnection)
 
-	parsedARN, err := validateAndParseARN(a, "ecs")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	region := parsedARN.Region
+	region := ref.Region
 	clusterName := ""
-	if res := strings.Split(parsedARN.Resource, "/"); len(res) == 3 {
+	if res := strings.Split(ref.Resource, "/"); len(res) == 3 {
 		clusterName = res[1]
 	}
 
 	svc := conn.Ecs(region)
 	ctx := context.Background()
-	params := &ecs.DescribeTasksInput{Tasks: []string{a}, Cluster: &clusterName, Include: []ecstypes.TaskField{ecstypes.TaskFieldTags}}
+	params := &ecs.DescribeTasksInput{Tasks: []string{ref.RawArn}, Cluster: &clusterName, Include: []ecstypes.TaskField{ecstypes.TaskFieldTags}}
 	taskDetails, err := svc.DescribeTasks(ctx, params)
 	if err != nil {
 		return nil, nil, err
@@ -755,27 +754,6 @@ func (s *mqlAwsEcsContainer) id() (string, error) {
 
 func ecsTagsToMap(tags []ecstypes.Tag) map[string]any {
 	return tagsToMap(tags, func(t ecstypes.Tag) *string { return t.Key }, func(t ecstypes.Tag) *string { return t.Value })
-}
-
-// validateAndParseARN validates that the given string is a valid ECS ARN
-// and returns the parsed ARN structure. Returns an error if the ARN is malformed
-// or does not belong to the expectedService.
-func validateAndParseARN(arnStr, expectedService string) (*arn.ARN, error) {
-	if !strings.HasPrefix(arnStr, "arn:") {
-		return nil, errors.Newf("invalid ARN format: %s", arnStr)
-	}
-
-	parsedArn, err := arn.Parse(arnStr)
-	if err != nil {
-		return nil, err
-	}
-
-	if parsedArn.Service != expectedService {
-		return nil, errors.Newf("invalid ARN (service is %s, expected %s): %s",
-			parsedArn.Service, expectedService, arnStr)
-	}
-
-	return &parsedArn, nil
 }
 
 func (a *mqlAwsEcs) taskDefinitions() ([]any, error) {
@@ -2068,27 +2046,26 @@ func (n *mqlAwsEcsServiceNetworkConfiguration) awsVpcConfiguration() (*mqlAwsEcs
 	return n.AwsVpcConfiguration.Data, nil
 }
 
+var ecsServiceArnSpec = arnSpec{
+	resource: ResourceAwsEcsService,
+	services: []string{"ecs"},
+}
+
 func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	a, err := resolveArnArg(runtime, args, "ecs service", "ecs")
+	ref, err := ecsServiceArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 	conn := runtime.Connection.(*connection.AwsConnection)
 
-	// Validate and parse ARN if provided
-	parsedARN, err := validateAndParseARN(a, "ecs")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	region := parsedARN.Region
+	region := ref.Region
 	clusterName := ""
 	serviceName := ""
-	if res := strings.Split(parsedARN.Resource, "/"); len(res) >= 2 {
+	if res := strings.Split(ref.Resource, "/"); len(res) >= 2 {
 		clusterName = res[1]
 		if len(res) >= 3 {
 			serviceName = res[2]
@@ -2097,7 +2074,7 @@ func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 
 	// Extract service name from ARN
 
-	clusterArn := fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", region, parsedARN.AccountID, clusterName)
+	clusterArn := fmt.Sprintf("arn:aws:ecs:%s:%s:cluster/%s", region, ref.AccountID, clusterName)
 
 	svc := conn.Ecs(region)
 	ctx := context.Background()
@@ -2120,7 +2097,7 @@ func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	var deploymentConfigResource any
 	if s.DeploymentConfiguration != nil {
 		var err error
-		deploymentConfigResource, err = createDeploymentConfigurationResource(runtime, s.DeploymentConfiguration, a)
+		deploymentConfigResource, err = createDeploymentConfigurationResource(runtime, s.DeploymentConfiguration, ref.RawArn)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2130,7 +2107,7 @@ func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	var networkConfigResource any
 	if s.NetworkConfiguration != nil {
 		var err error
-		networkConfigResource, err = createNetworkConfigurationResource(runtime, s.NetworkConfiguration, a)
+		networkConfigResource, err = createNetworkConfigurationResource(runtime, s.NetworkConfiguration, ref.RawArn)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2573,12 +2550,17 @@ func (a *mqlAwsEcsTaskSet) service() (*mqlAwsEcsService, error) {
 	return res.(*mqlAwsEcsService), nil
 }
 
+var ecsTaskDefinitionArnSpec = arnSpec{
+	resource: ResourceAwsEcsTaskDefinition,
+	services: []string{"ecs"},
+}
+
 func initAwsEcsTaskDefinition(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "aws ecs task definition", "ecs")
+	ref, err := ecsTaskDefinitionArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2596,11 +2578,11 @@ func initAwsEcsTaskDefinition(runtime *plugin.Runtime, args map[string]*llx.RawD
 
 	for _, rawResource := range rawResources.Data {
 		td := rawResource.(*mqlAwsEcsTaskDefinition)
-		if td.Arn.Data == arnVal {
+		if td.Arn.Data == ref.RawArn {
 			return args, td, nil
 		}
 	}
-	return nil, nil, errors.New("aws ecs task definition does not exist: " + arnVal)
+	return nil, nil, errors.New("aws ecs task definition does not exist: " + ref.RawArn)
 }
 
 func (a *mqlAwsEcs) capacityProviders() ([]any, error) {

--- a/providers/aws/resources/aws_ecs_test.go
+++ b/providers/aws/resources/aws_ecs_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateAndParseARN(t *testing.T) {
+// TestEcsArnSpecParse keeps the ARN-shape cases that used to guard the ECS
+// provider's own validateAndParseARN, now that arnSpec.parse does that work for
+// every resource.
+func TestEcsArnSpecParse(t *testing.T) {
 	tests := []struct {
 		name            string
 		arn             string
@@ -50,12 +53,13 @@ func TestValidateAndParseARN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := validateAndParseARN(tt.arn, tt.expectedService)
+			spec := arnSpec{resource: ResourceAwsEcsCluster, services: []string{tt.expectedService}}
+			got, err := spec.parse(tt.arn)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, got)
+				require.Equal(t, tt.arn, got.RawArn)
 				require.Equal(t, tt.expectedService, got.Service)
 			}
 		})

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -158,17 +158,10 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	arnVal, err := resolveArnArg(runtime, args, "efs filesystem", "elasticfilesystem")
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch efs filesystem")
-	}
-
-	arnVal := args["arn"].Value.(string)
 
 	// Derive region + filesystem id for a single targeted DescribeFileSystems
 	// call instead of listing every filesystem in every region.

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/efs"
 	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
 	"github.com/aws/smithy-go/transport/http"
@@ -153,12 +152,17 @@ func (a *mqlAwsEfsFilesystem) kmsKey() (*mqlAwsKmsKey, error) {
 	return nil, nil
 }
 
+var efsFilesystemArnSpec = arnSpec{
+	resource: ResourceAwsEfsFilesystem,
+	services: []string{"elasticfilesystem"},
+}
+
 func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "efs filesystem", "elasticfilesystem")
+	ref, err := efsFilesystemArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -166,9 +170,9 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	// Derive region + filesystem id for a single targeted DescribeFileSystems
 	// call instead of listing every filesystem in every region.
 	var region, fsId string
-	if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "file-system/") {
-		region = parsed.Region
-		fsId = strings.TrimPrefix(parsed.Resource, "file-system/")
+	if strings.HasPrefix(ref.Resource, "file-system/") {
+		region = ref.Region
+		fsId = strings.TrimPrefix(ref.Resource, "file-system/")
 	}
 
 	if region != "" && fsId != "" {
@@ -205,7 +209,7 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	for _, rawResource := range rawResources.Data {
 		fs := rawResource.(*mqlAwsEfsFilesystem)
-		if fs.Arn.Data == arnVal {
+		if fs.Arn.Data == ref.RawArn {
 			return args, fs, nil
 		}
 	}

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -479,12 +479,17 @@ func (a *mqlAwsEksCluster) certificateAuthority() (string, error) {
 	return "", a.fetchDetail()
 }
 
+var eksClusterArnSpec = arnSpec{
+	resource: ResourceAwsEksCluster,
+	services: []string{"eks"},
+}
+
 func initAwsEksCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "eks cluster", "eks")
+	ref, err := eksClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -500,7 +505,7 @@ func initAwsEksCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsEksCluster)
-		if cluster.Arn.Data == arnVal {
+		if cluster.Arn.Data == ref.RawArn {
 			return args, cluster, nil
 		}
 	}

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -484,14 +484,9 @@ func initAwsEksCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch eks cluster")
+	arnVal, err := resolveArnArg(runtime, args, "eks cluster", "eks")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// load all eks clusters
@@ -503,7 +498,6 @@ func initAwsEksCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	eks := obj.(*mqlAwsEks)
 	rawResources := eks.GetClusters()
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsEksCluster)
 		if cluster.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -646,14 +646,9 @@ func initAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch elasticache cluster")
+	arnVal, err := resolveArnArg(runtime, args, "elasticache cluster", "elasticache")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.elasticache", map[string]*llx.RawData{})
@@ -667,10 +662,6 @@ func initAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal, ok := args["arn"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("arn must be a string")
-	}
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsElasticacheCluster)
 		if cluster.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -641,12 +641,17 @@ func (a *mqlAwsElasticacheServerlessCache) subnets() ([]any, error) {
 	return res, nil
 }
 
+var elasticacheClusterArnSpec = arnSpec{
+	resource: ResourceAwsElasticacheCluster,
+	services: []string{"elasticache"},
+}
+
 func initAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "elasticache cluster", "elasticache")
+	ref, err := elasticacheClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -664,7 +669,7 @@ func initAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.Raw
 
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsElasticacheCluster)
-		if cluster.Arn.Data == arnVal {
+		if cluster.Arn.Data == ref.RawArn {
 			return args, cluster, nil
 		}
 	}

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -444,12 +444,17 @@ func buildElbV2LoadBalancerResource(runtime *plugin.Runtime, region, accountID s
 	return res, nil
 }
 
+var elbLoadbalancerArnSpec = arnSpec{
+	resource: ResourceAwsElbLoadbalancer,
+	services: []string{"elasticloadbalancing"},
+}
+
 func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "elb loadbalancer", "elasticloadbalancing")
+	ref, err := elbLoadbalancerArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -457,10 +462,10 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	// Issue a single targeted Describe against the ARN's region instead of
 	// listing every load balancer in every region. ELBv2 (app/net/gateway) and
 	// classic ELB live in different APIs; discriminate by the ARN form.
-	region, err := GetRegionFromArn(arnVal)
+	region, err := GetRegionFromArn(ref.RawArn)
 	if err == nil && region != "" {
 		conn := runtime.Connection.(*connection.AwsConnection)
-		if isV1LoadBalancerArn(arnVal) {
+		if isV1LoadBalancerArn(ref.RawArn) {
 			// Classic ELB: the synthetic ARN encodes the name as
 			// loadbalancer/classic/<name>.
 			name := ""
@@ -470,9 +475,7 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 				}
 			}
 			if name == "" {
-				if parsed, perr := arn.Parse(arnVal); perr == nil {
-					name = strings.TrimPrefix(parsed.Resource, "loadbalancer/classic/")
-				}
+				name = strings.TrimPrefix(ref.Resource, "loadbalancer/classic/")
 			}
 			if name != "" {
 				svc := conn.Elb(region)
@@ -496,7 +499,7 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		} else {
 			svc := conn.Elbv2(region)
 			resp, err := svc.DescribeLoadBalancers(context.Background(), &elasticloadbalancingv2.DescribeLoadBalancersInput{
-				LoadBalancerArns: []string{arnVal},
+				LoadBalancerArns: []string{ref.RawArn},
 			})
 			if err != nil {
 				// Surface unexpected errors; on access-denied or a stale ARN
@@ -528,7 +531,7 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 	for _, rawResource := range rawResources.Data {
 		lb := rawResource.(*mqlAwsElbLoadbalancer)
-		if lb.Arn.Data == arnVal {
+		if lb.Arn.Data == ref.RawArn {
 			return args, lb, nil
 		}
 	}
@@ -539,7 +542,7 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 	for _, rawResource := range classicResources.Data {
 		lb := rawResource.(*mqlAwsElbLoadbalancer)
-		if lb.Arn.Data == arnVal {
+		if lb.Arn.Data == ref.RawArn {
 			return args, lb, nil
 		}
 	}

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -449,23 +449,9 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch elb loadbalancer")
-	}
-
-	arnVal := args["arn"].Value.(string)
-
-	// Quick check: if the ARN doesn't belong to elasticloadbalancing, this asset
-	// is not an ELB. This happens when the query runs against non-ELB discovered
-	// assets (e.g., DynamoDB tables, IAM users, S3 buckets).
-	if arnVal == "" || !strings.Contains(arnVal, ":elasticloadbalancing:") {
-		return nil, nil, errors.New("elb load balancer does not exist")
+	arnVal, err := resolveArnArg(runtime, args, "elb loadbalancer", "elasticloadbalancing")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Issue a single targeted Describe against the ARN's region instead of

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -112,14 +112,9 @@ func initAwsEmrCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch emr cluster")
+	arnVal, err := resolveArnArg(runtime, args, "emr cluster", "elasticmapreduce")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.emr", map[string]*llx.RawData{})
@@ -133,10 +128,6 @@ func initAwsEmrCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal, ok := args["arn"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("arn must be a string")
-	}
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsEmrCluster)
 		if cluster.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -107,12 +107,17 @@ func (a *mqlAwsEmr) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 	return tasks
 }
 
+var emrClusterArnSpec = arnSpec{
+	resource: ResourceAwsEmrCluster,
+	services: []string{"elasticmapreduce"},
+}
+
 func initAwsEmrCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "emr cluster", "elasticmapreduce")
+	ref, err := emrClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -130,7 +135,7 @@ func initAwsEmrCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsEmrCluster)
-		if cluster.Arn.Data == arnVal {
+		if cluster.Arn.Data == ref.RawArn {
 			return args, cluster, nil
 		}
 	}

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -429,7 +429,7 @@ func initAwsEsDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "es"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -423,19 +423,19 @@ func newMqlAwsEsDomain(runtime *plugin.Runtime, region, accountID string, svc *e
 	return mqlDomain, nil
 }
 
+var esDomainArnSpec = arnSpec{
+	resource: ResourceAwsEsDomain,
+	services: []string{"es"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsEsDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "es"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch es domain")
+	if _, err := esDomainArnSpec.resolve(runtime, args); err != nil {
+		return nil, nil, err
 	}
 
 	// If we have an ARN but missing region or name, extract from ARN

--- a/providers/aws/resources/aws_fsx.go
+++ b/providers/aws/resources/aws_fsx.go
@@ -120,12 +120,17 @@ func (a *mqlAwsFsx) getFileSystems(conn *connection.AwsConnection) []*jobpool.Jo
 	return tasks
 }
 
+var fsxFilesystemArnSpec = arnSpec{
+	resource: ResourceAwsFsxFilesystem,
+	services: []string{"fsx"},
+}
+
 func initAwsFsxFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "fsx filesystem", "fsx")
+	ref, err := fsxFilesystemArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,7 +149,7 @@ func initAwsFsxFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	for _, rawResource := range rawResources.Data {
 		fs := rawResource.(*mqlAwsFsxFilesystem)
-		if fs.Arn.Data == arnVal {
+		if fs.Arn.Data == ref.RawArn {
 			return args, fs, nil
 		}
 	}
@@ -308,12 +313,17 @@ func (a *mqlAwsFsx) getCaches(conn *connection.AwsConnection) []*jobpool.Job {
 	return tasks
 }
 
+var fsxCacheArnSpec = arnSpec{
+	resource: ResourceAwsFsxCache,
+	services: []string{"fsx"},
+}
+
 func initAwsFsxCache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "fsx cache", "fsx")
+	ref, err := fsxCacheArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -332,7 +342,7 @@ func initAwsFsxCache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 
 	for _, rawResource := range rawResources.Data {
 		cache := rawResource.(*mqlAwsFsxCache)
-		if cache.Arn.Data == arnVal {
+		if cache.Arn.Data == ref.RawArn {
 			return args, cache, nil
 		}
 	}
@@ -479,12 +489,17 @@ func (a *mqlAwsFsx) getBackups(conn *connection.AwsConnection) []*jobpool.Job {
 	return tasks
 }
 
+var fsxBackupArnSpec = arnSpec{
+	resource: ResourceAwsFsxBackup,
+	services: []string{"fsx"},
+}
+
 func initAwsFsxBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "fsx backup", "fsx")
+	ref, err := fsxBackupArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -503,7 +518,7 @@ func initAwsFsxBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 
 	for _, rawResource := range rawResources.Data {
 		backup := rawResource.(*mqlAwsFsxBackup)
-		if backup.Arn.Data == arnVal {
+		if backup.Arn.Data == ref.RawArn {
 			return args, backup, nil
 		}
 	}

--- a/providers/aws/resources/aws_fsx.go
+++ b/providers/aws/resources/aws_fsx.go
@@ -125,14 +125,9 @@ func initAwsFsxFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch fsx filesystem")
+	arnVal, err := resolveArnArg(runtime, args, "fsx filesystem", "fsx")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// load all fsx filesystems
@@ -147,7 +142,6 @@ func initAwsFsxFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		fs := rawResource.(*mqlAwsFsxFilesystem)
 		if fs.Arn.Data == arnVal {
@@ -319,14 +313,9 @@ func initAwsFsxCache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch fsx cache")
+	arnVal, err := resolveArnArg(runtime, args, "fsx cache", "fsx")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// load all fsx caches
@@ -341,7 +330,6 @@ func initAwsFsxCache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		cache := rawResource.(*mqlAwsFsxCache)
 		if cache.Arn.Data == arnVal {
@@ -496,14 +484,9 @@ func initAwsFsxBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch fsx backup")
+	arnVal, err := resolveArnArg(runtime, args, "fsx backup", "fsx")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// load all fsx backups
@@ -518,7 +501,6 @@ func initAwsFsxBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		backup := rawResource.(*mqlAwsFsxBackup)
 		if backup.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -933,25 +933,24 @@ func (a *mqlAwsKmsGrant) key() (*mqlAwsKmsKey, error) {
 	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
+// allowRef is set because aws.kms.key accepts a bare key ID or an "alias/..."
+// name in the same "arn" arg, and normalizes them itself below.
+var kmsKeyArnSpec = arnSpec{
+	resource: ResourceAwsKmsKey,
+	services: []string{"kms"},
+	allowRef: true,
+}
+
 func initAwsKmsKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "kms"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	ref, err := kmsKeyArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	r := args["arn"]
-	if r == nil {
-		return nil, nil, errors.New("arn required to fetch aws kms key")
-	}
-	keyRef, ok := r.Value.(string)
-	if !ok {
-		return nil, nil, errors.New("invalid arn")
-	}
+	keyRef := ref.RawArn
 
 	conn := runtime.Connection.(*connection.AwsConnection)
 	region := rawStringArg(args["region"])

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -939,7 +939,7 @@ func initAwsKmsKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "kms"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -331,7 +331,7 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "lambda"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -325,22 +325,29 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 	return f, nil
 }
 
+var lambdaFunctionArnSpec = arnSpec{
+	resource: ResourceAwsLambdaFunction,
+	services: []string{"lambda"},
+	altKeys:  []string{"name", "region"},
+}
+
 func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "lambda"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	ref, err := lambdaFunctionArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	nameArg := args["name"]
 	regionArg := args["region"]
 
-	var arnVal string
-	if args["arn"] == nil {
+	// Without an ARN the function is identified by name + region, from which
+	// the ARN is synthesized.
+	arnVal := ref.RawArn
+	if arnVal == "" {
 		if nameArg == nil {
 			return nil, nil, errors.New("name required to fetch lambda function")
 		}
@@ -352,8 +359,6 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 		if arnVal == "" {
 			return nil, nil, errors.New("arn required to fetch lambda function")
 		}
-	} else {
-		arnVal = args["arn"].Value.(string)
 	}
 
 	// Targeted lookup: derive the region + function name from the ARN and fetch

--- a/providers/aws/resources/aws_memorydb.go
+++ b/providers/aws/resources/aws_memorydb.go
@@ -90,6 +90,11 @@ func (a *mqlAwsMemorydbCluster) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+var memorydbClusterArnSpec = arnSpec{
+	resource: ResourceAwsMemorydbCluster,
+	services: []string{"memorydb"},
+}
+
 func initAwsMemorydbCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -97,12 +102,12 @@ func initAwsMemorydbCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the cluster's region and name from the ARN carried on the asset.
-	arnVal, err := resolveArnArg(runtime, args, "memorydb cluster", "memorydb")
+	ref, err := memorydbClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	parsed, err := arn.Parse(arnVal)
+	parsed, err := arn.Parse(ref.RawArn)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/aws/resources/aws_memorydb.go
+++ b/providers/aws/resources/aws_memorydb.go
@@ -97,16 +97,11 @@ func initAwsMemorydbCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the cluster's region and name from the ARN carried on the asset.
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch memorydb cluster")
+	arnVal, err := resolveArnArg(runtime, args, "memorydb cluster", "memorydb")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	arnVal := args["arn"].Value.(string)
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_mq.go
+++ b/providers/aws/resources/aws_mq.go
@@ -693,7 +693,7 @@ func initAwsMqBroker(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "mq"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_mq.go
+++ b/providers/aws/resources/aws_mq.go
@@ -688,17 +688,18 @@ func (a *mqlAwsMqBroker) subnets() ([]any, error) {
 	return res, nil
 }
 
+var mqBrokerArnSpec = arnSpec{
+	resource: ResourceAwsMqBroker,
+	services: []string{"mq"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsMqBroker(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "mq"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch aws mq broker")
+	if _, err := mqBrokerArnSpec.resolve(runtime, args); err != nil {
+		return nil, nil, err
 	}
 
 	// When arn or name is supplied (e.g. via asset identifier from discovery),

--- a/providers/aws/resources/aws_msk.go
+++ b/providers/aws/resources/aws_msk.go
@@ -435,6 +435,11 @@ func newMqlAwsMskCluster(runtime *plugin.Runtime, region string, accountID strin
 	return mqlCluster, nil
 }
 
+var mskClusterArnSpec = arnSpec{
+	resource: ResourceAwsMskCluster,
+	services: []string{"kafka"},
+}
+
 // initAwsMskCluster tolerates a bare arn (for cross-account typed refs from Pipes/Firehose/Replicator).
 // When the cluster is accessible, DescribeClusterV2 populates all scalar fields; on access denied (cross-account)
 // the resource falls back to a minimal shell with just arn/__id so callers can still traverse other fields.
@@ -444,27 +449,27 @@ func initAwsMskCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if len(args) >= 2 {
 		return args, nil, nil
 	}
-	arnVal, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+	ref, err := mskClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
-	parsed, err := arn.Parse(arnVal)
+	parsed, err := arn.Parse(ref.RawArn)
 	if err != nil {
-		args["__id"] = llx.StringData(arnVal)
+		args["__id"] = llx.StringData(ref.RawArn)
 		return args, nil, nil
 	}
 	conn := runtime.Connection.(*connection.AwsConnection)
 	svc := conn.Kafka(parsed.Region)
-	out, err := svc.DescribeClusterV2(context.Background(), &kafka.DescribeClusterV2Input{ClusterArn: &arnVal})
+	out, err := svc.DescribeClusterV2(context.Background(), &kafka.DescribeClusterV2Input{ClusterArn: &ref.RawArn})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			args["__id"] = llx.StringData(arnVal)
+			args["__id"] = llx.StringData(ref.RawArn)
 			return args, nil, nil
 		}
 		return nil, nil, err
 	}
 	if out.ClusterInfo == nil {
-		args["__id"] = llx.StringData(arnVal)
+		args["__id"] = llx.StringData(ref.RawArn)
 		return args, nil, nil
 	}
 	mqlCluster, err := newMqlAwsMskCluster(runtime, parsed.Region, parsed.AccountID, *out.ClusterInfo)

--- a/providers/aws/resources/aws_msk.go
+++ b/providers/aws/resources/aws_msk.go
@@ -444,15 +444,10 @@ func initAwsMskCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if len(args) >= 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	arnVal, err := resolveArnArg(runtime, args, "aws msk cluster", "kafka")
+	if err != nil {
+		return nil, nil, err
 	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch aws msk cluster")
-	}
-	arnVal := args["arn"].Value.(string)
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		args["__id"] = llx.StringData(arnVal)

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -193,12 +193,17 @@ func (a *mqlAwsNeptuneCluster) securityGroups() ([]any, error) {
 	return a.newSecurityGroupResources(a.MqlRuntime)
 }
 
+var neptuneClusterArnSpec = arnSpec{
+	resource: ResourceAwsNeptuneCluster,
+	services: []string{"rds"},
+}
+
 func initAwsNeptuneCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "neptune cluster", "rds")
+	ref, err := neptuneClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -216,7 +221,7 @@ func initAwsNeptuneCluster(runtime *plugin.Runtime, args map[string]*llx.RawData
 
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsNeptuneCluster)
-		if cluster.Arn.Data == arnVal {
+		if cluster.Arn.Data == ref.RawArn {
 			return args, cluster, nil
 		}
 	}

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -198,14 +198,9 @@ func initAwsNeptuneCluster(runtime *plugin.Runtime, args map[string]*llx.RawData
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch neptune cluster")
+	arnVal, err := resolveArnArg(runtime, args, "neptune cluster", "rds")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.neptune", map[string]*llx.RawData{})
@@ -219,10 +214,6 @@ func initAwsNeptuneCluster(runtime *plugin.Runtime, args map[string]*llx.RawData
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal, ok := args["arn"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("arn must be a string")
-	}
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsNeptuneCluster)
 		if cluster.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_opensearch.go
+++ b/providers/aws/resources/aws_opensearch.go
@@ -108,20 +108,19 @@ func (a *mqlAwsOpensearchDomain) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+var opensearchDomainArnSpec = arnSpec{
+	resource: ResourceAwsOpensearchDomain,
+	services: []string{"es"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsOpensearchDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	// Get asset identifier if no args provided
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "es"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch opensearch domain")
+	if _, err := opensearchDomainArnSpec.resolve(runtime, args); err != nil {
+		return nil, nil, err
 	}
 
 	// If we have an ARN but missing region or name, extract from ARN

--- a/providers/aws/resources/aws_opensearch.go
+++ b/providers/aws/resources/aws_opensearch.go
@@ -115,7 +115,7 @@ func initAwsOpensearchDomain(runtime *plugin.Runtime, args map[string]*llx.RawDa
 
 	// Get asset identifier if no args provided
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "es"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -651,12 +651,17 @@ func (a *mqlAwsRdsDbinstanceAssociatedRole) iamRole() (*mqlAwsIamRole, error) {
 	return mqlRole.(*mqlAwsIamRole), nil
 }
 
+var rdsDbclusterArnSpec = arnSpec{
+	resource: ResourceAwsRdsDbcluster,
+	services: []string{"rds"},
+}
+
 func initAwsRdsDbcluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "rds db cluster", "rds")
+	ref, err := rdsDbclusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -675,11 +680,16 @@ func initAwsRdsDbcluster(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsRdsDbcluster)
-		if dbInstance.Arn.Data == arnVal {
+		if dbInstance.Arn.Data == ref.RawArn {
 			return args, dbInstance, nil
 		}
 	}
 	return nil, nil, errors.New("rds db cluster does not exist")
+}
+
+var rdsDbinstanceArnSpec = arnSpec{
+	resource: ResourceAwsRdsDbinstance,
+	services: []string{"rds"},
 }
 
 func initAwsRdsDbinstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -687,7 +697,7 @@ func initAwsRdsDbinstance(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "rds db instance", "rds")
+	ref, err := rdsDbinstanceArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -706,7 +716,7 @@ func initAwsRdsDbinstance(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsRdsDbinstance)
-		if dbInstance.Arn.Data == arnVal {
+		if dbInstance.Arn.Data == ref.RawArn {
 			return args, dbInstance, nil
 		}
 	}

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -656,14 +656,9 @@ func initAwsRdsDbcluster(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch rds db cluster")
+	arnVal, err := resolveArnArg(runtime, args, "rds db cluster", "rds")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// load all rds db clusters
@@ -678,7 +673,6 @@ func initAwsRdsDbcluster(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsRdsDbcluster)
 		if dbInstance.Arn.Data == arnVal {
@@ -693,14 +687,9 @@ func initAwsRdsDbinstance(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch rds db instance")
+	arnVal, err := resolveArnArg(runtime, args, "rds db instance", "rds")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// load all rds db instances
@@ -715,7 +704,6 @@ func initAwsRdsDbinstance(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		dbInstance := rawResource.(*mqlAwsRdsDbinstance)
 		if dbInstance.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -377,14 +377,9 @@ func initAwsRedshiftCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch redshift cluster")
+	arnVal, err := resolveArnArg(runtime, args, "redshift cluster", "redshift")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// load all rds db instances
@@ -399,7 +394,6 @@ func initAwsRedshiftCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsRedshiftCluster)
 		if cluster.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -372,12 +372,17 @@ func (a *mqlAwsRedshiftCluster) cloudformationStack() (*mqlAwsCloudformationStac
 	return stack, nil
 }
 
+var redshiftClusterArnSpec = arnSpec{
+	resource: ResourceAwsRedshiftCluster,
+	services: []string{"redshift"},
+}
+
 func initAwsRedshiftCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "redshift cluster", "redshift")
+	ref, err := redshiftClusterArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -396,7 +401,7 @@ func initAwsRedshiftCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	for _, rawResource := range rawResources.Data {
 		cluster := rawResource.(*mqlAwsRedshiftCluster)
-		if cluster.Arn.Data == arnVal {
+		if cluster.Arn.Data == ref.RawArn {
 			return args, cluster, nil
 		}
 	}

--- a/providers/aws/resources/aws_route53.go
+++ b/providers/aws/resources/aws_route53.go
@@ -196,7 +196,7 @@ func initAwsRoute53HostedZone(runtime *plugin.Runtime, args map[string]*llx.RawD
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "route53"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_route53.go
+++ b/providers/aws/resources/aws_route53.go
@@ -188,6 +188,12 @@ func (a *mqlAwsRoute53) queryLoggingConfigs() ([]any, error) {
 	return res, nil
 }
 
+var route53HostedZoneArnSpec = arnSpec{
+	resource: ResourceAwsRoute53HostedZone,
+	services: []string{"route53"},
+	altKeys:  []string{"id", "name"},
+}
+
 // initAwsRoute53HostedZone resolves a hosted zone by ID, ARN, or asset
 // identifier (set during platform discovery).
 func initAwsRoute53HostedZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -195,14 +201,8 @@ func initAwsRoute53HostedZone(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "route53"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["id"] == nil && args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("id, arn, or name required to fetch aws route53 hosted zone")
+	if _, err := route53HostedZoneArnSpec.resolve(runtime, args); err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.route53", map[string]*llx.RawData{})

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -172,7 +172,7 @@ func initAwsS3Bucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "s3"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3control"
@@ -166,31 +165,29 @@ func initAwsS3BucketPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData
 	return args, resource, nil
 }
 
+var s3BucketArnSpec = arnSpec{
+	resource: ResourceAwsS3Bucket,
+	services: []string{"s3"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsS3Bucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	// NOTE: bucket only initializes with arn and name
 	if len(args) >= 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "s3"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch aws s3 bucket")
+	ref, err := s3BucketArnSpec.resolve(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Resolve the bucket name and ARN. The bucket name is encoded directly in
 	// the ARN (arn:aws:s3:::<name>), so we can build the resource without
 	// listing every bucket in every region. Per-bucket fields lazy-load.
 	var arnVal, name string
-	if args["arn"] != nil {
-		arnVal = args["arn"].Value.(string)
-		parsed, err := arn.Parse(arnVal)
-		if err != nil || parsed.Service != "s3" {
-			return nil, nil, errors.Newf("not a valid bucket ARN '%s'", arnVal)
-		}
-		name = parsed.Resource
+	if ref.RawArn != "" {
+		arnVal = ref.RawArn
+		name = ref.Resource
 	} else {
 		name = args["name"].Value.(string)
 		arnVal = fmt.Sprintf(s3ArnPattern, name)

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -276,14 +276,9 @@ func initAwsSagemakerNotebookinstance(runtime *plugin.Runtime, args map[string]*
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch sagemaker notebookinstance")
+	arnVal, err := resolveArnArg(runtime, args, "sagemaker notebookinstance", "sagemaker")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.sagemaker", map[string]*llx.RawData{})
@@ -297,7 +292,6 @@ func initAwsSagemakerNotebookinstance(runtime *plugin.Runtime, args map[string]*
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		ni := rawResource.(*mqlAwsSagemakerNotebookinstance)
 		if ni.Arn.Data == arnVal {
@@ -2082,14 +2076,9 @@ func initAwsSagemakerDomain(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch sagemaker domain")
+	arnVal, err := resolveArnArg(runtime, args, "sagemaker domain", "sagemaker")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.sagemaker", map[string]*llx.RawData{})
@@ -2103,7 +2092,6 @@ func initAwsSagemakerDomain(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		d := rawResource.(*mqlAwsSagemakerDomain)
 		if d.Arn.Data == arnVal {
@@ -4514,7 +4502,7 @@ func initAwsSagemakerTrainingjob(runtime *plugin.Runtime, args map[string]*llx.R
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "sagemaker"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -4556,7 +4544,7 @@ func initAwsSagemakerProcessingjob(runtime *plugin.Runtime, args map[string]*llx
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "sagemaker"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -271,12 +271,17 @@ func (a *mqlAwsSagemaker) getNotebookInstances(conn *connection.AwsConnection) [
 	return tasks
 }
 
+var sagemakerNotebookinstanceArnSpec = arnSpec{
+	resource: ResourceAwsSagemakerNotebookinstance,
+	services: []string{"sagemaker"},
+}
+
 func initAwsSagemakerNotebookinstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "sagemaker notebookinstance", "sagemaker")
+	ref, err := sagemakerNotebookinstanceArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -294,7 +299,7 @@ func initAwsSagemakerNotebookinstance(runtime *plugin.Runtime, args map[string]*
 
 	for _, rawResource := range rawResources.Data {
 		ni := rawResource.(*mqlAwsSagemakerNotebookinstance)
-		if ni.Arn.Data == arnVal {
+		if ni.Arn.Data == ref.RawArn {
 			return args, ni, nil
 		}
 	}
@@ -2071,12 +2076,17 @@ func (a *mqlAwsSagemaker) getDomains(conn *connection.AwsConnection) []*jobpool.
 	return tasks
 }
 
+var sagemakerDomainArnSpec = arnSpec{
+	resource: ResourceAwsSagemakerDomain,
+	services: []string{"sagemaker"},
+}
+
 func initAwsSagemakerDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "sagemaker domain", "sagemaker")
+	ref, err := sagemakerDomainArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2094,7 +2104,7 @@ func initAwsSagemakerDomain(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	for _, rawResource := range rawResources.Data {
 		d := rawResource.(*mqlAwsSagemakerDomain)
-		if d.Arn.Data == arnVal {
+		if d.Arn.Data == ref.RawArn {
 			return args, d, nil
 		}
 	}
@@ -2102,7 +2112,7 @@ func initAwsSagemakerDomain(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	// Returning (args, nil, nil) here would let the runtime create a resource
 	// whose fields are all unset, which surfaces as malformed nil data when
 	// those fields are queried.
-	return nil, nil, fmt.Errorf("aws.sagemaker.domain with arn %q not found", arnVal)
+	return nil, nil, fmt.Errorf("aws.sagemaker.domain with arn %q not found", ref.RawArn)
 }
 
 type mqlAwsSagemakerDomainInternal struct {
@@ -4496,19 +4506,19 @@ func getSagemakerTags(ctx context.Context, svc *sagemaker.Client, arn *string) (
 	return tags, nil
 }
 
+var sagemakerTrainingjobArnSpec = arnSpec{
+	resource: ResourceAwsSagemakerTrainingjob,
+	services: []string{"sagemaker"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsSagemakerTrainingjob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "sagemaker"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch sagemaker training job")
+	if _, err := sagemakerTrainingjobArnSpec.resolve(runtime, args); err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.sagemaker", map[string]*llx.RawData{})
@@ -4538,19 +4548,19 @@ func initAwsSagemakerTrainingjob(runtime *plugin.Runtime, args map[string]*llx.R
 	return nil, nil, errors.New("sagemaker training job does not exist")
 }
 
+var sagemakerProcessingjobArnSpec = arnSpec{
+	resource: ResourceAwsSagemakerProcessingjob,
+	services: []string{"sagemaker"},
+	altKeys:  []string{"name"},
+}
+
 func initAwsSagemakerProcessingjob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "sagemaker"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil && args["name"] == nil {
-		return nil, nil, errors.New("arn or name required to fetch sagemaker processing job")
+	if _, err := sagemakerProcessingjobArnSpec.resolve(runtime, args); err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.sagemaker", map[string]*llx.RawData{})

--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -70,15 +70,10 @@ func initAwsSagemakerModel(runtime *plugin.Runtime, args map[string]*llx.RawData
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	arnVal, err := resolveArnArg(runtime, args, "sagemaker model", "sagemaker")
+	if err != nil {
+		return nil, nil, err
 	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to resolve sagemaker model")
-	}
-	arnVal := args["arn"].Value.(string)
 
 	obj, err := CreateResource(runtime, "aws.sagemaker", map[string]*llx.RawData{})
 	if err != nil {

--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -66,11 +66,16 @@ func initAwsSagemakerExperiment(runtime *plugin.Runtime, args map[string]*llx.Ra
 	return nil, nil, fmt.Errorf("aws.sagemaker.experiment with arn %q not found", arnVal)
 }
 
+var sagemakerModelArnSpec = arnSpec{
+	resource: ResourceAwsSagemakerModel,
+	services: []string{"sagemaker"},
+}
+
 func initAwsSagemakerModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	arnVal, err := resolveArnArg(runtime, args, "sagemaker model", "sagemaker")
+	ref, err := sagemakerModelArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,7 +90,7 @@ func initAwsSagemakerModel(runtime *plugin.Runtime, args map[string]*llx.RawData
 	if rawResources.Error == nil {
 		for _, rawResource := range rawResources.Data {
 			m := rawResource.(*mqlAwsSagemakerModel)
-			if m.Arn.Data == arnVal {
+			if m.Arn.Data == ref.RawArn {
 				return args, m, nil
 			}
 		}
@@ -94,7 +99,7 @@ func initAwsSagemakerModel(runtime *plugin.Runtime, args map[string]*llx.RawData
 	// Returning (args, nil, nil) here would let the runtime create a resource
 	// whose fields are all unset, which surfaces as malformed nil data when
 	// those fields are queried.
-	return nil, nil, fmt.Errorf("aws.sagemaker.model with arn %q not found", arnVal)
+	return nil, nil, fmt.Errorf("aws.sagemaker.model with arn %q not found", ref.RawArn)
 }
 
 // ---- Experiments ----

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -48,17 +48,22 @@ func (a *mqlAwsSecretsmanagerSecret) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+var secretsmanagerSecretArnSpec = arnSpec{
+	resource: ResourceAwsSecretsmanagerSecret,
+	services: []string{"secretsmanager"},
+}
+
 func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "secretsmanager secret", "secretsmanager")
+	ref, err := secretsmanagerSecretArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	region, err := GetRegionFromArn(arnVal)
+	region, err := GetRegionFromArn(ref.RawArn)
 	if err != nil {
 		// Returning (args, nil, nil) here would let the runtime create a
 		// resource whose fields are all unset, which surfaces as malformed
@@ -70,7 +75,7 @@ func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.R
 	svc := conn.Secretsmanager(region)
 	ctx := context.Background()
 
-	resp, err := svc.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: &arnVal})
+	resp, err := svc.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: &ref.RawArn})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -54,17 +53,11 @@ func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.R
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+	arnVal, err := resolveArnArg(runtime, args, "secretsmanager secret", "secretsmanager")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch secretsmanager secret")
-	}
-
-	arnVal := args["arn"].Value.(string)
 	region, err := GetRegionFromArn(arnVal)
 	if err != nil {
 		// Returning (args, nil, nil) here would let the runtime create a

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -284,14 +284,9 @@ func initAwsSsmInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch ssm instance")
+	arnVal, err := resolveArnArg(runtime, args, "ssm instance", "ssm")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, "aws.ssm", map[string]*llx.RawData{})
@@ -305,7 +300,6 @@ func initAwsSsmInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		instance := rawResource.(*mqlAwsSsmInstance)
 		if instance.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -279,12 +279,17 @@ func (a *mqlAwsSsmInstance) iamRole() (*mqlAwsIamRole, error) {
 
 const ssmInstanceArnPattern = "arn:aws:ssm:%s:%s:instance/%s"
 
+var ssmInstanceArnSpec = arnSpec{
+	resource: ResourceAwsSsmInstance,
+	services: []string{"ssm"},
+}
+
 func initAwsSsmInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "ssm instance", "ssm")
+	ref, err := ssmInstanceArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -302,7 +307,7 @@ func initAwsSsmInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 
 	for _, rawResource := range rawResources.Data {
 		instance := rawResource.(*mqlAwsSsmInstance)
-		if instance.Arn.Data == arnVal {
+		if instance.Arn.Data == ref.RawArn {
 			return args, instance, nil
 		}
 	}

--- a/providers/aws/resources/aws_storagegateway.go
+++ b/providers/aws/resources/aws_storagegateway.go
@@ -120,12 +120,17 @@ func (a *mqlAwsStoragegatewayGateway) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+var storagegatewayGatewayArnSpec = arnSpec{
+	resource: ResourceAwsStoragegatewayGateway,
+	services: []string{"storagegateway"},
+}
+
 func initAwsStoragegatewayGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
 
-	arnVal, err := resolveArnArg(runtime, args, "storage gateway", "storagegateway")
+	ref, err := storagegatewayGatewayArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,7 +147,7 @@ func initAwsStoragegatewayGateway(runtime *plugin.Runtime, args map[string]*llx.
 
 	for _, rawResource := range rawResources.Data {
 		gw := rawResource.(*mqlAwsStoragegatewayGateway)
-		if gw.Arn.Data == arnVal {
+		if gw.Arn.Data == ref.RawArn {
 			return args, gw, nil
 		}
 	}

--- a/providers/aws/resources/aws_storagegateway.go
+++ b/providers/aws/resources/aws_storagegateway.go
@@ -125,14 +125,9 @@ func initAwsStoragegatewayGateway(runtime *plugin.Runtime, args map[string]*llx.
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch storage gateway")
+	arnVal, err := resolveArnArg(runtime, args, "storage gateway", "storagegateway")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	obj, err := CreateResource(runtime, ResourceAwsStoragegateway, map[string]*llx.RawData{})
@@ -145,7 +140,6 @@ func initAwsStoragegatewayGateway(runtime *plugin.Runtime, args map[string]*llx.
 		return nil, nil, rawResources.Error
 	}
 
-	arnVal := args["arn"].Value.(string)
 	for _, rawResource := range rawResources.Data {
 		gw := rawResource.(*mqlAwsStoragegatewayGateway)
 		if gw.Arn.Data == arnVal {

--- a/providers/aws/resources/aws_transfer.go
+++ b/providers/aws/resources/aws_transfer.go
@@ -107,16 +107,11 @@ func initAwsTransferServer(runtime *plugin.Runtime, args map[string]*llx.RawData
 
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the server's region and id from the ARN carried on the asset.
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-	if args["arn"] == nil {
-		return nil, nil, errors.New("arn required to fetch transfer server")
+	arnVal, err := resolveArnArg(runtime, args, "transfer server", "transfer")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	arnVal := args["arn"].Value.(string)
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_transfer.go
+++ b/providers/aws/resources/aws_transfer.go
@@ -100,6 +100,11 @@ func (a *mqlAwsTransferServer) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+var transferServerArnSpec = arnSpec{
+	resource: ResourceAwsTransferServer,
+	services: []string{"transfer"},
+}
+
 func initAwsTransferServer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -107,12 +112,12 @@ func initAwsTransferServer(runtime *plugin.Runtime, args map[string]*llx.RawData
 
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the server's region and id from the ARN carried on the asset.
-	arnVal, err := resolveArnArg(runtime, args, "transfer server", "transfer")
+	ref, err := transferServerArnSpec.resolve(runtime, args)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	parsed, err := arn.Parse(arnVal)
+	parsed, err := arn.Parse(ref.RawArn)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,8 +138,8 @@ func initAwsTransferServer(runtime *plugin.Runtime, args map[string]*llx.RawData
 	s := resp.Server
 	mqlServer, err := CreateResource(runtime, "aws.transfer.server",
 		map[string]*llx.RawData{
-			"__id":         llx.StringData(arnVal),
-			"arn":          llx.StringData(arnVal),
+			"__id":         llx.StringData(ref.RawArn),
+			"arn":          llx.StringData(ref.RawArn),
 			"serverId":     llx.StringDataPtr(s.ServerId),
 			"region":       llx.StringData(region),
 			"endpointType": llx.StringData(string(s.EndpointType)),

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1464,33 +1464,38 @@ func initAwsVpcSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	return nil, nil, errors.New("subnet not found")
 }
 
+// VPC ARNs use the provider's custom vpcArnPattern service token "vpc" (see
+// deriveVpcTarget), not the "ec2" token real AWS would use. Only "vpc" is
+// accepted: allowing "ec2" here would let any EC2 asset (an instance, volume,
+// or security group) be adopted as this VPC's ARN.
+//
+// The spec declares no prefix because a "vpc" ARN with an unexpected resource
+// segment is not an error here, it just means the targeted lookup is skipped
+// in favour of scanning the cached list.
+// altKeys lists only "id", not "region": the fallback list-scan below matches
+// on arn or id alone, so a region-only args must still be rejected.
+var vpcArnSpec = arnSpec{
+	resource: ResourceAwsVpc,
+	services: []string{"vpc"},
+	altKeys:  []string{"id"},
+}
+
 // deriveVpcTarget resolves the region and VPC id to look up. It pulls the ARN
 // from the asset identifier when args are empty, then derives the id from the
 // ARN's resource segment or an explicit "id" arg — never from the asset name
 // (which may be a "Name" tag, not the vpc-id), keeping asset-name-vs-id
 // resolution correct. It may populate args["arn"] from the asset identifier.
-func deriveVpcTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (region, vpcId string) {
-	// aws.vpc also resolves by a bare "id" arg, so resolveArnArg (which requires
-	// an ARN) does not apply here.
-	//
-	// VPC ARNs use the provider's custom vpcArnPattern service token "vpc" (see
-	// the comment below), not the "ec2" token real AWS would use. Only "vpc" is
-	// accepted: allowing "ec2" here would let any EC2 asset (an instance,
-	// volume, or security group) be adopted as this VPC's ARN.
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifierForService(runtime, "vpc"); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
+func deriveVpcTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (region, vpcId string, err error) {
+	ref, err := vpcArnSpec.resolve(runtime, args)
+	if err != nil {
+		return "", "", err
 	}
-	if args["arn"] != nil {
-		arnVal := args["arn"].Value.(string)
-		// The VPC ARN uses a custom shape, vpcArnPattern =
-		// "arn:aws:vpc:<region>:<acct>:id/<vpc-id>", so the id lives behind an
-		// "id/" prefix (not the standard "vpc/").
-		if parsed, err := arn.Parse(arnVal); err == nil && strings.HasPrefix(parsed.Resource, "id/") {
-			region = parsed.Region
-			vpcId = strings.TrimPrefix(parsed.Resource, "id/")
-		}
+	// The VPC ARN uses a custom shape, vpcArnPattern =
+	// "arn:aws:vpc:<region>:<acct>:id/<vpc-id>", so the id lives behind an
+	// "id/" prefix (not the standard "vpc/").
+	if strings.HasPrefix(ref.Resource, "id/") {
+		region = ref.Region
+		vpcId = strings.TrimPrefix(ref.Resource, "id/")
 	}
 	if args["id"] != nil && vpcId == "" {
 		vpcId = args["id"].Value.(string)
@@ -1500,7 +1505,7 @@ func deriveVpcTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (reg
 			region = r
 		}
 	}
-	return region, vpcId
+	return region, vpcId, nil
 }
 
 func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -1511,10 +1516,9 @@ func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 	// Derive region + vpcId for a single targeted DescribeVpcs call instead of
 	// listing every VPC in every region. This also pulls the ARN from the asset
 	// identifier when args are empty.
-	region, vpcId := deriveVpcTarget(runtime, args)
-
-	if args["arn"] == nil && args["id"] == nil {
-		return nil, nil, errors.New("arn or id required to fetch aws vpc")
+	region, vpcId, err := deriveVpcTarget(runtime, args)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if region != "" && vpcId != "" {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1470,8 +1470,15 @@ func initAwsVpcSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 // (which may be a "Name" tag, not the vpc-id), keeping asset-name-vs-id
 // resolution correct. It may populate args["arn"] from the asset identifier.
 func deriveVpcTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (region, vpcId string) {
+	// aws.vpc also resolves by a bare "id" arg, so resolveArnArg (which requires
+	// an ARN) does not apply here.
+	//
+	// VPC ARNs use the provider's custom vpcArnPattern service token "vpc" (see
+	// the comment below), not the "ec2" token real AWS would use. Only "vpc" is
+	// accepted: allowing "ec2" here would let any EC2 asset (an instance,
+	// volume, or security group) be adopted as this VPC's ARN.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifierForService(runtime, "vpc"); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_vpc_init_test.go
+++ b/providers/aws/resources/aws_vpc_init_test.go
@@ -83,7 +83,8 @@ func TestInitAwsVpc(t *testing.T) {
 		)
 
 		args := map[string]*llx.RawData{}
-		region, gotVpcId := deriveVpcTarget(runtime, args)
+		region, gotVpcId, err := deriveVpcTarget(runtime, args)
+		require.NoError(t, err)
 		assert.Equal(t, "us-east-1", region)
 		assert.Equal(t, vpcId, gotVpcId)
 		assert.Equal(t, vpcArn, args["arn"].Value.(string))
@@ -101,7 +102,8 @@ func TestInitAwsVpc(t *testing.T) {
 		)
 
 		args := map[string]*llx.RawData{}
-		region, gotVpcId := deriveVpcTarget(runtime, args)
+		region, gotVpcId, err := deriveVpcTarget(runtime, args)
+		require.NoError(t, err)
 		assert.Equal(t, "us-east-1", region)
 		assert.Equal(t, vpcId, gotVpcId)
 	})
@@ -110,7 +112,8 @@ func TestInitAwsVpc(t *testing.T) {
 		runtime := testAwsRuntime("irrelevant", nil, []*mqlAwsVpc{testVpc})
 
 		args := map[string]*llx.RawData{"arn": llx.StringData(vpcArn)}
-		region, gotVpcId := deriveVpcTarget(runtime, args)
+		region, gotVpcId, err := deriveVpcTarget(runtime, args)
+		require.NoError(t, err)
 		assert.Equal(t, "us-east-1", region)
 		assert.Equal(t, vpcId, gotVpcId)
 	})


### PR DESCRIPTION
## Problem

Some cnspec runs produced malformed, unattributed errors like:

```
x provider returned no data and no error for a field; the field was never set on the resource (provider bug) field=tags id=arn:aws:logs:<region>:<acc-id>:log-group:/aws/apigateway/<resource>:* provider=aws resource=aws.msk.cluster

x llx: encountered a primitive with no type information, coercing to null (an upstream layer — a provider or the compiler — produced a malformed primitive)

! cross-account CloudWatch log group reference arn=arn:aws:route53:::hostedzone/<zone> currentAccount=<accId> logGroupAccount=
```

Root cause: a singular resource `init` that resolves itself from an ARN (e.g. `aws.msk.cluster`, `aws.es.domain`, `aws.cloudwatch.loggroup`) only nil-checked `args["arn"]` — it never verified the ARN actually belonged to that service. So an ARN from an *unrelated* service could be accepted on either path:

- **discovery adoption** — a bare singular query like `aws.msk.cluster` adopts whatever ARN the currently-scanned asset carries (a Route53 hosted zone, a CloudWatch log group, …), regardless of service;
- **explicit arg** — `aws.msk.cluster(arn: "arn:aws:logs:...")`.

The wrong ARN then builds a "husk" resource keyed on it with every field left **unset** (not null — unset). Those fields cross the plugin boundary as malformed nil data, which is exactly the errors above — and with no attribution back to the init at fault.

Example (old):
<img width="746" height="210" alt="image" src="https://github.com/user-attachments/assets/35f6d725-31ea-498b-a538-fd97f556fee0" />

Example (new):
<img width="763" height="196" alt="image" src="https://github.com/user-attachments/assets/ae64f37d-3720-489d-abff-cb2a7a3b04d2" />

## Fix

Each ARN-resolving init now declares a small `arnSpec` next to it with the ARN service token(s) it accepts, and calls `resolve()`, which:

- parses the ARN and rejects it early if its service (and optional resource-segment prefix) doesn't match — on **both** the adoption and explicit-arg paths, so a foreign ARN produces a clean, attributed error instead of a husk;
- reads the value with comma-ok, so a non-string `arn` arg returns an error instead of panicking the init.

Service tokens were cross-referenced against [AWS's policies.js](https://awspolicygen.s3.amazonaws.com/js/policies.js). The only deviation is `vpc` instead of `ec2`, because we construct that ARN ourselves rather than using the real service token. (The one token that couldn't be settled from that file, `es` vs `opensearch` for OpenSearch domains, was confirmed as `es` against a real domain ARN.)

## Old vs new

Scanning a Route53 hosted-zone asset while a policy references `aws.msk.cluster`:

- **Before:** adopts `arn:aws:route53:::hostedzone/Z…` as the cluster's ARN → husk resource → querying any field yields
  `provider returned no data and no error for a field … resource=aws.msk.cluster` + `llx: encountered a primitive with no type information`.
- **After:** the foreign ARN is not adopted → clean, attributed error:
  `arn required to fetch aws.msk.cluster`

And an explicitly-passed wrong-service ARN, e.g. `aws.es.domain(arn: "arn:aws:iam::…:role/x")`:

- **Before:** slips past the nil-check into the SDK →
  `operation error Elasticsearch Service: DescribeElasticsearchDomain, failed to resolve service endpoint … Invalid Configuration: Missing Region`
- **After:**
  `arn "arn:aws:iam::…:role/x" is not an aws.es.domain arn: service is "iam", expected es`
