### PR TITLE
🐛 os: parse Apache conditional container blocks instead of discarding them

### DIFF
--- a/providers/os/resources/apache2.go
+++ b/providers/os/resources/apache2.go
@@ -719,12 +719,7 @@ func (s *mqlApache2ConfEnvvars) params(file *mqlFile) (map[string]any, error) {
 }
 
 func (s *mqlApache2Conf) listenAddresses(params map[string]any) ([]any, error) {
-	raw, ok := params["Listen"]
-	if !ok {
-		return nil, nil
-	}
-
-	str, ok := raw.(string)
+	str, ok := apache2.ParamValue(params, "Listen")
 	if !ok {
 		return nil, nil
 	}

--- a/providers/os/resources/apache2/container_blocks_test.go
+++ b/providers/os/resources/apache2/container_blocks_test.go
@@ -1,0 +1,183 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package apache2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The stock Debian/Ubuntu layout wraps the entire TLS VirtualHost in
+// <IfModule mod_ssl.c> (sites-available/default-ssl.conf) and `Listen 443` in
+// <IfModule ssl_module> (ports.conf). Before container blocks were made
+// transparent, both were discarded: virtualHosts came back empty and the TLS
+// port was invisible, so every TLS audit passed over an empty set.
+func TestParse_IfModuleWrappedVirtualHost(t *testing.T) {
+	cfg := Parse(`Listen 80
+
+<IfModule ssl_module>
+	Listen 443
+</IfModule>
+
+<IfModule mod_ssl.c>
+<VirtualHost _default_:443>
+	ServerName secure.example.com
+	SSLEngine on
+	SSLProtocol -all +TLSv1.2 +TLSv1.3
+	SSLCertificateFile /etc/ssl/certs/site.pem
+</VirtualHost>
+</IfModule>
+`)
+
+	require.Len(t, cfg.VHosts, 1)
+	vh := cfg.VHosts[0]
+	assert.Equal(t, "_default_:443", vh.Address)
+	assert.Equal(t, "secure.example.com", vh.ServerName)
+	assert.True(t, vh.SSL)
+	assert.Equal(t, "-all +TLSv1.2 +TLSv1.3", vh.SSLProtocol)
+	assert.Equal(t, "/etc/ssl/certs/site.pem", vh.SSLCertificateFile)
+
+	// Both Listen directives must survive, including the conditional one.
+	assert.Equal(t, "80,443", cfg.Params["Listen"])
+}
+
+func TestParse_IfDefineAndIfVersionAreTransparent(t *testing.T) {
+	cfg := Parse(`<IfDefine ENABLE_ADMIN>
+	<VirtualHost *:8080>
+		ServerName admin.example.com
+	</VirtualHost>
+</IfDefine>
+
+<IfVersion >= 2.4>
+	ServerTokens Prod
+</IfVersion>
+`)
+
+	require.Len(t, cfg.VHosts, 1)
+	assert.Equal(t, "admin.example.com", cfg.VHosts[0].ServerName)
+	assert.Equal(t, "Prod", cfg.Params["ServerTokens"])
+}
+
+func TestParse_NestedIfModuleBlocks(t *testing.T) {
+	cfg := Parse(`<IfModule mod_ssl.c>
+	<IfDefine TLS>
+		<VirtualHost *:443>
+			ServerName deep.example.com
+		</VirtualHost>
+	</IfDefine>
+</IfModule>
+`)
+
+	require.Len(t, cfg.VHosts, 1)
+	assert.Equal(t, "deep.example.com", cfg.VHosts[0].ServerName)
+}
+
+// A <Directory> block declared inside a <VirtualHost> is real configuration
+// and must reach cfg.Dirs; otherwise directories.all(...) evaluates over an
+// empty set on a host that does enable Indexes and .htaccess overrides.
+func TestParse_DirectoryInsideVirtualHost(t *testing.T) {
+	cfg := Parse(`<VirtualHost *:80>
+	ServerName a.example.com
+	<Directory /var/www/secret>
+		AllowOverride All
+		Options Indexes FollowSymLinks
+		Require all granted
+	</Directory>
+	<IfModule mod_headers.c>
+		Header always set Strict-Transport-Security "max-age=63072000"
+	</IfModule>
+</VirtualHost>
+`)
+
+	require.Len(t, cfg.VHosts, 1)
+	require.Len(t, cfg.Dirs, 1)
+	d := cfg.Dirs[0]
+	assert.Equal(t, "/var/www/secret", d.Path)
+	assert.Equal(t, "All", d.AllowOverride)
+	assert.Equal(t, "Indexes FollowSymLinks", d.Options)
+	assert.Equal(t, []string{"all granted"}, d.Require)
+
+	// A Header inside a conditional block inside the vhost still registers.
+	require.Contains(t, cfg.Headers, "Strict-Transport-Security")
+	assert.Equal(t, []string{"max-age=63072000"}, cfg.Headers["Strict-Transport-Security"])
+}
+
+// <RequireAll>/<RequireAny>/<RequireNone> group access-control grants. The
+// grants inside them are the access-control answer, so they must be hoisted
+// into the enclosing <Directory> rather than dropped — a directory whose only
+// Require lives in a RequireAll must not read as having no grants at all.
+func TestParse_RequireInsideRequireAll(t *testing.T) {
+	cfg := Parse(`<Directory /var/www>
+	<RequireAll>
+		Require ip 10.0.0.0/8
+		Require not ip 10.1.0.0/16
+	</RequireAll>
+</Directory>
+`)
+
+	require.Len(t, cfg.Dirs, 1)
+	assert.Equal(t, []string{"ip 10.0.0.0/8", "not ip 10.1.0.0/16"}, cfg.Dirs[0].Require)
+}
+
+// Apache directive names are case-insensitive. Two spellings of the same
+// directive must fold onto one key, so a lookup finds both values.
+func TestParse_DirectiveNamesAreCaseInsensitive(t *testing.T) {
+	cfg := Parse("Listen 80\nlisten 443\nSERVERTOKENS Prod\n")
+
+	listen, ok := ParamValue(cfg.Params, "listen")
+	require.True(t, ok)
+	assert.Equal(t, "80,443", listen)
+
+	tokens, ok := ParamValue(cfg.Params, "ServerTokens")
+	require.True(t, ok)
+	assert.Equal(t, "Prod", tokens)
+
+	// exactly one key for Listen, not one per spelling
+	count := 0
+	for k := range cfg.Params {
+		if k == "Listen" || k == "listen" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+// A non-transparent block must still be treated as a scope: directives inside
+// a <Files> block must not leak into the enclosing level's params.
+func TestParse_NonTransparentBlocksStillScoped(t *testing.T) {
+	cfg := Parse(`ServerName outer.example.com
+<Files ".ht*">
+	Require all denied
+</Files>
+`)
+
+	assert.Equal(t, "outer.example.com", cfg.Params["ServerName"])
+	_, leaked := cfg.Params["Require"]
+	assert.False(t, leaked, "directives inside <Files> must not leak to the enclosing scope")
+}
+
+// An unterminated transparent block must not lose the directives it contains
+// nor loop forever.
+func TestParse_UnclosedIfModule(t *testing.T) {
+	cfg := Parse("<IfModule mod_ssl.c>\n\tListen 443\n")
+	assert.Equal(t, "443", cfg.Params["Listen"])
+}
+
+func TestFlattenTransparentBlocks_DepthCap(t *testing.T) {
+	// Build a nesting deeper than maxTransparentNesting and confirm the
+	// flattener terminates rather than exhausting the stack.
+	var lines []string
+	for i := 0; i < maxTransparentNesting+10; i++ {
+		lines = append(lines, "<IfModule mod_ssl.c>")
+	}
+	lines = append(lines, "Listen 443")
+	for i := 0; i < maxTransparentNesting+10; i++ {
+		lines = append(lines, "</IfModule>")
+	}
+
+	out := flattenTransparentBlocks(lines)
+	assert.NotEmpty(t, out)
+}

--- a/providers/os/resources/apache2/parser.go
+++ b/providers/os/resources/apache2/parser.go
@@ -119,7 +119,7 @@ func ParseWithGlob(rootPath string, fileContent fileContentFunc, globExpand glob
 }
 
 func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent fileContentFunc, globExpand globExpandFunc, vars map[string]string, visited map[string]bool) {
-	lines := splitAndClean(content)
+	lines := flattenTransparentBlocks(splitAndClean(content))
 	i := 0
 	for i < len(lines) {
 		line := lines[i]
@@ -135,8 +135,9 @@ func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent f
 			case "virtualhost":
 				vh := parseVirtualHost(blockArg, blockLines, vars)
 				cfg.VHosts = append(cfg.VHosts, vh)
-				// VirtualHosts can contain their own <Location> blocks + Header directives.
-				collectScopedHeadersAndLocations(cfg, blockLines)
+				// VirtualHosts can contain their own <Directory>/<Location>
+				// blocks and Header directives.
+				collectScopedBlocks(cfg, blockLines, vars)
 			case "directory", "directorymatch":
 				d := parseDirectory(blockArg, blockLines, vars)
 				cfg.Dirs = append(cfg.Dirs, d)
@@ -188,20 +189,25 @@ func parseWithGlobRecursive(cfg *Config, filePath, content string, fileContent f
 	}
 }
 
-// collectScopedHeadersAndLocations walks the lines inside a containing block
-// (typically a VirtualHost) and extracts any nested <Location> blocks and
+// collectScopedBlocks walks the lines inside a containing block (typically a
+// VirtualHost) and extracts any nested <Directory> and <Location> blocks and
 // `Header always set` directives so they're reachable from the top-level
 // Config aggregates without forcing the caller to walk the tree again.
-func collectScopedHeadersAndLocations(cfg *Config, lines []string) {
+func collectScopedBlocks(cfg *Config, lines []string, vars map[string]string) {
+	lines = flattenTransparentBlocks(lines)
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
 		if strings.HasPrefix(line, "<") {
 			blockTag, blockArg := parseBlockOpen(line)
+			blockArg = expandApacheVars(blockArg, vars)
 			blockLines, end := collectBlock(lines, i+1, blockTag)
 			switch strings.ToLower(blockTag) {
 			case "location", "locationmatch":
-				loc := parseLocation(blockArg, blockLines, nil, strings.EqualFold(blockTag, "locationmatch"))
+				loc := parseLocation(blockArg, blockLines, vars, strings.EqualFold(blockTag, "locationmatch"))
 				cfg.Locations = append(cfg.Locations, loc)
+			case "directory", "directorymatch":
+				d := parseDirectory(blockArg, blockLines, vars)
+				cfg.Dirs = append(cfg.Dirs, d)
 			}
 			i = end
 			continue
@@ -291,7 +297,8 @@ func expandInclude(cfg *Config, pattern string, fileContent fileContentFunc, glo
 
 // parseLines parses lines at the top level (no glob expansion).
 func parseLines(cfg *Config, lines []string, start int) {
-	i := start
+	lines = flattenTransparentBlocks(lines[start:])
+	i := 0
 	for i < len(lines) {
 		line := lines[i]
 
@@ -304,7 +311,7 @@ func parseLines(cfg *Config, lines []string, start int) {
 			case "virtualhost":
 				vh := parseVirtualHost(blockArg, blockLines, nil)
 				cfg.VHosts = append(cfg.VHosts, vh)
-				collectScopedHeadersAndLocations(cfg, blockLines)
+				collectScopedBlocks(cfg, blockLines, nil)
 			case "directory", "directorymatch":
 				d := parseDirectory(blockArg, blockLines, nil)
 				cfg.Dirs = append(cfg.Dirs, d)
@@ -352,6 +359,7 @@ func parseVirtualHost(address string, lines []string, vars map[string]string) Vi
 		Params:  map[string]any{},
 	}
 
+	lines = flattenTransparentBlocks(lines)
 	depth := 0
 	for _, line := range lines {
 		if strings.HasPrefix(line, "<") {
@@ -462,6 +470,7 @@ func parseDirectory(path string, lines []string, vars map[string]string) Directo
 		Params: map[string]any{},
 	}
 
+	lines = flattenTransparentBlocks(lines)
 	depth := 0
 	for _, line := range lines {
 		if strings.HasPrefix(line, "<") {
@@ -507,6 +516,7 @@ func parseLocation(path string, lines []string, vars map[string]string, isMatch 
 		Params:  map[string]any{},
 	}
 
+	lines = flattenTransparentBlocks(lines)
 	depth := 0
 	for _, line := range lines {
 		if strings.HasPrefix(line, "<") {
@@ -657,6 +667,69 @@ func parseBlockOpen(line string) (string, string) {
 
 // collectBlock collects lines until the matching </tag> closing tag.
 // Returns the inner lines and the index of the closing tag line.
+// transparentContainers are block directives whose contents belong to the
+// enclosing scope rather than introducing a scope of their own.
+//
+// The conditional containers cannot be evaluated from the configuration text
+// alone — whether a module is loaded or a define is set is runtime state — so
+// their contents are always included. That matches the daemon whenever the
+// condition holds, which is the case for any config that ships them: Debian's
+// default-ssl.conf wraps its entire <VirtualHost> in <IfModule mod_ssl.c>, and
+// ports.conf wraps `Listen 443` in <IfModule ssl_module>.
+//
+// The Require containers group access-control directives; the grants inside
+// them are the access-control answer, so they are hoisted into the parent
+// <Directory>/<Location> rather than dropped.
+var transparentContainers = map[string]bool{
+	"ifmodule":    true,
+	"ifdefine":    true,
+	"ifversion":   true,
+	"iffile":      true,
+	"ifdirective": true,
+	"ifsection":   true,
+	"requireall":  true,
+	"requireany":  true,
+	"requirenone": true,
+}
+
+// maxTransparentNesting bounds the recursion in flattenTransparentBlocks so a
+// pathologically nested config cannot exhaust the stack.
+const maxTransparentNesting = 64
+
+// flattenTransparentBlocks splices the contents of transparent container blocks
+// into the enclosing level, dropping the container's own open/close lines. Any
+// other block is passed through untouched — open and close lines included — so
+// scope-aware callers still see it as a block.
+func flattenTransparentBlocks(lines []string) []string {
+	return flattenTransparentBlocksDepth(lines, 0)
+}
+
+func flattenTransparentBlocksDepth(lines []string, depth int) []string {
+	if depth > maxTransparentNesting {
+		return lines
+	}
+
+	out := make([]string, 0, len(lines))
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if !strings.HasPrefix(line, "<") || strings.HasPrefix(line, "</") {
+			out = append(out, line)
+			continue
+		}
+
+		tag, _ := parseBlockOpen(line)
+		if !transparentContainers[strings.ToLower(tag)] {
+			out = append(out, line)
+			continue
+		}
+
+		inner, end := collectBlock(lines, i+1, tag)
+		out = append(out, flattenTransparentBlocksDepth(inner, depth+1)...)
+		i = end
+	}
+	return out
+}
+
 func collectBlock(lines []string, start int, tag string) ([]string, int) {
 	closeTag := "</" + strings.ToLower(tag)
 	depth := 1
@@ -682,13 +755,40 @@ func collectBlock(lines []string, start int, tag string) ([]string, int) {
 // setParam sets a directive value. For directives that can appear multiple
 // times (Listen, Header, etc.), values are comma-concatenated.
 func setParam(m map[string]any, key string, value string) {
-	if isMultiParam[strings.ToLower(key)] {
-		if v, ok := m[key]; ok {
-			m[key] = v.(string) + "," + value
-			return
+	// Apache directive names are case-insensitive, so fold onto whichever
+	// spelling was seen first. Without this, `Listen 80` in ports.conf and
+	// `listen 443` in a fragment land in two different keys, so neither the
+	// multi-value join below nor a lookup by either spelling finds both.
+	canonical := key
+	for k := range m {
+		if strings.EqualFold(k, key) {
+			canonical = k
+			break
 		}
 	}
-	m[key] = value
+
+	if isMultiParam[strings.ToLower(key)] {
+		if v, ok := m[canonical]; ok {
+			if s, ok := v.(string); ok {
+				m[canonical] = s + "," + value
+				return
+			}
+		}
+	}
+	m[canonical] = value
+}
+
+// ParamValue looks up a directive value case-insensitively, matching Apache's
+// case-insensitive directive names.
+func ParamValue(m map[string]any, key string) (string, bool) {
+	for k, v := range m {
+		if !strings.EqualFold(k, key) {
+			continue
+		}
+		s, ok := v.(string)
+		return s, ok
+	}
+	return "", false
 }
 
 // isMultiParam lists directives that can appear multiple times and should


### PR DESCRIPTION
## Problem

The Apache config parser switched on the block tag and silently fell through for any container it didn't recognize — but `collectBlock` had already consumed the block body, so **every directive inside was dropped**, including nested `<VirtualHost>` and `<Directory>` blocks.

This is the stock Debian/Ubuntu layout. `sites-available/default-ssl.conf` wraps its entire TLS vhost in `<IfModule mod_ssl.c>`, and `ports.conf` wraps `Listen 443` in `<IfModule ssl_module>`. Parsing that config on `main`:

```
VirtualHosts=0   Params={"Listen":"80"}
```

So `apache2.conf.virtualHosts` was empty on a host serving TLS — meaning `virtualHosts.all(...)` evaluated over an empty set and passed, and an exposure audit concluded the host did not serve TLS at all. No error, nothing to indicate the config had been partially discarded.

## Fix

Conditional containers (`IfModule`, `IfDefine`, `IfVersion`, `IfFile`, `IfDirective`, `IfSection`) can't be evaluated from the configuration text — whether a module is loaded is runtime state — so their contents are now always included. That matches the daemon whenever the condition holds, which is the case for any config that ships them.

`flattenTransparentBlocks` splices a transparent container's contents into the enclosing level before parsing, recursively and at every level (top-level, VirtualHost, Directory, Location), bounded by a nesting cap. Non-transparent blocks pass through untouched, so `<Files>` and friends are still treated as scopes and don't leak into their parent.

Three related fixes come along:

- **`<Directory>` inside a `<VirtualHost>` now reaches `apache2.conf.directories`.** It previously never did, so `directories.all(allowOverride == "None")` passed over an empty set on a host with a directory-listing-enabled, `.htaccess`-enabled docroot.
- **`Require` inside `<RequireAll>`/`<RequireAny>`/`<RequireNone>` is hoisted** into the enclosing block. A directory whose access control lives in a Require container previously read as having no grants at all.
- **Directive names fold case-insensitively**, as Apache treats them. `Listen 80` in `ports.conf` and `listen 443` in a fragment previously landed in two separate map keys, so the multi-value join never happened and `params["Listen"]` missed a config written in any other case. Added `apache2.ParamValue` for case-insensitive reads and routed `listenAddresses` through it.

## Tests

`container_blocks_test.go` adds 9 cases. Verified they fail on the unfixed parser — neutering the transparent-container set makes 5 of them fail with exactly the symptoms above, and they pass with the fix:

- `<IfModule>`-wrapped vhost + conditional `Listen` (the stock Debian shape)
- `<IfDefine>` / `<IfVersion>` transparency
- nested conditional containers
- `<Directory>` and a conditional `Header` inside a `<VirtualHost>`
- `Require` inside `<RequireAll>`
- case-insensitive directive folding, asserting one key rather than one per spelling
- **negative case:** `<Files>` stays scoped and does not leak into the parent
- unterminated `<IfModule>` still yields its directives and terminates
- nesting past the depth cap terminates

All 20 pre-existing apache2 tests still pass, as does `providers/os/resources`.

## Found by

A static review pass over the `os` provider parsers.
