### PR TITLE
🛑 digitalocean: remove all deprecated fields

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -115,6 +115,9 @@ type mqlDigitaloceanDropletInternal struct {
 	// accessors can resolve them without a refetch.
 	cacheSnapshotIDs []int
 	cacheBackupIDs   []int
+	// cacheVPCUUID holds the UUID of the VPC the droplet is attached to so
+	// the typed vpc() accessor can resolve it without a refetch.
+	cacheVPCUUID string
 }
 
 func (r *mqlDigitalocean) droplets() ([]interface{}, error) {
@@ -168,14 +171,6 @@ func (r *mqlDigitalocean) droplets() ([]interface{}, error) {
 			}
 		}
 
-		imageDict := map[string]interface{}{}
-		if d.Image != nil {
-			imageDict["id"] = float64(d.Image.ID)
-			imageDict["name"] = d.Image.Name
-			imageDict["distribution"] = d.Image.Distribution
-			imageDict["slug"] = d.Image.Slug
-		}
-
 		regionSlug := ""
 		if d.Region != nil {
 			regionSlug = d.Region.Slug
@@ -220,11 +215,9 @@ func (r *mqlDigitalocean) droplets() ([]interface{}, error) {
 			"privateIpv4":           llx.StringData(privateIPv4),
 			"publicIpv6":            llx.StringData(publicIPv6),
 			"tags":                  llx.ArrayData(tags, "\x02"),
-			"vpcUuid":               llx.StringData(d.VPCUUID),
 			"features":              llx.ArrayData(features, "\x02"),
 			"backupsEnabled":        llx.BoolData(backupsEnabled),
 			"monitoringEnabled":     llx.BoolData(monitoringEnabled),
-			"image":                 llx.DictData(imageDict),
 			"kernel":                llx.DictData(kernelDict),
 			"nextBackupWindowStart": llx.TimeDataPtr(nextBackupStart),
 			"nextBackupWindowEnd":   llx.TimeDataPtr(nextBackupEnd),
@@ -232,12 +225,14 @@ func (r *mqlDigitalocean) droplets() ([]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Cache the godo image for the typed baseImage() accessor, plus the
-		// volume / snapshot / backup image IDs for the typed volumes(),
-		// snapshots(), and backups() accessors — all without a refetch.
+		// Cache the godo image for the typed baseImage() accessor, the VPC
+		// UUID for vpc(), plus the volume / snapshot / backup image IDs for
+		// the typed volumes(), snapshots(), and backups() accessors — all
+		// without a refetch.
 		mqlDroplet := res.(*mqlDigitaloceanDroplet)
 		mqlDroplet.image = d.Image
 		mqlDroplet.size = d.Size
+		mqlDroplet.cacheVPCUUID = d.VPCUUID
 		mqlDroplet.cacheVolumeIDs = d.VolumeIDs
 		mqlDroplet.cacheSnapshotIDs = d.SnapshotIDs
 		mqlDroplet.cacheBackupIDs = d.BackupIDs
@@ -264,11 +259,7 @@ func (r *mqlDigitalocean) firewalls() ([]interface{}, error) {
 		if skipFirewall(conn.Filters.General, &fw) {
 			continue
 		}
-		fwArgs, err := firewallArgs(r.MqlRuntime, &fw)
-		if err != nil {
-			return nil, err
-		}
-		res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall", fwArgs)
+		res, err := newMqlFirewall(r.MqlRuntime, &fw)
 		if err != nil {
 			return nil, err
 		}
@@ -417,10 +408,6 @@ func (r *mqlDigitalocean) volumes() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, v := range volumes {
-			dropletIds := make([]interface{}, len(v.DropletIDs))
-			for i, id := range v.DropletIDs {
-				dropletIds[i] = int64(id)
-			}
 			tags := make([]interface{}, len(v.Tags))
 			for i, t := range v.Tags {
 				tags[i] = t
@@ -440,11 +427,13 @@ func (r *mqlDigitalocean) volumes() ([]interface{}, error) {
 				"filesystemLabel": llx.StringData(v.FilesystemLabel),
 				"createdAt":       llx.TimeData(v.CreatedAt),
 				"tags":            llx.ArrayData(tags, "\x02"),
-				"dropletIds":      llx.ArrayData(dropletIds, "\x05"),
 			})
 			if err != nil {
 				return nil, err
 			}
+			// Cache the attached droplet IDs so the typed droplets() accessor
+			// can resolve them without a refetch.
+			res.(*mqlDigitaloceanVolume).cacheDropletIDs = toIntSlice(v.DropletIDs)
 			all = append(all, res)
 		}
 		if resp.Links == nil || resp.Links.IsLastPage() {
@@ -457,6 +446,12 @@ func (r *mqlDigitalocean) volumes() ([]interface{}, error) {
 		opt.ListOptions.Page = page + 1
 	}
 	return all, nil
+}
+
+type mqlDigitaloceanVolumeInternal struct {
+	// cacheDropletIDs holds the IDs of the droplets the volume is attached
+	// to so the typed droplets() accessor can resolve them without a refetch.
+	cacheDropletIDs []any
 }
 
 func (r *mqlDigitaloceanVolume) id() (string, error) {
@@ -477,11 +472,10 @@ func (r *mqlDigitalocean) loadBalancers() ([]interface{}, error) {
 		if skipLoadBalancer(conn.Filters.General, &lb) {
 			continue
 		}
-		res, err := CreateResource(r.MqlRuntime, "digitalocean.loadBalancer", loadBalancerArgs(&lb))
+		res, err := newMqlLoadBalancer(r.MqlRuntime, &lb)
 		if err != nil {
 			return nil, err
 		}
-		res.(*mqlDigitaloceanLoadBalancer).cacheTargetLoadBalancerIDs = lb.TargetLoadBalancerIDs
 		all = append(all, res)
 	}
 	return all, nil
@@ -492,6 +486,11 @@ type mqlDigitaloceanLoadBalancerInternal struct {
 	// load balancer fans out to, so targetLoadBalancers() can resolve them
 	// without a refetch.
 	cacheTargetLoadBalancerIDs []string
+	// cacheVPCUUID and cacheDropletIDs hold the VPC the load balancer is
+	// attached to and the droplets behind it, so the typed vpc() and
+	// droplets() accessors can resolve them without a refetch.
+	cacheVPCUUID    string
+	cacheDropletIDs []any
 }
 
 func (r *mqlDigitaloceanLoadBalancer) id() (string, error) {
@@ -545,7 +544,7 @@ func (r *mqlDigitalocean) kubernetesClusters() ([]interface{}, error) {
 		if skipKubernetesCluster(conn.Filters.General, c) {
 			continue
 		}
-		res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.cluster", kubernetesClusterArgs(c))
+		res, err := newMqlKubernetesCluster(r.MqlRuntime, c)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -182,10 +182,6 @@ digitalocean.droplet @defaults("id name status") {
   publicIpv6 string
   // Tags applied to the droplet
   tags []string
-  // VPC UUID
-  //
-  // Deprecated in favor of `vpc()`.
-  vpcUuid @maturity("deprecated") string
   // VPC the droplet is attached to
   vpc() digitalocean.vpc
   // Features (e.g., monitoring, backups)
@@ -194,10 +190,6 @@ digitalocean.droplet @defaults("id name status") {
   backupsEnabled bool
   // Monitoring enabled
   monitoringEnabled bool
-  // Raw image details dict (id, name, distribution, slug)
-  //
-  // Deprecated in favor of `baseImage`.
-  image @maturity("deprecated") dict
   // Base image the droplet runs
   baseImage() digitalocean.image
   // Firewalls covering this droplet (by id or matching tag)
@@ -317,22 +309,10 @@ digitalocean.firewall @defaults("id name status") {
   status string
   // Time the resource was created
   createdAt time
-  // Rules controlling incoming traffic to protected droplets
-  //
-  // Deprecated in favor of `ingressRules`.
-  inboundRules @maturity("deprecated") []dict
-  // Rules controlling outgoing traffic from protected droplets
-  //
-  // Deprecated in favor of `egressRules`.
-  outboundRules @maturity("deprecated") []dict
   // Ingress rules controlling incoming traffic to protected droplets
   ingressRules() []digitalocean.firewall.ingressRule
   // Egress rules controlling outgoing traffic from protected droplets
   egressRules() []digitalocean.firewall.egressRule
-  // Droplet IDs protected by this firewall
-  //
-  // Deprecated in favor of `droplets()`.
-  dropletIds @maturity("deprecated") []int
   // Droplets covered by this firewall (by direct ID or matching tag)
   droplets() []digitalocean.droplet
   // Tags used to target droplets
@@ -863,10 +843,6 @@ digitalocean.volume @defaults("id name sizeGigabytes") {
   createdAt time
   // Tags
   tags []string
-  // Droplet IDs attached to this volume
-  //
-  // Deprecated in favor of `droplets`.
-  dropletIds @maturity("deprecated") []int
   // Droplets this volume is attached to
   droplets() []digitalocean.droplet
   // Snapshots taken of this volume
@@ -908,16 +884,8 @@ digitalocean.loadBalancer @defaults("id name status") {
   enableProxyProtocol bool
   // Enable backend keepalive
   enableBackendKeepalive bool
-  // VPC UUID
-  //
-  // Deprecated in favor of `vpc()`.
-  vpcUuid @maturity("deprecated") string
   // VPC the load balancer is attached to
   vpc() digitalocean.vpc
-  // Droplet IDs attached to the load balancer
-  //
-  // Deprecated in favor of `droplets()`.
-  dropletIds @maturity("deprecated") []int
   // Droplets attached to this load balancer
   droplets() []digitalocean.droplet
   // Tags
@@ -1094,10 +1062,6 @@ digitalocean.kubernetes.cluster @defaults("id name version") {
   clusterSubnet string
   // Service subnet
   serviceSubnet string
-  // VPC UUID
-  //
-  // Deprecated in favor of `vpc()`.
-  vpcUuid @maturity("deprecated") string
   // VPC the cluster is attached to
   vpc() digitalocean.vpc
   // Auto-upgrade enabled
@@ -2560,10 +2524,6 @@ digitalocean.gradientai.agent @defaults("uuid name region") {
   versionHash string
   // ID of the project the agent belongs to
   projectId string
-  // UUID of the VPC the agent runs in
-  //
-  // Deprecated in favor of `vpc`.
-  vpcUuid @maturity("deprecated") string
   // Public IPs the agent egresses from
   vpcEgressIps []string
   // Tags applied to the agent
@@ -3046,10 +3006,6 @@ private digitalocean.gradientai.dedicatedInferenceEndpoint @defaults("id name re
   region string
   // Lifecycle status
   status string
-  // UUID of the VPC the endpoint runs in
-  //
-  // Deprecated in favor of `vpc`.
-  vpcUuid @maturity("deprecated") string
   // Model IDs served by the endpoint
   providerModelIds []string
   // Public endpoint FQDN

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -713,9 +713,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.droplet.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetTags()).ToDataRes(types.Array(types.String))
 	},
-	"digitalocean.droplet.vpcUuid": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanDroplet).GetVpcUuid()).ToDataRes(types.String)
-	},
 	"digitalocean.droplet.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetVpc()).ToDataRes(types.Resource("digitalocean.vpc"))
 	},
@@ -727,9 +724,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.droplet.monitoringEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetMonitoringEnabled()).ToDataRes(types.Bool)
-	},
-	"digitalocean.droplet.image": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanDroplet).GetImage()).ToDataRes(types.Dict)
 	},
 	"digitalocean.droplet.baseImage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetBaseImage()).ToDataRes(types.Resource("digitalocean.image"))
@@ -827,20 +821,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.firewall.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewall).GetCreatedAt()).ToDataRes(types.Time)
 	},
-	"digitalocean.firewall.inboundRules": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanFirewall).GetInboundRules()).ToDataRes(types.Array(types.Dict))
-	},
-	"digitalocean.firewall.outboundRules": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanFirewall).GetOutboundRules()).ToDataRes(types.Array(types.Dict))
-	},
 	"digitalocean.firewall.ingressRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewall).GetIngressRules()).ToDataRes(types.Array(types.Resource("digitalocean.firewall.ingressRule")))
 	},
 	"digitalocean.firewall.egressRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewall).GetEgressRules()).ToDataRes(types.Array(types.Resource("digitalocean.firewall.egressRule")))
-	},
-	"digitalocean.firewall.dropletIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanFirewall).GetDropletIds()).ToDataRes(types.Array(types.Int))
 	},
 	"digitalocean.firewall.droplets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFirewall).GetDroplets()).ToDataRes(types.Array(types.Resource("digitalocean.droplet")))
@@ -1304,9 +1289,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.volume.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVolume).GetTags()).ToDataRes(types.Array(types.String))
 	},
-	"digitalocean.volume.dropletIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanVolume).GetDropletIds()).ToDataRes(types.Array(types.Int))
-	},
 	"digitalocean.volume.droplets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVolume).GetDroplets()).ToDataRes(types.Array(types.Resource("digitalocean.droplet")))
 	},
@@ -1343,14 +1325,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.loadBalancer.enableBackendKeepalive": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetEnableBackendKeepalive()).ToDataRes(types.Bool)
 	},
-	"digitalocean.loadBalancer.vpcUuid": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanLoadBalancer).GetVpcUuid()).ToDataRes(types.String)
-	},
 	"digitalocean.loadBalancer.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetVpc()).ToDataRes(types.Resource("digitalocean.vpc"))
-	},
-	"digitalocean.loadBalancer.dropletIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanLoadBalancer).GetDropletIds()).ToDataRes(types.Array(types.Int))
 	},
 	"digitalocean.loadBalancer.droplets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetDroplets()).ToDataRes(types.Array(types.Resource("digitalocean.droplet")))
@@ -1510,9 +1486,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.kubernetes.cluster.serviceSubnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesCluster).GetServiceSubnet()).ToDataRes(types.String)
-	},
-	"digitalocean.kubernetes.cluster.vpcUuid": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanKubernetesCluster).GetVpcUuid()).ToDataRes(types.String)
 	},
 	"digitalocean.kubernetes.cluster.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesCluster).GetVpc()).ToDataRes(types.Resource("digitalocean.vpc"))
@@ -2822,9 +2795,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.gradientai.agent.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiAgent).GetProjectId()).ToDataRes(types.String)
 	},
-	"digitalocean.gradientai.agent.vpcUuid": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanGradientaiAgent).GetVpcUuid()).ToDataRes(types.String)
-	},
 	"digitalocean.gradientai.agent.vpcEgressIps": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiAgent).GetVpcEgressIps()).ToDataRes(types.Array(types.String))
 	},
@@ -3337,9 +3307,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.gradientai.dedicatedInferenceEndpoint.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiDedicatedInferenceEndpoint).GetStatus()).ToDataRes(types.String)
-	},
-	"digitalocean.gradientai.dedicatedInferenceEndpoint.vpcUuid": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDigitaloceanGradientaiDedicatedInferenceEndpoint).GetVpcUuid()).ToDataRes(types.String)
 	},
 	"digitalocean.gradientai.dedicatedInferenceEndpoint.providerModelIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiDedicatedInferenceEndpoint).GetProviderModelIds()).ToDataRes(types.Array(types.String))
@@ -3862,10 +3829,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanDroplet).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"digitalocean.droplet.vpcUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanDroplet).VpcUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"digitalocean.droplet.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDroplet).Vpc, ok = plugin.RawToTValue[*mqlDigitaloceanVpc](v.Value, v.Error)
 		return
@@ -3880,10 +3843,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.droplet.monitoringEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDroplet).MonitoringEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"digitalocean.droplet.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanDroplet).Image, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.droplet.baseImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4022,24 +3981,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanFirewall).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
-	"digitalocean.firewall.inboundRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanFirewall).InboundRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"digitalocean.firewall.outboundRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanFirewall).OutboundRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"digitalocean.firewall.ingressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanFirewall).IngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.firewall.egressRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanFirewall).EgressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"digitalocean.firewall.dropletIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanFirewall).DropletIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.firewall.droplets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4718,10 +4665,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanVolume).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"digitalocean.volume.dropletIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanVolume).DropletIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"digitalocean.volume.droplets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanVolume).Droplets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -4774,16 +4717,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanLoadBalancer).EnableBackendKeepalive, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"digitalocean.loadBalancer.vpcUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanLoadBalancer).VpcUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"digitalocean.loadBalancer.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanLoadBalancer).Vpc, ok = plugin.RawToTValue[*mqlDigitaloceanVpc](v.Value, v.Error)
-		return
-	},
-	"digitalocean.loadBalancer.dropletIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanLoadBalancer).DropletIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.loadBalancer.droplets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5012,10 +4947,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.kubernetes.cluster.serviceSubnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanKubernetesCluster).ServiceSubnet, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"digitalocean.kubernetes.cluster.vpcUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanKubernetesCluster).VpcUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"digitalocean.kubernetes.cluster.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6918,10 +6849,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanGradientaiAgent).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"digitalocean.gradientai.agent.vpcUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanGradientaiAgent).VpcUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"digitalocean.gradientai.agent.vpcEgressIps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanGradientaiAgent).VpcEgressIps, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -7652,10 +7579,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.gradientai.dedicatedInferenceEndpoint.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanGradientaiDedicatedInferenceEndpoint).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"digitalocean.gradientai.dedicatedInferenceEndpoint.vpcUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDigitaloceanGradientaiDedicatedInferenceEndpoint).VpcUuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"digitalocean.gradientai.dedicatedInferenceEndpoint.providerModelIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8856,12 +8779,10 @@ type mqlDigitaloceanDroplet struct {
 	PrivateIpv4               plugin.TValue[string]
 	PublicIpv6                plugin.TValue[string]
 	Tags                      plugin.TValue[[]any]
-	VpcUuid                   plugin.TValue[string]
 	Vpc                       plugin.TValue[*mqlDigitaloceanVpc]
 	Features                  plugin.TValue[[]any]
 	BackupsEnabled            plugin.TValue[bool]
 	MonitoringEnabled         plugin.TValue[bool]
-	Image                     plugin.TValue[any]
 	BaseImage                 plugin.TValue[*mqlDigitaloceanImage]
 	Firewalls                 plugin.TValue[[]any]
 	MissingFirewall           plugin.TValue[bool]
@@ -8992,10 +8913,6 @@ func (c *mqlDigitaloceanDroplet) GetTags() *plugin.TValue[[]any] {
 	return &c.Tags
 }
 
-func (c *mqlDigitaloceanDroplet) GetVpcUuid() *plugin.TValue[string] {
-	return &c.VpcUuid
-}
-
 func (c *mqlDigitaloceanDroplet) GetVpc() *plugin.TValue[*mqlDigitaloceanVpc] {
 	return plugin.GetOrCompute[*mqlDigitaloceanVpc](&c.Vpc, func() (*mqlDigitaloceanVpc, error) {
 		if c.MqlRuntime.HasRecording {
@@ -9022,10 +8939,6 @@ func (c *mqlDigitaloceanDroplet) GetBackupsEnabled() *plugin.TValue[bool] {
 
 func (c *mqlDigitaloceanDroplet) GetMonitoringEnabled() *plugin.TValue[bool] {
 	return &c.MonitoringEnabled
-}
-
-func (c *mqlDigitaloceanDroplet) GetImage() *plugin.TValue[any] {
-	return &c.Image
 }
 
 func (c *mqlDigitaloceanDroplet) GetBaseImage() *plugin.TValue[*mqlDigitaloceanImage] {
@@ -9282,16 +9195,13 @@ func (c *mqlDigitaloceanMicroDroplet) GetCreatedAt() *plugin.TValue[*time.Time] 
 type mqlDigitaloceanFirewall struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDigitaloceanFirewallInternal it will be used here
+	mqlDigitaloceanFirewallInternal
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	Status         plugin.TValue[string]
 	CreatedAt      plugin.TValue[*time.Time]
-	InboundRules   plugin.TValue[[]any]
-	OutboundRules  plugin.TValue[[]any]
 	IngressRules   plugin.TValue[[]any]
 	EgressRules    plugin.TValue[[]any]
-	DropletIds     plugin.TValue[[]any]
 	Droplets       plugin.TValue[[]any]
 	Tags           plugin.TValue[[]any]
 	PendingChanges plugin.TValue[[]any]
@@ -9350,14 +9260,6 @@ func (c *mqlDigitaloceanFirewall) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
 
-func (c *mqlDigitaloceanFirewall) GetInboundRules() *plugin.TValue[[]any] {
-	return &c.InboundRules
-}
-
-func (c *mqlDigitaloceanFirewall) GetOutboundRules() *plugin.TValue[[]any] {
-	return &c.OutboundRules
-}
-
 func (c *mqlDigitaloceanFirewall) GetIngressRules() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.IngressRules, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -9388,10 +9290,6 @@ func (c *mqlDigitaloceanFirewall) GetEgressRules() *plugin.TValue[[]any] {
 
 		return c.egressRules()
 	})
-}
-
-func (c *mqlDigitaloceanFirewall) GetDropletIds() *plugin.TValue[[]any] {
-	return &c.DropletIds
 }
 
 func (c *mqlDigitaloceanFirewall) GetDroplets() *plugin.TValue[[]any] {
@@ -11001,7 +10899,7 @@ func (c *mqlDigitaloceanDomainRecord) GetFlags() *plugin.TValue[int64] {
 type mqlDigitaloceanVolume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDigitaloceanVolumeInternal it will be used here
+	mqlDigitaloceanVolumeInternal
 	Id              plugin.TValue[string]
 	Name            plugin.TValue[string]
 	SizeGigabytes   plugin.TValue[int64]
@@ -11011,7 +10909,6 @@ type mqlDigitaloceanVolume struct {
 	FilesystemLabel plugin.TValue[string]
 	CreatedAt       plugin.TValue[*time.Time]
 	Tags            plugin.TValue[[]any]
-	DropletIds      plugin.TValue[[]any]
 	Droplets        plugin.TValue[[]any]
 	Snapshots       plugin.TValue[[]any]
 }
@@ -11089,10 +10986,6 @@ func (c *mqlDigitaloceanVolume) GetTags() *plugin.TValue[[]any] {
 	return &c.Tags
 }
 
-func (c *mqlDigitaloceanVolume) GetDropletIds() *plugin.TValue[[]any] {
-	return &c.DropletIds
-}
-
 func (c *mqlDigitaloceanVolume) GetDroplets() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Droplets, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -11140,9 +11033,7 @@ type mqlDigitaloceanLoadBalancer struct {
 	RedirectHttpToHttps          plugin.TValue[bool]
 	EnableProxyProtocol          plugin.TValue[bool]
 	EnableBackendKeepalive       plugin.TValue[bool]
-	VpcUuid                      plugin.TValue[string]
 	Vpc                          plugin.TValue[*mqlDigitaloceanVpc]
-	DropletIds                   plugin.TValue[[]any]
 	Droplets                     plugin.TValue[[]any]
 	Tags                         plugin.TValue[[]any]
 	ForwardingRules              plugin.TValue[[]any]
@@ -11245,10 +11136,6 @@ func (c *mqlDigitaloceanLoadBalancer) GetEnableBackendKeepalive() *plugin.TValue
 	return &c.EnableBackendKeepalive
 }
 
-func (c *mqlDigitaloceanLoadBalancer) GetVpcUuid() *plugin.TValue[string] {
-	return &c.VpcUuid
-}
-
 func (c *mqlDigitaloceanLoadBalancer) GetVpc() *plugin.TValue[*mqlDigitaloceanVpc] {
 	return plugin.GetOrCompute[*mqlDigitaloceanVpc](&c.Vpc, func() (*mqlDigitaloceanVpc, error) {
 		if c.MqlRuntime.HasRecording {
@@ -11263,10 +11150,6 @@ func (c *mqlDigitaloceanLoadBalancer) GetVpc() *plugin.TValue[*mqlDigitaloceanVp
 
 		return c.vpc()
 	})
-}
-
-func (c *mqlDigitaloceanLoadBalancer) GetDropletIds() *plugin.TValue[[]any] {
-	return &c.DropletIds
 }
 
 func (c *mqlDigitaloceanLoadBalancer) GetDroplets() *plugin.TValue[[]any] {
@@ -11681,7 +11564,7 @@ func (c *mqlDigitaloceanVpcPeering) GetCreatedAt() *plugin.TValue[*time.Time] {
 type mqlDigitaloceanKubernetesCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDigitaloceanKubernetesClusterInternal it will be used here
+	mqlDigitaloceanKubernetesClusterInternal
 	Id                                       plugin.TValue[string]
 	Name                                     plugin.TValue[string]
 	Version                                  plugin.TValue[string]
@@ -11691,7 +11574,6 @@ type mqlDigitaloceanKubernetesCluster struct {
 	UpdatedAt                                plugin.TValue[*time.Time]
 	ClusterSubnet                            plugin.TValue[string]
 	ServiceSubnet                            plugin.TValue[string]
-	VpcUuid                                  plugin.TValue[string]
 	Vpc                                      plugin.TValue[*mqlDigitaloceanVpc]
 	AutoUpgrade                              plugin.TValue[bool]
 	SurgeUpgrade                             plugin.TValue[bool]
@@ -11793,10 +11675,6 @@ func (c *mqlDigitaloceanKubernetesCluster) GetClusterSubnet() *plugin.TValue[str
 
 func (c *mqlDigitaloceanKubernetesCluster) GetServiceSubnet() *plugin.TValue[string] {
 	return &c.ServiceSubnet
-}
-
-func (c *mqlDigitaloceanKubernetesCluster) GetVpcUuid() *plugin.TValue[string] {
-	return &c.VpcUuid
 }
 
 func (c *mqlDigitaloceanKubernetesCluster) GetVpc() *plugin.TValue[*mqlDigitaloceanVpc] {
@@ -16188,7 +16066,6 @@ type mqlDigitaloceanGradientaiAgent struct {
 	UserId                  plugin.TValue[string]
 	VersionHash             plugin.TValue[string]
 	ProjectId               plugin.TValue[string]
-	VpcUuid                 plugin.TValue[string]
 	VpcEgressIps            plugin.TValue[[]any]
 	Tags                    plugin.TValue[[]any]
 	DeploymentName          plugin.TValue[string]
@@ -16320,10 +16197,6 @@ func (c *mqlDigitaloceanGradientaiAgent) GetVersionHash() *plugin.TValue[string]
 
 func (c *mqlDigitaloceanGradientaiAgent) GetProjectId() *plugin.TValue[string] {
 	return &c.ProjectId
-}
-
-func (c *mqlDigitaloceanGradientaiAgent) GetVpcUuid() *plugin.TValue[string] {
-	return &c.VpcUuid
 }
 
 func (c *mqlDigitaloceanGradientaiAgent) GetVpcEgressIps() *plugin.TValue[[]any] {
@@ -17813,12 +17686,11 @@ func (c *mqlDigitaloceanGradientaiOpenaiApiKey) GetAgents() *plugin.TValue[[]any
 type mqlDigitaloceanGradientaiDedicatedInferenceEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDigitaloceanGradientaiDedicatedInferenceEndpointInternal it will be used here
+	mqlDigitaloceanGradientaiDedicatedInferenceEndpointInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Region              plugin.TValue[string]
 	Status              plugin.TValue[string]
-	VpcUuid             plugin.TValue[string]
 	ProviderModelIds    plugin.TValue[[]any]
 	PublicEndpointFqdn  plugin.TValue[string]
 	PrivateEndpointFqdn plugin.TValue[string]
@@ -17880,10 +17752,6 @@ func (c *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) GetRegion() *plugi
 
 func (c *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) GetStatus() *plugin.TValue[string] {
 	return &c.Status
-}
-
-func (c *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) GetVpcUuid() *plugin.TValue[string] {
-	return &c.VpcUuid
 }
 
 func (c *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) GetProviderModelIds() *plugin.TValue[[]any] {

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -280,7 +280,6 @@ digitalocean.droplet.features 13.0.1
 digitalocean.droplet.firewalls 13.0.2
 digitalocean.droplet.gpuPartitionMode 13.14.4
 digitalocean.droplet.id 13.0.1
-digitalocean.droplet.image 13.0.1
 digitalocean.droplet.kernel 13.6.2
 digitalocean.droplet.locked 13.1.7
 digitalocean.droplet.memory 13.0.1
@@ -300,7 +299,6 @@ digitalocean.droplet.tags 13.0.1
 digitalocean.droplet.vcpus 13.0.1
 digitalocean.droplet.volumes 13.6.2
 digitalocean.droplet.vpc 13.0.2
-digitalocean.droplet.vpcUuid 13.0.1
 digitalocean.dropletAutoscalePool 13.4.2
 digitalocean.dropletAutoscalePool.cooldownMinutes 13.4.2
 digitalocean.dropletAutoscalePool.createdAt 13.4.2
@@ -323,7 +321,6 @@ digitalocean.dropletAutoscalePools 13.4.2
 digitalocean.droplets 13.0.1
 digitalocean.firewall 13.0.1
 digitalocean.firewall.createdAt 13.0.1
-digitalocean.firewall.dropletIds 13.0.1
 digitalocean.firewall.droplets 13.0.2
 digitalocean.firewall.egressRule 13.5.2
 digitalocean.firewall.egressRule.destinationAddresses 13.5.2
@@ -336,7 +333,6 @@ digitalocean.firewall.egressRule.ports 13.5.2
 digitalocean.firewall.egressRule.protocol 13.5.2
 digitalocean.firewall.egressRules 13.5.2
 digitalocean.firewall.id 13.0.1
-digitalocean.firewall.inboundRules 13.0.1
 digitalocean.firewall.ingressRule 13.5.2
 digitalocean.firewall.ingressRule.openToInternet 13.5.2
 digitalocean.firewall.ingressRule.ports 13.5.2
@@ -348,7 +344,6 @@ digitalocean.firewall.ingressRule.sourceLoadBalancers 13.5.2
 digitalocean.firewall.ingressRule.sourceTags 13.5.2
 digitalocean.firewall.ingressRules 13.5.2
 digitalocean.firewall.name 13.0.1
-digitalocean.firewall.outboundRules 13.0.1
 digitalocean.firewall.pendingChange 13.15.2
 digitalocean.firewall.pendingChange.droplet 13.15.2
 digitalocean.firewall.pendingChange.removing 13.15.2
@@ -496,7 +491,6 @@ digitalocean.gradientai.agent.versionHash 13.4.2
 digitalocean.gradientai.agent.versions 13.4.2
 digitalocean.gradientai.agent.vpc 13.4.2
 digitalocean.gradientai.agent.vpcEgressIps 13.4.2
-digitalocean.gradientai.agent.vpcUuid 13.4.2
 digitalocean.gradientai.agents 13.4.2
 digitalocean.gradientai.anthropicApiKey 13.4.2
 digitalocean.gradientai.anthropicApiKey.agents 13.4.2
@@ -569,7 +563,6 @@ digitalocean.gradientai.dedicatedInferenceEndpoint.token.name 13.4.2
 digitalocean.gradientai.dedicatedInferenceEndpoint.tokens 13.4.2
 digitalocean.gradientai.dedicatedInferenceEndpoint.updatedAt 13.4.2
 digitalocean.gradientai.dedicatedInferenceEndpoint.vpc 13.4.2
-digitalocean.gradientai.dedicatedInferenceEndpoint.vpcUuid 13.4.2
 digitalocean.gradientai.dedicatedInferenceEndpoints 13.4.2
 digitalocean.gradientai.indexingJob 13.4.2
 digitalocean.gradientai.indexingJob.completedDatasources 13.4.2
@@ -703,7 +696,6 @@ digitalocean.kubernetes.cluster.tags 13.0.1
 digitalocean.kubernetes.cluster.updatedAt 13.0.1
 digitalocean.kubernetes.cluster.version 13.0.1
 digitalocean.kubernetes.cluster.vpc 13.0.2
-digitalocean.kubernetes.cluster.vpcUuid 13.0.1
 digitalocean.kubernetes.cluster.workerSubnetUuid 13.10.2
 digitalocean.kubernetes.node 13.6.2
 digitalocean.kubernetes.node.createdAt 13.6.2
@@ -735,7 +727,6 @@ digitalocean.loadBalancer.algorithm 13.0.1
 digitalocean.loadBalancer.createdAt 13.0.1
 digitalocean.loadBalancer.disableLetsEncryptDnsRecords 13.0.1
 digitalocean.loadBalancer.domains 13.6.2
-digitalocean.loadBalancer.dropletIds 13.0.1
 digitalocean.loadBalancer.droplets 13.0.2
 digitalocean.loadBalancer.enableBackendKeepalive 13.0.1
 digitalocean.loadBalancer.enableProxyProtocol 13.0.1
@@ -774,7 +765,6 @@ digitalocean.loadBalancer.targetLoadBalancers 13.6.2
 digitalocean.loadBalancer.tlsCipherPolicy 13.6.2
 digitalocean.loadBalancer.type 13.6.2
 digitalocean.loadBalancer.vpc 13.0.2
-digitalocean.loadBalancer.vpcUuid 13.0.1
 digitalocean.loadBalancers 13.0.1
 digitalocean.microDroplet 13.15.2
 digitalocean.microDroplet.autoPauseEnabled 13.15.2
@@ -1056,7 +1046,6 @@ digitalocean.vectorDatabases 13.4.2
 digitalocean.volume 13.0.1
 digitalocean.volume.createdAt 13.0.1
 digitalocean.volume.description 13.0.1
-digitalocean.volume.dropletIds 13.0.1
 digitalocean.volume.droplets 13.0.2
 digitalocean.volume.filesystemLabel 13.0.1
 digitalocean.volume.filesystemType 13.0.1

--- a/providers/digitalocean/resources/digitalocean_assets.go
+++ b/providers/digitalocean/resources/digitalocean_assets.go
@@ -161,41 +161,6 @@ func initDigitaloceanDatabase(runtime *plugin.Runtime, args map[string]*llx.RawD
 // populated when a firewall is reached one way and empty when it is reached
 // the other.
 func firewallArgs(runtime *plugin.Runtime, fw *godo.Firewall) (map[string]*llx.RawData, error) {
-	inbound := make([]interface{}, len(fw.InboundRules))
-	for i, rule := range fw.InboundRules {
-		m := map[string]interface{}{
-			"protocol": rule.Protocol,
-			"ports":    rule.PortRange,
-		}
-		if rule.Sources != nil {
-			m["sourceAddresses"] = toStringSlice(rule.Sources.Addresses)
-			m["sourceDropletIds"] = toIntSlice(rule.Sources.DropletIDs)
-			m["sourceLoadBalancerUids"] = toStringSlice(rule.Sources.LoadBalancerUIDs)
-			m["sourceKubernetesIds"] = toStringSlice(rule.Sources.KubernetesIDs)
-			m["sourceTags"] = toStringSlice(rule.Sources.Tags)
-		}
-		inbound[i] = m
-	}
-	outbound := make([]interface{}, len(fw.OutboundRules))
-	for i, rule := range fw.OutboundRules {
-		m := map[string]interface{}{
-			"protocol": rule.Protocol,
-			"ports":    rule.PortRange,
-		}
-		if rule.Destinations != nil {
-			m["destinationAddresses"] = toStringSlice(rule.Destinations.Addresses)
-			m["destinationDropletIds"] = toIntSlice(rule.Destinations.DropletIDs)
-			m["destinationLoadBalancerUids"] = toStringSlice(rule.Destinations.LoadBalancerUIDs)
-			m["destinationKubernetesIds"] = toStringSlice(rule.Destinations.KubernetesIDs)
-			m["destinationTags"] = toStringSlice(rule.Destinations.Tags)
-		}
-		outbound[i] = m
-	}
-
-	dropletIds := make([]interface{}, len(fw.DropletIDs))
-	for i, id := range fw.DropletIDs {
-		dropletIds[i] = int64(id)
-	}
 	tags := make([]interface{}, len(fw.Tags))
 	for i, t := range fw.Tags {
 		tags[i] = t
@@ -211,12 +176,28 @@ func firewallArgs(runtime *plugin.Runtime, fw *godo.Firewall) (map[string]*llx.R
 		"name":           llx.StringData(fw.Name),
 		"status":         llx.StringData(fw.Status),
 		"createdAt":      llx.TimeDataPtr(parseDoTime(fw.Created)),
-		"inboundRules":   llx.ArrayData(inbound, "\x13"),
-		"outboundRules":  llx.ArrayData(outbound, "\x13"),
-		"dropletIds":     llx.ArrayData(dropletIds, "\x05"),
 		"tags":           llx.ArrayData(tags, "\x02"),
 		"pendingChanges": llx.ArrayData(pending, types.Resource("digitalocean.firewall.pendingChange")),
 	}, nil
+}
+
+// newMqlFirewall builds a firewall resource, caching the raw rule set and
+// protected droplet IDs for the typed ingressRules(), egressRules(), and
+// droplets() accessors.
+func newMqlFirewall(runtime *plugin.Runtime, fw *godo.Firewall) (*mqlDigitaloceanFirewall, error) {
+	args, err := firewallArgs(runtime, fw)
+	if err != nil {
+		return nil, err
+	}
+	res, err := CreateResource(runtime, "digitalocean.firewall", args)
+	if err != nil {
+		return nil, err
+	}
+	mqlFirewall := res.(*mqlDigitaloceanFirewall)
+	mqlFirewall.cacheInboundRules = fw.InboundRules
+	mqlFirewall.cacheOutboundRules = fw.OutboundRules
+	mqlFirewall.cacheDropletIDs = toIntSlice(fw.DropletIDs)
+	return mqlFirewall, nil
 }
 
 // firewallPendingChanges builds the per-droplet changes a firewall has not
@@ -260,19 +241,15 @@ func initDigitaloceanFirewall(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if err != nil {
 		return nil, nil, err
 	}
-	fwArgs, err := firewallArgs(runtime, fw)
+	res, err := newMqlFirewall(runtime, fw)
 	if err != nil {
 		return nil, nil, err
 	}
-	return fwArgs, nil, nil
+	return nil, res, nil
 }
 
 // loadBalancerArgs maps a load balancer to its MQL fields.
 func loadBalancerArgs(lb *godo.LoadBalancer) map[string]*llx.RawData {
-	dropletIds := make([]interface{}, len(lb.DropletIDs))
-	for i, id := range lb.DropletIDs {
-		dropletIds[i] = int64(id)
-	}
 	tags := make([]interface{}, len(lb.Tags))
 	for i, t := range lb.Tags {
 		tags[i] = t
@@ -357,8 +334,6 @@ func loadBalancerArgs(lb *godo.LoadBalancer) map[string]*llx.RawData {
 		"redirectHttpToHttps":          llx.BoolData(lb.RedirectHttpToHttps),
 		"enableProxyProtocol":          llx.BoolData(lb.EnableProxyProtocol),
 		"enableBackendKeepalive":       llx.BoolData(lb.EnableBackendKeepalive),
-		"vpcUuid":                      llx.StringData(lb.VPCUUID),
-		"dropletIds":                   llx.ArrayData(dropletIds, "\x05"),
 		"tags":                         llx.ArrayData(tags, "\x02"),
 		"forwardingRules":              llx.ArrayData(fwdRules, "\x13"),
 		"healthCheck":                  llx.DictData(hc),
@@ -396,7 +371,26 @@ func initDigitaloceanLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.
 	if err != nil {
 		return nil, nil, err
 	}
-	return loadBalancerArgs(lb), nil, nil
+	res, err := newMqlLoadBalancer(runtime, lb)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+// newMqlLoadBalancer builds a load balancer resource, caching the VPC UUID,
+// attached droplet IDs, and regional target IDs for the typed vpc(),
+// droplets(), and targetLoadBalancers() accessors.
+func newMqlLoadBalancer(runtime *plugin.Runtime, lb *godo.LoadBalancer) (*mqlDigitaloceanLoadBalancer, error) {
+	res, err := CreateResource(runtime, "digitalocean.loadBalancer", loadBalancerArgs(lb))
+	if err != nil {
+		return nil, err
+	}
+	mqlLB := res.(*mqlDigitaloceanLoadBalancer)
+	mqlLB.cacheVPCUUID = lb.VPCUUID
+	mqlLB.cacheDropletIDs = toIntSlice(lb.DropletIDs)
+	mqlLB.cacheTargetLoadBalancerIDs = lb.TargetLoadBalancerIDs
+	return mqlLB, nil
 }
 
 // kubernetesClusterArgs maps a DOKS cluster to its MQL fields.
@@ -484,7 +478,6 @@ func kubernetesClusterArgs(c *godo.KubernetesCluster) map[string]*llx.RawData {
 		"updatedAt":                            llx.TimeData(c.UpdatedAt),
 		"clusterSubnet":                        llx.StringData(c.ClusterSubnet),
 		"serviceSubnet":                        llx.StringData(c.ServiceSubnet),
-		"vpcUuid":                              llx.StringData(c.VPCUUID),
 		"autoUpgrade":                          llx.BoolData(c.AutoUpgrade),
 		"surgeUpgrade":                         llx.BoolData(c.SurgeUpgrade),
 		"ha":                                   llx.BoolData(c.HA),
@@ -550,7 +543,30 @@ func initDigitaloceanKubernetesCluster(runtime *plugin.Runtime, args map[string]
 	if err != nil {
 		return nil, nil, err
 	}
-	return kubernetesClusterArgs(c), nil, nil
+	res, err := newMqlKubernetesCluster(runtime, c)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+// mqlDigitaloceanKubernetesClusterInternal caches the UUID of the VPC the
+// cluster is attached to so the typed vpc() accessor can resolve it without
+// a refetch.
+type mqlDigitaloceanKubernetesClusterInternal struct {
+	cacheVPCUUID string
+}
+
+// newMqlKubernetesCluster builds a DOKS cluster resource, caching the VPC
+// UUID for the typed vpc() accessor.
+func newMqlKubernetesCluster(runtime *plugin.Runtime, c *godo.KubernetesCluster) (*mqlDigitaloceanKubernetesCluster, error) {
+	res, err := CreateResource(runtime, "digitalocean.kubernetes.cluster", kubernetesClusterArgs(c))
+	if err != nil {
+		return nil, err
+	}
+	mqlCluster := res.(*mqlDigitaloceanKubernetesCluster)
+	mqlCluster.cacheVPCUUID = c.VPCUUID
+	return mqlCluster, nil
 }
 
 // stringArg returns the string value of args[key], or "" when absent.

--- a/providers/digitalocean/resources/digitalocean_firewall.go
+++ b/providers/digitalocean/resources/digitalocean_firewall.go
@@ -6,8 +6,18 @@ package resources
 import (
 	"fmt"
 
+	"github.com/digitalocean/godo"
 	"go.mondoo.com/mql/v13/llx"
 )
+
+// mqlDigitaloceanFirewallInternal caches the raw rule set and protected
+// droplet IDs of a cloud firewall so the typed ingressRules(), egressRules(),
+// and droplets() accessors can resolve them without a refetch.
+type mqlDigitaloceanFirewallInternal struct {
+	cacheInboundRules  []godo.InboundRule
+	cacheOutboundRules []godo.OutboundRule
+	cacheDropletIDs    []any
+}
 
 // mqlDigitaloceanFirewallIngressRuleInternal caches the source target IDs
 // of an ingress rule so the typed source* accessors can resolve them
@@ -26,30 +36,12 @@ type mqlDigitaloceanFirewallEgressRuleInternal struct {
 	destinationKubernetesIDs    []any
 }
 
-// ruleString returns the string value stored under key in a firewall-rule
-// dict, or the empty string when absent.
-func ruleString(rule map[string]any, key string) string {
-	if v, ok := rule[key].(string); ok {
-		return v
-	}
-	return ""
-}
-
-// ruleSlice returns the list stored under key in a firewall-rule dict, or
-// an empty slice when absent.
-func ruleSlice(rule map[string]any, key string) []any {
-	if v, ok := rule[key].([]any); ok {
-		return v
-	}
-	return []any{}
-}
-
 // openToInternet reports whether any of the given source/destination CIDRs
 // admit traffic from (or to) every address — the IPv4 or IPv6 "everything"
 // range.
-func openToInternet(addresses []any) bool {
-	for _, a := range addresses {
-		if s, ok := a.(string); ok && (s == "0.0.0.0/0" || s == "::/0") {
+func openToInternet(addresses []string) bool {
+	for _, s := range addresses {
+		if s == "0.0.0.0/0" || s == "::/0" {
 			return true
 		}
 	}
@@ -57,66 +49,66 @@ func openToInternet(addresses []any) bool {
 }
 
 func (r *mqlDigitaloceanFirewall) ingressRules() ([]any, error) {
-	rules := r.GetInboundRules()
-	if rules.Error != nil {
-		return nil, rules.Error
-	}
-	out := make([]any, 0, len(rules.Data))
-	for i, raw := range rules.Data {
-		rule, ok := raw.(map[string]any)
-		if !ok {
-			continue
+	out := make([]any, 0, len(r.cacheInboundRules))
+	for i, rule := range r.cacheInboundRules {
+		var addresses, tags, loadBalancerUIDs, kubernetesIDs []string
+		var dropletIDs []int
+		if rule.Sources != nil {
+			addresses = rule.Sources.Addresses
+			tags = rule.Sources.Tags
+			dropletIDs = rule.Sources.DropletIDs
+			loadBalancerUIDs = rule.Sources.LoadBalancerUIDs
+			kubernetesIDs = rule.Sources.KubernetesIDs
 		}
-		addresses := ruleSlice(rule, "sourceAddresses")
 
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall.ingressRule", map[string]*llx.RawData{
 			"__id":            llx.StringData(fmt.Sprintf("%s/inbound/%d", r.Id.Data, i)),
-			"protocol":        llx.StringData(ruleString(rule, "protocol")),
-			"ports":           llx.StringData(ruleString(rule, "ports")),
+			"protocol":        llx.StringData(rule.Protocol),
+			"ports":           llx.StringData(rule.PortRange),
 			"openToInternet":  llx.BoolData(openToInternet(addresses)),
-			"sourceAddresses": llx.ArrayData(addresses, "\x02"),
-			"sourceTags":      llx.ArrayData(ruleSlice(rule, "sourceTags"), "\x02"),
+			"sourceAddresses": llx.ArrayData(toStringSlice(addresses), "\x02"),
+			"sourceTags":      llx.ArrayData(toStringSlice(tags), "\x02"),
 		})
 		if err != nil {
 			return nil, err
 		}
 		mqlRule := res.(*mqlDigitaloceanFirewallIngressRule)
-		mqlRule.sourceDropletIDs = ruleSlice(rule, "sourceDropletIds")
-		mqlRule.sourceLoadBalancerUIDs = ruleSlice(rule, "sourceLoadBalancerUids")
-		mqlRule.sourceKubernetesIDs = ruleSlice(rule, "sourceKubernetesIds")
+		mqlRule.sourceDropletIDs = toIntSlice(dropletIDs)
+		mqlRule.sourceLoadBalancerUIDs = toStringSlice(loadBalancerUIDs)
+		mqlRule.sourceKubernetesIDs = toStringSlice(kubernetesIDs)
 		out = append(out, res)
 	}
 	return out, nil
 }
 
 func (r *mqlDigitaloceanFirewall) egressRules() ([]any, error) {
-	rules := r.GetOutboundRules()
-	if rules.Error != nil {
-		return nil, rules.Error
-	}
-	out := make([]any, 0, len(rules.Data))
-	for i, raw := range rules.Data {
-		rule, ok := raw.(map[string]any)
-		if !ok {
-			continue
+	out := make([]any, 0, len(r.cacheOutboundRules))
+	for i, rule := range r.cacheOutboundRules {
+		var addresses, tags, loadBalancerUIDs, kubernetesIDs []string
+		var dropletIDs []int
+		if rule.Destinations != nil {
+			addresses = rule.Destinations.Addresses
+			tags = rule.Destinations.Tags
+			dropletIDs = rule.Destinations.DropletIDs
+			loadBalancerUIDs = rule.Destinations.LoadBalancerUIDs
+			kubernetesIDs = rule.Destinations.KubernetesIDs
 		}
-		addresses := ruleSlice(rule, "destinationAddresses")
 
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall.egressRule", map[string]*llx.RawData{
 			"__id":                 llx.StringData(fmt.Sprintf("%s/outbound/%d", r.Id.Data, i)),
-			"protocol":             llx.StringData(ruleString(rule, "protocol")),
-			"ports":                llx.StringData(ruleString(rule, "ports")),
+			"protocol":             llx.StringData(rule.Protocol),
+			"ports":                llx.StringData(rule.PortRange),
 			"openToInternet":       llx.BoolData(openToInternet(addresses)),
-			"destinationAddresses": llx.ArrayData(addresses, "\x02"),
-			"destinationTags":      llx.ArrayData(ruleSlice(rule, "destinationTags"), "\x02"),
+			"destinationAddresses": llx.ArrayData(toStringSlice(addresses), "\x02"),
+			"destinationTags":      llx.ArrayData(toStringSlice(tags), "\x02"),
 		})
 		if err != nil {
 			return nil, err
 		}
 		mqlRule := res.(*mqlDigitaloceanFirewallEgressRule)
-		mqlRule.destinationDropletIDs = ruleSlice(rule, "destinationDropletIds")
-		mqlRule.destinationLoadBalancerUIDs = ruleSlice(rule, "destinationLoadBalancerUids")
-		mqlRule.destinationKubernetesIDs = ruleSlice(rule, "destinationKubernetesIds")
+		mqlRule.destinationDropletIDs = toIntSlice(dropletIDs)
+		mqlRule.destinationLoadBalancerUIDs = toStringSlice(loadBalancerUIDs)
+		mqlRule.destinationKubernetesIDs = toStringSlice(kubernetesIDs)
 		out = append(out, res)
 	}
 	return out, nil

--- a/providers/digitalocean/resources/digitalocean_firewall_test.go
+++ b/providers/digitalocean/resources/digitalocean_firewall_test.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpenToInternet(t *testing.T) {
+	cases := []struct {
+		name      string
+		addresses []string
+		want      bool
+	}{
+		{"ipv4 any", []string{"0.0.0.0/0"}, true},
+		{"ipv6 any", []string{"::/0"}, true},
+		{"any among specifics", []string{"10.0.0.0/8", "0.0.0.0/0"}, true},
+		{"specific only", []string{"10.0.0.0/8", "203.0.113.5/32"}, false},
+		{"ipv6 specific only", []string{"2001:db8::/32"}, false},
+		{"host address is not a range", []string{"0.0.0.0"}, false},
+		{"empty", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, openToInternet(c.addresses))
+		})
+	}
+}

--- a/providers/digitalocean/resources/digitalocean_gradientai.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai.go
@@ -137,6 +137,9 @@ type mqlDigitaloceanGradientaiAgentInternal struct {
 	cachedOpenAIKey    *godo.OpenAiApiKey
 	childUUIDs         []string
 	parentUUIDs        []string
+	// cacheVPCUUID holds the UUID of the VPC the agent runs in so the typed
+	// vpc() accessor can resolve it without a refetch.
+	cacheVPCUUID string
 }
 
 func (r *mqlDigitaloceanGradientai) agents() ([]interface{}, error) {
@@ -223,7 +226,6 @@ func newMqlGradientaiAgent(runtime *plugin.Runtime, a *godo.Agent) (*mqlDigitalo
 		"userId":                  llx.StringData(a.UserId),
 		"versionHash":             llx.StringData(a.VersionHash),
 		"projectId":               llx.StringData(a.ProjectId),
-		"vpcUuid":                 llx.StringData(a.VPCUuid),
 		"vpcEgressIps":            llx.ArrayData(egressIPs, types.String),
 		"tags":                    llx.ArrayData(tags, types.String),
 		"deploymentName":          llx.StringData(deploymentName),
@@ -240,6 +242,7 @@ func newMqlGradientaiAgent(runtime *plugin.Runtime, a *godo.Agent) (*mqlDigitalo
 	}
 
 	agent := res.(*mqlDigitaloceanGradientaiAgent)
+	agent.cacheVPCUUID = a.VPCUuid
 	agent.cachedModel = a.Model
 	agent.cachedKnowledgeB = a.KnowledgeBases
 	agent.cachedGuardrails = a.Guardrails
@@ -344,7 +347,7 @@ func (r *mqlDigitaloceanGradientaiAgent) project() (*mqlDigitaloceanProject, err
 }
 
 func (r *mqlDigitaloceanGradientaiAgent) vpc() (*mqlDigitaloceanVpc, error) {
-	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.VpcUuid.Data)
+	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.cacheVPCUUID)
 }
 
 func (r *mqlDigitaloceanGradientaiAgent) anthropicApiKey() (*mqlDigitaloceanGradientaiAnthropicApiKey, error) {

--- a/providers/digitalocean/resources/digitalocean_gradientai_inference.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai_inference.go
@@ -197,7 +197,6 @@ func (r *mqlDigitaloceanGradientai) dedicatedInferenceEndpoints() ([]interface{}
 				"name":                llx.StringData(e.Name),
 				"region":              llx.StringData(e.Region),
 				"status":              llx.StringData(e.Status),
-				"vpcUuid":             llx.StringData(e.VPCUUID),
 				"providerModelIds":    llx.ArrayData(modelIDs, types.String),
 				"publicEndpointFqdn":  llx.StringData(publicFQDN),
 				"privateEndpointFqdn": llx.StringData(privateFQDN),
@@ -207,6 +206,9 @@ func (r *mqlDigitaloceanGradientai) dedicatedInferenceEndpoints() ([]interface{}
 			if err != nil {
 				return nil, err
 			}
+			// Cache the VPC UUID so the typed vpc() accessor can resolve it
+			// without a refetch.
+			res.(*mqlDigitaloceanGradientaiDedicatedInferenceEndpoint).cacheVPCUUID = e.VPCUUID
 			all = append(all, res)
 		}
 		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
@@ -221,12 +223,19 @@ func (r *mqlDigitaloceanGradientai) dedicatedInferenceEndpoints() ([]interface{}
 	return all, nil
 }
 
+// mqlDigitaloceanGradientaiDedicatedInferenceEndpointInternal caches the UUID
+// of the VPC the endpoint runs in so the typed vpc() accessor can resolve it
+// without a refetch.
+type mqlDigitaloceanGradientaiDedicatedInferenceEndpointInternal struct {
+	cacheVPCUUID string
+}
+
 func (r *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) id() (string, error) {
 	return "digitalocean.gradientai.dedicatedInferenceEndpoint/" + r.Id.Data, nil
 }
 
 func (r *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) vpc() (*mqlDigitaloceanVpc, error) {
-	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.VpcUuid.Data)
+	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.cacheVPCUUID)
 }
 
 func (r *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) accelerators() ([]interface{}, error) {

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -464,7 +464,7 @@ func (r *mqlDigitalocean) firewallsCovering(dropletID int64, dropletTags []any) 
 		byTag := map[string][]*mqlDigitaloceanFirewall{}
 		for _, f := range fws.Data {
 			fw := f.(*mqlDigitaloceanFirewall)
-			for _, id := range fw.DropletIds.Data {
+			for _, id := range fw.cacheDropletIDs {
 				if i, ok := id.(int64); ok {
 					byDroplet[i] = append(byDroplet[i], fw)
 				}
@@ -577,7 +577,7 @@ func dropletRef(runtime *plugin.Runtime, dropletID int64, target *plugin.TValue[
 // --- Droplet typed refs / computed fields ---
 
 func (r *mqlDigitaloceanDroplet) vpc() (*mqlDigitaloceanVpc, error) {
-	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.VpcUuid.Data)
+	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.cacheVPCUUID)
 }
 
 // baseImage resolves the droplet's image to a typed digitalocean.image. The
@@ -628,7 +628,7 @@ func (r *mqlDigitaloceanFirewall) droplets() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	direct, err := parent.dropletByIDs(r.DropletIds.Data)
+	direct, err := parent.dropletByIDs(r.cacheDropletIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -717,7 +717,7 @@ func (r *mqlDigitaloceanDatabase) sqlMode() (string, error) {
 // --- LoadBalancer typed refs ---
 
 func (r *mqlDigitaloceanLoadBalancer) vpc() (*mqlDigitaloceanVpc, error) {
-	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.VpcUuid.Data)
+	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.cacheVPCUUID)
 }
 
 func (r *mqlDigitaloceanLoadBalancer) droplets() ([]any, error) {
@@ -725,7 +725,7 @@ func (r *mqlDigitaloceanLoadBalancer) droplets() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parent.dropletByIDs(r.DropletIds.Data)
+	return parent.dropletByIDs(r.cacheDropletIDs)
 }
 
 // --- Volume typed refs ---
@@ -735,11 +735,11 @@ func (r *mqlDigitaloceanVolume) droplets() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parent.dropletByIDs(r.DropletIds.Data)
+	return parent.dropletByIDs(r.cacheDropletIDs)
 }
 
 // --- Kubernetes typed refs ---
 
 func (r *mqlDigitaloceanKubernetesCluster) vpc() (*mqlDigitaloceanVpc, error) {
-	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.VpcUuid.Data)
+	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.cacheVPCUUID)
 }


### PR DESCRIPTION
Removes the 11 fields marked `@maturity("deprecated")` in the digitalocean provider. Every one had a typed replacement already shipped and named in its own deprecation note.

| removed | replacement |
| --- | --- |
| `digitalocean.droplet.vpcUuid` | `digitalocean.droplet.vpc` |
| `digitalocean.droplet.image` | `digitalocean.droplet.baseImage` |
| `digitalocean.firewall.inboundRules` | `digitalocean.firewall.ingressRules` |
| `digitalocean.firewall.outboundRules` | `digitalocean.firewall.egressRules` |
| `digitalocean.firewall.dropletIds` | `digitalocean.firewall.droplets` |
| `digitalocean.volume.dropletIds` | `digitalocean.volume.droplets` |
| `digitalocean.loadBalancer.vpcUuid` | `digitalocean.loadBalancer.vpc` |
| `digitalocean.loadBalancer.dropletIds` | `digitalocean.loadBalancer.droplets` |
| `digitalocean.kubernetes.cluster.vpcUuid` | `digitalocean.kubernetes.cluster.vpc` |
| `digitalocean.gradientai.agent.vpcUuid` | `digitalocean.gradientai.agent.vpc` |
| `digitalocean.gradientai.dedicatedInferenceEndpoint.vpcUuid` | `digitalocean.gradientai.dedicatedInferenceEndpoint.vpc` |

## Why this isn't just a delete

The deprecated fields were load-bearing. The typed replacements read the raw values back off the schema:

- `vpc()` resolved from `r.VpcUuid.Data`
- `droplets()` resolved from `r.DropletIds.Data`
- `ingressRules()` / `egressRules()` parsed the `[]dict` rule lists via `GetInboundRules()` / `GetOutboundRules()`
- the parent's droplet→firewall coverage index read `fw.DropletIds.Data`

Those values now live in `mql*Internal` cache structs populated at construction time, so the replacements keep working with no extra API calls.

## init functions now build their own resources

Firewalls, load balancers, and DOKS clusters are reachable two ways: the account-wide list, and a single-asset scan that goes through the resource's `init`. `init` returned only an args map, which the runtime hands to the generated `create*` — there is no hook there for `Internal` fields, so the cached values would have been empty on that path.

Each now builds its resource through a shared `newMqlFirewall` / `newMqlLoadBalancer` / `newMqlKubernetesCluster` constructor and returns it to the runtime, which the generated `NewResource` dispatcher already supports (it registers a non-nil resource returned from `Init` directly). The list paths call the same constructors, so both routes populate identical state.

## Firewall rules skip the dict round-trip

`ingressRules()` / `egressRules()` now build from the cached `godo.InboundRule` / `godo.OutboundRule` structs directly instead of marshalling them into `[]dict` and parsing them back out. That drops the `ruleString` / `ruleSlice` dict accessors entirely and lets `openToInternet` take a `[]string`. Field values are unchanged.

## Notes

- `.lr.versions` entries for the removed fields are dropped; no other entry changed.
- No provider `Version` bump — the release flow owns that.
- Nothing outside the provider referenced these fields.

## Verification

- `./mqlr generate` (twice, for the new `Internal` structs) — regenerated `.lr.go` / `.lr.versions` committed
- `go build ./...` and `go vet ./...` clean
- `go test ./...` passes, including a new `TestOpenToInternet`
- `gofmt -l` clean

Not validated against a live DigitalOcean account — there is no `DIGITALOCEAN_TOKEN` in this environment.
