### PR TITLE
🐛 MQL: bind a block to its own operand instead of the stack tail

### DIFF
--- a/mqlc/array_block_test.go
+++ b/mqlc/array_block_test.go
@@ -1,0 +1,55 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/mqlc"
+)
+
+// TestCompiler_ArrayLiteralWithBlock covers an array literal whose elements are
+// resources, with a block attached.
+//
+// The elements compile to refs, so the stack is already non-empty by the time the
+// block is handled. compileOperand only pushed the value onto the stack when the
+// stack looked empty, so for this shape the array primitive was never pushed and
+// the operand's own ref stayed 0 -- leaving the block bound to a chunk that is
+// not on the stack. Computing checksums then hit
+//
+//	panic: cannot compute checksum for chunk, it doesn't seem to reference a
+//	       function on the stack        (llx/chunk.go, Function.checksumV2)
+//
+// Compile() recovers only to re-panic with a wrapped error, so this crashed the
+// caller -- the CLI died and health.ReportPanic fired -- instead of returning a
+// compile error. A scalar array ([1,2] { _ }) was unaffected, which is why this
+// went unnoticed.
+func TestCompiler_ArrayLiteralWithBlock(t *testing.T) {
+	codes := []string{
+		"[asset] { name }",
+		"[mondoo] { version }",
+		"[asset] { name platform }",
+		// the shape that first surfaced this: two parameterized instances of one
+		// resource compared side by side
+		`[asset, asset] { name }`,
+		// scalars kept working throughout; pin them so the fix cannot regress them
+		"[1, 2] { _ }",
+		`["a", "b"] { _ }`,
+	}
+
+	for _, code := range codes {
+		t.Run(code, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				res, err := mqlc.Compile(code, nil, conf)
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.NotNil(t, res.CodeV2)
+				assert.NoError(t, mqlc.Invariants.Check(res))
+				require.NotEmpty(t, res.CodeV2.Blocks)
+			}, "compiling %q must not panic", code)
+		})
+	}
+}

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1608,17 +1608,24 @@ func (c *compiler) compileOperand(operand *parser.Operand) (*llx.Primitive, erro
 	}
 
 	if operand.Block != nil {
-		// for starters, we need the primitive to exist on the stack,
-		// so add it if it's missing
-		if x := c.tailRef(); (x & 0xFFFFFFFF) == 0 {
-			val, err := c.compileValue(operand.Value)
-			if err != nil {
-				return nil, err
-			}
+		// The block binds to this operand's value, so that value has to exist as a
+		// chunk on the stack. ref is still 0 when the value compiled to a bare
+		// primitive that nothing pushed (i.e. no calls followed it).
+		//
+		// This has to test the operand's own ref, not whether the stack is empty.
+		// An array literal whose elements are resources compiles those elements
+		// into chunks, so the stack is non-empty while the array itself was never
+		// pushed. Binding the block to a chunk that is not on the stack made
+		// checksumming panic ("doesn't seem to reference a function on the stack"),
+		// which Compile only recovers in order to re-panic -- taking the caller
+		// down. A scalar array pushes nothing, so it kept working.
+		if ref == 0 && res != nil {
+			// res is the already-compiled primitive for this value. Recompiling it
+			// here would emit a second copy of every chunk its elements produced.
 			c.addChunk(&llx.Chunk{
 				Call: llx.Chunk_PRIMITIVE,
 				// no ID for standalone
-				Primitive: val,
+				Primitive: res,
 			})
 			ref = c.tailRef()
 		}


### PR DESCRIPTION
## The bug

Attaching a block to an array literal whose elements are resources crashes the compiler:

```
$ mql run local -c '[asset] { name }'
panic: cannot compute checksum for chunk, it doesn't seem to reference a function on the stack
  llx.(*Function).checksumV2   llx/chunk.go:118
  llx.(*Chunk).ChecksumV2      llx/chunk.go:105
  llx.(*Block).AddChunk        llx/code.go:57
  mqlc.(*compiler).addChunk    mqlc/mqlc.go:223
  mqlc.Compile.func1           mqlc/mqlc.go:2337
```

`Compile()` recovers only in order to **re-panic** with a wrapped error, so this takes the caller down — the CLI dies and `health.ReportPanic` fires — instead of returning a compile error.

Provider-independent; reproduced with `core` and `os` resources:

```
[asset] { name }        panic
[mondoo] { version }    panic
[aws.waf] { scope }     panic
[1, 2] { _ }            fine
```

## Root cause

A block binds to its operand's value, so that value has to exist as a chunk on the stack. `compileOperand` pushed it only when the stack *looked* empty:

```go
if x := c.tailRef(); (x & 0xFFFFFFFF) == 0 {
```

That is not the same question as "did this operand produce a ref?". An array literal compiles its **elements** first, so `[aws.waf]` leaves a chunk on the stack (the resource) while the array primitive itself was never pushed and the operand's own `ref` stayed `0`. The block was then bound to a chunk that is not on the stack, and checksumming panicked.

A scalar array (`[1, 2]`) pushes nothing, so the old condition happened to hold — which is why this went unnoticed.

## The fix

Test the operand's own `ref`, and push the **already-compiled** primitive instead of recompiling the value (recompiling would emit a second copy of every chunk the elements produced).

## Verification

```
[asset] { name }       ->  [ { name: "..." } ]
[mondoo] { version }   ->  [ { version: "v13.0.0-rolling" } ]
[1,2] { _ }            ->  unchanged
```

New `TestCompiler_ArrayLiteralWithBlock` covers resource-element arrays, a multi-element array, and pins the scalar cases so the fix cannot regress them. It was confirmed to fail with the original panic before the change.

`./mqlc/...`, `./mqlc/parser`, and `./llx/...` are green.

`make test/go/plain` reports three failures — `cli/config`, `cli/selfupdate`, and `providers` (build, missing generated mocks). All three reproduce on an unmodified checkout of `main`, so they are pre-existing and unrelated to this change.
