### PR TITLE
🛑 hetzner: remove the deprecated fields

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -81,11 +81,6 @@ private hetzner.server @defaults("id name status") {
   primaryDiskSize int
   // Server type (VM size)
   serverType() hetzner.serverType
-  // Datacenter the server runs in
-  //
-  // Deprecated, please use location. Hetzner removed the datacenter
-  // association from servers, so this always resolves to null.
-  datacenter() @maturity("deprecated") hetzner.datacenter
   // Location the server runs in
   location() hetzner.location
   // Image the server was created from (nullable)
@@ -513,11 +508,6 @@ private hetzner.primaryIp @defaults("id ip type") {
   autoDelete bool
   // Whether the IP is blocked
   blocked bool
-  // Datacenter the IP belongs to
-  //
-  // Deprecated, please use location. Hetzner removed the datacenter
-  // association from primary IPs, so this always resolves to null.
-  datacenter() @maturity("deprecated") hetzner.datacenter
   // Location the IP belongs to
   location() hetzner.location
   // Server the IP is assigned to (nullable)
@@ -676,7 +666,7 @@ private hetzner.loadBalancer.target @defaults("type") {
 // maximum concurrent connections, services, targets, and assigned TLS
 // certificates. Use it to confirm a load balancer is provisioned on a
 // class that fits its expected traffic, or to spot classes that are
-// scheduled for retirement through the `deprecated` timestamp. Select a
+// scheduled for retirement through the `deprecation` schedule. Select a
 // type by id with `hetzner.loadBalancerType(id: 1)`.
 private hetzner.loadBalancerType @defaults("id name") {
   init(id? int)
@@ -694,12 +684,6 @@ private hetzner.loadBalancerType @defaults("id name") {
   maxTargets int
   // Maximum assigned certificates
   maxAssignedCertificates int
-  // Announcement timestamp
-  //
-  // Deprecated in favor of deprecation, which carries the retirement date
-  // as well. Holds the timestamp the deprecation was announced, and is null
-  // while the load balancer type is current.
-  deprecated @maturity("deprecated") time
   // Deprecation schedule
   //
   // Empty when the load balancer type is not deprecated. When present it
@@ -922,8 +906,7 @@ private hetzner.location @defaults("id name city") {
 // hetzner.datacenter(id: 4). Reports the location it belongs to, the
 // server types it supports, which of those are currently available for
 // new servers, and which are open for migration, so you can plan
-// placement and capacity. The servers field lists the servers running
-// in this datacenter.
+// placement and capacity.
 private hetzner.datacenter @defaults("id name") {
   init(id? int)
   // Datacenter ID
@@ -940,12 +923,6 @@ private hetzner.datacenter @defaults("id name") {
   availableServerTypes() []hetzner.serverType
   // Server types available for migration into this datacenter
   serverTypesAvailableForMigration() []hetzner.serverType
-  // Servers running in this datacenter
-  //
-  // Hetzner removed the datacenter association from servers, so servers can
-  // no longer be mapped back to a datacenter. This field is deprecated and
-  // always resolves to an empty list.
-  servers() @maturity("deprecated") []hetzner.server
 }
 
 // Hetzner Cloud Storage Box (managed backup/file storage)

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -323,9 +323,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.server.serverType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetServerType()).ToDataRes(types.Resource("hetzner.serverType"))
 	},
-	"hetzner.server.datacenter": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlHetznerServer).GetDatacenter()).ToDataRes(types.Resource("hetzner.datacenter"))
-	},
 	"hetzner.server.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServer).GetLocation()).ToDataRes(types.Resource("hetzner.location"))
 	},
@@ -719,9 +716,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.primaryIp.blocked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerPrimaryIp).GetBlocked()).ToDataRes(types.Bool)
 	},
-	"hetzner.primaryIp.datacenter": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlHetznerPrimaryIp).GetDatacenter()).ToDataRes(types.Resource("hetzner.datacenter"))
-	},
 	"hetzner.primaryIp.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerPrimaryIp).GetLocation()).ToDataRes(types.Resource("hetzner.location"))
 	},
@@ -880,9 +874,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.loadBalancerType.maxAssignedCertificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerType).GetMaxAssignedCertificates()).ToDataRes(types.Int)
-	},
-	"hetzner.loadBalancerType.deprecated": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlHetznerLoadBalancerType).GetDeprecated()).ToDataRes(types.Time)
 	},
 	"hetzner.loadBalancerType.deprecation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerType).GetDeprecation()).ToDataRes(types.Dict)
@@ -1060,9 +1051,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.datacenter.serverTypesAvailableForMigration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerDatacenter).GetServerTypesAvailableForMigration()).ToDataRes(types.Array(types.Resource("hetzner.serverType")))
-	},
-	"hetzner.datacenter.servers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlHetznerDatacenter).GetServers()).ToDataRes(types.Array(types.Resource("hetzner.server")))
 	},
 	"hetzner.storageBox.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerStorageBox).GetId()).ToDataRes(types.Int)
@@ -1449,10 +1437,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.server.serverType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServer).ServerType, ok = plugin.RawToTValue[*mqlHetznerServerType](v.Value, v.Error)
-		return
-	},
-	"hetzner.server.datacenter": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlHetznerServer).Datacenter, ok = plugin.RawToTValue[*mqlHetznerDatacenter](v.Value, v.Error)
 		return
 	},
 	"hetzner.server.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2023,10 +2007,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerPrimaryIp).Blocked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"hetzner.primaryIp.datacenter": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlHetznerPrimaryIp).Datacenter, ok = plugin.RawToTValue[*mqlHetznerDatacenter](v.Value, v.Error)
-		return
-	},
 	"hetzner.primaryIp.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerPrimaryIp).Location, ok = plugin.RawToTValue[*mqlHetznerLocation](v.Value, v.Error)
 		return
@@ -2257,10 +2237,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.loadBalancerType.maxAssignedCertificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerLoadBalancerType).MaxAssignedCertificates, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"hetzner.loadBalancerType.deprecated": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlHetznerLoadBalancerType).Deprecated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"hetzner.loadBalancerType.deprecation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2521,10 +2497,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.datacenter.serverTypesAvailableForMigration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerDatacenter).ServerTypesAvailableForMigration, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"hetzner.datacenter.servers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlHetznerDatacenter).Servers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"hetzner.storageBox.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3313,7 +3285,6 @@ type mqlHetznerServer struct {
 	Created           plugin.TValue[*time.Time]
 	PrimaryDiskSize   plugin.TValue[int64]
 	ServerType        plugin.TValue[*mqlHetznerServerType]
-	Datacenter        plugin.TValue[*mqlHetznerDatacenter]
 	Location          plugin.TValue[*mqlHetznerLocation]
 	Image             plugin.TValue[*mqlHetznerImage]
 	PrivateNet        plugin.TValue[[]any]
@@ -3415,22 +3386,6 @@ func (c *mqlHetznerServer) GetServerType() *plugin.TValue[*mqlHetznerServerType]
 		}
 
 		return c.serverType()
-	})
-}
-
-func (c *mqlHetznerServer) GetDatacenter() *plugin.TValue[*mqlHetznerDatacenter] {
-	return plugin.GetOrCompute[*mqlHetznerDatacenter](&c.Datacenter, func() (*mqlHetznerDatacenter, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.server", c.__id, "datacenter")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.(*mqlHetznerDatacenter), nil
-			}
-		}
-
-		return c.datacenter()
 	})
 }
 
@@ -4816,7 +4771,6 @@ type mqlHetznerPrimaryIp struct {
 	AssigneeId   plugin.TValue[int64]
 	AutoDelete   plugin.TValue[bool]
 	Blocked      plugin.TValue[bool]
-	Datacenter   plugin.TValue[*mqlHetznerDatacenter]
 	Location     plugin.TValue[*mqlHetznerLocation]
 	Server       plugin.TValue[*mqlHetznerServer]
 	DnsPtr       plugin.TValue[[]any]
@@ -4892,22 +4846,6 @@ func (c *mqlHetznerPrimaryIp) GetAutoDelete() *plugin.TValue[bool] {
 
 func (c *mqlHetznerPrimaryIp) GetBlocked() *plugin.TValue[bool] {
 	return &c.Blocked
-}
-
-func (c *mqlHetznerPrimaryIp) GetDatacenter() *plugin.TValue[*mqlHetznerDatacenter] {
-	return plugin.GetOrCompute[*mqlHetznerDatacenter](&c.Datacenter, func() (*mqlHetznerDatacenter, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.primaryIp", c.__id, "datacenter")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.(*mqlHetznerDatacenter), nil
-			}
-		}
-
-		return c.datacenter()
-	})
 }
 
 func (c *mqlHetznerPrimaryIp) GetLocation() *plugin.TValue[*mqlHetznerLocation] {
@@ -5514,7 +5452,6 @@ type mqlHetznerLoadBalancerType struct {
 	MaxServices             plugin.TValue[int64]
 	MaxTargets              plugin.TValue[int64]
 	MaxAssignedCertificates plugin.TValue[int64]
-	Deprecated              plugin.TValue[*time.Time]
 	Deprecation             plugin.TValue[any]
 }
 
@@ -5581,10 +5518,6 @@ func (c *mqlHetznerLoadBalancerType) GetMaxTargets() *plugin.TValue[int64] {
 
 func (c *mqlHetznerLoadBalancerType) GetMaxAssignedCertificates() *plugin.TValue[int64] {
 	return &c.MaxAssignedCertificates
-}
-
-func (c *mqlHetznerLoadBalancerType) GetDeprecated() *plugin.TValue[*time.Time] {
-	return &c.Deprecated
 }
 
 func (c *mqlHetznerLoadBalancerType) GetDeprecation() *plugin.TValue[any] {
@@ -6152,7 +6085,6 @@ type mqlHetznerDatacenter struct {
 	SupportedServerTypes             plugin.TValue[[]any]
 	AvailableServerTypes             plugin.TValue[[]any]
 	ServerTypesAvailableForMigration plugin.TValue[[]any]
-	Servers                          plugin.TValue[[]any]
 }
 
 // createHetznerDatacenter creates a new instance of this resource
@@ -6265,22 +6197,6 @@ func (c *mqlHetznerDatacenter) GetServerTypesAvailableForMigration() *plugin.TVa
 		}
 
 		return c.serverTypesAvailableForMigration()
-	})
-}
-
-func (c *mqlHetznerDatacenter) GetServers() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.Servers, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.datacenter", c.__id, "servers")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.servers()
 	})
 }
 

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -32,7 +32,6 @@ hetzner.datacenter.id 13.0.1
 hetzner.datacenter.location 13.0.1
 hetzner.datacenter.name 13.0.1
 hetzner.datacenter.serverTypesAvailableForMigration 13.0.1
-hetzner.datacenter.servers 13.5.2
 hetzner.datacenter.supportedServerTypes 13.0.1
 hetzner.datacenters 13.0.1
 hetzner.firewall 13.0.1
@@ -132,7 +131,6 @@ hetzner.loadBalancer.target.type 13.0.1
 hetzner.loadBalancer.target.usePrivateIp 13.0.1
 hetzner.loadBalancer.targets 13.0.1
 hetzner.loadBalancerType 13.0.1
-hetzner.loadBalancerType.deprecated 13.0.1
 hetzner.loadBalancerType.deprecation 13.7.5
 hetzner.loadBalancerType.description 13.0.1
 hetzner.loadBalancerType.id 13.0.1
@@ -186,7 +184,6 @@ hetzner.primaryIp.assigneeType 13.0.1
 hetzner.primaryIp.autoDelete 13.0.1
 hetzner.primaryIp.blocked 13.0.1
 hetzner.primaryIp.created 13.0.1
-hetzner.primaryIp.datacenter 13.0.1
 hetzner.primaryIp.dnsPtr 13.0.1
 hetzner.primaryIp.id 13.0.1
 hetzner.primaryIp.ip 13.0.1
@@ -201,7 +198,6 @@ hetzner.server 13.0.1
 hetzner.server.backupWindow 13.0.1
 hetzner.server.backupsEnabled 13.5.2
 hetzner.server.created 13.0.1
-hetzner.server.datacenter 13.0.1
 hetzner.server.dnsRecords 13.7.7
 hetzner.server.exposure 13.3.1
 hetzner.server.firewallBinding 13.1.2

--- a/providers/hetzner/resources/hetzner_datacenter.go
+++ b/providers/hetzner/resources/hetzner_datacenter.go
@@ -93,14 +93,6 @@ func (m *mqlHetznerDatacenter) serverTypesAvailableForMigration() ([]any, error)
 	return serverTypeRefs(m.MqlRuntime, m.cacheServerTypesAvailableMigration)
 }
 
-func (m *mqlHetznerDatacenter) servers() ([]any, error) {
-	// Hetzner removed the datacenter association from servers, so servers can no
-	// longer be mapped back to a datacenter (a location holds many datacenters,
-	// so the server's location cannot recover it). The field is retained
-	// (deprecated) and always resolves to an empty list.
-	return []any{}, nil
-}
-
 func serverTypeRefs(runtime *plugin.Runtime, types []*hcloud.ServerType) ([]any, error) {
 	out := make([]any, 0, len(types))
 	for _, t := range types {

--- a/providers/hetzner/resources/hetzner_loadbalancertype.go
+++ b/providers/hetzner/resources/hetzner_loadbalancertype.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"go.mondoo.com/mql/v13/llx"
@@ -36,14 +35,6 @@ func (h *mqlHetzner) loadBalancerTypes() ([]any, error) {
 }
 
 func newMqlHetznerLoadBalancerType(runtime *plugin.Runtime, t *hcloud.LoadBalancerType) (*mqlHetznerLoadBalancerType, error) {
-	// The legacy Deprecated string is populated by the SDK from the announcement
-	// date, so `deprecated` is read straight from the structured Deprecation
-	// info. That preserves the field's meaning while dropping the round-trip
-	// through an RFC3339 string that the API no longer returns.
-	var announced *time.Time
-	if t.Deprecation != nil {
-		announced = timePtr(t.Deprecation.Announced)
-	}
 	res, err := CreateResource(runtime, "hetzner.loadBalancerType", map[string]*llx.RawData{
 		"__id":                    llx.StringData(fmt.Sprintf("hetzner.loadBalancerType/%d", t.ID)),
 		"id":                      llx.IntData(t.ID),
@@ -53,7 +44,6 @@ func newMqlHetznerLoadBalancerType(runtime *plugin.Runtime, t *hcloud.LoadBalanc
 		"maxServices":             llx.IntData(int64(t.MaxServices)),
 		"maxTargets":              llx.IntData(int64(t.MaxTargets)),
 		"maxAssignedCertificates": llx.IntData(int64(t.MaxAssignedCertificates)),
-		"deprecated":              llx.TimeDataPtr(announced),
 		"deprecation":             llx.DictData(deprecationDict(t.Deprecation)),
 	})
 	if err != nil {

--- a/providers/hetzner/resources/hetzner_primaryip.go
+++ b/providers/hetzner/resources/hetzner_primaryip.go
@@ -86,14 +86,6 @@ func initHetznerPrimaryIp(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	return args, res, err
 }
 
-func (m *mqlHetznerPrimaryIp) datacenter() (*mqlHetznerDatacenter, error) {
-	// Hetzner removed the datacenter association from primary IPs; the API now
-	// reports only the location. The field is retained (deprecated) and always
-	// resolves to null.
-	m.Datacenter.State = plugin.StateIsSet | plugin.StateIsNull
-	return nil, nil
-}
-
 func (m *mqlHetznerPrimaryIp) location() (*mqlHetznerLocation, error) {
 	return resolveTypedResource(&m.Location, m.cacheLocation, func(l *hcloud.Location) (*mqlHetznerLocation, error) {
 		return newMqlHetznerLocation(m.MqlRuntime, l)

--- a/providers/hetzner/resources/hetzner_server.go
+++ b/providers/hetzner/resources/hetzner_server.go
@@ -206,14 +206,6 @@ func (m *mqlHetznerServer) serverType() (*mqlHetznerServerType, error) {
 	})
 }
 
-func (m *mqlHetznerServer) datacenter() (*mqlHetznerDatacenter, error) {
-	// Hetzner removed the datacenter association from servers; the API now
-	// reports only the location. The field is retained (deprecated) and
-	// always resolves to null.
-	m.Datacenter.State = plugin.StateIsSet | plugin.StateIsNull
-	return nil, nil
-}
-
 func (m *mqlHetznerServer) location() (*mqlHetznerLocation, error) {
 	return resolveTypedResource(&m.Location, m.cacheLocation, func(l *hcloud.Location) (*mqlHetznerLocation, error) {
 		return newMqlHetznerLocation(m.MqlRuntime, l)


### PR DESCRIPTION
Removes the four fields marked `@maturity("deprecated")` in `hetzner.lr`. All four are dead stubs that carry no data — every one of them was hard-coded to return null or an empty list, so nothing queryable is lost.

Held as a draft for the **v14** cycle, since removing shipped fields is breaking.

## What's removed

| Field | Version | Why it's dead | Migration |
|---|---|---|---|
| `hetzner.server.datacenter` | 13.0.1 | Accessor hard-coded `StateIsSet \| StateIsNull` | `location` |
| `hetzner.primaryIp.datacenter` | 13.0.1 | Same | `location` |
| `hetzner.datacenter.servers` | 13.5.2 | Accessor returned `[]any{}` unconditionally | none — see below |
| `hetzner.loadBalancerType.deprecated` | 13.0.1 | Lossy subset of `deprecation` | `deprecation` |

The three datacenter-related fields died when [Hetzner removed the datacenter association](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) from servers and primary IPs — the API now reports only the location. `hetzner.datacenter.servers` has no replacement: a location holds many datacenters, so a server's location cannot recover which datacenter it ran in. The association genuinely no longer exists.

`hetzner.loadBalancerType.deprecated` held only the announcement timestamp. `deprecation` carries that same value plus `unavailableAfter`, the retirement date that actually matters for planning a migration off a retiring type.

The `hetzner.datacenter` resource itself is **unchanged** and stays reachable through `hetzner.datacenters`.

## Breaking-change impact

Queries naming these fields stop compiling rather than silently returning null. In practice the blast radius is small — the fields only ever returned null/empty, so any policy asserting on them was already vacuous. Worth noting that `null && null` evaluates to `true` in MQL, so an assertion combining two of these was passing without verifying anything.

## Follow-up (not in this PR)

`go vet` surfaced that the upstream SDK has deprecated the datacenter concept wholesale, with a hard removal date:

- `hcloud.Datacenter`, `DatacenterClient`, `DatacenterListOpts`, `.List`, `.GetByID` — all removed after **2026-10-01**
- `Datacenter.ServerTypes` stops being returned after the same date; the SDK points at `ServerType.Locations`

That means the `hetzner.datacenter` resource and `hetzner.datacenters` need their own plan before October, and `supportedServerTypes`/`availableServerTypes`/`serverTypesAvailableForMigration` will need re-sourcing from `ServerType.Locations`. Left alone here to keep this PR to the fields that are already dead.

## Verification

- `./mqlr generate` — regenerated `hetzner.lr.go`; `hetzner.lr.versions` self-pruned the four entries (366 total)
- `make providers/build/hetzner` — clean
- `gofmt -l` — clean
- `go vet ./...` — no new findings
- `go test ./...` — all packages pass

Not live-verified against a Hetzner project; the change is a pure removal of accessors that returned constants, so there is no new API behavior to exercise.
