### PR TITLE
🛑 azure: remove all deprecated fields

### DIFF
--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -311,14 +311,14 @@ func TestCompiler_Semicolon(t *testing.T) {
 func TestCompiler_DeterministicChecksum(t *testing.T) {
 	// this is a query that in the past used to produce different checksum every now and then
 	// this test ensures that the checksum is always deterministic now
-	mql := `azure.subscription.sql.servers.all(databases.one (transparentDataEncryption["state"] == "Enabled") && encryptionProtector["serverKeyType"] == "AzureKeyVault" )`
+	mql := `azure.subscription.sql.servers.all(databases.one (transparentDataEncryptionEnabled) && encryptionProtectorServerKeyType == "AzureKeyVault" )`
 	azure_schema := testutils.MustLoadSchema(testutils.SchemaProvider{Provider: "azure"})
 
 	for range 10000 {
 		azureConf := mqlc.NewConfig(azure_schema, features)
 		res, err := mqlc.Compile(mql, mqlc.EmptyPropsHandler, azureConf)
 		require.Nil(t, err)
-		require.Equal(t, res.CodeV2.Id, "kQFJ+8v6Z98=")
+		require.Equal(t, res.CodeV2.Id, "TJlKTvhw1pU=")
 	}
 }
 

--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -290,11 +290,6 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			agentPoolProfiles, err := convert.JsonToDictSlice(entry.Properties.AgentPoolProfiles)
-			if err != nil {
-				return nil, err
-			}
-
 			var createdAt *time.Time
 			if entry.SystemData != nil {
 				createdAt = entry.SystemData.CreatedAt
@@ -406,7 +401,6 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 					"fqdn":                              llx.StringDataPtr(entry.Properties.Fqdn),
 					"fqdnSubdomain":                     llx.StringDataPtr(entry.Properties.FqdnSubdomain),
 					"privateFqdn":                       llx.StringDataPtr(entry.Properties.PrivateFQDN),
-					"agentPoolProfiles":                 llx.DictData(agentPoolProfiles),
 					"addonProfiles":                     llx.DictData(addonProfiles),
 					"httpProxyConfig":                   llx.DictData(httpProxyConfig),
 					"networkProfile":                    llx.DictData(networkProfile),

--- a/providers/azure/resources/apimanagement.go
+++ b/providers/azure/resources/apimanagement.go
@@ -138,40 +138,39 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 			}
 
 			var (
-				provisioningState              string
-				targetProvisioningState        string
-				publisherEmail                 string
-				publisherName                  string
-				notificationSenderEmail        string
-				gatewayUrl                     string
-				gatewayRegionalUrl             string
-				managementApiUrl               string
-				portalUrl                      string
-				developerPortalUrl             string
-				scmUrl                         string
-				virtualNetworkType             string
-				publicNetworkAccess            string
-				natGatewayState                string
-				disableGateway                 *bool
-				enableClientCertificate        *bool
-				developerPortalStatus          string
-				legacyPortalStatus             string
-				platformVersion                string
-				customProperties               = map[string]any{}
-				tls10Enabled                   *bool
-				tls11Enabled                   *bool
-				ssl30Enabled                   *bool
-				backendTls10Enabled            *bool
-				backendTls11Enabled            *bool
-				backendSsl30Enabled            *bool
-				tripleDesEnabled               *bool
-				http2Enabled                   *bool
-				publicIpAddresses              = []any{}
-				privateIpAddresses             = []any{}
-				outboundPublicIpAddresses      = []any{}
-				privateEndpointConnectionCount int64
-				publicIpAddressId              string
-				createdAt                      *time.Time
+				provisioningState         string
+				targetProvisioningState   string
+				publisherEmail            string
+				publisherName             string
+				notificationSenderEmail   string
+				gatewayUrl                string
+				gatewayRegionalUrl        string
+				managementApiUrl          string
+				portalUrl                 string
+				developerPortalUrl        string
+				scmUrl                    string
+				virtualNetworkType        string
+				publicNetworkAccess       string
+				natGatewayState           string
+				disableGateway            *bool
+				enableClientCertificate   *bool
+				developerPortalStatus     string
+				legacyPortalStatus        string
+				platformVersion           string
+				customProperties          = map[string]any{}
+				tls10Enabled              *bool
+				tls11Enabled              *bool
+				ssl30Enabled              *bool
+				backendTls10Enabled       *bool
+				backendTls11Enabled       *bool
+				backendSsl30Enabled       *bool
+				tripleDesEnabled          *bool
+				http2Enabled              *bool
+				publicIpAddresses         = []any{}
+				privateIpAddresses        = []any{}
+				outboundPublicIpAddresses = []any{}
+				publicIpAddressId         string
+				createdAt                 *time.Time
 			)
 			if p := svc.Properties; p != nil {
 				if p.ProvisioningState != nil {
@@ -255,7 +254,6 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 						outboundPublicIpAddresses = append(outboundPublicIpAddresses, *ip)
 					}
 				}
-				privateEndpointConnectionCount = int64(len(p.PrivateEndpointConnections))
 				if p.PublicIPAddressID != nil {
 					publicIpAddressId = *p.PublicIPAddressID
 				}
@@ -271,49 +269,48 @@ func (a *mqlAzureSubscriptionApiManagementService) services() ([]any, error) {
 
 			mqlSvc, err := CreateResource(a.MqlRuntime, "azure.subscription.apiManagementService.service",
 				map[string]*llx.RawData{
-					"id":                             llx.StringDataPtr(svc.ID),
-					"name":                           llx.StringDataPtr(svc.Name),
-					"location":                       llx.StringDataPtr(svc.Location),
-					"tags":                           llx.MapData(convert.PtrMapStrToInterface(svc.Tags), types.String),
-					"skuName":                        llx.StringData(skuName),
-					"skuCapacity":                    llx.IntDataPtr(skuCapacity),
-					"provisioningState":              llx.StringData(provisioningState),
-					"targetProvisioningState":        llx.StringData(targetProvisioningState),
-					"publisherEmail":                 llx.StringData(publisherEmail),
-					"publisherName":                  llx.StringData(publisherName),
-					"notificationSenderEmail":        llx.StringData(notificationSenderEmail),
-					"gatewayUrl":                     llx.StringData(gatewayUrl),
-					"gatewayRegionalUrl":             llx.StringData(gatewayRegionalUrl),
-					"managementApiUrl":               llx.StringData(managementApiUrl),
-					"portalUrl":                      llx.StringData(portalUrl),
-					"developerPortalUrl":             llx.StringData(developerPortalUrl),
-					"scmUrl":                         llx.StringData(scmUrl),
-					"virtualNetworkType":             llx.StringData(virtualNetworkType),
-					"publicNetworkAccess":            llx.StringData(publicNetworkAccess),
-					"natGatewayState":                llx.StringData(natGatewayState),
-					"disableGateway":                 llx.BoolDataPtr(disableGateway),
-					"enableClientCertificate":        llx.BoolDataPtr(enableClientCertificate),
-					"developerPortalStatus":          llx.StringData(developerPortalStatus),
-					"legacyPortalStatus":             llx.StringData(legacyPortalStatus),
-					"platformVersion":                llx.StringData(platformVersion),
-					"customProperties":               llx.MapData(customProperties, types.String),
-					"tls10Enabled":                   llx.BoolDataPtr(tls10Enabled),
-					"tls11Enabled":                   llx.BoolDataPtr(tls11Enabled),
-					"ssl30Enabled":                   llx.BoolDataPtr(ssl30Enabled),
-					"backendTls10Enabled":            llx.BoolDataPtr(backendTls10Enabled),
-					"backendTls11Enabled":            llx.BoolDataPtr(backendTls11Enabled),
-					"backendSsl30Enabled":            llx.BoolDataPtr(backendSsl30Enabled),
-					"tripleDesEnabled":               llx.BoolDataPtr(tripleDesEnabled),
-					"http2Enabled":                   llx.BoolDataPtr(http2Enabled),
-					"identityType":                   llx.StringData(identityType),
-					"principalId":                    llx.StringDataPtr(identityPrincipalId),
-					"tenantId":                       llx.StringDataPtr(identityTenantId),
-					"publicIpAddresses":              llx.ArrayData(publicIpAddresses, types.String),
-					"privateIpAddresses":             llx.ArrayData(privateIpAddresses, types.String),
-					"outboundPublicIpAddresses":      llx.ArrayData(outboundPublicIpAddresses, types.String),
-					"privateEndpointConnectionCount": llx.IntData(privateEndpointConnectionCount),
-					"zones":                          llx.ArrayData(zones, types.String),
-					"createdAt":                      llx.TimeDataPtr(createdAt),
+					"id":                        llx.StringDataPtr(svc.ID),
+					"name":                      llx.StringDataPtr(svc.Name),
+					"location":                  llx.StringDataPtr(svc.Location),
+					"tags":                      llx.MapData(convert.PtrMapStrToInterface(svc.Tags), types.String),
+					"skuName":                   llx.StringData(skuName),
+					"skuCapacity":               llx.IntDataPtr(skuCapacity),
+					"provisioningState":         llx.StringData(provisioningState),
+					"targetProvisioningState":   llx.StringData(targetProvisioningState),
+					"publisherEmail":            llx.StringData(publisherEmail),
+					"publisherName":             llx.StringData(publisherName),
+					"notificationSenderEmail":   llx.StringData(notificationSenderEmail),
+					"gatewayUrl":                llx.StringData(gatewayUrl),
+					"gatewayRegionalUrl":        llx.StringData(gatewayRegionalUrl),
+					"managementApiUrl":          llx.StringData(managementApiUrl),
+					"portalUrl":                 llx.StringData(portalUrl),
+					"developerPortalUrl":        llx.StringData(developerPortalUrl),
+					"scmUrl":                    llx.StringData(scmUrl),
+					"virtualNetworkType":        llx.StringData(virtualNetworkType),
+					"publicNetworkAccess":       llx.StringData(publicNetworkAccess),
+					"natGatewayState":           llx.StringData(natGatewayState),
+					"disableGateway":            llx.BoolDataPtr(disableGateway),
+					"enableClientCertificate":   llx.BoolDataPtr(enableClientCertificate),
+					"developerPortalStatus":     llx.StringData(developerPortalStatus),
+					"legacyPortalStatus":        llx.StringData(legacyPortalStatus),
+					"platformVersion":           llx.StringData(platformVersion),
+					"customProperties":          llx.MapData(customProperties, types.String),
+					"tls10Enabled":              llx.BoolDataPtr(tls10Enabled),
+					"tls11Enabled":              llx.BoolDataPtr(tls11Enabled),
+					"ssl30Enabled":              llx.BoolDataPtr(ssl30Enabled),
+					"backendTls10Enabled":       llx.BoolDataPtr(backendTls10Enabled),
+					"backendTls11Enabled":       llx.BoolDataPtr(backendTls11Enabled),
+					"backendSsl30Enabled":       llx.BoolDataPtr(backendSsl30Enabled),
+					"tripleDesEnabled":          llx.BoolDataPtr(tripleDesEnabled),
+					"http2Enabled":              llx.BoolDataPtr(http2Enabled),
+					"identityType":              llx.StringData(identityType),
+					"principalId":               llx.StringDataPtr(identityPrincipalId),
+					"tenantId":                  llx.StringDataPtr(identityTenantId),
+					"publicIpAddresses":         llx.ArrayData(publicIpAddresses, types.String),
+					"privateIpAddresses":        llx.ArrayData(privateIpAddresses, types.String),
+					"outboundPublicIpAddresses": llx.ArrayData(outboundPublicIpAddresses, types.String),
+					"zones":                     llx.ArrayData(zones, types.String),
+					"createdAt":                 llx.TimeDataPtr(createdAt),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -26,6 +26,7 @@ import (
 type mqlAzureSubscriptionContainerAppServiceContainerAppInternal struct {
 	cacheSystemData              any
 	cacheUserAssignedIdentityIds []string
+	cacheIdentityTenantId        string
 	cacheRGAndName               struct {
 		resourceGroup string
 		name          string
@@ -249,7 +250,7 @@ func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) userAssignedIdenti
 }
 
 func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantIDFromIdentityDict(a.Identity), &a.SystemAssignedIdentity)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, a.cacheIdentityTenantId, &a.SystemAssignedIdentity)
 }
 
 // managedEnvironment resolves the parent managed environment of the container
@@ -775,7 +776,6 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 	registries := []any{}
 	registryUsesIdentity := false
 	secretNames := []any{}
-	identity := map[string]any{}
 	scaleRules := []any{}
 	volumes := []any{}
 	var minReplicas, maxReplicas *int32
@@ -911,14 +911,13 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 
 	var principalId *string
 	var userAssignedIdentityIds []string
+	var identityTenantId string
 	if entry.Identity != nil {
-		d, err := convert.JsonToDict(entry.Identity)
-		if err != nil {
-			return nil, err
-		}
-		identity = d
 		principalId = entry.Identity.PrincipalID
 		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(entry.Identity.UserAssignedIdentities)
+		if entry.Identity.TenantID != nil {
+			identityTenantId = *entry.Identity.TenantID
+		}
 	}
 	if entry.Kind != nil {
 		kind = string(*entry.Kind)
@@ -952,7 +951,6 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 			"minReplicas":              llx.IntDataDefault(minReplicas, 0),
 			"maxReplicas":              llx.IntDataDefault(maxReplicas, 0),
 			"scaleRules":               llx.ArrayData(scaleRules, types.Dict),
-			"identity":                 llx.DictData(identity),
 			"principalId":              llx.StringDataPtr(principalId),
 			"registries":               llx.ArrayData(registries, types.Dict),
 			"registryAuthUsesIdentity": llx.BoolData(registryUsesIdentity),
@@ -965,6 +963,7 @@ func acaContainerAppToMQL(runtime *plugin.Runtime, entry *apps.ContainerApp) (pl
 
 	appRes := mqlApp.(*mqlAzureSubscriptionContainerAppServiceContainerApp)
 	appRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+	appRes.cacheIdentityTenantId = identityTenantId
 	rg, name := resourceGroupAndName(appRes.Id.Data, "containerApps")
 	appRes.cacheRGAndName.resourceGroup = rg
 	appRes.cacheRGAndName.name = name

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -644,12 +644,6 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   resiliencyProfile dict
   // Scheduled-events policy (UserInitiatedReboot, UserInitiatedRedeploy, additional publishing targets)
   scheduledEventsPolicy dict
-  // Azure Resource Manager system metadata
-  //
-  // Deprecated in favor of systemMetadata, which exposes createdBy,
-  // createdByType, createdAt, lastModifiedBy, lastModifiedByType, and
-  // lastModifiedAt as typed fields.
-  systemData @maturity("deprecated") dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
   // VM computer name (OS hostname)
@@ -804,12 +798,6 @@ azure.subscription.computeService.hybridMachine @defaults("name location osName 
   licenseProfile dict
   // Raw HybridCompute machine properties
   properties dict
-  // Azure Resource Manager system metadata
-  //
-  // Deprecated in favor of systemMetadata, which exposes createdBy,
-  // createdByType, createdAt, lastModifiedBy, lastModifiedByType, and
-  // lastModifiedAt as typed fields.
-  systemData @maturity("deprecated") dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
   // Installed Arc machine extensions
@@ -844,12 +832,6 @@ private azure.subscription.computeService.hybridMachine.extension @defaults("nam
   settings dict
   // Tag used to trigger a re-run of the extension handler even when settings are unchanged
   forceUpdateTag string
-  // Azure Resource Manager system metadata
-  //
-  // Deprecated in favor of systemMetadata, which exposes createdBy,
-  // createdByType, createdAt, lastModifiedBy, lastModifiedByType, and
-  // lastModifiedAt as typed fields.
-  systemData @maturity("deprecated") dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
   // Latest extension instance view reported by the handler (status code, level, display status, message)
@@ -937,12 +919,6 @@ azure.subscription.computeService.disk @defaults("name location properties.osTyp
   diskAccessId string
   // Behavior when the disk experiences slow I/O (AutomaticReattach)
   availabilityPolicy dict
-  // Azure Resource Manager system metadata
-  //
-  // Deprecated in favor of systemMetadata, which exposes createdBy,
-  // createdByType, createdAt, lastModifiedBy, lastModifiedByType, and
-  // lastModifiedAt as typed fields.
-  systemData @maturity("deprecated") dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
@@ -1093,12 +1069,6 @@ azure.subscription.computeService.snapshot @defaults("name location diskSizeByte
   immutabilityPolicyStartTime time
   // When the immutability policy expires on the snapshot
   immutabilityPolicyExpirationTime time
-  // Azure Resource Manager system metadata
-  //
-  // Deprecated in favor of systemMetadata, which exposes createdBy,
-  // createdByType, createdAt, lastModifiedBy, lastModifiedByType, and
-  // lastModifiedAt as typed fields.
-  systemData @maturity("deprecated") dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
   // Source disk for this snapshot (resolved from creationData.sourceResourceId when it points to a managed disk)
@@ -1174,12 +1144,6 @@ azure.subscription.computeService.vmScaleSet @defaults("name location orchestrat
   vtpmEnabled bool
   // Align mode between VMSS compute and storage Fault Domain count
   zonalPlatformFaultDomainAlignMode string
-  // Azure Resource Manager system metadata
-  //
-  // Deprecated in favor of systemMetadata, which exposes createdBy,
-  // createdByType, createdAt, lastModifiedBy, lastModifiedByType, and
-  // lastModifiedAt as typed fields.
-  systemData @maturity("deprecated") dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
   // VMs that belong to this scale set
@@ -1551,10 +1515,6 @@ azure.subscription.batchService.account @defaults("id name location") {
   tags map[string]string
   // Batch account type
   type string
-  // Raw identity block for the Batch account
-  //
-  // Deprecated in favor of principalId and userAssignedIdentities.
-  identity @maturity("deprecated") dict
   // Principal ID of the account's system-assigned managed identity; empty when only user-assigned identities are used
   principalId string
   // User-assigned managed identities attached to the Batch account
@@ -1593,18 +1553,6 @@ azure.subscription.batchService.account @defaults("id name location") {
   poolQuota int
   // Batch account allowed authentication modes
   allowedAuthenticationModes []string
-  // Batch account auto storage settings
-  //
-  // Deprecated in favor of autoStorageAccount.
-  autoStorage @maturity("deprecated") dict
-  // Batch account encryption settings
-  //
-  // Deprecated in favor of encryptionKey.
-  encryption @maturity("deprecated") dict
-  // Batch account key vault reference
-  //
-  // Deprecated in favor of keyVault.
-  keyVaultReference @maturity("deprecated") dict
   // Storage account used for auto-storage by the Batch account
   autoStorageAccount() azure.subscription.storageService.account
   // Key Vault associated with the Batch account for user-subscription pool allocation
@@ -2195,12 +2143,6 @@ azure.subscription.networkService.virtualNetworkGateway @defaults("id name locat
   // lifetimes. Empty when the gateway has no point-to-site configuration
   // or uses Azure default cryptography.
   vpnClientIpsecPolicies() []azure.subscription.networkService.virtualNetworkGateway.connection.ipsecPolicy
-  // VPN client configuration, set only when P2S is configured
-  //
-  // Deprecated in favor of vpnClientAuthenticationTypes,
-  // vpnClientAddressPool, aadTenant, aadAudience, aadIssuer, and
-  // radiusAuthenticationConfigured.
-  vpnClientConfiguration @maturity("deprecated") dict
   // Point-to-site client authentication types enabled ("AAD", "Certificate", "Radius"); empty when P2S is not configured
   vpnClientAuthenticationTypes []string
   // Address pool (CIDRs) assigned to point-to-site VPN clients
@@ -2314,10 +2256,6 @@ private azure.subscription.networkService.firewall.networkRule @defaults("name a
   name string
   // Firewall network rule etag
   etag string
-  // Raw rule collection properties
-  //
-  // Deprecated in favor of action, priority, and rules.
-  properties @maturity("deprecated") dict
   // Action applied to traffic matching a rule in this collection ("Allow" or "Deny")
   action string
   // Evaluation priority of the rule collection; lower numbers are evaluated first
@@ -2334,10 +2272,6 @@ private azure.subscription.networkService.firewall.applicationRule @defaults("na
   name string
   // Firewall application rule etag
   etag string
-  // Raw rule collection properties
-  //
-  // Deprecated in favor of action, priority, and rules.
-  properties @maturity("deprecated") dict
   // Action applied to traffic matching a rule in this collection ("Allow" or "Deny")
   action string
   // Evaluation priority of the rule collection; lower numbers are evaluated first
@@ -2354,10 +2288,6 @@ private azure.subscription.networkService.firewall.natRule @defaults("name actio
   name string
   // Firewall NAT rule etag
   etag string
-  // Raw rule collection properties
-  //
-  // Deprecated in favor of action, priority, and rules.
-  properties @maturity("deprecated") dict
   // NAT action applied by this collection ("Dnat" or "Snat")
   action string
   // Evaluation priority of the rule collection; lower numbers are evaluated first
@@ -2451,20 +2381,10 @@ private azure.subscription.networkService.firewallPolicy.idpsBypassRule @default
   protocol string
   // Source IP addresses or ranges
   sourceAddresses []string
-  // Source IP group IDs
-  //
-  // Deprecated in favor of sourceIpGroupRefs, which resolves each IP group to
-  // its typed resource.
-  sourceIpGroups @maturity("deprecated") []string
   // Source IP groups referenced by the bypass rule
   sourceIpGroupRefs() []azure.subscription.networkService.ipGroup
   // Destination IP addresses or ranges
   destinationAddresses []string
-  // Destination IP group IDs
-  //
-  // Deprecated in favor of destinationIpGroupRefs, which resolves each IP
-  // group to its typed resource.
-  destinationIpGroups @maturity("deprecated") []string
   // Destination IP groups referenced by the bypass rule
   destinationIpGroupRefs() []azure.subscription.networkService.ipGroup
   // Destination ports or ranges
@@ -2964,10 +2884,6 @@ azure.subscription.networkService.virtualNetwork.peering @defaults("id name peer
   peeringSyncLevel string
   // The provisioning state: Succeeded, Updating, Deleting, Failed, Creating, Canceled
   provisioningState string
-  // The remote virtual network reference ID
-  //
-  // Deprecated in favor of remoteVirtualNetwork.
-  remoteVirtualNetworkId @maturity("deprecated") string
   // The peered remote virtual network
   remoteVirtualNetwork() azure.subscription.networkService.virtualNetwork
   // Whether traffic between the two VNets is encrypted (Azure global VNet peering encryption)
@@ -3101,11 +3017,6 @@ private azure.subscription.networkService.frontendIpConfig @defaults("id name") 
   zones []string
   // Whether this frontend IP configuration uses a public IP address
   isPublic bool
-  // Resource ID of the associated public IP address
-  //
-  // Deprecated in favor of publicIpAddress, which resolves to the typed public
-  // IP address resource.
-  publicIpAddressId @maturity("deprecated") string
   // Public IP address bound to this frontend (internet-facing); null for an internal frontend
   publicIpAddress() azure.subscription.networkService.ipAddress
   // Subnet the frontend is bound to (internal load balancer); null for a public frontend
@@ -3174,10 +3085,6 @@ azure.subscription.networkService.interface @defaults("name location properties.
   enableAcceleratedNetworking bool
   // Whether this is a primary network interface on a VM
   primary bool
-  // Raw network security group resource ID
-  //
-  // Deprecated in favor of `networkSecurityGroup()`.
-  networkSecurityGroupId @maturity("deprecated") string
   // Network security group attached to the NIC; null when the NIC inherits NSG enforcement from its subnet only
   networkSecurityGroup() azure.subscription.networkService.securityGroup
   // Custom DNS servers configured on the network interface (overrides VNet-level DNS); empty when the NIC inherits VNet DNS
@@ -3186,12 +3093,6 @@ azure.subscription.networkService.interface @defaults("name location properties.
   appliedDnsServers []string
   // Internal DNS name label assigned to the NIC; empty when unset
   internalDnsNameLabel string
-  // Raw IP configuration dicts
-  //
-  // Deprecated in favor of ipConfigs, which exposes each IP configuration as a
-  // resource with typed subnet, public IP, and application security group
-  // references.
-  ipConfigurations @maturity("deprecated") []dict
   // IP configurations bound to the network interface
   ipConfigs() []azure.subscription.networkService.interface.ipConfiguration
   // Network interface compute vm
@@ -3626,19 +3527,10 @@ private azure.subscription.networkService.watcher.flowlog @defaults("name locati
   version int
   // Network watcher flow log format
   format string
-  // Network watcher flow log retention policy
-  //
-  // Deprecated in favor of retentionEnabled and retentionDays.
-  retentionPolicy @maturity("deprecated") dict
   // Whether a retention policy is enforced on the flow logs
   retentionEnabled bool
   // Number of days flow logs are retained; 0 means logs are retained indefinitely
   retentionDays int
-  // Network watcher flow log analytics
-  //
-  // Deprecated in favor of trafficAnalyticsEnabled,
-  // trafficAnalyticsInterval, and trafficAnalyticsWorkspaceId.
-  analytics @maturity("deprecated") dict
   // Whether Traffic Analytics is enabled for the flow logs
   trafficAnalyticsEnabled bool
   // Traffic Analytics processing interval, in minutes
@@ -3891,11 +3783,6 @@ private azure.subscription.networkService.applicationGateway.sslCertificate @def
   id string
   // Certificate name
   name string
-  // Key Vault secret URI backing the certificate
-  //
-  // Deprecated in favor of keyVaultSecret, which resolves the typed Key
-  // Vault secret. Empty when the certificate was uploaded directly.
-  keyVaultSecretId @maturity("deprecated") string
   // Key Vault secret backing the certificate (null when the cert was uploaded directly)
   keyVaultSecret() azure.subscription.keyVaultService.secret
   // Base64-encoded public certificate data
@@ -4071,10 +3958,6 @@ azure.subscription.networkService.applicationFirewallPolicy @defaults("id name l
   properties dict
   // Policy enforcement mode ("Prevention" blocks matching requests; "Detection" only logs them)
   mode string
-  // Policy enabled state
-  //
-  // Deprecated in favor of enabled, which exposes this as a boolean.
-  enabledState @maturity("deprecated") string
   // Whether the policy is enabled
   enabled bool
   // Whether the request body is inspected by the WAF
@@ -4274,10 +4157,6 @@ private azure.subscription.networkService.privateEndpoint @defaults("id name loc
   type string
   // Provisioning state of the private endpoint
   provisioningState string
-  // Subnet ID from which the private IP is allocated
-  //
-  // Deprecated in favor of subnet.
-  subnetId @maturity("deprecated") string
   // Subnet the private endpoint's network interface is allocated in; null when the endpoint has no subnet
   //
   // Resolves the subnet hosting the private endpoint so its network security
@@ -4305,15 +4184,11 @@ private azure.subscription.networkService.privateEndpoint @defaults("id name loc
 }
 
 // Azure network private endpoint service connection
-private azure.subscription.networkService.privateEndpoint.serviceconnection @defaults("name privateLinkServiceId") {
+private azure.subscription.networkService.privateEndpoint.serviceconnection @defaults("name connectionStatus") {
   // Connection ID
   id string
   // Connection name
   name string
-  // Raw private link service resource ID
-  //
-  // Deprecated in favor of `privateLinkService()`.
-  privateLinkServiceId @maturity("deprecated") string
   // Private link service being connected to
   privateLinkService() azure.subscription.networkService.privateLinkService
   // Group IDs obtained from the remote resource
@@ -4461,10 +4336,6 @@ azure.subscription.networkService.trafficManagerProfile @defaults("id name locat
   type string
   // Traffic Manager profile properties
   properties dict
-  // Profile status
-  //
-  // Deprecated in favor of status, which exposes this as a boolean.
-  profileStatus @maturity("deprecated") string
   // Whether the profile is enabled
   status bool
   // Traffic routing method ("Performance", "Weighted", "Priority", "Geographic", "MultiValue", "Subnet")
@@ -4507,10 +4378,6 @@ private azure.subscription.networkService.trafficManagerProfile.endpoint @defaul
   type string
   // Endpoint properties
   properties dict
-  // Endpoint status
-  //
-  // Deprecated in favor of status, which exposes this as a boolean.
-  endpointStatus @maturity("deprecated") string
   // Whether the endpoint is enabled
   status bool
   // Most recent monitor probe result ("CheckingEndpoint", "Online", "Degraded", "Disabled", "Inactive", "Stopped")
@@ -5534,12 +5401,6 @@ private azure.subscription.storageService.account @defaults("id name location") 
   // fields, the encryption fields, and so on); prefer those over reading
   // raw keys here.
   properties dict
-  // Storage account identity
-  //
-  // Deprecated in favor of principalId, tenantId, userAssignedIdentities,
-  // and encryptionIdentity, which expose the managed identity configuration
-  // as typed accessors.
-  identity @maturity("deprecated") dict
   // Principal ID of the account's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
   // Tenant ID of the account's managed identity; empty when no managed identity is configured
@@ -6077,10 +5938,6 @@ private azure.subscription.storageService.account.privateEndpointConnection @def
   name string
   // Resource type
   type string
-  // ARM resource ID of the consumer-side private endpoint, when present
-  //
-  // Deprecated in favor of privateEndpoint.
-  privateEndpointId @maturity("deprecated") string
   // Consumer-side private endpoint, or null when the connection has none
   //
   // Resolves the private endpoint connecting to this storage account so the
@@ -6309,10 +6166,6 @@ azure.subscription.webService.appsite @defaults("id name location") {
   tags map[string]string
   // App site properties
   properties dict
-  // App site identity
-  //
-  // Deprecated in favor of principalId, userAssignedIdentities, and identityType.
-  identity @maturity("deprecated") dict
   // Managed identity type ("None", "SystemAssigned", "UserAssigned", "SystemAssigned,UserAssigned")
   identityType string
   // Principal ID of the app's system-assigned managed identity; empty when no system-assigned identity is enabled
@@ -6424,10 +6277,6 @@ private azure.subscription.privateEndpointConnection @defaults("id name type") {
   // return an empty list; the addresses are always available through
   // privateEndpoint and its network interfaces.
   ipAddresses []string
-  // Raw private endpoint resource ID
-  //
-  // Deprecated in favor of `privateEndpoint()`.
-  privateEndpointId @maturity("deprecated") string
   // Associated private endpoint
   privateEndpoint() azure.subscription.networkService.privateEndpoint
   // Private link service connection state details
@@ -6888,28 +6737,8 @@ private azure.subscription.sqlService.server @defaults("name location properties
   firewallRules() []azure.subscription.sqlService.firewallrule
   // SQL Database server Entra ID administrators
   azureAdAdministrators() []azure.subscription.sqlService.server.administrator
-  // Raw server connection policy
-  //
-  // Deprecated in favor of `connectionType`.
-  connectionPolicy() @maturity("deprecated") dict
-  // Raw server auditing policy
-  //
-  // Deprecated in favor of `blobAuditingPolicy`.
-  auditingPolicy() @maturity("deprecated") dict
   // SQL Database server administrator login
   administratorLogin string
-  // Raw server security alert policy
-  //
-  // Deprecated in favor of `securityAlertPolicyConfig`.
-  securityAlertPolicy() @maturity("deprecated") dict
-  // Raw server encryption protector
-  //
-  // Deprecated in favor of `encryptionProtectorConfig`.
-  encryptionProtector() @maturity("deprecated") dict
-  // Legacy preview threat detection policy
-  //
-  // Deprecated in favor of `securityAlertPolicyConfig` and `advancedThreatProtectionSetting`.
-  threatDetectionPolicy() @maturity("deprecated") dict
   // SQL Database server vulnerability assessment settings
   vulnerabilityAssessmentSettings() azure.subscription.sqlService.server.vulnerabilityassessmentsettings
   virtualNetworkRules() []azure.subscription.sqlService.virtualNetworkRule
@@ -7052,10 +6881,6 @@ private azure.subscription.sqlService.database @defaults("name edition zoneRedun
   sampleName string
   // Whether the database is zone redundant
   zoneRedundant bool
-  // Raw transparent data encryption configuration
-  //
-  // Deprecated in favor of `transparentDataEncryptionEnabled`.
-  transparentDataEncryption() @maturity("deprecated") dict
   // Automatic tuning advisors for the database
   //
   // Raw Database Advisor objects returned by Azure SQL. Each entry has
@@ -7063,18 +6888,6 @@ private azure.subscription.sqlService.database @defaults("name edition zoneRedun
   // `recommendedActions` list holds the index and query-plan
   // recommendations Azure SQL generated for the database.
   advisor() []dict
-  // Legacy preview threat detection policy
-  //
-  // Deprecated in favor of `securityAlertPolicy`.
-  threatDetectionPolicy() @maturity("deprecated") dict
-  // Legacy per-database connection policy
-  //
-  // Deprecated, please use `azure.subscription.sqlService.server.connectionType`. Azure SQL DB has no per-database connection policy.
-  connectionPolicy() @maturity("deprecated") dict
-  // Raw database auditing policy
-  //
-  // Deprecated in favor of `blobAuditingPolicy`.
-  auditingPolicy() @maturity("deprecated") dict
   // SQL database advanced threat protection settings
   advancedThreatProtection() azure.subscription.sqlService.database.advancedthreatprotection
   // SQL database backup short-term retention policy
@@ -9338,73 +9151,33 @@ private azure.subscription.monitorService.diagnosticSettingsCategory @defaults("
 // access policies, alert suppression rules, workspace settings, and security
 // contacts. Audit it to confirm the intended protections are turned on and to
 // review the subscription's overall security posture.
-private azure.subscription.cloudDefenderService @defaults("defenderForServers.enabled defenderForContainers.enabled"){
+private azure.subscription.cloudDefenderService @defaults("forServers.enabled forContainers.enabled"){
   // Subscription identifier
   subscriptionId string
   // Whether the monitoring agent is automatically provisioned on new VMs
   monitoringAgentAutoProvision() bool
   // List of Defender for Servers components and whether they are enabled
-  //
-  // Deprecated in favor of `forServers`.
-  defenderForServers() @maturity("deprecated") dict
-  // List of Defender for Servers components and whether they are enabled
   forServers() azure.subscription.cloudDefenderService.defenderForServers
-  // Microsoft Defender for App Service configuration
-  //
-  // Deprecated in favor of `forAppServices`.
-  defenderForAppServices() @maturity("deprecated") dict
   // Microsoft Defender for App Service configuration
   forAppServices() azure.subscription.cloudDefenderService.defenderForAppServices
   // Microsoft Defender for SQL servers on machines configuration
-  //
-  // Deprecated in favor of `forSqlServersOnMachines`.
-  defenderForSqlServersOnMachines() @maturity("deprecated") dict
-  // Microsoft Defender for SQL servers on machines configuration
   forSqlServersOnMachines() azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines
-  // Microsoft Defender for Azure SQL Databases configuration
-  //
-  // Deprecated in favor of `forSqlDatabases`.
-  defenderForSqlDatabases() @maturity("deprecated") dict
   // Microsoft Defender for Azure SQL Databases configuration
   forSqlDatabases() azure.subscription.cloudDefenderService.defenderForSqlDatabases
   // Microsoft Defender for open-source relational databases configuration
-  //
-  // Deprecated in favor of `forOpenSourceDatabases`.
-  defenderForOpenSourceDatabases() @maturity("deprecated") dict
-  // Microsoft Defender for open-source relational databases configuration
   forOpenSourceDatabases() azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases
-  // Microsoft Defender for Azure Cosmos DB configuration
-  //
-  // Deprecated in favor of `forCosmosDb`.
-  defenderForCosmosDb() @maturity("deprecated") dict
   // Microsoft Defender for Azure Cosmos DB configuration
   forCosmosDb() azure.subscription.cloudDefenderService.defenderForCosmosDb
   // Microsoft Defender for Storage Accounts configuration
-  //
-  // Deprecated in favor of `forStorageAccounts`.
-  defenderForStorageAccounts() @maturity("deprecated") dict
-  // Microsoft Defender for Storage Accounts configuration
   forStorageAccounts() azure.subscription.cloudDefenderService.defenderForStorageAccounts
   // Microsoft Defender for Key Vault configuration
-  //
-  // Deprecated in favor of `forKeyVaults`.
-  defenderForKeyVaults() @maturity("deprecated") dict
-  // Microsoft Defender for Key Vault configuration
   forKeyVaults() azure.subscription.cloudDefenderService.defenderForKeyVaults
-  // Microsoft Defender for Resource Manager configuration
-  //
-  // Deprecated in favor of `forResourceManager`.
-  defenderForResourceManager() @maturity("deprecated") dict
   // Microsoft Defender for Resource Manager configuration
   forResourceManager() azure.subscription.cloudDefenderService.defenderForResourceManager
   // Microsoft Defender for APIs configuration
   defenderForApis() azure.subscription.cloudDefenderService.defenderForApis
   // Microsoft Defender Cloud Security Posture Management (CSPM) configuration
   defenderCSPM() azure.subscription.cloudDefenderService.defenderCSPM
-  // Defender for Containers components configuration
-  //
-  // Deprecated in favor of `forContainers`.
-  defenderForContainers() @maturity("deprecated") dict
   // Defender for Containers components configuration
   forContainers() azure.subscription.cloudDefenderService.defenderForContainers
   // List of configured security contacts
@@ -10539,12 +10312,6 @@ private azure.subscription.authorizationService.roleDefinition.permission @defau
 private azure.subscription.authorizationService.roleAssignment  @defaults("principalId principalType role.name") {
   id string
   description string
-  // Principal type of the assignment
-  //
-  // Deprecated in favor of `principalType`, which carries the same value
-  // under a correctly descriptive name (this field is named `type` but
-  // holds the principal type, not the ARM resource type).
-  type @maturity("deprecated") string
   scope string
   principalId string
   // Type of the assigned principal ("User", "Group", "ServicePrincipal", "ForeignGroup", or "Device")
@@ -10688,10 +10455,6 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   // or `ingressApplicationGateway`) and whose value is an object with
   // `enabled`, `config`, and `identity`.
   addonProfiles []dict
-  // Raw agent pool profiles attached to the cluster
-  //
-  // Deprecated in favor of `nodePools()`.
-  agentPoolProfiles @maturity("deprecated") []dict
   // Node pools (agent pools) attached to the cluster
   nodePools() []azure.subscription.aksService.cluster.nodePool
   // Kubernetes API server access configuration
@@ -11300,10 +11063,6 @@ private azure.subscription.policy.complianceSummary @defaults("nonCompliantResou
 private azure.subscription.iotService {
   // Subscription identifier
   subscriptionId string
-  // Raw IoT hubs in the subscription
-  //
-  // Deprecated in favor of `iotHubs`.
-  hubs() @maturity("deprecated") []dict
   // Typed IoT hubs in the subscription
   iotHubs() []azure.subscription.iotService.iotHub
 }
@@ -11473,13 +11232,6 @@ azure.subscription.cacheService.redisInstance @defaults("id hostName") {
   principalId string
   // User-assigned managed identities attached to the cache
   userAssignedIdentities() []azure.subscription.managedIdentity
-  // Key Vault key used for customer-managed encryption
-  //
-  // Deprecated in favor of the Redis Enterprise resources. Always null:
-  // customer-managed key encryption is not available on Azure Cache for
-  // Redis, only on Redis Enterprise / Azure Managed Redis, and the Redis
-  // management API exposes no encryption model on this resource.
-  encryptionKey() @maturity("deprecated") azure.subscription.keyVaultService.key
   // Private endpoint connections for the Redis cache
   privateEndpointConnections() []azure.subscription.cacheService.redisInstance.privateEndpointConnection
   // Firewall rules for the Redis cache
@@ -11528,10 +11280,6 @@ private azure.subscription.cacheService.redisInstance.privateEndpointConnection 
   name string
   // Private endpoint connection type
   type string
-  // Raw private endpoint resource ID
-  //
-  // Deprecated in favor of `privateEndpoint()`.
-  privateEndpointId @maturity("deprecated") string
   // Associated private endpoint
   privateEndpoint() azure.subscription.networkService.privateEndpoint
   // Connection status (Approved, Pending, Rejected)
@@ -11595,27 +11343,6 @@ azure.subscription.dataFactoryService.factory @defaults("name location") {
   // (Azure DevOps only), repositoryName, collaborationBranch, rootFolder,
   // and lastCommitId. Null when the factory is not bound to a repository.
   repoConfiguration dict
-  // Encryption configuration
-  //
-  // Deprecated in favor of cmkKeyName, cmkKeyVaultUri, cmkKeyVersion, and
-  // cmkUserAssignedIdentity.
-  encryption @maturity("deprecated") dict
-  // Customer-managed key name in Key Vault used to encrypt the factory
-  //
-  // Deprecated in favor of cmkKey.
-  cmkKeyName @maturity("deprecated") string
-  // Key Vault base URL backing the customer-managed encryption key
-  //
-  // Deprecated in favor of cmkKey.
-  cmkKeyVaultUri @maturity("deprecated") string
-  // Version of the customer-managed encryption key
-  //
-  // Deprecated in favor of cmkKey.
-  cmkKeyVersion @maturity("deprecated") string
-  // User-assigned identity resource ID used to access the customer-managed key
-  //
-  // Deprecated in favor of cmkIdentity.
-  cmkUserAssignedIdentity @maturity("deprecated") string
   // Customer-managed key in Key Vault used to encrypt the factory (null for platform-managed encryption)
   cmkKey() azure.subscription.keyVaultService.key
   // User-assigned managed identity used to access the customer-managed encryption key (null when the factory's system-assigned identity is used)
@@ -11958,11 +11685,6 @@ azure.subscription.containerRegistryService.registry @defaults("id name location
   tags map[string]string
   // SKU name ("Basic", "Standard", or "Premium")
   skuName string
-  // Identity configuration
-  //
-  // Deprecated in favor of principalId, tenantId, and userAssignedIdentities,
-  // which expose the managed identity configuration as typed accessors.
-  identity @maturity("deprecated") dict
   // Principal ID of the registry's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
   // Tenant ID of the registry's managed identity; empty when no managed identity is configured
@@ -12852,10 +12574,6 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
   clientCertEnabled bool
   // Client certificate mode (Required, Optional, OptionalInteractiveUser)
   clientCertMode string
-  // Managed service identity ID
-  //
-  // Deprecated in favor of principalId and userAssignedIdentities.
-  managedServiceIdentityId @maturity("deprecated") string
   // Principal ID of the function app's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
   // System-assigned managed identity of the function app; null when no system-assigned identity is enabled
@@ -13006,10 +12724,6 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
   // Each entry has keys `keyName`, `keyVaultUri`, `keyVersion`, and
   // `identity` (the user-assigned identity used to reach the vault).
   cmkKeys []dict
-  // Raw namespace network rule set
-  //
-  // Deprecated in favor of `networkRules()`.
-  networkRuleSet() @maturity("deprecated") dict
   // Namespace network rules (default action, public network access, IP / VNet rules, trusted-service access)
   networkRules() azure.subscription.serviceBusService.namespace.networkRules
   // Queues in this namespace
@@ -13249,10 +12963,6 @@ azure.subscription.eventHubService.namespace @defaults("id name location") {
   // `keyName`, `keyVaultUri`, `keyVersion`, and an `identity` used to
   // reach the key.
   cmkKeys []dict
-  // Raw namespace network rule set
-  //
-  // Deprecated in favor of `networkRules()`.
-  networkRuleSet() @maturity("deprecated") dict
   // Namespace network rules (default action, public network access, IP / VNet rules, trusted-service access)
   networkRules() azure.subscription.eventHubService.namespace.networkRules
   // Event Hubs in this namespace
@@ -14498,10 +14208,6 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   //   azureQueue: {queueName, queueLength}
   //   custom:     {type, metadata, identity}
   scaleRules []dict
-  // Identity block (system + user-assigned principal IDs)
-  //
-  // Deprecated in favor of principalId and userAssignedIdentities.
-  identity @maturity("deprecated") dict
   // Principal ID of the container app's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
   // System-assigned managed identity of the container app; null when no system-assigned identity is enabled
@@ -14789,12 +14495,6 @@ private azure.subscription.containerInstanceService.containerGroup.container @de
   // Keys: exec, httpGet, initialDelaySeconds, periodSeconds,
   // failureThreshold, successThreshold, and timeoutSeconds.
   readinessProbe dict
-  // Raw security context
-  //
-  // Deprecated in favor of privileged, allowPrivilegeEscalation,
-  // runAsUser, runAsGroup, seccompProfile, addedCapabilities, and
-  // droppedCapabilities.
-  securityContext @maturity("deprecated") dict
   // Whether the container runs in privileged mode (full host access)
   privileged bool
   // Whether a process can gain more privileges than its parent
@@ -15036,10 +14736,6 @@ azure.subscription.apiManagementService.service @defaults("name location skuName
   privateIpAddresses []string
   // Outbound public IPv4 prefixes associated with NAT Gateway-deployed services (Premium SKU on stv2)
   outboundPublicIpAddresses []string
-  // Number of private endpoint connections to the service
-  //
-  // Deprecated in favor of `privateEndpointConnections`.
-  privateEndpointConnectionCount @maturity("deprecated") int
   // Private endpoint connections to the service
   privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Availability zones the service is spread across
@@ -16610,10 +16306,6 @@ private azure.subscription.cognitiveServicesService.account.raiTopic @defaults("
   failedReason string
   // URL of the sample blob used to train the topic
   sampleBlobUrl string
-  // When the topic was created
-  //
-  // Deprecated in favor of creationTime.
-  createdAt @maturity("deprecated") time
   // When the topic was created
   creationTime time
   // When the topic was last modified

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -3201,9 +3201,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.vm.scheduledEventsPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetScheduledEventsPolicy()).ToDataRes(types.Dict)
 	},
-	"azure.subscription.computeService.vm.systemData": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetSystemData()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.computeService.vm.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVm).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -3369,9 +3366,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.hybridMachine.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceHybridMachine).GetProperties()).ToDataRes(types.Dict)
 	},
-	"azure.subscription.computeService.hybridMachine.systemData": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionComputeServiceHybridMachine).GetSystemData()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.computeService.hybridMachine.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceHybridMachine).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -3416,9 +3410,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.hybridMachine.extension.forceUpdateTag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceHybridMachineExtension).GetForceUpdateTag()).ToDataRes(types.String)
-	},
-	"azure.subscription.computeService.hybridMachine.extension.systemData": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionComputeServiceHybridMachineExtension).GetSystemData()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.computeService.hybridMachine.extension.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceHybridMachineExtension).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -3524,9 +3515,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.disk.availabilityPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDisk).GetAvailabilityPolicy()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.computeService.disk.systemData": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionComputeServiceDisk).GetSystemData()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.computeService.disk.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceDisk).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -3687,9 +3675,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.snapshot.immutabilityPolicyExpirationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetImmutabilityPolicyExpirationTime()).ToDataRes(types.Time)
 	},
-	"azure.subscription.computeService.snapshot.systemData": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetSystemData()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.computeService.snapshot.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -3782,9 +3767,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.vmScaleSet.zonalPlatformFaultDomainAlignMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetZonalPlatformFaultDomainAlignMode()).ToDataRes(types.String)
-	},
-	"azure.subscription.computeService.vmScaleSet.systemData": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetSystemData()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.computeService.vmScaleSet.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
@@ -4182,9 +4164,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.batchService.account.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetType()).ToDataRes(types.String)
 	},
-	"azure.subscription.batchService.account.identity": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetIdentity()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.batchService.account.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetPrincipalId()).ToDataRes(types.String)
 	},
@@ -4229,15 +4208,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.batchService.account.allowedAuthenticationModes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetAllowedAuthenticationModes()).ToDataRes(types.Array(types.String))
-	},
-	"azure.subscription.batchService.account.autoStorage": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetAutoStorage()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.batchService.account.encryption": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetEncryption()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.batchService.account.keyVaultReference": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetKeyVaultReference()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.batchService.account.autoStorageAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchServiceAccount).GetAutoStorageAccount()).ToDataRes(types.Resource("azure.subscription.storageService.account"))
@@ -4872,9 +4842,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.virtualNetworkGateway.vpnClientIpsecPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway).GetVpnClientIpsecPolicies()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.virtualNetworkGateway.connection.ipsecPolicy")))
 	},
-	"azure.subscription.networkService.virtualNetworkGateway.vpnClientConfiguration": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway).GetVpnClientConfiguration()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.networkService.virtualNetworkGateway.vpnClientAuthenticationTypes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway).GetVpnClientAuthenticationTypes()).ToDataRes(types.Array(types.String))
 	},
@@ -5001,9 +4968,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.firewall.networkRule.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallNetworkRule).GetEtag()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.firewall.networkRule.properties": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallNetworkRule).GetProperties()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.networkService.firewall.networkRule.action": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallNetworkRule).GetAction()).ToDataRes(types.String)
 	},
@@ -5022,9 +4986,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.firewall.applicationRule.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallApplicationRule).GetEtag()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.firewall.applicationRule.properties": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallApplicationRule).GetProperties()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.networkService.firewall.applicationRule.action": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallApplicationRule).GetAction()).ToDataRes(types.String)
 	},
@@ -5042,9 +5003,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.firewall.natRule.etag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallNatRule).GetEtag()).ToDataRes(types.String)
-	},
-	"azure.subscription.networkService.firewall.natRule.properties": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallNatRule).GetProperties()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.networkService.firewall.natRule.action": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallNatRule).GetAction()).ToDataRes(types.String)
@@ -5136,17 +5094,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceAddresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).GetSourceAddresses()).ToDataRes(types.Array(types.String))
 	},
-	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceIpGroups": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).GetSourceIpGroups()).ToDataRes(types.Array(types.String))
-	},
 	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceIpGroupRefs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).GetSourceIpGroupRefs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.ipGroup")))
 	},
 	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationAddresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).GetDestinationAddresses()).ToDataRes(types.Array(types.String))
-	},
-	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationIpGroups": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).GetDestinationIpGroups()).ToDataRes(types.Array(types.String))
 	},
 	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationIpGroupRefs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).GetDestinationIpGroupRefs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.ipGroup")))
@@ -5643,9 +5595,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.virtualNetwork.peering.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).GetProvisioningState()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).GetRemoteVirtualNetworkId()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).GetRemoteVirtualNetwork()).ToDataRes(types.Resource("azure.subscription.networkService.virtualNetwork"))
 	},
@@ -5790,9 +5739,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.frontendIpConfig.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetIsPublic()).ToDataRes(types.Bool)
 	},
-	"azure.subscription.networkService.frontendIpConfig.publicIpAddressId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetPublicIpAddressId()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.frontendIpConfig.publicIpAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetPublicIpAddress()).ToDataRes(types.Resource("azure.subscription.networkService.ipAddress"))
 	},
@@ -5865,9 +5811,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.interface.primary": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetPrimary()).ToDataRes(types.Bool)
 	},
-	"azure.subscription.networkService.interface.networkSecurityGroupId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetNetworkSecurityGroupId()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.interface.networkSecurityGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetNetworkSecurityGroup()).ToDataRes(types.Resource("azure.subscription.networkService.securityGroup"))
 	},
@@ -5879,9 +5822,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.interface.internalDnsNameLabel": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetInternalDnsNameLabel()).ToDataRes(types.String)
-	},
-	"azure.subscription.networkService.interface.ipConfigurations": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetIpConfigurations()).ToDataRes(types.Array(types.Dict))
 	},
 	"azure.subscription.networkService.interface.ipConfigs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceInterface).GetIpConfigs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.interface.ipConfiguration")))
@@ -6318,17 +6258,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.watcher.flowlog.format": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).GetFormat()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.watcher.flowlog.retentionPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).GetRetentionPolicy()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.networkService.watcher.flowlog.retentionEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).GetRetentionEnabled()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.watcher.flowlog.retentionDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).GetRetentionDays()).ToDataRes(types.Int)
-	},
-	"azure.subscription.networkService.watcher.flowlog.analytics": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).GetAnalytics()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.networkService.watcher.flowlog.trafficAnalyticsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).GetTrafficAnalyticsEnabled()).ToDataRes(types.Bool)
@@ -6579,9 +6513,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.applicationGateway.sslCertificate.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetName()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecretId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetKeyVaultSecretId()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecret": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).GetKeyVaultSecret()).ToDataRes(types.Resource("azure.subscription.keyVaultService.secret"))
 	},
@@ -6744,9 +6675,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.applicationFirewallPolicy.mode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).GetMode()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.applicationFirewallPolicy.enabledState": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).GetEnabledState()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.applicationFirewallPolicy.enabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).GetEnabled()).ToDataRes(types.Bool)
 	},
@@ -6870,9 +6798,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.privateEndpoint.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetProvisioningState()).ToDataRes(types.String)
 	},
-	"azure.subscription.networkService.privateEndpoint.subnetId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetSubnetId()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.privateEndpoint.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).GetSubnet()).ToDataRes(types.Resource("azure.subscription.networkService.subnet"))
 	},
@@ -6899,9 +6824,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).GetName()).ToDataRes(types.String)
-	},
-	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkServiceId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).GetPrivateLinkServiceId()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkService": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).GetPrivateLinkService()).ToDataRes(types.Resource("azure.subscription.networkService.privateLinkService"))
@@ -7074,9 +6996,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.trafficManagerProfile.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).GetProperties()).ToDataRes(types.Dict)
 	},
-	"azure.subscription.networkService.trafficManagerProfile.profileStatus": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).GetProfileStatus()).ToDataRes(types.String)
-	},
 	"azure.subscription.networkService.trafficManagerProfile.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).GetStatus()).ToDataRes(types.Bool)
 	},
@@ -7112,9 +7031,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).GetProperties()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.networkService.trafficManagerProfile.endpoint.endpointStatus": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).GetEndpointStatus()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).GetStatus()).ToDataRes(types.Bool)
@@ -8169,9 +8085,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetProperties()).ToDataRes(types.Dict)
 	},
-	"azure.subscription.storageService.account.identity": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetIdentity()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.storageService.account.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccount).GetPrincipalId()).ToDataRes(types.String)
 	},
@@ -8781,9 +8694,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.privateEndpointConnection.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetType()).ToDataRes(types.String)
 	},
-	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpointId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetPrivateEndpointId()).ToDataRes(types.String)
-	},
 	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpoint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetPrivateEndpoint()).ToDataRes(types.Resource("azure.subscription.networkService.privateEndpoint"))
 	},
@@ -8997,9 +8907,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsite.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetProperties()).ToDataRes(types.Dict)
 	},
-	"azure.subscription.webService.appsite.identity": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetIdentity()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.webService.appsite.identityType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsite).GetIdentityType()).ToDataRes(types.String)
 	},
@@ -9140,9 +9047,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.privateEndpointConnection.ipAddresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPrivateEndpointConnection).GetIpAddresses()).ToDataRes(types.Array(types.String))
-	},
-	"azure.subscription.privateEndpointConnection.privateEndpointId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionPrivateEndpointConnection).GetPrivateEndpointId()).ToDataRes(types.String)
 	},
 	"azure.subscription.privateEndpointConnection.privateEndpoint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionPrivateEndpointConnection).GetPrivateEndpoint()).ToDataRes(types.Resource("azure.subscription.networkService.privateEndpoint"))
@@ -9690,23 +9594,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.sqlService.server.azureAdAdministrators": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetAzureAdAdministrators()).ToDataRes(types.Array(types.Resource("azure.subscription.sqlService.server.administrator")))
 	},
-	"azure.subscription.sqlService.server.connectionPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetConnectionPolicy()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.sqlService.server.auditingPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetAuditingPolicy()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.sqlService.server.administratorLogin": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetAdministratorLogin()).ToDataRes(types.String)
-	},
-	"azure.subscription.sqlService.server.securityAlertPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetSecurityAlertPolicy()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.sqlService.server.encryptionProtector": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetEncryptionProtector()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.sqlService.server.threatDetectionPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetThreatDetectionPolicy()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.sqlService.server.vulnerabilityAssessmentSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServer).GetVulnerabilityAssessmentSettings()).ToDataRes(types.Resource("azure.subscription.sqlService.server.vulnerabilityassessmentsettings"))
@@ -9894,20 +9783,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.sqlService.database.zoneRedundant": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetZoneRedundant()).ToDataRes(types.Bool)
 	},
-	"azure.subscription.sqlService.database.transparentDataEncryption": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetTransparentDataEncryption()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.sqlService.database.advisor": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetAdvisor()).ToDataRes(types.Array(types.Dict))
-	},
-	"azure.subscription.sqlService.database.threatDetectionPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetThreatDetectionPolicy()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.sqlService.database.connectionPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetConnectionPolicy()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.sqlService.database.auditingPolicy": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetAuditingPolicy()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.sqlService.database.advancedThreatProtection": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetAdvancedThreatProtection()).ToDataRes(types.Resource("azure.subscription.sqlService.database.advancedthreatprotection"))
@@ -12399,56 +12276,29 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cloudDefenderService.monitoringAgentAutoProvision": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetMonitoringAgentAutoProvision()).ToDataRes(types.Bool)
 	},
-	"azure.subscription.cloudDefenderService.defenderForServers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForServers()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.cloudDefenderService.forServers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForServers()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForServers"))
-	},
-	"azure.subscription.cloudDefenderService.defenderForAppServices": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForAppServices()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.cloudDefenderService.forAppServices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForAppServices()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForAppServices"))
 	},
-	"azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForSqlServersOnMachines()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.cloudDefenderService.forSqlServersOnMachines": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForSqlServersOnMachines()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines"))
-	},
-	"azure.subscription.cloudDefenderService.defenderForSqlDatabases": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForSqlDatabases()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.cloudDefenderService.forSqlDatabases": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForSqlDatabases()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForSqlDatabases"))
 	},
-	"azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForOpenSourceDatabases()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.cloudDefenderService.forOpenSourceDatabases": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForOpenSourceDatabases()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases"))
-	},
-	"azure.subscription.cloudDefenderService.defenderForCosmosDb": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForCosmosDb()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.cloudDefenderService.forCosmosDb": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForCosmosDb()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForCosmosDb"))
 	},
-	"azure.subscription.cloudDefenderService.defenderForStorageAccounts": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForStorageAccounts()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.cloudDefenderService.forStorageAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForStorageAccounts()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForStorageAccounts"))
 	},
-	"azure.subscription.cloudDefenderService.defenderForKeyVaults": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForKeyVaults()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.cloudDefenderService.forKeyVaults": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForKeyVaults()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForKeyVaults"))
-	},
-	"azure.subscription.cloudDefenderService.defenderForResourceManager": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForResourceManager()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.cloudDefenderService.forResourceManager": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForResourceManager()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForResourceManager"))
@@ -12458,9 +12308,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cloudDefenderService.defenderCSPM": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderCSPM()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderCSPM"))
-	},
-	"azure.subscription.cloudDefenderService.defenderForContainers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetDefenderForContainers()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.cloudDefenderService.forContainers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderService).GetForContainers()).ToDataRes(types.Resource("azure.subscription.cloudDefenderService.defenderForContainers"))
@@ -13674,9 +13521,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.authorizationService.roleAssignment.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).GetDescription()).ToDataRes(types.String)
 	},
-	"azure.subscription.authorizationService.roleAssignment.type": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).GetType()).ToDataRes(types.String)
-	},
 	"azure.subscription.authorizationService.roleAssignment.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).GetScope()).ToDataRes(types.String)
 	},
@@ -13787,9 +13631,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.aksService.cluster.addonProfiles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetAddonProfiles()).ToDataRes(types.Array(types.Dict))
-	},
-	"azure.subscription.aksService.cluster.agentPoolProfiles": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetAgentPoolProfiles()).ToDataRes(types.Array(types.Dict))
 	},
 	"azure.subscription.aksService.cluster.nodePools": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAksServiceCluster).GetNodePools()).ToDataRes(types.Array(types.Resource("azure.subscription.aksService.cluster.nodePool")))
@@ -14409,9 +14250,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.iotService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionIotService).GetSubscriptionId()).ToDataRes(types.String)
 	},
-	"azure.subscription.iotService.hubs": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionIotService).GetHubs()).ToDataRes(types.Array(types.Dict))
-	},
 	"azure.subscription.iotService.iotHubs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionIotService).GetIotHubs()).ToDataRes(types.Array(types.Resource("azure.subscription.iotService.iotHub")))
 	},
@@ -14577,9 +14415,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cacheService.redisInstance.userAssignedIdentities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetUserAssignedIdentities()).ToDataRes(types.Array(types.Resource("azure.subscription.managedIdentity")))
 	},
-	"azure.subscription.cacheService.redisInstance.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetEncryptionKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
-	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstance).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.cacheService.redisInstance.privateEndpointConnection")))
 	},
@@ -14633,9 +14468,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).GetType()).ToDataRes(types.String)
-	},
-	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateEndpointId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).GetPrivateEndpointId()).ToDataRes(types.String)
 	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateEndpoint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).GetPrivateEndpoint()).ToDataRes(types.Resource("azure.subscription.networkService.privateEndpoint"))
@@ -14693,21 +14525,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.dataFactoryService.factory.repoConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetRepoConfiguration()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.dataFactoryService.factory.encryption": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetEncryption()).ToDataRes(types.Dict)
-	},
-	"azure.subscription.dataFactoryService.factory.cmkKeyName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkKeyName()).ToDataRes(types.String)
-	},
-	"azure.subscription.dataFactoryService.factory.cmkKeyVaultUri": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkKeyVaultUri()).ToDataRes(types.String)
-	},
-	"azure.subscription.dataFactoryService.factory.cmkKeyVersion": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkKeyVersion()).ToDataRes(types.String)
-	},
-	"azure.subscription.dataFactoryService.factory.cmkUserAssignedIdentity": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkUserAssignedIdentity()).ToDataRes(types.String)
 	},
 	"azure.subscription.dataFactoryService.factory.cmkKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetCmkKey()).ToDataRes(types.Resource("azure.subscription.keyVaultService.key"))
@@ -15008,9 +14825,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerRegistryService.registry.skuName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetSkuName()).ToDataRes(types.String)
-	},
-	"azure.subscription.containerRegistryService.registry.identity": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetIdentity()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.containerRegistryService.registry.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).GetPrincipalId()).ToDataRes(types.String)
@@ -15999,9 +15813,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.functionsService.functionApp.clientCertMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetClientCertMode()).ToDataRes(types.String)
 	},
-	"azure.subscription.functionsService.functionApp.managedServiceIdentityId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetManagedServiceIdentityId()).ToDataRes(types.String)
-	},
 	"azure.subscription.functionsService.functionApp.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).GetPrincipalId()).ToDataRes(types.String)
 	},
@@ -16121,9 +15932,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.serviceBusService.namespace.cmkKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetCmkKeys()).ToDataRes(types.Array(types.Dict))
-	},
-	"azure.subscription.serviceBusService.namespace.networkRuleSet": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetNetworkRuleSet()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.serviceBusService.namespace.networkRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionServiceBusServiceNamespace).GetNetworkRules()).ToDataRes(types.Resource("azure.subscription.serviceBusService.namespace.networkRules"))
@@ -16349,9 +16157,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.eventHubService.namespace.cmkKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetCmkKeys()).ToDataRes(types.Array(types.Dict))
-	},
-	"azure.subscription.eventHubService.namespace.networkRuleSet": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetNetworkRuleSet()).ToDataRes(types.Dict)
 	},
 	"azure.subscription.eventHubService.namespace.networkRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionEventHubServiceNamespace).GetNetworkRules()).ToDataRes(types.Resource("azure.subscription.eventHubService.namespace.networkRules"))
@@ -17484,9 +17289,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerAppService.containerApp.scaleRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetScaleRules()).ToDataRes(types.Array(types.Dict))
 	},
-	"azure.subscription.containerAppService.containerApp.identity": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetIdentity()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.containerAppService.containerApp.principalId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).GetPrincipalId()).ToDataRes(types.String)
 	},
@@ -17805,9 +17607,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerInstanceService.containerGroup.container.readinessProbe": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer).GetReadinessProbe()).ToDataRes(types.Dict)
 	},
-	"azure.subscription.containerInstanceService.containerGroup.container.securityContext": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer).GetSecurityContext()).ToDataRes(types.Dict)
-	},
 	"azure.subscription.containerInstanceService.containerGroup.container.privileged": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer).GetPrivileged()).ToDataRes(types.Bool)
 	},
@@ -18047,9 +17846,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.apiManagementService.service.outboundPublicIpAddresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetOutboundPublicIpAddresses()).ToDataRes(types.Array(types.String))
-	},
-	"azure.subscription.apiManagementService.service.privateEndpointConnectionCount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetPrivateEndpointConnectionCount()).ToDataRes(types.Int)
 	},
 	"azure.subscription.apiManagementService.service.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionApiManagementServiceService).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
@@ -19481,9 +19277,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.sampleBlobUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetSampleBlobUrl()).ToDataRes(types.String)
-	},
-	"azure.subscription.cognitiveServicesService.account.raiTopic.createdAt": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).GetCreationTime()).ToDataRes(types.Time)
@@ -21300,10 +21093,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceVm).ScheduledEventsPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.computeService.vm.systemData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionComputeServiceVm).SystemData, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.computeService.vm.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVm).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -21532,10 +21321,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceHybridMachine).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.computeService.hybridMachine.systemData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionComputeServiceHybridMachine).SystemData, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.computeService.hybridMachine.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceHybridMachine).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -21598,10 +21383,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.hybridMachine.extension.forceUpdateTag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceHybridMachineExtension).ForceUpdateTag, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.computeService.hybridMachine.extension.systemData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionComputeServiceHybridMachineExtension).SystemData, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.hybridMachine.extension.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21746,10 +21527,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.disk.availabilityPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceDisk).AvailabilityPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.computeService.disk.systemData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionComputeServiceDisk).SystemData, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.disk.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21976,10 +21753,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceSnapshot).ImmutabilityPolicyExpirationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.computeService.snapshot.systemData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionComputeServiceSnapshot).SystemData, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.computeService.snapshot.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceSnapshot).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
@@ -22106,10 +21879,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.vmScaleSet.zonalPlatformFaultDomainAlignMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).ZonalPlatformFaultDomainAlignMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.computeService.vmScaleSet.systemData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionComputeServiceVmScaleSet).SystemData, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.vmScaleSet.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22680,10 +22449,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionBatchServiceAccount).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.batchService.account.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionBatchServiceAccount).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.batchService.account.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionBatchServiceAccount).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -22742,18 +22507,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.batchService.account.allowedAuthenticationModes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionBatchServiceAccount).AllowedAuthenticationModes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.batchService.account.autoStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionBatchServiceAccount).AutoStorage, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.batchService.account.encryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionBatchServiceAccount).Encryption, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.batchService.account.keyVaultReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionBatchServiceAccount).KeyVaultReference, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.batchService.account.autoStorageAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23652,10 +23405,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway).VpnClientIpsecPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.virtualNetworkGateway.vpnClientConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway).VpnClientConfiguration, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.virtualNetworkGateway.vpnClientAuthenticationTypes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway).VpnClientAuthenticationTypes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -23840,10 +23589,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallNetworkRule).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.firewall.networkRule.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceFirewallNetworkRule).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.firewall.networkRule.action": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallNetworkRule).Action, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -23872,10 +23617,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallApplicationRule).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.firewall.applicationRule.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceFirewallApplicationRule).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.firewall.applicationRule.action": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallApplicationRule).Action, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -23902,10 +23643,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.firewall.natRule.etag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallNatRule).Etag, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.networkService.firewall.natRule.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceFirewallNatRule).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.firewall.natRule.action": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24040,20 +23777,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).SourceAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceIpGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).SourceIpGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceIpGroupRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).SourceIpGroupRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).DestinationAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationIpGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule).DestinationIpGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationIpGroupRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24780,10 +24509,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).RemoteVirtualNetworkId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).RemoteVirtualNetwork, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork](v.Value, v.Error)
 		return
@@ -25004,10 +24729,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.frontendIpConfig.publicIpAddressId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).PublicIpAddressId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.frontendIpConfig.publicIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).PublicIpAddress, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceIpAddress](v.Value, v.Error)
 		return
@@ -25116,10 +24837,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceInterface).Primary, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.interface.networkSecurityGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceInterface).NetworkSecurityGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.interface.networkSecurityGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceInterface).NetworkSecurityGroup, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSecurityGroup](v.Value, v.Error)
 		return
@@ -25134,10 +24851,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.interface.internalDnsNameLabel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceInterface).InternalDnsNameLabel, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.networkService.interface.ipConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceInterface).IpConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.interface.ipConfigs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25764,20 +25477,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).Format, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.watcher.flowlog.retentionPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).RetentionPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.watcher.flowlog.retentionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).RetentionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.watcher.flowlog.retentionDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).RetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.networkService.watcher.flowlog.analytics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceWatcherFlowlog).Analytics, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.watcher.flowlog.trafficAnalyticsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26140,10 +25845,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecretId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).KeyVaultSecretId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate).KeyVaultSecret, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceSecret](v.Value, v.Error)
 		return
@@ -26384,10 +26085,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).Mode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.applicationFirewallPolicy.enabledState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).EnabledState, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.applicationFirewallPolicy.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -26576,10 +26273,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.privateEndpoint.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).SubnetId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.privateEndpoint.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint).Subnet, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceSubnet](v.Value, v.Error)
 		return
@@ -26618,10 +26311,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkServiceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).PrivateLinkServiceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26872,10 +26561,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.networkService.trafficManagerProfile.profileStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).ProfileStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.networkService.trafficManagerProfile.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfile).Status, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -26926,10 +26611,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.networkService.trafficManagerProfile.endpoint.endpointStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint).EndpointStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.trafficManagerProfile.endpoint.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28448,10 +28129,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccount).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.storageService.account.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionStorageServiceAccount).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.storageService.account.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccount).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -29344,10 +29021,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpointId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).PrivateEndpointId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.storageService.account.privateEndpointConnection.privateEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).PrivateEndpoint, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint](v.Value, v.Error)
 		return
@@ -29660,10 +29333,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppsite).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.webService.appsite.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionWebServiceAppsite).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.webService.appsite.identityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsite).IdentityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -29858,10 +29527,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.privateEndpointConnection.ipAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionPrivateEndpointConnection).IpAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.privateEndpointConnection.privateEndpointId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionPrivateEndpointConnection).PrivateEndpointId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.privateEndpointConnection.privateEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30652,28 +30317,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSqlServiceServer).AzureAdAdministrators, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.sqlService.server.connectionPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceServer).ConnectionPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.sqlService.server.auditingPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceServer).AuditingPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.sqlService.server.administratorLogin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceServer).AdministratorLogin, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.sqlService.server.securityAlertPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceServer).SecurityAlertPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.sqlService.server.encryptionProtector": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceServer).EncryptionProtector, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.sqlService.server.threatDetectionPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceServer).ThreatDetectionPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.sqlService.server.vulnerabilityAssessmentSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30936,24 +30581,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSqlServiceDatabase).ZoneRedundant, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.sqlService.database.transparentDataEncryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceDatabase).TransparentDataEncryption, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.sqlService.database.advisor": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceDatabase).Advisor, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.sqlService.database.threatDetectionPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceDatabase).ThreatDetectionPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.sqlService.database.connectionPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceDatabase).ConnectionPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.sqlService.database.auditingPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionSqlServiceDatabase).AuditingPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.sqlService.database.advancedThreatProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34588,72 +34217,36 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCloudDefenderService).MonitoringAgentAutoProvision, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.cloudDefenderService.defenderForServers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForServers, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.cloudDefenderService.forServers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForServers, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.cloudDefenderService.defenderForAppServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForAppServices, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.forAppServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForAppServices, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForSqlServersOnMachines, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.cloudDefenderService.forSqlServersOnMachines": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForSqlServersOnMachines, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.cloudDefenderService.defenderForSqlDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForSqlDatabases, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.forSqlDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForSqlDatabases, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForOpenSourceDatabases, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.cloudDefenderService.forOpenSourceDatabases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForOpenSourceDatabases, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.cloudDefenderService.defenderForCosmosDb": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForCosmosDb, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.forCosmosDb": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForCosmosDb, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.cloudDefenderService.defenderForStorageAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForStorageAccounts, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.cloudDefenderService.forStorageAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForStorageAccounts, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.cloudDefenderService.defenderForKeyVaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForKeyVaults, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.cloudDefenderService.forKeyVaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).ForKeyVaults, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.cloudDefenderService.defenderForResourceManager": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForResourceManager, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.forResourceManager": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34666,10 +34259,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cloudDefenderService.defenderCSPM": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderCSPM, ok = plugin.RawToTValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.cloudDefenderService.defenderForContainers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCloudDefenderService).DefenderForContainers, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.forContainers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36440,10 +36029,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.authorizationService.roleAssignment.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.authorizationService.roleAssignment.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -36602,10 +36187,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.aksService.cluster.addonProfiles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAksServiceCluster).AddonProfiles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.aksService.cluster.agentPoolProfiles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionAksServiceCluster).AgentPoolProfiles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.aksService.cluster.nodePools": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37504,10 +37085,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionIotService).SubscriptionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.iotService.hubs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionIotService).Hubs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.iotService.iotHubs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionIotService).IotHubs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -37740,10 +37317,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).UserAssignedIdentities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.cacheService.redisInstance.encryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).EncryptionKey, ok = plugin.RawToTValue[*mqlAzureSubscriptionKeyVaultServiceKey](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstance).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -37828,10 +37401,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateEndpointId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).PrivateEndpointId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).PrivateEndpoint, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint](v.Value, v.Error)
 		return
@@ -37914,26 +37483,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.dataFactoryService.factory.repoConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).RepoConfiguration, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.dataFactoryService.factory.encryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).Encryption, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.dataFactoryService.factory.cmkKeyName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).CmkKeyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.dataFactoryService.factory.cmkKeyVaultUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).CmkKeyVaultUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.dataFactoryService.factory.cmkKeyVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).CmkKeyVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.dataFactoryService.factory.cmkUserAssignedIdentity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).CmkUserAssignedIdentity, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.dataFactoryService.factory.cmkKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -38374,10 +37923,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerRegistryService.registry.skuName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).SkuName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.containerRegistryService.registry.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistry).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerRegistryService.registry.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39832,10 +39377,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).ClientCertMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.functionsService.functionApp.managedServiceIdentityId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).ManagedServiceIdentityId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.functionsService.functionApp.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFunctionsServiceFunctionApp).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -40010,10 +39551,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.serviceBusService.namespace.cmkKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).CmkKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.serviceBusService.namespace.networkRuleSet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionServiceBusServiceNamespace).NetworkRuleSet, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.serviceBusService.namespace.networkRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40346,10 +39883,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.eventHubService.namespace.cmkKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionEventHubServiceNamespace).CmkKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.eventHubService.namespace.networkRuleSet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionEventHubServiceNamespace).NetworkRuleSet, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.eventHubService.namespace.networkRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -42012,10 +41545,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).ScaleRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.containerAppService.containerApp.identity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).Identity, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.containerAppService.containerApp.principalId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerAppServiceContainerApp).PrincipalId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -42468,10 +41997,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer).ReadinessProbe, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"azure.subscription.containerInstanceService.containerGroup.container.securityContext": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer).SecurityContext, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"azure.subscription.containerInstanceService.containerGroup.container.privileged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer).Privileged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -42806,10 +42331,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.apiManagementService.service.outboundPublicIpAddresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionApiManagementServiceService).OutboundPublicIpAddresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.apiManagementService.service.privateEndpointConnectionCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionApiManagementServiceService).PrivateEndpointConnectionCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.apiManagementService.service.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44874,10 +44395,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.sampleBlobUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).SampleBlobUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"azure.subscription.cognitiveServicesService.account.raiTopic.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cognitiveServicesService.account.raiTopic.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48490,7 +48007,6 @@ type mqlAzureSubscriptionComputeServiceVm struct {
 	FipsEncryptionEnabled         plugin.TValue[bool]
 	ResiliencyProfile             plugin.TValue[any]
 	ScheduledEventsPolicy         plugin.TValue[any]
-	SystemData                    plugin.TValue[any]
 	SystemMetadata                plugin.TValue[*mqlAzureSubscriptionSystemData]
 	ComputerName                  plugin.TValue[string]
 	AdminUsername                 plugin.TValue[string]
@@ -48748,10 +48264,6 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetScheduledEventsPolicy() *plugi
 	return &c.ScheduledEventsPolicy
 }
 
-func (c *mqlAzureSubscriptionComputeServiceVm) GetSystemData() *plugin.TValue[any] {
-	return &c.SystemData
-}
-
 func (c *mqlAzureSubscriptionComputeServiceVm) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -48975,7 +48487,7 @@ func (c *mqlAzureSubscriptionComputeServiceVmImageReference) GetCommunityGallery
 type mqlAzureSubscriptionComputeServiceHybridMachine struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceHybridMachineInternal it will be used here
+	mqlAzureSubscriptionComputeServiceHybridMachineInternal
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Location                   plugin.TValue[string]
@@ -49003,7 +48515,6 @@ type mqlAzureSubscriptionComputeServiceHybridMachine struct {
 	CloudMetadata              plugin.TValue[any]
 	LicenseProfile             plugin.TValue[any]
 	Properties                 plugin.TValue[any]
-	SystemData                 plugin.TValue[any]
 	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
 	Extensions                 plugin.TValue[[]any]
 }
@@ -49153,10 +48664,6 @@ func (c *mqlAzureSubscriptionComputeServiceHybridMachine) GetProperties() *plugi
 	return &c.Properties
 }
 
-func (c *mqlAzureSubscriptionComputeServiceHybridMachine) GetSystemData() *plugin.TValue[any] {
-	return &c.SystemData
-}
-
 func (c *mqlAzureSubscriptionComputeServiceHybridMachine) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -49193,7 +48700,7 @@ func (c *mqlAzureSubscriptionComputeServiceHybridMachine) GetExtensions() *plugi
 type mqlAzureSubscriptionComputeServiceHybridMachineExtension struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceHybridMachineExtensionInternal it will be used here
+	mqlAzureSubscriptionComputeServiceHybridMachineExtensionInternal
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
 	Type                    plugin.TValue[string]
@@ -49207,7 +48714,6 @@ type mqlAzureSubscriptionComputeServiceHybridMachineExtension struct {
 	ProvisioningState       plugin.TValue[string]
 	Settings                plugin.TValue[any]
 	ForceUpdateTag          plugin.TValue[string]
-	SystemData              plugin.TValue[any]
 	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
 	InstanceView            plugin.TValue[any]
 }
@@ -49301,10 +48807,6 @@ func (c *mqlAzureSubscriptionComputeServiceHybridMachineExtension) GetForceUpdat
 	return &c.ForceUpdateTag
 }
 
-func (c *mqlAzureSubscriptionComputeServiceHybridMachineExtension) GetSystemData() *plugin.TValue[any] {
-	return &c.SystemData
-}
-
 func (c *mqlAzureSubscriptionComputeServiceHybridMachineExtension) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -49329,7 +48831,7 @@ func (c *mqlAzureSubscriptionComputeServiceHybridMachineExtension) GetInstanceVi
 type mqlAzureSubscriptionComputeServiceDisk struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceDiskInternal it will be used here
+	mqlAzureSubscriptionComputeServiceDiskInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Location                  plugin.TValue[string]
@@ -49363,7 +48865,6 @@ type mqlAzureSubscriptionComputeServiceDisk struct {
 	SupportsHibernation       plugin.TValue[bool]
 	DiskAccessId              plugin.TValue[string]
 	AvailabilityPolicy        plugin.TValue[any]
-	SystemData                plugin.TValue[any]
 	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -49546,10 +49047,6 @@ func (c *mqlAzureSubscriptionComputeServiceDisk) GetDiskAccessId() *plugin.TValu
 
 func (c *mqlAzureSubscriptionComputeServiceDisk) GetAvailabilityPolicy() *plugin.TValue[any] {
 	return &c.AvailabilityPolicy
-}
-
-func (c *mqlAzureSubscriptionComputeServiceDisk) GetSystemData() *plugin.TValue[any] {
-	return &c.SystemData
 }
 
 func (c *mqlAzureSubscriptionComputeServiceDisk) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -49837,7 +49334,6 @@ type mqlAzureSubscriptionComputeServiceSnapshot struct {
 	ImmutabilityPolicyExpired        plugin.TValue[bool]
 	ImmutabilityPolicyStartTime      plugin.TValue[*time.Time]
 	ImmutabilityPolicyExpirationTime plugin.TValue[*time.Time]
-	SystemData                       plugin.TValue[any]
 	SystemMetadata                   plugin.TValue[*mqlAzureSubscriptionSystemData]
 	SourceDisk                       plugin.TValue[*mqlAzureSubscriptionComputeServiceDisk]
 	DiskEncryptionSet                plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
@@ -50000,10 +49496,6 @@ func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetImmutabilityPolicyExpira
 	return &c.ImmutabilityPolicyExpirationTime
 }
 
-func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetSystemData() *plugin.TValue[any] {
-	return &c.SystemData
-}
-
 func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -50085,7 +49577,6 @@ type mqlAzureSubscriptionComputeServiceVmScaleSet struct {
 	SecureBootEnabled                 plugin.TValue[bool]
 	VtpmEnabled                       plugin.TValue[bool]
 	ZonalPlatformFaultDomainAlignMode plugin.TValue[string]
-	SystemData                        plugin.TValue[any]
 	SystemMetadata                    plugin.TValue[*mqlAzureSubscriptionSystemData]
 	Instances                         plugin.TValue[[]any]
 	Extensions                        plugin.TValue[[]any]
@@ -50242,10 +49733,6 @@ func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetVtpmEnabled() *plugin.
 
 func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetZonalPlatformFaultDomainAlignMode() *plugin.TValue[string] {
 	return &c.ZonalPlatformFaultDomainAlignMode
-}
-
-func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetSystemData() *plugin.TValue[any] {
-	return &c.SystemData
 }
 
 func (c *mqlAzureSubscriptionComputeServiceVmScaleSet) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
@@ -51488,7 +50975,6 @@ type mqlAzureSubscriptionBatchServiceAccount struct {
 	Location                              plugin.TValue[string]
 	Tags                                  plugin.TValue[map[string]any]
 	Type                                  plugin.TValue[string]
-	Identity                              plugin.TValue[any]
 	PrincipalId                           plugin.TValue[string]
 	UserAssignedIdentities                plugin.TValue[[]any]
 	Properties                            plugin.TValue[any]
@@ -51504,9 +50990,6 @@ type mqlAzureSubscriptionBatchServiceAccount struct {
 	LowPriorityCoreQuota                  plugin.TValue[int64]
 	PoolQuota                             plugin.TValue[int64]
 	AllowedAuthenticationModes            plugin.TValue[[]any]
-	AutoStorage                           plugin.TValue[any]
-	Encryption                            plugin.TValue[any]
-	KeyVaultReference                     plugin.TValue[any]
 	AutoStorageAccount                    plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount]
 	KeyVault                              plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceVault]
 	EncryptionKey                         plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
@@ -51573,10 +51056,6 @@ func (c *mqlAzureSubscriptionBatchServiceAccount) GetTags() *plugin.TValue[map[s
 
 func (c *mqlAzureSubscriptionBatchServiceAccount) GetType() *plugin.TValue[string] {
 	return &c.Type
-}
-
-func (c *mqlAzureSubscriptionBatchServiceAccount) GetIdentity() *plugin.TValue[any] {
-	return &c.Identity
 }
 
 func (c *mqlAzureSubscriptionBatchServiceAccount) GetPrincipalId() *plugin.TValue[string] {
@@ -51649,18 +51128,6 @@ func (c *mqlAzureSubscriptionBatchServiceAccount) GetPoolQuota() *plugin.TValue[
 
 func (c *mqlAzureSubscriptionBatchServiceAccount) GetAllowedAuthenticationModes() *plugin.TValue[[]any] {
 	return &c.AllowedAuthenticationModes
-}
-
-func (c *mqlAzureSubscriptionBatchServiceAccount) GetAutoStorage() *plugin.TValue[any] {
-	return &c.AutoStorage
-}
-
-func (c *mqlAzureSubscriptionBatchServiceAccount) GetEncryption() *plugin.TValue[any] {
-	return &c.Encryption
-}
-
-func (c *mqlAzureSubscriptionBatchServiceAccount) GetKeyVaultReference() *plugin.TValue[any] {
-	return &c.KeyVaultReference
 }
 
 func (c *mqlAzureSubscriptionBatchServiceAccount) GetAutoStorageAccount() *plugin.TValue[*mqlAzureSubscriptionStorageServiceAccount] {
@@ -53906,7 +53373,6 @@ type mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway struct {
 	NatRules                        plugin.TValue[[]any]
 	Connections                     plugin.TValue[[]any]
 	VpnClientIpsecPolicies          plugin.TValue[[]any]
-	VpnClientConfiguration          plugin.TValue[any]
 	VpnClientAuthenticationTypes    plugin.TValue[[]any]
 	VpnClientAddressPool            plugin.TValue[[]any]
 	AadTenant                       plugin.TValue[string]
@@ -54115,10 +53581,6 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) GetVpnClientIp
 
 		return c.vpnClientIpsecPolicies()
 	})
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) GetVpnClientConfiguration() *plugin.TValue[any] {
-	return &c.VpnClientConfiguration
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) GetVpnClientAuthenticationTypes() *plugin.TValue[[]any] {
@@ -54554,13 +54016,12 @@ type mqlAzureSubscriptionNetworkServiceFirewallNetworkRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionNetworkServiceFirewallNetworkRuleInternal it will be used here
-	Id         plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Etag       plugin.TValue[string]
-	Properties plugin.TValue[any]
-	Action     plugin.TValue[string]
-	Priority   plugin.TValue[int64]
-	Rules      plugin.TValue[[]any]
+	Id       plugin.TValue[string]
+	Name     plugin.TValue[string]
+	Etag     plugin.TValue[string]
+	Action   plugin.TValue[string]
+	Priority plugin.TValue[int64]
+	Rules    plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceFirewallNetworkRule creates a new instance of this resource
@@ -54612,10 +54073,6 @@ func (c *mqlAzureSubscriptionNetworkServiceFirewallNetworkRule) GetEtag() *plugi
 	return &c.Etag
 }
 
-func (c *mqlAzureSubscriptionNetworkServiceFirewallNetworkRule) GetProperties() *plugin.TValue[any] {
-	return &c.Properties
-}
-
 func (c *mqlAzureSubscriptionNetworkServiceFirewallNetworkRule) GetAction() *plugin.TValue[string] {
 	return &c.Action
 }
@@ -54633,13 +54090,12 @@ type mqlAzureSubscriptionNetworkServiceFirewallApplicationRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionNetworkServiceFirewallApplicationRuleInternal it will be used here
-	Id         plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Etag       plugin.TValue[string]
-	Properties plugin.TValue[any]
-	Action     plugin.TValue[string]
-	Priority   plugin.TValue[int64]
-	Rules      plugin.TValue[[]any]
+	Id       plugin.TValue[string]
+	Name     plugin.TValue[string]
+	Etag     plugin.TValue[string]
+	Action   plugin.TValue[string]
+	Priority plugin.TValue[int64]
+	Rules    plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceFirewallApplicationRule creates a new instance of this resource
@@ -54691,10 +54147,6 @@ func (c *mqlAzureSubscriptionNetworkServiceFirewallApplicationRule) GetEtag() *p
 	return &c.Etag
 }
 
-func (c *mqlAzureSubscriptionNetworkServiceFirewallApplicationRule) GetProperties() *plugin.TValue[any] {
-	return &c.Properties
-}
-
 func (c *mqlAzureSubscriptionNetworkServiceFirewallApplicationRule) GetAction() *plugin.TValue[string] {
 	return &c.Action
 }
@@ -54712,13 +54164,12 @@ type mqlAzureSubscriptionNetworkServiceFirewallNatRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAzureSubscriptionNetworkServiceFirewallNatRuleInternal it will be used here
-	Id         plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Etag       plugin.TValue[string]
-	Properties plugin.TValue[any]
-	Action     plugin.TValue[string]
-	Priority   plugin.TValue[int64]
-	Rules      plugin.TValue[[]any]
+	Id       plugin.TValue[string]
+	Name     plugin.TValue[string]
+	Etag     plugin.TValue[string]
+	Action   plugin.TValue[string]
+	Priority plugin.TValue[int64]
+	Rules    plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionNetworkServiceFirewallNatRule creates a new instance of this resource
@@ -54768,10 +54219,6 @@ func (c *mqlAzureSubscriptionNetworkServiceFirewallNatRule) GetName() *plugin.TV
 
 func (c *mqlAzureSubscriptionNetworkServiceFirewallNatRule) GetEtag() *plugin.TValue[string] {
 	return &c.Etag
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceFirewallNatRule) GetProperties() *plugin.TValue[any] {
-	return &c.Properties
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceFirewallNatRule) GetAction() *plugin.TValue[string] {
@@ -55060,10 +54507,8 @@ type mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule struct {
 	Description            plugin.TValue[string]
 	Protocol               plugin.TValue[string]
 	SourceAddresses        plugin.TValue[[]any]
-	SourceIpGroups         plugin.TValue[[]any]
 	SourceIpGroupRefs      plugin.TValue[[]any]
 	DestinationAddresses   plugin.TValue[[]any]
-	DestinationIpGroups    plugin.TValue[[]any]
 	DestinationIpGroupRefs plugin.TValue[[]any]
 	DestinationPorts       plugin.TValue[[]any]
 }
@@ -55125,10 +54570,6 @@ func (c *mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule) GetSour
 	return &c.SourceAddresses
 }
 
-func (c *mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule) GetSourceIpGroups() *plugin.TValue[[]any] {
-	return &c.SourceIpGroups
-}
-
 func (c *mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule) GetSourceIpGroupRefs() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.SourceIpGroupRefs, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -55147,10 +54588,6 @@ func (c *mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule) GetSour
 
 func (c *mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule) GetDestinationAddresses() *plugin.TValue[[]any] {
 	return &c.DestinationAddresses
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule) GetDestinationIpGroups() *plugin.TValue[[]any] {
-	return &c.DestinationIpGroups
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceFirewallPolicyIdpsBypassRule) GetDestinationIpGroupRefs() *plugin.TValue[[]any] {
@@ -56837,7 +56274,7 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualNetwork) GetFlowLogs() *plugin
 type mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceVirtualNetworkPeeringInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceVirtualNetworkPeeringInternal
 	Id                                        plugin.TValue[string]
 	Name                                      plugin.TValue[string]
 	AllowForwardedTraffic                     plugin.TValue[bool]
@@ -56847,7 +56284,6 @@ type mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering struct {
 	PeeringState                              plugin.TValue[string]
 	PeeringSyncLevel                          plugin.TValue[string]
 	ProvisioningState                         plugin.TValue[string]
-	RemoteVirtualNetworkId                    plugin.TValue[string]
 	RemoteVirtualNetwork                      plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork]
 	RemoteVirtualNetworkEncryptionEnabled     plugin.TValue[bool]
 	RemoteVirtualNetworkEncryptionEnforcement plugin.TValue[string]
@@ -56924,10 +56360,6 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetPeeringSync
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetRemoteVirtualNetworkId() *plugin.TValue[string] {
-	return &c.RemoteVirtualNetworkId
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) GetRemoteVirtualNetwork() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork] {
@@ -57504,7 +56936,6 @@ type mqlAzureSubscriptionNetworkServiceFrontendIpConfig struct {
 	Properties         plugin.TValue[any]
 	Zones              plugin.TValue[[]any]
 	IsPublic           plugin.TValue[bool]
-	PublicIpAddressId  plugin.TValue[string]
 	PublicIpAddress    plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
 	Subnet             plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 	PrivateIpAddress   plugin.TValue[string]
@@ -57574,10 +57005,6 @@ func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetZones() *plugin.
 
 func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetIsPublic() *plugin.TValue[bool] {
 	return &c.IsPublic
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPublicIpAddressId() *plugin.TValue[string] {
-	return &c.PublicIpAddressId
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPublicIpAddress() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress] {
@@ -57763,12 +57190,10 @@ type mqlAzureSubscriptionNetworkServiceInterface struct {
 	EnableIPForwarding          plugin.TValue[bool]
 	EnableAcceleratedNetworking plugin.TValue[bool]
 	Primary                     plugin.TValue[bool]
-	NetworkSecurityGroupId      plugin.TValue[string]
 	NetworkSecurityGroup        plugin.TValue[*mqlAzureSubscriptionNetworkServiceSecurityGroup]
 	DnsServers                  plugin.TValue[[]any]
 	AppliedDnsServers           plugin.TValue[[]any]
 	InternalDnsNameLabel        plugin.TValue[string]
-	IpConfigurations            plugin.TValue[[]any]
 	IpConfigs                   plugin.TValue[[]any]
 	Vm                          plugin.TValue[*mqlAzureSubscriptionComputeServiceVm]
 	EffectiveSecurityRules      plugin.TValue[[]any]
@@ -57854,10 +57279,6 @@ func (c *mqlAzureSubscriptionNetworkServiceInterface) GetPrimary() *plugin.TValu
 	return &c.Primary
 }
 
-func (c *mqlAzureSubscriptionNetworkServiceInterface) GetNetworkSecurityGroupId() *plugin.TValue[string] {
-	return &c.NetworkSecurityGroupId
-}
-
 func (c *mqlAzureSubscriptionNetworkServiceInterface) GetNetworkSecurityGroup() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSecurityGroup] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSecurityGroup](&c.NetworkSecurityGroup, func() (*mqlAzureSubscriptionNetworkServiceSecurityGroup, error) {
 		if c.MqlRuntime.HasRecording {
@@ -57884,10 +57305,6 @@ func (c *mqlAzureSubscriptionNetworkServiceInterface) GetAppliedDnsServers() *pl
 
 func (c *mqlAzureSubscriptionNetworkServiceInterface) GetInternalDnsNameLabel() *plugin.TValue[string] {
 	return &c.InternalDnsNameLabel
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceInterface) GetIpConfigurations() *plugin.TValue[[]any] {
-	return &c.IpConfigurations
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceInterface) GetIpConfigs() *plugin.TValue[[]any] {
@@ -59279,10 +58696,8 @@ type mqlAzureSubscriptionNetworkServiceWatcherFlowlog struct {
 	TargetResourceGuid          plugin.TValue[string]
 	Version                     plugin.TValue[int64]
 	Format                      plugin.TValue[string]
-	RetentionPolicy             plugin.TValue[any]
 	RetentionEnabled            plugin.TValue[bool]
 	RetentionDays               plugin.TValue[int64]
-	Analytics                   plugin.TValue[any]
 	TrafficAnalyticsEnabled     plugin.TValue[bool]
 	TrafficAnalyticsInterval    plugin.TValue[int64]
 	TrafficAnalyticsWorkspaceId plugin.TValue[string]
@@ -59377,20 +58792,12 @@ func (c *mqlAzureSubscriptionNetworkServiceWatcherFlowlog) GetFormat() *plugin.T
 	return &c.Format
 }
 
-func (c *mqlAzureSubscriptionNetworkServiceWatcherFlowlog) GetRetentionPolicy() *plugin.TValue[any] {
-	return &c.RetentionPolicy
-}
-
 func (c *mqlAzureSubscriptionNetworkServiceWatcherFlowlog) GetRetentionEnabled() *plugin.TValue[bool] {
 	return &c.RetentionEnabled
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceWatcherFlowlog) GetRetentionDays() *plugin.TValue[int64] {
 	return &c.RetentionDays
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceWatcherFlowlog) GetAnalytics() *plugin.TValue[any] {
-	return &c.Analytics
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceWatcherFlowlog) GetTrafficAnalyticsEnabled() *plugin.TValue[bool] {
@@ -60150,7 +59557,6 @@ type mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate struct {
 	mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificateInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
-	KeyVaultSecretId  plugin.TValue[string]
 	KeyVaultSecret    plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceSecret]
 	PublicCertData    plugin.TValue[string]
 	HsmKey            plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
@@ -60200,10 +59606,6 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) Get
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) GetKeyVaultSecretId() *plugin.TValue[string] {
-	return &c.KeyVaultSecretId
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) GetKeyVaultSecret() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceSecret] {
@@ -60701,7 +60103,6 @@ type mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy struct {
 	Etag                   plugin.TValue[string]
 	Properties             plugin.TValue[any]
 	Mode                   plugin.TValue[string]
-	EnabledState           plugin.TValue[string]
 	Enabled                plugin.TValue[bool]
 	RequestBodyCheck       plugin.TValue[bool]
 	MaxRequestBodySizeInKb plugin.TValue[int64]
@@ -60781,10 +60182,6 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetPropert
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetMode() *plugin.TValue[string] {
 	return &c.Mode
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetEnabledState() *plugin.TValue[string] {
-	return &c.EnabledState
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) GetEnabled() *plugin.TValue[bool] {
@@ -61230,7 +60627,6 @@ type mqlAzureSubscriptionNetworkServicePrivateEndpoint struct {
 	Tags                                plugin.TValue[map[string]any]
 	Type                                plugin.TValue[string]
 	ProvisioningState                   plugin.TValue[string]
-	SubnetId                            plugin.TValue[string]
 	Subnet                              plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
 	NetworkInterfaces                   plugin.TValue[[]any]
 	CustomNetworkInterfaceName          plugin.TValue[string]
@@ -61296,10 +60692,6 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetProvisioningState
 	return &c.ProvisioningState
 }
 
-func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetSubnetId() *plugin.TValue[string] {
-	return &c.SubnetId
-}
-
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetSubnet() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceSubnet](&c.Subnet, func() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
 		if c.MqlRuntime.HasRecording {
@@ -61358,14 +60750,13 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetPrivateDnsZoneGro
 type mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnectionInternal it will be used here
-	Id                   plugin.TValue[string]
-	Name                 plugin.TValue[string]
-	PrivateLinkServiceId plugin.TValue[string]
-	PrivateLinkService   plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateLinkService]
-	GroupIds             plugin.TValue[[]any]
-	ConnectionStatus     plugin.TValue[string]
-	RequestMessage       plugin.TValue[string]
+	mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnectionInternal
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	PrivateLinkService plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateLinkService]
+	GroupIds           plugin.TValue[[]any]
+	ConnectionStatus   plugin.TValue[string]
+	RequestMessage     plugin.TValue[string]
 }
 
 // createAzureSubscriptionNetworkServicePrivateEndpointServiceconnection creates a new instance of this resource
@@ -61406,10 +60797,6 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) Get
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) GetPrivateLinkServiceId() *plugin.TValue[string] {
-	return &c.PrivateLinkServiceId
 }
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) GetPrivateLinkService() *plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateLinkService] {
@@ -61876,7 +61263,6 @@ type mqlAzureSubscriptionNetworkServiceTrafficManagerProfile struct {
 	Tags                        plugin.TValue[map[string]any]
 	Type                        plugin.TValue[string]
 	Properties                  plugin.TValue[any]
-	ProfileStatus               plugin.TValue[string]
 	Status                      plugin.TValue[bool]
 	TrafficRoutingMethod        plugin.TValue[string]
 	TrafficViewEnrollmentStatus plugin.TValue[string]
@@ -61948,10 +61334,6 @@ func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfile) GetProperties(
 	return &c.Properties
 }
 
-func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfile) GetProfileStatus() *plugin.TValue[string] {
-	return &c.ProfileStatus
-}
-
 func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfile) GetStatus() *plugin.TValue[bool] {
 	return &c.Status
 }
@@ -61993,7 +61375,6 @@ type mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint struct {
 	Name                  plugin.TValue[string]
 	Type                  plugin.TValue[string]
 	Properties            plugin.TValue[any]
-	EndpointStatus        plugin.TValue[string]
 	Status                plugin.TValue[bool]
 	EndpointMonitorStatus plugin.TValue[string]
 	AlwaysServe           plugin.TValue[string]
@@ -62061,10 +61442,6 @@ func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetTyp
 
 func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
-}
-
-func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetEndpointStatus() *plugin.TValue[string] {
-	return &c.EndpointStatus
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceTrafficManagerProfileEndpoint) GetStatus() *plugin.TValue[bool] {
@@ -65325,7 +64702,6 @@ type mqlAzureSubscriptionStorageServiceAccount struct {
 	Tags                                             plugin.TValue[map[string]any]
 	Type                                             plugin.TValue[string]
 	Properties                                       plugin.TValue[any]
-	Identity                                         plugin.TValue[any]
 	PrincipalId                                      plugin.TValue[string]
 	TenantId                                         plugin.TValue[string]
 	UserAssignedIdentities                           plugin.TValue[[]any]
@@ -65451,10 +64827,6 @@ func (c *mqlAzureSubscriptionStorageServiceAccount) GetType() *plugin.TValue[str
 
 func (c *mqlAzureSubscriptionStorageServiceAccount) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
-}
-
-func (c *mqlAzureSubscriptionStorageServiceAccount) GetIdentity() *plugin.TValue[any] {
-	return &c.Identity
 }
 
 func (c *mqlAzureSubscriptionStorageServiceAccount) GetPrincipalId() *plugin.TValue[string] {
@@ -67554,7 +66926,6 @@ type mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection struct {
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
-	PrivateEndpointId plugin.TValue[string]
 	PrivateEndpoint   plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint]
 	Status            plugin.TValue[string]
 	Description       plugin.TValue[string]
@@ -67610,10 +66981,6 @@ func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) Get
 
 func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) GetType() *plugin.TValue[string] {
 	return &c.Type
-}
-
-func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) GetPrivateEndpointId() *plugin.TValue[string] {
-	return &c.PrivateEndpointId
 }
 
 func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) GetPrivateEndpoint() *plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint] {
@@ -68333,7 +67700,6 @@ type mqlAzureSubscriptionWebServiceAppsite struct {
 	Type                         plugin.TValue[string]
 	Tags                         plugin.TValue[map[string]any]
 	Properties                   plugin.TValue[any]
-	Identity                     plugin.TValue[any]
 	IdentityType                 plugin.TValue[string]
 	PrincipalId                  plugin.TValue[string]
 	SystemAssignedIdentity       plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
@@ -68436,10 +67802,6 @@ func (c *mqlAzureSubscriptionWebServiceAppsite) GetTags() *plugin.TValue[map[str
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
-}
-
-func (c *mqlAzureSubscriptionWebServiceAppsite) GetIdentity() *plugin.TValue[any] {
-	return &c.Identity
 }
 
 func (c *mqlAzureSubscriptionWebServiceAppsite) GetIdentityType() *plugin.TValue[string] {
@@ -68868,12 +68230,11 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteOutboundVnetRouting) GetImagePullT
 type mqlAzureSubscriptionPrivateEndpointConnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionPrivateEndpointConnectionInternal it will be used here
+	mqlAzureSubscriptionPrivateEndpointConnectionInternal
 	Id                                plugin.TValue[string]
 	Name                              plugin.TValue[string]
 	Type                              plugin.TValue[string]
 	IpAddresses                       plugin.TValue[[]any]
-	PrivateEndpointId                 plugin.TValue[string]
 	PrivateEndpoint                   plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint]
 	PrivateLinkServiceConnectionState plugin.TValue[*mqlAzureSubscriptionPrivateEndpointConnectionConnectionState]
 	ProvisioningState                 plugin.TValue[string]
@@ -68926,10 +68287,6 @@ func (c *mqlAzureSubscriptionPrivateEndpointConnection) GetType() *plugin.TValue
 
 func (c *mqlAzureSubscriptionPrivateEndpointConnection) GetIpAddresses() *plugin.TValue[[]any] {
 	return &c.IpAddresses
-}
-
-func (c *mqlAzureSubscriptionPrivateEndpointConnection) GetPrivateEndpointId() *plugin.TValue[string] {
-	return &c.PrivateEndpointId
 }
 
 func (c *mqlAzureSubscriptionPrivateEndpointConnection) GetPrivateEndpoint() *plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint] {
@@ -70656,12 +70013,7 @@ type mqlAzureSubscriptionSqlServiceServer struct {
 	Databases                        plugin.TValue[[]any]
 	FirewallRules                    plugin.TValue[[]any]
 	AzureAdAdministrators            plugin.TValue[[]any]
-	ConnectionPolicy                 plugin.TValue[any]
-	AuditingPolicy                   plugin.TValue[any]
 	AdministratorLogin               plugin.TValue[string]
-	SecurityAlertPolicy              plugin.TValue[any]
-	EncryptionProtector              plugin.TValue[any]
-	ThreatDetectionPolicy            plugin.TValue[any]
 	VulnerabilityAssessmentSettings  plugin.TValue[*mqlAzureSubscriptionSqlServiceServerVulnerabilityassessmentsettings]
 	VirtualNetworkRules              plugin.TValue[[]any]
 	EncryptionProtectorServerKeyType plugin.TValue[string]
@@ -70818,38 +70170,8 @@ func (c *mqlAzureSubscriptionSqlServiceServer) GetAzureAdAdministrators() *plugi
 	})
 }
 
-func (c *mqlAzureSubscriptionSqlServiceServer) GetConnectionPolicy() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.ConnectionPolicy, func() (any, error) {
-		return c.connectionPolicy()
-	})
-}
-
-func (c *mqlAzureSubscriptionSqlServiceServer) GetAuditingPolicy() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.AuditingPolicy, func() (any, error) {
-		return c.auditingPolicy()
-	})
-}
-
 func (c *mqlAzureSubscriptionSqlServiceServer) GetAdministratorLogin() *plugin.TValue[string] {
 	return &c.AdministratorLogin
-}
-
-func (c *mqlAzureSubscriptionSqlServiceServer) GetSecurityAlertPolicy() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.SecurityAlertPolicy, func() (any, error) {
-		return c.securityAlertPolicy()
-	})
-}
-
-func (c *mqlAzureSubscriptionSqlServiceServer) GetEncryptionProtector() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.EncryptionProtector, func() (any, error) {
-		return c.encryptionProtector()
-	})
-}
-
-func (c *mqlAzureSubscriptionSqlServiceServer) GetThreatDetectionPolicy() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.ThreatDetectionPolicy, func() (any, error) {
-		return c.threatDetectionPolicy()
-	})
 }
 
 func (c *mqlAzureSubscriptionSqlServiceServer) GetVulnerabilityAssessmentSettings() *plugin.TValue[*mqlAzureSubscriptionSqlServiceServerVulnerabilityassessmentsettings] {
@@ -71310,11 +70632,7 @@ type mqlAzureSubscriptionSqlServiceDatabase struct {
 	ReadScale                               plugin.TValue[string]
 	SampleName                              plugin.TValue[string]
 	ZoneRedundant                           plugin.TValue[bool]
-	TransparentDataEncryption               plugin.TValue[any]
 	Advisor                                 plugin.TValue[[]any]
-	ThreatDetectionPolicy                   plugin.TValue[any]
-	ConnectionPolicy                        plugin.TValue[any]
-	AuditingPolicy                          plugin.TValue[any]
 	AdvancedThreatProtection                plugin.TValue[*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection]
 	BackupShortTermRetentionPolicy          plugin.TValue[*mqlAzureSubscriptionSqlServiceDatabaseBackupshorttermretentionpolicy]
 	LongTermRetentionPolicy                 plugin.TValue[*mqlAzureSubscriptionSqlServiceDatabaseLongtermretentionpolicy]
@@ -71465,33 +70783,9 @@ func (c *mqlAzureSubscriptionSqlServiceDatabase) GetZoneRedundant() *plugin.TVal
 	return &c.ZoneRedundant
 }
 
-func (c *mqlAzureSubscriptionSqlServiceDatabase) GetTransparentDataEncryption() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.TransparentDataEncryption, func() (any, error) {
-		return c.transparentDataEncryption()
-	})
-}
-
 func (c *mqlAzureSubscriptionSqlServiceDatabase) GetAdvisor() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Advisor, func() ([]any, error) {
 		return c.advisor()
-	})
-}
-
-func (c *mqlAzureSubscriptionSqlServiceDatabase) GetThreatDetectionPolicy() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.ThreatDetectionPolicy, func() (any, error) {
-		return c.threatDetectionPolicy()
-	})
-}
-
-func (c *mqlAzureSubscriptionSqlServiceDatabase) GetConnectionPolicy() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.ConnectionPolicy, func() (any, error) {
-		return c.connectionPolicy()
-	})
-}
-
-func (c *mqlAzureSubscriptionSqlServiceDatabase) GetAuditingPolicy() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.AuditingPolicy, func() (any, error) {
-		return c.auditingPolicy()
 	})
 }
 
@@ -80570,43 +79864,33 @@ type mqlAzureSubscriptionCloudDefenderService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionCloudDefenderServiceInternal
-	SubscriptionId                  plugin.TValue[string]
-	MonitoringAgentAutoProvision    plugin.TValue[bool]
-	DefenderForServers              plugin.TValue[any]
-	ForServers                      plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers]
-	DefenderForAppServices          plugin.TValue[any]
-	ForAppServices                  plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices]
-	DefenderForSqlServersOnMachines plugin.TValue[any]
-	ForSqlServersOnMachines         plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines]
-	DefenderForSqlDatabases         plugin.TValue[any]
-	ForSqlDatabases                 plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases]
-	DefenderForOpenSourceDatabases  plugin.TValue[any]
-	ForOpenSourceDatabases          plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases]
-	DefenderForCosmosDb             plugin.TValue[any]
-	ForCosmosDb                     plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb]
-	DefenderForStorageAccounts      plugin.TValue[any]
-	ForStorageAccounts              plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts]
-	DefenderForKeyVaults            plugin.TValue[any]
-	ForKeyVaults                    plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults]
-	DefenderForResourceManager      plugin.TValue[any]
-	ForResourceManager              plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager]
-	DefenderForApis                 plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForApis]
-	DefenderCSPM                    plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM]
-	DefenderForContainers           plugin.TValue[any]
-	ForContainers                   plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers]
-	SecurityContacts                plugin.TValue[[]any]
-	SettingsMCAS                    plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
-	SettingsWDATP                   plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
-	SettingsSentinel                plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
-	SecureScores                    plugin.TValue[[]any]
-	SecureScoreControls             plugin.TValue[[]any]
-	RegulatoryComplianceStandards   plugin.TValue[[]any]
-	Assessments                     plugin.TValue[[]any]
-	Alerts                          plugin.TValue[[]any]
-	JitNetworkAccessPolicies        plugin.TValue[[]any]
-	AlertSuppressionRules           plugin.TValue[[]any]
-	WorkspaceSettings               plugin.TValue[[]any]
-	ApiCollections                  plugin.TValue[[]any]
+	SubscriptionId                plugin.TValue[string]
+	MonitoringAgentAutoProvision  plugin.TValue[bool]
+	ForServers                    plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers]
+	ForAppServices                plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices]
+	ForSqlServersOnMachines       plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines]
+	ForSqlDatabases               plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases]
+	ForOpenSourceDatabases        plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases]
+	ForCosmosDb                   plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb]
+	ForStorageAccounts            plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts]
+	ForKeyVaults                  plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults]
+	ForResourceManager            plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager]
+	DefenderForApis               plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForApis]
+	DefenderCSPM                  plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderCSPM]
+	ForContainers                 plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers]
+	SecurityContacts              plugin.TValue[[]any]
+	SettingsMCAS                  plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
+	SettingsWDATP                 plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
+	SettingsSentinel              plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceSettings]
+	SecureScores                  plugin.TValue[[]any]
+	SecureScoreControls           plugin.TValue[[]any]
+	RegulatoryComplianceStandards plugin.TValue[[]any]
+	Assessments                   plugin.TValue[[]any]
+	Alerts                        plugin.TValue[[]any]
+	JitNetworkAccessPolicies      plugin.TValue[[]any]
+	AlertSuppressionRules         plugin.TValue[[]any]
+	WorkspaceSettings             plugin.TValue[[]any]
+	ApiCollections                plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionCloudDefenderService creates a new instance of this resource
@@ -80656,12 +79940,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetMonitoringAgentAutoProvisi
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForServers() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForServers, func() (any, error) {
-		return c.defenderForServers()
-	})
-}
-
 func (c *mqlAzureSubscriptionCloudDefenderService) GetForServers() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers](&c.ForServers, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80675,12 +79953,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForServers() *plugin.TValu
 		}
 
 		return c.forServers()
-	})
-}
-
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForAppServices() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForAppServices, func() (any, error) {
-		return c.defenderForAppServices()
 	})
 }
 
@@ -80700,12 +79972,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForAppServices() *plugin.T
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlServersOnMachines() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForSqlServersOnMachines, func() (any, error) {
-		return c.defenderForSqlServersOnMachines()
-	})
-}
-
 func (c *mqlAzureSubscriptionCloudDefenderService) GetForSqlServersOnMachines() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines](&c.ForSqlServersOnMachines, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80719,12 +79985,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForSqlServersOnMachines() 
 		}
 
 		return c.forSqlServersOnMachines()
-	})
-}
-
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForSqlDatabases() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForSqlDatabases, func() (any, error) {
-		return c.defenderForSqlDatabases()
 	})
 }
 
@@ -80744,12 +80004,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForSqlDatabases() *plugin.
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForOpenSourceDatabases() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForOpenSourceDatabases, func() (any, error) {
-		return c.defenderForOpenSourceDatabases()
-	})
-}
-
 func (c *mqlAzureSubscriptionCloudDefenderService) GetForOpenSourceDatabases() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases](&c.ForOpenSourceDatabases, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80763,12 +80017,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForOpenSourceDatabases() *
 		}
 
 		return c.forOpenSourceDatabases()
-	})
-}
-
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForCosmosDb() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForCosmosDb, func() (any, error) {
-		return c.defenderForCosmosDb()
 	})
 }
 
@@ -80788,12 +80036,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForCosmosDb() *plugin.TVal
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForStorageAccounts() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForStorageAccounts, func() (any, error) {
-		return c.defenderForStorageAccounts()
-	})
-}
-
 func (c *mqlAzureSubscriptionCloudDefenderService) GetForStorageAccounts() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts](&c.ForStorageAccounts, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80810,12 +80052,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForStorageAccounts() *plug
 	})
 }
 
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForKeyVaults() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForKeyVaults, func() (any, error) {
-		return c.defenderForKeyVaults()
-	})
-}
-
 func (c *mqlAzureSubscriptionCloudDefenderService) GetForKeyVaults() *plugin.TValue[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults](&c.ForKeyVaults, func() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80829,12 +80065,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetForKeyVaults() *plugin.TVa
 		}
 
 		return c.forKeyVaults()
-	})
-}
-
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForResourceManager() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForResourceManager, func() (any, error) {
-		return c.defenderForResourceManager()
 	})
 }
 
@@ -80883,12 +80113,6 @@ func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderCSPM() *plugin.TVa
 		}
 
 		return c.defenderCSPM()
-	})
-}
-
-func (c *mqlAzureSubscriptionCloudDefenderService) GetDefenderForContainers() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.DefenderForContainers, func() (any, error) {
-		return c.defenderForContainers()
 	})
 }
 
@@ -84977,7 +84201,6 @@ type mqlAzureSubscriptionAuthorizationServiceRoleAssignment struct {
 	mqlAzureSubscriptionAuthorizationServiceRoleAssignmentInternal
 	Id            plugin.TValue[string]
 	Description   plugin.TValue[string]
-	Type          plugin.TValue[string]
 	Scope         plugin.TValue[string]
 	PrincipalId   plugin.TValue[string]
 	PrincipalType plugin.TValue[string]
@@ -85026,10 +84249,6 @@ func (c *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) GetId() *plugin
 
 func (c *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) GetType() *plugin.TValue[string] {
-	return &c.Type
 }
 
 func (c *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) GetScope() *plugin.TValue[string] {
@@ -85279,7 +84498,6 @@ type mqlAzureSubscriptionAksServiceCluster struct {
 	NetworkProfile                    plugin.TValue[any]
 	HttpProxyConfig                   plugin.TValue[any]
 	AddonProfiles                     plugin.TValue[[]any]
-	AgentPoolProfiles                 plugin.TValue[[]any]
 	NodePools                         plugin.TValue[[]any]
 	ApiServerAccessProfile            plugin.TValue[any]
 	FqdnSubdomain                     plugin.TValue[string]
@@ -85438,10 +84656,6 @@ func (c *mqlAzureSubscriptionAksServiceCluster) GetHttpProxyConfig() *plugin.TVa
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetAddonProfiles() *plugin.TValue[[]any] {
 	return &c.AddonProfiles
-}
-
-func (c *mqlAzureSubscriptionAksServiceCluster) GetAgentPoolProfiles() *plugin.TValue[[]any] {
-	return &c.AgentPoolProfiles
 }
 
 func (c *mqlAzureSubscriptionAksServiceCluster) GetNodePools() *plugin.TValue[[]any] {
@@ -87509,7 +86723,6 @@ type mqlAzureSubscriptionIotService struct {
 	__id       string
 	// optional: if you define mqlAzureSubscriptionIotServiceInternal it will be used here
 	SubscriptionId plugin.TValue[string]
-	Hubs           plugin.TValue[[]any]
 	IotHubs        plugin.TValue[[]any]
 }
 
@@ -87552,12 +86765,6 @@ func (c *mqlAzureSubscriptionIotService) MqlID() string {
 
 func (c *mqlAzureSubscriptionIotService) GetSubscriptionId() *plugin.TValue[string] {
 	return &c.SubscriptionId
-}
-
-func (c *mqlAzureSubscriptionIotService) GetHubs() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.Hubs, func() ([]any, error) {
-		return c.hubs()
-	})
 }
 
 func (c *mqlAzureSubscriptionIotService) GetIotHubs() *plugin.TValue[[]any] {
@@ -87907,7 +87114,6 @@ type mqlAzureSubscriptionCacheServiceRedisInstance struct {
 	Identity                   plugin.TValue[any]
 	PrincipalId                plugin.TValue[string]
 	UserAssignedIdentities     plugin.TValue[[]any]
-	EncryptionKey              plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
 	PrivateEndpointConnections plugin.TValue[[]any]
 	FirewallRules              plugin.TValue[[]any]
 	PatchSchedules             plugin.TValue[[]any]
@@ -88076,22 +87282,6 @@ func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetUserAssignedIdentitie
 		}
 
 		return c.userAssignedIdentities()
-	})
-}
-
-func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetEncryptionKey() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey] {
-	return plugin.GetOrCompute[*mqlAzureSubscriptionKeyVaultServiceKey](&c.EncryptionKey, func() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cacheService.redisInstance", c.__id, "encryptionKey")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.(*mqlAzureSubscriptionKeyVaultServiceKey), nil
-			}
-		}
-
-		return c.encryptionKey()
 	})
 }
 
@@ -88334,7 +87524,6 @@ type mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection stru
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
-	PrivateEndpointId plugin.TValue[string]
 	PrivateEndpoint   plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint]
 	Status            plugin.TValue[string]
 	Description       plugin.TValue[string]
@@ -88390,10 +87579,6 @@ func (c *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection)
 
 func (c *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) GetType() *plugin.TValue[string] {
 	return &c.Type
-}
-
-func (c *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) GetPrivateEndpointId() *plugin.TValue[string] {
-	return &c.PrivateEndpointId
 }
 
 func (c *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) GetPrivateEndpoint() *plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateEndpoint] {
@@ -88515,30 +87700,25 @@ type mqlAzureSubscriptionDataFactoryServiceFactory struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionDataFactoryServiceFactoryInternal
-	Id                      plugin.TValue[string]
-	Name                    plugin.TValue[string]
-	Location                plugin.TValue[string]
-	Tags                    plugin.TValue[map[string]any]
-	Type                    plugin.TValue[string]
-	Properties              plugin.TValue[any]
-	PublicNetworkAccess     plugin.TValue[string]
-	Identity                plugin.TValue[any]
-	ProvisioningState       plugin.TValue[string]
-	Version                 plugin.TValue[string]
-	RepoConfiguration       plugin.TValue[any]
-	Encryption              plugin.TValue[any]
-	CmkKeyName              plugin.TValue[string]
-	CmkKeyVaultUri          plugin.TValue[string]
-	CmkKeyVersion           plugin.TValue[string]
-	CmkUserAssignedIdentity plugin.TValue[string]
-	CmkKey                  plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
-	CmkIdentity             plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
-	UserAssignedIdentities  plugin.TValue[[]any]
-	Created                 plugin.TValue[*time.Time]
-	LinkedServices          plugin.TValue[[]any]
-	IntegrationRuntimes     plugin.TValue[[]any]
-	ManagedVirtualNetwork   plugin.TValue[*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork]
-	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
+	Id                     plugin.TValue[string]
+	Name                   plugin.TValue[string]
+	Location               plugin.TValue[string]
+	Tags                   plugin.TValue[map[string]any]
+	Type                   plugin.TValue[string]
+	Properties             plugin.TValue[any]
+	PublicNetworkAccess    plugin.TValue[string]
+	Identity               plugin.TValue[any]
+	ProvisioningState      plugin.TValue[string]
+	Version                plugin.TValue[string]
+	RepoConfiguration      plugin.TValue[any]
+	CmkKey                 plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey]
+	CmkIdentity            plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
+	UserAssignedIdentities plugin.TValue[[]any]
+	Created                plugin.TValue[*time.Time]
+	LinkedServices         plugin.TValue[[]any]
+	IntegrationRuntimes    plugin.TValue[[]any]
+	ManagedVirtualNetwork  plugin.TValue[*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDataFactoryServiceFactory creates a new instance of this resource
@@ -88620,26 +87800,6 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetVersion() *plugin.TVa
 
 func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetRepoConfiguration() *plugin.TValue[any] {
 	return &c.RepoConfiguration
-}
-
-func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetEncryption() *plugin.TValue[any] {
-	return &c.Encryption
-}
-
-func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkKeyName() *plugin.TValue[string] {
-	return &c.CmkKeyName
-}
-
-func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkKeyVaultUri() *plugin.TValue[string] {
-	return &c.CmkKeyVaultUri
-}
-
-func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkKeyVersion() *plugin.TValue[string] {
-	return &c.CmkKeyVersion
-}
-
-func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkUserAssignedIdentity() *plugin.TValue[string] {
-	return &c.CmkUserAssignedIdentity
 }
 
 func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetCmkKey() *plugin.TValue[*mqlAzureSubscriptionKeyVaultServiceKey] {
@@ -89747,7 +88907,6 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistry struct {
 	Type                             plugin.TValue[string]
 	Tags                             plugin.TValue[map[string]any]
 	SkuName                          plugin.TValue[string]
-	Identity                         plugin.TValue[any]
 	PrincipalId                      plugin.TValue[string]
 	TenantId                         plugin.TValue[string]
 	UserAssignedIdentities           plugin.TValue[[]any]
@@ -89835,10 +88994,6 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetTags() *plugin
 
 func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetSkuName() *plugin.TValue[string] {
 	return &c.SkuName
-}
-
-func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetIdentity() *plugin.TValue[any] {
-	return &c.Identity
 }
 
 func (c *mqlAzureSubscriptionContainerRegistryServiceRegistry) GetPrincipalId() *plugin.TValue[string] {
@@ -93539,7 +92694,6 @@ type mqlAzureSubscriptionFunctionsServiceFunctionApp struct {
 	HttpsOnly                 plugin.TValue[bool]
 	ClientCertEnabled         plugin.TValue[bool]
 	ClientCertMode            plugin.TValue[string]
-	ManagedServiceIdentityId  plugin.TValue[string]
 	PrincipalId               plugin.TValue[string]
 	SystemAssignedIdentity    plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities    plugin.TValue[[]any]
@@ -93630,10 +92784,6 @@ func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetClientCertEnabled()
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetClientCertMode() *plugin.TValue[string] {
 	return &c.ClientCertMode
-}
-
-func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetManagedServiceIdentityId() *plugin.TValue[string] {
-	return &c.ManagedServiceIdentityId
 }
 
 func (c *mqlAzureSubscriptionFunctionsServiceFunctionApp) GetPrincipalId() *plugin.TValue[string] {
@@ -94018,7 +93168,6 @@ type mqlAzureSubscriptionServiceBusServiceNamespace struct {
 	CmkKeySource                    plugin.TValue[string]
 	RequireInfrastructureEncryption plugin.TValue[bool]
 	CmkKeys                         plugin.TValue[[]any]
-	NetworkRuleSet                  plugin.TValue[any]
 	NetworkRules                    plugin.TValue[*mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules]
 	Queues                          plugin.TValue[[]any]
 	Topics                          plugin.TValue[[]any]
@@ -94115,12 +93264,6 @@ func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetRequireInfrastructur
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetCmkKeys() *plugin.TValue[[]any] {
 	return &c.CmkKeys
-}
-
-func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetNetworkRuleSet() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.NetworkRuleSet, func() (any, error) {
-		return c.networkRuleSet()
-	})
 }
 
 func (c *mqlAzureSubscriptionServiceBusServiceNamespace) GetNetworkRules() *plugin.TValue[*mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules] {
@@ -94910,7 +94053,6 @@ type mqlAzureSubscriptionEventHubServiceNamespace struct {
 	CmkKeySource                    plugin.TValue[string]
 	RequireInfrastructureEncryption plugin.TValue[bool]
 	CmkKeys                         plugin.TValue[[]any]
-	NetworkRuleSet                  plugin.TValue[any]
 	NetworkRules                    plugin.TValue[*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules]
 	EventHubs                       plugin.TValue[[]any]
 	AuthorizationRules              plugin.TValue[[]any]
@@ -95018,12 +94160,6 @@ func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetRequireInfrastructureE
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetCmkKeys() *plugin.TValue[[]any] {
 	return &c.CmkKeys
-}
-
-func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetNetworkRuleSet() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.NetworkRuleSet, func() (any, error) {
-		return c.networkRuleSet()
-	})
 }
 
 func (c *mqlAzureSubscriptionEventHubServiceNamespace) GetNetworkRules() *plugin.TValue[*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules] {
@@ -99136,7 +98272,6 @@ type mqlAzureSubscriptionContainerAppServiceContainerApp struct {
 	MinReplicas              plugin.TValue[int64]
 	MaxReplicas              plugin.TValue[int64]
 	ScaleRules               plugin.TValue[[]any]
-	Identity                 plugin.TValue[any]
 	PrincipalId              plugin.TValue[string]
 	SystemAssignedIdentity   plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	UserAssignedIdentities   plugin.TValue[[]any]
@@ -99306,10 +98441,6 @@ func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetMaxReplicas() *
 
 func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetScaleRules() *plugin.TValue[[]any] {
 	return &c.ScaleRules
-}
-
-func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetIdentity() *plugin.TValue[any] {
-	return &c.Identity
 }
 
 func (c *mqlAzureSubscriptionContainerAppServiceContainerApp) GetPrincipalId() *plugin.TValue[string] {
@@ -100199,7 +99330,6 @@ type mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer struct 
 	VolumeMounts             plugin.TValue[[]any]
 	LivenessProbe            plugin.TValue[any]
 	ReadinessProbe           plugin.TValue[any]
-	SecurityContext          plugin.TValue[any]
 	Privileged               plugin.TValue[bool]
 	AllowPrivilegeEscalation plugin.TValue[bool]
 	RunAsUser                plugin.TValue[int64]
@@ -100302,10 +99432,6 @@ func (c *mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer) Ge
 
 func (c *mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer) GetReadinessProbe() *plugin.TValue[any] {
 	return &c.ReadinessProbe
-}
-
-func (c *mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer) GetSecurityContext() *plugin.TValue[any] {
-	return &c.SecurityContext
 }
 
 func (c *mqlAzureSubscriptionContainerInstanceServiceContainerGroupContainer) GetPrivileged() *plugin.TValue[bool] {
@@ -100650,59 +99776,58 @@ type mqlAzureSubscriptionApiManagementServiceService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionApiManagementServiceServiceInternal
-	Id                             plugin.TValue[string]
-	Name                           plugin.TValue[string]
-	Location                       plugin.TValue[string]
-	Tags                           plugin.TValue[map[string]any]
-	SkuName                        plugin.TValue[string]
-	SkuCapacity                    plugin.TValue[int64]
-	ProvisioningState              plugin.TValue[string]
-	TargetProvisioningState        plugin.TValue[string]
-	PublisherEmail                 plugin.TValue[string]
-	PublisherName                  plugin.TValue[string]
-	NotificationSenderEmail        plugin.TValue[string]
-	GatewayUrl                     plugin.TValue[string]
-	GatewayRegionalUrl             plugin.TValue[string]
-	ManagementApiUrl               plugin.TValue[string]
-	PortalUrl                      plugin.TValue[string]
-	DeveloperPortalUrl             plugin.TValue[string]
-	ScmUrl                         plugin.TValue[string]
-	VirtualNetworkType             plugin.TValue[string]
-	PublicNetworkAccess            plugin.TValue[string]
-	NatGatewayState                plugin.TValue[string]
-	DisableGateway                 plugin.TValue[bool]
-	EnableClientCertificate        plugin.TValue[bool]
-	DeveloperPortalStatus          plugin.TValue[string]
-	LegacyPortalStatus             plugin.TValue[string]
-	PlatformVersion                plugin.TValue[string]
-	CustomProperties               plugin.TValue[map[string]any]
-	Tls10Enabled                   plugin.TValue[bool]
-	Tls11Enabled                   plugin.TValue[bool]
-	Ssl30Enabled                   plugin.TValue[bool]
-	BackendTls10Enabled            plugin.TValue[bool]
-	BackendTls11Enabled            plugin.TValue[bool]
-	BackendSsl30Enabled            plugin.TValue[bool]
-	TripleDesEnabled               plugin.TValue[bool]
-	Http2Enabled                   plugin.TValue[bool]
-	IdentityType                   plugin.TValue[string]
-	PrincipalId                    plugin.TValue[string]
-	TenantId                       plugin.TValue[string]
-	SystemAssignedIdentity         plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
-	UserAssignedIdentities         plugin.TValue[[]any]
-	PublicIpAddresses              plugin.TValue[[]any]
-	PrivateIpAddresses             plugin.TValue[[]any]
-	OutboundPublicIpAddresses      plugin.TValue[[]any]
-	PrivateEndpointConnectionCount plugin.TValue[int64]
-	PrivateEndpointConnections     plugin.TValue[[]any]
-	Zones                          plugin.TValue[[]any]
-	PublicIpAddress                plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
-	CreatedAt                      plugin.TValue[*time.Time]
-	SystemMetadata                 plugin.TValue[*mqlAzureSubscriptionSystemData]
-	Apis                           plugin.TValue[[]any]
-	Products                       plugin.TValue[[]any]
-	NamedValues                    plugin.TValue[[]any]
-	Subscriptions                  plugin.TValue[[]any]
-	PolicyXml                      plugin.TValue[string]
+	Id                         plugin.TValue[string]
+	Name                       plugin.TValue[string]
+	Location                   plugin.TValue[string]
+	Tags                       plugin.TValue[map[string]any]
+	SkuName                    plugin.TValue[string]
+	SkuCapacity                plugin.TValue[int64]
+	ProvisioningState          plugin.TValue[string]
+	TargetProvisioningState    plugin.TValue[string]
+	PublisherEmail             plugin.TValue[string]
+	PublisherName              plugin.TValue[string]
+	NotificationSenderEmail    plugin.TValue[string]
+	GatewayUrl                 plugin.TValue[string]
+	GatewayRegionalUrl         plugin.TValue[string]
+	ManagementApiUrl           plugin.TValue[string]
+	PortalUrl                  plugin.TValue[string]
+	DeveloperPortalUrl         plugin.TValue[string]
+	ScmUrl                     plugin.TValue[string]
+	VirtualNetworkType         plugin.TValue[string]
+	PublicNetworkAccess        plugin.TValue[string]
+	NatGatewayState            plugin.TValue[string]
+	DisableGateway             plugin.TValue[bool]
+	EnableClientCertificate    plugin.TValue[bool]
+	DeveloperPortalStatus      plugin.TValue[string]
+	LegacyPortalStatus         plugin.TValue[string]
+	PlatformVersion            plugin.TValue[string]
+	CustomProperties           plugin.TValue[map[string]any]
+	Tls10Enabled               plugin.TValue[bool]
+	Tls11Enabled               plugin.TValue[bool]
+	Ssl30Enabled               plugin.TValue[bool]
+	BackendTls10Enabled        plugin.TValue[bool]
+	BackendTls11Enabled        plugin.TValue[bool]
+	BackendSsl30Enabled        plugin.TValue[bool]
+	TripleDesEnabled           plugin.TValue[bool]
+	Http2Enabled               plugin.TValue[bool]
+	IdentityType               plugin.TValue[string]
+	PrincipalId                plugin.TValue[string]
+	TenantId                   plugin.TValue[string]
+	SystemAssignedIdentity     plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
+	UserAssignedIdentities     plugin.TValue[[]any]
+	PublicIpAddresses          plugin.TValue[[]any]
+	PrivateIpAddresses         plugin.TValue[[]any]
+	OutboundPublicIpAddresses  plugin.TValue[[]any]
+	PrivateEndpointConnections plugin.TValue[[]any]
+	Zones                      plugin.TValue[[]any]
+	PublicIpAddress            plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
+	CreatedAt                  plugin.TValue[*time.Time]
+	SystemMetadata             plugin.TValue[*mqlAzureSubscriptionSystemData]
+	Apis                       plugin.TValue[[]any]
+	Products                   plugin.TValue[[]any]
+	NamedValues                plugin.TValue[[]any]
+	Subscriptions              plugin.TValue[[]any]
+	PolicyXml                  plugin.TValue[string]
 }
 
 // createAzureSubscriptionApiManagementServiceService creates a new instance of this resource
@@ -100932,10 +100057,6 @@ func (c *mqlAzureSubscriptionApiManagementServiceService) GetPrivateIpAddresses(
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetOutboundPublicIpAddresses() *plugin.TValue[[]any] {
 	return &c.OutboundPublicIpAddresses
-}
-
-func (c *mqlAzureSubscriptionApiManagementServiceService) GetPrivateEndpointConnectionCount() *plugin.TValue[int64] {
-	return &c.PrivateEndpointConnectionCount
 }
 
 func (c *mqlAzureSubscriptionApiManagementServiceService) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
@@ -105809,7 +104930,6 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic struct {
 	Status         plugin.TValue[string]
 	FailedReason   plugin.TValue[string]
 	SampleBlobUrl  plugin.TValue[string]
-	CreatedAt      plugin.TValue[*time.Time]
 	CreationTime   plugin.TValue[*time.Time]
 	LastModifiedAt plugin.TValue[*time.Time]
 	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
@@ -105882,10 +105002,6 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetFailedR
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetSampleBlobUrl() *plugin.TValue[string] {
 	return &c.SampleBlobUrl
-}
-
-func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetCreatedAt() *plugin.TValue[*time.Time] {
-	return &c.CreatedAt
 }
 
 func (c *mqlAzureSubscriptionCognitiveServicesServiceAccountRaiTopic) GetCreationTime() *plugin.TValue[*time.Time] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -77,7 +77,6 @@ azure.subscription.aksService.cluster.advancedNetworking.enabled 13.1.8
 azure.subscription.aksService.cluster.advancedNetworking.id 13.1.8
 azure.subscription.aksService.cluster.advancedNetworking.securityEnabled 13.1.8
 azure.subscription.aksService.cluster.advancedNetworking.transitEncryptionType 13.1.8
-azure.subscription.aksService.cluster.agentPoolProfiles 9.0.1
 azure.subscription.aksService.cluster.apiServerAccessProfile 11.0.22
 azure.subscription.aksService.cluster.apiServerAuthorizedIPRanges 11.4.28
 azure.subscription.aksService.cluster.autoUpgradeProfile 11.4.28
@@ -250,7 +249,6 @@ azure.subscription.apiManagementService.service.platformVersion 13.10.2
 azure.subscription.apiManagementService.service.policyXml 13.33.8
 azure.subscription.apiManagementService.service.portalUrl 13.10.2
 azure.subscription.apiManagementService.service.principalId 13.24.1
-azure.subscription.apiManagementService.service.privateEndpointConnectionCount 13.10.2
 azure.subscription.apiManagementService.service.privateEndpointConnections 13.24.1
 azure.subscription.apiManagementService.service.privateIpAddresses 13.10.2
 azure.subscription.apiManagementService.service.product 13.33.8
@@ -356,7 +354,6 @@ azure.subscription.authorizationService.roleAssignment.principalId 11.2.1
 azure.subscription.authorizationService.roleAssignment.principalType 13.16.2
 azure.subscription.authorizationService.roleAssignment.role 11.2.1
 azure.subscription.authorizationService.roleAssignment.scope 11.2.1
-azure.subscription.authorizationService.roleAssignment.type 11.2.1
 azure.subscription.authorizationService.roleAssignment.updatedAt 11.2.1
 azure.subscription.authorizationService.roleAssignmentSchedule 13.25.1
 azure.subscription.authorizationService.roleAssignmentSchedule.assignmentType 13.25.1
@@ -489,19 +486,15 @@ azure.subscription.batchService.account 11.4.0
 azure.subscription.batchService.account.accountEndpoint 11.4.0
 azure.subscription.batchService.account.activeJobAndJobScheduleQuota 11.4.0
 azure.subscription.batchService.account.allowedAuthenticationModes 11.4.0
-azure.subscription.batchService.account.autoStorage 11.4.0
 azure.subscription.batchService.account.autoStorageAccount 13.23.1
 azure.subscription.batchService.account.dedicatedCoreQuota 11.4.0
 azure.subscription.batchService.account.dedicatedCoreQuotaPerVmFamily 11.4.0
 azure.subscription.batchService.account.dedicatedCoreQuotaPerVmFamilyEnforced 11.4.0
 azure.subscription.batchService.account.diagnosticSettings 11.4.0
 azure.subscription.batchService.account.diagnosticSettingsCategories 13.30.1
-azure.subscription.batchService.account.encryption 11.4.0
 azure.subscription.batchService.account.encryptionKey 13.23.1
 azure.subscription.batchService.account.id 11.4.0
-azure.subscription.batchService.account.identity 11.4.0
 azure.subscription.batchService.account.keyVault 13.23.1
-azure.subscription.batchService.account.keyVaultReference 11.4.0
 azure.subscription.batchService.account.location 11.4.0
 azure.subscription.batchService.account.lowPriorityCoreQuota 11.4.0
 azure.subscription.batchService.account.name 11.4.0
@@ -545,7 +538,6 @@ azure.subscription.cacheService 11.4.4
 azure.subscription.cacheService.redis 11.4.28
 azure.subscription.cacheService.redisInstance 11.4.4
 azure.subscription.cacheService.redisInstance.enableNonSslPort 11.4.4
-azure.subscription.cacheService.redisInstance.encryptionKey 13.1.8
 azure.subscription.cacheService.redisInstance.firewallRule 11.4.32
 azure.subscription.cacheService.redisInstance.firewallRule.endIpAddress 11.4.32
 azure.subscription.cacheService.redisInstance.firewallRule.id 11.4.32
@@ -575,7 +567,6 @@ azure.subscription.cacheService.redisInstance.privateEndpointConnection.groupIds
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.id 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.name 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateEndpoint 13.9.3
-azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateEndpointId 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.provisioningState 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.status 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.systemMetadata 13.28.1
@@ -1148,7 +1139,6 @@ azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef.source 13
 azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef.topic 13.12.2
 azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef.topicName 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic 13.12.2
-azure.subscription.cognitiveServicesService.account.raiTopic.createdAt 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.creationTime 13.22.1
 azure.subscription.cognitiveServicesService.account.raiTopic.description 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.failedReason 13.12.2
@@ -1242,7 +1232,6 @@ azure.subscription.computeService.disk.provisioningState 11.6.2
 azure.subscription.computeService.disk.publicNetworkAccess 11.4.28
 azure.subscription.computeService.disk.sku 9.0.1
 azure.subscription.computeService.disk.supportsHibernation 11.6.2
-azure.subscription.computeService.disk.systemData 13.8.2
 azure.subscription.computeService.disk.systemMetadata 13.19.2
 azure.subscription.computeService.disk.tags 9.0.1
 azure.subscription.computeService.disk.tier 11.6.2
@@ -1351,7 +1340,6 @@ azure.subscription.computeService.hybridMachine.extension.name 13.10.1
 azure.subscription.computeService.hybridMachine.extension.provisioningState 13.10.1
 azure.subscription.computeService.hybridMachine.extension.publisher 13.10.1
 azure.subscription.computeService.hybridMachine.extension.settings 13.10.1
-azure.subscription.computeService.hybridMachine.extension.systemData 13.10.1
 azure.subscription.computeService.hybridMachine.extension.systemMetadata 13.19.2
 azure.subscription.computeService.hybridMachine.extension.tags 13.10.1
 azure.subscription.computeService.hybridMachine.extension.type 13.10.1
@@ -1373,7 +1361,6 @@ azure.subscription.computeService.hybridMachine.privateLinkScopeResourceId 13.10
 azure.subscription.computeService.hybridMachine.properties 13.10.0
 azure.subscription.computeService.hybridMachine.provisioningState 13.10.0
 azure.subscription.computeService.hybridMachine.status 13.10.0
-azure.subscription.computeService.hybridMachine.systemData 13.10.0
 azure.subscription.computeService.hybridMachine.systemMetadata 13.19.2
 azure.subscription.computeService.hybridMachine.tags 13.10.0
 azure.subscription.computeService.hybridMachine.type 13.10.0
@@ -1438,7 +1425,6 @@ azure.subscription.computeService.snapshot.sku 13.7.1
 azure.subscription.computeService.snapshot.snapshotAccessState 13.8.2
 azure.subscription.computeService.snapshot.sourceDisk 13.7.1
 azure.subscription.computeService.snapshot.supportsHibernation 13.7.1
-azure.subscription.computeService.snapshot.systemData 13.8.2
 azure.subscription.computeService.snapshot.systemMetadata 13.19.2
 azure.subscription.computeService.snapshot.tags 13.7.1
 azure.subscription.computeService.snapshot.timeCreated 13.7.1
@@ -1498,7 +1484,6 @@ azure.subscription.computeService.vm.securityType 11.4.28
 azure.subscription.computeService.vm.sshPublicKeys 13.5.1
 azure.subscription.computeService.vm.state 9.0.1
 azure.subscription.computeService.vm.systemAssignedIdentity 13.26.1
-azure.subscription.computeService.vm.systemData 13.8.2
 azure.subscription.computeService.vm.systemMetadata 13.19.2
 azure.subscription.computeService.vm.tags 9.0.1
 azure.subscription.computeService.vm.timeCreated 11.6.2
@@ -1550,7 +1535,6 @@ azure.subscription.computeService.vmScaleSet.sku 13.7.1
 azure.subscription.computeService.vmScaleSet.skuProfile 13.8.2
 azure.subscription.computeService.vmScaleSet.spotRestorePolicy 13.8.2
 azure.subscription.computeService.vmScaleSet.systemAssignedIdentity 13.26.1
-azure.subscription.computeService.vmScaleSet.systemData 13.8.2
 azure.subscription.computeService.vmScaleSet.systemMetadata 13.19.2
 azure.subscription.computeService.vmScaleSet.tags 13.7.1
 azure.subscription.computeService.vmScaleSet.timeCreated 13.7.1
@@ -1594,7 +1578,6 @@ azure.subscription.containerAppService.containerApp.corsAllowedOrigins 13.10.2
 azure.subscription.containerAppService.containerApp.eventStreamEndpoint 13.11.3
 azure.subscription.containerAppService.containerApp.httpsOnly 13.10.2
 azure.subscription.containerAppService.containerApp.id 13.10.2
-azure.subscription.containerAppService.containerApp.identity 13.10.2
 azure.subscription.containerAppService.containerApp.ingressEnabled 13.10.2
 azure.subscription.containerAppService.containerApp.ingressExternal 13.10.2
 azure.subscription.containerAppService.containerApp.initContainers 13.10.2
@@ -1769,7 +1752,6 @@ azure.subscription.containerInstanceService.containerGroup.container.restartCoun
 azure.subscription.containerInstanceService.containerGroup.container.runAsGroup 13.16.2
 azure.subscription.containerInstanceService.containerGroup.container.runAsUser 13.16.2
 azure.subscription.containerInstanceService.containerGroup.container.seccompProfile 13.16.2
-azure.subscription.containerInstanceService.containerGroup.container.securityContext 13.10.2
 azure.subscription.containerInstanceService.containerGroup.container.volumeMounts 13.10.2
 azure.subscription.containerInstanceService.containerGroup.containers 13.10.2
 azure.subscription.containerInstanceService.containerGroup.dnsConfig 13.10.2
@@ -1864,7 +1846,6 @@ azure.subscription.containerRegistryService.registry.encryption.keyVaultKeyIdent
 azure.subscription.containerRegistryService.registry.encryption.lastKeyRotationTimestamp 13.3.3
 azure.subscription.containerRegistryService.registry.encryption.status 13.3.3
 azure.subscription.containerRegistryService.registry.id 13.3.3
-azure.subscription.containerRegistryService.registry.identity 13.3.3
 azure.subscription.containerRegistryService.registry.location 13.3.3
 azure.subscription.containerRegistryService.registry.loginServer 13.3.3
 azure.subscription.containerRegistryService.registry.name 13.3.3
@@ -2180,12 +2161,7 @@ azure.subscription.dataFactoryService.factories 13.3.0
 azure.subscription.dataFactoryService.factory 13.3.0
 azure.subscription.dataFactoryService.factory.cmkIdentity 13.23.1
 azure.subscription.dataFactoryService.factory.cmkKey 13.23.1
-azure.subscription.dataFactoryService.factory.cmkKeyName 13.16.2
-azure.subscription.dataFactoryService.factory.cmkKeyVaultUri 13.16.2
-azure.subscription.dataFactoryService.factory.cmkKeyVersion 13.16.2
-azure.subscription.dataFactoryService.factory.cmkUserAssignedIdentity 13.16.2
 azure.subscription.dataFactoryService.factory.created 13.3.0
-azure.subscription.dataFactoryService.factory.encryption 13.3.0
 azure.subscription.dataFactoryService.factory.id 13.3.0
 azure.subscription.dataFactoryService.factory.identity 13.3.0
 azure.subscription.dataFactoryService.factory.integrationRuntime 13.10.2
@@ -2496,7 +2472,6 @@ azure.subscription.eventHubService.namespace.location 13.3.3
 azure.subscription.eventHubService.namespace.maximumThroughputUnits 13.3.3
 azure.subscription.eventHubService.namespace.minimumTlsVersion 13.3.3
 azure.subscription.eventHubService.namespace.name 13.3.3
-azure.subscription.eventHubService.namespace.networkRuleSet 13.5.1
 azure.subscription.eventHubService.namespace.networkRules 13.12.2
 azure.subscription.eventHubService.namespace.networkRules.defaultAction 13.12.2
 azure.subscription.eventHubService.namespace.networkRules.ipRules 13.12.2
@@ -2684,7 +2659,6 @@ azure.subscription.functionsService.functionApp.id 13.3.3
 azure.subscription.functionsService.functionApp.keyVaultReferenceIdentity 13.11.3
 azure.subscription.functionsService.functionApp.kind 13.3.3
 azure.subscription.functionsService.functionApp.location 13.3.3
-azure.subscription.functionsService.functionApp.managedServiceIdentityId 13.3.3
 azure.subscription.functionsService.functionApp.name 13.3.3
 azure.subscription.functionsService.functionApp.principalId 13.23.1
 azure.subscription.functionsService.functionApp.properties 13.3.3
@@ -2702,7 +2676,6 @@ azure.subscription.iam 11.4.28
 azure.subscription.id 11.4.28
 azure.subscription.iot 11.4.28
 azure.subscription.iotService 11.3.0
-azure.subscription.iotService.hubs 11.3.0
 azure.subscription.iotService.iotHub 13.5.1
 azure.subscription.iotService.iotHub.allowedFqdnList 13.5.1
 azure.subscription.iotService.iotHub.diagnosticSettings 13.16.2
@@ -3634,7 +3607,6 @@ azure.subscription.networkService.applicationFirewallPolicy.customRule.state 13.
 azure.subscription.networkService.applicationFirewallPolicy.customRules 13.33.8
 azure.subscription.networkService.applicationFirewallPolicy.customRulesCount 13.16.2
 azure.subscription.networkService.applicationFirewallPolicy.enabled 13.25.1
-azure.subscription.networkService.applicationFirewallPolicy.enabledState 13.16.2
 azure.subscription.networkService.applicationFirewallPolicy.etag 9.0.13
 azure.subscription.networkService.applicationFirewallPolicy.exclusions 13.33.8
 azure.subscription.networkService.applicationFirewallPolicy.fileUploadLimitInMb 13.16.2
@@ -3722,7 +3694,6 @@ azure.subscription.networkService.applicationGateway.sslCertificate 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.hsmKey 13.25.1
 azure.subscription.networkService.applicationGateway.sslCertificate.id 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecret 13.25.1
-azure.subscription.networkService.applicationGateway.sslCertificate.keyVaultSecretId 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.name 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.provisioningState 13.12.2
 azure.subscription.networkService.applicationGateway.sslCertificate.publicCertData 13.12.2
@@ -3956,7 +3927,6 @@ azure.subscription.networkService.firewall.applicationRule.etag 9.0.8
 azure.subscription.networkService.firewall.applicationRule.id 9.0.8
 azure.subscription.networkService.firewall.applicationRule.name 9.0.8
 azure.subscription.networkService.firewall.applicationRule.priority 13.16.2
-azure.subscription.networkService.firewall.applicationRule.properties 9.0.8
 azure.subscription.networkService.firewall.applicationRule.rules 13.16.2
 azure.subscription.networkService.firewall.applicationRules 9.0.8
 azure.subscription.networkService.firewall.etag 9.0.8
@@ -3979,7 +3949,6 @@ azure.subscription.networkService.firewall.natRule.etag 9.0.8
 azure.subscription.networkService.firewall.natRule.id 9.0.8
 azure.subscription.networkService.firewall.natRule.name 9.0.8
 azure.subscription.networkService.firewall.natRule.priority 13.16.2
-azure.subscription.networkService.firewall.natRule.properties 9.0.8
 azure.subscription.networkService.firewall.natRule.rules 13.16.2
 azure.subscription.networkService.firewall.natRules 9.0.8
 azure.subscription.networkService.firewall.networkRule 9.0.8
@@ -3988,7 +3957,6 @@ azure.subscription.networkService.firewall.networkRule.etag 9.0.8
 azure.subscription.networkService.firewall.networkRule.id 9.0.8
 azure.subscription.networkService.firewall.networkRule.name 9.0.8
 azure.subscription.networkService.firewall.networkRule.priority 13.16.2
-azure.subscription.networkService.firewall.networkRule.properties 9.0.8
 azure.subscription.networkService.firewall.networkRule.rules 13.16.2
 azure.subscription.networkService.firewall.networkRules 9.0.8
 azure.subscription.networkService.firewall.policy 9.0.8
@@ -4010,14 +3978,12 @@ azure.subscription.networkService.firewallPolicy.idpsBypassRule 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.description 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationAddresses 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationIpGroupRefs 13.25.1
-azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationIpGroups 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.destinationPorts 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.id 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.name 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.protocol 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceAddresses 13.3.3
 azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceIpGroupRefs 13.25.1
-azure.subscription.networkService.firewallPolicy.idpsBypassRule.sourceIpGroups 13.3.3
 azure.subscription.networkService.firewallPolicy.intrusionDetectionBypassRules 13.3.3
 azure.subscription.networkService.firewallPolicy.intrusionDetectionMode 13.3.3
 azure.subscription.networkService.firewallPolicy.intrusionDetectionProfile 13.3.3
@@ -4046,7 +4012,6 @@ azure.subscription.networkService.frontendIpConfig.name 9.0.8
 azure.subscription.networkService.frontendIpConfig.privateIpAddress 9.0.8
 azure.subscription.networkService.frontendIpConfig.properties 9.0.8
 azure.subscription.networkService.frontendIpConfig.publicIpAddress 13.25.1
-azure.subscription.networkService.frontendIpConfig.publicIpAddressId 9.0.8
 azure.subscription.networkService.frontendIpConfig.subnet 13.25.1
 azure.subscription.networkService.frontendIpConfig.type 9.0.8
 azure.subscription.networkService.frontendIpConfig.zones 9.0.8
@@ -4113,11 +4078,9 @@ azure.subscription.networkService.interface.ipConfiguration.provisioningState 13
 azure.subscription.networkService.interface.ipConfiguration.publicIpAddress 13.25.1
 azure.subscription.networkService.interface.ipConfiguration.subnet 13.25.1
 azure.subscription.networkService.interface.ipConfiguration.virtualNetworkTaps 13.25.1
-azure.subscription.networkService.interface.ipConfigurations 13.1.8
 azure.subscription.networkService.interface.location 9.0.1
 azure.subscription.networkService.interface.name 9.0.1
 azure.subscription.networkService.interface.networkSecurityGroup 13.12.2
-azure.subscription.networkService.interface.networkSecurityGroupId 11.6.1
 azure.subscription.networkService.interface.primary 11.4.28
 azure.subscription.networkService.interface.properties 9.0.1
 azure.subscription.networkService.interface.tags 9.0.1
@@ -4326,10 +4289,8 @@ azure.subscription.networkService.privateEndpoint.serviceconnection.groupIds 11.
 azure.subscription.networkService.privateEndpoint.serviceconnection.id 11.4.28
 azure.subscription.networkService.privateEndpoint.serviceconnection.name 11.4.28
 azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkService 13.9.3
-azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkServiceId 11.4.28
 azure.subscription.networkService.privateEndpoint.serviceconnection.requestMessage 11.4.28
 azure.subscription.networkService.privateEndpoint.subnet 13.26.1
-azure.subscription.networkService.privateEndpoint.subnetId 11.4.28
 azure.subscription.networkService.privateEndpoint.tags 11.4.28
 azure.subscription.networkService.privateEndpoint.type 11.4.28
 azure.subscription.networkService.privateEndpoints 11.4.28
@@ -4564,7 +4525,6 @@ azure.subscription.networkService.trafficManagerProfile.endpoint.alwaysServe 13.
 azure.subscription.networkService.trafficManagerProfile.endpoint.customHeaders 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.endpointLocation 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.endpointMonitorStatus 13.12.2
-azure.subscription.networkService.trafficManagerProfile.endpoint.endpointStatus 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.geoMapping 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.id 13.12.2
 azure.subscription.networkService.trafficManagerProfile.endpoint.minChildEndpoints 13.12.2
@@ -4585,7 +4545,6 @@ azure.subscription.networkService.trafficManagerProfile.location 13.12.2
 azure.subscription.networkService.trafficManagerProfile.maxReturn 13.12.2
 azure.subscription.networkService.trafficManagerProfile.monitorConfig 13.12.2
 azure.subscription.networkService.trafficManagerProfile.name 13.12.2
-azure.subscription.networkService.trafficManagerProfile.profileStatus 13.12.2
 azure.subscription.networkService.trafficManagerProfile.properties 13.12.2
 azure.subscription.networkService.trafficManagerProfile.status 13.25.1
 azure.subscription.networkService.trafficManagerProfile.tags 13.12.2
@@ -4680,7 +4639,6 @@ azure.subscription.networkService.virtualNetwork.peering.provisioningState 13.0.
 azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetwork 13.23.1
 azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkEncryptionEnabled 13.5.1
 azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkEncryptionEnforcement 13.5.1
-azure.subscription.networkService.virtualNetwork.peering.remoteVirtualNetworkId 13.0.2
 azure.subscription.networkService.virtualNetwork.peering.useRemoteGateways 13.0.2
 azure.subscription.networkService.virtualNetwork.peerings 13.0.2
 azure.subscription.networkService.virtualNetwork.properties 9.0.8
@@ -4771,7 +4729,6 @@ azure.subscription.networkService.virtualNetworkGateway.tags 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.type 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.vpnClientAddressPool 13.16.2
 azure.subscription.networkService.virtualNetworkGateway.vpnClientAuthenticationTypes 13.16.2
-azure.subscription.networkService.virtualNetworkGateway.vpnClientConfiguration 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.vpnClientIpsecPolicies 13.29.1
 azure.subscription.networkService.virtualNetworkGateway.vpnGatewayGeneration 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.vpnType 9.0.8
@@ -4909,7 +4866,6 @@ azure.subscription.networkService.watcher.connectionMonitors 13.12.2
 azure.subscription.networkService.watcher.etag 9.0.1
 azure.subscription.networkService.watcher.flowLogs 9.0.1
 azure.subscription.networkService.watcher.flowlog 9.0.1
-azure.subscription.networkService.watcher.flowlog.analytics 9.0.1
 azure.subscription.networkService.watcher.flowlog.enabled 9.0.1
 azure.subscription.networkService.watcher.flowlog.etag 9.0.1
 azure.subscription.networkService.watcher.flowlog.format 9.0.1
@@ -4919,7 +4875,6 @@ azure.subscription.networkService.watcher.flowlog.name 9.0.1
 azure.subscription.networkService.watcher.flowlog.provisioningState 9.0.1
 azure.subscription.networkService.watcher.flowlog.retentionDays 13.16.2
 azure.subscription.networkService.watcher.flowlog.retentionEnabled 13.16.2
-azure.subscription.networkService.watcher.flowlog.retentionPolicy 9.0.1
 azure.subscription.networkService.watcher.flowlog.storageAccountId 9.0.1
 azure.subscription.networkService.watcher.flowlog.tags 9.0.1
 azure.subscription.networkService.watcher.flowlog.targetResourceGuid 9.0.1
@@ -5095,7 +5050,6 @@ azure.subscription.privateEndpointConnection.id 11.4.4
 azure.subscription.privateEndpointConnection.ipAddresses 11.4.4
 azure.subscription.privateEndpointConnection.name 11.4.4
 azure.subscription.privateEndpointConnection.privateEndpoint 13.9.3
-azure.subscription.privateEndpointConnection.privateEndpointId 11.4.4
 azure.subscription.privateEndpointConnection.privateLinkServiceConnectionState 11.4.4
 azure.subscription.privateEndpointConnection.properties 11.4.4
 azure.subscription.privateEndpointConnection.provisioningState 11.4.4
@@ -5354,7 +5308,6 @@ azure.subscription.serviceBusService.namespace.disableLocalAuth 13.3.3
 azure.subscription.serviceBusService.namespace.id 13.3.3
 azure.subscription.serviceBusService.namespace.location 13.3.3
 azure.subscription.serviceBusService.namespace.name 13.3.3
-azure.subscription.serviceBusService.namespace.networkRuleSet 13.5.1
 azure.subscription.serviceBusService.namespace.networkRules 13.12.2
 azure.subscription.serviceBusService.namespace.networkRules.defaultAction 13.12.2
 azure.subscription.serviceBusService.namespace.networkRules.ipRules 13.12.2
@@ -5462,7 +5415,6 @@ azure.subscription.sqlService.database.advancedthreatprotection.id 11.4.28
 azure.subscription.sqlService.database.advancedthreatprotection.state 11.4.28
 azure.subscription.sqlService.database.advancedthreatprotection.systemMetadata 13.28.1
 azure.subscription.sqlService.database.advisor 9.0.1
-azure.subscription.sqlService.database.auditingPolicy 9.0.1
 azure.subscription.sqlService.database.backupShortTermRetentionPolicy 11.4.28
 azure.subscription.sqlService.database.backupshorttermretentionpolicy 11.4.28
 azure.subscription.sqlService.database.backupshorttermretentionpolicy.diffBackupIntervalInHours 11.4.28
@@ -5480,7 +5432,6 @@ azure.subscription.sqlService.database.blobAuditingPolicy.state 13.8.2
 azure.subscription.sqlService.database.blobAuditingPolicy.storageAccountSubscriptionId 13.8.2
 azure.subscription.sqlService.database.blobAuditingPolicy.storageEndpoint 13.8.2
 azure.subscription.sqlService.database.collation 9.0.1
-azure.subscription.sqlService.database.connectionPolicy 9.0.1
 azure.subscription.sqlService.database.createMode 9.0.1
 azure.subscription.sqlService.database.creationDate 9.0.1
 azure.subscription.sqlService.database.dataMaskingPolicy 13.8.2
@@ -5556,8 +5507,6 @@ azure.subscription.sqlService.database.sourceDatabaseDeletionDate 9.0.1
 azure.subscription.sqlService.database.sourceDatabaseId 9.0.1
 azure.subscription.sqlService.database.status 9.0.1
 azure.subscription.sqlService.database.tags 13.34.1
-azure.subscription.sqlService.database.threatDetectionPolicy 9.0.1
-azure.subscription.sqlService.database.transparentDataEncryption 9.0.1
 azure.subscription.sqlService.database.transparentDataEncryptionEnabled 13.8.2
 azure.subscription.sqlService.database.type 9.0.1
 azure.subscription.sqlService.database.usage 9.0.1
@@ -5646,7 +5595,6 @@ azure.subscription.sqlService.server.advancedThreatProtectionSetting.creationTim
 azure.subscription.sqlService.server.advancedThreatProtectionSetting.id 13.8.2
 azure.subscription.sqlService.server.advancedThreatProtectionSetting.state 13.8.2
 azure.subscription.sqlService.server.advancedThreatProtectionSetting.systemMetadata 13.28.1
-azure.subscription.sqlService.server.auditingPolicy 9.0.1
 azure.subscription.sqlService.server.azureAdAdministrators 9.0.1
 azure.subscription.sqlService.server.azureAdOnlyAuthentication 13.1.8
 azure.subscription.sqlService.server.blobAuditingPolicy 13.8.2
@@ -5660,7 +5608,6 @@ azure.subscription.sqlService.server.blobAuditingPolicy.retentionDays 13.8.2
 azure.subscription.sqlService.server.blobAuditingPolicy.state 13.8.2
 azure.subscription.sqlService.server.blobAuditingPolicy.storageAccountSubscriptionId 13.8.2
 azure.subscription.sqlService.server.blobAuditingPolicy.storageEndpoint 13.8.2
-azure.subscription.sqlService.server.connectionPolicy 9.0.1
 azure.subscription.sqlService.server.connectionType 13.8.2
 azure.subscription.sqlService.server.databases 9.0.1
 azure.subscription.sqlService.server.devOpsAuditingSetting 13.8.2
@@ -5670,7 +5617,6 @@ azure.subscription.sqlService.server.devOpsAuditingSetting.state 13.8.2
 azure.subscription.sqlService.server.devOpsAuditingSetting.storageAccountSubscriptionId 13.8.2
 azure.subscription.sqlService.server.devOpsAuditingSetting.storageEndpoint 13.8.2
 azure.subscription.sqlService.server.devOpsAuditingSetting.systemMetadata 13.28.1
-azure.subscription.sqlService.server.encryptionProtector 9.0.1
 azure.subscription.sqlService.server.encryptionProtectorConfig 13.8.2
 azure.subscription.sqlService.server.encryptionProtectorConfig.autoRotationEnabled 13.8.2
 azure.subscription.sqlService.server.encryptionProtectorConfig.id 13.8.2
@@ -5741,7 +5687,6 @@ azure.subscription.sqlService.server.replicationLink.role 13.8.2
 azure.subscription.sqlService.server.replicationLink.startTime 13.8.2
 azure.subscription.sqlService.server.replicationLinks 13.8.2
 azure.subscription.sqlService.server.restrictOutboundNetworkAccess 11.4.28
-azure.subscription.sqlService.server.securityAlertPolicy 9.0.1
 azure.subscription.sqlService.server.securityAlertPolicyConfig 13.8.2
 azure.subscription.sqlService.server.securityAlertPolicyConfig.creationTime 13.8.2
 azure.subscription.sqlService.server.securityAlertPolicyConfig.disabledAlerts 13.8.2
@@ -5755,7 +5700,6 @@ azure.subscription.sqlService.server.securityAlertPolicyConfig.systemMetadata 13
 azure.subscription.sqlService.server.state 11.4.28
 azure.subscription.sqlService.server.tags 9.0.1
 azure.subscription.sqlService.server.tenantId 13.23.1
-azure.subscription.sqlService.server.threatDetectionPolicy 9.0.1
 azure.subscription.sqlService.server.type 9.0.1
 azure.subscription.sqlService.server.version 11.4.28
 azure.subscription.sqlService.server.virtualNetworkRules 9.0.1
@@ -5909,7 +5853,6 @@ azure.subscription.storageService.account.fileShare.systemMetadata 13.28.1
 azure.subscription.storageService.account.fileShare.type 13.10.2
 azure.subscription.storageService.account.fileShares 13.10.2
 azure.subscription.storageService.account.id 9.0.1
-azure.subscription.storageService.account.identity 9.0.1
 azure.subscription.storageService.account.immutableStorageEnabled 13.10.2
 azure.subscription.storageService.account.immutableStoragePolicyAllowProtectedAppendWrites 13.10.2
 azure.subscription.storageService.account.immutableStoragePolicyPeriodDays 13.10.2
@@ -5999,7 +5942,6 @@ azure.subscription.storageService.account.privateEndpointConnection.description 
 azure.subscription.storageService.account.privateEndpointConnection.id 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.name 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.privateEndpoint 13.26.1
-azure.subscription.storageService.account.privateEndpointConnection.privateEndpointId 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.provisioningState 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.status 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.systemMetadata 13.28.1
@@ -6220,7 +6162,6 @@ azure.subscription.webService.appsite.hostNameBinding.virtualIP 11.4.32
 azure.subscription.webService.appsite.hostNameBindings 11.4.32
 azure.subscription.webService.appsite.httpsOnly 11.4.28
 azure.subscription.webService.appsite.id 9.0.1
-azure.subscription.webService.appsite.identity 9.0.1
 azure.subscription.webService.appsite.identityType 13.1.8
 azure.subscription.webService.appsite.ipMode 13.1.8
 azure.subscription.webService.appsite.keyVaultReferenceIdentity 13.5.1

--- a/providers/azure/resources/batch.go
+++ b/providers/azure/resources/batch.go
@@ -125,17 +125,9 @@ func (a *mqlAzureSubscriptionBatchService) accounts() ([]any, error) {
 }
 
 func createBatchAccountRawData(account *armbatch.Account) (map[string]*llx.RawData, error) {
-	identityData := llx.NilData
 	principalId := llx.StringData("")
-	if account.Identity != nil {
-		identity, err := convert.JsonToDict(account.Identity)
-		if err != nil {
-			return nil, err
-		}
-		identityData = llx.DictData(identity)
-		if account.Identity.PrincipalID != nil {
-			principalId = llx.StringData(*account.Identity.PrincipalID)
-		}
+	if account.Identity != nil && account.Identity.PrincipalID != nil {
+		principalId = llx.StringData(*account.Identity.PrincipalID)
 	}
 
 	propertiesData := llx.NilData
@@ -152,9 +144,6 @@ func createBatchAccountRawData(account *armbatch.Account) (map[string]*llx.RawDa
 		lowPriorityCoreQuota                  = llx.NilData
 		poolQuota                             = llx.NilData
 		allowedAuthenticationModes            = llx.NilData
-		autoStorage                           = llx.NilData
-		encryption                            = llx.NilData
-		keyVaultReference                     = llx.NilData
 		networkProfile                        = llx.NilData
 		privateEndpointConnections            = llx.NilData
 	)
@@ -210,27 +199,6 @@ func createBatchAccountRawData(account *armbatch.Account) (map[string]*llx.RawDa
 			allowedAuthenticationModes = llx.ArrayData(values, types.String)
 		}
 
-		if props.AutoStorage != nil {
-			if dict, err := convert.JsonToDict(props.AutoStorage); err != nil {
-				return nil, err
-			} else if dict != nil {
-				autoStorage = llx.DictData(dict)
-			}
-		}
-		if props.Encryption != nil {
-			if dict, err := convert.JsonToDict(props.Encryption); err != nil {
-				return nil, err
-			} else if dict != nil {
-				encryption = llx.DictData(dict)
-			}
-		}
-		if props.KeyVaultReference != nil {
-			if dict, err := convert.JsonToDict(props.KeyVaultReference); err != nil {
-				return nil, err
-			} else if dict != nil {
-				keyVaultReference = llx.DictData(dict)
-			}
-		}
 		if props.NetworkProfile != nil {
 			if dict, err := convert.JsonToDict(props.NetworkProfile); err != nil {
 				return nil, err
@@ -276,7 +244,6 @@ func createBatchAccountRawData(account *armbatch.Account) (map[string]*llx.RawDa
 		"location":                              llx.StringDataPtr(account.Location),
 		"tags":                                  llx.MapData(convert.PtrMapStrToInterface(account.Tags), types.String),
 		"type":                                  llx.StringDataPtr(account.Type),
-		"identity":                              identityData,
 		"principalId":                           principalId,
 		"properties":                            propertiesData,
 		"accountEndpoint":                       accountEndpoint,
@@ -291,9 +258,6 @@ func createBatchAccountRawData(account *armbatch.Account) (map[string]*llx.RawDa
 		"lowPriorityCoreQuota":                  lowPriorityCoreQuota,
 		"poolQuota":                             poolQuota,
 		"allowedAuthenticationModes":            allowedAuthenticationModes,
-		"autoStorage":                           autoStorage,
-		"encryption":                            encryption,
-		"keyVaultReference":                     keyVaultReference,
 		"networkProfile":                        networkProfile,
 		"privateEndpointConnections":            privateEndpointConnections,
 	}, nil

--- a/providers/azure/resources/batch_test.go
+++ b/providers/azure/resources/batch_test.go
@@ -80,8 +80,8 @@ func TestBatchAccountDataConversion(t *testing.T) {
 
 		// Dict fields
 		assert.NotNil(t, rawData["properties"].Value)
-		assert.NotNil(t, rawData["identity"].Value)
 		assert.NotNil(t, rawData["tags"].Value)
+		assert.Equal(t, "principal-123", rawData["principalId"].Value)
 	})
 
 	t.Run("EnumConversions", func(t *testing.T) {
@@ -121,15 +121,12 @@ func TestBatchAccountDataConversion(t *testing.T) {
 		assert.Nil(t, rawData["poolQuota"].Value)
 		assert.Nil(t, rawData["dedicatedCoreQuotaPerVmFamilyEnforced"].Value)
 		assert.Nil(t, rawData["allowedAuthenticationModes"].Value)
-		assert.Nil(t, rawData["autoStorage"].Value)
-		assert.Nil(t, rawData["encryption"].Value)
-		assert.Nil(t, rawData["keyVaultReference"].Value)
 		assert.Nil(t, rawData["networkProfile"].Value)
 		assert.Nil(t, rawData["privateEndpointConnections"].Value)
 		assert.Nil(t, rawData["dedicatedCoreQuotaPerVmFamily"].Value)
 
 		// Nil identity
-		assert.Nil(t, rawData["identity"].Value)
+		assert.Equal(t, "", rawData["principalId"].Value)
 
 		// Present fields still work
 		assert.Equal(t, "Succeeded", rawData["provisioningState"].Value)

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -191,17 +191,6 @@ func (a *mqlAzureSubscriptionCloudDefenderService) cachedPolicyAssignments(ctx c
 	return a.policyAssignments, a.policyAssignmentsErr
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForServers() (any, error) {
-	typed := a.GetForServers()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return map[string]any{
-		"enabled":                         typed.Data.GetEnabled().Data,
-		"vulnerabilityManagementToolName": typed.Data.GetVulnerabilityManagementToolName().Data,
-	}, nil
-}
-
 func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -276,28 +265,12 @@ func simpleDefenderDict(enabled *plugin.TValue[bool]) (any, error) {
 	return map[string]any{"enabled": enabled.Data}, nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForAppServices() (any, error) {
-	typed := a.GetForAppServices()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
-}
-
 func (a *mqlAzureSubscriptionCloudDefenderService) forAppServices() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices, error) {
 	resource, err := a.getSimpleDefenderPricing("AppServices", ResourceAzureSubscriptionCloudDefenderServiceDefenderForAppServices)
 	if err != nil {
 		return nil, err
 	}
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices), nil
-}
-
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlServersOnMachines() (any, error) {
-	typed := a.GetForSqlServersOnMachines()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forSqlServersOnMachines() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines, error) {
@@ -308,28 +281,12 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forSqlServersOnMachines() (*m
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForSqlDatabases() (any, error) {
-	typed := a.GetForSqlDatabases()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
-}
-
 func (a *mqlAzureSubscriptionCloudDefenderService) forSqlDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases, error) {
 	resource, err := a.getSimpleDefenderPricing("SqlServers", ResourceAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases)
 	if err != nil {
 		return nil, err
 	}
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases), nil
-}
-
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForOpenSourceDatabases() (any, error) {
-	typed := a.GetForOpenSourceDatabases()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forOpenSourceDatabases() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases, error) {
@@ -340,28 +297,12 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forOpenSourceDatabases() (*mq
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForOpenSourceDatabases), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForCosmosDb() (any, error) {
-	typed := a.GetForCosmosDb()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
-}
-
 func (a *mqlAzureSubscriptionCloudDefenderService) forCosmosDb() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb, error) {
 	resource, err := a.getSimpleDefenderPricing("CosmosDbs", ResourceAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb)
 	if err != nil {
 		return nil, err
 	}
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForCosmosDb), nil
-}
-
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForStorageAccounts() (any, error) {
-	typed := a.GetForStorageAccounts()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forStorageAccounts() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts, error) {
@@ -372,28 +313,12 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forStorageAccounts() (*mqlAzu
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForStorageAccounts), nil
 }
 
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForKeyVaults() (any, error) {
-	typed := a.GetForKeyVaults()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
-}
-
 func (a *mqlAzureSubscriptionCloudDefenderService) forKeyVaults() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults, error) {
 	resource, err := a.getSimpleDefenderPricing("KeyVaults", ResourceAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults)
 	if err != nil {
 		return nil, err
 	}
 	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForKeyVaults), nil
-}
-
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForResourceManager() (any, error) {
-	typed := a.GetForResourceManager()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-	return simpleDefenderDict(typed.Data.GetEnabled())
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forResourceManager() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForResourceManager, error) {
@@ -485,35 +410,6 @@ func (a *mqlAzureSubscriptionCloudDefenderService) monitoringAgentAutoProvision(
 		return false, nil
 	}
 	return *setting.Properties.AutoProvision == security.AutoProvisionOn, nil
-}
-
-func (a *mqlAzureSubscriptionCloudDefenderService) defenderForContainers() (any, error) {
-	typed := a.GetForContainers()
-	if typed.Error != nil {
-		return nil, typed.Error
-	}
-
-	rawExts, err := typed.Data.fetchRawExtensions()
-	if err != nil {
-		return nil, err
-	}
-	exts := make([]map[string]any, 0, len(rawExts))
-	for _, ext := range rawExts {
-		if ext.IsEnabled == nil || ext.Name == nil {
-			continue
-		}
-		exts = append(exts, map[string]any{
-			"name":      *ext.Name,
-			"isEnabled": *ext.IsEnabled == security.IsEnabledTrue,
-		})
-	}
-
-	return map[string]any{
-		"defenderDaemonSet":        typed.Data.GetDefenderDaemonSet().Data,
-		"azurePolicyForKubernetes": typed.Data.GetAzurePolicyForKubernetes().Data,
-		"enabled":                  typed.Data.GetEnabled().Data,
-		"extensions":               exts,
-	}, nil
 }
 
 func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSubscriptionCloudDefenderServiceDefenderForContainers, error) {

--- a/providers/azure/resources/cognitiveservices.go
+++ b/providers/azure/resources/cognitiveservices.go
@@ -1092,7 +1092,6 @@ func raiTopicToMql(runtime *plugin.Runtime, t *armcognitiveservices.RaiTopic) (*
 		"status":         llx.StringData(status),
 		"failedReason":   llx.StringData(failedReason),
 		"sampleBlobUrl":  llx.StringData(sampleBlobUrl),
-		"createdAt":      llx.TimeDataPtr(createdAt),
 		"creationTime":   llx.TimeDataPtr(createdAt),
 		"lastModifiedAt": llx.TimeDataPtr(lastModifiedAt),
 	})

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -283,7 +283,6 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 			"fipsEncryptionEnabled":         llx.BoolDataPtr(fipsEncryptionEnabled),
 			"resiliencyProfile":             llx.DictData(resiliencyProfileDict),
 			"scheduledEventsPolicy":         llx.DictData(scheduledEventsPolicyDict),
-			"systemData":                    llx.DictData(systemDataDict),
 			"computerName":                  llx.StringDataPtr(computerName),
 			"adminUsername":                 llx.StringDataPtr(adminUsername),
 			"licenseType":                   llx.StringDataPtr(licenseType),
@@ -307,6 +306,7 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 		return nil, err
 	}
 	mqlVm := res.(*mqlAzureSubscriptionComputeServiceVm)
+	mqlVm.cacheSystemData = systemDataDict
 	mqlVm.cacheUserAssignedIdentityIds = userAssignedIdentityIds
 	return mqlVm, nil
 }
@@ -363,6 +363,7 @@ type mqlAzureSubscriptionComputeServiceVmInternal struct {
 	extensionsList               []*compute.VirtualMachineExtension
 	extensionsError              error
 	cacheUserAssignedIdentityIds []string
+	cacheSystemData              any
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) fetchExtensions() ([]*compute.VirtualMachineExtension, error) {
@@ -570,7 +571,6 @@ func diskToMql(runtime *plugin.Runtime, disk compute.Disk) (*mqlAzureSubscriptio
 		"zones":             llx.ArrayData(zones, types.String),
 		"sku":               llx.DictData(sku),
 		"properties":        llx.DictData(properties),
-		"systemData":        llx.DictData(systemData),
 	}
 
 	if disk.Properties != nil {
@@ -616,7 +616,13 @@ func diskToMql(runtime *plugin.Runtime, disk compute.Disk) (*mqlAzureSubscriptio
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionComputeServiceDisk), nil
+	mqlDisk := res.(*mqlAzureSubscriptionComputeServiceDisk)
+	mqlDisk.cacheSystemData = systemData
+	return mqlDisk, nil
+}
+
+type mqlAzureSubscriptionComputeServiceDiskInternal struct {
+	cacheSystemData any
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) osDisk() (*mqlAzureSubscriptionComputeServiceDisk, error) {
@@ -1327,6 +1333,7 @@ func (a *mqlAzureSubscriptionComputeServiceDiskAccess) privateEndpointConnection
 			resType = "Microsoft.Compute/diskAccesses/privateEndpointConnections"
 		}
 
+		var pecPrivateEndpointID string
 		privateEndpoint := map[string]*llx.RawData{
 			"__id": llx.StringDataPtr(entry.ID),
 			"id":   llx.StringDataPtr(entry.ID),
@@ -1346,7 +1353,7 @@ func (a *mqlAzureSubscriptionComputeServiceDiskAccess) privateEndpointConnection
 			privateEndpoint["properties"] = llx.DictData(propsMap)
 
 			if props.PrivateEndpoint != nil {
-				privateEndpoint["privateEndpointId"] = llx.StringDataPtr(props.PrivateEndpoint.ID)
+				pecPrivateEndpointID = convert.ToValue(props.PrivateEndpoint.ID)
 			}
 			if props.PrivateLinkServiceConnectionState != nil {
 				stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(entry.ID),
@@ -1363,7 +1370,7 @@ func (a *mqlAzureSubscriptionComputeServiceDiskAccess) privateEndpointConnection
 			}
 		}
 
-		mqlRes, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, privateEndpoint)
+		mqlRes, err := newAzurePrivateEndpointConnection(a.MqlRuntime, privateEndpoint, pecPrivateEndpointID)
 		if err != nil {
 			return nil, err
 		}
@@ -1463,6 +1470,7 @@ func initAzureSubscriptionComputeServiceDiskEncryptionSet(runtime *plugin.Runtim
 type mqlAzureSubscriptionComputeServiceSnapshotInternal struct {
 	cacheSourceDiskId *string
 	cacheDESId        *string
+	cacheSystemData   any
 }
 
 func (a *mqlAzureSubscriptionComputeServiceSnapshot) id() (string, error) {
@@ -1532,7 +1540,6 @@ func snapshotToMql(runtime *plugin.Runtime, snap compute.Snapshot) (*mqlAzureSub
 		"type":       llx.StringDataPtr(snap.Type),
 		"sku":        llx.DictData(sku),
 		"properties": llx.DictData(properties),
-		"systemData": llx.DictData(systemData),
 	}
 
 	var cacheSourceDiskId, cacheDESId *string
@@ -1600,6 +1607,7 @@ func snapshotToMql(runtime *plugin.Runtime, snap compute.Snapshot) (*mqlAzureSub
 	mqlSnap := res.(*mqlAzureSubscriptionComputeServiceSnapshot)
 	mqlSnap.cacheSourceDiskId = cacheSourceDiskId
 	mqlSnap.cacheDESId = cacheDESId
+	mqlSnap.cacheSystemData = systemData
 	return mqlSnap, nil
 }
 

--- a/providers/azure/resources/compute_vmss.go
+++ b/providers/azure/resources/compute_vmss.go
@@ -153,7 +153,6 @@ func vmScaleSetToMql(runtime *plugin.Runtime, vmss compute.VirtualMachineScaleSe
 		"zones":       llx.ArrayData(strPtrsToAny(vmss.Zones), types.String),
 		"sku":         llx.DictData(sku),
 		"properties":  llx.DictData(properties),
-		"systemData":  llx.DictData(systemData),
 		"identity":    llx.DictData(identityDict),
 		"principalId": llx.StringDataPtr(principalId),
 	}
@@ -233,11 +232,13 @@ func vmScaleSetToMql(runtime *plugin.Runtime, vmss compute.VirtualMachineScaleSe
 	}
 	mqlVmss := res.(*mqlAzureSubscriptionComputeServiceVmScaleSet)
 	mqlVmss.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+	mqlVmss.cacheSystemData = systemData
 	return mqlVmss, nil
 }
 
 type mqlAzureSubscriptionComputeServiceVmScaleSetInternal struct {
 	cacheUserAssignedIdentityIds []string
+	cacheSystemData              any
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) userAssignedIdentities() ([]any, error) {

--- a/providers/azure/resources/containerinstance.go
+++ b/providers/azure/resources/containerinstance.go
@@ -345,18 +345,12 @@ func aciContainersToMQL(runtime *plugin.Runtime, parentId string, specs []*aci.C
 			}
 			readiness = d
 		}
-		secCtx := map[string]any{}
 		var privileged, allowPrivilegeEscalation *bool
 		var runAsUser, runAsGroup *int64
 		var seccompProfile *string
 		addedCapabilities := []any{}
 		droppedCapabilities := []any{}
 		if sc := c.Properties.SecurityContext; sc != nil {
-			d, err := convert.JsonToDict(sc)
-			if err != nil {
-				return nil, err
-			}
-			secCtx = d
 			privileged = sc.Privileged
 			allowPrivilegeEscalation = sc.AllowPrivilegeEscalation
 			seccompProfile = sc.SeccompProfile
@@ -410,7 +404,6 @@ func aciContainersToMQL(runtime *plugin.Runtime, parentId string, specs []*aci.C
 				"volumeMounts":             llx.ArrayData(mounts, types.Dict),
 				"livenessProbe":            llx.DictData(liveness),
 				"readinessProbe":           llx.DictData(readiness),
-				"securityContext":          llx.DictData(secCtx),
 				"privileged":               llx.BoolDataPtr(privileged),
 				"allowPrivilegeEscalation": llx.BoolDataPtr(allowPrivilegeEscalation),
 				"runAsUser":                llx.IntDataPtr(runAsUser),

--- a/providers/azure/resources/containerregistry.go
+++ b/providers/azure/resources/containerregistry.go
@@ -165,10 +165,6 @@ func createRegistryResource(runtime *plugin.Runtime, reg *armcontainerregistry.R
 		props = &armcontainerregistry.RegistryProperties{}
 	}
 
-	identity, err := convert.JsonToDict(reg.Identity)
-	if err != nil {
-		return nil, err
-	}
 	var regPrincipalId, regTenantId *string
 	var userAssignedIdentityIds []string
 	if reg.Identity != nil {
@@ -222,7 +218,6 @@ func createRegistryResource(runtime *plugin.Runtime, reg *armcontainerregistry.R
 			"type":                             llx.StringDataPtr(reg.Type),
 			"tags":                             llx.MapData(convert.PtrMapStrToInterface(reg.Tags), types.String),
 			"skuName":                          llx.StringData(skuName),
-			"identity":                         llx.DictData(identity),
 			"principalId":                      llx.StringDataPtr(regPrincipalId),
 			"tenantId":                         llx.StringDataPtr(regTenantId),
 			"adminUserEnabled":                 llx.BoolDataPtr(props.AdminUserEnabled),
@@ -487,6 +482,7 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) privateEndpointCo
 			resType = "Microsoft.ContainerRegistry/registries/privateEndpointConnections"
 		}
 
+		var pecPrivateEndpointID string
 		pecArgs := map[string]*llx.RawData{
 			"__id": llx.StringDataPtr(pec.ID),
 			"id":   llx.StringDataPtr(pec.ID),
@@ -503,7 +499,7 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) privateEndpointCo
 			pecArgs["properties"] = llx.DictData(propsMap)
 
 			if props.PrivateEndpoint != nil {
-				pecArgs["privateEndpointId"] = llx.StringDataPtr(props.PrivateEndpoint.ID)
+				pecPrivateEndpointID = convert.ToValue(props.PrivateEndpoint.ID)
 			}
 			if props.PrivateLinkServiceConnectionState != nil {
 				stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(pec.ID),
@@ -520,7 +516,7 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) privateEndpointCo
 			}
 		}
 
-		mqlRes, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, pecArgs)
+		mqlRes, err := newAzurePrivateEndpointConnection(a.MqlRuntime, pecArgs, pecPrivateEndpointID)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/azure/resources/cosmosdb.go
+++ b/providers/azure/resources/cosmosdb.go
@@ -652,6 +652,7 @@ func (a *mqlAzureSubscriptionCosmosDbServiceAccount) privateEndpointConnections(
 			if pec == nil {
 				continue
 			}
+			var pecPrivateEndpointID string
 			args := map[string]*llx.RawData{
 				"__id": llx.StringDataPtr(pec.ID),
 				"id":   llx.StringDataPtr(pec.ID),
@@ -665,7 +666,7 @@ func (a *mqlAzureSubscriptionCosmosDbServiceAccount) privateEndpointConnections(
 				}
 				args["properties"] = llx.DictData(propsMap)
 				if pec.Properties.PrivateEndpoint != nil {
-					args["privateEndpointId"] = llx.StringDataPtr(pec.Properties.PrivateEndpoint.ID)
+					pecPrivateEndpointID = convert.ToValue(pec.Properties.PrivateEndpoint.ID)
 				}
 				if pec.Properties.ProvisioningState != nil {
 					args["provisioningState"] = llx.StringDataPtr(pec.Properties.ProvisioningState)
@@ -681,7 +682,7 @@ func (a *mqlAzureSubscriptionCosmosDbServiceAccount) privateEndpointConnections(
 					args["privateLinkServiceConnectionState"] = llx.ResourceData(stateRes, ResourceAzureSubscriptionPrivateEndpointConnectionConnectionState)
 				}
 			}
-			mqlConn, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, args)
+			mqlConn, err := newAzurePrivateEndpointConnection(a.MqlRuntime, args, pecPrivateEndpointID)
 			if err != nil {
 				return nil, err
 			}

--- a/providers/azure/resources/datafactory.go
+++ b/providers/azure/resources/datafactory.go
@@ -22,6 +22,10 @@ import (
 
 type mqlAzureSubscriptionDataFactoryServiceFactoryInternal struct {
 	cacheUserAssignedIdentityIds []string
+	cacheCmkKeyName              string
+	cacheCmkKeyVaultUri          string
+	cacheCmkKeyVersion           string
+	cacheCmkUserAssignedIdentity string
 	cacheSystemData              any
 }
 
@@ -94,7 +98,6 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 			var provisioningState string
 			var version string
 			var repoConfig any
-			var encryption any
 			var cmkKeyName, cmkKeyVaultUri, cmkKeyVersion, cmkUserAssignedIdentity string
 			var created *llx.RawData
 
@@ -115,10 +118,6 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 					}
 				}
 				if factory.Properties.Encryption != nil {
-					encryption, err = convert.JsonToDict(factory.Properties.Encryption)
-					if err != nil {
-						return nil, err
-					}
 					if factory.Properties.Encryption.KeyName != nil {
 						cmkKeyName = *factory.Properties.Encryption.KeyName
 					}
@@ -140,30 +139,29 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 
 			mqlFactory, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionDataFactoryServiceFactory,
 				map[string]*llx.RawData{
-					"__id":                    llx.StringDataPtr(factory.ID),
-					"id":                      llx.StringDataPtr(factory.ID),
-					"name":                    llx.StringDataPtr(factory.Name),
-					"location":                llx.StringDataPtr(factory.Location),
-					"tags":                    llx.MapData(convert.PtrMapStrToInterface(factory.Tags), types.String),
-					"type":                    llx.StringDataPtr(factory.Type),
-					"properties":              llx.DictData(properties),
-					"publicNetworkAccess":     llx.StringData(publicNetworkAccess),
-					"identity":                llx.DictData(identity),
-					"provisioningState":       llx.StringData(provisioningState),
-					"version":                 llx.StringData(version),
-					"repoConfiguration":       llx.DictData(repoConfig),
-					"encryption":              llx.DictData(encryption),
-					"cmkKeyName":              llx.StringData(cmkKeyName),
-					"cmkKeyVaultUri":          llx.StringData(cmkKeyVaultUri),
-					"cmkKeyVersion":           llx.StringData(cmkKeyVersion),
-					"cmkUserAssignedIdentity": llx.StringData(cmkUserAssignedIdentity),
-					"created":                 created,
+					"__id":                llx.StringDataPtr(factory.ID),
+					"id":                  llx.StringDataPtr(factory.ID),
+					"name":                llx.StringDataPtr(factory.Name),
+					"location":            llx.StringDataPtr(factory.Location),
+					"tags":                llx.MapData(convert.PtrMapStrToInterface(factory.Tags), types.String),
+					"type":                llx.StringDataPtr(factory.Type),
+					"properties":          llx.DictData(properties),
+					"publicNetworkAccess": llx.StringData(publicNetworkAccess),
+					"identity":            llx.DictData(identity),
+					"provisioningState":   llx.StringData(provisioningState),
+					"version":             llx.StringData(version),
+					"repoConfiguration":   llx.DictData(repoConfig),
+					"created":             created,
 				})
 			if err != nil {
 				return nil, err
 			}
 			factoryRes := mqlFactory.(*mqlAzureSubscriptionDataFactoryServiceFactory)
 			factoryRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+			factoryRes.cacheCmkKeyName = cmkKeyName
+			factoryRes.cacheCmkKeyVaultUri = cmkKeyVaultUri
+			factoryRes.cacheCmkKeyVersion = cmkKeyVersion
+			factoryRes.cacheCmkUserAssignedIdentity = cmkUserAssignedIdentity
 			sysData, err := convert.JsonToDict(factory.SystemData)
 			if err != nil {
 				return nil, err
@@ -181,14 +179,14 @@ func (a *mqlAzureSubscriptionDataFactoryServiceFactory) id() (string, error) {
 
 // cmkKey returns a typed reference to the Key Vault key used for customer-managed encryption.
 func (a *mqlAzureSubscriptionDataFactoryServiceFactory) cmkKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
-	vaultURI := strings.TrimSuffix(a.CmkKeyVaultUri.Data, "/")
-	keyName := a.CmkKeyName.Data
+	vaultURI := strings.TrimSuffix(a.cacheCmkKeyVaultUri, "/")
+	keyName := a.cacheCmkKeyName
 	if vaultURI == "" || keyName == "" {
 		a.CmkKey.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
 	keyURI := vaultURI + "/keys/" + keyName
-	if version := a.CmkKeyVersion.Data; version != "" {
+	if version := a.cacheCmkKeyVersion; version != "" {
 		keyURI += "/" + version
 	}
 	return newKeyVaultKeyResource(a.MqlRuntime, keyURI)
@@ -196,7 +194,7 @@ func (a *mqlAzureSubscriptionDataFactoryServiceFactory) cmkKey() (*mqlAzureSubsc
 
 // cmkIdentity returns the user-assigned managed identity used to access the CMK.
 func (a *mqlAzureSubscriptionDataFactoryServiceFactory) cmkIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	id := a.CmkUserAssignedIdentity.Data
+	id := a.cacheCmkUserAssignedIdentity
 	if id == "" {
 		a.CmkIdentity.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -441,18 +441,6 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() 
 	return res, nil
 }
 
-// networkRuleSet fetches the namespace-level network rule set.
-func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRuleSet() (any, error) {
-	props, err := a.fetchNetworkRuleSetProperties()
-	if err != nil {
-		return nil, err
-	}
-	if props == nil {
-		return nil, nil
-	}
-	return convert.JsonToDict(props)
-}
-
 func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRules() (*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules, error) {
 	props, err := a.fetchNetworkRuleSetProperties()
 	if err != nil {

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -161,7 +161,7 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		return nil, err
 	}
 
-	var state, defaultHostName, clientCertMode, managedServiceIdentityId string
+	var state, defaultHostName, clientCertMode string
 	var keyVaultReferenceIdentity, virtualNetworkSubnetId string
 	var httpsOnly, clientCertEnabled bool
 	publicNetworkAccess := functionAppPublicNetworkAccess(site.Properties)
@@ -193,7 +193,6 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 	if site.Identity != nil {
 		principalId = site.Identity.PrincipalID
 		if principalId != nil {
-			managedServiceIdentityId = *principalId
 		}
 		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(site.Identity.UserAssignedIdentities)
 	}
@@ -209,7 +208,6 @@ func functionAppSiteToMql(runtime *plugin.Runtime, site *web.Site) (plugin.Resou
 		"httpsOnly":                 llx.BoolData(httpsOnly),
 		"clientCertEnabled":         llx.BoolData(clientCertEnabled),
 		"clientCertMode":            llx.StringData(clientCertMode),
-		"managedServiceIdentityId":  llx.StringData(managedServiceIdentityId),
 		"principalId":               llx.StringDataPtr(principalId),
 		"keyVaultReferenceIdentity": llx.StringData(keyVaultReferenceIdentity),
 		"publicNetworkAccess":       llx.StringData(publicNetworkAccess),

--- a/providers/azure/resources/hybridcompute.go
+++ b/providers/azure/resources/hybridcompute.go
@@ -144,11 +144,11 @@ func (a *mqlAzureSubscriptionComputeService) hybridMachines() ([]any, error) {
 					"cloudMetadata":              llx.DictData(cloudMetadataDict),
 					"licenseProfile":             llx.DictData(licenseProfileDict),
 					"properties":                 llx.DictData(properties),
-					"systemData":                 llx.DictData(systemDataDict),
 				})
 			if err != nil {
 				return nil, err
 			}
+			mqlMachine.(*mqlAzureSubscriptionComputeServiceHybridMachine).cacheSystemData = systemDataDict
 			res = append(res, mqlMachine)
 		}
 	}
@@ -264,13 +264,22 @@ func hybridMachineExtensionToMql(runtime *plugin.Runtime, ext *hybridcompute.Mac
 			"provisioningState":       llx.StringDataPtr(provisioningState),
 			"settings":                llx.DictData(settingsDict),
 			"forceUpdateTag":          llx.StringDataPtr(forceUpdateTag),
-			"systemData":              llx.DictData(systemData),
 			"instanceView":            llx.DictData(instanceViewDict),
 		})
 	if err != nil {
 		return nil, err
 	}
-	return mqlExt.(*mqlAzureSubscriptionComputeServiceHybridMachineExtension), nil
+	mqlExtension := mqlExt.(*mqlAzureSubscriptionComputeServiceHybridMachineExtension)
+	mqlExtension.cacheSystemData = systemData
+	return mqlExtension, nil
+}
+
+type mqlAzureSubscriptionComputeServiceHybridMachineInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionComputeServiceHybridMachineExtensionInternal struct {
+	cacheSystemData any
 }
 
 func initAzureSubscriptionComputeServiceHybridMachine(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -316,7 +316,6 @@ func newMqlRoleAssignment(runtime *plugin.Runtime, roleAssignment *authorization
 			"id":            llx.StringDataPtr(roleAssignment.Name), // name is the id :-)
 			"description":   llx.StringDataPtr(roleAssignment.Properties.Description),
 			"scope":         llx.StringDataPtr(roleAssignment.Properties.Scope),
-			"type":          llx.StringData(principalType),
 			"principalId":   llx.StringDataPtr(roleAssignment.Properties.PrincipalID),
 			"principalType": llx.StringData(principalType),
 			"condition":     llx.StringDataPtr(roleAssignment.Properties.Condition),

--- a/providers/azure/resources/iot.go
+++ b/providers/azure/resources/iot.go
@@ -116,44 +116,6 @@ func initAzureSubscriptionIotServiceIotHub(runtime *plugin.Runtime, args map[str
 	return nil, nil, fmt.Errorf("azure iot hub does not exist")
 }
 
-func (a *mqlAzureSubscriptionIotService) hubs() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-
-	subscriptionID := a.SubscriptionId.Data
-
-	clientFactory, err := armiothub.NewClientFactory(subscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	client := clientFactory.NewResourceClient()
-	hubsPager := client.NewListBySubscriptionPager(nil)
-	var hubs []any
-
-	for hubsPager.More() {
-		page, err := hubsPager.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, hub := range page.Value {
-			if hub == nil {
-				continue
-			}
-			hubData, err := convert.JsonToDict(hub)
-			if err != nil {
-				return nil, err
-			}
-			hubs = append(hubs, hubData)
-		}
-	}
-
-	return hubs, nil
-}
-
 // iotHubs returns typed IoT hub resources with security-relevant fields populated.
 func (a *mqlAzureSubscriptionIotService) iotHubs() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -729,6 +729,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) privateEndpointConnections() 
 			resType = "Microsoft.KeyVault/vaults/privateEndpointConnections"
 		}
 
+		var pecPrivateEndpointID string
 		privateEndpoint := map[string]*llx.RawData{
 			"__id": llx.StringDataPtr(entry.ID),
 			"id":   llx.StringDataPtr(entry.ID),
@@ -748,7 +749,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) privateEndpointConnections() 
 			privateEndpoint["properties"] = llx.DictData(propsMap)
 
 			if props.PrivateEndpoint != nil {
-				privateEndpoint["privateEndpointId"] = llx.StringDataPtr(props.PrivateEndpoint.ID)
+				pecPrivateEndpointID = convert.ToValue(props.PrivateEndpoint.ID)
 			}
 			if props.PrivateLinkServiceConnectionState != nil {
 				stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(entry.ID),
@@ -765,7 +766,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) privateEndpointConnections() 
 			}
 		}
 
-		mqlRes, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, privateEndpoint)
+		mqlRes, err := newAzurePrivateEndpointConnection(a.MqlRuntime, privateEndpoint, pecPrivateEndpointID)
 		if err != nil {
 			return nil, err
 		}
@@ -2151,6 +2152,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceManagedHsm) privateEndpointConnectio
 			resType = "Microsoft.KeyVault/managedHSMs/privateEndpointConnections"
 		}
 
+		var pecPrivateEndpointID string
 		privateEndpoint := map[string]*llx.RawData{
 			"__id": llx.StringDataPtr(entry.ID),
 			"id":   llx.StringDataPtr(entry.ID),
@@ -2170,7 +2172,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceManagedHsm) privateEndpointConnectio
 			privateEndpoint["properties"] = llx.DictData(propsMap)
 
 			if props.PrivateEndpoint != nil {
-				privateEndpoint["privateEndpointId"] = llx.StringDataPtr(props.PrivateEndpoint.ID)
+				pecPrivateEndpointID = convert.ToValue(props.PrivateEndpoint.ID)
 			}
 			if props.PrivateLinkServiceConnectionState != nil {
 				stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(entry.ID),
@@ -2187,7 +2189,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceManagedHsm) privateEndpointConnectio
 			}
 		}
 
-		mqlRes, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, privateEndpoint)
+		mqlRes, err := newAzurePrivateEndpointConnection(a.MqlRuntime, privateEndpoint, pecPrivateEndpointID)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -578,10 +578,6 @@ func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSu
 				RetentionDays: int(convert.ToValue(rp.Days)),
 			}
 		}
-		retentionPolicyDict, err := convert.JsonToDict(retentionPolicy)
-		if err != nil {
-			return nil, err
-		}
 		var flowLogAnalytics flowLogAnalyticsConfig
 		if fac := props.FlowAnalyticsConfiguration; fac != nil && fac.NetworkWatcherFlowAnalyticsConfiguration != nil {
 			nwfac := fac.NetworkWatcherFlowAnalyticsConfiguration
@@ -593,17 +589,12 @@ func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSu
 				WorkspaceId:         convert.ToValue(nwfac.WorkspaceID),
 			}
 		}
-		flowLogAnalyticsDict, err := convert.JsonToDict(flowLogAnalytics)
-		if err != nil {
-			return nil, err
-		}
 		var formatType *string
 		var formatVersion *int32
 		if f := props.Format; f != nil {
 			formatType = (*string)(f.Type)
 			formatVersion = f.Version
 		}
-		args["retentionPolicy"] = llx.DictData(retentionPolicyDict)
 		args["retentionEnabled"] = llx.BoolData(retentionPolicy.Enabled)
 		args["retentionDays"] = llx.IntData(int64(retentionPolicy.RetentionDays))
 		args["format"] = llx.StringDataPtr(formatType)
@@ -613,7 +604,6 @@ func flowLogToMql(runtime *plugin.Runtime, flowLog network.FlowLog) (*mqlAzureSu
 		args["targetResourceId"] = llx.StringDataPtr(props.TargetResourceID)
 		args["targetResourceGuid"] = llx.StringDataPtr(props.TargetResourceGUID)
 		args["provisioningState"] = llx.StringDataPtr((*string)(props.ProvisioningState))
-		args["analytics"] = llx.DictData(flowLogAnalyticsDict)
 		args["trafficAnalyticsEnabled"] = llx.BoolData(flowLogAnalytics.Enabled)
 		args["trafficAnalyticsInterval"] = llx.IntData(int64(flowLogAnalytics.AnalyticsInterval))
 		args["trafficAnalyticsWorkspaceId"] = llx.StringData(flowLogAnalytics.WorkspaceResourceId)
@@ -758,14 +748,12 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 			return nil, err
 		}
 		isPublic := false
-		var publicIpAddressId string
 		var privateIpAddress string
 		var ddosCustomPolicyId string
 		var publicIpAddressIDPtr, subnetIDPtr *string
 		if ipConfig.Properties != nil {
 			if ipConfig.Properties.PublicIPAddress != nil && ipConfig.Properties.PublicIPAddress.ID != nil {
 				isPublic = true
-				publicIpAddressId = *ipConfig.Properties.PublicIPAddress.ID
 				publicIpAddressIDPtr = ipConfig.Properties.PublicIPAddress.ID
 			}
 			if ipConfig.Properties.Subnet != nil {
@@ -788,7 +776,6 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 				"zones":              llx.ArrayData(strPtrsToAny(ipConfig.Zones), types.String),
 				"properties":         llx.DictData(props),
 				"isPublic":           llx.BoolData(isPublic),
-				"publicIpAddressId":  llx.StringData(publicIpAddressId),
 				"privateIpAddress":   llx.StringData(privateIpAddress),
 				"ddosCustomPolicyId": llx.StringData(ddosCustomPolicyId),
 			})
@@ -1534,17 +1521,21 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetwork) peerings() ([]any, er
 					"peeringState":                          llx.StringDataPtr((*string)(p.Properties.PeeringState)),
 					"peeringSyncLevel":                      llx.StringDataPtr((*string)(p.Properties.PeeringSyncLevel)),
 					"provisioningState":                     llx.StringDataPtr((*string)(p.Properties.ProvisioningState)),
-					"remoteVirtualNetworkId":                llx.StringData(remoteVnetId),
 					"remoteVirtualNetworkEncryptionEnabled": llx.BoolData(remoteEncEnabled),
 					"remoteVirtualNetworkEncryptionEnforcement": llx.StringData(remoteEncEnforcement),
 				})
 			if err != nil {
 				return nil, err
 			}
+			mqlPeering.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering).cacheRemoteVirtualNetworkId = remoteVnetId
 			res = append(res, mqlPeering)
 		}
 	}
 	return res, nil
+}
+
+type mqlAzureSubscriptionNetworkServiceVirtualNetworkPeeringInternal struct {
+	cacheRemoteVirtualNetworkId string
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) id() (string, error) {
@@ -1557,14 +1548,14 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) id() (string, 
 // correctly. Returns null when the peering has no remote virtual network
 // reference.
 func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) remoteVirtualNetwork() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
-	if a.RemoteVirtualNetworkId.Data == "" {
+	if a.cacheRemoteVirtualNetworkId == "" {
 		a.RemoteVirtualNetwork.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
 	token := conn.Token()
-	resourceID, err := ParseResourceID(a.RemoteVirtualNetworkId.Data)
+	resourceID, err := ParseResourceID(a.cacheRemoteVirtualNetworkId)
 	if err != nil {
 		return nil, err
 	}
@@ -1707,16 +1698,6 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 				var aadTenant, aadAudience, aadIssuer string
 				radiusConfigured := false
 				if vc := vng.Properties.VPNClientConfiguration; vc != nil {
-					// Scrub the RADIUS shared secret before serializing the raw
-					// configuration so it is never exposed through the dict.
-					scrubbed := *vc
-					scrubbed.RadiusServerSecret = nil
-					vpnClientDict, err := convert.JsonToDict(&scrubbed)
-					if err != nil {
-						return nil, err
-					}
-					args["vpnClientConfiguration"] = llx.DictData(vpnClientDict)
-
 					for _, at := range vc.VPNAuthenticationTypes {
 						if at != nil {
 							vpnClientAuthTypes = append(vpnClientAuthTypes, string(*at))
@@ -1729,8 +1710,6 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 					aadAudience = convert.ToValue(vc.AADAudience)
 					aadIssuer = convert.ToValue(vc.AADIssuer)
 					radiusConfigured = (vc.RadiusServerAddress != nil && *vc.RadiusServerAddress != "") || len(vc.RadiusServers) > 0
-				} else {
-					args["vpnClientConfiguration"] = llx.NilData
 				}
 				args["vpnClientAuthenticationTypes"] = llx.ArrayData(vpnClientAuthTypes, types.String)
 				args["vpnClientAddressPool"] = llx.ArrayData(vpnClientAddressPool, types.String)
@@ -2092,7 +2071,6 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 			"tags":                                llx.MapData(convert.PtrMapStrToInterface(pe.Tags), types.String),
 			"type":                                llx.StringDataPtr(pe.Type),
 			"provisioningState":                   llx.StringData(provisioningState),
-			"subnetId":                            llx.StringData(subnetId),
 			"customNetworkInterfaceName":          llx.StringData(customNicName),
 			"billingSku":                          llx.StringData(billingSku),
 			"privateLinkServiceConnections":       llx.ArrayData(plsConns, types.ResourceLike),
@@ -2103,23 +2081,25 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 	}
 	mqlPe := res.(*mqlAzureSubscriptionNetworkServicePrivateEndpoint)
 	mqlPe.cacheNetworkInterfaceIDs = nicIDs
+	mqlPe.cacheSubnetId = subnetId
 	return mqlPe, nil
 }
 
 type mqlAzureSubscriptionNetworkServicePrivateEndpointInternal struct {
 	cacheNetworkInterfaceIDs []string
+	cacheSubnetId            string
 }
 
 // subnet resolves the subnet the private endpoint's network interface is
 // allocated in, the network location from which the linked resource is
 // privately reachable.
 func (a *mqlAzureSubscriptionNetworkServicePrivateEndpoint) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
-	if a.SubnetId.Data == "" {
+	if a.cacheSubnetId == "" {
 		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
-		map[string]*llx.RawData{"id": llx.StringData(a.SubnetId.Data)})
+		map[string]*llx.RawData{"id": llx.StringData(a.cacheSubnetId)})
 	if err != nil {
 		return nil, err
 	}
@@ -2319,22 +2299,27 @@ func privateLinkServiceConnectionToMql(runtime *plugin.Runtime, c *network.Priva
 
 	res, err := CreateResource(runtime, "azure.subscription.networkService.privateEndpoint.serviceconnection",
 		map[string]*llx.RawData{
-			"__id":                 llx.StringData(subResourceCacheID(c.ID, parentID, collection, convert.ToValue(c.Name))),
-			"id":                   llx.StringDataPtr(c.ID),
-			"name":                 llx.StringDataPtr(c.Name),
-			"privateLinkServiceId": llx.StringData(plsId),
-			"groupIds":             llx.ArrayData(groupIds, types.String),
-			"connectionStatus":     llx.StringData(connectionStatus),
-			"requestMessage":       llx.StringData(requestMessage),
+			"__id":             llx.StringData(subResourceCacheID(c.ID, parentID, collection, convert.ToValue(c.Name))),
+			"id":               llx.StringDataPtr(c.ID),
+			"name":             llx.StringDataPtr(c.Name),
+			"groupIds":         llx.ArrayData(groupIds, types.String),
+			"connectionStatus": llx.StringData(connectionStatus),
+			"requestMessage":   llx.StringData(requestMessage),
 		})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection), nil
+	mqlConn := res.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection)
+	mqlConn.cachePrivateLinkServiceId = plsId
+	return mqlConn, nil
+}
+
+type mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnectionInternal struct {
+	cachePrivateLinkServiceId string
 }
 
 func (a *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) privateLinkService() (*mqlAzureSubscriptionNetworkServicePrivateLinkService, error) {
-	plsId := a.PrivateLinkServiceId.Data
+	plsId := a.cachePrivateLinkServiceId
 	if plsId == "" {
 		a.PrivateLinkService.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
@@ -2649,7 +2634,7 @@ func (a *mqlAzureSubscriptionNetworkServicePrivateLinkServicePrivateEndpointConn
 }
 
 func (a *mqlAzureSubscriptionPrivateEndpointConnection) privateEndpoint() (*mqlAzureSubscriptionNetworkServicePrivateEndpoint, error) {
-	peId := a.PrivateEndpointId.Data
+	peId := a.cachePrivateEndpointId
 	if peId == "" {
 		a.PrivateEndpoint.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
@@ -3415,7 +3400,7 @@ func azureAppFirewallPolicyToMql(runtime *plugin.Runtime, waf network.WebApplica
 	if err != nil {
 		return nil, err
 	}
-	var mode, enabledState string
+	var mode string
 	enabled := true
 	var requestBodyCheck *bool
 	var maxRequestBodySizeInKb, fileUploadLimitInMb *int64
@@ -3432,7 +3417,6 @@ func azureAppFirewallPolicyToMql(runtime *plugin.Runtime, waf network.WebApplica
 				mode = string(*ps.Mode)
 			}
 			if ps.State != nil {
-				enabledState = string(*ps.State)
 			}
 			requestBodyCheck = ps.RequestBodyCheck
 			if ps.MaxRequestBodySizeInKb != nil {
@@ -3470,7 +3454,6 @@ func azureAppFirewallPolicyToMql(runtime *plugin.Runtime, waf network.WebApplica
 		"etag":                   llx.StringDataPtr(waf.Etag),
 		"properties":             llx.DictData(props),
 		"mode":                   llx.StringData(mode),
-		"enabledState":           llx.StringData(enabledState),
 		"enabled":                llx.BoolData(enabled),
 		"requestBodyCheck":       llx.BoolDataPtr(requestBodyCheck),
 		"maxRequestBodySizeInKb": llx.IntDataPtr(maxRequestBodySizeInKb),
@@ -3861,7 +3844,6 @@ func azureAppGatewaySSLCertToMql(runtime *plugin.Runtime, c *network.Application
 	res, err := CreateResource(runtime, "azure.subscription.networkService.applicationGateway.sslCertificate", map[string]*llx.RawData{
 		"id":                llx.StringData(id),
 		"name":              llx.StringData(name),
-		"keyVaultSecretId":  llx.StringData(keyVaultSecretId),
 		"publicCertData":    llx.StringData(publicCertData),
 		"provisioningState": llx.StringData(provisioningState),
 	})
@@ -3870,21 +3852,23 @@ func azureAppGatewaySSLCertToMql(runtime *plugin.Runtime, c *network.Application
 	}
 	sslCert := res.(*mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate)
 	sslCert.cacheHsmKeyId = hsmKeyId
+	sslCert.cacheKeyVaultSecretId = keyVaultSecretId
 	return sslCert, nil
 }
 
 type mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificateInternal struct {
-	cacheHsmKeyId string
+	cacheHsmKeyId         string
+	cacheKeyVaultSecretId string
 }
 
 // keyVaultSecret resolves the typed Key Vault secret backing this certificate
 // from its secret URI. Returns null for certificates uploaded directly.
 func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewaySslCertificate) keyVaultSecret() (*mqlAzureSubscriptionKeyVaultServiceSecret, error) {
-	if a.KeyVaultSecretId.Data == "" {
+	if a.cacheKeyVaultSecretId == "" {
 		a.KeyVaultSecret.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return newKeyVaultSecretResource(a.MqlRuntime, a.KeyVaultSecretId.Data)
+	return newKeyVaultSecretResource(a.MqlRuntime, a.cacheKeyVaultSecretId)
 }
 
 // hsmKey resolves the typed Managed HSM key backing this certificate from its
@@ -4368,10 +4352,6 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewall) natRules() ([]any, error) {
 		if natRule == nil {
 			continue
 		}
-		props, err := convert.JsonToDict(natRule.Properties)
-		if err != nil {
-			return nil, err
-		}
 		var action string
 		var priority *int64
 		rules := []any{}
@@ -4383,20 +4363,20 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewall) natRules() ([]any, error) {
 				v := int64(*p.Priority)
 				priority = &v
 			}
-			rules, err = convert.JsonToDictSlice(p.Rules)
+			r, err := convert.JsonToDictSlice(p.Rules)
 			if err != nil {
 				return nil, err
 			}
+			rules = r
 		}
 		mqlNatRule, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.firewall.natRule",
 			map[string]*llx.RawData{
-				"id":         llx.StringDataPtr(natRule.ID),
-				"name":       llx.StringDataPtr(natRule.Name),
-				"etag":       llx.StringDataPtr(natRule.Etag),
-				"properties": llx.DictData(props),
-				"action":     llx.StringData(action),
-				"priority":   llx.IntDataPtr(priority),
-				"rules":      llx.ArrayData(rules, types.Dict),
+				"id":       llx.StringDataPtr(natRule.ID),
+				"name":     llx.StringDataPtr(natRule.Name),
+				"etag":     llx.StringDataPtr(natRule.Etag),
+				"action":   llx.StringData(action),
+				"priority": llx.IntDataPtr(priority),
+				"rules":    llx.ArrayData(rules, types.Dict),
 			})
 		if err != nil {
 			return nil, err
@@ -4415,10 +4395,6 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewall) networkRules() ([]any, erro
 		if networkRule == nil {
 			continue
 		}
-		props, err := convert.JsonToDict(networkRule.Properties)
-		if err != nil {
-			return nil, err
-		}
 		var action string
 		var priority *int64
 		rules := []any{}
@@ -4430,20 +4406,20 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewall) networkRules() ([]any, erro
 				v := int64(*p.Priority)
 				priority = &v
 			}
-			rules, err = convert.JsonToDictSlice(p.Rules)
+			r, err := convert.JsonToDictSlice(p.Rules)
 			if err != nil {
 				return nil, err
 			}
+			rules = r
 		}
 		mqlNetworkRule, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.firewall.networkRule",
 			map[string]*llx.RawData{
-				"id":         llx.StringDataPtr(networkRule.ID),
-				"name":       llx.StringDataPtr(networkRule.Name),
-				"etag":       llx.StringDataPtr(networkRule.Etag),
-				"properties": llx.DictData(props),
-				"action":     llx.StringData(action),
-				"priority":   llx.IntDataPtr(priority),
-				"rules":      llx.ArrayData(rules, types.Dict),
+				"id":       llx.StringDataPtr(networkRule.ID),
+				"name":     llx.StringDataPtr(networkRule.Name),
+				"etag":     llx.StringDataPtr(networkRule.Etag),
+				"action":   llx.StringData(action),
+				"priority": llx.IntDataPtr(priority),
+				"rules":    llx.ArrayData(rules, types.Dict),
 			})
 		if err != nil {
 			return nil, err
@@ -4462,10 +4438,6 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewall) applicationRules() ([]any, 
 		if appRule == nil {
 			continue
 		}
-		props, err := convert.JsonToDict(appRule.Properties)
-		if err != nil {
-			return nil, err
-		}
 		var action string
 		var priority *int64
 		rules := []any{}
@@ -4477,20 +4449,20 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewall) applicationRules() ([]any, 
 				v := int64(*p.Priority)
 				priority = &v
 			}
-			rules, err = convert.JsonToDictSlice(p.Rules)
+			r, err := convert.JsonToDictSlice(p.Rules)
 			if err != nil {
 				return nil, err
 			}
+			rules = r
 		}
 		mqlAppRule, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.firewall.applicationRule",
 			map[string]*llx.RawData{
-				"id":         llx.StringDataPtr(appRule.ID),
-				"name":       llx.StringDataPtr(appRule.Name),
-				"etag":       llx.StringDataPtr(appRule.Etag),
-				"properties": llx.DictData(props),
-				"action":     llx.StringData(action),
-				"priority":   llx.IntDataPtr(priority),
-				"rules":      llx.ArrayData(rules, types.Dict),
+				"id":       llx.StringDataPtr(appRule.ID),
+				"name":     llx.StringDataPtr(appRule.Name),
+				"etag":     llx.StringDataPtr(appRule.Etag),
+				"action":   llx.StringData(action),
+				"priority": llx.IntDataPtr(priority),
+				"rules":    llx.ArrayData(rules, types.Dict),
 			})
 		if err != nil {
 			return nil, err
@@ -5088,11 +5060,9 @@ func azureInterfaceToMql(runtime *plugin.Runtime, iface network.Interface) (*mql
 			"enableIPForwarding":          enableIPForwarding,
 			"enableAcceleratedNetworking": enableAcceleratedNetworking,
 			"primary":                     primary,
-			"networkSecurityGroupId":      llx.StringData(networkSecurityGroupId),
 			"dnsServers":                  llx.ArrayData(dnsServers, types.String),
 			"appliedDnsServers":           llx.ArrayData(appliedDnsServers, types.String),
 			"internalDnsNameLabel":        llx.StringData(internalDnsNameLabel),
-			"ipConfigurations":            llx.ArrayData(ipConfigs, types.Dict),
 		})
 	if err != nil {
 		return nil, err
@@ -6036,9 +6006,7 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) intrusionDetectionByp
 				"description":          llx.StringDataPtr(rule.Description),
 				"protocol":             llx.StringData(protocol),
 				"sourceAddresses":      llx.ArrayData(strPtrsToAny(rule.SourceAddresses), types.String),
-				"sourceIpGroups":       llx.ArrayData(strPtrsToAny(rule.SourceIPGroups), types.String),
 				"destinationAddresses": llx.ArrayData(strPtrsToAny(rule.DestinationAddresses), types.String),
-				"destinationIpGroups":  llx.ArrayData(strPtrsToAny(rule.DestinationIPGroups), types.String),
 				"destinationPorts":     llx.ArrayData(strPtrsToAny(rule.DestinationPorts), types.String),
 			})
 		if err != nil {

--- a/providers/azure/resources/network_expansion.go
+++ b/providers/azure/resources/network_expansion.go
@@ -158,7 +158,6 @@ func azureTrafficManagerProfileToMql(runtime *plugin.Runtime, p *trafficmanager.
 		"tags":                        llx.MapData(convert.PtrMapStrToInterface(p.Tags), types.String),
 		"type":                        llx.StringDataPtr(p.Type),
 		"properties":                  llx.DictData(properties),
-		"profileStatus":               llx.StringDataPtr(nil),
 		"status":                      llx.BoolData(false),
 		"trafficRoutingMethod":        llx.StringDataPtr(nil),
 		"trafficViewEnrollmentStatus": llx.StringDataPtr(nil),
@@ -174,10 +173,6 @@ func azureTrafficManagerProfileToMql(runtime *plugin.Runtime, p *trafficmanager.
 		return CreateResource(runtime, "azure.subscription.networkService.trafficManagerProfile", args)
 	}
 
-	if props.ProfileStatus != nil {
-		s := string(*props.ProfileStatus)
-		args["profileStatus"] = llx.StringData(s)
-	}
 	args["status"] = llx.BoolData(trafficManagerProfileEnabled(props))
 	if props.TrafficRoutingMethod != nil {
 		s := string(*props.TrafficRoutingMethod)
@@ -239,7 +234,6 @@ func azureTrafficManagerEndpointToMql(runtime *plugin.Runtime, ep *trafficmanage
 		"type":                  llx.StringDataPtr(ep.Type),
 		"properties":            llx.DictData(properties),
 		"alwaysServe":           llx.StringDataPtr(nil),
-		"endpointStatus":        llx.StringDataPtr(nil),
 		"status":                llx.BoolData(false),
 		"endpointMonitorStatus": llx.StringDataPtr(nil),
 		"target":                llx.StringDataPtr(nil),
@@ -263,10 +257,6 @@ func azureTrafficManagerEndpointToMql(runtime *plugin.Runtime, ep *trafficmanage
 	if props.AlwaysServe != nil {
 		s := string(*props.AlwaysServe)
 		args["alwaysServe"] = llx.StringData(s)
-	}
-	if props.EndpointStatus != nil {
-		s := string(*props.EndpointStatus)
-		args["endpointStatus"] = llx.StringData(s)
 	}
 	args["status"] = llx.BoolData(trafficManagerEndpointEnabled(props))
 	if props.EndpointMonitorStatus != nil {

--- a/providers/azure/resources/private_endpoint_connections.go
+++ b/providers/azure/resources/private_endpoint_connections.go
@@ -38,6 +38,22 @@ func azurePrivateEndpointConnectionsToMql[T any](runtime *plugin.Runtime, entrie
 // azurePrivateEndpointConnectionToMql builds a single shared private endpoint
 // connection resource from any Azure SDK connection value. It returns nil when
 // the value carries no usable data (e.g. a nil pointer in the slice).
+type mqlAzureSubscriptionPrivateEndpointConnectionInternal struct {
+	cachePrivateEndpointId string
+}
+
+// newAzurePrivateEndpointConnection creates the shared private endpoint
+// connection resource. The linked private endpoint's ARM ID is kept off the
+// schema and cached here so privateEndpoint() can resolve it on demand.
+func newAzurePrivateEndpointConnection(runtime *plugin.Runtime, args map[string]*llx.RawData, privateEndpointID string) (plugin.Resource, error) {
+	res, err := CreateResource(runtime, ResourceAzureSubscriptionPrivateEndpointConnection, args)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionPrivateEndpointConnection).cachePrivateEndpointId = privateEndpointID
+	return res, nil
+}
+
 // newPrivateLinkServiceConnectionState builds the typed connection-state
 // resource for a private endpoint connection.
 //
@@ -72,6 +88,7 @@ func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (pl
 	if id == "" {
 		return nil, nil
 	}
+	var privateEndpointID string
 	// Seed every declared field with an explicit default. A key that never
 	// lands in args leaves its TValue unset rather than null, which crosses
 	// the plugin boundary as an empty DataRes and surfaces client-side as
@@ -82,7 +99,6 @@ func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (pl
 		"name":                              llx.NilData,
 		"type":                              llx.NilData,
 		"ipAddresses":                       llx.ArrayData([]any{}, types.String),
-		"privateEndpointId":                 llx.NilData,
 		"provisioningState":                 llx.NilData,
 		"properties":                        llx.NilData,
 		"privateLinkServiceConnectionState": llx.NilData,
@@ -124,9 +140,7 @@ func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (pl
 			args["ipAddresses"] = llx.ArrayData(addrs, types.String)
 		}
 		if pe, ok := props["privateEndpoint"].(map[string]any); ok {
-			if peID, _ := pe["id"].(string); peID != "" {
-				args["privateEndpointId"] = llx.StringData(peID)
-			}
+			privateEndpointID, _ = pe["id"].(string)
 		}
 		if provState, _ := props["provisioningState"].(string); provState != "" {
 			args["provisioningState"] = llx.StringData(provState)
@@ -154,5 +168,5 @@ func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (pl
 		}
 	}
 
-	return CreateResource(runtime, ResourceAzureSubscriptionPrivateEndpointConnection, args)
+	return newAzurePrivateEndpointConnection(runtime, args, privateEndpointID)
 }

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -604,6 +604,7 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) privateEndpointConnec
 			resType = "Microsoft.RecoveryServices/vaults/privateEndpointConnections"
 		}
 
+		var pecPrivateEndpointID string
 		pecArgs := map[string]*llx.RawData{
 			"__id": llx.StringDataPtr(pec.ID),
 			"id":   llx.StringDataPtr(pec.ID),
@@ -620,7 +621,7 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) privateEndpointConnec
 			pecArgs["properties"] = llx.DictData(propsMap)
 
 			if props.PrivateEndpoint != nil {
-				pecArgs["privateEndpointId"] = llx.StringDataPtr(props.PrivateEndpoint.ID)
+				pecPrivateEndpointID = convert.ToValue(props.PrivateEndpoint.ID)
 			}
 			if props.PrivateLinkServiceConnectionState != nil {
 				stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(pec.ID),
@@ -637,7 +638,7 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) privateEndpointConnec
 			}
 		}
 
-		mqlRes, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, pecArgs)
+		mqlRes, err := newAzurePrivateEndpointConnection(a.MqlRuntime, pecArgs, pecPrivateEndpointID)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -311,7 +311,6 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstance) privateEndpointConnectio
 				"id":                llx.StringDataPtr(pec.ID),
 				"name":              llx.StringDataPtr(pec.Name),
 				"type":              llx.StringDataPtr(pec.Type),
-				"privateEndpointId": llx.StringDataPtr(privateEndpointId),
 				"status":            llx.StringDataPtr(status),
 				"description":       llx.StringDataPtr(description),
 				"provisioningState": llx.StringDataPtr(pecProvisioningState),
@@ -324,7 +323,9 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstance) privateEndpointConnectio
 		if err != nil {
 			return nil, err
 		}
-		pecResource.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).cacheSystemData = sysData
+		mqlPec := pecResource.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection)
+		mqlPec.cacheSystemData = sysData
+		mqlPec.cachePrivateEndpointId = convert.ToValue(privateEndpointId)
 		res = append(res, pecResource)
 	}
 	return res, nil
@@ -467,17 +468,6 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstance) patchSchedules() ([]any,
 	return res, nil
 }
 
-// encryptionKey always resolves to null for Azure Cache for Redis. Customer-
-// managed key encryption is a Redis Enterprise / Azure Managed Redis feature
-// (Microsoft.Cache/redisEnterprise), and armredis/v4 exposes no encryption or
-// customer-managed-key model on the classic Redis resource at all, so there is
-// nothing to read. Null is the truthful answer rather than a stub, but the
-// field is marked deprecated so no new audit is written against it.
-func (a *mqlAzureSubscriptionCacheServiceRedisInstance) encryptionKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
-	a.EncryptionKey.State = plugin.StateIsNull | plugin.StateIsSet
-	return nil, nil
-}
-
 func (a *mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule) id() (string, error) {
 	return a.Id.Data, nil
 }
@@ -507,7 +497,8 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection)
 }
 
 type mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnectionInternal struct {
-	cacheSystemData any
+	cacheSystemData        any
+	cachePrivateEndpointId string
 }
 
 func (a *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
@@ -515,7 +506,7 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection)
 }
 
 func (a *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) privateEndpoint() (*mqlAzureSubscriptionNetworkServicePrivateEndpoint, error) {
-	peId := a.PrivateEndpointId.Data
+	peId := a.cachePrivateEndpointId
 	if peId == "" {
 		a.PrivateEndpoint.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil

--- a/providers/azure/resources/servicebus.go
+++ b/providers/azure/resources/servicebus.go
@@ -617,19 +617,6 @@ func (a *mqlAzureSubscriptionServiceBusServiceNamespaceTopic) authorizationRules
 	return serviceBusAuthorizationRulesToMql(a.MqlRuntime, rules)
 }
 
-// networkRuleSet fetches the namespace-level network rule set (default action, public network access,
-// IP rules, virtual-network rules, trusted-service-access).
-func (a *mqlAzureSubscriptionServiceBusServiceNamespace) networkRuleSet() (any, error) {
-	props, err := a.fetchNetworkRuleSetProperties()
-	if err != nil {
-		return nil, err
-	}
-	if props == nil {
-		return nil, nil
-	}
-	return convert.JsonToDict(props)
-}
-
 func (a *mqlAzureSubscriptionServiceBusServiceNamespace) networkRules() (*mqlAzureSubscriptionServiceBusServiceNamespaceNetworkRules, error) {
 	props, err := a.fetchNetworkRuleSetProperties()
 	if err != nil {

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -44,10 +44,6 @@ type mqlAzureSubscriptionSqlServiceServerInternal struct {
 	encryptionProtectorResp *sql.EncryptionProtectorsClientGetResponse
 	encryptionProtectorErr  error
 
-	connectionPolicyOnce sync.Once
-	connectionPolicyResp *sql.ServerConnectionPoliciesClientGetResponse
-	connectionPolicyErr  error
-
 	cachePrimaryUserAssignedIdentityId string
 }
 
@@ -62,40 +58,6 @@ func (a *mqlAzureSubscriptionSqlServiceServer) primaryUserAssignedIdentity() (*m
 		return nil, err
 	}
 	return res.(*mqlAzureSubscriptionManagedIdentity), nil
-}
-
-// fetchConnectionPolicy retrieves the server-scoped ConnectionPolicy. Cached
-// with sync.Once so the server's connectionPolicy() accessor and per-database
-// connectionPolicy() accessors share a single API call (the policy is keyed
-// on the server, not the database — see Azure docs).
-func (a *mqlAzureSubscriptionSqlServiceServer) fetchConnectionPolicy() (*sql.ServerConnectionPoliciesClientGetResponse, error) {
-	a.connectionPolicyOnce.Do(func() {
-		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-		resourceID, err := ParseResourceID(a.Id.Data)
-		if err != nil {
-			a.connectionPolicyErr = err
-			return
-		}
-		server, err := resourceID.Component("servers")
-		if err != nil {
-			a.connectionPolicyErr = err
-			return
-		}
-		client, err := sql.NewServerConnectionPoliciesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-			ClientOptions: conn.ClientOptions(),
-		})
-		if err != nil {
-			a.connectionPolicyErr = err
-			return
-		}
-		resp, err := client.Get(context.Background(), resourceID.ResourceGroup, server, sql.ConnectionPolicyNameDefault, &sql.ServerConnectionPoliciesClientGetOptions{})
-		if err != nil {
-			a.connectionPolicyErr = err
-			return
-		}
-		a.connectionPolicyResp = &resp
-	})
-	return a.connectionPolicyResp, a.connectionPolicyErr
 }
 
 type mqlAzureSubscriptionSqlServiceServerFailoverGroupInternal struct {
@@ -501,117 +463,6 @@ func (a *mqlAzureSubscriptionSqlServiceServer) azureAdAdministrators() ([]any, e
 	return res, nil
 }
 
-func (a *mqlAzureSubscriptionSqlServiceServer) connectionPolicy() (any, error) {
-	policy, err := a.fetchConnectionPolicy()
-	if err != nil {
-		return nil, err
-	}
-	return convert.JsonToDict(policy)
-}
-
-func (a *mqlAzureSubscriptionSqlServiceServer) securityAlertPolicy() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	server, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-
-	secAlertClient, err := sql.NewServerSecurityAlertPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	policy, err := secAlertClient.Get(ctx, resourceID.ResourceGroup, server, sql.SecurityAlertPolicyNameDefault, &sql.ServerSecurityAlertPoliciesClientGetOptions{})
-	if err != nil {
-		if isAzureNotConfigured(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return convert.JsonToDict(policy.ServerSecurityAlertPolicy.Properties)
-}
-
-func (a *mqlAzureSubscriptionSqlServiceServer) auditingPolicy() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	server, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-	auditClient, err := sql.NewServerBlobAuditingPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	policy, err := auditClient.Get(ctx, resourceID.ResourceGroup, server, &sql.ServerBlobAuditingPoliciesClientGetOptions{})
-	if err != nil {
-		if isAzureNotConfigured(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return convert.JsonToDict(policy.ServerBlobAuditingPolicy.Properties)
-}
-
-func (a *mqlAzureSubscriptionSqlServiceServer) threatDetectionPolicy() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	server, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-
-	serverClient, err := sql.NewServerAdvancedThreatProtectionSettingsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	threatPolicy, err := serverClient.Get(ctx, resourceID.ResourceGroup, server, sql.AdvancedThreatProtectionNameDefault, &sql.ServerAdvancedThreatProtectionSettingsClientGetOptions{})
-	if err != nil {
-		if isAzureNotConfigured(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return convert.JsonToDict(threatPolicy.Properties)
-}
-
-func (a *mqlAzureSubscriptionSqlServiceServer) encryptionProtector() (any, error) {
-	resp, err := a.fetchEncryptionProtector()
-	if err != nil {
-		return nil, err
-	}
-	return convert.JsonToDict(resp.EncryptionProtector.Properties)
-}
-
 func (a *mqlAzureSubscriptionSqlServiceServer) encryptionProtectorServerKeyType() (string, error) {
 	resp, err := a.fetchEncryptionProtector()
 	if err != nil {
@@ -734,44 +585,6 @@ func (a *mqlAzureSubscriptionSqlServiceServer) vulnerabilityAssessmentSettings()
 	return res.(*mqlAzureSubscriptionSqlServiceServerVulnerabilityassessmentsettings), err
 }
 
-func (a *mqlAzureSubscriptionSqlServiceDatabase) transparentDataEncryption() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	server, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-
-	database, err := resourceID.Component("databases")
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := sql.NewTransparentDataEncryptionsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	policy, err := client.Get(ctx, resourceID.ResourceGroup, server, database, sql.TransparentDataEncryptionNameCurrent, &sql.TransparentDataEncryptionsClientGetOptions{})
-	if err != nil {
-		if isAzureNotConfigured(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return convert.JsonToDict(policy.LogicalDatabaseTransparentDataEncryption.Properties)
-}
-
 func (a *mqlAzureSubscriptionSqlServiceDatabase) advisor() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -816,106 +629,6 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) advisor() ([]any, error) {
 	}
 
 	return res, nil
-}
-
-func (a *mqlAzureSubscriptionSqlServiceDatabase) threatDetectionPolicy() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	server, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-
-	database, err := resourceID.Component("databases")
-	if err != nil {
-		return nil, err
-	}
-	client, err := sql.NewDatabaseSecurityAlertPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	policy, err := client.Get(ctx, resourceID.ResourceGroup, server, database, sql.SecurityAlertPolicyNameDefault, &sql.DatabaseSecurityAlertPoliciesClientGetOptions{})
-	if err != nil {
-		if isAzureNotConfigured(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return convert.JsonToDict(policy.DatabaseSecurityAlertPolicy.Properties)
-}
-
-func (a *mqlAzureSubscriptionSqlServiceDatabase) connectionPolicy() (any, error) {
-	resourceID, err := ParseResourceID(a.Id.Data)
-	if err != nil {
-		return nil, err
-	}
-	serverName, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-	serverId := "/subscriptions/" + resourceID.SubscriptionID +
-		"/resourceGroups/" + resourceID.ResourceGroup +
-		"/providers/Microsoft.Sql/servers/" + serverName
-
-	serverRes, err := NewResource(a.MqlRuntime, "azure.subscription.sqlService.server",
-		map[string]*llx.RawData{"id": llx.StringData(serverId)})
-	if err != nil {
-		return nil, err
-	}
-	policy, err := serverRes.(*mqlAzureSubscriptionSqlServiceServer).fetchConnectionPolicy()
-	if err != nil {
-		return nil, err
-	}
-	return convert.JsonToDict(policy.ServerConnectionPolicy.Properties)
-}
-
-func (a *mqlAzureSubscriptionSqlServiceDatabase) auditingPolicy() (any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	server, err := resourceID.Component("servers")
-	if err != nil {
-		return nil, err
-	}
-
-	database, err := resourceID.Component("databases")
-	if err != nil {
-		return nil, err
-	}
-
-	auditClient, err := sql.NewDatabaseBlobAuditingPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	policy, err := auditClient.Get(ctx, resourceID.ResourceGroup, server, database, &sql.DatabaseBlobAuditingPoliciesClientGetOptions{})
-	if err != nil {
-		if isAzureNotConfigured(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	return convert.JsonToDict(policy.DatabaseBlobAuditingPolicy.Properties)
 }
 
 type mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotectionInternal struct {

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -974,10 +974,6 @@ func storageAccountToMql(runtime *plugin.Runtime, account *storage.Account) (*mq
 		}
 	}
 
-	identity, err := convert.JsonToDict(account.Identity)
-	if err != nil {
-		return nil, err
-	}
 	var accountPrincipalId, accountTenantId *string
 	var userAssignedIdentityIds []string
 	if account.Identity != nil {
@@ -1003,7 +999,6 @@ func storageAccountToMql(runtime *plugin.Runtime, account *storage.Account) (*mq
 			"tags":                               llx.MapData(convert.PtrMapStrToInterface(account.Tags), types.String),
 			"type":                               llx.StringDataPtr(account.Type),
 			"properties":                         llx.DictData(properties),
-			"identity":                           llx.DictData(identity),
 			"principalId":                        llx.StringDataPtr(accountPrincipalId),
 			"tenantId":                           llx.StringDataPtr(accountTenantId),
 			"sku":                                llx.DictData(sku),

--- a/providers/azure/resources/storage_extras.go
+++ b/providers/azure/resources/storage_extras.go
@@ -40,7 +40,8 @@ func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) id(
 }
 
 type mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnectionInternal struct {
-	cacheSystemData any
+	cacheSystemData        any
+	cachePrivateEndpointId string
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
@@ -51,12 +52,12 @@ func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) sys
 // connection so the subnet and virtual network it is reachable from can be
 // traversed, giving the private-access path into the storage account.
 func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) privateEndpoint() (*mqlAzureSubscriptionNetworkServicePrivateEndpoint, error) {
-	if a.PrivateEndpointId.Data == "" {
+	if a.cachePrivateEndpointId == "" {
 		a.PrivateEndpoint.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.privateEndpoint",
-		map[string]*llx.RawData{"id": llx.StringData(a.PrivateEndpointId.Data)})
+		map[string]*llx.RawData{"id": llx.StringData(a.cachePrivateEndpointId)})
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +290,6 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) privateEndpointConnections()
 					"id":                llx.StringDataPtr(c.ID),
 					"name":              llx.StringDataPtr(c.Name),
 					"type":              llx.StringDataPtr(c.Type),
-					"privateEndpointId": llx.StringData(privateEndpointId),
 					"status":            llx.StringData(status),
 					"description":       llx.StringData(description),
 					"actionsRequired":   llx.StringData(actionsRequired),
@@ -302,7 +302,9 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) privateEndpointConnections()
 			if err != nil {
 				return nil, err
 			}
-			mqlPe.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).cacheSystemData = sysData
+			mqlPec := mqlPe.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection)
+			mqlPec.cacheSystemData = sysData
+			mqlPec.cachePrivateEndpointId = privateEndpointId
 			res = append(res, mqlPe)
 		}
 	}

--- a/providers/azure/resources/systemdata.go
+++ b/providers/azure/resources/systemdata.go
@@ -71,27 +71,27 @@ func (a *mqlAzureSubscriptionResource) systemMetadata() (*mqlAzureSubscriptionSy
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
-	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.GetSystemData().Data, &a.SystemMetadata)
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceDisk) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
-	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.GetSystemData().Data, &a.SystemMetadata)
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceSnapshot) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
-	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.GetSystemData().Data, &a.SystemMetadata)
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVmScaleSet) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
-	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.GetSystemData().Data, &a.SystemMetadata)
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceHybridMachine) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
-	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.GetSystemData().Data, &a.SystemMetadata)
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceHybridMachineExtension) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
-	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.GetSystemData().Data, &a.SystemMetadata)
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -98,7 +98,12 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 		"type":       llx.StringDataPtr(site.Type),
 		"kind":       llx.StringDataPtr(site.Kind),
 		"properties": llx.DictData(properties),
-		"identity":   llx.DictData(identity),
+	}
+
+	// appslot still exposes the raw identity dict; appsite models it through
+	// identityType, principalId, systemAssignedIdentity and userAssignedIdentities.
+	if resourceType == ResourceAzureSubscriptionWebServiceAppslot {
+		args["identity"] = llx.DictData(identity)
 	}
 
 	// Only set these fields for appsite, not appslot (which doesn't have them)
@@ -167,6 +172,9 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 		mqlAppsite := res.(*mqlAzureSubscriptionWebServiceAppsite)
 		mqlAppsite.cacheSystemData = sysData
 		mqlAppsite.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+		if site.Identity != nil && site.Identity.TenantID != nil {
+			mqlAppsite.cacheIdentityTenantId = *site.Identity.TenantID
+		}
 	case ResourceAzureSubscriptionWebServiceAppslot:
 		res.(*mqlAzureSubscriptionWebServiceAppslot).cacheSystemData = sysData
 	}
@@ -176,6 +184,7 @@ func createWebAppResourceFromSite(runtime *plugin.Runtime, resourceType string, 
 type mqlAzureSubscriptionWebServiceAppsiteInternal struct {
 	cacheSystemData              any
 	cacheUserAssignedIdentityIds []string
+	cacheIdentityTenantId        string
 }
 
 type mqlAzureSubscriptionWebServiceAppslotInternal struct {
@@ -723,7 +732,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) userAssignedIdentities() ([]any,
 }
 
 func (a *mqlAzureSubscriptionWebServiceAppsite) systemAssignedIdentity() (*mqlAzureSubscriptionManagedIdentity, error) {
-	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, tenantIDFromIdentityDict(a.Identity), &a.SystemAssignedIdentity)
+	return newSystemAssignedManagedIdentity(a.MqlRuntime, a.Id.Data, a.PrincipalId.Data, a.cacheIdentityTenantId, &a.SystemAssignedIdentity)
 }
 
 // keyVaultReferenceIdentityRef resolves the user-assigned managed identity used
@@ -1687,6 +1696,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) privateEndpointConnections() ([]
 			if entry.ID == nil || *entry.ID == "" {
 				continue
 			}
+			var pecPrivateEndpointID string
 			privateEndpoint := map[string]*llx.RawData{
 				"__id":        llx.StringDataPtr(entry.ID),
 				"id":          llx.StringDataPtr(entry.ID),
@@ -1706,7 +1716,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) privateEndpointConnections() ([]
 
 				privateEndpoint["ipAddresses"] = llx.ArrayData(strPtrsToAny(props.IPAddresses), types.String)
 				if props.PrivateEndpoint != nil {
-					privateEndpoint["privateEndpointId"] = llx.StringDataPtr(props.PrivateEndpoint.ID)
+					pecPrivateEndpointID = convert.ToValue(props.PrivateEndpoint.ID)
 				}
 				if props.PrivateLinkServiceConnectionState != nil {
 					stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(entry.ID),
@@ -1723,7 +1733,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) privateEndpointConnections() ([]
 				}
 			}
 
-			mqlRes, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, privateEndpoint)
+			mqlRes, err := newAzurePrivateEndpointConnection(a.MqlRuntime, privateEndpoint, pecPrivateEndpointID)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Removes all 69 fields marked `@maturity("deprecated")` in the azure provider. Every one has a documented replacement that already ships, so this drops duplicate surface rather than capability.

**This is a breaking change.** A query or policy still reading a removed field now fails to *compile* rather than resolving, so this is v14 material.

## What was removed, and what replaces it

| Removed | Replacement |
|---|---|
| `systemData` dict (6 compute resources) | `systemMetadata` |
| `identity` dict (batch, storage, web appsite, container registry, container app) | `principalId` / `userAssignedIdentities` / `identityType` / `systemAssignedIdentity` |
| `remoteVirtualNetworkId`, `publicIpAddressId`, `networkSecurityGroupId`, `subnetId`, `privateLinkServiceId`, `privateEndpointId`, `keyVaultSecretId` | typed accessors `remoteVirtualNetwork`, `publicIpAddress`, `networkSecurityGroup`, `subnet`, `privateLinkService`, `privateEndpoint`, `keyVaultSecret` |
| `managedServiceIdentityId` | `principalId` |
| `enabledState`, `profileStatus`, `endpointStatus` (strings) | `enabled`, `status` (booleans) |
| `retentionPolicy`, `analytics` dicts | `retentionEnabled` + `retentionDays`, `trafficAnalytics*` |
| `vpnClientConfiguration` dict | `vpnClientAuthenticationTypes`, `vpnClientAddressPool`, `aad*` |
| `encryption` + `cmkKeyName`/`cmkKeyVaultUri`/`cmkKeyVersion`/`cmkUserAssignedIdentity` | `cmkKey`, `cmkIdentity` |
| `autoStorage`, `keyVaultReference` | `autoStorageAccount`, `keyVault` |
| firewall rule `properties` dicts | `action` + `priority` + `rules` |
| sql server/database `connectionPolicy`, `auditingPolicy`, `securityAlertPolicy`, `encryptionProtector`, `threatDetectionPolicy`, `transparentDataEncryption` | `connectionType`, `blobAuditingPolicy`, `securityAlertPolicyConfig`, `encryptionProtectorConfig`, `advancedThreatProtectionSetting`, `transparentDataEncryptionEnabled` |
| cloudDefender `defenderFor*` dicts (10) | the typed `for*` resources |
| `iotService.hubs` | `iotHubs` |
| eventHub / serviceBus `networkRuleSet` | typed network rule set fields |
| `sourceIpGroups`, `destinationIpGroups` | `sourceIpGroupRefs`, `destinationIpGroupRefs` |
| `agentPoolProfiles`, `securityContext`, `privateEndpointConnectionCount`, `ipConfigurations`, `roleAssignment.type`, `raiTopic.createdAt`, redis `encryptionKey` | superseded / always-null; no replacement needed |

## Notable implementation details

**Replacement accessors that fed off the raw field.** Several typed accessors derived their value from the very field being deleted — `privateLinkService()` read `PrivateLinkServiceId`, `systemMetadata()` read `GetSystemData()`, `cmkKey()` read four `Cmk*` fields. Those values now ride on the resource's `Internal` struct (`cacheSystemData`, `cacheSubnetId`, `cachePrivateEndpointId`, `cacheCmk*`, …), matching the existing `cache*` pattern already used by 15 of the 21 `systemMetadata()` implementations.

**Shared private endpoint connection.** `azure.subscription.privateEndpointConnection` is built by ten different services. Rather than repeat the cache assignment ten times, they now go through a `newAzurePrivateEndpointConnection` helper.

**`@defaults` strings.** Two referenced fields being deleted. Since `@defaults` is a string literal, nothing would have caught this at build time — it would have silently rendered an empty column. Repointed `cloudDefenderService` to `forServers`/`forContainers` and `privateEndpoint.serviceconnection` to `connectionStatus`.

**Stale `CreateResource` arg keys.** Deleting a schema field does *not* produce a Go compile error for a leftover `"fieldName":` key in an arg map — those are strings, and would fail at query time instead. Verification was done with a throwaway `go/ast` checker that resolved every `CreateResource`/`NewResource` call site against the regenerated schema; it found 43 stale keys (including ones the compiler and a regex sweep both missed, e.g. helper functions that *return* an arg map). It now reports zero.

**Dead code.** Removed the 22 accessor methods whose schema fields are gone, plus `fetchConnectionPolicy` and its `sync.Once` machinery, which became orphaned once `connectionPolicy()` was deleted (`connectionType` makes its own call).

`config.go` `Version` is intentionally untouched — the release flow owns the major bump.

## Verification

- `go build ./...` clean
- `go test ./...` passes (updated `batch_test.go`, which asserted on removed keys and panicked on the nil `RawData`)
- `golangci-lint run ./resources/...` — no new findings; the remaining ones (`cosmosdb` `cacheBackup*`, an unchecked `io.Copy`, depguard on SDK imports) are pre-existing on `main`
- `mqlr generate` is idempotent on the result
- `azure.permissions.json` regenerated: no permissions dropped, since the deprecated accessors shared SDK clients with their replacements

Not live-verified against a real subscription — this is a pure removal with no new data paths, but the `Internal`-struct rewiring of `systemMetadata` / `privateEndpoint` / `cmkKey` is worth a smoke test before release.
