### PR TITLE
🎉 azure-13.33.3

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.33.2",
+	Version:   "13.33.3",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

## azure 13.33.2 → 13.33.3

- 🐛 azure: scope the root asset to an explicitly named subscription (#9444)
- 🐛 azure: fix bug-review findings across all severity tiers (#9440)
- ✨ Update cloud deps and expose the new fields and resources they bring (#9432)
