### PR TITLE
🛑 oci: remove all deprecated fields

### DIFF
--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -62,19 +62,18 @@ func (o *mqlOciApigateway) gateways() ([]any, error) {
 					updated = &g.TimeUpdated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.apigateway.gateway", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(g.Id),
-					"name":          llx.StringDataPtr(g.DisplayName),
-					"compartmentID": llx.StringDataPtr(g.CompartmentId),
-					"endpointType":  llx.StringData(string(g.EndpointType)),
-					"ipMode":        llx.StringData(string(g.IpMode)),
-					"hostname":      llx.StringDataPtr(g.Hostname),
-					"state":         llx.StringData(string(g.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"timeUpdated":   llx.TimeDataPtr(updated),
-					"freeformTags":  llx.MapData(strMapToAny(g.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(g.DefinedTags), types.Any),
-					"systemTags":    llx.MapData(definedTagsToAny(g.SystemTags), types.Dict),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.apigateway.gateway", stringValue(g.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(g.Id),
+					"name":         llx.StringDataPtr(g.DisplayName),
+					"endpointType": llx.StringData(string(g.EndpointType)),
+					"ipMode":       llx.StringData(string(g.IpMode)),
+					"hostname":     llx.StringDataPtr(g.Hostname),
+					"state":        llx.StringData(string(g.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"timeUpdated":  llx.TimeDataPtr(updated),
+					"freeformTags": llx.MapData(strMapToAny(g.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(g.DefinedTags), types.Any),
+					"systemTags":   llx.MapData(definedTagsToAny(g.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -92,6 +91,7 @@ func (o *mqlOciApigateway) gateways() ([]any, error) {
 }
 
 type mqlOciApigatewayGatewayInternal struct {
+	ociCompartmentRef
 	cacheRegion        string
 	cacheSubnetID      string
 	cacheCertificateID string
@@ -261,18 +261,17 @@ func (o *mqlOciApigateway) deployments() ([]any, error) {
 					updated = &d.TimeUpdated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.apigateway.deployment", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(d.Id),
-					"name":          llx.StringDataPtr(d.DisplayName),
-					"compartmentID": llx.StringDataPtr(d.CompartmentId),
-					"pathPrefix":    llx.StringDataPtr(d.PathPrefix),
-					"endpoint":      llx.StringDataPtr(d.Endpoint),
-					"state":         llx.StringData(string(d.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"timeUpdated":   llx.TimeDataPtr(updated),
-					"freeformTags":  llx.MapData(strMapToAny(d.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(d.DefinedTags), types.Any),
-					"systemTags":    llx.MapData(definedTagsToAny(d.SystemTags), types.Dict),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.apigateway.deployment", stringValue(d.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(d.Id),
+					"name":         llx.StringDataPtr(d.DisplayName),
+					"pathPrefix":   llx.StringDataPtr(d.PathPrefix),
+					"endpoint":     llx.StringDataPtr(d.Endpoint),
+					"state":        llx.StringData(string(d.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"timeUpdated":  llx.TimeDataPtr(updated),
+					"freeformTags": llx.MapData(strMapToAny(d.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(d.DefinedTags), types.Any),
+					"systemTags":   llx.MapData(definedTagsToAny(d.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -288,6 +287,7 @@ func (o *mqlOciApigateway) deployments() ([]any, error) {
 }
 
 type mqlOciApigatewayDeploymentInternal struct {
+	ociCompartmentRef
 	cacheRegion    string
 	cacheGatewayID string
 
@@ -632,10 +632,9 @@ func (o *mqlOciApigateway) certificates() ([]any, error) {
 
 				subjectNames := convert.SliceAnyToInterface(c.SubjectNames)
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.apigateway.certificate", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.apigateway.certificate", stringValue(c.CompartmentId), map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(c.Id),
 					"name":              llx.StringDataPtr(c.DisplayName),
-					"compartmentID":     llx.StringDataPtr(c.CompartmentId),
 					"subjectNames":      llx.ArrayData(subjectNames, types.String),
 					"timeNotValidAfter": llx.TimeDataPtr(notValidAfter),
 					"state":             llx.StringData(string(c.LifecycleState)),
@@ -683,4 +682,8 @@ func initOciApigatewayCertificate(runtime *plugin.Runtime, args map[string]*llx.
 
 func (o *mqlOciApigatewayCertificate) id() (string, error) {
 	return "oci.apigateway.certificate/" + o.Id.Data, nil
+}
+
+type mqlOciApigatewayCertificateInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -59,10 +59,9 @@ func (o *mqlOciBastion) bastions() ([]any, error) {
 					timeUpdated = &b.TimeUpdated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.bastion.instance", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.bastion.instance", stringValue(b.CompartmentId), map[string]*llx.RawData{
 					"id":             llx.StringDataPtr(b.Id),
 					"name":           llx.StringDataPtr(b.Name),
-					"compartmentID":  llx.StringDataPtr(b.CompartmentId),
 					"bastionType":    llx.StringDataPtr(b.BastionType),
 					"state":          llx.StringData(string(b.LifecycleState)),
 					"dnsProxyStatus": llx.StringData(string(b.DnsProxyStatus)),
@@ -87,6 +86,7 @@ func (o *mqlOciBastion) bastions() ([]any, error) {
 }
 
 type mqlOciBastionInstanceInternal struct {
+	ociCompartmentRef
 	cacheTargetVcnID    string
 	cacheTargetSubnetID string
 	cacheRegion         string

--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -127,19 +127,12 @@ func (o *mqlOciObjectStorage) getBuckets(conn *connection.OciConnection, namespa
 					created = &bucket.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.objectStorage.bucket", map[string]*llx.RawData{
-					"__id": llx.StringData(ociBucketCacheKey(stringValue(bucket.Namespace), stringValue(bucket.Name))),
-					// ListBuckets carries no OCID. Set the deprecated id field
-					// explicitly null so it reads as a null rather than crossing
-					// the plugin boundary unset, which surfaced client-side as an
-					// unattributed "primitive with no type information" warning.
-					// Use ocid for a value that resolves on both paths.
-					"id":            llx.NilData,
-					"namespace":     llx.StringDataPtr(bucket.Namespace),
-					"name":          llx.StringDataPtr(bucket.Name),
-					"compartmentID": llx.StringDataPtr(bucket.CompartmentId),
-					"region":        llx.ResourceData(regionResource, "oci.region"),
-					"created":       llx.TimeDataPtr(created),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.objectStorage.bucket", stringValue(bucket.CompartmentId), map[string]*llx.RawData{
+					"__id":      llx.StringData(ociBucketCacheKey(stringValue(bucket.Namespace), stringValue(bucket.Name))),
+					"namespace": llx.StringDataPtr(bucket.Namespace),
+					"name":      llx.StringDataPtr(bucket.Name),
+					"region":    llx.ResourceData(regionResource, "oci.region"),
+					"created":   llx.TimeDataPtr(created),
 				})
 				if err != nil {
 					return nil, err
@@ -155,6 +148,7 @@ func (o *mqlOciObjectStorage) getBuckets(conn *connection.OciConnection, namespa
 }
 
 type mqlOciObjectStorageBucketInternal struct {
+	ociCompartmentRef
 	bucket ociRetryLazy[*objectstorage.Bucket]
 }
 
@@ -167,9 +161,9 @@ func ociBucketCacheKey(namespace, name string) string {
 	return "oci.objectStorage.bucket/" + namespace + "/" + name
 }
 
-// ocid reports the bucket OCID, which ListBuckets does not return. The
-// deprecated `id` field is left as-is for compatibility; this accessor resolves
-// identically on the listing and single-bucket paths.
+// ocid reports the bucket OCID, which ListBuckets does not return. It resolves
+// identically on the listing and single-bucket paths, since both reach the
+// detail call.
 func (o *mqlOciObjectStorageBucket) ocid() (string, error) {
 	bucketInfo, err := o.getBucketDetails()
 	if err != nil {
@@ -232,12 +226,16 @@ func initOciObjectStorageBucket(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 	bucket := obj.(*mqlOciObjectStorageBucket)
 
-	// getBucketDetails sets Id on the resource itself. Writing args["id"] here
-	// would be a no-op: NewResource discards the returned args whenever the
-	// init also returns a resource.
-	if _, err := bucket.getBucketDetails(); err != nil {
+	// This is the only compartment-bearing resource whose init constructs its
+	// own resource rather than handing back one the listing path already built,
+	// so nothing has recorded the compartment OCID for it. The detail call is
+	// made here anyway, and it carries the compartment - take it from there, or
+	// a single-bucket lookup reports a null compartment().
+	details, err := bucket.getBucketDetails()
+	if err != nil {
 		return nil, nil, err
 	}
+	bucket.setCompartmentID(stringValue(details.CompartmentId))
 
 	return args, bucket, nil
 }
@@ -288,13 +286,6 @@ func (o *mqlOciObjectStorageBucket) getBucketDetails() (*objectstorage.Bucket, e
 			return nil, err
 		}
 
-		// ListBuckets returns a BucketSummary, which carries no Id at all, so
-		// the bucket OCID is only knowable from this call. Populate it here so
-		// both the collection path and the single-bucket init resolve `id`
-		// identically.
-		if response.Bucket.Id != nil {
-			o.Id = plugin.TValue[string]{Data: *response.Bucket.Id, State: plugin.StateIsSet}
-		}
 		return &response.Bucket, nil
 	})
 }

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -88,11 +88,10 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 
 				autoRenewal, renewalInterval := extractCertificateRenewal(c.CertificateRules)
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.certificates.certificate", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.certificates.certificate", stringValue(c.CompartmentId), map[string]*llx.RawData{
 					"id":                 llx.StringDataPtr(c.Id),
 					"name":               llx.StringDataPtr(c.Name),
 					"description":        llx.StringDataPtr(c.Description),
-					"compartmentID":      llx.StringDataPtr(c.CompartmentId),
 					"configType":         llx.StringData(string(c.ConfigType)),
 					"subject":            llx.StringData(subject),
 					"sans":               llx.ArrayData(sans, types.String),
@@ -121,6 +120,7 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 }
 
 type mqlOciCertificatesCertificateInternal struct {
+	ociCompartmentRef
 	cacheIssuerCaID string
 }
 
@@ -254,11 +254,10 @@ func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 
 				kind := caKindFromConfigType(string(ca.ConfigType))
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.certificates.certificateAuthority", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.certificates.certificateAuthority", stringValue(ca.CompartmentId), map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(ca.Id),
 					"name":              llx.StringDataPtr(ca.Name),
 					"description":       llx.StringDataPtr(ca.Description),
-					"compartmentID":     llx.StringDataPtr(ca.CompartmentId),
 					"kind":              llx.StringData(kind),
 					"configType":        llx.StringData(string(ca.ConfigType)),
 					"subject":           llx.StringData(subject),
@@ -283,6 +282,7 @@ func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 }
 
 type mqlOciCertificatesCertificateAuthorityInternal struct {
+	ociCompartmentRef
 	cacheIssuerCaID string
 	cacheKmsKeyID   string
 }
@@ -390,15 +390,14 @@ func (o *mqlOciCertificates) caBundles() ([]any, error) {
 					created = &b.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.certificates.caBundle", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(b.Id),
-					"name":          llx.StringDataPtr(b.Name),
-					"description":   llx.StringDataPtr(b.Description),
-					"compartmentID": llx.StringDataPtr(b.CompartmentId),
-					"state":         llx.StringData(string(b.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(b.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(b.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.certificates.caBundle", stringValue(b.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(b.Id),
+					"name":         llx.StringDataPtr(b.Name),
+					"description":  llx.StringDataPtr(b.Description),
+					"state":        llx.StringData(string(b.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(b.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(b.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -455,4 +454,8 @@ func sanSliceToAny(sans []certificatesmanagement.CertificateSubjectAlternativeNa
 		out = append(out, string(sans[i].Type)+":"+stringValue(sans[i].Value))
 	}
 	return out
+}
+
+type mqlOciCertificatesCaBundleInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -229,10 +229,9 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 			created = &target.TimeCreated.Time
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.cloudGuard.target", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.cloudGuard.target", stringValue(target.CompartmentId), map[string]*llx.RawData{
 			"id":                 llx.StringDataPtr(target.Id),
 			"name":               llx.StringDataPtr(target.DisplayName),
-			"compartmentID":      llx.StringDataPtr(target.CompartmentId),
 			"targetResourceId":   llx.StringDataPtr(target.TargetResourceId),
 			"targetResourceType": llx.StringData(string(target.TargetResourceType)),
 			"state":              llx.StringData(string(target.LifecycleState)),
@@ -411,10 +410,9 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.DetectorRecipeDetectorRuleSummary, *string, error) {
 		response, err := client.ListDetectorRecipeDetectorRules(ctx, cloudguard.ListDetectorRecipeDetectorRulesRequest{
 			DetectorRecipeId: common.String(o.Id.Data),
-			// Read from the cached value rather than the public compartmentID
-			// field, which is marked deprecated in favour of compartment().
-			// Removing that field in a later major version would otherwise
-			// quietly scope this listing to the empty string.
+			// The compartment OCID is no longer a schema field, so it comes
+			// from the value recorded when the recipe was listed. An empty
+			// value here would quietly scope this listing to nothing.
 			CompartmentId: common.String(o.cacheCompartmentID),
 			Page:          page,
 		})
@@ -547,18 +545,17 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 			created = &recipe.TimeCreated.Time
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.cloudGuard.detectorRecipe", map[string]*llx.RawData{
-			"id":            llx.StringDataPtr(recipe.Id),
-			"name":          llx.StringDataPtr(recipe.DisplayName),
-			"description":   llx.StringDataPtr(recipe.Description),
-			"compartmentID": llx.StringDataPtr(recipe.CompartmentId),
-			"owner":         llx.StringData(string(recipe.Owner)),
-			"detectorType":  llx.StringData(string(recipe.Detector)),
-			"state":         llx.StringData(string(recipe.LifecycleState)),
-			"created":       llx.TimeDataPtr(created),
-			"freeformTags":  llx.MapData(strMapToAny(recipe.FreeformTags), types.String),
-			"definedTags":   llx.MapData(definedTagsToAny(recipe.DefinedTags), types.Any),
-			"systemTags":    llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.cloudGuard.detectorRecipe", stringValue(recipe.CompartmentId), map[string]*llx.RawData{
+			"id":           llx.StringDataPtr(recipe.Id),
+			"name":         llx.StringDataPtr(recipe.DisplayName),
+			"description":  llx.StringDataPtr(recipe.Description),
+			"owner":        llx.StringData(string(recipe.Owner)),
+			"detectorType": llx.StringData(string(recipe.Detector)),
+			"state":        llx.StringData(string(recipe.LifecycleState)),
+			"created":      llx.TimeDataPtr(created),
+			"freeformTags": llx.MapData(strMapToAny(recipe.FreeformTags), types.String),
+			"definedTags":  llx.MapData(definedTagsToAny(recipe.DefinedTags), types.Any),
+			"systemTags":   llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -616,11 +613,10 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 			created = &zone.TimeCreated.Time
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.cloudGuard.securityZone", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.cloudGuard.securityZone", stringValue(zone.CompartmentId), map[string]*llx.RawData{
 			"id":                              llx.StringDataPtr(zone.Id),
 			"name":                            llx.StringDataPtr(zone.DisplayName),
 			"description":                     llx.StringDataPtr(zone.Description),
-			"compartmentID":                   llx.StringDataPtr(zone.CompartmentId),
 			"isInheritanceAfterDeleteEnabled": llx.BoolDataPtr(zone.IsInheritanceAfterDeleteEnabled),
 			"state":                           llx.StringData(string(zone.LifecycleState)),
 			"created":                         llx.TimeDataPtr(created),
@@ -676,17 +672,16 @@ func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 			created = &recipe.TimeCreated.Time
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.cloudGuard.securityZoneRecipe", map[string]*llx.RawData{
-			"id":            llx.StringDataPtr(recipe.Id),
-			"name":          llx.StringDataPtr(recipe.DisplayName),
-			"description":   llx.StringDataPtr(recipe.Description),
-			"compartmentID": llx.StringDataPtr(recipe.CompartmentId),
-			"owner":         llx.StringData(string(recipe.Owner)),
-			"state":         llx.StringData(string(recipe.LifecycleState)),
-			"created":       llx.TimeDataPtr(created),
-			"freeformTags":  llx.MapData(strMapToAny(recipe.FreeformTags), types.String),
-			"definedTags":   llx.MapData(definedTagsToAny(recipe.DefinedTags), types.Any),
-			"systemTags":    llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.cloudGuard.securityZoneRecipe", stringValue(recipe.CompartmentId), map[string]*llx.RawData{
+			"id":           llx.StringDataPtr(recipe.Id),
+			"name":         llx.StringDataPtr(recipe.DisplayName),
+			"description":  llx.StringDataPtr(recipe.Description),
+			"owner":        llx.StringData(string(recipe.Owner)),
+			"state":        llx.StringData(string(recipe.LifecycleState)),
+			"created":      llx.TimeDataPtr(created),
+			"freeformTags": llx.MapData(strMapToAny(recipe.FreeformTags), types.String),
+			"definedTags":  llx.MapData(definedTagsToAny(recipe.DefinedTags), types.Any),
+			"systemTags":   llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -741,20 +736,19 @@ func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 			services = append(services, s)
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.cloudGuard.securityPolicy", map[string]*llx.RawData{
-			"id":            llx.StringDataPtr(policy.Id),
-			"name":          llx.StringDataPtr(policy.DisplayName),
-			"friendlyName":  llx.StringDataPtr(policy.FriendlyName),
-			"description":   llx.StringDataPtr(policy.Description),
-			"compartmentID": llx.StringDataPtr(policy.CompartmentId),
-			"owner":         llx.StringData(string(policy.Owner)),
-			"category":      llx.StringDataPtr(policy.Category),
-			"services":      llx.ArrayData(services, types.String),
-			"state":         llx.StringData(string(policy.LifecycleState)),
-			"created":       llx.TimeDataPtr(created),
-			"freeformTags":  llx.MapData(strMapToAny(policy.FreeformTags), types.String),
-			"definedTags":   llx.MapData(definedTagsToAny(policy.DefinedTags), types.Any),
-			"systemTags":    llx.MapData(definedTagsToAny(policy.SystemTags), types.Dict),
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.cloudGuard.securityPolicy", stringValue(policy.CompartmentId), map[string]*llx.RawData{
+			"id":           llx.StringDataPtr(policy.Id),
+			"name":         llx.StringDataPtr(policy.DisplayName),
+			"friendlyName": llx.StringDataPtr(policy.FriendlyName),
+			"description":  llx.StringDataPtr(policy.Description),
+			"owner":        llx.StringData(string(policy.Owner)),
+			"category":     llx.StringDataPtr(policy.Category),
+			"services":     llx.ArrayData(services, types.String),
+			"state":        llx.StringData(string(policy.LifecycleState)),
+			"created":      llx.TimeDataPtr(created),
+			"freeformTags": llx.MapData(strMapToAny(policy.FreeformTags), types.String),
+			"definedTags":  llx.MapData(definedTagsToAny(policy.DefinedTags), types.Any),
+			"systemTags":   llx.MapData(definedTagsToAny(policy.SystemTags), types.Dict),
 		})
 		if err != nil {
 			return nil, err
@@ -766,10 +760,12 @@ func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 }
 
 type mqlOciCloudGuardSecurityZoneInternal struct {
+	ociCompartmentRef
 	cacheRecipeID string
 }
 
 type mqlOciCloudGuardSecurityZoneRecipeInternal struct {
+	ociCompartmentRef
 	cachePolicyIDs []string
 }
 
@@ -850,4 +846,12 @@ func (o *mqlOciCloudGuardSecurityZoneRecipe) securityPolicies() ([]any, error) {
 
 func (o *mqlOciCloudGuardSecurityPolicy) id() (string, error) {
 	return "oci.cloudGuard.securityPolicy/" + o.Id.Data, nil
+}
+
+type mqlOciCloudGuardSecurityPolicyInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciCloudGuardTargetInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -157,7 +157,6 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 					"availabilityDomain":          llx.StringDataPtr(instance.AvailabilityDomain),
 					"compartment":                 llx.ResourceData(compartment, "oci.compartment"),
 					"faultDomain":                 llx.StringDataPtr(instance.FaultDomain),
-					"imageId":                     llx.StringDataPtr(instance.ImageId),
 					"dedicatedVmHostId":           llx.StringDataPtr(instance.DedicatedVmHostId),
 					"platformConfig":              llx.DictData(platformConfig),
 					"launchOptions":               llx.DictData(launchOptions),
@@ -180,6 +179,7 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 				}
 				mqlInst := mqlInstance.(*mqlOciComputeInstance)
 				mqlInst.cacheRegion = region
+				mqlInst.cacheImageID = stringValue(instance.ImageId)
 				mqlInst.cacheCompartmentID = stringValue(instance.CompartmentId)
 				if src, ok := instance.SourceDetails.(core.InstanceSourceViaBootVolumeDetails); ok {
 					mqlInst.cacheBootVolumeID = stringValue(src.BootVolumeId)
@@ -212,6 +212,7 @@ func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, comput
 }
 
 type mqlOciComputeInstanceInternal struct {
+	cacheImageID       string
 	cacheRegion        string
 	cacheBootVolumeID  string
 	cacheCompartmentID string
@@ -300,6 +301,8 @@ func (o *mqlOciComputeInstance) vnics() ([]any, error) {
 }
 
 type mqlOciComputeVnicInternal struct {
+	ociCompartmentRef
+	cacheNsgIDs   []any
 	cacheSubnetID string
 }
 
@@ -457,10 +460,9 @@ func (o *mqlOciCompute) blockVolumes() ([]any, error) {
 					sourceVolumeBackupID = stringValue(d.Id)
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.compute.blockVolume", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.compute.blockVolume", stringValue(vol.CompartmentId), map[string]*llx.RawData{
 					"id":                   llx.StringDataPtr(vol.Id),
 					"name":                 llx.StringDataPtr(vol.DisplayName),
-					"compartmentID":        llx.StringDataPtr(vol.CompartmentId),
 					"availabilityDomain":   llx.StringDataPtr(vol.AvailabilityDomain),
 					"sizeInGBs":            llx.IntDataPtr(vol.SizeInGBs),
 					"vpusPerGB":            llx.IntDataPtr(vol.VpusPerGB),
@@ -507,6 +509,7 @@ func (o *mqlOciCompute) getBlockVolumesForRegion(ctx context.Context, client *co
 }
 
 type mqlOciComputeBlockVolumeInternal struct {
+	ociCompartmentRef
 	cacheKmsKeyID       string
 	cacheSourceVolumeID string
 }
@@ -563,13 +566,11 @@ func (o *mqlOciCompute) bootVolumes() ([]any, error) {
 					sourceBootVolumeBackupID = stringValue(d.Id)
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.compute.bootVolume", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.compute.bootVolume", stringValue(bv.CompartmentId), map[string]*llx.RawData{
 					"id":                       llx.StringDataPtr(bv.Id),
 					"name":                     llx.StringDataPtr(bv.DisplayName),
-					"compartmentID":            llx.StringDataPtr(bv.CompartmentId),
 					"availabilityDomain":       llx.StringDataPtr(bv.AvailabilityDomain),
 					"sizeInGBs":                llx.IntDataPtr(bv.SizeInGBs),
-					"imageId":                  llx.StringDataPtr(bv.ImageId),
 					"state":                    llx.StringData(string(bv.LifecycleState)),
 					"sourceBootVolumeBackupId": llx.StringData(sourceBootVolumeBackupID),
 					"created":                  llx.TimeDataPtr(created),
@@ -581,6 +582,7 @@ func (o *mqlOciCompute) bootVolumes() ([]any, error) {
 					return nil, err
 				}
 				mqlBV := mqlInstance.(*mqlOciComputeBootVolume)
+				mqlBV.cacheImageID = stringValue(bv.ImageId)
 				mqlBV.cacheKmsKeyID = stringValue(bv.KmsKeyId)
 				mqlBV.cacheSourceBootVolumeID = sourceBootVolumeID
 				res = append(res, mqlBV)
@@ -611,6 +613,8 @@ func (o *mqlOciCompute) getBootVolumesForRegion(ctx context.Context, client *cor
 }
 
 type mqlOciComputeBootVolumeInternal struct {
+	ociCompartmentRef
+	cacheImageID            string
 	cacheKmsKeyID           string
 	cacheSourceBootVolumeID string
 }

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -107,10 +107,9 @@ func (o *mqlOciContainerInstances) instances() ([]any, error) {
 					return nil, err
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.containerInstances.instance", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.containerInstances.instance", stringValue(ci.CompartmentId), map[string]*llx.RawData{
 					"id":                               llx.StringDataPtr(ci.Id),
 					"name":                             llx.StringDataPtr(ci.DisplayName),
-					"compartmentID":                    llx.StringDataPtr(ci.CompartmentId),
 					"availabilityDomain":               llx.StringDataPtr(ci.AvailabilityDomain),
 					"state":                            llx.StringData(string(ci.LifecycleState)),
 					"shape":                            llx.StringDataPtr(ci.Shape),
@@ -139,6 +138,7 @@ func (o *mqlOciContainerInstances) instances() ([]any, error) {
 }
 
 type mqlOciContainerInstancesInstanceInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 }
 
@@ -157,7 +157,7 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 
 	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerinstances.ContainerSummary, *string, error) {
 		response, err := svc.ListContainers(ctx, containerinstances.ListContainersRequest{
-			CompartmentId:       common.String(o.CompartmentID.Data),
+			CompartmentId:       common.String(o.cacheCompartmentID),
 			ContainerInstanceId: common.String(o.Id.Data),
 			Page:                page,
 		})
@@ -189,10 +189,9 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 
 		sec := ociContainerSecurityContext(c.SecurityContext)
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.containerInstances.container", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.containerInstances.container", stringValue(c.CompartmentId), map[string]*llx.RawData{
 			"id":                          llx.StringDataPtr(c.Id),
 			"name":                        llx.StringDataPtr(c.DisplayName),
-			"compartmentID":               llx.StringDataPtr(c.CompartmentId),
 			"availabilityDomain":          llx.StringDataPtr(c.AvailabilityDomain),
 			"state":                       llx.StringData(string(c.LifecycleState)),
 			"containerInstanceId":         llx.StringDataPtr(c.ContainerInstanceId),
@@ -222,4 +221,8 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 
 func (o *mqlOciContainerInstancesContainer) id() (string, error) {
 	return "oci.containerInstances.container/" + o.Id.Data, nil
+}
+
+type mqlOciContainerInstancesContainerInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -58,10 +58,9 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 					created = &s.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.database.dbSystem", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.database.dbSystem", stringValue(s.CompartmentId), map[string]*llx.RawData{
 					"id":                   llx.StringDataPtr(s.Id),
 					"name":                 llx.StringDataPtr(s.DisplayName),
-					"compartmentID":        llx.StringDataPtr(s.CompartmentId),
 					"availabilityDomain":   llx.StringDataPtr(s.AvailabilityDomain),
 					"shape":                llx.StringDataPtr(s.Shape),
 					"databaseEdition":      llx.StringData(string(s.DatabaseEdition)),
@@ -75,8 +74,6 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 					"nodeCount":            llx.IntData(intValue(s.NodeCount)),
 					"dataStorageSizeInGBs": llx.IntData(intValue(s.DataStorageSizeInGBs)),
 					"licenseModel":         llx.StringData(string(s.LicenseModel)),
-					"nsgIds":               llx.ArrayData(convert.SliceAnyToInterface(s.NsgIds), types.String),
-					"backupNetworkNsgIds":  llx.ArrayData(convert.SliceAnyToInterface(s.BackupNetworkNsgIds), types.String),
 					"state":                llx.StringData(string(s.LifecycleState)),
 					"created":              llx.TimeDataPtr(created),
 					"freeformTags":         llx.MapData(strMapToAny(s.FreeformTags), types.String),
@@ -87,6 +84,8 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 					return nil, err
 				}
 				mqlDb := mqlInstance.(*mqlOciDatabaseDbSystem)
+				mqlDb.cacheNsgIDs = convert.SliceAnyToInterface(s.NsgIds)
+				mqlDb.cacheBackupNetworkNsgIDs = convert.SliceAnyToInterface(s.BackupNetworkNsgIds)
 				mqlDb.cacheKmsKeyID = stringValue(s.KmsKeyId)
 				mqlDb.cacheSubnetID = stringValue(s.SubnetId)
 				mqlDb.cacheSourceDbSystemID = stringValue(s.SourceDbSystemId)
@@ -98,9 +97,12 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 }
 
 type mqlOciDatabaseDbSystemInternal struct {
-	cacheKmsKeyID         string
-	cacheSubnetID         string
-	cacheSourceDbSystemID string
+	ociCompartmentRef
+	cacheNsgIDs              []any
+	cacheBackupNetworkNsgIDs []any
+	cacheKmsKeyID            string
+	cacheSubnetID            string
+	cacheSourceDbSystemID    string
 }
 
 func (o *mqlOciDatabaseDbSystem) id() (string, error) {
@@ -188,10 +190,9 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 					}
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.database.autonomousDatabase", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.database.autonomousDatabase", stringValue(a.CompartmentId), map[string]*llx.RawData{
 					"id":                          llx.StringDataPtr(a.Id),
 					"name":                        llx.StringDataPtr(a.DisplayName),
-					"compartmentID":               llx.StringDataPtr(a.CompartmentId),
 					"dbName":                      llx.StringDataPtr(a.DbName),
 					"isRefreshableClone":          llx.BoolDataPtr(a.IsRefreshableClone),
 					"dbVersion":                   llx.StringDataPtr(a.DbVersion),
@@ -214,7 +215,6 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 					"openMode":                    llx.StringData(string(a.OpenMode)),
 					"permissionLevel":             llx.StringData(string(a.PermissionLevel)),
 					"licenseModel":                llx.StringData(string(a.LicenseModel)),
-					"nsgIds":                      llx.ArrayData(convert.SliceAnyToInterface(a.NsgIds), types.String),
 					"privateEndpointIp":           llx.StringDataPtr(a.PrivateEndpointIp),
 					"privateEndpointLabel":        llx.StringDataPtr(a.PrivateEndpointLabel),
 					"connectionUrls":              llx.DictData(connectionUrls),
@@ -229,6 +229,7 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 					return nil, err
 				}
 				mqlAdb := mqlInstance.(*mqlOciDatabaseAutonomousDatabase)
+				mqlAdb.cacheNsgIDs = convert.SliceAnyToInterface(a.NsgIds)
 				mqlAdb.cacheKmsKeyID = stringValue(a.KmsKeyId)
 				mqlAdb.cacheVaultID = stringValue(a.VaultId)
 				mqlAdb.cacheSubnetID = stringValue(a.SubnetId)
@@ -241,6 +242,8 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 }
 
 type mqlOciDatabaseAutonomousDatabaseInternal struct {
+	ociCompartmentRef
+	cacheNsgIDs   []any
 	cacheKmsKeyID string
 	cacheVaultID  string
 	cacheSubnetID string
@@ -341,10 +344,9 @@ func (o *mqlOciDatabase) backups() ([]any, error) {
 					sizeGBs = *b.DatabaseSizeInGBs
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.database.backup", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.database.backup", stringValue(b.CompartmentId), map[string]*llx.RawData{
 					"id":                       llx.StringDataPtr(b.Id),
 					"name":                     llx.StringDataPtr(b.DisplayName),
-					"compartmentID":            llx.StringDataPtr(b.CompartmentId),
 					"databaseId":               llx.StringDataPtr(b.DatabaseId),
 					"availabilityDomain":       llx.StringDataPtr(b.AvailabilityDomain),
 					"type":                     llx.StringData(string(b.Type)),
@@ -375,6 +377,7 @@ func (o *mqlOciDatabase) backups() ([]any, error) {
 }
 
 type mqlOciDatabaseBackupInternal struct {
+	ociCompartmentRef
 	cacheKmsKeyID string
 	cacheVaultID  string
 }
@@ -462,10 +465,9 @@ func (o *mqlOciDatabase) autonomousDatabaseBackups() ([]any, error) {
 					sizeTBs = *b.SizeInTBs
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.database.autonomousDatabaseBackup", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.database.autonomousDatabaseBackup", stringValue(b.CompartmentId), map[string]*llx.RawData{
 					"id":                    llx.StringDataPtr(b.Id),
 					"name":                  llx.StringDataPtr(b.DisplayName),
-					"compartmentID":         llx.StringDataPtr(b.CompartmentId),
 					"type":                  llx.StringData(string(b.Type)),
 					"isAutomatic":           llx.BoolDataPtr(b.IsAutomatic),
 					"isRestorable":          llx.BoolDataPtr(b.IsRestorable),
@@ -519,6 +521,7 @@ func (o *mqlOciDatabaseAutonomousDatabase) backups() ([]any, error) {
 }
 
 type mqlOciDatabaseAutonomousDatabaseBackupInternal struct {
+	ociCompartmentRef
 	cacheAutonomousDatabaseID string
 	cacheKmsKeyID             string
 	cacheVaultID              string

--- a/providers/oci/resources/datasafe.go
+++ b/providers/oci/resources/datasafe.go
@@ -122,7 +122,6 @@ func (o *mqlOciDataSafe) configurations() ([]any, error) {
 				"region":              llx.StringData(regionId),
 				"isEnabled":           llx.BoolData(boolValue(cfg.IsEnabled)),
 				"url":                 llx.StringData(stringValue(cfg.Url)),
-				"compartmentId":       llx.StringData(stringValue(cfg.CompartmentId)),
 				"lifecycleState":      llx.StringData(string(cfg.LifecycleState)),
 				"natGatewayIpAddress": llx.StringData(stringValue(cfg.DataSafeNatGatewayIpAddress)),
 				"globalSettings":      llx.DictData(globalSettingsDict),
@@ -135,7 +134,7 @@ func (o *mqlOciDataSafe) configurations() ([]any, error) {
 				args["enabledAt"] = llx.NilData
 			}
 
-			mqlCfg, err := CreateResource(o.MqlRuntime, "oci.dataSafe.configuration", args)
+			mqlCfg, err := createOciResourceInCompartment(o.MqlRuntime, "oci.dataSafe.configuration", stringValue(cfg.CompartmentId), args)
 			if err != nil {
 				return nil, err
 			}
@@ -187,7 +186,6 @@ func (o *mqlOciDataSafe) targetDatabases() ([]any, error) {
 				t := items[i]
 				args := map[string]*llx.RawData{
 					"id":                    llx.StringDataPtr(t.Id),
-					"compartmentId":         llx.StringDataPtr(t.CompartmentId),
 					"region":                llx.StringData(regionId),
 					"displayName":           llx.StringDataPtr(t.DisplayName),
 					"description":           llx.StringData(stringValue(t.Description)),
@@ -201,7 +199,7 @@ func (o *mqlOciDataSafe) targetDatabases() ([]any, error) {
 					"definedTags":           llx.MapData(definedTagsToAny(t.DefinedTags), types.Any),
 					"systemTags":            llx.MapData(definedTagsToAny(t.SystemTags), types.Dict),
 				}
-				mql, err := CreateResource(o.MqlRuntime, "oci.dataSafe.targetDatabase", args)
+				mql, err := createOciResourceInCompartment(o.MqlRuntime, "oci.dataSafe.targetDatabase", stringValue(t.CompartmentId), args)
 				if err != nil {
 					return nil, err
 				}
@@ -255,7 +253,6 @@ func (o *mqlOciDataSafe) securityAssessments() ([]any, error) {
 				a := items[i]
 				args := map[string]*llx.RawData{
 					"id":                     llx.StringDataPtr(a.Id),
-					"compartmentId":          llx.StringDataPtr(a.CompartmentId),
 					"region":                 llx.StringData(regionId),
 					"displayName":            llx.StringDataPtr(a.DisplayName),
 					"lifecycleState":         llx.StringData(string(a.LifecycleState)),
@@ -268,7 +265,7 @@ func (o *mqlOciDataSafe) securityAssessments() ([]any, error) {
 					"freeformTags":           llx.MapData(strMapToAny(a.FreeformTags), types.String),
 					"definedTags":            llx.MapData(definedTagsToAny(a.DefinedTags), types.Any),
 				}
-				mql, err := CreateResource(o.MqlRuntime, "oci.dataSafe.securityAssessment", args)
+				mql, err := createOciResourceInCompartment(o.MqlRuntime, "oci.dataSafe.securityAssessment", stringValue(a.CompartmentId), args)
 				if err != nil {
 					return nil, err
 				}
@@ -322,7 +319,6 @@ func (o *mqlOciDataSafe) userAssessments() ([]any, error) {
 				a := items[i]
 				args := map[string]*llx.RawData{
 					"id":                     llx.StringDataPtr(a.Id),
-					"compartmentId":          llx.StringDataPtr(a.CompartmentId),
 					"region":                 llx.StringData(regionId),
 					"displayName":            llx.StringDataPtr(a.DisplayName),
 					"lifecycleState":         llx.StringData(string(a.LifecycleState)),
@@ -335,7 +331,7 @@ func (o *mqlOciDataSafe) userAssessments() ([]any, error) {
 					"freeformTags":           llx.MapData(strMapToAny(a.FreeformTags), types.String),
 					"definedTags":            llx.MapData(definedTagsToAny(a.DefinedTags), types.Any),
 				}
-				mql, err := CreateResource(o.MqlRuntime, "oci.dataSafe.userAssessment", args)
+				mql, err := createOciResourceInCompartment(o.MqlRuntime, "oci.dataSafe.userAssessment", stringValue(a.CompartmentId), args)
 				if err != nil {
 					return nil, err
 				}
@@ -389,7 +385,6 @@ func (o *mqlOciDataSafe) sensitiveDataModels() ([]any, error) {
 				m := items[i]
 				args := map[string]*llx.RawData{
 					"id":             llx.StringDataPtr(m.Id),
-					"compartmentId":  llx.StringDataPtr(m.CompartmentId),
 					"region":         llx.StringData(regionId),
 					"displayName":    llx.StringDataPtr(m.DisplayName),
 					"description":    llx.StringData(stringValue(m.Description)),
@@ -401,7 +396,7 @@ func (o *mqlOciDataSafe) sensitiveDataModels() ([]any, error) {
 					"freeformTags":   llx.MapData(strMapToAny(m.FreeformTags), types.String),
 					"definedTags":    llx.MapData(definedTagsToAny(m.DefinedTags), types.Any),
 				}
-				mql, err := CreateResource(o.MqlRuntime, "oci.dataSafe.sensitiveDataModel", args)
+				mql, err := createOciResourceInCompartment(o.MqlRuntime, "oci.dataSafe.sensitiveDataModel", stringValue(m.CompartmentId), args)
 				if err != nil {
 					return nil, err
 				}
@@ -455,7 +450,6 @@ func (o *mqlOciDataSafe) sensitiveTypes() ([]any, error) {
 				t := items[i]
 				args := map[string]*llx.RawData{
 					"id":             llx.StringDataPtr(t.Id),
-					"compartmentId":  llx.StringDataPtr(t.CompartmentId),
 					"region":         llx.StringData(regionId),
 					"displayName":    llx.StringDataPtr(t.DisplayName),
 					"shortName":      llx.StringData(stringValue(t.ShortName)),
@@ -467,7 +461,7 @@ func (o *mqlOciDataSafe) sensitiveTypes() ([]any, error) {
 					"freeformTags":   llx.MapData(strMapToAny(t.FreeformTags), types.String),
 					"definedTags":    llx.MapData(definedTagsToAny(t.DefinedTags), types.Any),
 				}
-				mql, err := CreateResource(o.MqlRuntime, "oci.dataSafe.sensitiveType", args)
+				mql, err := createOciResourceInCompartment(o.MqlRuntime, "oci.dataSafe.sensitiveType", stringValue(t.CompartmentId), args)
 				if err != nil {
 					return nil, err
 				}
@@ -525,7 +519,6 @@ func (o *mqlOciDataSafe) maskingPolicies() ([]any, error) {
 				}
 				args := map[string]*llx.RawData{
 					"id":             llx.StringDataPtr(p.Id),
-					"compartmentId":  llx.StringDataPtr(p.CompartmentId),
 					"region":         llx.StringData(regionId),
 					"displayName":    llx.StringDataPtr(p.DisplayName),
 					"description":    llx.StringData(stringValue(p.Description)),
@@ -536,7 +529,7 @@ func (o *mqlOciDataSafe) maskingPolicies() ([]any, error) {
 					"freeformTags":   llx.MapData(strMapToAny(p.FreeformTags), types.String),
 					"definedTags":    llx.MapData(definedTagsToAny(p.DefinedTags), types.Any),
 				}
-				mql, err := CreateResource(o.MqlRuntime, "oci.dataSafe.maskingPolicy", args)
+				mql, err := createOciResourceInCompartment(o.MqlRuntime, "oci.dataSafe.maskingPolicy", stringValue(p.CompartmentId), args)
 				if err != nil {
 					return nil, err
 				}
@@ -547,4 +540,32 @@ func (o *mqlOciDataSafe) maskingPolicies() ([]any, error) {
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return o.gatherResults(tasks, nil)
+}
+
+type mqlOciDataSafeConfigurationInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciDataSafeMaskingPolicyInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciDataSafeSecurityAssessmentInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciDataSafeSensitiveDataModelInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciDataSafeSensitiveTypeInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciDataSafeTargetDatabaseInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciDataSafeUserAssessmentInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/discovery.go
+++ b/providers/oci/resources/discovery.go
@@ -115,7 +115,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			// empty only when the enumeration didn't hit a region.
 			return ociDiscovered{
 				id: sl.Id.Data, name: sl.Name.Data,
-				compartment: sl.CompartmentID.Data, region: sl.cacheRegion,
+				compartment: sl.cacheCompartmentID, region: sl.cacheRegion,
 				labels: tagsToLabels(sl.FreeformTags.Data),
 			}, true
 		},
@@ -136,7 +136,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			// scan connects to.
 			return ociDiscovered{
 				id: u.Id.Data, name: u.Name.Data,
-				compartment: u.CompartmentID.Data, region: "global",
+				compartment: u.cacheCompartmentID, region: "global",
 				labels: tagsToLabels(u.FreeformTags.Data),
 			}, true
 		},
@@ -154,7 +154,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: p.Id.Data, name: p.Name.Data,
-				compartment: p.CompartmentID.Data, region: "global",
+				compartment: p.cacheCompartmentID, region: "global",
 				labels: tagsToLabels(p.FreeformTags.Data),
 			}, true
 		},
@@ -180,7 +180,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 				// Buckets aren't globally unique by name alone - namespace
 				// qualifies them - so use namespace/name to match the __id.
 				id: b.Namespace.Data + "/" + b.Name.Data, name: b.Name.Data,
-				compartment: b.CompartmentID.Data, region: regionKey,
+				compartment: b.cacheCompartmentID, region: regionKey,
 				// Tags on a bucket require an extra GetBucket call. Surface
 				// empty labels rather than paying N round-trips at discovery
 				// time just to populate them.
@@ -201,7 +201,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: d.Id.Data, name: d.Name.Data,
-				compartment: d.CompartmentID.Data, region: d.cacheRegion,
+				compartment: d.cacheCompartmentID, region: d.cacheRegion,
 				labels: tagsToLabels(d.FreeformTags.Data),
 			}, true
 		},
@@ -219,7 +219,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: lb.Id.Data, name: lb.Name.Data,
-				compartment: lb.CompartmentID.Data, region: lb.cacheRegion,
+				compartment: lb.cacheCompartmentID, region: lb.cacheRegion,
 				labels: tagsToLabels(lb.FreeformTags.Data),
 			}, true
 		},
@@ -237,7 +237,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: c.Id.Data, name: c.Name.Data,
-				compartment: c.CompartmentID.Data, region: c.cacheRegion,
+				compartment: c.cacheCompartmentID, region: c.cacheRegion,
 				labels: tagsToLabels(c.FreeformTags.Data),
 			}, true
 		},
@@ -255,7 +255,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: s.Id.Data, name: s.Name.Data,
-				compartment: s.CompartmentID.Data, region: s.cacheRegion,
+				compartment: s.cacheCompartmentID, region: s.cacheRegion,
 				labels: tagsToLabels(s.FreeformTags.Data),
 			}, true
 		},
@@ -273,7 +273,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: c.Id.Data, name: c.Name.Data,
-				compartment: c.CompartmentID.Data, region: c.cacheRegion,
+				compartment: c.cacheCompartmentID, region: c.cacheRegion,
 				labels: tagsToLabels(c.FreeformTags.Data),
 			}, true
 		},

--- a/providers/oci/resources/events.go
+++ b/providers/oci/resources/events.go
@@ -45,17 +45,16 @@ func (o *mqlOciEvents) rules() ([]any, error) {
 					created = &rule.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.events.rule", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(rule.Id),
-					"name":          llx.StringDataPtr(rule.DisplayName),
-					"description":   llx.StringDataPtr(rule.Description),
-					"compartmentID": llx.StringDataPtr(rule.CompartmentId),
-					"condition":     llx.StringDataPtr(rule.Condition),
-					"isEnabled":     llx.BoolDataPtr(rule.IsEnabled),
-					"state":         llx.StringData(string(rule.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(rule.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(rule.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.events.rule", stringValue(rule.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(rule.Id),
+					"name":         llx.StringDataPtr(rule.DisplayName),
+					"description":  llx.StringDataPtr(rule.Description),
+					"condition":    llx.StringDataPtr(rule.Condition),
+					"isEnabled":    llx.BoolDataPtr(rule.IsEnabled),
+					"state":        llx.StringData(string(rule.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(rule.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(rule.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -92,6 +91,7 @@ func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *event
 }
 
 type mqlOciEventsRuleInternal struct {
+	ociCompartmentRef
 	rule        ociRetryLazy[*events.Rule]
 	cacheRegion string
 }

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -70,10 +70,9 @@ func (o *mqlOciFileStorage) fileSystems() ([]any, error) {
 						parentFileSystemId = stringValue(fs.SourceDetails.ParentFileSystemId)
 					}
 
-					mqlInstance, err := CreateResource(o.MqlRuntime, "oci.fileStorage.fileSystem", map[string]*llx.RawData{
+					mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.fileStorage.fileSystem", stringValue(fs.CompartmentId), map[string]*llx.RawData{
 						"id":                 llx.StringDataPtr(fs.Id),
 						"name":               llx.StringDataPtr(fs.DisplayName),
-						"compartmentID":      llx.StringDataPtr(fs.CompartmentId),
 						"availabilityDomain": llx.StringDataPtr(fs.AvailabilityDomain),
 						"state":              llx.StringData(string(fs.LifecycleState)),
 						"meteredBytes":       llx.IntDataPtr(fs.MeteredBytes),
@@ -119,6 +118,7 @@ func (o *mqlOciFileStorage) getFileSystemsForAD(ctx context.Context, fsClient *f
 }
 
 type mqlOciFileStorageFileSystemInternal struct {
+	ociCompartmentRef
 	cacheKmsKeyID           string
 	cacheParentFileSystemID string
 }

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -69,10 +69,9 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 					return nil, err
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.functions.application", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.functions.application", stringValue(app.CompartmentId), map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(app.Id),
 					"name":              llx.StringDataPtr(app.DisplayName),
-					"compartmentID":     llx.StringDataPtr(app.CompartmentId),
 					"state":             llx.StringData(string(app.LifecycleState)),
 					"shape":             llx.StringData(string(app.Shape)),
 					"traceConfig":       llx.DictData(traceConfig),
@@ -97,6 +96,7 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 }
 
 type mqlOciFunctionsApplicationInternal struct {
+	ociCompartmentRef
 	app            ociRetryLazy[*functions.Application]
 	cacheRegion    string
 	cacheSubnetIDs []string
@@ -222,10 +222,9 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 			return nil, err
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.functions.function", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.functions.function", stringValue(fn.CompartmentId), map[string]*llx.RawData{
 			"id":               llx.StringDataPtr(fn.Id),
 			"name":             llx.StringDataPtr(fn.DisplayName),
-			"compartmentID":    llx.StringDataPtr(fn.CompartmentId),
 			"applicationId":    llx.StringDataPtr(fn.ApplicationId),
 			"state":            llx.StringData(string(fn.LifecycleState)),
 			"image":            llx.StringDataPtr(fn.Image),
@@ -252,6 +251,7 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 }
 
 type mqlOciFunctionsFunctionInternal struct {
+	ociCompartmentRef
 	fn          ociRetryLazy[*functions.Function]
 	cacheRegion string
 }

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -107,14 +107,13 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 				capabilities["canUseOAuth2ClientCredentials"] = boolValue(user.Capabilities.CanUseOAuth2ClientCredentials)
 			}
 
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.user", map[string]*llx.RawData{
+			mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.identity.user", stringValue(user.CompartmentId), map[string]*llx.RawData{
 				"id":                 llx.StringDataPtr(user.Id),
 				"name":               llx.StringDataPtr(user.Name),
 				"description":        llx.StringDataPtr(user.Description),
 				"created":            llx.TimeDataPtr(created),
 				"state":              llx.StringData(string(user.LifecycleState)),
 				"mfaActivated":       llx.BoolData(boolValue(user.IsMfaActivated)),
-				"compartmentID":      llx.StringDataPtr(user.CompartmentId),
 				"email":              llx.StringDataPtr(user.Email),
 				"emailVerified":      llx.BoolData(boolValue(user.EmailVerified)),
 				"externalIdentifier": llx.StringDataPtr(user.ExternalIdentifier),
@@ -137,6 +136,7 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 }
 
 type mqlOciIdentityUserInternal struct {
+	ociCompartmentRef
 	cacheIdentityProviderID string
 }
 
@@ -348,7 +348,7 @@ func (o *mqlOciIdentityUser) groups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
 	userId := o.Id.Data
-	compartmentID := o.CompartmentID.Data
+	compartmentID := o.cacheCompartmentID
 
 	client, err := conn.IdentityClient()
 	if err != nil {
@@ -455,15 +455,14 @@ func (o *mqlOciIdentity) getGroups(conn *connection.OciConnection) []*jobpool.Jo
 				created = &grp.TimeCreated.Time
 			}
 
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.group", map[string]*llx.RawData{
-				"id":            llx.StringDataPtr(grp.Id),
-				"name":          llx.StringDataPtr(grp.Name),
-				"description":   llx.StringDataPtr(grp.Description),
-				"created":       llx.TimeDataPtr(created),
-				"state":         llx.StringData(string(grp.LifecycleState)),
-				"compartmentID": llx.StringDataPtr(grp.CompartmentId),
-				"freeformTags":  llx.MapData(strMapToAny(grp.FreeformTags), types.String),
-				"definedTags":   llx.MapData(definedTagsToAny(grp.DefinedTags), types.Any),
+			mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.identity.group", stringValue(grp.CompartmentId), map[string]*llx.RawData{
+				"id":           llx.StringDataPtr(grp.Id),
+				"name":         llx.StringDataPtr(grp.Name),
+				"description":  llx.StringDataPtr(grp.Description),
+				"created":      llx.TimeDataPtr(created),
+				"state":        llx.StringData(string(grp.LifecycleState)),
+				"freeformTags": llx.MapData(strMapToAny(grp.FreeformTags), types.String),
+				"definedTags":  llx.MapData(definedTagsToAny(grp.DefinedTags), types.Any),
 			})
 			if err != nil {
 				return nil, err
@@ -538,17 +537,16 @@ func (o *mqlOciIdentity) getPolicies(conn *connection.OciConnection) []*jobpool.
 				versionDate = &policy.VersionDate.Date
 			}
 
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.policy", map[string]*llx.RawData{
-				"id":            llx.StringDataPtr(policy.Id),
-				"name":          llx.StringDataPtr(policy.Name),
-				"description":   llx.StringDataPtr(policy.Description),
-				"created":       llx.TimeDataPtr(created),
-				"state":         llx.StringData(string(policy.LifecycleState)),
-				"compartmentID": llx.StringDataPtr(policy.CompartmentId),
-				"statements":    llx.ArrayData(convert.SliceAnyToInterface(policy.Statements), types.String),
-				"versionDate":   llx.TimeDataPtr(versionDate),
-				"freeformTags":  llx.MapData(strMapToAny(policy.FreeformTags), types.String),
-				"definedTags":   llx.MapData(definedTagsToAny(policy.DefinedTags), types.Any),
+			mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.identity.policy", stringValue(policy.CompartmentId), map[string]*llx.RawData{
+				"id":           llx.StringDataPtr(policy.Id),
+				"name":         llx.StringDataPtr(policy.Name),
+				"description":  llx.StringDataPtr(policy.Description),
+				"created":      llx.TimeDataPtr(created),
+				"state":        llx.StringData(string(policy.LifecycleState)),
+				"statements":   llx.ArrayData(convert.SliceAnyToInterface(policy.Statements), types.String),
+				"versionDate":  llx.TimeDataPtr(versionDate),
+				"freeformTags": llx.MapData(strMapToAny(policy.FreeformTags), types.String),
+				"definedTags":  llx.MapData(definedTagsToAny(policy.DefinedTags), types.Any),
 			})
 			if err != nil {
 				return nil, err
@@ -674,7 +672,7 @@ func (o *mqlOciIdentityGroup) members() ([]any, error) {
 	userMember := map[string]bool{}
 	memberships, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.UserGroupMembership, *string, error) {
 		response, err := client.ListUserGroupMemberships(ctx, identity.ListUserGroupMembershipsRequest{
-			CompartmentId: common.String(o.CompartmentID.Data),
+			CompartmentId: common.String(o.cacheCompartmentID),
 			GroupId:       common.String(o.Id.Data),
 			Page:          page,
 		})
@@ -848,15 +846,14 @@ func (o *mqlOciIdentityUser) oauth2ClientCredentials() ([]any, error) {
 			return nil, err
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.oauth2ClientCredential", map[string]*llx.RawData{
-			"id":            llx.StringDataPtr(cred.Id),
-			"name":          llx.StringDataPtr(cred.Name),
-			"description":   llx.StringDataPtr(cred.Description),
-			"compartmentID": llx.StringDataPtr(cred.CompartmentId),
-			"scopes":        llx.ArrayData(scopesDict, types.Dict),
-			"created":       sdkTimeData(cred.TimeCreated),
-			"expires":       sdkTimeData(cred.ExpiresOn),
-			"state":         llx.StringData(string(cred.LifecycleState)),
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.identity.oauth2ClientCredential", stringValue(cred.CompartmentId), map[string]*llx.RawData{
+			"id":          llx.StringDataPtr(cred.Id),
+			"name":        llx.StringDataPtr(cred.Name),
+			"description": llx.StringDataPtr(cred.Description),
+			"scopes":      llx.ArrayData(scopesDict, types.Dict),
+			"created":     sdkTimeData(cred.TimeCreated),
+			"expires":     sdkTimeData(cred.ExpiresOn),
+			"state":       llx.StringData(string(cred.LifecycleState)),
 		})
 		if err != nil {
 			return nil, err
@@ -865,6 +862,10 @@ func (o *mqlOciIdentityUser) oauth2ClientCredentials() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+type mqlOciIdentityOauth2ClientCredentialInternal struct {
+	ociCompartmentRef
 }
 
 func (o *mqlOciIdentityOauth2ClientCredential) id() (string, error) {
@@ -898,16 +899,15 @@ func (o *mqlOciIdentity) dynamicGroups() ([]any, error) {
 	for i := range groups {
 		dg := groups[i]
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.dynamicGroup", map[string]*llx.RawData{
-			"id":            llx.StringDataPtr(dg.Id),
-			"compartmentID": llx.StringDataPtr(dg.CompartmentId),
-			"name":          llx.StringDataPtr(dg.Name),
-			"description":   llx.StringDataPtr(dg.Description),
-			"matchingRule":  llx.StringDataPtr(dg.MatchingRule),
-			"created":       sdkTimeData(dg.TimeCreated),
-			"state":         llx.StringData(string(dg.LifecycleState)),
-			"freeformTags":  llx.MapData(strMapToAny(dg.FreeformTags), types.String),
-			"definedTags":   llx.MapData(definedTagsToAny(dg.DefinedTags), types.Any),
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.identity.dynamicGroup", stringValue(dg.CompartmentId), map[string]*llx.RawData{
+			"id":           llx.StringDataPtr(dg.Id),
+			"name":         llx.StringDataPtr(dg.Name),
+			"description":  llx.StringDataPtr(dg.Description),
+			"matchingRule": llx.StringDataPtr(dg.MatchingRule),
+			"created":      sdkTimeData(dg.TimeCreated),
+			"state":        llx.StringData(string(dg.LifecycleState)),
+			"freeformTags": llx.MapData(strMapToAny(dg.FreeformTags), types.String),
+			"definedTags":  llx.MapData(definedTagsToAny(dg.DefinedTags), types.Any),
 		})
 		if err != nil {
 			return nil, err
@@ -953,7 +953,6 @@ func (o *mqlOciIdentity) identityProviders() ([]any, error) {
 
 		args := map[string]*llx.RawData{
 			"id":                 llx.StringDataPtr(idp.GetId()),
-			"compartmentID":      llx.StringDataPtr(idp.GetCompartmentId()),
 			"name":               llx.StringDataPtr(idp.GetName()),
 			"description":        llx.StringDataPtr(idp.GetDescription()),
 			"productType":        llx.StringDataPtr(idp.GetProductType()),
@@ -978,7 +977,7 @@ func (o *mqlOciIdentity) identityProviders() ([]any, error) {
 				Msgf("oci.identity.identityProvider: unexpected provider type %T, SAML2-specific fields left empty", idp)
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.identityProvider", args)
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.identity.identityProvider", stringValue(idp.GetCompartmentId()), args)
 		if err != nil {
 			return nil, err
 		}
@@ -1039,9 +1038,8 @@ func (o *mqlOciIdentity) networkSources() ([]any, error) {
 			return nil, err
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.networkSource", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.identity.networkSource", stringValue(ns.CompartmentId), map[string]*llx.RawData{
 			"id":                llx.StringDataPtr(ns.Id),
-			"compartmentID":     llx.StringDataPtr(ns.CompartmentId),
 			"name":              llx.StringDataPtr(ns.Name),
 			"description":       llx.StringDataPtr(ns.Description),
 			"publicSourceList":  llx.ArrayData(stringsToAny(ns.PublicSourceList), types.String),
@@ -1150,4 +1148,20 @@ func initOciIdentityAuthenticationPolicy(runtime *plugin.Runtime, args map[strin
 
 func (o *mqlOciIdentityAuthenticationPolicy) id() (string, error) {
 	return "oci.identity.authenticationPolicy/" + o.CompartmentID.Data, nil
+}
+
+type mqlOciIdentityDynamicGroupInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciIdentityGroupInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciIdentityIdentityProviderInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciIdentityNetworkSourceInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -53,10 +53,9 @@ func (o *mqlOciKms) vaults() ([]any, error) {
 					created = &vault.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.kms.vault", stringValue(vault.CompartmentId), map[string]*llx.RawData{
 					"id":                 llx.StringDataPtr(vault.Id),
 					"name":               llx.StringDataPtr(vault.DisplayName),
-					"compartmentID":      llx.StringDataPtr(vault.CompartmentId),
 					"vaultType":          llx.StringData(string(vault.VaultType)),
 					"state":              llx.StringData(string(vault.LifecycleState)),
 					"managementEndpoint": llx.StringDataPtr(vault.ManagementEndpoint),
@@ -96,6 +95,7 @@ func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagemen
 }
 
 type mqlOciKmsVaultInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 }
 
@@ -148,7 +148,7 @@ func (o *mqlOciKmsVault) keys() ([]any, error) {
 		return nil, err
 	}
 
-	keys, err := o.getKeysForVault(ctx, svc, o.CompartmentID.Data)
+	keys, err := o.getKeysForVault(ctx, svc, o.cacheCompartmentID)
 	if err != nil {
 		return nil, err
 	}
@@ -164,11 +164,9 @@ func (o *mqlOciKmsVault) keys() ([]any, error) {
 
 		algorithm := string(key.Algorithm)
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.kms.key", stringValue(key.CompartmentId), map[string]*llx.RawData{
 			"id":                    llx.StringDataPtr(key.Id),
 			"name":                  llx.StringDataPtr(key.DisplayName),
-			"compartmentID":         llx.StringDataPtr(key.CompartmentId),
-			"vaultId":               llx.StringDataPtr(key.VaultId),
 			"algorithm":             llx.StringData(algorithm),
 			"protectionMode":        llx.StringData(string(key.ProtectionMode)),
 			"state":                 llx.StringData(string(key.LifecycleState)),
@@ -182,6 +180,7 @@ func (o *mqlOciKmsVault) keys() ([]any, error) {
 		}
 		mqlKey := mqlInstance.(*mqlOciKmsKey)
 		mqlKey.cacheManagementEndpoint = managementEndpoint
+		mqlKey.cacheVaultID = stringValue(key.VaultId)
 		res = append(res, mqlKey)
 	}
 
@@ -247,6 +246,8 @@ func initOciKmsKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 }
 
 type mqlOciKmsKeyInternal struct {
+	ociCompartmentRef
+	cacheVaultID            string
 	cacheManagementEndpoint string
 
 	keyShapeOnce sync.Once
@@ -347,11 +348,9 @@ func (o *mqlOciKmsKey) keyVersions() ([]any, error) {
 			timeOfDeletion = &v.TimeOfDeletion.Time
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.kms.keyVersion", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.kms.keyVersion", stringValue(v.CompartmentId), map[string]*llx.RawData{
 			"id":             llx.StringDataPtr(v.Id),
 			"keyId":          llx.StringDataPtr(v.KeyId),
-			"vaultId":        llx.StringDataPtr(v.VaultId),
-			"compartmentID":  llx.StringDataPtr(v.CompartmentId),
 			"origin":         llx.StringData(string(v.Origin)),
 			"state":          llx.StringData(string(v.LifecycleState)),
 			"isAutoRotated":  llx.BoolDataPtr(v.IsAutoRotated),
@@ -361,6 +360,7 @@ func (o *mqlOciKmsKey) keyVersions() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlInstance.(*mqlOciKmsKeyVersion).cacheVaultID = stringValue(v.VaultId)
 		res = append(res, mqlInstance)
 	}
 

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -79,14 +79,12 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 					ipAddresses = append(ipAddresses, entry)
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.loadBalancer", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.loadBalancer.loadBalancer", stringValue(lb.CompartmentId), map[string]*llx.RawData{
 					"id":                        llx.StringDataPtr(lb.Id),
 					"name":                      llx.StringDataPtr(lb.DisplayName),
-					"compartmentID":             llx.StringDataPtr(lb.CompartmentId),
 					"shape":                     llx.StringDataPtr(lb.ShapeName),
 					"isPrivate":                 llx.BoolDataPtr(lb.IsPrivate),
 					"ipAddresses":               llx.ArrayData(ipAddresses, types.Dict),
-					"nsgIds":                    llx.ArrayData(convert.SliceAnyToInterface(lb.NetworkSecurityGroupIds), types.String),
 					"isDeleteProtectionEnabled": llx.BoolDataPtr(lb.IsDeleteProtectionEnabled),
 					"state":                     llx.StringData(string(lb.LifecycleState)),
 					"created":                   llx.TimeDataPtr(created),
@@ -98,6 +96,7 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 					return nil, err
 				}
 				mqlLb := mqlInstance.(*mqlOciLoadBalancerLoadBalancer)
+				mqlLb.cacheNsgIDs = convert.SliceAnyToInterface(lb.NetworkSecurityGroupIds)
 				mqlLb.cacheListeners = lb.Listeners
 				mqlLb.cacheBackendSets = lb.BackendSets
 				mqlLb.cacheRegion = region
@@ -110,6 +109,8 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 }
 
 type mqlOciLoadBalancerLoadBalancerInternal struct {
+	ociCompartmentRef
+	cacheNsgIDs      []any
 	cacheListeners   map[string]loadbalancer.Listener
 	cacheBackendSets map[string]loadbalancer.BackendSet
 	cacheRegion      string

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -48,16 +48,15 @@ func (o *mqlOciLogging) logGroups() ([]any, error) {
 					created = &lg.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.logging.logGroup", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(lg.Id),
-					"name":          llx.StringDataPtr(lg.DisplayName),
-					"description":   llx.StringDataPtr(lg.Description),
-					"compartmentID": llx.StringDataPtr(lg.CompartmentId),
-					"state":         llx.StringData(string(lg.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(lg.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(lg.DefinedTags), types.Any),
-					"systemTags":    llx.MapData(definedTagsToAny(lg.SystemTags), types.Dict),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.logging.logGroup", stringValue(lg.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(lg.Id),
+					"name":         llx.StringDataPtr(lg.DisplayName),
+					"description":  llx.StringDataPtr(lg.Description),
+					"state":        llx.StringData(string(lg.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(lg.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(lg.DefinedTags), types.Any),
+					"systemTags":   llx.MapData(definedTagsToAny(lg.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -93,6 +92,7 @@ func (o *mqlOciLogging) getLogGroupsForRegion(ctx context.Context, client *loggi
 }
 
 type mqlOciLoggingLogGroupInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 }
 

--- a/providers/oci/resources/monitoring.go
+++ b/providers/oci/resources/monitoring.go
@@ -56,15 +56,13 @@ func (o *mqlOciMonitoring) alarms() ([]any, error) {
 					destinations = append(destinations, d)
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.monitoring.alarm", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.monitoring.alarm", stringValue(alarm.CompartmentId), map[string]*llx.RawData{
 					"id":                  llx.StringDataPtr(alarm.Id),
 					"name":                llx.StringDataPtr(alarm.DisplayName),
-					"compartmentID":       llx.StringDataPtr(alarm.CompartmentId),
 					"metricCompartmentId": llx.StringDataPtr(alarm.MetricCompartmentId),
 					"namespace":           llx.StringDataPtr(alarm.Namespace),
 					"query":               llx.StringDataPtr(alarm.Query),
 					"severity":            llx.StringData(string(alarm.Severity)),
-					"destinations":        llx.ArrayData(destinations, types.String),
 					"isEnabled":           llx.BoolDataPtr(alarm.IsEnabled),
 					"state":               llx.StringData(string(alarm.LifecycleState)),
 					"freeformTags":        llx.MapData(strMapToAny(alarm.FreeformTags), types.String),
@@ -73,6 +71,7 @@ func (o *mqlOciMonitoring) alarms() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				mqlInstance.(*mqlOciMonitoringAlarm).cacheDestinations = destinations
 				res = append(res, mqlInstance)
 			}
 

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -53,13 +53,11 @@ func (o *mqlOciNetwork) vcns() ([]any, error) {
 					created = &vcn.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.vcn", stringValue(vcn.CompartmentId), map[string]*llx.RawData{
 					"id":                    llx.StringDataPtr(vcn.Id),
 					"name":                  llx.StringDataPtr(vcn.DisplayName),
 					"created":               llx.TimeDataPtr(created),
 					"state":                 llx.StringData(string(vcn.LifecycleState)),
-					"compartmentID":         llx.StringDataPtr(vcn.CompartmentId),
-					"cidrBlock":             llx.StringDataPtr(vcn.CidrBlock),
 					"cidrBlocks":            llx.ArrayData(convert.SliceAnyToInterface(vcn.CidrBlocks), types.String),
 					"vcnDomainName":         llx.StringDataPtr(vcn.VcnDomainName),
 					"defaultDhcpOptionsId":  llx.StringDataPtr(vcn.DefaultDhcpOptionsId),
@@ -221,17 +219,15 @@ func (o *mqlOciNetwork) securityLists() ([]any, error) {
 					return nil, err
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.securityList", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.securityList", stringValue(securityList.CompartmentId), map[string]*llx.RawData{
 					"id":                   llx.StringDataPtr(securityList.Id),
 					"name":                 llx.StringDataPtr(securityList.DisplayName),
 					"created":              llx.TimeDataPtr(created),
 					"state":                llx.StringData(string(securityList.LifecycleState)),
-					"compartmentID":        llx.StringDataPtr(securityList.CompartmentId),
 					"egressSecurityRules":  llx.ArrayData(egress, types.Dict),
 					"ingressSecurityRules": llx.ArrayData(ingress, types.Dict),
 					"egressRules":          llx.ArrayData(egressRules, types.Resource("oci.network.securityRule")),
 					"ingressRules":         llx.ArrayData(ingressRules, types.Resource("oci.network.securityRule")),
-					"vcnId":                llx.StringDataPtr(securityList.VcnId),
 					"freeformTags":         llx.MapData(strMapToAny(securityList.FreeformTags), types.String),
 					"definedTags":          llx.MapData(definedTagsToAny(securityList.DefinedTags), types.Any),
 				})
@@ -311,6 +307,7 @@ type ingressSecurityRule struct {
 }
 
 type mqlOciNetworkSecurityListInternal struct {
+	ociCompartmentRef
 	cacheVcnID string
 	// cacheRegion is the region key (e.g. "IAD") discovered when the security
 	// list was enumerated. Used by discovery to emit per-region platform IDs
@@ -376,7 +373,7 @@ func (o *mqlOciNetworkSecurityList) vcn() (*mqlOciNetworkVcn, error) {
 }
 
 func (o *mqlOciNetworkSecurityList) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkSecurityList) hasStatelessRules() (bool, error) {
@@ -445,10 +442,9 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 					created = &subnet.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.subnet", stringValue(subnet.CompartmentId), map[string]*llx.RawData{
 					"id":                      llx.StringDataPtr(subnet.Id),
 					"name":                    llx.StringDataPtr(subnet.DisplayName),
-					"compartmentID":           llx.StringDataPtr(subnet.CompartmentId),
 					"availabilityDomain":      llx.StringDataPtr(subnet.AvailabilityDomain),
 					"cidrBlock":               llx.StringDataPtr(subnet.CidrBlock),
 					"state":                   llx.StringData(string(subnet.LifecycleState)),
@@ -475,6 +471,7 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 }
 
 type mqlOciNetworkSubnetInternal struct {
+	ociCompartmentRef
 	cacheVcnID           string
 	cacheRouteTableID    string
 	cacheSecurityListIDs []string
@@ -560,14 +557,13 @@ func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 					created = &nsg.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(nsg.Id),
-					"name":          llx.StringDataPtr(nsg.DisplayName),
-					"compartmentID": llx.StringDataPtr(nsg.CompartmentId),
-					"state":         llx.StringData(string(nsg.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(nsg.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(nsg.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.networkSecurityGroup", stringValue(nsg.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(nsg.Id),
+					"name":         llx.StringDataPtr(nsg.DisplayName),
+					"state":        llx.StringData(string(nsg.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(nsg.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(nsg.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -603,6 +599,7 @@ func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *cor
 }
 
 type mqlOciNetworkNetworkSecurityGroupInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 	cacheVcnID  string
 	rules       ociOnce
@@ -662,14 +659,13 @@ func initOciNetworkNetworkSecurityGroup(runtime *plugin.Runtime, args map[string
 		created = &nsg.TimeCreated.Time
 	}
 
-	mqlInstance, err := CreateResource(runtime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
-		"id":            llx.StringDataPtr(nsg.Id),
-		"name":          llx.StringDataPtr(nsg.DisplayName),
-		"compartmentID": llx.StringDataPtr(nsg.CompartmentId),
-		"state":         llx.StringData(string(nsg.LifecycleState)),
-		"created":       llx.TimeDataPtr(created),
-		"freeformTags":  llx.MapData(strMapToAny(nsg.FreeformTags), types.String),
-		"definedTags":   llx.MapData(definedTagsToAny(nsg.DefinedTags), types.Any),
+	mqlInstance, err := createOciResourceInCompartment(runtime, "oci.network.networkSecurityGroup", stringValue(nsg.CompartmentId), map[string]*llx.RawData{
+		"id":           llx.StringDataPtr(nsg.Id),
+		"name":         llx.StringDataPtr(nsg.DisplayName),
+		"state":        llx.StringData(string(nsg.LifecycleState)),
+		"created":      llx.TimeDataPtr(created),
+		"freeformTags": llx.MapData(strMapToAny(nsg.FreeformTags), types.String),
+		"definedTags":  llx.MapData(definedTagsToAny(nsg.DefinedTags), types.Any),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -834,7 +830,7 @@ func (o *mqlOciNetworkNetworkSecurityGroup) egressSecurityRules() ([]any, error)
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) hasStatelessRules() (bool, error) {
@@ -897,17 +893,15 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 		created = &vnic.TimeCreated.Time
 	}
 
-	res, err := CreateResource(runtime, "oci.compute.vnic", map[string]*llx.RawData{
+	res, err := createOciResourceInCompartment(runtime, "oci.compute.vnic", stringValue(vnic.CompartmentId), map[string]*llx.RawData{
 		"id":                  llx.StringDataPtr(vnic.Id),
 		"name":                llx.StringDataPtr(vnic.DisplayName),
-		"compartmentID":       llx.StringDataPtr(vnic.CompartmentId),
 		"isPrimary":           llx.BoolDataPtr(vnic.IsPrimary),
 		"privateIp":           llx.StringDataPtr(vnic.PrivateIp),
 		"publicIp":            llx.StringDataPtr(vnic.PublicIp),
 		"ipv6Addresses":       llx.ArrayData(stringsToAny(vnic.Ipv6Addresses), types.String),
 		"macAddress":          llx.StringDataPtr(vnic.MacAddress),
 		"hostnameLabel":       llx.StringDataPtr(vnic.HostnameLabel),
-		"nsgIds":              llx.ArrayData(convert.SliceAnyToInterface(vnic.NsgIds), types.String),
 		"skipSourceDestCheck": llx.BoolDataPtr(vnic.SkipSourceDestCheck),
 		"state":               llx.StringData(string(vnic.LifecycleState)),
 		"created":             llx.TimeDataPtr(created),
@@ -919,6 +913,7 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 	}
 	mqlVnic := res.(*mqlOciComputeVnic)
 	mqlVnic.cacheSubnetID = stringValue(vnic.SubnetId)
+	mqlVnic.cacheNsgIDs = convert.SliceAnyToInterface(vnic.NsgIds)
 	return mqlVnic, nil
 }
 
@@ -959,15 +954,14 @@ func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 					created = &igw.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.internetGateway", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(igw.Id),
-					"name":          llx.StringDataPtr(igw.DisplayName),
-					"compartmentID": llx.StringDataPtr(igw.CompartmentId),
-					"isEnabled":     llx.BoolDataPtr(igw.IsEnabled),
-					"state":         llx.StringData(string(igw.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(igw.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(igw.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.internetGateway", stringValue(igw.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(igw.Id),
+					"name":         llx.StringDataPtr(igw.DisplayName),
+					"isEnabled":    llx.BoolDataPtr(igw.IsEnabled),
+					"state":        llx.StringData(string(igw.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(igw.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(igw.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -982,6 +976,7 @@ func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 }
 
 type mqlOciNetworkInternetGatewayInternal struct {
+	ociCompartmentRef
 	cacheVcnID string
 }
 
@@ -1040,16 +1035,15 @@ func (o *mqlOciNetwork) natGateways() ([]any, error) {
 					created = &ngw.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.natGateway", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(ngw.Id),
-					"name":          llx.StringDataPtr(ngw.DisplayName),
-					"compartmentID": llx.StringDataPtr(ngw.CompartmentId),
-					"blockTraffic":  llx.BoolDataPtr(ngw.BlockTraffic),
-					"natIp":         llx.StringDataPtr(ngw.NatIp),
-					"state":         llx.StringData(string(ngw.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(ngw.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(ngw.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.natGateway", stringValue(ngw.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(ngw.Id),
+					"name":         llx.StringDataPtr(ngw.DisplayName),
+					"blockTraffic": llx.BoolDataPtr(ngw.BlockTraffic),
+					"natIp":        llx.StringDataPtr(ngw.NatIp),
+					"state":        llx.StringData(string(ngw.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(ngw.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(ngw.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -1064,6 +1058,7 @@ func (o *mqlOciNetwork) natGateways() ([]any, error) {
 }
 
 type mqlOciNetworkNatGatewayInternal struct {
+	ociCompartmentRef
 	cacheVcnID string
 }
 
@@ -1157,15 +1152,14 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 					return nil, err
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.routeTable", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(rt.Id),
-					"name":          llx.StringDataPtr(rt.DisplayName),
-					"compartmentID": llx.StringDataPtr(rt.CompartmentId),
-					"routeRules":    llx.ArrayData(routeRules, types.Dict),
-					"state":         llx.StringData(string(rt.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(rt.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(rt.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.routeTable", stringValue(rt.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(rt.Id),
+					"name":         llx.StringDataPtr(rt.DisplayName),
+					"routeRules":   llx.ArrayData(routeRules, types.Dict),
+					"state":        llx.StringData(string(rt.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(rt.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(rt.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -1180,6 +1174,7 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 }
 
 type mqlOciNetworkRouteTableInternal struct {
+	ociCompartmentRef
 	cacheVcnID string
 }
 
@@ -1296,11 +1291,10 @@ func (o *mqlOciNetwork) publicIps() ([]any, error) {
 					created = &publicIp.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.publicIp", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.publicIp", stringValue(publicIp.CompartmentId), map[string]*llx.RawData{
 					"id":                 llx.StringDataPtr(publicIp.Id),
 					"ipAddress":          llx.StringDataPtr(publicIp.IpAddress),
 					"name":               llx.StringDataPtr(publicIp.DisplayName),
-					"compartmentID":      llx.StringDataPtr(publicIp.CompartmentId),
 					"lifetime":           llx.StringData(string(publicIp.Lifetime)),
 					"scope":              llx.StringData(string(publicIp.Scope)),
 					"assignedEntityType": llx.StringData(string(publicIp.AssignedEntityType)),
@@ -1323,4 +1317,8 @@ func (o *mqlOciNetwork) publicIps() ([]any, error) {
 
 func (o *mqlOciNetworkPublicIp) id() (string, error) {
 	return "oci.network.publicIp/" + o.Id.Data, nil
+}
+
+type mqlOciNetworkPublicIpInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/network_vcn_children.go
+++ b/providers/oci/resources/network_vcn_children.go
@@ -112,3 +112,7 @@ func (o *mqlOciNetworkVcn) defaultSecurityList() (*mqlOciNetworkSecurityList, er
 	}
 	return res.(*mqlOciNetworkSecurityList), nil
 }
+
+type mqlOciNetworkVcnInternal struct {
+	ociCompartmentRef
+}

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -60,10 +60,9 @@ func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 					timeUpdated = &fw.TimeUpdated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.networkFirewall.firewall", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.networkFirewall.firewall", stringValue(fw.CompartmentId), map[string]*llx.RawData{
 					"id":                 llx.StringDataPtr(fw.Id),
 					"name":               llx.StringDataPtr(fw.DisplayName),
-					"compartmentID":      llx.StringDataPtr(fw.CompartmentId),
 					"ipv4Address":        llx.StringDataPtr(fw.Ipv4Address),
 					"ipv6Address":        llx.StringDataPtr(fw.Ipv6Address),
 					"shape":              llx.StringDataPtr(fw.Shape),
@@ -90,6 +89,7 @@ func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 }
 
 type mqlOciNetworkFirewallFirewallInternal struct {
+	ociCompartmentRef
 	cacheSubnetID string
 	cachePolicyID string
 	cacheRegion   string
@@ -177,15 +177,14 @@ func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 					created = &p.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.networkFirewall.policy", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(p.Id),
-					"name":          llx.StringDataPtr(p.DisplayName),
-					"compartmentID": llx.StringDataPtr(p.CompartmentId),
-					"state":         llx.StringData(string(p.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(p.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(p.DefinedTags), types.Any),
-					"systemTags":    llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.networkFirewall.policy", stringValue(p.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(p.Id),
+					"name":         llx.StringDataPtr(p.DisplayName),
+					"state":        llx.StringData(string(p.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(p.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(p.DefinedTags), types.Any),
+					"systemTags":   llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -199,6 +198,7 @@ func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 }
 
 type mqlOciNetworkFirewallPolicyInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 	detail      ociRetryLazy[*networkfirewall.NetworkFirewallPolicy]
 }

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -419,10 +419,6 @@ private oci.identity.domain.app @defaults("displayName isOAuthClient active") {
 private oci.identity.user @defaults("name") {
   // User OCID
   id string
-  // Compartment OCID containing the user
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the user
   compartment() oci.compartment
   // User's login name within the OCI tenancy
@@ -536,10 +532,6 @@ private oci.identity.authToken @defaults("description") {
 private oci.identity.group @defaults("name") {
   // Group OCID
   id string
-  // Compartment OCID containing the group
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the group
   compartment() oci.compartment
   // Group name
@@ -562,10 +554,6 @@ private oci.identity.group @defaults("name") {
 private oci.identity.policy @defaults("name description") {
   // Policy OCID
   id string
-  // Compartment OCID containing the policy
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the policy
   compartment() oci.compartment
   // Policy name
@@ -699,10 +687,6 @@ private oci.identity.oauth2ClientCredential @defaults("name") {
   name string
   // Credential description
   description string
-  // Compartment OCID containing the credential
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the oauth2 client credential
   compartment() oci.compartment
   // Allowed scopes, each with an `audience` and a `scope`
@@ -719,10 +703,6 @@ private oci.identity.oauth2ClientCredential @defaults("name") {
 private oci.identity.dynamicGroup @defaults("name") {
   // Dynamic group OCID
   id string
-  // Compartment OCID containing the dynamic group
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the dynamic group
   compartment() oci.compartment
   // Dynamic group name
@@ -745,10 +725,6 @@ private oci.identity.dynamicGroup @defaults("name") {
 private oci.identity.identityProvider @defaults("name") {
   // Identity provider OCID
   id string
-  // Compartment OCID containing the identity provider
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the identity provider
   compartment() oci.compartment
   // Identity provider name
@@ -779,10 +755,6 @@ private oci.identity.identityProvider @defaults("name") {
 private oci.identity.networkSource @defaults("name") {
   // Network source OCID
   id string
-  // Compartment OCID containing the network source
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the network source
   compartment() oci.compartment
   // Network source name
@@ -918,10 +890,6 @@ private oci.compute.instance @defaults("name") {
   compartment oci.compartment
   // Fault domain for fault tolerance (e.g., FAULT-DOMAIN-1)
   faultDomain string
-  // Image OCID
-  //
-  // Deprecated in favor of `image()`.
-  imageId @maturity("deprecated") string
   // Image used to launch the instance
   image() oci.compute.image
   // Dedicated VM host OCID if running on dedicated infrastructure
@@ -1037,10 +1005,6 @@ private oci.compute.vnic @defaults("name") {
   id string
   // VNIC display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the VNIC
   compartment() oci.compartment
   // Whether this is the primary VNIC
@@ -1062,10 +1026,6 @@ private oci.compute.vnic @defaults("name") {
   hostnameLabel string
   // Subnet the VNIC is in
   subnet() oci.network.subnet
-  // Network Security Group OCIDs attached to the VNIC
-  //
-  // Deprecated in favor of `securityGroups()`.
-  nsgIds @maturity("deprecated") []string
   // Network Security Groups attached to the VNIC
   securityGroups() []oci.network.networkSecurityGroup
   // Whether source/destination check is skipped
@@ -1124,10 +1084,6 @@ private oci.compute.blockVolume @defaults("name") {
   id string
   // Block volume display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the block volume
   compartment() oci.compartment
   // Availability domain where the block volume is located
@@ -1173,20 +1129,12 @@ private oci.compute.bootVolume @defaults("name") {
   id string
   // Boot volume display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the boot volume
   compartment() oci.compartment
   // Availability domain where the boot volume is located
   availabilityDomain string
   // Size of the boot volume in GBs
   sizeInGBs int
-  // Image OCID
-  //
-  // Deprecated in favor of `image()`.
-  imageId @maturity("deprecated") string
   // Image used to create the boot volume
   image() oci.compute.image
   // Source boot volume this boot volume was cloned from, when cloned from another boot volume
@@ -1275,10 +1223,6 @@ private oci.network.publicIp @defaults("ipAddress lifetime assignedEntityType") 
   ipAddress string
   // Display name
   name string
-  // Compartment OCID containing the public IP
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the public ip
   compartment() oci.compartment
   // Allocation lifetime (EPHEMERAL or RESERVED)
@@ -1311,10 +1255,6 @@ private oci.network.publicIp @defaults("ipAddress lifetime assignedEntityType") 
 private oci.network.vcn @defaults("name") {
   // VCN OCID
   id string
-  // Compartment OCID containing the VCN
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the vcn
   compartment() oci.compartment
   // VCN display name
@@ -1323,10 +1263,6 @@ private oci.network.vcn @defaults("name") {
   created time
   // VCN lifecycle state (e.g., PROVISIONING, AVAILABLE, TERMINATING, TERMINATED, UPDATING)
   state string
-  // Primary IPv4 CIDR block for the VCN
-  //
-  // Deprecated in favor of `cidrBlocks`.
-  cidrBlock @maturity("deprecated") string
   // IPv4 CIDR blocks for the VCN address space
   cidrBlocks []string
   // VCN domain name for DNS resolution
@@ -1386,10 +1322,6 @@ private oci.network.subnet @defaults("name") {
   id string
   // Subnet display name
   name string
-  // Compartment OCID containing the subnet
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the subnet
   compartment() oci.compartment
   // VCN the subnet belongs to
@@ -1432,10 +1364,6 @@ private oci.network.subnet @defaults("name") {
 private oci.network.securityList @defaults("name") {
   // Security list OCID
   id string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the security list
   compartment() oci.compartment
   // Security list display name
@@ -1461,10 +1389,6 @@ private oci.network.securityList @defaults("name") {
   egressRules []oci.network.securityRule
   // Whether any rule (ingress or egress) is stateless
   hasStatelessRules() bool
-  // VCN OCID
-  //
-  // Deprecated in favor of `vcn()`.
-  vcnId @maturity("deprecated") string
   // VCN that this security list belongs to
   vcn() oci.network.vcn
   // Free-form tags for resource management
@@ -1485,10 +1409,6 @@ private oci.network.networkSecurityGroup @defaults("name") {
   id string
   // NSG display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the NSG
   compartment() oci.compartment
   // VCN the NSG belongs to
@@ -1609,10 +1529,6 @@ private oci.network.internetGateway @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the internet gateway
   compartment() oci.compartment
   // VCN the internet gateway belongs to
@@ -1641,10 +1557,6 @@ private oci.network.natGateway @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the nat gateway
   compartment() oci.compartment
   // VCN the NAT gateway belongs to
@@ -1675,10 +1587,6 @@ private oci.network.routeTable @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the route table
   compartment() oci.compartment
   // VCN the route table belongs to
@@ -1743,10 +1651,6 @@ private oci.network.drg @defaults("name state") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the DRG
   compartment() oci.compartment
   // Lifecycle state (e.g., PROVISIONING, AVAILABLE, TERMINATING, TERMINATED)
@@ -1775,10 +1679,6 @@ private oci.network.drgAttachment @defaults("name networkType state") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the DRG attachment
   compartment() oci.compartment
   // DRG the attachment belongs to
@@ -1816,10 +1716,6 @@ private oci.network.localPeeringGateway @defaults("name peeringStatus") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the LPG
   compartment() oci.compartment
   // VCN that uses the LPG
@@ -1855,10 +1751,6 @@ private oci.network.remotePeeringConnection @defaults("name peeringStatus") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the RPC
   compartment() oci.compartment
   // DRG that hosts the RPC
@@ -1892,10 +1784,6 @@ private oci.network.serviceGateway @defaults("name state") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the service gateway
   compartment() oci.compartment
   // VCN the service gateway belongs to
@@ -1946,10 +1834,6 @@ private oci.network.cpe @defaults("name ipAddress") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the CPE
   compartment() oci.compartment
   // Public IP address of the on-premises router terminating the VPN
@@ -1978,10 +1862,6 @@ private oci.network.ipsecConnection @defaults("name state") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the IPSec connection
   compartment() oci.compartment
   // Customer-premises equipment terminating the on-premises end of the connection
@@ -2020,10 +1900,6 @@ private oci.network.ipsecConnectionTunnel @defaults("name status ikeVersion") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the tunnel
   compartment() oci.compartment
   // Tunnel connection status (UP, DOWN, DOWN_FOR_MAINTENANCE, PARTIAL_UP)
@@ -2127,10 +2003,6 @@ private oci.network.virtualCircuit @defaults("name type state") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the virtual circuit
   compartment() oci.compartment
   // Circuit type (PUBLIC exposes Oracle public services; PRIVATE reaches a VCN through a DRG)
@@ -2179,10 +2051,6 @@ private oci.network.crossConnect @defaults("name state") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the cross-connect
   compartment() oci.compartment
   // Name of the FastConnect location housing the physical port
@@ -2224,10 +2092,6 @@ private oci.logging.logGroup @defaults("name") {
   name string
   // Log group description
   description string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the log group
   compartment() oci.compartment
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, INACTIVE, DELETING, FAILED)
@@ -2316,10 +2180,6 @@ private oci.kms.vault @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the vault
   compartment() oci.compartment
   // Vault type (DEFAULT, VIRTUAL_PRIVATE, EXTERNAL)
@@ -2346,16 +2206,8 @@ private oci.kms.key @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the key
   compartment() oci.compartment
-  // Parent vault OCID
-  //
-  // Deprecated in favor of `vault`.
-  vaultId @maturity("deprecated") string
   // Parent vault containing the key
   vault() oci.kms.vault
   // Key algorithm (AES, RSA, ECDSA)
@@ -2395,16 +2247,8 @@ private oci.kms.keyVersion @defaults("id") {
   id string
   // Master encryption key OCID
   keyId string
-  // Parent vault OCID
-  //
-  // Deprecated in favor of `vault`.
-  vaultId @maturity("deprecated") string
   // Parent vault containing the key version
   vault() oci.kms.vault
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the key version
   compartment() oci.compartment
   // Origin of the key material (INTERNAL, EXTERNAL)
@@ -2442,10 +2286,6 @@ private oci.objectStorage.bucket {
   namespace string
   // Bucket name
   name string
-  // Compartment OCID containing the bucket
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the bucket
   compartment() oci.compartment
   // Bucket creation time
@@ -2468,13 +2308,6 @@ private oci.objectStorage.bucket {
   objectEventsEnabled() bool
   // Whether the bucket is configured as a replication source
   replicationEnabled() bool
-  // Bucket OCID
-  //
-  // Deprecated in favor of ocid. ListBuckets returns no OCID, so this is null
-  // on the listing path unless a detail-backed field happened to be resolved
-  // first in the same query, which made its presence depend on what else the
-  // query selected.
-  id @maturity("deprecated") string
   // Bucket OCID
   //
   // Resolved from the bucket detail call, so it reports the same value whether
@@ -2574,10 +2407,6 @@ private oci.fileStorage.fileSystem @defaults("name") {
   id string
   // File system display name
   name string
-  // Compartment OCID containing the file system
-  //
-  // Deprecated in favor of `compartment`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the file system
   compartment() oci.compartment
   // Availability domain where the file system is located
@@ -2634,10 +2463,6 @@ private oci.events.rule @defaults("name") {
   name string
   // Rule description
   description string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the rule
   compartment() oci.compartment
   // Event matching condition (JSON)
@@ -2701,10 +2526,6 @@ private oci.cloudGuard.target @defaults("name") {
   id string
   // Target display name
   name string
-  // Compartment OCID containing the target
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the target
   compartment() oci.compartment
   // OCID of the resource being monitored
@@ -2737,10 +2558,6 @@ private oci.cloudGuard.detectorRecipe @defaults("name") {
   name string
   // Detector recipe description
   description string
-  // Compartment OCID containing the detector recipe
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the detector recipe
   compartment() oci.compartment
   // Owner of the detector recipe (CUSTOMER or ORACLE)
@@ -2886,10 +2703,6 @@ private oci.cloudGuard.securityZone @defaults("name") {
   name string
   // Security zone description
   description string
-  // Compartment OCID associated with the security zone
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the security zone
   compartment() oci.compartment
   // Security zone recipe applied to the zone
@@ -2920,10 +2733,6 @@ private oci.cloudGuard.securityZoneRecipe @defaults("name") {
   name string
   // Security zone recipe description
   description string
-  // Compartment OCID containing the recipe
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the security zone recipe
   compartment() oci.compartment
   // Owner of the recipe (CUSTOMER or ORACLE)
@@ -2956,10 +2765,6 @@ private oci.cloudGuard.securityPolicy @defaults("name category") {
   friendlyName string
   // Security policy description
   description string
-  // Compartment OCID containing the policy
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the security policy
   compartment() oci.compartment
   // Owner of the policy (CUSTOMER or ORACLE)
@@ -3006,10 +2811,6 @@ private oci.ons.topic @defaults("name") {
   name string
   // Topic description
   description string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the topic
   compartment() oci.compartment
   // Topic lifecycle state (e.g., ACTIVE, DELETING, CREATING)
@@ -3296,10 +3097,6 @@ private oci.bastion.instance @defaults("name") {
   id string
   // Bastion display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the bastion
   compartment() oci.compartment
   // Bastion type (e.g., standard)
@@ -3376,10 +3173,6 @@ private oci.monitoring.alarm @defaults("name") {
   id string
   // Alarm display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the alarm
   compartment() oci.compartment
   // Metric compartment OCID being monitored
@@ -3390,11 +3183,7 @@ private oci.monitoring.alarm @defaults("name") {
   query string
   // Alarm severity (CRITICAL, ERROR, WARNING, INFO)
   severity string
-  // Notification topic OCIDs the alarm publishes to
-  //
-  // Deprecated in favor of `topics()`.
-  destinations @maturity("deprecated") []string
-  // Notification topics the alarm publishes to (resolved from destinations OCIDs)
+  // Notification topics the alarm publishes to
   topics() []oci.ons.topic
   // Whether the alarm is enabled
   isEnabled bool
@@ -3430,10 +3219,6 @@ private oci.vault.secret @defaults("name") {
   id string
   // Secret name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the secret
   compartment() oci.compartment
   // Vault containing this secret
@@ -3516,10 +3301,6 @@ private oci.loadBalancer.loadBalancer @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the load balancer
   compartment() oci.compartment
   // Shape name (e.g., flexible, 100Mbps, 400Mbps)
@@ -3540,10 +3321,6 @@ private oci.loadBalancer.loadBalancer @defaults("name") {
   state string
   // Load balancer listeners
   listeners() []oci.loadBalancer.listener
-  // Network Security Group OCIDs attached to the load balancer
-  //
-  // Deprecated in favor of `securityGroups()`.
-  nsgIds @maturity("deprecated") []string
   // Network Security Groups attached to the load balancer
   securityGroups() []oci.network.networkSecurityGroup
   // Internet-exposure breakdown (a public IP and a listener, gated on the network security group ingress rules)
@@ -4722,10 +4499,6 @@ private oci.networkFirewall.firewall @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the firewall
   compartment() oci.compartment
   // Subnet the firewall is deployed in
@@ -4771,10 +4544,6 @@ private oci.networkFirewall.policy @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the policy
   compartment() oci.compartment
   // Policy description
@@ -4951,10 +4720,6 @@ private oci.oke.cluster @defaults("name") {
   id string
   // Cluster name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the cluster
   compartment() oci.compartment
   // Kubernetes version
@@ -5009,10 +4774,6 @@ private oci.oke.nodePool @defaults("name") {
   id string
   // Node pool name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the node pool
   compartment() oci.compartment
   // Kubernetes version on nodes
@@ -5027,17 +4788,11 @@ private oci.oke.nodePool @defaults("name") {
   // The `ocpus` key holds the number of OCPUs and `memoryInGBs` the
   // memory in gigabytes.
   nodeShapeConfig dict
-  // Node image name
-  //
-  // Deprecated in favor of nodeImage. OCI leaves this empty on node pools
-  // created through nodeSourceDetails, which is every node pool provisioned by
-  // current tooling.
-  nodeImageName @maturity("deprecated") string
   // Image the nodes boot from
   //
-  // Resolved from the node pool's node source, so it is populated on modern
-  // node pools where nodeImageName is empty. Null when the node pool boots
-  // from a source that is not an image.
+  // Resolved from the node pool's node source, so it is populated on node
+  // pools provisioned by current tooling. Null when the node pool boots from
+  // a source that is not an image.
   nodeImage() oci.compute.image
   // Boot volume size in GB for each node
   //
@@ -5083,10 +4838,6 @@ private oci.waf.firewall @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the firewall
   compartment() oci.compartment
   // WAF policy attached to this firewall
@@ -5117,10 +4868,6 @@ private oci.waf.policy @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the policy
   compartment() oci.compartment
   // Lifecycle state (e.g., CREATING, UPDATING, ACTIVE, DELETING, DELETED, FAILED)
@@ -5170,10 +4917,6 @@ private oci.functions.application @defaults("name") {
   id string
   // Application display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the application
   compartment() oci.compartment
   // Lifecycle state (CREATING, ACTIVE, INACTIVE, UPDATING, DELETING, DELETED, FAILED)
@@ -5226,10 +4969,6 @@ private oci.functions.function @defaults("name") {
   id string
   // Function display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the function
   compartment() oci.compartment
   // Parent application OCID
@@ -5290,10 +5029,6 @@ private oci.containerInstances.instance @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the instance
   compartment() oci.compartment
   // Availability domain
@@ -5349,10 +5084,6 @@ private oci.containerInstances.container @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the container
   compartment() oci.compartment
   // Availability domain
@@ -5438,10 +5169,6 @@ private oci.database.backup @defaults("name") {
   id string
   // Backup display name
   name string
-  // Compartment OCID containing the backup
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the backup
   compartment() oci.compartment
   // OCID of the source database (not the DB system)
@@ -5488,10 +5215,6 @@ private oci.database.autonomousDatabaseBackup @defaults("name") {
   id string
   // Backup display name
   name string
-  // Compartment OCID containing the backup
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the autonomous database backup
   compartment() oci.compartment
   // Autonomous database the backup belongs to
@@ -5532,10 +5255,6 @@ private oci.database.dbSystem @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the db system
   compartment() oci.compartment
   // Availability domain
@@ -5572,16 +5291,8 @@ private oci.database.dbSystem @defaults("name") {
   kmsKey() oci.kms.key
   // Subnet the DB system is in
   subnet() oci.network.subnet
-  // Network Security Group OCIDs attached to the DB system
-  //
-  // Deprecated in favor of `securityGroups()`.
-  nsgIds @maturity("deprecated") []string
   // Network Security Groups attached to the DB system
   securityGroups() []oci.network.networkSecurityGroup
-  // Network Security Group OCIDs attached to the backup network
-  //
-  // Deprecated in favor of `backupSecurityGroups()`.
-  backupNetworkNsgIds @maturity("deprecated") []string
   // Network Security Groups attached to the backup network
   backupSecurityGroups() []oci.network.networkSecurityGroup
   // Lifecycle state
@@ -5608,10 +5319,6 @@ private oci.database.autonomousDatabase @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the autonomous database
   compartment() oci.compartment
   // Database name
@@ -5681,10 +5388,6 @@ private oci.database.autonomousDatabase @defaults("name") {
   kmsVault() oci.kms.vault
   // Subnet for private endpoint
   subnet() oci.network.subnet
-  // Network Security Group OCIDs attached to the autonomous database
-  //
-  // Deprecated in favor of `securityGroups()`.
-  nsgIds @maturity("deprecated") []string
   // Network Security Groups attached to the autonomous database
   securityGroups() []oci.network.networkSecurityGroup
   // Private endpoint IP address
@@ -5756,10 +5459,6 @@ private oci.apigateway.gateway @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the gateway
   compartment() oci.compartment
   // Endpoint type (PUBLIC, PRIVATE)
@@ -5813,10 +5512,6 @@ private oci.apigateway.deployment @defaults("name pathPrefix") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the deployment
   compartment() oci.compartment
   // Parent gateway
@@ -5878,10 +5573,6 @@ private oci.apigateway.certificate @defaults("name") {
   id string
   // Display name
   name string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the certificate
   compartment() oci.compartment
   // Subject names secured by the certificate (CN plus SANs)
@@ -5934,10 +5625,6 @@ private oci.certificates.certificate @defaults("name") {
   name string
   // Certificate description
   description string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the certificate
   compartment() oci.compartment
   // Configuration origin (ISSUED_BY_INTERNAL_CA, MANAGED_EXTERNALLY_ISSUED_BY_INTERNAL_CA, IMPORTED)
@@ -5982,10 +5669,6 @@ private oci.certificates.certificateAuthority @defaults("name") {
   name string
   // CA description
   description string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the certificate authority
   compartment() oci.compartment
   // CA kind inferred from configType (ROOT for ROOT_CA_*, SUBORDINATE for SUBORDINATE_CA_*)
@@ -6024,10 +5707,6 @@ private oci.certificates.caBundle @defaults("name") {
   name string
   // CA bundle description
   description string
-  // Compartment OCID
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the ca bundle
   compartment() oci.compartment
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED)
@@ -6070,10 +5749,6 @@ private oci.redis.cluster @defaults("name softwareVersion state") {
   id string
   // Cluster display name
   name string
-  // Compartment OCID containing the cluster
-  //
-  // Deprecated in favor of `compartment`.
-  compartmentID @maturity("deprecated") string
   // Compartment containing the cluster
   compartment() oci.compartment
   // Cache engine version (e.g., REDIS_7_0, VALKEY_7_2, VALKEY_8_1)
@@ -6161,10 +5836,6 @@ private oci.dataSafe.configuration @defaults("region isEnabled lifecycleState") 
   isEnabled bool
   // URL of the Data Safe service in this region
   url string
-  // OCID of the tenancy used to enable Data Safe
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentId @maturity("deprecated") string
   // Compartment containing the configuration
   compartment() oci.compartment
   // Lifecycle state of Data Safe in this region (CREATING, UPDATING, ACTIVE, INACTIVE, DELETING, DELETED, FAILED)
@@ -6197,10 +5868,6 @@ private oci.dataSafe.configuration @defaults("region isEnabled lifecycleState") 
 private oci.dataSafe.targetDatabase @defaults("displayName databaseType lifecycleState region") {
   // OCID of the target database
   id string
-  // OCID of the compartment that contains the target database
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentId @maturity("deprecated") string
   // Compartment containing the target database
   compartment() oci.compartment
   // OCI region the target is registered in
@@ -6244,10 +5911,6 @@ private oci.dataSafe.targetDatabase @defaults("displayName databaseType lifecycl
 private oci.dataSafe.securityAssessment @defaults("displayName type lifecycleState region") {
   // OCID of the security assessment
   id string
-  // OCID of the compartment that contains the assessment
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentId @maturity("deprecated") string
   // Compartment containing the security assessment
   compartment() oci.compartment
   // OCI region the assessment was produced in
@@ -6283,10 +5946,6 @@ private oci.dataSafe.securityAssessment @defaults("displayName type lifecycleSta
 private oci.dataSafe.userAssessment @defaults("displayName type lifecycleState region") {
   // OCID of the user assessment
   id string
-  // OCID of the compartment that contains the user assessment
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentId @maturity("deprecated") string
   // Compartment containing the user assessment
   compartment() oci.compartment
   // OCI region the assessment was produced in
@@ -6322,10 +5981,6 @@ private oci.dataSafe.userAssessment @defaults("displayName type lifecycleState r
 private oci.dataSafe.sensitiveDataModel @defaults("displayName lifecycleState appSuiteName region") {
   // OCID of the sensitive data model
   id string
-  // OCID of the compartment that contains the sensitive data model
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentId @maturity("deprecated") string
   // Compartment containing the sensitive data model
   compartment() oci.compartment
   // OCI region the sensitive data model is hosted in
@@ -6361,10 +6016,6 @@ private oci.dataSafe.sensitiveDataModel @defaults("displayName lifecycleState ap
 private oci.dataSafe.sensitiveType @defaults("displayName entityType source region") {
   // OCID of the sensitive type
   id string
-  // OCID of the compartment that contains the sensitive type
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentId @maturity("deprecated") string
   // Compartment containing the sensitive type
   compartment() oci.compartment
   // OCI region the sensitive type is hosted in
@@ -6398,10 +6049,6 @@ private oci.dataSafe.sensitiveType @defaults("displayName entityType source regi
 private oci.dataSafe.maskingPolicy @defaults("displayName lifecycleState region") {
   // OCID of the masking policy
   id string
-  // OCID of the compartment that contains the masking policy
-  //
-  // Deprecated in favor of `compartment()`.
-  compartmentId @maturity("deprecated") string
   // Compartment containing the masking policy
   compartment() oci.compartment
   // OCI region the masking policy is hosted in

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -1523,9 +1523,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.identity.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityUser).GetId()).ToDataRes(types.String)
 	},
-	"oci.identity.user.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciIdentityUser).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.identity.user.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityUser).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -1658,9 +1655,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.identity.group.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityGroup).GetId()).ToDataRes(types.String)
 	},
-	"oci.identity.group.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciIdentityGroup).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.identity.group.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityGroup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -1687,9 +1681,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.policy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityPolicy).GetId()).ToDataRes(types.String)
-	},
-	"oci.identity.policy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciIdentityPolicy).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.identity.policy.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -1799,9 +1790,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.identity.oauth2ClientCredential.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityOauth2ClientCredential).GetDescription()).ToDataRes(types.String)
 	},
-	"oci.identity.oauth2ClientCredential.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciIdentityOauth2ClientCredential).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.identity.oauth2ClientCredential.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityOauth2ClientCredential).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -1819,9 +1807,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.dynamicGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityDynamicGroup).GetId()).ToDataRes(types.String)
-	},
-	"oci.identity.dynamicGroup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciIdentityDynamicGroup).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.identity.dynamicGroup.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityDynamicGroup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -1849,9 +1834,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.identityProvider.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityIdentityProvider).GetId()).ToDataRes(types.String)
-	},
-	"oci.identity.identityProvider.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciIdentityIdentityProvider).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.identity.identityProvider.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityIdentityProvider).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -1891,9 +1873,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.identity.networkSource.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityNetworkSource).GetId()).ToDataRes(types.String)
-	},
-	"oci.identity.networkSource.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciIdentityNetworkSource).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.identity.networkSource.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentityNetworkSource).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -2006,9 +1985,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.instance.faultDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetFaultDomain()).ToDataRes(types.String)
 	},
-	"oci.compute.instance.imageId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciComputeInstance).GetImageId()).ToDataRes(types.String)
-	},
 	"oci.compute.instance.image": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeInstance).GetImage()).ToDataRes(types.Resource("oci.compute.image"))
 	},
@@ -2090,9 +2066,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.vnic.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetName()).ToDataRes(types.String)
 	},
-	"oci.compute.vnic.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciComputeVnic).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.compute.vnic.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2116,9 +2089,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compute.vnic.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetSubnet()).ToDataRes(types.Resource("oci.network.subnet"))
-	},
-	"oci.compute.vnic.nsgIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciComputeVnic).GetNsgIds()).ToDataRes(types.Array(types.String))
 	},
 	"oci.compute.vnic.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
@@ -2180,9 +2150,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.blockVolume.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetName()).ToDataRes(types.String)
 	},
-	"oci.compute.blockVolume.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciComputeBlockVolume).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.compute.blockVolume.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2231,9 +2198,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.bootVolume.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetName()).ToDataRes(types.String)
 	},
-	"oci.compute.bootVolume.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciComputeBootVolume).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.compute.bootVolume.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2242,9 +2206,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compute.bootVolume.sizeInGBs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetSizeInGBs()).ToDataRes(types.Int)
-	},
-	"oci.compute.bootVolume.imageId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciComputeBootVolume).GetImageId()).ToDataRes(types.String)
 	},
 	"oci.compute.bootVolume.image": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetImage()).ToDataRes(types.Resource("oci.compute.image"))
@@ -2327,9 +2288,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.publicIp.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkPublicIp).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.publicIp.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkPublicIp).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.publicIp.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkPublicIp).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2363,9 +2321,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.vcn.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVcn).GetId()).ToDataRes(types.String)
 	},
-	"oci.network.vcn.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkVcn).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.vcn.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVcn).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2377,9 +2332,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.vcn.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVcn).GetState()).ToDataRes(types.String)
-	},
-	"oci.network.vcn.cidrBlock": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkVcn).GetCidrBlock()).ToDataRes(types.String)
 	},
 	"oci.network.vcn.cidrBlocks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVcn).GetCidrBlocks()).ToDataRes(types.Array(types.String))
@@ -2438,9 +2390,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.subnet.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.subnet.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkSubnet).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.subnet.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSubnet).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2489,9 +2438,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.securityList.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSecurityList).GetId()).ToDataRes(types.String)
 	},
-	"oci.network.securityList.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkSecurityList).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.securityList.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSecurityList).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2519,9 +2465,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.securityList.hasStatelessRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSecurityList).GetHasStatelessRules()).ToDataRes(types.Bool)
 	},
-	"oci.network.securityList.vcnId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkSecurityList).GetVcnId()).ToDataRes(types.String)
-	},
 	"oci.network.securityList.vcn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkSecurityList).GetVcn()).ToDataRes(types.Resource("oci.network.vcn"))
 	},
@@ -2536,9 +2479,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.networkSecurityGroup.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkNetworkSecurityGroup).GetName()).ToDataRes(types.String)
-	},
-	"oci.network.networkSecurityGroup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkNetworkSecurityGroup).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.network.networkSecurityGroup.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkNetworkSecurityGroup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -2624,9 +2564,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.internetGateway.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkInternetGateway).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.internetGateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkInternetGateway).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.internetGateway.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkInternetGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2653,9 +2590,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.natGateway.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkNatGateway).GetName()).ToDataRes(types.String)
-	},
-	"oci.network.natGateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkNatGateway).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.network.natGateway.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkNatGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -2686,9 +2620,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.routeTable.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkRouteTable).GetName()).ToDataRes(types.String)
-	},
-	"oci.network.routeTable.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkRouteTable).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.network.routeTable.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkRouteTable).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -2753,9 +2684,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.drg.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkDrg).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.drg.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkDrg).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.drg.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkDrg).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2782,9 +2710,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.drgAttachment.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkDrgAttachment).GetName()).ToDataRes(types.String)
-	},
-	"oci.network.drgAttachment.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkDrgAttachment).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.network.drgAttachment.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkDrgAttachment).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -2828,9 +2753,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.localPeeringGateway.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkLocalPeeringGateway).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.localPeeringGateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkLocalPeeringGateway).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.localPeeringGateway.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkLocalPeeringGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2870,9 +2792,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.remotePeeringConnection.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkRemotePeeringConnection).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.remotePeeringConnection.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkRemotePeeringConnection).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.remotePeeringConnection.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkRemotePeeringConnection).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2908,9 +2827,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.serviceGateway.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkServiceGateway).GetName()).ToDataRes(types.String)
-	},
-	"oci.network.serviceGateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkServiceGateway).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.network.serviceGateway.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkServiceGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -2957,9 +2873,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.cpe.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkCpe).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.cpe.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkCpe).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.cpe.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkCpe).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -2986,9 +2899,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.ipsecConnection.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkIpsecConnection).GetName()).ToDataRes(types.String)
-	},
-	"oci.network.ipsecConnection.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkIpsecConnection).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.network.ipsecConnection.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkIpsecConnection).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3031,9 +2941,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.ipsecConnectionTunnel.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkIpsecConnectionTunnel).GetName()).ToDataRes(types.String)
-	},
-	"oci.network.ipsecConnectionTunnel.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkIpsecConnectionTunnel).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.network.ipsecConnectionTunnel.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkIpsecConnectionTunnel).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3134,9 +3041,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.virtualCircuit.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVirtualCircuit).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.virtualCircuit.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkVirtualCircuit).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.virtualCircuit.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVirtualCircuit).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -3191,9 +3095,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.crossConnect.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkCrossConnect).GetName()).ToDataRes(types.String)
 	},
-	"oci.network.crossConnect.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkCrossConnect).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.network.crossConnect.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkCrossConnect).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -3232,9 +3133,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.logging.logGroup.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLogGroup).GetDescription()).ToDataRes(types.String)
-	},
-	"oci.logging.logGroup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoggingLogGroup).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.logging.logGroup.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLogGroup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3314,9 +3212,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.kms.vault.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsVault).GetName()).ToDataRes(types.String)
 	},
-	"oci.kms.vault.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciKmsVault).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.kms.vault.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsVault).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -3347,14 +3242,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.kms.key.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetName()).ToDataRes(types.String)
 	},
-	"oci.kms.key.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciKmsKey).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.kms.key.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
-	},
-	"oci.kms.key.vaultId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciKmsKey).GetVaultId()).ToDataRes(types.String)
 	},
 	"oci.kms.key.vault": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetVault()).ToDataRes(types.Resource("oci.kms.vault"))
@@ -3395,14 +3284,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.kms.keyVersion.keyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKeyVersion).GetKeyId()).ToDataRes(types.String)
 	},
-	"oci.kms.keyVersion.vaultId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciKmsKeyVersion).GetVaultId()).ToDataRes(types.String)
-	},
 	"oci.kms.keyVersion.vault": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKeyVersion).GetVault()).ToDataRes(types.Resource("oci.kms.vault"))
-	},
-	"oci.kms.keyVersion.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciKmsKeyVersion).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.kms.keyVersion.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKeyVersion).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3433,9 +3316,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.objectStorage.bucket.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetName()).ToDataRes(types.String)
-	},
-	"oci.objectStorage.bucket.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciObjectStorageBucket).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.objectStorage.bucket.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3469,9 +3349,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.objectStorage.bucket.replicationEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetReplicationEnabled()).ToDataRes(types.Bool)
-	},
-	"oci.objectStorage.bucket.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciObjectStorageBucket).GetId()).ToDataRes(types.String)
 	},
 	"oci.objectStorage.bucket.ocid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciObjectStorageBucket).GetOcid()).ToDataRes(types.String)
@@ -3557,9 +3434,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.fileStorage.fileSystem.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetName()).ToDataRes(types.String)
 	},
-	"oci.fileStorage.fileSystem.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciFileStorageFileSystem).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.fileStorage.fileSystem.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -3604,9 +3478,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.events.rule.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciEventsRule).GetDescription()).ToDataRes(types.String)
-	},
-	"oci.events.rule.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciEventsRule).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.events.rule.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciEventsRule).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3665,9 +3536,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.target.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardTarget).GetName()).ToDataRes(types.String)
 	},
-	"oci.cloudGuard.target.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCloudGuardTarget).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.cloudGuard.target.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardTarget).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -3703,9 +3571,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.detectorRecipe.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetDescription()).ToDataRes(types.String)
-	},
-	"oci.cloudGuard.detectorRecipe.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.cloudGuard.detectorRecipe.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3848,9 +3713,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.securityZone.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetDescription()).ToDataRes(types.String)
 	},
-	"oci.cloudGuard.securityZone.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCloudGuardSecurityZone).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.cloudGuard.securityZone.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -3883,9 +3745,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.securityZoneRecipe.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetDescription()).ToDataRes(types.String)
-	},
-	"oci.cloudGuard.securityZoneRecipe.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.cloudGuard.securityZoneRecipe.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3922,9 +3781,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.securityPolicy.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetDescription()).ToDataRes(types.String)
-	},
-	"oci.cloudGuard.securityPolicy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCloudGuardSecurityPolicy).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.cloudGuard.securityPolicy.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -3964,9 +3820,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.ons.topic.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOnsTopic).GetDescription()).ToDataRes(types.String)
-	},
-	"oci.ons.topic.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciOnsTopic).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.ons.topic.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOnsTopic).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -4181,9 +4034,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.bastion.instance.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciBastionInstance).GetName()).ToDataRes(types.String)
 	},
-	"oci.bastion.instance.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciBastionInstance).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.bastion.instance.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciBastionInstance).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -4241,9 +4091,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.monitoring.alarm.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetName()).ToDataRes(types.String)
 	},
-	"oci.monitoring.alarm.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciMonitoringAlarm).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.monitoring.alarm.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -4258,9 +4105,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.monitoring.alarm.severity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetSeverity()).ToDataRes(types.String)
-	},
-	"oci.monitoring.alarm.destinations": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciMonitoringAlarm).GetDestinations()).ToDataRes(types.Array(types.String))
 	},
 	"oci.monitoring.alarm.topics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetTopics()).ToDataRes(types.Array(types.Resource("oci.ons.topic")))
@@ -4285,9 +4129,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.vault.secret.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVaultSecret).GetName()).ToDataRes(types.String)
-	},
-	"oci.vault.secret.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciVaultSecret).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.vault.secret.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVaultSecret).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -4376,9 +4217,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.loadBalancer.loadBalancer.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetName()).ToDataRes(types.String)
 	},
-	"oci.loadBalancer.loadBalancer.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoadBalancerLoadBalancer).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.loadBalancer.loadBalancer.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -4402,9 +4240,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.loadBalancer.loadBalancer.listeners": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetListeners()).ToDataRes(types.Array(types.Resource("oci.loadBalancer.listener")))
-	},
-	"oci.loadBalancer.loadBalancer.nsgIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoadBalancerLoadBalancer).GetNsgIds()).ToDataRes(types.Array(types.String))
 	},
 	"oci.loadBalancer.loadBalancer.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerLoadBalancer).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
@@ -5387,9 +5222,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.networkFirewall.firewall.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetName()).ToDataRes(types.String)
 	},
-	"oci.networkFirewall.firewall.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkFirewallFirewall).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.networkFirewall.firewall.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -5437,9 +5269,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.networkFirewall.policy.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetName()).ToDataRes(types.String)
-	},
-	"oci.networkFirewall.policy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciNetworkFirewallPolicy).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.networkFirewall.policy.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -5552,9 +5381,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.oke.cluster.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeCluster).GetName()).ToDataRes(types.String)
 	},
-	"oci.oke.cluster.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciOkeCluster).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.oke.cluster.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeCluster).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -5615,9 +5441,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.oke.nodePool.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetName()).ToDataRes(types.String)
 	},
-	"oci.oke.nodePool.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciOkeNodePool).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.oke.nodePool.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -5632,9 +5455,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.oke.nodePool.nodeShapeConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetNodeShapeConfig()).ToDataRes(types.Dict)
-	},
-	"oci.oke.nodePool.nodeImageName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciOkeNodePool).GetNodeImageName()).ToDataRes(types.String)
 	},
 	"oci.oke.nodePool.nodeImage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetNodeImage()).ToDataRes(types.Resource("oci.compute.image"))
@@ -5675,9 +5495,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.waf.firewall.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafFirewall).GetName()).ToDataRes(types.String)
 	},
-	"oci.waf.firewall.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciWafFirewall).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.waf.firewall.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafFirewall).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -5711,9 +5528,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.waf.policy.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafPolicy).GetName()).ToDataRes(types.String)
 	},
-	"oci.waf.policy.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciWafPolicy).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.waf.policy.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciWafPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -5743,9 +5557,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.functions.application.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsApplication).GetName()).ToDataRes(types.String)
-	},
-	"oci.functions.application.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciFunctionsApplication).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.functions.application.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsApplication).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -5794,9 +5605,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.functions.function.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsFunction).GetName()).ToDataRes(types.String)
-	},
-	"oci.functions.function.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciFunctionsFunction).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.functions.function.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFunctionsFunction).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -5852,9 +5660,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.containerInstances.instance.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesInstance).GetName()).ToDataRes(types.String)
 	},
-	"oci.containerInstances.instance.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciContainerInstancesInstance).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.containerInstances.instance.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesInstance).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -5908,9 +5713,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.containerInstances.container.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesContainer).GetName()).ToDataRes(types.String)
-	},
-	"oci.containerInstances.container.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciContainerInstancesContainer).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.containerInstances.container.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciContainerInstancesContainer).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -5984,9 +5786,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.backup.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseBackup).GetName()).ToDataRes(types.String)
 	},
-	"oci.database.backup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseBackup).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.database.backup.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseBackup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6047,9 +5846,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.autonomousDatabaseBackup.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabaseBackup).GetName()).ToDataRes(types.String)
 	},
-	"oci.database.autonomousDatabaseBackup.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseAutonomousDatabaseBackup).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.database.autonomousDatabaseBackup.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabaseBackup).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6104,9 +5900,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.dbSystem.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetName()).ToDataRes(types.String)
 	},
-	"oci.database.dbSystem.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseDbSystem).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.database.dbSystem.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6158,14 +5951,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.dbSystem.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetSubnet()).ToDataRes(types.Resource("oci.network.subnet"))
 	},
-	"oci.database.dbSystem.nsgIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseDbSystem).GetNsgIds()).ToDataRes(types.Array(types.String))
-	},
 	"oci.database.dbSystem.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
-	},
-	"oci.database.dbSystem.backupNetworkNsgIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseDbSystem).GetBackupNetworkNsgIds()).ToDataRes(types.Array(types.String))
 	},
 	"oci.database.dbSystem.backupSecurityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseDbSystem).GetBackupSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
@@ -6190,9 +5977,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.database.autonomousDatabase.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetName()).ToDataRes(types.String)
-	},
-	"oci.database.autonomousDatabase.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseAutonomousDatabase).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.database.autonomousDatabase.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -6278,9 +6062,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.autonomousDatabase.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetSubnet()).ToDataRes(types.Resource("oci.network.subnet"))
 	},
-	"oci.database.autonomousDatabase.nsgIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDatabaseAutonomousDatabase).GetNsgIds()).ToDataRes(types.Array(types.String))
-	},
 	"oci.database.autonomousDatabase.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
 	},
@@ -6328,9 +6109,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.apigateway.gateway.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayGateway).GetName()).ToDataRes(types.String)
-	},
-	"oci.apigateway.gateway.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciApigatewayGateway).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.apigateway.gateway.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayGateway).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -6385,9 +6163,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.apigateway.deployment.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayDeployment).GetName()).ToDataRes(types.String)
-	},
-	"oci.apigateway.deployment.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciApigatewayDeployment).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.apigateway.deployment.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayDeployment).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -6458,9 +6233,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.apigateway.certificate.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayCertificate).GetName()).ToDataRes(types.String)
 	},
-	"oci.apigateway.certificate.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciApigatewayCertificate).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.apigateway.certificate.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciApigatewayCertificate).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6505,9 +6277,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.certificates.certificate.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificate).GetDescription()).ToDataRes(types.String)
-	},
-	"oci.certificates.certificate.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCertificatesCertificate).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.certificates.certificate.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificate).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -6569,9 +6338,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.certificates.certificateAuthority.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificateAuthority).GetDescription()).ToDataRes(types.String)
 	},
-	"oci.certificates.certificateAuthority.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCertificatesCertificateAuthority).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.certificates.certificateAuthority.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCertificateAuthority).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6620,9 +6386,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.certificates.caBundle.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCaBundle).GetDescription()).ToDataRes(types.String)
 	},
-	"oci.certificates.caBundle.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciCertificatesCaBundle).GetCompartmentID()).ToDataRes(types.String)
-	},
 	"oci.certificates.caBundle.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCertificatesCaBundle).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6646,9 +6409,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.redis.cluster.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciRedisCluster).GetName()).ToDataRes(types.String)
-	},
-	"oci.redis.cluster.compartmentID": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciRedisCluster).GetCompartmentID()).ToDataRes(types.String)
 	},
 	"oci.redis.cluster.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciRedisCluster).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -6740,9 +6500,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.configuration.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeConfiguration).GetUrl()).ToDataRes(types.String)
 	},
-	"oci.dataSafe.configuration.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDataSafeConfiguration).GetCompartmentId()).ToDataRes(types.String)
-	},
 	"oci.dataSafe.configuration.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeConfiguration).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6766,9 +6523,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.dataSafe.targetDatabase.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeTargetDatabase).GetId()).ToDataRes(types.String)
-	},
-	"oci.dataSafe.targetDatabase.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDataSafeTargetDatabase).GetCompartmentId()).ToDataRes(types.String)
 	},
 	"oci.dataSafe.targetDatabase.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeTargetDatabase).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -6812,9 +6566,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.securityAssessment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSecurityAssessment).GetId()).ToDataRes(types.String)
 	},
-	"oci.dataSafe.securityAssessment.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDataSafeSecurityAssessment).GetCompartmentId()).ToDataRes(types.String)
-	},
 	"oci.dataSafe.securityAssessment.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSecurityAssessment).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6853,9 +6604,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.dataSafe.userAssessment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeUserAssessment).GetId()).ToDataRes(types.String)
-	},
-	"oci.dataSafe.userAssessment.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDataSafeUserAssessment).GetCompartmentId()).ToDataRes(types.String)
 	},
 	"oci.dataSafe.userAssessment.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeUserAssessment).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -6896,9 +6644,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.sensitiveDataModel.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveDataModel).GetId()).ToDataRes(types.String)
 	},
-	"oci.dataSafe.sensitiveDataModel.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDataSafeSensitiveDataModel).GetCompartmentId()).ToDataRes(types.String)
-	},
 	"oci.dataSafe.sensitiveDataModel.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveDataModel).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6935,9 +6680,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.dataSafe.sensitiveType.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveType).GetId()).ToDataRes(types.String)
 	},
-	"oci.dataSafe.sensitiveType.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDataSafeSensitiveType).GetCompartmentId()).ToDataRes(types.String)
-	},
 	"oci.dataSafe.sensitiveType.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeSensitiveType).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
 	},
@@ -6973,9 +6715,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.dataSafe.maskingPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeMaskingPolicy).GetId()).ToDataRes(types.String)
-	},
-	"oci.dataSafe.maskingPolicy.compartmentId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciDataSafeMaskingPolicy).GetCompartmentId()).ToDataRes(types.String)
 	},
 	"oci.dataSafe.maskingPolicy.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDataSafeMaskingPolicy).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
@@ -9154,10 +8893,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciIdentityUser).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.identity.user.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciIdentityUser).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.identity.user.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityUser).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -9354,10 +9089,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciIdentityGroup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.identity.group.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciIdentityGroup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.identity.group.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityGroup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -9396,10 +9127,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.policy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.identity.policy.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciIdentityPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.identity.policy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9562,10 +9289,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciIdentityOauth2ClientCredential).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.identity.oauth2ClientCredential.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciIdentityOauth2ClientCredential).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.identity.oauth2ClientCredential.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityOauth2ClientCredential).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -9592,10 +9315,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.dynamicGroup.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityDynamicGroup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.identity.dynamicGroup.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciIdentityDynamicGroup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.identity.dynamicGroup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9636,10 +9355,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.identityProvider.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityIdentityProvider).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.identity.identityProvider.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciIdentityIdentityProvider).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.identity.identityProvider.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9696,10 +9411,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.identity.networkSource.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciIdentityNetworkSource).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.identity.networkSource.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciIdentityNetworkSource).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.identity.networkSource.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9866,10 +9577,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeInstance).FaultDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.compute.instance.imageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciComputeInstance).ImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.compute.instance.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeInstance).Image, ok = plugin.RawToTValue[*mqlOciComputeImage](v.Value, v.Error)
 		return
@@ -9982,10 +9689,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeVnic).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.compute.vnic.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciComputeVnic).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.compute.vnic.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeVnic).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10016,10 +9719,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.vnic.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeVnic).Subnet, ok = plugin.RawToTValue[*mqlOciNetworkSubnet](v.Value, v.Error)
-		return
-	},
-	"oci.compute.vnic.nsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciComputeVnic).NsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.compute.vnic.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10110,10 +9809,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeBlockVolume).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.compute.blockVolume.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciComputeBlockVolume).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.compute.blockVolume.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBlockVolume).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10182,10 +9877,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeBootVolume).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.compute.bootVolume.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciComputeBootVolume).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.compute.bootVolume.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBootVolume).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10196,10 +9887,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.bootVolume.sizeInGBs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBootVolume).SizeInGBs, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"oci.compute.bootVolume.imageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciComputeBootVolume).ImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.compute.bootVolume.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10318,10 +10005,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkPublicIp).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.publicIp.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkPublicIp).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.publicIp.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkPublicIp).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10370,10 +10053,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkVcn).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.vcn.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkVcn).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.vcn.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkVcn).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10388,10 +10067,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.vcn.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkVcn).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.vcn.cidrBlock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkVcn).CidrBlock, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.vcn.cidrBlocks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10474,10 +10149,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkSubnet).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.subnet.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkSubnet).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.subnet.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkSubnet).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10546,10 +10217,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkSecurityList).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.securityList.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkSecurityList).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.securityList.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkSecurityList).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10586,10 +10253,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkSecurityList).HasStatelessRules, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"oci.network.securityList.vcnId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkSecurityList).VcnId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.securityList.vcn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkSecurityList).Vcn, ok = plugin.RawToTValue[*mqlOciNetworkVcn](v.Value, v.Error)
 		return
@@ -10612,10 +10275,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.networkSecurityGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkNetworkSecurityGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.networkSecurityGroup.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkNetworkSecurityGroup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.networkSecurityGroup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10738,10 +10397,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkInternetGateway).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.internetGateway.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkInternetGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.internetGateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkInternetGateway).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10780,10 +10435,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.natGateway.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkNatGateway).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.natGateway.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkNatGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.natGateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10828,10 +10479,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.routeTable.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkRouteTable).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.routeTable.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkRouteTable).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.routeTable.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10926,10 +10573,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkDrg).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.drg.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkDrg).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.drg.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkDrg).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -10968,10 +10611,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.drgAttachment.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkDrgAttachment).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.drgAttachment.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkDrgAttachment).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.drgAttachment.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11034,10 +10673,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkLocalPeeringGateway).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.localPeeringGateway.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkLocalPeeringGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.localPeeringGateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkLocalPeeringGateway).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -11094,10 +10729,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkRemotePeeringConnection).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.remotePeeringConnection.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkRemotePeeringConnection).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.remotePeeringConnection.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkRemotePeeringConnection).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -11148,10 +10779,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.serviceGateway.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkServiceGateway).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.serviceGateway.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkServiceGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.serviceGateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11222,10 +10849,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkCpe).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.cpe.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkCpe).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.cpe.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkCpe).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -11264,10 +10887,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.ipsecConnection.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkIpsecConnection).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.ipsecConnection.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkIpsecConnection).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.ipsecConnection.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11328,10 +10947,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.ipsecConnectionTunnel.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkIpsecConnectionTunnel).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.network.ipsecConnectionTunnel.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkIpsecConnectionTunnel).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.network.ipsecConnectionTunnel.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11470,10 +11085,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkVirtualCircuit).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.virtualCircuit.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkVirtualCircuit).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.virtualCircuit.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkVirtualCircuit).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -11550,10 +11161,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkCrossConnect).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.network.crossConnect.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkCrossConnect).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.network.crossConnect.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkCrossConnect).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -11612,10 +11219,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.logging.logGroup.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoggingLogGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.logging.logGroup.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoggingLogGroup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.logging.logGroup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11734,10 +11337,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciKmsVault).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.kms.vault.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciKmsVault).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.kms.vault.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsVault).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -11782,16 +11381,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciKmsKey).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.kms.key.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciKmsKey).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.kms.key.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsKey).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
-		return
-	},
-	"oci.kms.key.vaultId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciKmsKey).VaultId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.kms.key.vault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11850,16 +11441,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciKmsKeyVersion).KeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.kms.keyVersion.vaultId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciKmsKeyVersion).VaultId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.kms.keyVersion.vault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsKeyVersion).Vault, ok = plugin.RawToTValue[*mqlOciKmsVault](v.Value, v.Error)
-		return
-	},
-	"oci.kms.keyVersion.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciKmsKeyVersion).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.kms.keyVersion.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11910,10 +11493,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciObjectStorageBucket).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.objectStorage.bucket.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciObjectStorageBucket).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.objectStorage.bucket.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciObjectStorageBucket).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -11956,10 +11535,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.objectStorage.bucket.replicationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciObjectStorageBucket).ReplicationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"oci.objectStorage.bucket.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciObjectStorageBucket).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.objectStorage.bucket.ocid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12090,10 +11665,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciFileStorageFileSystem).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.fileStorage.fileSystem.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciFileStorageFileSystem).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.fileStorage.fileSystem.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFileStorageFileSystem).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -12160,10 +11731,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.events.rule.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciEventsRule).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.events.rule.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciEventsRule).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.events.rule.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12250,10 +11817,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardTarget).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.cloudGuard.target.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCloudGuardTarget).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.cloudGuard.target.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardTarget).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -12304,10 +11867,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.detectorRecipe.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardDetectorRecipe).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.cloudGuard.detectorRecipe.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCloudGuardDetectorRecipe).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.detectorRecipe.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12510,10 +12069,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardSecurityZone).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.cloudGuard.securityZone.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCloudGuardSecurityZone).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.cloudGuard.securityZone.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZone).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -12560,10 +12115,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.securityZoneRecipe.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZoneRecipe).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.cloudGuard.securityZoneRecipe.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCloudGuardSecurityZoneRecipe).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.securityZoneRecipe.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12616,10 +12167,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.securityPolicy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.cloudGuard.securityPolicy.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCloudGuardSecurityPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.securityPolicy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12680,10 +12227,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.ons.topic.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOnsTopic).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.ons.topic.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciOnsTopic).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.ons.topic.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12998,10 +12541,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciBastionInstance).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.bastion.instance.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciBastionInstance).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.bastion.instance.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciBastionInstance).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -13086,10 +12625,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciMonitoringAlarm).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.monitoring.alarm.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciMonitoringAlarm).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.monitoring.alarm.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciMonitoringAlarm).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -13108,10 +12643,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.monitoring.alarm.severity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciMonitoringAlarm).Severity, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.monitoring.alarm.destinations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciMonitoringAlarm).Destinations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.monitoring.alarm.topics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13152,10 +12683,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.vault.secret.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciVaultSecret).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.vault.secret.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciVaultSecret).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.vault.secret.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13286,10 +12813,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoadBalancerLoadBalancer).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.loadBalancer.loadBalancer.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoadBalancerLoadBalancer).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.loadBalancer.loadBalancer.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerLoadBalancer).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -13320,10 +12843,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.loadBalancer.loadBalancer.listeners": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerLoadBalancer).Listeners, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"oci.loadBalancer.loadBalancer.nsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoadBalancerLoadBalancer).NsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.loadBalancer.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14766,10 +14285,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkFirewallFirewall).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.networkFirewall.firewall.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkFirewallFirewall).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.networkFirewall.firewall.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallFirewall).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -14836,10 +14351,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.networkFirewall.policy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.networkFirewall.policy.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciNetworkFirewallPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.networkFirewall.policy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15010,10 +14521,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciOkeCluster).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.oke.cluster.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciOkeCluster).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.oke.cluster.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeCluster).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15098,10 +14605,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciOkeNodePool).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.oke.nodePool.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciOkeNodePool).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.oke.nodePool.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeNodePool).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15120,10 +14623,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.oke.nodePool.nodeShapeConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeNodePool).NodeShapeConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"oci.oke.nodePool.nodeImageName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciOkeNodePool).NodeImageName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.oke.nodePool.nodeImage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15186,10 +14685,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciWafFirewall).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.waf.firewall.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciWafFirewall).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.waf.firewall.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciWafFirewall).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15238,10 +14733,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciWafPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.waf.policy.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciWafPolicy).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.waf.policy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciWafPolicy).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15288,10 +14779,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.functions.application.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFunctionsApplication).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.functions.application.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciFunctionsApplication).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.functions.application.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15360,10 +14847,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.functions.function.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFunctionsFunction).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.functions.function.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciFunctionsFunction).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.functions.function.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15446,10 +14929,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciContainerInstancesInstance).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.containerInstances.instance.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciContainerInstancesInstance).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.containerInstances.instance.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciContainerInstancesInstance).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15524,10 +15003,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.containerInstances.container.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciContainerInstancesContainer).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.containerInstances.container.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciContainerInstancesContainer).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.containerInstances.container.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15634,10 +15109,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseBackup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.database.backup.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseBackup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.database.backup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseBackup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15722,10 +15193,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseAutonomousDatabaseBackup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.database.autonomousDatabaseBackup.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseAutonomousDatabaseBackup).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.database.autonomousDatabaseBackup.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabaseBackup).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15802,10 +15269,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseDbSystem).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.database.dbSystem.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseDbSystem).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.database.dbSystem.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseDbSystem).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -15874,16 +15337,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseDbSystem).Subnet, ok = plugin.RawToTValue[*mqlOciNetworkSubnet](v.Value, v.Error)
 		return
 	},
-	"oci.database.dbSystem.nsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseDbSystem).NsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"oci.database.dbSystem.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseDbSystem).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"oci.database.dbSystem.backupNetworkNsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseDbSystem).BackupNetworkNsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.database.dbSystem.backupSecurityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15920,10 +15375,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.autonomousDatabase.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.database.autonomousDatabase.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseAutonomousDatabase).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.database.autonomousDatabase.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16038,10 +15489,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDatabaseAutonomousDatabase).Subnet, ok = plugin.RawToTValue[*mqlOciNetworkSubnet](v.Value, v.Error)
 		return
 	},
-	"oci.database.autonomousDatabase.nsgIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDatabaseAutonomousDatabase).NsgIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"oci.database.autonomousDatabase.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -16112,10 +15559,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.apigateway.gateway.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayGateway).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.apigateway.gateway.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciApigatewayGateway).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.apigateway.gateway.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16192,10 +15635,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.apigateway.deployment.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayDeployment).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.apigateway.deployment.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciApigatewayDeployment).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.apigateway.deployment.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16294,10 +15733,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciApigatewayCertificate).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.apigateway.certificate.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciApigatewayCertificate).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.apigateway.certificate.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciApigatewayCertificate).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -16364,10 +15799,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.certificates.certificate.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCertificatesCertificate).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.certificates.certificate.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCertificatesCertificate).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.certificates.certificate.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16454,10 +15885,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCertificatesCertificateAuthority).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.certificates.certificateAuthority.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCertificatesCertificateAuthority).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.certificates.certificateAuthority.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCertificatesCertificateAuthority).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -16526,10 +15953,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCertificatesCaBundle).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.certificates.caBundle.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciCertificatesCaBundle).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.certificates.caBundle.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCertificatesCaBundle).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -16568,10 +15991,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.redis.cluster.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciRedisCluster).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.redis.cluster.compartmentID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciRedisCluster).CompartmentID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.redis.cluster.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16702,10 +16121,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeConfiguration).Url, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.dataSafe.configuration.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDataSafeConfiguration).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.dataSafe.configuration.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeConfiguration).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -16740,10 +16155,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.dataSafe.targetDatabase.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeTargetDatabase).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.dataSafe.targetDatabase.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDataSafeTargetDatabase).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.dataSafe.targetDatabase.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16806,10 +16217,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeSecurityAssessment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.dataSafe.securityAssessment.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDataSafeSecurityAssessment).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.dataSafe.securityAssessment.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeSecurityAssessment).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -16864,10 +16271,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.dataSafe.userAssessment.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeUserAssessment).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.dataSafe.userAssessment.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDataSafeUserAssessment).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.dataSafe.userAssessment.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16926,10 +16329,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeSensitiveDataModel).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.dataSafe.sensitiveDataModel.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDataSafeSensitiveDataModel).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.dataSafe.sensitiveDataModel.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeSensitiveDataModel).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -16982,10 +16381,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciDataSafeSensitiveType).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.dataSafe.sensitiveType.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDataSafeSensitiveType).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"oci.dataSafe.sensitiveType.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeSensitiveType).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
 		return
@@ -17036,10 +16431,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.dataSafe.maskingPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDataSafeMaskingPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"oci.dataSafe.maskingPolicy.compartmentId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciDataSafeMaskingPolicy).CompartmentId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"oci.dataSafe.maskingPolicy.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20681,7 +20072,6 @@ type mqlOciIdentityUser struct {
 	__id       string
 	mqlOciIdentityUserInternal
 	Id                      plugin.TValue[string]
-	CompartmentID           plugin.TValue[string]
 	Compartment             plugin.TValue[*mqlOciCompartment]
 	Name                    plugin.TValue[string]
 	Description             plugin.TValue[string]
@@ -20746,10 +20136,6 @@ func (c *mqlOciIdentityUser) MqlID() string {
 
 func (c *mqlOciIdentityUser) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciIdentityUser) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciIdentityUser) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -21244,17 +20630,16 @@ func (c *mqlOciIdentityAuthToken) GetState() *plugin.TValue[string] {
 type mqlOciIdentityGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciIdentityGroupInternal it will be used here
-	Id            plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Name          plugin.TValue[string]
-	Description   plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	State         plugin.TValue[string]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
-	Members       plugin.TValue[[]any]
+	mqlOciIdentityGroupInternal
+	Id           plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	State        plugin.TValue[string]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
+	Members      plugin.TValue[[]any]
 }
 
 // createOciIdentityGroup creates a new instance of this resource
@@ -21296,10 +20681,6 @@ func (c *mqlOciIdentityGroup) MqlID() string {
 
 func (c *mqlOciIdentityGroup) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciIdentityGroup) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciIdentityGroup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -21362,9 +20743,8 @@ func (c *mqlOciIdentityGroup) GetMembers() *plugin.TValue[[]any] {
 type mqlOciIdentityPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciIdentityPolicyInternal it will be used here
+	mqlOciIdentityPolicyInternal
 	Id               plugin.TValue[string]
-	CompartmentID    plugin.TValue[string]
 	Compartment      plugin.TValue[*mqlOciCompartment]
 	Name             plugin.TValue[string]
 	Description      plugin.TValue[string]
@@ -21416,10 +20796,6 @@ func (c *mqlOciIdentityPolicy) MqlID() string {
 
 func (c *mqlOciIdentityPolicy) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciIdentityPolicy) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciIdentityPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -21768,16 +21144,15 @@ func (c *mqlOciIdentitySmtpCredential) GetState() *plugin.TValue[string] {
 type mqlOciIdentityOauth2ClientCredential struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciIdentityOauth2ClientCredentialInternal it will be used here
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	Description   plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Scopes        plugin.TValue[[]any]
-	Created       plugin.TValue[*time.Time]
-	Expires       plugin.TValue[*time.Time]
-	State         plugin.TValue[string]
+	mqlOciIdentityOauth2ClientCredentialInternal
+	Id          plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Description plugin.TValue[string]
+	Compartment plugin.TValue[*mqlOciCompartment]
+	Scopes      plugin.TValue[[]any]
+	Created     plugin.TValue[*time.Time]
+	Expires     plugin.TValue[*time.Time]
+	State       plugin.TValue[string]
 }
 
 // createOciIdentityOauth2ClientCredential creates a new instance of this resource
@@ -21829,10 +21204,6 @@ func (c *mqlOciIdentityOauth2ClientCredential) GetDescription() *plugin.TValue[s
 	return &c.Description
 }
 
-func (c *mqlOciIdentityOauth2ClientCredential) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciIdentityOauth2ClientCredential) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -21869,17 +21240,16 @@ func (c *mqlOciIdentityOauth2ClientCredential) GetState() *plugin.TValue[string]
 type mqlOciIdentityDynamicGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciIdentityDynamicGroupInternal it will be used here
-	Id            plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Name          plugin.TValue[string]
-	Description   plugin.TValue[string]
-	MatchingRule  plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	State         plugin.TValue[string]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
+	mqlOciIdentityDynamicGroupInternal
+	Id           plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	MatchingRule plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	State        plugin.TValue[string]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciIdentityDynamicGroup creates a new instance of this resource
@@ -21921,10 +21291,6 @@ func (c *mqlOciIdentityDynamicGroup) MqlID() string {
 
 func (c *mqlOciIdentityDynamicGroup) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciIdentityDynamicGroup) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciIdentityDynamicGroup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -21975,9 +21341,8 @@ func (c *mqlOciIdentityDynamicGroup) GetDefinedTags() *plugin.TValue[map[string]
 type mqlOciIdentityIdentityProvider struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciIdentityIdentityProviderInternal it will be used here
+	mqlOciIdentityIdentityProviderInternal
 	Id                 plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
 	Compartment        plugin.TValue[*mqlOciCompartment]
 	Name               plugin.TValue[string]
 	Description        plugin.TValue[string]
@@ -22031,10 +21396,6 @@ func (c *mqlOciIdentityIdentityProvider) MqlID() string {
 
 func (c *mqlOciIdentityIdentityProvider) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciIdentityIdentityProvider) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciIdentityIdentityProvider) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -22101,9 +21462,8 @@ func (c *mqlOciIdentityIdentityProvider) GetDefinedTags() *plugin.TValue[map[str
 type mqlOciIdentityNetworkSource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciIdentityNetworkSourceInternal it will be used here
+	mqlOciIdentityNetworkSourceInternal
 	Id                plugin.TValue[string]
-	CompartmentID     plugin.TValue[string]
 	Compartment       plugin.TValue[*mqlOciCompartment]
 	Name              plugin.TValue[string]
 	Description       plugin.TValue[string]
@@ -22155,10 +21515,6 @@ func (c *mqlOciIdentityNetworkSource) MqlID() string {
 
 func (c *mqlOciIdentityNetworkSource) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciIdentityNetworkSource) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciIdentityNetworkSource) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -22492,7 +21848,6 @@ type mqlOciComputeInstance struct {
 	AvailabilityDomain           plugin.TValue[string]
 	Compartment                  plugin.TValue[*mqlOciCompartment]
 	FaultDomain                  plugin.TValue[string]
-	ImageId                      plugin.TValue[string]
 	Image                        plugin.TValue[*mqlOciComputeImage]
 	DedicatedVmHostId            plugin.TValue[string]
 	PlatformConfig               plugin.TValue[any]
@@ -22591,10 +21946,6 @@ func (c *mqlOciComputeInstance) GetCompartment() *plugin.TValue[*mqlOciCompartme
 
 func (c *mqlOciComputeInstance) GetFaultDomain() *plugin.TValue[string] {
 	return &c.FaultDomain
-}
-
-func (c *mqlOciComputeInstance) GetImageId() *plugin.TValue[string] {
-	return &c.ImageId
 }
 
 func (c *mqlOciComputeInstance) GetImage() *plugin.TValue[*mqlOciComputeImage] {
@@ -22802,7 +22153,6 @@ type mqlOciComputeVnic struct {
 	mqlOciComputeVnicInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
-	CompartmentID       plugin.TValue[string]
 	Compartment         plugin.TValue[*mqlOciCompartment]
 	IsPrimary           plugin.TValue[bool]
 	PrivateIp           plugin.TValue[string]
@@ -22811,7 +22161,6 @@ type mqlOciComputeVnic struct {
 	MacAddress          plugin.TValue[string]
 	HostnameLabel       plugin.TValue[string]
 	Subnet              plugin.TValue[*mqlOciNetworkSubnet]
-	NsgIds              plugin.TValue[[]any]
 	SecurityGroups      plugin.TValue[[]any]
 	SkipSourceDestCheck plugin.TValue[bool]
 	State               plugin.TValue[string]
@@ -22863,10 +22212,6 @@ func (c *mqlOciComputeVnic) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciComputeVnic) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciComputeVnic) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciComputeVnic) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -22923,10 +22268,6 @@ func (c *mqlOciComputeVnic) GetSubnet() *plugin.TValue[*mqlOciNetworkSubnet] {
 
 		return c.subnet()
 	})
-}
-
-func (c *mqlOciComputeVnic) GetNsgIds() *plugin.TValue[[]any] {
-	return &c.NsgIds
 }
 
 func (c *mqlOciComputeVnic) GetSecurityGroups() *plugin.TValue[[]any] {
@@ -23088,7 +22429,6 @@ type mqlOciComputeBlockVolume struct {
 	mqlOciComputeBlockVolumeInternal
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
-	CompartmentID        plugin.TValue[string]
 	Compartment          plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain   plugin.TValue[string]
 	SizeInGBs            plugin.TValue[int64]
@@ -23148,10 +22488,6 @@ func (c *mqlOciComputeBlockVolume) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciComputeBlockVolume) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciComputeBlockVolume) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciComputeBlockVolume) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -23253,11 +22589,9 @@ type mqlOciComputeBootVolume struct {
 	mqlOciComputeBootVolumeInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
-	CompartmentID            plugin.TValue[string]
 	Compartment              plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain       plugin.TValue[string]
 	SizeInGBs                plugin.TValue[int64]
-	ImageId                  plugin.TValue[string]
 	Image                    plugin.TValue[*mqlOciComputeImage]
 	SourceBootVolume         plugin.TValue[*mqlOciComputeBootVolume]
 	SourceBootVolumeBackupId plugin.TValue[string]
@@ -23314,10 +22648,6 @@ func (c *mqlOciComputeBootVolume) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOciComputeBootVolume) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciComputeBootVolume) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -23340,10 +22670,6 @@ func (c *mqlOciComputeBootVolume) GetAvailabilityDomain() *plugin.TValue[string]
 
 func (c *mqlOciComputeBootVolume) GetSizeInGBs() *plugin.TValue[int64] {
 	return &c.SizeInGBs
-}
-
-func (c *mqlOciComputeBootVolume) GetImageId() *plugin.TValue[string] {
-	return &c.ImageId
 }
 
 func (c *mqlOciComputeBootVolume) GetImage() *plugin.TValue[*mqlOciComputeImage] {
@@ -23721,11 +23047,10 @@ func (c *mqlOciNetwork) GetCrossConnects() *plugin.TValue[[]any] {
 type mqlOciNetworkPublicIp struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciNetworkPublicIpInternal it will be used here
+	mqlOciNetworkPublicIpInternal
 	Id                 plugin.TValue[string]
 	IpAddress          plugin.TValue[string]
 	Name               plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
 	Compartment        plugin.TValue[*mqlOciCompartment]
 	Lifetime           plugin.TValue[string]
 	Scope              plugin.TValue[string]
@@ -23787,10 +23112,6 @@ func (c *mqlOciNetworkPublicIp) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOciNetworkPublicIp) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciNetworkPublicIp) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -23847,14 +23168,12 @@ func (c *mqlOciNetworkPublicIp) GetDefinedTags() *plugin.TValue[map[string]any] 
 type mqlOciNetworkVcn struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciNetworkVcnInternal it will be used here
+	mqlOciNetworkVcnInternal
 	Id                    plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	Name                  plugin.TValue[string]
 	Created               plugin.TValue[*time.Time]
 	State                 plugin.TValue[string]
-	CidrBlock             plugin.TValue[string]
 	CidrBlocks            plugin.TValue[[]any]
 	VcnDomainName         plugin.TValue[string]
 	DefaultDhcpOptionsId  plugin.TValue[string]
@@ -23915,10 +23234,6 @@ func (c *mqlOciNetworkVcn) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
 
-func (c *mqlOciNetworkVcn) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciNetworkVcn) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -23945,10 +23260,6 @@ func (c *mqlOciNetworkVcn) GetCreated() *plugin.TValue[*time.Time] {
 
 func (c *mqlOciNetworkVcn) GetState() *plugin.TValue[string] {
 	return &c.State
-}
-
-func (c *mqlOciNetworkVcn) GetCidrBlock() *plugin.TValue[string] {
-	return &c.CidrBlock
 }
 
 func (c *mqlOciNetworkVcn) GetCidrBlocks() *plugin.TValue[[]any] {
@@ -24134,7 +23445,6 @@ type mqlOciNetworkSubnet struct {
 	mqlOciNetworkSubnetInternal
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
-	CompartmentID           plugin.TValue[string]
 	Compartment             plugin.TValue[*mqlOciCompartment]
 	Vcn                     plugin.TValue[*mqlOciNetworkVcn]
 	AvailabilityDomain      plugin.TValue[string]
@@ -24195,10 +23505,6 @@ func (c *mqlOciNetworkSubnet) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkSubnet) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkSubnet) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkSubnet) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -24327,7 +23633,6 @@ type mqlOciNetworkSecurityList struct {
 	__id       string
 	mqlOciNetworkSecurityListInternal
 	Id                   plugin.TValue[string]
-	CompartmentID        plugin.TValue[string]
 	Compartment          plugin.TValue[*mqlOciCompartment]
 	Name                 plugin.TValue[string]
 	Created              plugin.TValue[*time.Time]
@@ -24337,7 +23642,6 @@ type mqlOciNetworkSecurityList struct {
 	IngressRules         plugin.TValue[[]any]
 	EgressRules          plugin.TValue[[]any]
 	HasStatelessRules    plugin.TValue[bool]
-	VcnId                plugin.TValue[string]
 	Vcn                  plugin.TValue[*mqlOciNetworkVcn]
 	FreeformTags         plugin.TValue[map[string]any]
 	DefinedTags          plugin.TValue[map[string]any]
@@ -24382,10 +23686,6 @@ func (c *mqlOciNetworkSecurityList) MqlID() string {
 
 func (c *mqlOciNetworkSecurityList) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciNetworkSecurityList) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkSecurityList) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -24438,10 +23738,6 @@ func (c *mqlOciNetworkSecurityList) GetHasStatelessRules() *plugin.TValue[bool] 
 	})
 }
 
-func (c *mqlOciNetworkSecurityList) GetVcnId() *plugin.TValue[string] {
-	return &c.VcnId
-}
-
 func (c *mqlOciNetworkSecurityList) GetVcn() *plugin.TValue[*mqlOciNetworkVcn] {
 	return plugin.GetOrCompute[*mqlOciNetworkVcn](&c.Vcn, func() (*mqlOciNetworkVcn, error) {
 		if c.MqlRuntime.HasRecording {
@@ -24473,7 +23769,6 @@ type mqlOciNetworkNetworkSecurityGroup struct {
 	mqlOciNetworkNetworkSecurityGroupInternal
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
-	CompartmentID        plugin.TValue[string]
 	Compartment          plugin.TValue[*mqlOciCompartment]
 	Vcn                  plugin.TValue[*mqlOciNetworkVcn]
 	State                plugin.TValue[string]
@@ -24531,10 +23826,6 @@ func (c *mqlOciNetworkNetworkSecurityGroup) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkNetworkSecurityGroup) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkNetworkSecurityGroup) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkNetworkSecurityGroup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -24765,16 +24056,15 @@ type mqlOciNetworkInternetGateway struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciNetworkInternetGatewayInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Vcn           plugin.TValue[*mqlOciNetworkVcn]
-	IsEnabled     plugin.TValue[bool]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Vcn          plugin.TValue[*mqlOciNetworkVcn]
+	IsEnabled    plugin.TValue[bool]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciNetworkInternetGateway creates a new instance of this resource
@@ -24820,10 +24110,6 @@ func (c *mqlOciNetworkInternetGateway) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkInternetGateway) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkInternetGateway) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkInternetGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -24883,17 +24169,16 @@ type mqlOciNetworkNatGateway struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciNetworkNatGatewayInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Vcn           plugin.TValue[*mqlOciNetworkVcn]
-	BlockTraffic  plugin.TValue[bool]
-	NatIp         plugin.TValue[string]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Vcn          plugin.TValue[*mqlOciNetworkVcn]
+	BlockTraffic plugin.TValue[bool]
+	NatIp        plugin.TValue[string]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciNetworkNatGateway creates a new instance of this resource
@@ -24939,10 +24224,6 @@ func (c *mqlOciNetworkNatGateway) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkNatGateway) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkNatGateway) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkNatGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -25006,17 +24287,16 @@ type mqlOciNetworkRouteTable struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciNetworkRouteTableInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Vcn           plugin.TValue[*mqlOciNetworkVcn]
-	RouteRules    plugin.TValue[[]any]
-	Routes        plugin.TValue[[]any]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Vcn          plugin.TValue[*mqlOciNetworkVcn]
+	RouteRules   plugin.TValue[[]any]
+	Routes       plugin.TValue[[]any]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciNetworkRouteTable creates a new instance of this resource
@@ -25062,10 +24342,6 @@ func (c *mqlOciNetworkRouteTable) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkRouteTable) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkRouteTable) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkRouteTable) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -25297,7 +24573,6 @@ type mqlOciNetworkDrg struct {
 	mqlOciNetworkDrgInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
-	CompartmentID            plugin.TValue[string]
 	Compartment              plugin.TValue[*mqlOciCompartment]
 	State                    plugin.TValue[string]
 	Created                  plugin.TValue[*time.Time]
@@ -25350,10 +24625,6 @@ func (c *mqlOciNetworkDrg) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkDrg) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkDrg) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkDrg) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -25427,7 +24698,6 @@ type mqlOciNetworkDrgAttachment struct {
 	mqlOciNetworkDrgAttachmentInternal
 	Id              plugin.TValue[string]
 	Name            plugin.TValue[string]
-	CompartmentID   plugin.TValue[string]
 	Compartment     plugin.TValue[*mqlOciCompartment]
 	Drg             plugin.TValue[*mqlOciNetworkDrg]
 	NetworkType     plugin.TValue[string]
@@ -25485,10 +24755,6 @@ func (c *mqlOciNetworkDrgAttachment) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkDrgAttachment) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkDrgAttachment) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkDrgAttachment) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -25606,7 +24872,6 @@ type mqlOciNetworkLocalPeeringGateway struct {
 	mqlOciNetworkLocalPeeringGatewayInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	Vcn                   plugin.TValue[*mqlOciNetworkVcn]
 	Peer                  plugin.TValue[*mqlOciNetworkLocalPeeringGateway]
@@ -25663,10 +24928,6 @@ func (c *mqlOciNetworkLocalPeeringGateway) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkLocalPeeringGateway) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkLocalPeeringGateway) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkLocalPeeringGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -25768,7 +25029,6 @@ type mqlOciNetworkRemotePeeringConnection struct {
 	mqlOciNetworkRemotePeeringConnectionInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	Drg                   plugin.TValue[*mqlOciNetworkDrg]
 	IsCrossTenancyPeering plugin.TValue[bool]
@@ -25824,10 +25084,6 @@ func (c *mqlOciNetworkRemotePeeringConnection) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkRemotePeeringConnection) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkRemotePeeringConnection) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkRemotePeeringConnection) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -25899,18 +25155,17 @@ type mqlOciNetworkServiceGateway struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciNetworkServiceGatewayInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Vcn           plugin.TValue[*mqlOciNetworkVcn]
-	RouteTable    plugin.TValue[*mqlOciNetworkRouteTable]
-	BlockTraffic  plugin.TValue[bool]
-	Services      plugin.TValue[[]any]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Vcn          plugin.TValue[*mqlOciNetworkVcn]
+	RouteTable   plugin.TValue[*mqlOciNetworkRouteTable]
+	BlockTraffic plugin.TValue[bool]
+	Services     plugin.TValue[[]any]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciNetworkServiceGateway creates a new instance of this resource
@@ -25956,10 +25211,6 @@ func (c *mqlOciNetworkServiceGateway) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkServiceGateway) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkServiceGateway) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkServiceGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -26114,10 +25365,9 @@ func (c *mqlOciNetworkService) GetDescription() *plugin.TValue[string] {
 type mqlOciNetworkCpe struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciNetworkCpeInternal it will be used here
+	mqlOciNetworkCpeInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
-	CompartmentID    plugin.TValue[string]
 	Compartment      plugin.TValue[*mqlOciCompartment]
 	IpAddress        plugin.TValue[string]
 	CpeDeviceShapeId plugin.TValue[string]
@@ -26172,10 +25422,6 @@ func (c *mqlOciNetworkCpe) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOciNetworkCpe) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciNetworkCpe) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -26223,7 +25469,6 @@ type mqlOciNetworkIpsecConnection struct {
 	mqlOciNetworkIpsecConnectionInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
-	CompartmentID          plugin.TValue[string]
 	Compartment            plugin.TValue[*mqlOciCompartment]
 	Cpe                    plugin.TValue[*mqlOciNetworkCpe]
 	Drg                    plugin.TValue[*mqlOciNetworkDrg]
@@ -26281,10 +25526,6 @@ func (c *mqlOciNetworkIpsecConnection) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkIpsecConnection) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkIpsecConnection) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkIpsecConnection) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -26390,7 +25631,6 @@ type mqlOciNetworkIpsecConnectionTunnel struct {
 	mqlOciNetworkIpsecConnectionTunnelInternal
 	Id                                      plugin.TValue[string]
 	Name                                    plugin.TValue[string]
-	CompartmentID                           plugin.TValue[string]
 	Compartment                             plugin.TValue[*mqlOciCompartment]
 	Status                                  plugin.TValue[string]
 	IkeVersion                              plugin.TValue[string]
@@ -26467,10 +25707,6 @@ func (c *mqlOciNetworkIpsecConnectionTunnel) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkIpsecConnectionTunnel) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkIpsecConnectionTunnel) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkIpsecConnectionTunnel) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -26654,7 +25890,6 @@ type mqlOciNetworkVirtualCircuit struct {
 	mqlOciNetworkVirtualCircuitInternal
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
-	CompartmentID        plugin.TValue[string]
 	Compartment          plugin.TValue[*mqlOciCompartment]
 	Type                 plugin.TValue[string]
 	ServiceType          plugin.TValue[string]
@@ -26716,10 +25951,6 @@ func (c *mqlOciNetworkVirtualCircuit) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkVirtualCircuit) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkVirtualCircuit) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkVirtualCircuit) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -26814,10 +26045,9 @@ func (c *mqlOciNetworkVirtualCircuit) GetDefinedTags() *plugin.TValue[map[string
 type mqlOciNetworkCrossConnect struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciNetworkCrossConnectInternal it will be used here
+	mqlOciNetworkCrossConnectInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
-	CompartmentID       plugin.TValue[string]
 	Compartment         plugin.TValue[*mqlOciCompartment]
 	LocationName        plugin.TValue[string]
 	PortName            plugin.TValue[string]
@@ -26872,10 +26102,6 @@ func (c *mqlOciNetworkCrossConnect) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkCrossConnect) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkCrossConnect) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkCrossConnect) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -26992,17 +26218,16 @@ type mqlOciLoggingLogGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciLoggingLogGroupInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	Description   plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	State         plugin.TValue[string]
-	Logs          plugin.TValue[[]any]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
-	SystemTags    plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	State        plugin.TValue[string]
+	Logs         plugin.TValue[[]any]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
+	SystemTags   plugin.TValue[map[string]any]
 }
 
 // createOciLoggingLogGroup creates a new instance of this resource
@@ -27052,10 +26277,6 @@ func (c *mqlOciLoggingLogGroup) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciLoggingLogGroup) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciLoggingLogGroup) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciLoggingLogGroup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -27314,7 +26535,6 @@ type mqlOciKmsVault struct {
 	mqlOciKmsVaultInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
 	Compartment        plugin.TValue[*mqlOciCompartment]
 	VaultType          plugin.TValue[string]
 	State              plugin.TValue[string]
@@ -27368,10 +26588,6 @@ func (c *mqlOciKmsVault) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciKmsVault) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciKmsVault) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciKmsVault) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -27437,9 +26653,7 @@ type mqlOciKmsKey struct {
 	mqlOciKmsKeyInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
-	VaultId               plugin.TValue[string]
 	Vault                 plugin.TValue[*mqlOciKmsVault]
 	Algorithm             plugin.TValue[string]
 	Length                plugin.TValue[int64]
@@ -27498,10 +26712,6 @@ func (c *mqlOciKmsKey) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOciKmsKey) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciKmsKey) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -27516,10 +26726,6 @@ func (c *mqlOciKmsKey) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 
 		return c.compartment()
 	})
-}
-
-func (c *mqlOciKmsKey) GetVaultId() *plugin.TValue[string] {
-	return &c.VaultId
 }
 
 func (c *mqlOciKmsKey) GetVault() *plugin.TValue[*mqlOciKmsVault] {
@@ -27598,12 +26804,10 @@ func (c *mqlOciKmsKey) GetDefinedTags() *plugin.TValue[map[string]any] {
 type mqlOciKmsKeyVersion struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciKmsKeyVersionInternal it will be used here
+	mqlOciKmsKeyVersionInternal
 	Id             plugin.TValue[string]
 	KeyId          plugin.TValue[string]
-	VaultId        plugin.TValue[string]
 	Vault          plugin.TValue[*mqlOciKmsVault]
-	CompartmentID  plugin.TValue[string]
 	Compartment    plugin.TValue[*mqlOciCompartment]
 	Origin         plugin.TValue[string]
 	State          plugin.TValue[string]
@@ -27657,10 +26861,6 @@ func (c *mqlOciKmsKeyVersion) GetKeyId() *plugin.TValue[string] {
 	return &c.KeyId
 }
 
-func (c *mqlOciKmsKeyVersion) GetVaultId() *plugin.TValue[string] {
-	return &c.VaultId
-}
-
 func (c *mqlOciKmsKeyVersion) GetVault() *plugin.TValue[*mqlOciKmsVault] {
 	return plugin.GetOrCompute[*mqlOciKmsVault](&c.Vault, func() (*mqlOciKmsVault, error) {
 		if c.MqlRuntime.HasRecording {
@@ -27675,10 +26875,6 @@ func (c *mqlOciKmsKeyVersion) GetVault() *plugin.TValue[*mqlOciKmsVault] {
 
 		return c.vault()
 	})
-}
-
-func (c *mqlOciKmsKeyVersion) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciKmsKeyVersion) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -27792,7 +26988,6 @@ type mqlOciObjectStorageBucket struct {
 	mqlOciObjectStorageBucketInternal
 	Namespace                 plugin.TValue[string]
 	Name                      plugin.TValue[string]
-	CompartmentID             plugin.TValue[string]
 	Compartment               plugin.TValue[*mqlOciCompartment]
 	Created                   plugin.TValue[*time.Time]
 	Region                    plugin.TValue[*mqlOciRegion]
@@ -27804,7 +26999,6 @@ type mqlOciObjectStorageBucket struct {
 	Versioning                plugin.TValue[string]
 	ObjectEventsEnabled       plugin.TValue[bool]
 	ReplicationEnabled        plugin.TValue[bool]
-	Id                        plugin.TValue[string]
 	Ocid                      plugin.TValue[string]
 	IsReadOnly                plugin.TValue[bool]
 	Etag                      plugin.TValue[string]
@@ -27856,10 +27050,6 @@ func (c *mqlOciObjectStorageBucket) GetNamespace() *plugin.TValue[string] {
 
 func (c *mqlOciObjectStorageBucket) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciObjectStorageBucket) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciObjectStorageBucket) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -27942,10 +27132,6 @@ func (c *mqlOciObjectStorageBucket) GetReplicationEnabled() *plugin.TValue[bool]
 	return plugin.GetOrCompute[bool](&c.ReplicationEnabled, func() (bool, error) {
 		return c.replicationEnabled()
 	})
-}
-
-func (c *mqlOciObjectStorageBucket) GetId() *plugin.TValue[string] {
-	return &c.Id
 }
 
 func (c *mqlOciObjectStorageBucket) GetOcid() *plugin.TValue[string] {
@@ -28260,7 +27446,6 @@ type mqlOciFileStorageFileSystem struct {
 	mqlOciFileStorageFileSystemInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
 	Compartment        plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain plugin.TValue[string]
 	State              plugin.TValue[string]
@@ -28317,10 +27502,6 @@ func (c *mqlOciFileStorageFileSystem) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciFileStorageFileSystem) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciFileStorageFileSystem) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciFileStorageFileSystem) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -28469,18 +27650,17 @@ type mqlOciEventsRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciEventsRuleInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	Description   plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Condition     plugin.TValue[string]
-	IsEnabled     plugin.TValue[bool]
-	State         plugin.TValue[string]
-	Actions       plugin.TValue[[]any]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Condition    plugin.TValue[string]
+	IsEnabled    plugin.TValue[bool]
+	State        plugin.TValue[string]
+	Actions      plugin.TValue[[]any]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciEventsRule creates a new instance of this resource
@@ -28530,10 +27710,6 @@ func (c *mqlOciEventsRule) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciEventsRule) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciEventsRule) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciEventsRule) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -28753,10 +27929,9 @@ func (c *mqlOciCloudGuard) GetSecurityPolicies() *plugin.TValue[[]any] {
 type mqlOciCloudGuardTarget struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciCloudGuardTargetInternal it will be used here
+	mqlOciCloudGuardTargetInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
 	Compartment        plugin.TValue[*mqlOciCompartment]
 	TargetResourceId   plugin.TValue[string]
 	TargetResourceType plugin.TValue[string]
@@ -28813,10 +27988,6 @@ func (c *mqlOciCloudGuardTarget) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOciCloudGuardTarget) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciCloudGuardTarget) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -28870,19 +28041,18 @@ type mqlOciCloudGuardDetectorRecipe struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciCloudGuardDetectorRecipeInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	Description   plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Owner         plugin.TValue[string]
-	DetectorType  plugin.TValue[string]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	Rules         plugin.TValue[[]any]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
-	SystemTags    plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Owner        plugin.TValue[string]
+	DetectorType plugin.TValue[string]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	Rules        plugin.TValue[[]any]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
+	SystemTags   plugin.TValue[map[string]any]
 }
 
 // createOciCloudGuardDetectorRecipe creates a new instance of this resource
@@ -28932,10 +28102,6 @@ func (c *mqlOciCloudGuardDetectorRecipe) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciCloudGuardDetectorRecipe) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciCloudGuardDetectorRecipe) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciCloudGuardDetectorRecipe) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -29288,7 +28454,6 @@ type mqlOciCloudGuardSecurityZone struct {
 	Id                              plugin.TValue[string]
 	Name                            plugin.TValue[string]
 	Description                     plugin.TValue[string]
-	CompartmentID                   plugin.TValue[string]
 	Compartment                     plugin.TValue[*mqlOciCompartment]
 	SecurityZoneRecipe              plugin.TValue[*mqlOciCloudGuardSecurityZoneRecipe]
 	IsInheritanceAfterDeleteEnabled plugin.TValue[bool]
@@ -29346,10 +28511,6 @@ func (c *mqlOciCloudGuardSecurityZone) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciCloudGuardSecurityZone) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciCloudGuardSecurityZone) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciCloudGuardSecurityZone) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -29416,7 +28577,6 @@ type mqlOciCloudGuardSecurityZoneRecipe struct {
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Description      plugin.TValue[string]
-	CompartmentID    plugin.TValue[string]
 	Compartment      plugin.TValue[*mqlOciCompartment]
 	Owner            plugin.TValue[string]
 	SecurityPolicies plugin.TValue[[]any]
@@ -29474,10 +28634,6 @@ func (c *mqlOciCloudGuardSecurityZoneRecipe) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciCloudGuardSecurityZoneRecipe) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciCloudGuardSecurityZoneRecipe) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciCloudGuardSecurityZoneRecipe) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -29540,21 +28696,20 @@ func (c *mqlOciCloudGuardSecurityZoneRecipe) GetSystemTags() *plugin.TValue[map[
 type mqlOciCloudGuardSecurityPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciCloudGuardSecurityPolicyInternal it will be used here
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	FriendlyName  plugin.TValue[string]
-	Description   plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Owner         plugin.TValue[string]
-	Category      plugin.TValue[string]
-	Services      plugin.TValue[[]any]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
-	SystemTags    plugin.TValue[map[string]any]
+	mqlOciCloudGuardSecurityPolicyInternal
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	FriendlyName plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Owner        plugin.TValue[string]
+	Category     plugin.TValue[string]
+	Services     plugin.TValue[[]any]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
+	SystemTags   plugin.TValue[map[string]any]
 }
 
 // createOciCloudGuardSecurityPolicy creates a new instance of this resource
@@ -29608,10 +28763,6 @@ func (c *mqlOciCloudGuardSecurityPolicy) GetFriendlyName() *plugin.TValue[string
 
 func (c *mqlOciCloudGuardSecurityPolicy) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciCloudGuardSecurityPolicy) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciCloudGuardSecurityPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -29731,7 +28882,6 @@ type mqlOciOnsTopic struct {
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
 	Compartment   plugin.TValue[*mqlOciCompartment]
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
@@ -29787,10 +28937,6 @@ func (c *mqlOciOnsTopic) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciOnsTopic) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciOnsTopic) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciOnsTopic) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -30573,7 +29719,6 @@ type mqlOciBastionInstance struct {
 	mqlOciBastionInstanceInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
-	CompartmentID             plugin.TValue[string]
 	Compartment               plugin.TValue[*mqlOciCompartment]
 	BastionType               plugin.TValue[string]
 	TargetVcn                 plugin.TValue[*mqlOciNetworkVcn]
@@ -30635,10 +29780,6 @@ func (c *mqlOciBastionInstance) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciBastionInstance) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciBastionInstance) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciBastionInstance) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -30816,16 +29957,14 @@ func (c *mqlOciMonitoring) GetAlarms() *plugin.TValue[[]any] {
 type mqlOciMonitoringAlarm struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciMonitoringAlarmInternal it will be used here
+	mqlOciMonitoringAlarmInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
-	CompartmentID       plugin.TValue[string]
 	Compartment         plugin.TValue[*mqlOciCompartment]
 	MetricCompartmentId plugin.TValue[string]
 	Namespace           plugin.TValue[string]
 	Query               plugin.TValue[string]
 	Severity            plugin.TValue[string]
-	Destinations        plugin.TValue[[]any]
 	Topics              plugin.TValue[[]any]
 	IsEnabled           plugin.TValue[bool]
 	State               plugin.TValue[string]
@@ -30878,10 +30017,6 @@ func (c *mqlOciMonitoringAlarm) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOciMonitoringAlarm) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciMonitoringAlarm) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -30912,10 +30047,6 @@ func (c *mqlOciMonitoringAlarm) GetQuery() *plugin.TValue[string] {
 
 func (c *mqlOciMonitoringAlarm) GetSeverity() *plugin.TValue[string] {
 	return &c.Severity
-}
-
-func (c *mqlOciMonitoringAlarm) GetDestinations() *plugin.TValue[[]any] {
-	return &c.Destinations
 }
 
 func (c *mqlOciMonitoringAlarm) GetTopics() *plugin.TValue[[]any] {
@@ -31018,7 +30149,6 @@ type mqlOciVaultSecret struct {
 	mqlOciVaultSecretInternal
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
-	CompartmentID              plugin.TValue[string]
 	Compartment                plugin.TValue[*mqlOciCompartment]
 	KmsVault                   plugin.TValue[*mqlOciKmsVault]
 	KmsKey                     plugin.TValue[*mqlOciKmsKey]
@@ -31081,10 +30211,6 @@ func (c *mqlOciVaultSecret) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciVaultSecret) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciVaultSecret) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciVaultSecret) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -31366,7 +30492,6 @@ type mqlOciLoadBalancerLoadBalancer struct {
 	mqlOciLoadBalancerLoadBalancerInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
-	CompartmentID             plugin.TValue[string]
 	Compartment               plugin.TValue[*mqlOciCompartment]
 	Shape                     plugin.TValue[string]
 	IsPrivate                 plugin.TValue[bool]
@@ -31375,7 +30500,6 @@ type mqlOciLoadBalancerLoadBalancer struct {
 	Subnets                   plugin.TValue[[]any]
 	State                     plugin.TValue[string]
 	Listeners                 plugin.TValue[[]any]
-	NsgIds                    plugin.TValue[[]any]
 	SecurityGroups            plugin.TValue[[]any]
 	Exposure                  plugin.TValue[*mqlOciNetworkExposure]
 	BackendSets               plugin.TValue[[]any]
@@ -31428,10 +30552,6 @@ func (c *mqlOciLoadBalancerLoadBalancer) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciLoadBalancerLoadBalancer) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciLoadBalancerLoadBalancer) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciLoadBalancerLoadBalancer) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -31500,10 +30620,6 @@ func (c *mqlOciLoadBalancerLoadBalancer) GetListeners() *plugin.TValue[[]any] {
 
 		return c.listeners()
 	})
-}
-
-func (c *mqlOciLoadBalancerLoadBalancer) GetNsgIds() *plugin.TValue[[]any] {
-	return &c.NsgIds
 }
 
 func (c *mqlOciLoadBalancerLoadBalancer) GetSecurityGroups() *plugin.TValue[[]any] {
@@ -35295,7 +34411,6 @@ type mqlOciNetworkFirewallFirewall struct {
 	mqlOciNetworkFirewallFirewallInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
-	CompartmentID      plugin.TValue[string]
 	Compartment        plugin.TValue[*mqlOciCompartment]
 	Subnet             plugin.TValue[*mqlOciNetworkSubnet]
 	Policy             plugin.TValue[*mqlOciNetworkFirewallPolicy]
@@ -35355,10 +34470,6 @@ func (c *mqlOciNetworkFirewallFirewall) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkFirewallFirewall) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkFirewallFirewall) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkFirewallFirewall) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -35462,7 +34573,6 @@ type mqlOciNetworkFirewallPolicy struct {
 	mqlOciNetworkFirewallPolicyInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	Description           plugin.TValue[string]
 	AttachedFirewallCount plugin.TValue[int64]
@@ -35519,10 +34629,6 @@ func (c *mqlOciNetworkFirewallPolicy) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkFirewallPolicy) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciNetworkFirewallPolicy) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciNetworkFirewallPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -35921,7 +35027,6 @@ type mqlOciOkeCluster struct {
 	mqlOciOkeClusterInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
-	CompartmentID               plugin.TValue[string]
 	Compartment                 plugin.TValue[*mqlOciCompartment]
 	KubernetesVersion           plugin.TValue[string]
 	Type                        plugin.TValue[string]
@@ -35985,10 +35090,6 @@ func (c *mqlOciOkeCluster) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciOkeCluster) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciOkeCluster) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciOkeCluster) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -36118,13 +35219,11 @@ type mqlOciOkeNodePool struct {
 	mqlOciOkeNodePoolInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	KubernetesVersion     plugin.TValue[string]
 	NodeShape             plugin.TValue[string]
 	Cluster               plugin.TValue[*mqlOciOkeCluster]
 	NodeShapeConfig       plugin.TValue[any]
-	NodeImageName         plugin.TValue[string]
 	NodeImage             plugin.TValue[*mqlOciComputeImage]
 	BootVolumeSizeInGBs   plugin.TValue[int64]
 	SshPublicKey          plugin.TValue[string]
@@ -36181,10 +35280,6 @@ func (c *mqlOciOkeNodePool) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlOciOkeNodePool) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
-}
-
 func (c *mqlOciOkeNodePool) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -36227,10 +35322,6 @@ func (c *mqlOciOkeNodePool) GetCluster() *plugin.TValue[*mqlOciOkeCluster] {
 
 func (c *mqlOciOkeNodePool) GetNodeShapeConfig() *plugin.TValue[any] {
 	return &c.NodeShapeConfig
-}
-
-func (c *mqlOciOkeNodePool) GetNodeImageName() *plugin.TValue[string] {
-	return &c.NodeImageName
 }
 
 func (c *mqlOciOkeNodePool) GetNodeImage() *plugin.TValue[*mqlOciComputeImage] {
@@ -36388,18 +35479,17 @@ type mqlOciWafFirewall struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciWafFirewallInternal
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	Policy        plugin.TValue[*mqlOciWafPolicy]
-	LoadBalancer  plugin.TValue[*mqlOciLoadBalancerLoadBalancer]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	TimeUpdated   plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
-	SystemTags    plugin.TValue[map[string]any]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Policy       plugin.TValue[*mqlOciWafPolicy]
+	LoadBalancer plugin.TValue[*mqlOciLoadBalancerLoadBalancer]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	TimeUpdated  plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
+	SystemTags   plugin.TValue[map[string]any]
 }
 
 // createOciWafFirewall creates a new instance of this resource
@@ -36445,10 +35535,6 @@ func (c *mqlOciWafFirewall) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciWafFirewall) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciWafFirewall) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciWafFirewall) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -36527,17 +35613,16 @@ func (c *mqlOciWafFirewall) GetSystemTags() *plugin.TValue[map[string]any] {
 type mqlOciWafPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciWafPolicyInternal it will be used here
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	TimeUpdated   plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
-	SystemTags    plugin.TValue[map[string]any]
+	mqlOciWafPolicyInternal
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	TimeUpdated  plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
+	SystemTags   plugin.TValue[map[string]any]
 }
 
 // createOciWafPolicy creates a new instance of this resource
@@ -36583,10 +35668,6 @@ func (c *mqlOciWafPolicy) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciWafPolicy) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciWafPolicy) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciWafPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -36697,7 +35778,6 @@ type mqlOciFunctionsApplication struct {
 	mqlOciFunctionsApplicationInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	State                 plugin.TValue[string]
 	Shape                 plugin.TValue[string]
@@ -36757,10 +35837,6 @@ func (c *mqlOciFunctionsApplication) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciFunctionsApplication) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciFunctionsApplication) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciFunctionsApplication) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -36878,7 +35954,6 @@ type mqlOciFunctionsFunction struct {
 	mqlOciFunctionsFunctionInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
-	CompartmentID    plugin.TValue[string]
 	Compartment      plugin.TValue[*mqlOciCompartment]
 	ApplicationId    plugin.TValue[string]
 	State            plugin.TValue[string]
@@ -36939,10 +36014,6 @@ func (c *mqlOciFunctionsFunction) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciFunctionsFunction) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciFunctionsFunction) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciFunctionsFunction) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -37087,7 +36158,6 @@ type mqlOciContainerInstancesInstance struct {
 	mqlOciContainerInstancesInstanceInternal
 	Id                               plugin.TValue[string]
 	Name                             plugin.TValue[string]
-	CompartmentID                    plugin.TValue[string]
 	Compartment                      plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain               plugin.TValue[string]
 	State                            plugin.TValue[string]
@@ -37149,10 +36219,6 @@ func (c *mqlOciContainerInstancesInstance) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciContainerInstancesInstance) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciContainerInstancesInstance) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciContainerInstancesInstance) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -37247,10 +36313,9 @@ func (c *mqlOciContainerInstancesInstance) GetContainers() *plugin.TValue[[]any]
 type mqlOciContainerInstancesContainer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciContainerInstancesContainerInternal it will be used here
+	mqlOciContainerInstancesContainerInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
-	CompartmentID               plugin.TValue[string]
 	Compartment                 plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain          plugin.TValue[string]
 	State                       plugin.TValue[string]
@@ -37314,10 +36379,6 @@ func (c *mqlOciContainerInstancesContainer) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciContainerInstancesContainer) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciContainerInstancesContainer) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciContainerInstancesContainer) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -37523,7 +36584,6 @@ type mqlOciDatabaseBackup struct {
 	mqlOciDatabaseBackupInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
-	CompartmentID            plugin.TValue[string]
 	Compartment              plugin.TValue[*mqlOciCompartment]
 	DatabaseId               plugin.TValue[string]
 	AvailabilityDomain       plugin.TValue[string]
@@ -37587,10 +36647,6 @@ func (c *mqlOciDatabaseBackup) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciDatabaseBackup) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciDatabaseBackup) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciDatabaseBackup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -37708,7 +36764,6 @@ type mqlOciDatabaseAutonomousDatabaseBackup struct {
 	mqlOciDatabaseAutonomousDatabaseBackupInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	AutonomousDatabase    plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
 	Type                  plugin.TValue[string]
@@ -37770,10 +36825,6 @@ func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetId() *plugin.TValue[string] 
 
 func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciDatabaseAutonomousDatabaseBackup) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -37895,7 +36946,6 @@ type mqlOciDatabaseDbSystem struct {
 	mqlOciDatabaseDbSystemInternal
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
-	CompartmentID        plugin.TValue[string]
 	Compartment          plugin.TValue[*mqlOciCompartment]
 	AvailabilityDomain   plugin.TValue[string]
 	Shape                plugin.TValue[string]
@@ -37913,9 +36963,7 @@ type mqlOciDatabaseDbSystem struct {
 	LicenseModel         plugin.TValue[string]
 	KmsKey               plugin.TValue[*mqlOciKmsKey]
 	Subnet               plugin.TValue[*mqlOciNetworkSubnet]
-	NsgIds               plugin.TValue[[]any]
 	SecurityGroups       plugin.TValue[[]any]
-	BackupNetworkNsgIds  plugin.TValue[[]any]
 	BackupSecurityGroups plugin.TValue[[]any]
 	State                plugin.TValue[string]
 	Created              plugin.TValue[*time.Time]
@@ -37967,10 +37015,6 @@ func (c *mqlOciDatabaseDbSystem) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciDatabaseDbSystem) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciDatabaseDbSystem) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciDatabaseDbSystem) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -38089,10 +37133,6 @@ func (c *mqlOciDatabaseDbSystem) GetSubnet() *plugin.TValue[*mqlOciNetworkSubnet
 	})
 }
 
-func (c *mqlOciDatabaseDbSystem) GetNsgIds() *plugin.TValue[[]any] {
-	return &c.NsgIds
-}
-
 func (c *mqlOciDatabaseDbSystem) GetSecurityGroups() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.SecurityGroups, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -38107,10 +37147,6 @@ func (c *mqlOciDatabaseDbSystem) GetSecurityGroups() *plugin.TValue[[]any] {
 
 		return c.securityGroups()
 	})
-}
-
-func (c *mqlOciDatabaseDbSystem) GetBackupNetworkNsgIds() *plugin.TValue[[]any] {
-	return &c.BackupNetworkNsgIds
 }
 
 func (c *mqlOciDatabaseDbSystem) GetBackupSecurityGroups() *plugin.TValue[[]any] {
@@ -38156,7 +37192,6 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	mqlOciDatabaseAutonomousDatabaseInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
-	CompartmentID               plugin.TValue[string]
 	Compartment                 plugin.TValue[*mqlOciCompartment]
 	DbName                      plugin.TValue[string]
 	SourceDatabase              plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
@@ -38185,7 +37220,6 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	KmsKey                      plugin.TValue[*mqlOciKmsKey]
 	KmsVault                    plugin.TValue[*mqlOciKmsVault]
 	Subnet                      plugin.TValue[*mqlOciNetworkSubnet]
-	NsgIds                      plugin.TValue[[]any]
 	SecurityGroups              plugin.TValue[[]any]
 	PrivateEndpointIp           plugin.TValue[string]
 	PrivateEndpointLabel        plugin.TValue[string]
@@ -38242,10 +37276,6 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciDatabaseAutonomousDatabase) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -38422,10 +37452,6 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetSubnet() *plugin.TValue[*mqlOciNet
 	})
 }
 
-func (c *mqlOciDatabaseAutonomousDatabase) GetNsgIds() *plugin.TValue[[]any] {
-	return &c.NsgIds
-}
-
 func (c *mqlOciDatabaseAutonomousDatabase) GetSecurityGroups() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.SecurityGroups, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -38596,7 +37622,6 @@ type mqlOciApigatewayGateway struct {
 	mqlOciApigatewayGatewayInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
-	CompartmentID         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	EndpointType          plugin.TValue[string]
 	IpMode                plugin.TValue[string]
@@ -38658,10 +37683,6 @@ func (c *mqlOciApigatewayGateway) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciApigatewayGateway) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciApigatewayGateway) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciApigatewayGateway) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -38789,7 +37810,6 @@ type mqlOciApigatewayDeployment struct {
 	mqlOciApigatewayDeploymentInternal
 	Id                                plugin.TValue[string]
 	Name                              plugin.TValue[string]
-	CompartmentID                     plugin.TValue[string]
 	Compartment                       plugin.TValue[*mqlOciCompartment]
 	Gateway                           plugin.TValue[*mqlOciApigatewayGateway]
 	PathPrefix                        plugin.TValue[string]
@@ -38856,10 +37876,6 @@ func (c *mqlOciApigatewayDeployment) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciApigatewayDeployment) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciApigatewayDeployment) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciApigatewayDeployment) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -38996,10 +38012,9 @@ func (c *mqlOciApigatewayDeployment) GetSystemTags() *plugin.TValue[map[string]a
 type mqlOciApigatewayCertificate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciApigatewayCertificateInternal it will be used here
+	mqlOciApigatewayCertificateInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
-	CompartmentID     plugin.TValue[string]
 	Compartment       plugin.TValue[*mqlOciCompartment]
 	SubjectNames      plugin.TValue[[]any]
 	TimeNotValidAfter plugin.TValue[*time.Time]
@@ -39054,10 +38069,6 @@ func (c *mqlOciApigatewayCertificate) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciApigatewayCertificate) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciApigatewayCertificate) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciApigatewayCertificate) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -39211,7 +38222,6 @@ type mqlOciCertificatesCertificate struct {
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Description                plugin.TValue[string]
-	CompartmentID              plugin.TValue[string]
 	Compartment                plugin.TValue[*mqlOciCompartment]
 	ConfigType                 plugin.TValue[string]
 	IssuerCertificateAuthority plugin.TValue[*mqlOciCertificatesCertificateAuthority]
@@ -39278,10 +38288,6 @@ func (c *mqlOciCertificatesCertificate) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciCertificatesCertificate) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciCertificatesCertificate) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciCertificatesCertificate) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -39384,7 +38390,6 @@ type mqlOciCertificatesCertificateAuthority struct {
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Description                plugin.TValue[string]
-	CompartmentID              plugin.TValue[string]
 	Compartment                plugin.TValue[*mqlOciCompartment]
 	Kind                       plugin.TValue[string]
 	ConfigType                 plugin.TValue[string]
@@ -39447,10 +38452,6 @@ func (c *mqlOciCertificatesCertificateAuthority) GetName() *plugin.TValue[string
 
 func (c *mqlOciCertificatesCertificateAuthority) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciCertificatesCertificateAuthority) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciCertificatesCertificateAuthority) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -39545,16 +38546,15 @@ func (c *mqlOciCertificatesCertificateAuthority) GetDefinedTags() *plugin.TValue
 type mqlOciCertificatesCaBundle struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciCertificatesCaBundleInternal it will be used here
-	Id            plugin.TValue[string]
-	Name          plugin.TValue[string]
-	Description   plugin.TValue[string]
-	CompartmentID plugin.TValue[string]
-	Compartment   plugin.TValue[*mqlOciCompartment]
-	State         plugin.TValue[string]
-	Created       plugin.TValue[*time.Time]
-	FreeformTags  plugin.TValue[map[string]any]
-	DefinedTags   plugin.TValue[map[string]any]
+	mqlOciCertificatesCaBundleInternal
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciCertificatesCaBundle creates a new instance of this resource
@@ -39604,10 +38604,6 @@ func (c *mqlOciCertificatesCaBundle) GetName() *plugin.TValue[string] {
 
 func (c *mqlOciCertificatesCaBundle) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlOciCertificatesCaBundle) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciCertificatesCaBundle) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -39710,7 +38706,6 @@ type mqlOciRedisCluster struct {
 	mqlOciRedisClusterInternal
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
-	CompartmentID              plugin.TValue[string]
 	Compartment                plugin.TValue[*mqlOciCompartment]
 	SoftwareVersion            plugin.TValue[string]
 	ClusterMode                plugin.TValue[string]
@@ -39776,10 +38771,6 @@ func (c *mqlOciRedisCluster) GetId() *plugin.TValue[string] {
 
 func (c *mqlOciRedisCluster) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOciRedisCluster) GetCompartmentID() *plugin.TValue[string] {
-	return &c.CompartmentID
 }
 
 func (c *mqlOciRedisCluster) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -40065,11 +39056,10 @@ func (c *mqlOciDataSafe) GetMaskingPolicies() *plugin.TValue[[]any] {
 type mqlOciDataSafeConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciDataSafeConfigurationInternal it will be used here
+	mqlOciDataSafeConfigurationInternal
 	Region              plugin.TValue[string]
 	IsEnabled           plugin.TValue[bool]
 	Url                 plugin.TValue[string]
-	CompartmentId       plugin.TValue[string]
 	Compartment         plugin.TValue[*mqlOciCompartment]
 	LifecycleState      plugin.TValue[string]
 	NatGatewayIpAddress plugin.TValue[string]
@@ -40128,10 +39118,6 @@ func (c *mqlOciDataSafeConfiguration) GetUrl() *plugin.TValue[string] {
 	return &c.Url
 }
 
-func (c *mqlOciDataSafeConfiguration) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
-}
-
 func (c *mqlOciDataSafeConfiguration) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
 	return plugin.GetOrCompute[*mqlOciCompartment](&c.Compartment, func() (*mqlOciCompartment, error) {
 		if c.MqlRuntime.HasRecording {
@@ -40176,9 +39162,8 @@ func (c *mqlOciDataSafeConfiguration) GetDefinedTags() *plugin.TValue[map[string
 type mqlOciDataSafeTargetDatabase struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciDataSafeTargetDatabaseInternal it will be used here
+	mqlOciDataSafeTargetDatabaseInternal
 	Id                    plugin.TValue[string]
-	CompartmentId         plugin.TValue[string]
 	Compartment           plugin.TValue[*mqlOciCompartment]
 	Region                plugin.TValue[string]
 	DisplayName           plugin.TValue[string]
@@ -40233,10 +39218,6 @@ func (c *mqlOciDataSafeTargetDatabase) MqlID() string {
 
 func (c *mqlOciDataSafeTargetDatabase) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciDataSafeTargetDatabase) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
 }
 
 func (c *mqlOciDataSafeTargetDatabase) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -40307,9 +39288,8 @@ func (c *mqlOciDataSafeTargetDatabase) GetSystemTags() *plugin.TValue[map[string
 type mqlOciDataSafeSecurityAssessment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciDataSafeSecurityAssessmentInternal it will be used here
+	mqlOciDataSafeSecurityAssessmentInternal
 	Id                     plugin.TValue[string]
-	CompartmentId          plugin.TValue[string]
 	Compartment            plugin.TValue[*mqlOciCompartment]
 	Region                 plugin.TValue[string]
 	DisplayName            plugin.TValue[string]
@@ -40363,10 +39343,6 @@ func (c *mqlOciDataSafeSecurityAssessment) MqlID() string {
 
 func (c *mqlOciDataSafeSecurityAssessment) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciDataSafeSecurityAssessment) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
 }
 
 func (c *mqlOciDataSafeSecurityAssessment) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -40433,9 +39409,8 @@ func (c *mqlOciDataSafeSecurityAssessment) GetDefinedTags() *plugin.TValue[map[s
 type mqlOciDataSafeUserAssessment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciDataSafeUserAssessmentInternal it will be used here
+	mqlOciDataSafeUserAssessmentInternal
 	Id                     plugin.TValue[string]
-	CompartmentId          plugin.TValue[string]
 	Compartment            plugin.TValue[*mqlOciCompartment]
 	Region                 plugin.TValue[string]
 	DisplayName            plugin.TValue[string]
@@ -40489,10 +39464,6 @@ func (c *mqlOciDataSafeUserAssessment) MqlID() string {
 
 func (c *mqlOciDataSafeUserAssessment) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciDataSafeUserAssessment) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
 }
 
 func (c *mqlOciDataSafeUserAssessment) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -40559,9 +39530,8 @@ func (c *mqlOciDataSafeUserAssessment) GetDefinedTags() *plugin.TValue[map[strin
 type mqlOciDataSafeSensitiveDataModel struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciDataSafeSensitiveDataModelInternal it will be used here
+	mqlOciDataSafeSensitiveDataModelInternal
 	Id             plugin.TValue[string]
-	CompartmentId  plugin.TValue[string]
 	Compartment    plugin.TValue[*mqlOciCompartment]
 	Region         plugin.TValue[string]
 	DisplayName    plugin.TValue[string]
@@ -40614,10 +39584,6 @@ func (c *mqlOciDataSafeSensitiveDataModel) MqlID() string {
 
 func (c *mqlOciDataSafeSensitiveDataModel) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciDataSafeSensitiveDataModel) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
 }
 
 func (c *mqlOciDataSafeSensitiveDataModel) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -40680,9 +39646,8 @@ func (c *mqlOciDataSafeSensitiveDataModel) GetDefinedTags() *plugin.TValue[map[s
 type mqlOciDataSafeSensitiveType struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciDataSafeSensitiveTypeInternal it will be used here
+	mqlOciDataSafeSensitiveTypeInternal
 	Id             plugin.TValue[string]
-	CompartmentId  plugin.TValue[string]
 	Compartment    plugin.TValue[*mqlOciCompartment]
 	Region         plugin.TValue[string]
 	DisplayName    plugin.TValue[string]
@@ -40735,10 +39700,6 @@ func (c *mqlOciDataSafeSensitiveType) MqlID() string {
 
 func (c *mqlOciDataSafeSensitiveType) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciDataSafeSensitiveType) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
 }
 
 func (c *mqlOciDataSafeSensitiveType) GetCompartment() *plugin.TValue[*mqlOciCompartment] {
@@ -40801,9 +39762,8 @@ func (c *mqlOciDataSafeSensitiveType) GetDefinedTags() *plugin.TValue[map[string
 type mqlOciDataSafeMaskingPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciDataSafeMaskingPolicyInternal it will be used here
+	mqlOciDataSafeMaskingPolicyInternal
 	Id             plugin.TValue[string]
-	CompartmentId  plugin.TValue[string]
 	Compartment    plugin.TValue[*mqlOciCompartment]
 	Region         plugin.TValue[string]
 	DisplayName    plugin.TValue[string]
@@ -40855,10 +39815,6 @@ func (c *mqlOciDataSafeMaskingPolicy) MqlID() string {
 
 func (c *mqlOciDataSafeMaskingPolicy) GetId() *plugin.TValue[string] {
 	return &c.Id
-}
-
-func (c *mqlOciDataSafeMaskingPolicy) GetCompartmentId() *plugin.TValue[string] {
-	return &c.CompartmentId
 }
 
 func (c *mqlOciDataSafeMaskingPolicy) GetCompartment() *plugin.TValue[*mqlOciCompartment] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -387,7 +387,6 @@ oci.ai.vision.projects 13.9.2
 oci.apigateway 13.4.1
 oci.apigateway.certificate 13.4.1
 oci.apigateway.certificate.compartment 13.12.2
-oci.apigateway.certificate.compartmentID 13.4.1
 oci.apigateway.certificate.created 13.4.1
 oci.apigateway.certificate.definedTags 13.4.1
 oci.apigateway.certificate.freeformTags 13.4.1
@@ -402,7 +401,6 @@ oci.apigateway.certificates 13.4.1
 oci.apigateway.deployment 13.4.1
 oci.apigateway.deployment.authenticationType 13.4.1
 oci.apigateway.deployment.compartment 13.12.2
-oci.apigateway.deployment.compartmentID 13.4.1
 oci.apigateway.deployment.corsAllowCredentials 13.4.1
 oci.apigateway.deployment.corsAllowedOrigins 13.4.1
 oci.apigateway.deployment.created 13.4.1
@@ -429,7 +427,6 @@ oci.apigateway.gateway 13.4.1
 oci.apigateway.gateway.caBundleIds 13.4.1
 oci.apigateway.gateway.certificate 13.4.1
 oci.apigateway.gateway.compartment 13.12.2
-oci.apigateway.gateway.compartmentID 13.4.1
 oci.apigateway.gateway.created 13.4.1
 oci.apigateway.gateway.definedTags 13.4.1
 oci.apigateway.gateway.endpointType 13.4.1
@@ -486,7 +483,6 @@ oci.bastion.instance 13.0.6
 oci.bastion.instance.bastionType 13.0.6
 oci.bastion.instance.clientCidrBlockAllowList 13.16.4
 oci.bastion.instance.compartment 13.6.2
-oci.bastion.instance.compartmentID 13.0.6
 oci.bastion.instance.created 13.0.6
 oci.bastion.instance.definedTags 13.18.1
 oci.bastion.instance.dnsProxyStatus 13.0.6
@@ -505,7 +501,6 @@ oci.bastion.instance.timeUpdated 13.0.6
 oci.certificates 13.4.1
 oci.certificates.caBundle 13.4.1
 oci.certificates.caBundle.compartment 13.12.2
-oci.certificates.caBundle.compartmentID 13.4.1
 oci.certificates.caBundle.created 13.4.1
 oci.certificates.caBundle.definedTags 13.4.1
 oci.certificates.caBundle.description 13.4.1
@@ -517,7 +512,6 @@ oci.certificates.caBundles 13.4.1
 oci.certificates.certificate 13.4.1
 oci.certificates.certificate.autoRenewalEnabled 13.4.1
 oci.certificates.certificate.compartment 13.12.2
-oci.certificates.certificate.compartmentID 13.4.1
 oci.certificates.certificate.configType 13.4.1
 oci.certificates.certificate.created 13.4.1
 oci.certificates.certificate.currentVersion 13.4.1
@@ -539,7 +533,6 @@ oci.certificates.certificate.validityNotBefore 13.4.1
 oci.certificates.certificateAuthorities 13.4.1
 oci.certificates.certificateAuthority 13.4.1
 oci.certificates.certificateAuthority.compartment 13.12.2
-oci.certificates.certificateAuthority.compartmentID 13.4.1
 oci.certificates.certificateAuthority.configType 13.4.1
 oci.certificates.certificateAuthority.created 13.4.1
 oci.certificates.certificateAuthority.definedTags 13.4.1
@@ -559,7 +552,6 @@ oci.certificates.certificates 13.4.1
 oci.cloudGuard 13.0.6
 oci.cloudGuard.detectorRecipe 13.0.6
 oci.cloudGuard.detectorRecipe.compartment 13.12.2
-oci.cloudGuard.detectorRecipe.compartmentID 13.12.2
 oci.cloudGuard.detectorRecipe.created 13.0.6
 oci.cloudGuard.detectorRecipe.definedTags 13.18.1
 oci.cloudGuard.detectorRecipe.description 13.0.6
@@ -615,7 +607,6 @@ oci.cloudGuard.securityPolicies 13.5.1
 oci.cloudGuard.securityPolicy 13.5.1
 oci.cloudGuard.securityPolicy.category 13.5.1
 oci.cloudGuard.securityPolicy.compartment 13.12.2
-oci.cloudGuard.securityPolicy.compartmentID 13.5.1
 oci.cloudGuard.securityPolicy.created 13.5.1
 oci.cloudGuard.securityPolicy.definedTags 13.18.1
 oci.cloudGuard.securityPolicy.description 13.5.1
@@ -629,7 +620,6 @@ oci.cloudGuard.securityPolicy.state 13.5.1
 oci.cloudGuard.securityPolicy.systemTags 13.12.2
 oci.cloudGuard.securityZone 13.5.1
 oci.cloudGuard.securityZone.compartment 13.12.2
-oci.cloudGuard.securityZone.compartmentID 13.5.1
 oci.cloudGuard.securityZone.created 13.5.1
 oci.cloudGuard.securityZone.definedTags 13.18.1
 oci.cloudGuard.securityZone.description 13.5.1
@@ -642,7 +632,6 @@ oci.cloudGuard.securityZone.state 13.5.1
 oci.cloudGuard.securityZone.systemTags 13.12.2
 oci.cloudGuard.securityZoneRecipe 13.5.1
 oci.cloudGuard.securityZoneRecipe.compartment 13.12.2
-oci.cloudGuard.securityZoneRecipe.compartmentID 13.5.1
 oci.cloudGuard.securityZoneRecipe.created 13.5.1
 oci.cloudGuard.securityZoneRecipe.definedTags 13.18.1
 oci.cloudGuard.securityZoneRecipe.description 13.5.1
@@ -659,7 +648,6 @@ oci.cloudGuard.selfManageResources 13.0.6
 oci.cloudGuard.status 13.0.6
 oci.cloudGuard.target 13.0.6
 oci.cloudGuard.target.compartment 13.12.2
-oci.cloudGuard.target.compartmentID 13.0.6
 oci.cloudGuard.target.created 13.0.6
 oci.cloudGuard.target.definedTags 13.18.1
 oci.cloudGuard.target.freeformTags 13.18.1
@@ -684,7 +672,6 @@ oci.compute 9.0.0
 oci.compute.blockVolume 13.0.6
 oci.compute.blockVolume.availabilityDomain 13.0.6
 oci.compute.blockVolume.compartment 13.6.2
-oci.compute.blockVolume.compartmentID 13.0.6
 oci.compute.blockVolume.created 13.0.6
 oci.compute.blockVolume.definedTags 13.18.1
 oci.compute.blockVolume.freeformTags 13.18.1
@@ -703,13 +690,11 @@ oci.compute.blockVolumes 13.0.6
 oci.compute.bootVolume 13.0.6
 oci.compute.bootVolume.availabilityDomain 13.0.6
 oci.compute.bootVolume.compartment 13.6.2
-oci.compute.bootVolume.compartmentID 13.0.6
 oci.compute.bootVolume.created 13.0.6
 oci.compute.bootVolume.definedTags 13.18.1
 oci.compute.bootVolume.freeformTags 13.18.1
 oci.compute.bootVolume.id 13.0.6
 oci.compute.bootVolume.image 13.6.2
-oci.compute.bootVolume.imageId 13.0.6
 oci.compute.bootVolume.kmsKey 13.0.6
 oci.compute.bootVolume.name 13.0.6
 oci.compute.bootVolume.sizeInGBs 13.0.6
@@ -748,7 +733,6 @@ oci.compute.instance.faultDomain 11.1.0
 oci.compute.instance.freeformTags 11.1.0
 oci.compute.instance.id 9.0.0
 oci.compute.instance.image 13.6.2
-oci.compute.instance.imageId 11.1.0
 oci.compute.instance.instanceOptions 13.0.6
 oci.compute.instance.launchOptions 13.0.6
 oci.compute.instance.legacyImdsEndpointsDisabled 13.10.1
@@ -771,7 +755,6 @@ oci.compute.instance.vulnerabilityScanResult 13.7.1
 oci.compute.instances 9.0.0
 oci.compute.vnic 13.1.1
 oci.compute.vnic.compartment 13.6.2
-oci.compute.vnic.compartmentID 13.1.1
 oci.compute.vnic.created 13.1.1
 oci.compute.vnic.definedTags 13.1.1
 oci.compute.vnic.freeformTags 13.1.1
@@ -781,7 +764,6 @@ oci.compute.vnic.ipv6Addresses 13.16.4
 oci.compute.vnic.isPrimary 13.1.1
 oci.compute.vnic.macAddress 13.1.1
 oci.compute.vnic.name 13.1.1
-oci.compute.vnic.nsgIds 13.1.1
 oci.compute.vnic.privateIp 13.1.1
 oci.compute.vnic.publicIp 13.1.1
 oci.compute.vnic.securityGroups 13.6.2
@@ -793,7 +775,6 @@ oci.containerInstances.container 13.1.1
 oci.containerInstances.container.addedCapabilities 13.16.4
 oci.containerInstances.container.availabilityDomain 13.1.1
 oci.containerInstances.container.compartment 13.12.2
-oci.containerInstances.container.compartmentID 13.1.1
 oci.containerInstances.container.containerInstanceId 13.1.1
 oci.containerInstances.container.created 13.1.1
 oci.containerInstances.container.definedTags 13.1.1
@@ -814,7 +795,6 @@ oci.containerInstances.container.timeUpdated 13.1.1
 oci.containerInstances.instance 13.1.1
 oci.containerInstances.instance.availabilityDomain 13.1.1
 oci.containerInstances.instance.compartment 13.12.2
-oci.containerInstances.instance.compartmentID 13.1.1
 oci.containerInstances.instance.containerCount 13.1.1
 oci.containerInstances.instance.containerRestartPolicy 13.1.1
 oci.containerInstances.instance.containers 13.1.1
@@ -835,7 +815,6 @@ oci.containerInstances.instances 13.1.1
 oci.dataSafe 13.5.5
 oci.dataSafe.configuration 13.5.5
 oci.dataSafe.configuration.compartment 13.12.2
-oci.dataSafe.configuration.compartmentId 13.5.5
 oci.dataSafe.configuration.definedTags 13.5.5
 oci.dataSafe.configuration.enabledAt 13.5.5
 oci.dataSafe.configuration.freeformTags 13.5.5
@@ -850,7 +829,6 @@ oci.dataSafe.maskingPolicies 13.5.5
 oci.dataSafe.maskingPolicy 13.5.5
 oci.dataSafe.maskingPolicy.columnSource 13.5.5
 oci.dataSafe.maskingPolicy.compartment 13.12.2
-oci.dataSafe.maskingPolicy.compartmentId 13.5.5
 oci.dataSafe.maskingPolicy.created 13.5.5
 oci.dataSafe.maskingPolicy.definedTags 13.5.5
 oci.dataSafe.maskingPolicy.description 13.5.5
@@ -862,7 +840,6 @@ oci.dataSafe.maskingPolicy.region 13.5.5
 oci.dataSafe.maskingPolicy.timeUpdated 13.5.5
 oci.dataSafe.securityAssessment 13.5.5
 oci.dataSafe.securityAssessment.compartment 13.12.2
-oci.dataSafe.securityAssessment.compartmentId 13.5.5
 oci.dataSafe.securityAssessment.created 13.5.5
 oci.dataSafe.securityAssessment.definedTags 13.5.5
 oci.dataSafe.securityAssessment.displayName 13.5.5
@@ -879,7 +856,6 @@ oci.dataSafe.securityAssessments 13.5.5
 oci.dataSafe.sensitiveDataModel 13.5.5
 oci.dataSafe.sensitiveDataModel.appSuiteName 13.5.5
 oci.dataSafe.sensitiveDataModel.compartment 13.12.2
-oci.dataSafe.sensitiveDataModel.compartmentId 13.5.5
 oci.dataSafe.sensitiveDataModel.created 13.5.5
 oci.dataSafe.sensitiveDataModel.definedTags 13.5.5
 oci.dataSafe.sensitiveDataModel.description 13.5.5
@@ -893,7 +869,6 @@ oci.dataSafe.sensitiveDataModel.timeUpdated 13.5.5
 oci.dataSafe.sensitiveDataModels 13.5.5
 oci.dataSafe.sensitiveType 13.5.5
 oci.dataSafe.sensitiveType.compartment 13.12.2
-oci.dataSafe.sensitiveType.compartmentId 13.5.5
 oci.dataSafe.sensitiveType.created 13.5.5
 oci.dataSafe.sensitiveType.definedTags 13.5.5
 oci.dataSafe.sensitiveType.displayName 13.5.5
@@ -909,7 +884,6 @@ oci.dataSafe.sensitiveTypes 13.5.5
 oci.dataSafe.targetDatabase 13.5.5
 oci.dataSafe.targetDatabase.associatedResourceIds 13.5.5
 oci.dataSafe.targetDatabase.compartment 13.12.2
-oci.dataSafe.targetDatabase.compartmentId 13.5.5
 oci.dataSafe.targetDatabase.created 13.5.5
 oci.dataSafe.targetDatabase.databaseType 13.5.5
 oci.dataSafe.targetDatabase.definedTags 13.5.5
@@ -925,7 +899,6 @@ oci.dataSafe.targetDatabase.systemTags 13.12.2
 oci.dataSafe.targetDatabases 13.5.5
 oci.dataSafe.userAssessment 13.5.5
 oci.dataSafe.userAssessment.compartment 13.12.2
-oci.dataSafe.userAssessment.compartmentId 13.5.5
 oci.dataSafe.userAssessment.created 13.5.5
 oci.dataSafe.userAssessment.definedTags 13.5.5
 oci.dataSafe.userAssessment.displayName 13.5.5
@@ -944,7 +917,6 @@ oci.database.autonomousDatabase 13.1.1
 oci.database.autonomousDatabase.backupRetentionPeriodInDays 13.10.1
 oci.database.autonomousDatabase.backups 13.4.1
 oci.database.autonomousDatabase.compartment 13.6.2
-oci.database.autonomousDatabase.compartmentID 13.1.1
 oci.database.autonomousDatabase.connectionUrls 13.3.1
 oci.database.autonomousDatabase.cpuCoreCount 13.1.1
 oci.database.autonomousDatabase.created 13.1.1
@@ -971,7 +943,6 @@ oci.database.autonomousDatabase.kmsKey 13.1.1
 oci.database.autonomousDatabase.kmsVault 13.1.1
 oci.database.autonomousDatabase.licenseModel 13.1.1
 oci.database.autonomousDatabase.name 13.1.1
-oci.database.autonomousDatabase.nsgIds 13.1.1
 oci.database.autonomousDatabase.openMode 13.1.1
 oci.database.autonomousDatabase.permissionLevel 13.1.1
 oci.database.autonomousDatabase.privateEndpointIp 13.1.1
@@ -987,7 +958,6 @@ oci.database.autonomousDatabase.whitelistedIps 13.1.1
 oci.database.autonomousDatabaseBackup 13.4.1
 oci.database.autonomousDatabaseBackup.autonomousDatabase 13.4.1
 oci.database.autonomousDatabaseBackup.compartment 13.12.2
-oci.database.autonomousDatabaseBackup.compartmentID 13.4.1
 oci.database.autonomousDatabaseBackup.databaseSizeInTBs 13.4.1
 oci.database.autonomousDatabaseBackup.dbVersion 13.4.1
 oci.database.autonomousDatabaseBackup.id 13.4.1
@@ -1010,7 +980,6 @@ oci.database.backup 13.4.1
 oci.database.backup.availabilityDomain 13.4.1
 oci.database.backup.backupDestinationType 13.4.1
 oci.database.backup.compartment 13.12.2
-oci.database.backup.compartmentID 13.4.1
 oci.database.backup.databaseEdition 13.4.1
 oci.database.backup.databaseId 13.4.1
 oci.database.backup.databaseSizeInGBs 13.4.1
@@ -1031,10 +1000,8 @@ oci.database.backup.version 13.4.1
 oci.database.backups 13.4.1
 oci.database.dbSystem 13.1.1
 oci.database.dbSystem.availabilityDomain 13.1.1
-oci.database.dbSystem.backupNetworkNsgIds 13.1.1
 oci.database.dbSystem.backupSecurityGroups 13.6.2
 oci.database.dbSystem.compartment 13.12.2
-oci.database.dbSystem.compartmentID 13.1.1
 oci.database.dbSystem.cpuCoreCount 13.1.1
 oci.database.dbSystem.created 13.1.1
 oci.database.dbSystem.dataStorageSizeInGBs 13.1.1
@@ -1050,7 +1017,6 @@ oci.database.dbSystem.licenseModel 13.1.1
 oci.database.dbSystem.listenerPort 13.10.1
 oci.database.dbSystem.name 13.1.1
 oci.database.dbSystem.nodeCount 13.1.1
-oci.database.dbSystem.nsgIds 13.1.1
 oci.database.dbSystem.scanDnsName 13.10.1
 oci.database.dbSystem.securityGroups 13.6.2
 oci.database.dbSystem.shape 13.1.1
@@ -1103,7 +1069,6 @@ oci.events 13.0.6
 oci.events.rule 13.0.6
 oci.events.rule.actions 13.0.6
 oci.events.rule.compartment 13.6.2
-oci.events.rule.compartmentID 13.0.6
 oci.events.rule.condition 13.0.6
 oci.events.rule.created 13.0.6
 oci.events.rule.definedTags 13.18.1
@@ -1118,7 +1083,6 @@ oci.fileStorage 13.0.6
 oci.fileStorage.fileSystem 13.0.6
 oci.fileStorage.fileSystem.availabilityDomain 13.0.6
 oci.fileStorage.fileSystem.compartment 13.12.2
-oci.fileStorage.fileSystem.compartmentID 13.0.6
 oci.fileStorage.fileSystem.created 13.0.6
 oci.fileStorage.fileSystem.definedTags 13.18.1
 oci.fileStorage.fileSystem.freeformTags 13.18.1
@@ -1134,7 +1098,6 @@ oci.fileStorage.fileSystems 13.0.6
 oci.functions 13.1.1
 oci.functions.application 13.1.1
 oci.functions.application.compartment 13.12.2
-oci.functions.application.compartmentID 13.1.1
 oci.functions.application.config 13.1.1
 oci.functions.application.created 13.1.1
 oci.functions.application.definedTags 13.1.1
@@ -1154,7 +1117,6 @@ oci.functions.applications 13.1.1
 oci.functions.function 13.1.1
 oci.functions.function.applicationId 13.1.1
 oci.functions.function.compartment 13.12.2
-oci.functions.function.compartmentID 13.1.1
 oci.functions.function.config 13.1.1
 oci.functions.function.created 13.1.1
 oci.functions.function.definedTags 13.1.1
@@ -1339,7 +1301,6 @@ oci.identity.domain.users 13.17.2
 oci.identity.domains 13.17.2
 oci.identity.dynamicGroup 13.5.6
 oci.identity.dynamicGroup.compartment 13.12.2
-oci.identity.dynamicGroup.compartmentID 13.5.6
 oci.identity.dynamicGroup.created 13.5.6
 oci.identity.dynamicGroup.definedTags 13.5.6
 oci.identity.dynamicGroup.description 13.5.6
@@ -1351,7 +1312,6 @@ oci.identity.dynamicGroup.state 13.5.6
 oci.identity.dynamicGroups 13.5.6
 oci.identity.group 9.0.0
 oci.identity.group.compartment 13.12.2
-oci.identity.group.compartmentID 9.0.0
 oci.identity.group.created 9.0.0
 oci.identity.group.definedTags 11.1.0
 oci.identity.group.description 9.0.0
@@ -1363,7 +1323,6 @@ oci.identity.group.state 9.0.0
 oci.identity.groups 9.0.0
 oci.identity.identityProvider 13.5.6
 oci.identity.identityProvider.compartment 13.12.2
-oci.identity.identityProvider.compartmentID 13.5.6
 oci.identity.identityProvider.created 13.5.6
 oci.identity.identityProvider.definedTags 13.5.6
 oci.identity.identityProvider.description 13.5.6
@@ -1386,7 +1345,6 @@ oci.identity.mfaDevice.state 13.1.1
 oci.identity.mfaDevice.userId 13.1.1
 oci.identity.networkSource 13.5.6
 oci.identity.networkSource.compartment 13.12.2
-oci.identity.networkSource.compartmentID 13.5.6
 oci.identity.networkSource.created 13.5.6
 oci.identity.networkSource.definedTags 13.5.6
 oci.identity.networkSource.description 13.5.6
@@ -1400,7 +1358,6 @@ oci.identity.networkSource.virtualSourceList 13.5.6
 oci.identity.networkSources 13.5.6
 oci.identity.oauth2ClientCredential 13.5.6
 oci.identity.oauth2ClientCredential.compartment 13.12.2
-oci.identity.oauth2ClientCredential.compartmentID 13.5.6
 oci.identity.oauth2ClientCredential.created 13.5.6
 oci.identity.oauth2ClientCredential.description 13.5.6
 oci.identity.oauth2ClientCredential.expires 13.5.6
@@ -1411,7 +1368,6 @@ oci.identity.oauth2ClientCredential.state 13.5.6
 oci.identity.policies 9.0.0
 oci.identity.policy 9.0.0
 oci.identity.policy.compartment 13.12.2
-oci.identity.policy.compartmentID 9.0.0
 oci.identity.policy.created 9.0.0
 oci.identity.policy.definedTags 11.1.0
 oci.identity.policy.description 9.0.0
@@ -1447,7 +1403,6 @@ oci.identity.user.apiKeys 9.0.0
 oci.identity.user.authTokens 9.0.0
 oci.identity.user.capabilities 9.0.0
 oci.identity.user.compartment 13.12.2
-oci.identity.user.compartmentID 9.0.0
 oci.identity.user.created 9.0.0
 oci.identity.user.customerSecretKeys 9.0.0
 oci.identity.user.dbCredentials 13.5.6
@@ -1495,7 +1450,6 @@ oci.kms 13.0.6
 oci.kms.key 13.0.6
 oci.kms.key.algorithm 13.0.6
 oci.kms.key.compartment 13.6.2
-oci.kms.key.compartmentID 13.0.6
 oci.kms.key.created 13.0.6
 oci.kms.key.curveId 13.15.1
 oci.kms.key.definedTags 13.18.1
@@ -1508,10 +1462,8 @@ oci.kms.key.name 13.0.6
 oci.kms.key.protectionMode 13.0.6
 oci.kms.key.state 13.0.6
 oci.kms.key.vault 13.6.2
-oci.kms.key.vaultId 13.0.6
 oci.kms.keyVersion 13.1.1
 oci.kms.keyVersion.compartment 13.6.2
-oci.kms.keyVersion.compartmentID 13.1.1
 oci.kms.keyVersion.created 13.1.1
 oci.kms.keyVersion.id 13.1.1
 oci.kms.keyVersion.isAutoRotated 13.1.1
@@ -1520,10 +1472,8 @@ oci.kms.keyVersion.origin 13.1.1
 oci.kms.keyVersion.state 13.1.1
 oci.kms.keyVersion.timeOfDeletion 13.1.1
 oci.kms.keyVersion.vault 13.6.2
-oci.kms.keyVersion.vaultId 13.1.1
 oci.kms.vault 13.0.6
 oci.kms.vault.compartment 13.6.2
-oci.kms.vault.compartmentID 13.0.6
 oci.kms.vault.created 13.0.6
 oci.kms.vault.definedTags 13.18.1
 oci.kms.vault.freeformTags 13.18.1
@@ -1556,7 +1506,6 @@ oci.loadBalancer.listener.trustedCertificateAuthorities 13.10.1
 oci.loadBalancer.loadBalancer 13.0.6
 oci.loadBalancer.loadBalancer.backendSets 13.0.6
 oci.loadBalancer.loadBalancer.compartment 13.12.2
-oci.loadBalancer.loadBalancer.compartmentID 13.0.6
 oci.loadBalancer.loadBalancer.created 13.0.6
 oci.loadBalancer.loadBalancer.definedTags 13.7.2
 oci.loadBalancer.loadBalancer.exposure 13.12.0
@@ -1567,7 +1516,6 @@ oci.loadBalancer.loadBalancer.isDeleteProtectionEnabled 13.0.6
 oci.loadBalancer.loadBalancer.isPrivate 13.0.6
 oci.loadBalancer.loadBalancer.listeners 13.0.6
 oci.loadBalancer.loadBalancer.name 13.0.6
-oci.loadBalancer.loadBalancer.nsgIds 13.12.0
 oci.loadBalancer.loadBalancer.securityGroups 13.12.0
 oci.loadBalancer.loadBalancer.shape 13.0.6
 oci.loadBalancer.loadBalancer.state 13.0.6
@@ -1594,7 +1542,6 @@ oci.logging.log.systemTags 13.12.2
 oci.logging.log.timeLastModified 13.0.6
 oci.logging.logGroup 13.0.6
 oci.logging.logGroup.compartment 13.12.2
-oci.logging.logGroup.compartmentID 13.0.6
 oci.logging.logGroup.created 13.0.6
 oci.logging.logGroup.definedTags 13.18.1
 oci.logging.logGroup.description 13.0.6
@@ -1608,9 +1555,7 @@ oci.logging.logGroups 13.0.6
 oci.monitoring 13.0.6
 oci.monitoring.alarm 13.0.6
 oci.monitoring.alarm.compartment 13.6.2
-oci.monitoring.alarm.compartmentID 13.0.6
 oci.monitoring.alarm.definedTags 13.18.1
-oci.monitoring.alarm.destinations 13.0.6
 oci.monitoring.alarm.freeformTags 13.18.1
 oci.monitoring.alarm.id 13.0.6
 oci.monitoring.alarm.isEnabled 13.0.6
@@ -1657,7 +1602,6 @@ oci.mysql.dbSystems 13.17.2
 oci.network 9.0.0
 oci.network.cpe 13.13.1
 oci.network.cpe.compartment 13.13.1
-oci.network.cpe.compartmentID 13.13.1
 oci.network.cpe.cpeDeviceShapeId 13.13.1
 oci.network.cpe.created 13.13.1
 oci.network.cpe.definedTags 13.13.1
@@ -1669,7 +1613,6 @@ oci.network.cpe.name 13.13.1
 oci.network.cpes 13.13.1
 oci.network.crossConnect 13.13.1
 oci.network.crossConnect.compartment 13.13.1
-oci.network.crossConnect.compartmentID 13.13.1
 oci.network.crossConnect.created 13.13.1
 oci.network.crossConnect.crossConnectGroupId 13.13.1
 oci.network.crossConnect.definedTags 13.13.1
@@ -1684,7 +1627,6 @@ oci.network.crossConnects 13.13.1
 oci.network.drg 13.13.1
 oci.network.drg.attachments 13.13.1
 oci.network.drg.compartment 13.13.1
-oci.network.drg.compartmentID 13.13.1
 oci.network.drg.created 13.13.1
 oci.network.drg.definedTags 13.13.1
 oci.network.drg.freeformTags 13.13.1
@@ -1694,7 +1636,6 @@ oci.network.drg.remotePeeringConnections 13.13.1
 oci.network.drg.state 13.13.1
 oci.network.drgAttachment 13.13.1
 oci.network.drgAttachment.compartment 13.13.1
-oci.network.drgAttachment.compartmentID 13.13.1
 oci.network.drgAttachment.created 13.13.1
 oci.network.drgAttachment.definedTags 13.18.1
 oci.network.drgAttachment.drg 13.13.1
@@ -1718,7 +1659,6 @@ oci.network.exposure.securityGroupAllowsIngress 13.12.0
 oci.network.exposure.securityListAllowsIngress 13.13.1
 oci.network.internetGateway 13.1.1
 oci.network.internetGateway.compartment 13.12.2
-oci.network.internetGateway.compartmentID 13.1.1
 oci.network.internetGateway.created 13.1.1
 oci.network.internetGateway.definedTags 13.1.1
 oci.network.internetGateway.freeformTags 13.1.1
@@ -1730,7 +1670,6 @@ oci.network.internetGateway.vcn 13.1.1
 oci.network.internetGateways 13.1.1
 oci.network.ipsecConnection 13.13.1
 oci.network.ipsecConnection.compartment 13.13.1
-oci.network.ipsecConnection.compartmentID 13.13.1
 oci.network.ipsecConnection.cpe 13.13.1
 oci.network.ipsecConnection.cpeLocalIdentifier 13.13.1
 oci.network.ipsecConnection.cpeLocalIdentifierType 13.13.1
@@ -1747,7 +1686,6 @@ oci.network.ipsecConnection.tunnels 13.13.1
 oci.network.ipsecConnectionTunnel 13.13.1
 oci.network.ipsecConnectionTunnel.bgpState 13.13.1
 oci.network.ipsecConnectionTunnel.compartment 13.13.1
-oci.network.ipsecConnectionTunnel.compartmentID 13.13.1
 oci.network.ipsecConnectionTunnel.cpeIp 13.13.1
 oci.network.ipsecConnectionTunnel.created 13.13.1
 oci.network.ipsecConnectionTunnel.dpdMode 13.13.1
@@ -1782,7 +1720,6 @@ oci.network.ipsecConnectionTunnel.vpnIp 13.13.1
 oci.network.ipsecConnections 13.13.1
 oci.network.localPeeringGateway 13.13.1
 oci.network.localPeeringGateway.compartment 13.13.1
-oci.network.localPeeringGateway.compartmentID 13.13.1
 oci.network.localPeeringGateway.created 13.13.1
 oci.network.localPeeringGateway.definedTags 13.13.1
 oci.network.localPeeringGateway.freeformTags 13.13.1
@@ -1799,7 +1736,6 @@ oci.network.localPeeringGateways 13.13.1
 oci.network.natGateway 13.1.1
 oci.network.natGateway.blockTraffic 13.1.1
 oci.network.natGateway.compartment 13.12.2
-oci.network.natGateway.compartmentID 13.1.1
 oci.network.natGateway.created 13.1.1
 oci.network.natGateway.definedTags 13.1.1
 oci.network.natGateway.freeformTags 13.1.1
@@ -1812,7 +1748,6 @@ oci.network.natGateways 13.1.1
 oci.network.networkSecurityGroup 13.0.6
 oci.network.networkSecurityGroup.attachedVnics 13.5.5
 oci.network.networkSecurityGroup.compartment 13.5.5
-oci.network.networkSecurityGroup.compartmentID 13.0.6
 oci.network.networkSecurityGroup.created 13.0.6
 oci.network.networkSecurityGroup.definedTags 13.0.6
 oci.network.networkSecurityGroup.egressRules 13.17.2
@@ -1831,7 +1766,6 @@ oci.network.publicIp.assignedEntityId 13.8.2
 oci.network.publicIp.assignedEntityType 13.8.2
 oci.network.publicIp.availabilityDomain 13.8.2
 oci.network.publicIp.compartment 13.12.2
-oci.network.publicIp.compartmentID 13.8.2
 oci.network.publicIp.created 13.8.2
 oci.network.publicIp.definedTags 13.18.1
 oci.network.publicIp.freeformTags 13.18.1
@@ -1844,7 +1778,6 @@ oci.network.publicIp.state 13.8.2
 oci.network.publicIps 13.8.2
 oci.network.remotePeeringConnection 13.13.1
 oci.network.remotePeeringConnection.compartment 13.13.1
-oci.network.remotePeeringConnection.compartmentID 13.13.1
 oci.network.remotePeeringConnection.created 13.13.1
 oci.network.remotePeeringConnection.definedTags 13.13.1
 oci.network.remotePeeringConnection.drg 13.13.1
@@ -1858,7 +1791,6 @@ oci.network.remotePeeringConnection.peeringStatus 13.13.1
 oci.network.remotePeeringConnection.state 13.13.1
 oci.network.routeTable 13.1.1
 oci.network.routeTable.compartment 13.12.2
-oci.network.routeTable.compartmentID 13.1.1
 oci.network.routeTable.created 13.1.1
 oci.network.routeTable.definedTags 13.1.1
 oci.network.routeTable.freeformTags 13.1.1
@@ -1883,7 +1815,6 @@ oci.network.routeTable.vcn 13.1.1
 oci.network.routeTables 13.1.1
 oci.network.securityList 9.0.0
 oci.network.securityList.compartment 13.5.5
-oci.network.securityList.compartmentID 9.0.0
 oci.network.securityList.created 9.0.0
 oci.network.securityList.definedTags 11.1.0
 oci.network.securityList.egressRules 13.17.2
@@ -1896,7 +1827,6 @@ oci.network.securityList.ingressSecurityRules 9.0.0
 oci.network.securityList.name 9.0.0
 oci.network.securityList.state 9.0.0
 oci.network.securityList.vcn 13.0.6
-oci.network.securityList.vcnId 13.0.6
 oci.network.securityLists 9.0.0
 oci.network.securityRule 13.17.2
 oci.network.securityRule.description 13.17.2
@@ -1921,7 +1851,6 @@ oci.network.service.name 13.13.1
 oci.network.serviceGateway 13.13.1
 oci.network.serviceGateway.blockTraffic 13.13.1
 oci.network.serviceGateway.compartment 13.13.1
-oci.network.serviceGateway.compartmentID 13.13.1
 oci.network.serviceGateway.created 13.13.1
 oci.network.serviceGateway.definedTags 13.13.1
 oci.network.serviceGateway.freeformTags 13.13.1
@@ -1936,7 +1865,6 @@ oci.network.subnet 13.0.6
 oci.network.subnet.availabilityDomain 13.0.6
 oci.network.subnet.cidrBlock 13.0.6
 oci.network.subnet.compartment 13.12.2
-oci.network.subnet.compartmentID 13.0.6
 oci.network.subnet.created 13.0.6
 oci.network.subnet.definedTags 13.0.6
 oci.network.subnet.dnsLabel 13.0.6
@@ -1953,10 +1881,8 @@ oci.network.subnet.subnetDomainName 13.0.6
 oci.network.subnet.vcn 13.0.6
 oci.network.subnets 13.0.6
 oci.network.vcn 9.0.0
-oci.network.vcn.cidrBlock 9.0.0
 oci.network.vcn.cidrBlocks 9.0.0
 oci.network.vcn.compartment 13.12.2
-oci.network.vcn.compartmentID 9.0.0
 oci.network.vcn.created 9.0.0
 oci.network.vcn.defaultDhcpOptionsId 11.1.0
 oci.network.vcn.defaultRouteTable 13.17.2
@@ -1984,7 +1910,6 @@ oci.network.virtualCircuit.bgpAdminState 13.13.1
 oci.network.virtualCircuit.bgpManagement 13.13.1
 oci.network.virtualCircuit.bgpSessionState 13.13.1
 oci.network.virtualCircuit.compartment 13.13.1
-oci.network.virtualCircuit.compartmentID 13.13.1
 oci.network.virtualCircuit.created 13.13.1
 oci.network.virtualCircuit.crossConnectMappings 13.13.1
 oci.network.virtualCircuit.definedTags 13.13.1
@@ -2002,7 +1927,6 @@ oci.network.virtualCircuits 13.13.1
 oci.networkFirewall 13.0.6
 oci.networkFirewall.firewall 13.0.6
 oci.networkFirewall.firewall.compartment 13.12.2
-oci.networkFirewall.firewall.compartmentID 13.0.6
 oci.networkFirewall.firewall.created 13.0.6
 oci.networkFirewall.firewall.definedTags 13.18.1
 oci.networkFirewall.firewall.freeformTags 13.18.1
@@ -2023,7 +1947,6 @@ oci.networkFirewall.policies 13.0.6
 oci.networkFirewall.policy 13.0.6
 oci.networkFirewall.policy.attachedFirewallCount 13.0.6
 oci.networkFirewall.policy.compartment 13.12.2
-oci.networkFirewall.policy.compartmentID 13.0.6
 oci.networkFirewall.policy.created 13.0.6
 oci.networkFirewall.policy.decryptionProfile 13.15.1
 oci.networkFirewall.policy.decryptionProfile.areCertificateExtensionsRestricted 13.15.1
@@ -2135,14 +2058,12 @@ oci.objectStorage.bucket.approximateCount 11.1.0
 oci.objectStorage.bucket.approximateSize 11.1.0
 oci.objectStorage.bucket.autoTiering 9.0.0
 oci.objectStorage.bucket.compartment 13.12.2
-oci.objectStorage.bucket.compartmentID 9.0.0
 oci.objectStorage.bucket.created 9.0.0
 oci.objectStorage.bucket.createdBy 13.12.2
 oci.objectStorage.bucket.createdByUser 13.12.2
 oci.objectStorage.bucket.definedTags 11.1.0
 oci.objectStorage.bucket.etag 11.1.0
 oci.objectStorage.bucket.freeformTags 11.1.0
-oci.objectStorage.bucket.id 11.1.0
 oci.objectStorage.bucket.isReadOnly 11.1.0
 oci.objectStorage.bucket.kmsKeyId 11.1.0
 oci.objectStorage.bucket.name 9.0.0
@@ -2179,7 +2100,6 @@ oci.oke 13.0.6
 oci.oke.cluster 13.0.6
 oci.oke.cluster.availableKubernetesUpgrades 13.0.6
 oci.oke.cluster.compartment 13.12.2
-oci.oke.cluster.compartmentID 13.0.6
 oci.oke.cluster.created 13.0.6
 oci.oke.cluster.definedTags 13.7.2
 oci.oke.cluster.freeformTags 13.7.2
@@ -2203,7 +2123,6 @@ oci.oke.nodePool 13.0.6
 oci.oke.nodePool.bootVolumeSizeInGBs 13.16.4
 oci.oke.nodePool.cluster 13.12.2
 oci.oke.nodePool.compartment 13.12.2
-oci.oke.nodePool.compartmentID 13.0.6
 oci.oke.nodePool.definedTags 13.18.1
 oci.oke.nodePool.freeformTags 13.18.1
 oci.oke.nodePool.id 13.0.6
@@ -2211,7 +2130,6 @@ oci.oke.nodePool.kubernetesVersion 13.0.6
 oci.oke.nodePool.name 13.0.6
 oci.oke.nodePool.networkSecurityGroups 13.3.1
 oci.oke.nodePool.nodeImage 13.16.4
-oci.oke.nodePool.nodeImageName 13.0.6
 oci.oke.nodePool.nodeShape 13.0.6
 oci.oke.nodePool.nodeShapeConfig 13.0.6
 oci.oke.nodePool.sshPublicKey 13.0.6
@@ -2230,7 +2148,6 @@ oci.ons.subscription.state 13.0.6
 oci.ons.subscription.topic 13.0.6
 oci.ons.topic 13.0.6
 oci.ons.topic.compartment 13.6.2
-oci.ons.topic.compartmentID 13.0.6
 oci.ons.topic.created 13.0.6
 oci.ons.topic.definedTags 13.18.1
 oci.ons.topic.description 13.0.6
@@ -2320,7 +2237,6 @@ oci.redis 13.5.1
 oci.redis.cluster 13.5.1
 oci.redis.cluster.clusterMode 13.5.1
 oci.redis.cluster.compartment 13.12.2
-oci.redis.cluster.compartmentID 13.5.1
 oci.redis.cluster.created 13.5.1
 oci.redis.cluster.definedTags 13.5.1
 oci.redis.cluster.discoveryEndpointIpAddress 13.5.1
@@ -2443,7 +2359,6 @@ oci.tenancy.retentionPeriod 9.0.0
 oci.vault 13.0.6
 oci.vault.secret 13.0.6
 oci.vault.secret.compartment 13.6.2
-oci.vault.secret.compartmentID 13.0.6
 oci.vault.secret.created 13.0.6
 oci.vault.secret.definedTags 13.7.2
 oci.vault.secret.description 13.0.6
@@ -2668,7 +2583,6 @@ oci.vulnerabilityScanning.vulnerability.vulnerabilityType 13.7.1
 oci.waf 13.1.1
 oci.waf.firewall 13.1.1
 oci.waf.firewall.compartment 13.12.2
-oci.waf.firewall.compartmentID 13.1.1
 oci.waf.firewall.created 13.1.1
 oci.waf.firewall.definedTags 13.1.1
 oci.waf.firewall.freeformTags 13.1.1
@@ -2683,7 +2597,6 @@ oci.waf.firewalls 13.1.1
 oci.waf.policies 13.1.1
 oci.waf.policy 13.1.1
 oci.waf.policy.compartment 13.12.2
-oci.waf.policy.compartmentID 13.1.1
 oci.waf.policy.created 13.1.1
 oci.waf.policy.definedTags 13.1.1
 oci.waf.policy.freeformTags 13.1.1

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -99,10 +99,9 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 					upgrades = append(upgrades, u)
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.oke.cluster", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.oke.cluster", stringValue(cluster.CompartmentId), map[string]*llx.RawData{
 					"id":                          llx.StringDataPtr(cluster.Id),
 					"name":                        llx.StringDataPtr(cluster.Name),
-					"compartmentID":               llx.StringDataPtr(cluster.CompartmentId),
 					"kubernetesVersion":           llx.StringDataPtr(cluster.KubernetesVersion),
 					"type":                        llx.StringData(string(cluster.Type)),
 					"isPublicEndpointEnabled":     llx.BoolData(isPublicEndpointEnabled),
@@ -132,6 +131,7 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 }
 
 type mqlOciOkeClusterInternal struct {
+	ociCompartmentRef
 	cluster     ociRetryLazy[*containerengine.Cluster]
 	cacheVcnID  string
 	cacheRegion string
@@ -248,7 +248,7 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 	clusterId := o.Id.Data
 	pools, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerengine.NodePoolSummary, *string, error) {
 		response, err := svc.ListNodePools(ctx, containerengine.ListNodePoolsRequest{
-			CompartmentId: common.String(o.CompartmentID.Data),
+			CompartmentId: common.String(o.cacheCompartmentID),
 			ClusterId:     common.String(clusterId),
 			Page:          page,
 		})
@@ -296,14 +296,12 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 			bootVolumeSizeInGBs = src.BootVolumeSizeInGBs
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.oke.nodePool", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.oke.nodePool", stringValue(np.CompartmentId), map[string]*llx.RawData{
 			"id":                  llx.StringDataPtr(np.Id),
 			"name":                llx.StringDataPtr(np.Name),
-			"compartmentID":       llx.StringDataPtr(np.CompartmentId),
 			"kubernetesVersion":   llx.StringDataPtr(np.KubernetesVersion),
 			"nodeShape":           llx.StringDataPtr(np.NodeShape),
 			"nodeShapeConfig":     llx.DictData(nodeShapeConfig),
-			"nodeImageName":       llx.StringDataPtr(np.NodeImageName),
 			"bootVolumeSizeInGBs": llx.IntDataPtr(bootVolumeSizeInGBs),
 			"sshPublicKey":        llx.StringDataPtr(np.SshPublicKey),
 			"state":               llx.StringData(string(np.LifecycleState)),
@@ -326,6 +324,7 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 }
 
 type mqlOciOkeNodePoolInternal struct {
+	ociCompartmentRef
 	cacheSubnetIDs   []string
 	cacheNsgIDs      []string
 	cacheClusterID   string

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -52,15 +52,14 @@ func (o *mqlOciOns) topics() ([]any, error) {
 					created = &topic.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.ons.topic", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(topic.TopicId),
-					"name":          llx.StringDataPtr(topic.Name),
-					"description":   llx.StringDataPtr(topic.Description),
-					"compartmentID": llx.StringDataPtr(topic.CompartmentId),
-					"state":         llx.StringData(string(topic.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(topic.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(topic.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.ons.topic", stringValue(topic.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(topic.TopicId),
+					"name":         llx.StringDataPtr(topic.Name),
+					"description":  llx.StringDataPtr(topic.Description),
+					"state":        llx.StringData(string(topic.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(topic.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(topic.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -97,6 +96,7 @@ func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.Notifica
 }
 
 type mqlOciOnsTopicInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 }
 

--- a/providers/oci/resources/policy_statement.go
+++ b/providers/oci/resources/policy_statement.go
@@ -437,3 +437,7 @@ func (a *mqlOciIdentityPolicyStatement) compartment() (*mqlOciCompartment, error
 	}
 	return match, nil
 }
+
+type mqlOciIdentityPolicyInternal struct {
+	ociCompartmentRef
+}

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -64,10 +64,9 @@ func (o *mqlOciRedis) clusters() ([]any, error) {
 					nodeMemory = float64(*c.NodeMemoryInGBs)
 				}
 
-				mqlCluster, err := CreateResource(o.MqlRuntime, "oci.redis.cluster", map[string]*llx.RawData{
+				mqlCluster, err := createOciResourceInCompartment(o.MqlRuntime, "oci.redis.cluster", stringValue(c.CompartmentId), map[string]*llx.RawData{
 					"id":                         llx.StringDataPtr(c.Id),
 					"name":                       llx.StringDataPtr(c.DisplayName),
-					"compartmentID":              llx.StringDataPtr(c.CompartmentId),
 					"softwareVersion":            llx.StringData(string(c.SoftwareVersion)),
 					"clusterMode":                llx.StringData(string(c.ClusterMode)),
 					"nodeCount":                  llx.IntDataPtr(c.NodeCount),
@@ -101,6 +100,7 @@ func (o *mqlOciRedis) clusters() ([]any, error) {
 }
 
 type mqlOciRedisClusterInternal struct {
+	ociCompartmentRef
 	cacheSubnetID string
 	cacheNsgIDs   []string
 	cacheRegion   string

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -70,10 +70,9 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 					nextRotation = &s.NextRotationTime.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.vault.secret", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.vault.secret", stringValue(s.CompartmentId), map[string]*llx.RawData{
 					"id":                      llx.StringDataPtr(s.Id),
 					"name":                    llx.StringDataPtr(s.SecretName),
-					"compartmentID":           llx.StringDataPtr(s.CompartmentId),
 					"description":             llx.StringDataPtr(s.Description),
 					"state":                   llx.StringData(string(s.LifecycleState)),
 					"rotationStatus":          llx.StringData(string(s.RotationStatus)),
@@ -108,6 +107,7 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 }
 
 type mqlOciVaultSecretInternal struct {
+	ociCompartmentRef
 	cacheKeyID   string
 	cacheVaultID string
 	cacheRegion  string

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -21,6 +21,7 @@ import (
 // Dynamic Routing Gateways
 
 type mqlOciNetworkDrgInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 }
 
@@ -59,14 +60,13 @@ func (o *mqlOciNetwork) drgs() ([]any, error) {
 					created = &drg.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.drg", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(drg.Id),
-					"name":          llx.StringDataPtr(drg.DisplayName),
-					"compartmentID": llx.StringDataPtr(drg.CompartmentId),
-					"state":         llx.StringData(string(drg.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(drg.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(drg.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.drg", stringValue(drg.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(drg.Id),
+					"name":         llx.StringDataPtr(drg.DisplayName),
+					"state":        llx.StringData(string(drg.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(drg.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(drg.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -113,7 +113,7 @@ func (o *mqlOciNetworkDrg) id() (string, error) {
 }
 
 func (o *mqlOciNetworkDrg) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkDrg) drgRegion() string {
@@ -197,10 +197,9 @@ func (o *mqlOciNetworkDrg) newDrgAttachment(att core.DrgAttachment) (*mqlOciNetw
 		networkType = "VCN"
 	}
 
-	mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.drgAttachment", map[string]*llx.RawData{
+	mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.drgAttachment", stringValue(att.CompartmentId), map[string]*llx.RawData{
 		"id":             llx.StringDataPtr(att.Id),
 		"name":           llx.StringDataPtr(att.DisplayName),
-		"compartmentID":  llx.StringDataPtr(att.CompartmentId),
 		"networkType":    llx.StringData(networkType),
 		"networkId":      llx.StringData(networkID),
 		"isCrossTenancy": llx.BoolDataPtr(att.IsCrossTenancy),
@@ -254,10 +253,9 @@ func (o *mqlOciNetworkDrg) remotePeeringConnections() ([]any, error) {
 			created = &rpc.TimeCreated.Time
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.remotePeeringConnection", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.remotePeeringConnection", stringValue(rpc.CompartmentId), map[string]*llx.RawData{
 			"id":                    llx.StringDataPtr(rpc.Id),
 			"name":                  llx.StringDataPtr(rpc.DisplayName),
-			"compartmentID":         llx.StringDataPtr(rpc.CompartmentId),
 			"isCrossTenancyPeering": llx.BoolDataPtr(rpc.IsCrossTenancyPeering),
 			"peeringStatus":         llx.StringData(string(rpc.PeeringStatus)),
 			"peerId":                llx.StringDataPtr(rpc.PeerId),
@@ -280,6 +278,7 @@ func (o *mqlOciNetworkDrg) remotePeeringConnections() ([]any, error) {
 // DRG attachments
 
 type mqlOciNetworkDrgAttachmentInternal struct {
+	ociCompartmentRef
 	cacheDrgID             string
 	cacheVcnID             string
 	cacheIpsecConnectionID string
@@ -291,7 +290,7 @@ func (o *mqlOciNetworkDrgAttachment) id() (string, error) {
 }
 
 func (o *mqlOciNetworkDrgAttachment) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkDrgAttachment) drg() (*mqlOciNetworkDrg, error) {
@@ -353,6 +352,7 @@ func (o *mqlOciNetworkDrgAttachment) virtualCircuit() (*mqlOciNetworkVirtualCirc
 // Remote peering connections
 
 type mqlOciNetworkRemotePeeringConnectionInternal struct {
+	ociCompartmentRef
 	cacheDrgID string
 }
 
@@ -361,7 +361,7 @@ func (o *mqlOciNetworkRemotePeeringConnection) id() (string, error) {
 }
 
 func (o *mqlOciNetworkRemotePeeringConnection) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkRemotePeeringConnection) drg() (*mqlOciNetworkDrg, error) {
@@ -381,6 +381,7 @@ func (o *mqlOciNetworkRemotePeeringConnection) drg() (*mqlOciNetworkDrg, error) 
 // Local peering gateways
 
 type mqlOciNetworkLocalPeeringGatewayInternal struct {
+	ociCompartmentRef
 	cacheVcnID        string
 	cachePeerID       string
 	cacheRouteTableID string
@@ -421,10 +422,9 @@ func (o *mqlOciNetwork) localPeeringGateways() ([]any, error) {
 					created = &lpg.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.localPeeringGateway", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.localPeeringGateway", stringValue(lpg.CompartmentId), map[string]*llx.RawData{
 					"id":                    llx.StringDataPtr(lpg.Id),
 					"name":                  llx.StringDataPtr(lpg.DisplayName),
-					"compartmentID":         llx.StringDataPtr(lpg.CompartmentId),
 					"isCrossTenancyPeering": llx.BoolDataPtr(lpg.IsCrossTenancyPeering),
 					"peeringStatus":         llx.StringData(string(lpg.PeeringStatus)),
 					"peerAdvertisedCidr":    llx.StringDataPtr(lpg.PeerAdvertisedCidr),
@@ -480,7 +480,7 @@ func (o *mqlOciNetworkLocalPeeringGateway) id() (string, error) {
 }
 
 func (o *mqlOciNetworkLocalPeeringGateway) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkLocalPeeringGateway) vcn() (*mqlOciNetworkVcn, error) {
@@ -529,6 +529,7 @@ func (o *mqlOciNetworkLocalPeeringGateway) routeTable() (*mqlOciNetworkRouteTabl
 // Service gateways
 
 type mqlOciNetworkServiceGatewayInternal struct {
+	ociCompartmentRef
 	cacheRegion       string
 	cacheVcnID        string
 	cacheRouteTableID string
@@ -575,15 +576,14 @@ func (o *mqlOciNetwork) serviceGateways() ([]any, error) {
 					serviceIDs = append(serviceIDs, stringValue(sgw.Services[j].ServiceId))
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.serviceGateway", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(sgw.Id),
-					"name":          llx.StringDataPtr(sgw.DisplayName),
-					"compartmentID": llx.StringDataPtr(sgw.CompartmentId),
-					"blockTraffic":  llx.BoolDataPtr(sgw.BlockTraffic),
-					"state":         llx.StringData(string(sgw.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(strMapToAny(sgw.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(sgw.DefinedTags), types.Any),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.serviceGateway", stringValue(sgw.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(sgw.Id),
+					"name":         llx.StringDataPtr(sgw.DisplayName),
+					"blockTraffic": llx.BoolDataPtr(sgw.BlockTraffic),
+					"state":        llx.StringData(string(sgw.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"freeformTags": llx.MapData(strMapToAny(sgw.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(sgw.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -633,7 +633,7 @@ func (o *mqlOciNetworkServiceGateway) id() (string, error) {
 }
 
 func (o *mqlOciNetworkServiceGateway) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkServiceGateway) vcn() (*mqlOciNetworkVcn, error) {

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -29,6 +29,43 @@ import (
 //
 // resolveRef does both once.
 
+// ociCompartmentRef carries a resource's raw compartment OCID. The OCID is not
+// part of the schema, so it rides on the internal struct and feeds only the
+// compartment() accessor and asset discovery. Every resource exposing
+// compartment() embeds this through its mqlOci<Resource>Internal struct.
+type ociCompartmentRef struct {
+	cacheCompartmentID string
+}
+
+func (c *ociCompartmentRef) setCompartmentID(id string) {
+	c.cacheCompartmentID = id
+}
+
+// ociCompartmentSetter is satisfied by every resource embedding
+// ociCompartmentRef, which lets createOciResourceInCompartment stash the OCID
+// without knowing the concrete resource type.
+type ociCompartmentSetter interface {
+	setCompartmentID(string)
+}
+
+// createOciResourceInCompartment creates a resource and records the compartment
+// OCID it was listed from, so compartment() resolves without the OCID being a
+// field on the resource. A resource that reaches here without embedding
+// ociCompartmentRef would silently lose its compartment(), so the mismatch is
+// reported rather than ignored.
+func createOciResourceInCompartment(runtime *plugin.Runtime, name string, compartmentID string, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res, err := CreateResource(runtime, name, args)
+	if err != nil {
+		return nil, err
+	}
+	setter, ok := res.(ociCompartmentSetter)
+	if !ok {
+		return nil, errors.New(name + " does not embed ociCompartmentRef")
+	}
+	setter.setCompartmentID(compartmentID)
+	return res, nil
+}
+
 // resolveRef resolves a typed resource from an OCID, marking the field null
 // when there is no id to resolve.
 //
@@ -205,315 +242,297 @@ func resolveOciTopics(runtime *plugin.Runtime, ids []any) ([]any, error) {
 // ----- compute -----
 
 func (o *mqlOciComputeInstance) image() (*mqlOciComputeImage, error) {
-	return resolveOciImage(o.MqlRuntime, o.ImageId.Data, &o.Image)
+	return resolveOciImage(o.MqlRuntime, o.cacheImageID, &o.Image)
 }
 
 func (o *mqlOciComputeBootVolume) image() (*mqlOciComputeImage, error) {
-	return resolveOciImage(o.MqlRuntime, o.ImageId.Data, &o.Image)
+	return resolveOciImage(o.MqlRuntime, o.cacheImageID, &o.Image)
 }
 
 func (o *mqlOciComputeBootVolume) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciComputeBlockVolume) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciComputeVnic) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciComputeVnic) securityGroups() ([]any, error) {
-	if o.NsgIds.Error != nil {
-		return nil, o.NsgIds.Error
-	}
-	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
+	return resolveOciSecurityGroups(o.MqlRuntime, o.cacheNsgIDs)
 }
 
 func (o *mqlOciLoadBalancerLoadBalancer) securityGroups() ([]any, error) {
-	if o.NsgIds.Error != nil {
-		return nil, o.NsgIds.Error
-	}
-	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
+	return resolveOciSecurityGroups(o.MqlRuntime, o.cacheNsgIDs)
 }
 
 // ----- kms -----
 
 func (o *mqlOciKmsVault) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciKmsKey) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciKmsKey) vault() (*mqlOciKmsVault, error) {
-	return resolveOciVault(o.MqlRuntime, o.VaultId.Data, &o.Vault)
+	return resolveOciVault(o.MqlRuntime, o.cacheVaultID, &o.Vault)
 }
 
 func (o *mqlOciKmsKeyVersion) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciKmsKeyVersion) vault() (*mqlOciKmsVault, error) {
-	return resolveOciVault(o.MqlRuntime, o.VaultId.Data, &o.Vault)
+	return resolveOciVault(o.MqlRuntime, o.cacheVaultID, &o.Vault)
 }
 
 // ----- events / ons / monitoring -----
 
 func (o *mqlOciEventsRule) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciOnsTopic) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciMonitoringAlarm) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciMonitoringAlarm) topics() ([]any, error) {
-	if o.Destinations.Error != nil {
-		return nil, o.Destinations.Error
-	}
-	return resolveOciTopics(o.MqlRuntime, o.Destinations.Data)
+	return resolveOciTopics(o.MqlRuntime, o.cacheDestinations)
 }
 
 // ----- bastion / vault.secret -----
 
 func (o *mqlOciBastionInstance) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciVaultSecret) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 // ----- database -----
 
 func (o *mqlOciDatabaseDbSystem) securityGroups() ([]any, error) {
-	if o.NsgIds.Error != nil {
-		return nil, o.NsgIds.Error
-	}
-	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
+	return resolveOciSecurityGroups(o.MqlRuntime, o.cacheNsgIDs)
 }
 
 func (o *mqlOciDatabaseDbSystem) backupSecurityGroups() ([]any, error) {
-	if o.BackupNetworkNsgIds.Error != nil {
-		return nil, o.BackupNetworkNsgIds.Error
-	}
-	return resolveOciSecurityGroups(o.MqlRuntime, o.BackupNetworkNsgIds.Data)
+	return resolveOciSecurityGroups(o.MqlRuntime, o.cacheBackupNetworkNsgIDs)
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) securityGroups() ([]any, error) {
-	if o.NsgIds.Error != nil {
-		return nil, o.NsgIds.Error
-	}
-	return resolveOciSecurityGroups(o.MqlRuntime, o.NsgIds.Data)
+	return resolveOciSecurityGroups(o.MqlRuntime, o.cacheNsgIDs)
 }
 
 // ----- compartment accessors (ownership) -----
 
 func (o *mqlOciIdentityUser) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciIdentityGroup) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciIdentityPolicy) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciIdentityOauth2ClientCredential) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciIdentityDynamicGroup) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciIdentityIdentityProvider) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciIdentityNetworkSource) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkPublicIp) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkVcn) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkSubnet) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkInternetGateway) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkNatGateway) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkRouteTable) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciLoggingLogGroup) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciObjectStorageBucket) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciFileStorageFileSystem) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCloudGuardTarget) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCloudGuardSecurityZone) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCloudGuardSecurityZoneRecipe) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCloudGuardSecurityPolicy) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciLoadBalancerLoadBalancer) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkFirewallFirewall) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkFirewallPolicy) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciOkeCluster) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciOkeNodePool) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciWafFirewall) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciWafPolicy) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciFunctionsApplication) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciFunctionsFunction) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciContainerInstancesInstance) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciContainerInstancesContainer) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDatabaseBackup) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDatabaseAutonomousDatabaseBackup) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDatabaseDbSystem) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciApigatewayGateway) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciApigatewayDeployment) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciApigatewayCertificate) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCertificatesCertificate) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCertificatesCertificateAuthority) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCertificatesCaBundle) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciRedisCluster) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDataSafeConfiguration) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDataSafeTargetDatabase) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDataSafeSecurityAssessment) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDataSafeUserAssessment) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDataSafeSensitiveDataModel) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDataSafeSensitiveType) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciDataSafeMaskingPolicy) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentId.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCloudGuardDetectorRecipe) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 // ----- source / lineage accessors -----
@@ -586,4 +605,14 @@ func (o *mqlOciDatabaseDbSystem) sourceDbSystem() (*mqlOciDatabaseDbSystem, erro
 
 func (o *mqlOciDatabaseAutonomousDatabase) sourceDatabase() (*mqlOciDatabaseAutonomousDatabase, error) {
 	return resolveRef(o.MqlRuntime, "oci.database.autonomousDatabase", ocidOrEmpty(o.cacheSourceID), &o.SourceDatabase)
+}
+
+type mqlOciKmsKeyVersionInternal struct {
+	ociCompartmentRef
+	cacheVaultID string
+}
+
+type mqlOciMonitoringAlarmInternal struct {
+	ociCompartmentRef
+	cacheDestinations []any
 }

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -55,10 +55,9 @@ func (o *mqlOciNetwork) cpes() ([]any, error) {
 					created = &cpe.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.cpe", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.cpe", stringValue(cpe.CompartmentId), map[string]*llx.RawData{
 					"id":               llx.StringDataPtr(cpe.Id),
 					"name":             llx.StringDataPtr(cpe.DisplayName),
-					"compartmentID":    llx.StringDataPtr(cpe.CompartmentId),
 					"ipAddress":        llx.StringDataPtr(cpe.IpAddress),
 					"cpeDeviceShapeId": llx.StringDataPtr(cpe.CpeDeviceShapeId),
 					"isPrivate":        llx.BoolDataPtr(cpe.IsPrivate),
@@ -109,12 +108,13 @@ func (o *mqlOciNetworkCpe) id() (string, error) {
 }
 
 func (o *mqlOciNetworkCpe) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 // IPSec connections
 
 type mqlOciNetworkIpsecConnectionInternal struct {
+	ociCompartmentRef
 	cacheRegion string
 	cacheCpeID  string
 	cacheDrgID  string
@@ -155,10 +155,9 @@ func (o *mqlOciNetwork) ipsecConnections() ([]any, error) {
 					created = &ipsc.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.ipsecConnection", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.ipsecConnection", stringValue(ipsc.CompartmentId), map[string]*llx.RawData{
 					"id":                     llx.StringDataPtr(ipsc.Id),
 					"name":                   llx.StringDataPtr(ipsc.DisplayName),
-					"compartmentID":          llx.StringDataPtr(ipsc.CompartmentId),
 					"staticRoutes":           llx.ArrayData(stringsToAny(ipsc.StaticRoutes), types.String),
 					"cpeLocalIdentifier":     llx.StringDataPtr(ipsc.CpeLocalIdentifier),
 					"cpeLocalIdentifierType": llx.StringData(string(ipsc.CpeLocalIdentifierType)),
@@ -215,7 +214,7 @@ func (o *mqlOciNetworkIpsecConnection) id() (string, error) {
 }
 
 func (o *mqlOciNetworkIpsecConnection) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkIpsecConnection) cpe() (*mqlOciNetworkCpe, error) {
@@ -286,10 +285,9 @@ func (o *mqlOciNetworkIpsecConnection) tunnels() ([]any, error) {
 			bgpState = string(tunnel.BgpSessionInfo.BgpState)
 		}
 
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.ipsecConnectionTunnel", map[string]*llx.RawData{
+		mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.ipsecConnectionTunnel", stringValue(tunnel.CompartmentId), map[string]*llx.RawData{
 			"id":                    llx.StringDataPtr(tunnel.Id),
 			"name":                  llx.StringDataPtr(tunnel.DisplayName),
-			"compartmentID":         llx.StringDataPtr(tunnel.CompartmentId),
 			"status":                llx.StringData(string(tunnel.Status)),
 			"ikeVersion":            llx.StringData(string(tunnel.IkeVersion)),
 			"routing":               llx.StringData(string(tunnel.Routing)),
@@ -318,6 +316,7 @@ func (o *mqlOciNetworkIpsecConnectionTunnel) id() (string, error) {
 }
 
 type mqlOciNetworkIpsecConnectionTunnelInternal struct {
+	ociCompartmentRef
 	cacheIpscID string
 	cacheRegion string
 	details     ociOnce
@@ -599,12 +598,13 @@ func ociTunnelLifetime(field *plugin.TValue[int64], v *int64) (int64, error) {
 }
 
 func (o *mqlOciNetworkIpsecConnectionTunnel) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 // FastConnect virtual circuits
 
 type mqlOciNetworkVirtualCircuitInternal struct {
+	ociCompartmentRef
 	cacheDrgID string
 }
 
@@ -671,10 +671,9 @@ func (o *mqlOciNetwork) virtualCircuits() ([]any, error) {
 					return nil, err
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.virtualCircuit", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.virtualCircuit", stringValue(vc.CompartmentId), map[string]*llx.RawData{
 					"id":                   llx.StringDataPtr(vc.Id),
 					"name":                 llx.StringDataPtr(vc.DisplayName),
-					"compartmentID":        llx.StringDataPtr(vc.CompartmentId),
 					"type":                 llx.StringData(string(vc.Type)),
 					"serviceType":          llx.StringData(string(vc.ServiceType)),
 					"bandwidthShapeName":   llx.StringDataPtr(vc.BandwidthShapeName),
@@ -737,7 +736,7 @@ func (o *mqlOciNetworkVirtualCircuit) id() (string, error) {
 }
 
 func (o *mqlOciNetworkVirtualCircuit) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkVirtualCircuit) drg() (*mqlOciNetworkDrg, error) {
@@ -791,10 +790,9 @@ func (o *mqlOciNetwork) crossConnects() ([]any, error) {
 					created = &xc.TimeCreated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.crossConnect", map[string]*llx.RawData{
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.network.crossConnect", stringValue(xc.CompartmentId), map[string]*llx.RawData{
 					"id":                  llx.StringDataPtr(xc.Id),
 					"name":                llx.StringDataPtr(xc.DisplayName),
-					"compartmentID":       llx.StringDataPtr(xc.CompartmentId),
 					"locationName":        llx.StringDataPtr(xc.LocationName),
 					"portName":            llx.StringDataPtr(xc.PortName),
 					"portSpeedShapeName":  llx.StringDataPtr(xc.PortSpeedShapeName),
@@ -819,5 +817,13 @@ func (o *mqlOciNetworkCrossConnect) id() (string, error) {
 }
 
 func (o *mqlOciNetworkCrossConnect) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.CompartmentID.Data, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
+}
+
+type mqlOciNetworkCpeInternal struct {
+	ociCompartmentRef
+}
+
+type mqlOciNetworkCrossConnectInternal struct {
+	ociCompartmentRef
 }

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -64,16 +64,15 @@ func (o *mqlOciWaf) firewalls() ([]any, error) {
 					timeUpdated = &lbWaf.TimeUpdated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.waf.firewall", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(lbWaf.Id),
-					"name":          llx.StringDataPtr(lbWaf.DisplayName),
-					"compartmentID": llx.StringDataPtr(lbWaf.CompartmentId),
-					"state":         llx.StringData(string(lbWaf.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"timeUpdated":   llx.TimeDataPtr(timeUpdated),
-					"freeformTags":  llx.MapData(strMapToAny(lbWaf.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(lbWaf.DefinedTags), types.Any),
-					"systemTags":    llx.MapData(definedTagsToAny(lbWaf.SystemTags), types.Dict),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.waf.firewall", stringValue(lbWaf.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(lbWaf.Id),
+					"name":         llx.StringDataPtr(lbWaf.DisplayName),
+					"state":        llx.StringData(string(lbWaf.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"timeUpdated":  llx.TimeDataPtr(timeUpdated),
+					"freeformTags": llx.MapData(strMapToAny(lbWaf.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(lbWaf.DefinedTags), types.Any),
+					"systemTags":   llx.MapData(definedTagsToAny(lbWaf.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -89,6 +88,7 @@ func (o *mqlOciWaf) firewalls() ([]any, error) {
 }
 
 type mqlOciWafFirewallInternal struct {
+	ociCompartmentRef
 	cachePolicyID       string
 	cacheLoadBalancerID string
 }
@@ -164,16 +164,15 @@ func (o *mqlOciWaf) policies() ([]any, error) {
 					timeUpdated = &p.TimeUpdated.Time
 				}
 
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.waf.policy", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(p.Id),
-					"name":          llx.StringDataPtr(p.DisplayName),
-					"compartmentID": llx.StringDataPtr(p.CompartmentId),
-					"state":         llx.StringData(string(p.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-					"timeUpdated":   llx.TimeDataPtr(timeUpdated),
-					"freeformTags":  llx.MapData(strMapToAny(p.FreeformTags), types.String),
-					"definedTags":   llx.MapData(definedTagsToAny(p.DefinedTags), types.Any),
-					"systemTags":    llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
+				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.waf.policy", stringValue(p.CompartmentId), map[string]*llx.RawData{
+					"id":           llx.StringDataPtr(p.Id),
+					"name":         llx.StringDataPtr(p.DisplayName),
+					"state":        llx.StringData(string(p.LifecycleState)),
+					"created":      llx.TimeDataPtr(created),
+					"timeUpdated":  llx.TimeDataPtr(timeUpdated),
+					"freeformTags": llx.MapData(strMapToAny(p.FreeformTags), types.String),
+					"definedTags":  llx.MapData(definedTagsToAny(p.DefinedTags), types.Any),
+					"systemTags":   llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -218,4 +217,8 @@ func initOciWafPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 
 func (o *mqlOciWafPolicy) id() (string, error) {
 	return "oci.waf.policy/" + o.Id.Data, nil
+}
+
+type mqlOciWafPolicyInternal struct {
+	ociCompartmentRef
 }


### PR DESCRIPTION
Removes the 87 fields marked `@maturity("deprecated")` in `oci.lr`. Every one of
them already had a live replacement, so nothing becomes unqueryable:

| Removed | Replacement |
|---|---|
| `compartmentID` / `compartmentId` (73) | `compartment()` |
| `nsgIds` (4) | `securityGroups()` |
| `backupNetworkNsgIds` | `backupSecurityGroups()` |
| `imageId` (2) | `image()` |
| `vaultId` (2) | `vault()` |
| `vcnId` | `vcn()` |
| `cidrBlock` (`oci.network.vcn`) | `cidrBlocks` |
| `destinations` | `topics()` |
| `nodeImageName` | `nodeImage()` |
| `id` (`oci.objectStorage.bucket`) | `ocid()` |

### These fields were not inert

The raw compartment OCID was what fed `compartment()`, so deleting the schema
field also deletes the Go struct field those accessors read. The OCID now rides
on the internal struct instead: `ociCompartmentRef` is embedded into each
affected `mqlOci<X>Internal`, and `createOciResourceInCompartment` records the
OCID at construction.

That helper returns an error when a resource reaches it without the embed, so a
resource missed during the sweep fails loudly instead of silently reporting a
null `compartment()`. The other removals use per-resource `cache*` fields the
same way.

Resources that were never marked deprecated keep their `compartmentID` field and
read it unchanged: **34** of them, across `vulnerabilityScanning`,
`generativeai`, `datascience` and others.

### Bug fixed along the way

`oci.objectStorage.bucket` is the only compartment-bearing resource whose `init`
constructs the resource rather than returning a listed one, so a single-bucket
lookup left `compartment()` null. It now takes the compartment from the detail
call it already makes.

### Six deprecations deliberately left in place

Marked deprecated upstream after this work began:

- `oci.network.vcn.defaultRouteTableId`, `defaultSecurityListId`
- `ingressSecurityRules` / `egressSecurityRules` on `oci.network.networkSecurityGroup` and `oci.network.securityList`

They shipped long ago (9.0.0 / 11.1.0 / 13.0.6) but were only *marked*
deprecated recently, so removing them here would give users no migration window.
They come out in the next major instead. Their replacements
(`defaultRouteTable`, `defaultSecurityList`, `ingressRules`, `egressRules`)
already exist.

### Verification

- `go build`, `go vet`, `go test ./...` green in `providers/oci`
- `.lr` field inventory diffed against `v14-pre`: exactly **87 removed, 0 added**
- All 73 compartment-bearing resources confirmed to have a
  `createOciResourceInCompartment` construction site; no plain `CreateResource`
  construction remains for any of them
- A `go/ast` checker validated every `CreateResource` / `NewResource` arg key
  against `oci.lr.versions`: **0 stale keys** (these are string literals the
  compiler cannot see, and fail only at query time)
- `@defaults` tokens swept for removed field names: **0 stale**
- `oci.lr.versions`: 87 entries removed, 0 added
- Regenerating produces no diff

Mondoo's own OCI policy bundle contains no MQL references to any removed field.
Custom queries using them will need updating, hence the major bump.

> **Note for reviewers:** this branch was re-derived against current `v14-pre`
> rather than rebased. Roughly 15 OCI refactor PRs landed after it was first cut,
> and they rewrote the same call sites — a rebase produced 97 conflict hunks
> across 27 files. Replaying the schema removal onto current `main` and letting
> the compiler re-enumerate the fallout was both smaller and safer. The end state
> is the same set of 87 removals.
