### PR TITLE
🛑 gcp: remove all deprecated fields

### DIFF
--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -228,22 +228,11 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) servicePerimeters() ([]any, err
 			return nil, err
 		}
 
-		status, err := protoToDict(perimeter.Status)
-		if err != nil {
-			return nil, err
-		}
-		spec, err := protoToDict(perimeter.Spec)
-		if err != nil {
-			return nil, err
-		}
-
 		mqlPerimeter, err := CreateResource(g.MqlRuntime, "gcp.accesscontextmanager.servicePerimeter", map[string]*llx.RawData{
 			"name":                  llx.StringData(perimeter.Name),
 			"title":                 llx.StringData(perimeter.Title),
 			"description":           llx.StringData(perimeter.Description),
 			"perimeterType":         llx.StringData(perimeter.PerimeterType.String()),
-			"status":                llx.DictData(status),
-			"spec":                  llx.DictData(spec),
 			"useExplicitDryRunSpec": llx.BoolData(perimeter.UseExplicitDryRunSpec),
 			"createTime":            llx.TimeDataPtr(timestampAsTimePtr(perimeter.CreateTime)),
 			"updateTime":            llx.TimeDataPtr(timestampAsTimePtr(perimeter.UpdateTime)),

--- a/providers/gcp/resources/apigateway.go
+++ b/providers/gcp/resources/apigateway.go
@@ -16,6 +16,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectApiGatewayServiceApiConfigInternal struct {
+	cacheGatewayServiceAccount string
+}
+
 func newApiGatewayService(conn *connection.GcpConnection) (*apigateway.Service, error) {
 	client, err := conn.Client(apigateway.CloudPlatformScope)
 	if err != nil {
@@ -166,20 +170,21 @@ func (g *mqlGcpProjectApiGatewayServiceApi) configs() ([]any, error) {
 			}
 
 			mqlConfig, err := CreateResource(g.MqlRuntime, "gcp.project.apiGatewayService.apiConfig", map[string]*llx.RawData{
-				"projectId":             llx.StringData(projectId),
-				"name":                  llx.StringData(c.Name),
-				"displayName":           llx.StringData(c.DisplayName),
-				"state":                 llx.StringData(c.State),
-				"serviceConfigId":       llx.StringData(c.ServiceConfigId),
-				"gatewayServiceAccount": llx.StringData(c.GatewayServiceAccount),
-				"createTime":            llx.TimeDataPtr(parseTime(c.CreateTime)),
-				"updateTime":            llx.TimeDataPtr(parseTime(c.UpdateTime)),
-				"labels":                llx.MapData(convert.MapToInterfaceMap(c.Labels), types.String),
-				"openapiDocuments":      llx.ArrayData(openapiDocuments, types.Dict),
+				"projectId":        llx.StringData(projectId),
+				"name":             llx.StringData(c.Name),
+				"displayName":      llx.StringData(c.DisplayName),
+				"state":            llx.StringData(c.State),
+				"serviceConfigId":  llx.StringData(c.ServiceConfigId),
+				"createTime":       llx.TimeDataPtr(parseTime(c.CreateTime)),
+				"updateTime":       llx.TimeDataPtr(parseTime(c.UpdateTime)),
+				"labels":           llx.MapData(convert.MapToInterfaceMap(c.Labels), types.String),
+				"openapiDocuments": llx.ArrayData(openapiDocuments, types.Dict),
 			})
 			if err != nil {
 				return err
 			}
+			mqlRef := mqlConfig.(*mqlGcpProjectApiGatewayServiceApiConfig)
+			mqlRef.cacheGatewayServiceAccount = c.GatewayServiceAccount
 			res = append(res, mqlConfig)
 		}
 		return nil
@@ -194,10 +199,7 @@ func (g *mqlGcpProjectApiGatewayServiceApi) configs() ([]any, error) {
 }
 
 func (g *mqlGcpProjectApiGatewayServiceApiConfig) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.GatewayServiceAccount.Error != nil {
-		return nil, g.GatewayServiceAccount.Error
-	}
-	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.GatewayServiceAccount.Data, g.ProjectId.Data)
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheGatewayServiceAccount, g.ProjectId.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/artifactregistry.go
+++ b/providers/gcp/resources/artifactregistry.go
@@ -24,6 +24,10 @@ import (
 	iampb "google.golang.org/genproto/googleapis/iam/v1"
 )
 
+type mqlGcpProjectArtifactRegistryServiceRepositoryInternal struct {
+	cacheKmsKeyName string
+}
+
 func (g *mqlGcpProject) artifactRegistry() (*mqlGcpProjectArtifactRegistryService, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -157,7 +161,6 @@ func newArtifactRegistryRepository(runtime *plugin.Runtime, projectId string, r 
 		"format":                      llx.StringData(r.Format.String()),
 		"mode":                        llx.StringData(r.Mode.String()),
 		"labels":                      llx.MapData(convert.MapToInterfaceMap(r.Labels), types.String),
-		"kmsKeyName":                  llx.StringData(r.KmsKeyName),
 		"createTime":                  llx.TimeDataPtr(timestampAsTimePtr(r.CreateTime)),
 		"updateTime":                  llx.TimeDataPtr(timestampAsTimePtr(r.UpdateTime)),
 		"sizeBytes":                   llx.IntData(r.SizeBytes),
@@ -173,6 +176,8 @@ func newArtifactRegistryRepository(runtime *plugin.Runtime, projectId string, r 
 	if err != nil {
 		return nil, err
 	}
+	mqlRef := res.(*mqlGcpProjectArtifactRegistryServiceRepository)
+	mqlRef.cacheKmsKeyName = r.KmsKeyName
 	return res.(*mqlGcpProjectArtifactRegistryServiceRepository), nil
 }
 
@@ -185,11 +190,7 @@ func (g *mqlGcpProjectArtifactRegistryServiceRepository) managedBy() (string, er
 }
 
 func (g *mqlGcpProjectArtifactRegistryServiceRepository) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
-	keyName := g.GetKmsKeyName()
-	if keyName.Error != nil {
-		return nil, keyName.Error
-	}
-	return newKmsCryptoKeyRef(g.MqlRuntime, &g.KmsKey, keyName.Data)
+	return newKmsCryptoKeyRef(g.MqlRuntime, &g.KmsKey, g.cacheKmsKeyName)
 }
 
 func initGcpProjectArtifactRegistryServiceRepository(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -202,7 +202,6 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 			"created":                      llx.TimeData(metadata.CreationTime),
 			"modified":                     llx.TimeData(metadata.LastModifiedTime),
 			"tags":                         llx.MapData(convert.MapToInterfaceMap(tags), types.String),
-			"kmsName":                      llx.StringData(kmsName),
 			"access":                       llx.ArrayData(access, types.Resource("gcp.project.bigqueryService.dataset.accessEntry")),
 			"defaultTableExpirationMs":     llx.IntData(metadata.DefaultTableExpiration.Milliseconds()),
 			"maxTimeTravelHours":           llx.IntData(int64(metadata.MaxTimeTravel / time.Hour)),
@@ -598,7 +597,6 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 			"numRows":                llx.IntData(int64(metadata.NumRows)),
 			"type":                   llx.StringData(string(metadata.Type)),
 			"expirationTime":         llx.TimeData(metadata.ExpirationTime),
-			"kmsName":                llx.StringData(kmsName),
 			"snapshotTime":           llx.TimeDataPtr(snapshotTime),
 			"cloneTime":              llx.TimeDataPtr(cloneTime),
 			"viewQuery":              llx.StringData(metadata.ViewQuery),
@@ -694,7 +692,6 @@ func (g *mqlGcpProjectBigqueryServiceDataset) models() ([]any, error) {
 			"modified":       llx.TimeData(metadata.LastModifiedTime),
 			"type":           llx.StringData(string(metadata.Type)),
 			"expirationTime": llx.TimeData(metadata.ExpirationTime),
-			"kmsName":        llx.StringData(kmsName),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gcp/resources/binary_authorization.go
+++ b/providers/gcp/resources/binary_authorization.go
@@ -184,11 +184,6 @@ func (g *mqlGcpProjectBinaryAuthorizationControl) attestors() ([]any, error) {
 			return nil, err
 		}
 
-		userOwnedGrafeasNote, err := protoToDict(attestor.GetUserOwnedGrafeasNote())
-		if err != nil {
-			return nil, err
-		}
-
 		note := attestor.GetUserOwnedGrafeasNote()
 		publicKeys, err := flattenAttestorPublicKeys(g.MqlRuntime, attestor.GetName(), note)
 		if err != nil {
@@ -198,7 +193,6 @@ func (g *mqlGcpProjectBinaryAuthorizationControl) attestors() ([]any, error) {
 		mqlAttestor, err := CreateResource(g.MqlRuntime, "gcp.project.binaryAuthorizationControl.attestor", map[string]*llx.RawData{
 			"name":                          llx.StringData(attestor.GetName()),
 			"description":                   llx.StringData(attestor.GetDescription()),
-			"userOwnedGrafeasNote":          llx.DictData(userOwnedGrafeasNote),
 			"noteReference":                 llx.StringData(note.GetNoteReference()),
 			"publicKeys":                    llx.ArrayData(publicKeys, types.Resource("gcp.project.binaryAuthorizationControl.attestor.publicKey")),
 			"delegationServiceAccountEmail": llx.StringData(note.GetDelegationServiceAccountEmail()),

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -182,7 +182,6 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 			"labels":              llx.MapData(convert.MapToInterfaceMap(f.Labels), types.String),
 			"envVars":             llx.MapData(convert.MapToInterfaceMap(f.EnvironmentVariables), types.String),
 			"buildEnvVars":        llx.MapData(convert.MapToInterfaceMap(f.BuildEnvironmentVariables), types.String),
-			"network":             llx.StringData(f.Network),
 			"maxInstances":        llx.IntData(int64(f.MaxInstances)),
 			"minInstances":        llx.IntData(int64(f.MinInstances)),
 			"vpcConnector":        llx.StringData(f.VpcConnector),
@@ -194,12 +193,14 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 			"buildName":           llx.StringData(f.BuildName),
 			"secretEnvVars":       llx.MapData(secretEnvVars, types.Dict),
 			"secretVolumes":       llx.ArrayData(secretVolumes, types.Dict),
-			"dockerRepository":    llx.StringData(f.DockerRepository),
 			"dockerRegistry":      llx.StringData(f.DockerRegistry.String()),
 		})
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlCloudFuncs.(*mqlGcpProjectCloudFunction)
+		mqlRef.cacheNetwork = f.Network
+		mqlRef.cacheDockerRepository = f.DockerRepository
 		mqlFunc := mqlCloudFuncs.(*mqlGcpProjectCloudFunction)
 		mqlFunc.cacheKmsKeyName = f.KmsKeyName
 		mqlFunc.cacheBuildServiceAccount = f.BuildServiceAccount
@@ -213,6 +214,8 @@ type mqlGcpProjectCloudFunctionInternal struct {
 	cacheKmsKeyName           string
 	cacheBuildServiceAccount  string
 	cacheEventTriggerResource string
+	cacheDockerRepository     string
+	cacheNetwork              string
 }
 
 func (g *mqlGcpProjectCloudFunction) managedBy() (string, error) {
@@ -220,10 +223,7 @@ func (g *mqlGcpProjectCloudFunction) managedBy() (string, error) {
 }
 
 func (g *mqlGcpProjectCloudFunction) dockerRepositoryRef() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
-	if g.DockerRepository.Error != nil {
-		return nil, g.DockerRepository.Error
-	}
-	project, location, repo := artifactRegistryRepoFromPath(g.DockerRepository.Data)
+	project, location, repo := artifactRegistryRepoFromPath(g.cacheDockerRepository)
 	ref, err := resolveArtifactRegistryRepoRef(g.MqlRuntime, project, location, repo)
 	if err != nil {
 		return nil, err
@@ -380,10 +380,7 @@ func (g *mqlGcpProjectCloudFunction) buildServiceAccount() (*mqlGcpProjectIamSer
 }
 
 func (g *mqlGcpProjectCloudFunction) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.Network.Error != nil {
-		return nil, g.Network.Error
-	}
-	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cacheNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -22,6 +22,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type mqlGcpProjectCloudFunctionV2BuildConfigInternal struct {
+	cacheDockerRepository string
+	cacheServiceAccount   string
+}
+
 func (g *mqlGcpProject) cloudFunctionsV2() ([]any, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -246,8 +251,6 @@ func fnV2BuildConfig(runtime *plugin.Runtime, parentName string, cfg *functionsp
 		"source":               llx.DictData(sourceDict),
 		"buildWorkerPool":      llx.StringData(cfg.WorkerPool),
 		"environmentVariables": llx.MapData(envVars, types.String),
-		"dockerRepository":     llx.StringData(cfg.DockerRepository),
-		"serviceAccount":       llx.StringData(cfg.ServiceAccount),
 		"build":                llx.StringData(cfg.Build),
 		"sourceProvenance":     llx.DictData(sourceProvenanceDict),
 		"gitUri":               llx.StringData(gitUri),
@@ -255,16 +258,16 @@ func fnV2BuildConfig(runtime *plugin.Runtime, parentName string, cfg *functionsp
 	if err != nil {
 		return nil, err
 	}
+	mqlRef := res.(*mqlGcpProjectCloudFunctionV2BuildConfig)
+	mqlRef.cacheDockerRepository = cfg.DockerRepository
+	mqlRef.cacheServiceAccount = cfg.ServiceAccount
 	return res.(*mqlGcpProjectCloudFunctionV2BuildConfig), nil
 }
 
 func (g *mqlGcpProjectCloudFunctionV2BuildConfig) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.ServiceAccount.Error != nil {
-		return nil, g.ServiceAccount.Error
-	}
 	// buildConfig.serviceAccount is a full "projects/{p}/serviceAccounts/{email}"
 	// path, so resolveServiceAccountRef derives the project — no fallback needed.
-	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.ServiceAccount.Data, "")
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheServiceAccount, "")
 	if err != nil {
 		return nil, err
 	}
@@ -279,10 +282,7 @@ func (g *mqlGcpProjectCloudFunctionV2BuildConfig) id() (string, error) {
 }
 
 func (g *mqlGcpProjectCloudFunctionV2BuildConfig) dockerRepositoryRef() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
-	if g.DockerRepository.Error != nil {
-		return nil, g.DockerRepository.Error
-	}
-	project, location, repo := artifactRegistryRepoFromPath(g.DockerRepository.Data)
+	project, location, repo := artifactRegistryRepoFromPath(g.cacheDockerRepository)
 	ref, err := resolveArtifactRegistryRepoRef(g.MqlRuntime, project, location, repo)
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -22,6 +22,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfigInternal struct {
+	cachePeeredNetwork string
+}
+
 func (g *mqlGcpProject) cloudBuild() (*mqlGcpProjectCloudBuildService, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -517,21 +521,19 @@ func buildWorkerPoolNetworkConfig(runtime *plugin.Runtime, parentName string, cf
 	nc := cfg.NetworkConfig
 	res, err := CreateResource(runtime, "gcp.project.cloudBuildService.workerPool.networkConfig", map[string]*llx.RawData{
 		"id":                   llx.StringData(parentName + "/networkConfig"),
-		"peeredNetwork":        llx.StringData(nc.PeeredNetwork),
 		"peeredNetworkIpRange": llx.StringData(nc.PeeredNetworkIpRange),
 		"egressOption":         llx.StringData(nc.EgressOption.String()),
 	})
 	if err != nil {
 		return nil, err
 	}
+	mqlRef := res.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig)
+	mqlRef.cachePeeredNetwork = nc.PeeredNetwork
 	return res.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig), nil
 }
 
 func (g *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) peeredNetworkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.PeeredNetwork.Error != nil {
-		return nil, g.PeeredNetwork.Error
-	}
-	n, err := getNetworkByUrl(g.PeeredNetwork.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cachePeeredNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -659,7 +661,6 @@ func newCloudBuild(runtime *plugin.Runtime, projectId string, b *cloudbuildpb.Bu
 		"buildTriggerId":   llx.StringData(b.BuildTriggerId),
 		"logUrl":           llx.StringData(b.LogUrl),
 		"logsBucket":       llx.StringData(b.LogsBucket),
-		"serviceAccount":   llx.StringData(b.ServiceAccount),
 		"substitutions":    llx.MapData(substitutions, types.String),
 		"tags":             llx.ArrayData(tags, types.String),
 	})

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -477,11 +477,6 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 						}
 					}
 
-					vpcCfg, err := mqlVpcAccess(s.Template.VpcAccess)
-					if err != nil {
-						log.Error().Err(err).Send()
-					}
-
 					templateId := fmt.Sprintf("gcp.project.cloudRunService.service/%s/%s/revisionTemplate", projectId, s.Name)
 					mqlVpcAccessCfg, err := mqlVpcAccessConfig(g.MqlRuntime, templateId+"/vpcAccess", s.Template.VpcAccess)
 					if err != nil {
@@ -500,7 +495,6 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 						"labels":                        llx.MapData(convert.MapToInterfaceMap(s.Template.Labels), types.String),
 						"annotations":                   llx.MapData(convert.MapToInterfaceMap(s.Template.Annotations), types.String),
 						"scaling":                       llx.DictData(scalingCfg),
-						"vpcAccess":                     llx.DictData(vpcCfg),
 						"vpcAccessConfig":               llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
 						"timeout":                       llx.TimeData(llx.DurationToTime(s.Template.GetTimeout().GetSeconds())),
 						"serviceAccountEmail":           llx.StringData(s.Template.ServiceAccount),
@@ -834,12 +828,6 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 					templateId := fmt.Sprintf("%s/executionTemplate", j.Name)
 					var mqlTaskTemplate plugin.Resource
 					if j.Template.Template != nil {
-						vpcAccess, err := mqlVpcAccess(j.Template.Template.VpcAccess)
-						if err != nil {
-							log.Error().Err(err).Send()
-							return
-						}
-
 						taskTemplateId := fmt.Sprintf("%s/template", templateId)
 						mqlVpcAccessCfg, err := mqlVpcAccessConfig(g.MqlRuntime, taskTemplateId+"/vpcAccess", j.Template.Template.VpcAccess)
 						if err != nil {
@@ -856,7 +844,6 @@ func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
 						mqlTaskTemplate, err = CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.job.executionTemplate.taskTemplate", map[string]*llx.RawData{
 							"id":                   llx.StringData(taskTemplateId),
 							"projectId":            llx.StringData(projectId),
-							"vpcAccess":            llx.DictData(vpcAccess),
 							"vpcAccessConfig":      llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
 							"timeout":              llx.TimeData(llx.DurationToTime(j.Template.Template.GetTimeout().GetSeconds())),
 							"serviceAccountEmail":  llx.StringData(j.Template.Template.ServiceAccount),
@@ -996,20 +983,6 @@ func mqlCondition(runtime *plugin.Runtime, c *runpb.Condition, parentId, suffix 
 		"message":            llx.StringData(c.Message),
 		"lastTransitionTime": llx.TimeDataPtr(timestampAsTimePtr(c.LastTransitionTime)),
 		"severity":           llx.StringData(c.Severity.String()),
-	})
-}
-
-func mqlVpcAccess(vpcAccess *runpb.VpcAccess) (map[string]any, error) {
-	type mqlVpcAccess struct {
-		Connector string `json:"connector"`
-		Egress    string `json:"egress"`
-	}
-	if vpcAccess == nil {
-		return nil, nil
-	}
-	return convert.JsonToDict(mqlVpcAccess{
-		Connector: vpcAccess.Connector,
-		Egress:    vpcAccess.Egress.String(),
 	})
 }
 

--- a/providers/gcp/resources/cloudscheduler.go
+++ b/providers/gcp/resources/cloudscheduler.go
@@ -22,6 +22,11 @@ type mqlGcpProjectCloudSchedulerServiceInternal struct {
 	serviceGate
 }
 
+type mqlGcpProjectCloudSchedulerServiceJobInternal struct {
+	cacheOauthServiceAccountEmail string
+	cacheOidcServiceAccountEmail  string
+}
+
 func (g *mqlGcpProject) cloudScheduler() (*mqlGcpProjectCloudSchedulerService, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -140,18 +145,16 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 		}
 
 		jobArgs := map[string]*llx.RawData{
-			"projectId":                llx.StringData(projectId),
-			"name":                     llx.StringData(job.Name),
-			"schedule":                 llx.StringData(job.Schedule),
-			"timeZone":                 llx.StringData(job.TimeZone),
-			"state":                    llx.StringData(job.State.String()),
-			"description":              llx.StringData(job.Description),
-			"lastAttemptTime":          llx.TimeDataPtr(lastAttemptTime),
-			"scheduleTime":             llx.TimeDataPtr(scheduleTime),
-			"userUpdateTime":           llx.TimeDataPtr(userUpdateTime),
-			"targetType":               llx.StringData(targetType),
-			"oidcServiceAccountEmail":  llx.StringData(oidcServiceAccountEmail),
-			"oauthServiceAccountEmail": llx.StringData(oauthServiceAccountEmail),
+			"projectId":       llx.StringData(projectId),
+			"name":            llx.StringData(job.Name),
+			"schedule":        llx.StringData(job.Schedule),
+			"timeZone":        llx.StringData(job.TimeZone),
+			"state":           llx.StringData(job.State.String()),
+			"description":     llx.StringData(job.Description),
+			"lastAttemptTime": llx.TimeDataPtr(lastAttemptTime),
+			"scheduleTime":    llx.TimeDataPtr(scheduleTime),
+			"userUpdateTime":  llx.TimeDataPtr(userUpdateTime),
+			"targetType":      llx.StringData(targetType),
 		}
 		if retryConfig != nil {
 			jobArgs["retryConfig"] = llx.ResourceData(retryConfig, "gcp.retryConfig")
@@ -160,8 +163,11 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlJ := mqlJob.(*mqlGcpProjectCloudSchedulerServiceJob)
+		mqlJ.cacheOidcServiceAccountEmail = oidcServiceAccountEmail
+		mqlJ.cacheOauthServiceAccountEmail = oauthServiceAccountEmail
 		if retryConfig == nil {
-			mqlJob.(*mqlGcpProjectCloudSchedulerServiceJob).RetryConfig.State = plugin.StateIsNull | plugin.StateIsSet
+			mqlJ.RetryConfig.State = plugin.StateIsNull | plugin.StateIsSet
 		}
 		res = append(res, mqlJob)
 	}
@@ -170,10 +176,7 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 }
 
 func (g *mqlGcpProjectCloudSchedulerServiceJob) oidcServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.OidcServiceAccountEmail.Error != nil {
-		return nil, g.OidcServiceAccountEmail.Error
-	}
-	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.OidcServiceAccountEmail.Data, g.ProjectId.Data)
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheOidcServiceAccountEmail, g.ProjectId.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -184,10 +187,7 @@ func (g *mqlGcpProjectCloudSchedulerServiceJob) oidcServiceAccount() (*mqlGcpPro
 }
 
 func (g *mqlGcpProjectCloudSchedulerServiceJob) oauthServiceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.OauthServiceAccountEmail.Error != nil {
-		return nil, g.OauthServiceAccountEmail.Error
-	}
-	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.OauthServiceAccountEmail.Data, g.ProjectId.Data)
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheOauthServiceAccountEmail, g.ProjectId.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -552,11 +552,12 @@ func getSubnetworkByUrl(subnetUrl string, runtime *plugin.Runtime) (*mqlGcpProje
 	res, err := NewResource(runtime, "gcp.project.computeService.subnetwork", map[string]*llx.RawData{
 		"name":      llx.StringData(name),
 		"projectId": llx.StringData(project),
-		"regionUrl": llx.StringData(regionUrl),
 	})
 	if err != nil {
 		return nil, err
 	}
+	mqlRef := res.(*mqlGcpProjectComputeServiceSubnetwork)
+	mqlRef.cacheRegionUrl = regionUrl
 	return res.(*mqlGcpProjectComputeServiceSubnetwork), nil
 }
 

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -31,6 +31,36 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectComputeServiceAddressInternal struct {
+	cacheNetworkUrl    string
+	cacheRegionUrl     string
+	cacheSubnetworkUrl string
+}
+
+type mqlGcpProjectComputeServiceBackendServiceInternal struct {
+	cacheEdgeSecurityPolicyUrl string
+	cacheNetworkUrl            string
+	cacheRegionUrl             string
+	cacheSecurityPolicyUrl     string
+}
+
+type mqlGcpProjectComputeServiceNetworkPeeringInternal struct {
+	cacheNetworkUrl string
+}
+
+type mqlGcpProjectComputeServiceSslCertificateInternal struct {
+	cacheRegionUrl string
+}
+
+type mqlGcpProjectComputeServiceSslPolicyInternal struct {
+	cacheRegionUrl string
+}
+
+type mqlGcpProjectComputeServiceSubnetworkInternal struct {
+	cacheNetworkUrl string
+	cacheRegionUrl  string
+}
+
 func initGcpProjectComputeService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -801,11 +831,6 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		return nil, err
 	}
 
-	networkInterfaces, err := convert.JsonToDictSlice(instance.NetworkInterfaces)
-	if err != nil {
-		return nil, err
-	}
-
 	mqlNics := make([]any, 0, len(instance.NetworkInterfaces))
 	for _, ni := range instance.NetworkInterfaces {
 		if ni == nil {
@@ -902,17 +927,8 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		attachedDisks = append(attachedDisks, attachedDisk)
 	}
 
-	var mqlConfCompute map[string]any
 	var mqlConfidentialCompute plugin.Resource
 	if instance.ConfidentialInstanceConfig != nil {
-		type mqlConfidentialInstanceConfig struct {
-			Enabled bool `json:"serviceEnabled,omitempty"`
-		}
-		mqlConfCompute, err = convert.JsonToDict(
-			mqlConfidentialInstanceConfig{Enabled: instance.ConfidentialInstanceConfig.EnableConfidentialCompute})
-		if err != nil {
-			return nil, err
-		}
 		mqlConfidentialCompute, err = CreateResource(runtime, "gcp.project.computeService.instance.confidentialCompute", map[string]*llx.RawData{
 			"__id":         llx.StringData(fmt.Sprintf("%d/confidentialCompute", instance.Id)),
 			"enabled":      llx.BoolData(instance.ConfidentialInstanceConfig.EnableConfidentialCompute),
@@ -933,7 +949,6 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		"projectId":                       llx.StringData(projectId),
 		"name":                            llx.StringData(instance.Name),
 		"description":                     llx.StringData(instance.Description),
-		"confidentialInstanceConfig":      llx.DictData(mqlConfCompute),
 		"confidentialCompute":             llx.ResourceData(mqlConfidentialCompute, "gcp.project.computeService.instance.confidentialCompute"),
 		"canIpForward":                    llx.BoolData(instance.CanIpForward),
 		"cpuPlatform":                     llx.StringData(instance.CpuPlatform),
@@ -951,7 +966,6 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		"lastSuspendedTimestamp":          llx.TimeDataPtr(parseTime(instance.LastSuspendedTimestamp)),
 		"metadata":                        llx.MapData(convert.MapToInterfaceMap(metadata), types.String),
 		"minCpuPlatform":                  llx.StringData(instance.MinCpuPlatform),
-		"networkInterfaces":               llx.ArrayData(networkInterfaces, types.Dict),
 		"nics":                            llx.ArrayData(mqlNics, types.Resource("gcp.project.computeService.instance.networkInterface")),
 		"networkStackTypes":               llx.ArrayData(networkStackTypes, types.String),
 		"privateIpv6GoogleAccess":         llx.StringData(instance.PrivateIpv6GoogleAccess),
@@ -961,9 +975,6 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 		"scheduling":                      llx.DictData(scheduling),
 		"shieldedInstanceConfig":          llx.ResourceData(mqlShieldedInstanceConfig, "gcp.project.computeService.instance.shieldedInstanceConfig"),
 		"shieldedInstanceIntegrityPolicy": llx.DictData(shieldedIntegrityPolicy),
-		"enableIntegrityMonitoring":       llx.BoolData(enableIntegrityMonitoring),
-		"enableSecureBoot":                llx.BoolData(enableSecureBoot),
-		"enableVtpm":                      llx.BoolData(enableVtpm),
 		"startRestricted":                 llx.BoolData(instance.StartRestricted),
 		"status":                          llx.StringData(instance.Status),
 		"statusMessage":                   llx.StringData(instance.StatusMessage),
@@ -2077,7 +2088,6 @@ func (g *mqlGcpProjectComputeServiceNetwork) networkPeerings() ([]any, error) {
 		mqlPeering, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.network.peering", map[string]*llx.RawData{
 			"id":                             llx.StringData(fmt.Sprintf("gcloud.compute.network/%s/peering/%s", networkId, p.Name)),
 			"name":                           llx.StringData(p.Name),
-			"networkUrl":                     llx.StringData(p.Network),
 			"state":                          llx.StringData(p.State),
 			"stateDetails":                   llx.StringData(p.StateDetails),
 			"autoCreateRoutes":               llx.BoolData(p.AutoCreateRoutes),
@@ -2090,6 +2100,8 @@ func (g *mqlGcpProjectComputeServiceNetwork) networkPeerings() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlPeering.(*mqlGcpProjectComputeServiceNetworkPeering)
+		mqlRef.cacheNetworkUrl = p.Network
 		res = append(res, mqlPeering)
 	}
 	return res, nil
@@ -2100,10 +2112,7 @@ func (g *mqlGcpProjectComputeServiceNetworkPeering) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceNetworkPeering) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	url := g.NetworkUrl.Data
+	url := g.cacheNetworkUrl
 	if url == "" {
 		g.Network.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -2217,11 +2226,6 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 		return nil, nil, err
 	}
 
-	peerings, err := convert.JsonToDictSlice(network.Peerings)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	var routingMode string
 	if network.RoutingConfig != nil {
 		routingMode = network.RoutingConfig.RoutingMode
@@ -2238,7 +2242,6 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 		"mtu":                                   llx.IntData(network.Mtu),
 		"networkFirewallPolicyEnforcementOrder": llx.StringData(network.NetworkFirewallPolicyEnforcementOrder),
 		"created":                               llx.TimeDataPtr(parseTime(network.CreationTimestamp)),
-		"peerings":                              llx.ArrayData(peerings, types.Dict),
 		"routingMode":                           llx.StringData(routingMode),
 		"mode":                                  llx.StringData(networkMode(network)),
 		"subnetworkUrls":                        llx.ArrayData(convert.SliceAnyToInterface(network.Subnetworks), types.String),
@@ -2281,11 +2284,6 @@ func (g *mqlGcpProjectComputeService) networks() ([]any, error) {
 	req := computeSvc.Networks.List(projectId)
 	if err := req.Pages(ctx, func(page *compute.NetworkList) error {
 		for _, network := range page.Items {
-			peerings, err := convert.JsonToDictSlice(network.Peerings)
-			if err != nil {
-				return err
-			}
-
 			var routingMode string
 			if network.RoutingConfig != nil {
 				routingMode = network.RoutingConfig.RoutingMode
@@ -2305,11 +2303,9 @@ func (g *mqlGcpProjectComputeService) networks() ([]any, error) {
 				"routingMode":                           llx.StringData(routingMode),
 				"mode":                                  llx.StringData(networkMode(network)),
 				"subnetworkUrls":                        llx.ArrayData(convert.SliceAnyToInterface(network.Subnetworks), types.String),
-				"peerings":                              llx.ArrayData(peerings, types.Dict),
 				"internalIpv6Range":                     llx.StringData(network.InternalIpv6Range),
 				"firewallPolicy":                        llx.StringData(network.FirewallPolicy),
 				"networkProfile":                        llx.StringData(network.NetworkProfile),
-				"ipv4Range":                             llx.StringData(network.IPv4Range),
 			})
 			if err != nil {
 				return err
@@ -2387,11 +2383,7 @@ func initGcpProjectComputeServiceSubnetwork(runtime *plugin.Runtime, args map[st
 		if name.Error != nil {
 			return nil, nil, name.Error
 		}
-		regionUrl := subnetwork.GetRegionUrl()
-		if regionUrl.Error != nil {
-			return nil, nil, regionUrl.Error
-		}
-		subnetRegion := RegionNameFromRegionUrl(regionUrl.Data)
+		subnetRegion := RegionNameFromRegionUrl(subnetwork.cacheRegionUrl)
 		projectId := subnetwork.GetProjectId()
 		if projectId.Error != nil {
 			return nil, nil, projectId.Error
@@ -2448,12 +2440,7 @@ func (g *mqlGcpProjectComputeServiceSubnetwork) region() (*mqlGcpProjectComputeS
 	}
 	projectId := g.ProjectId.Data
 
-	regionUrl := g.GetRegionUrl()
-	if regionUrl.Error != nil {
-		return nil, regionUrl.Error
-	}
-
-	regionName := RegionNameFromRegionUrl(regionUrl.Data)
+	regionName := RegionNameFromRegionUrl(g.cacheRegionUrl)
 
 	// Find regionName for projectId
 	obj, err := CreateResource(g.MqlRuntime, "gcp.project.computeService", map[string]*llx.RawData{
@@ -2483,10 +2470,7 @@ func (g *mqlGcpProjectComputeServiceSubnetwork) region() (*mqlGcpProjectComputeS
 }
 
 func (g *mqlGcpProjectComputeServiceSubnetwork) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	url := g.NetworkUrl.Data
+	url := g.cacheNetworkUrl
 	if url == "" {
 		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
@@ -2574,20 +2558,25 @@ func newMqlSubnetwork(projectId string, runtime *plugin.Runtime, subnetwork *com
 		"privateIpGoogleAccess":        llx.BoolData(subnetwork.GetPrivateIpGoogleAccess()),
 		"privateIpv6GoogleAccess":      llx.StringData(subnetwork.GetPrivateIpv6GoogleAccess()),
 		"purpose":                      llx.StringData(subnetwork.GetPurpose()),
-		"regionUrl":                    llx.StringData(subnetwork.GetRegion()),
 		"role":                         llx.StringData(subnetwork.GetRole()),
 		"stackType":                    llx.StringData(subnetwork.GetStackType()),
 		"state":                        llx.StringData(subnetwork.GetState()),
 		"created":                      llx.TimeDataPtr(parseTime(subnetwork.GetCreationTimestamp())),
 		"reservedInternalRange":        llx.StringData(subnetwork.GetReservedInternalRange()),
-		"networkUrl":                   llx.StringData(subnetwork.GetNetwork()),
 		"allowSubnetCidrRoutesOverlap": llx.BoolData(subnetwork.GetAllowSubnetCidrRoutesOverlap()),
 		"secondaryIpRanges":            llx.ArrayData(secondaryIpRanges, types.Dict),
 	}
 	if region != nil {
 		args["region"] = llx.ResourceData(region, "gcp.project.computeService.region")
 	}
-	return CreateResource(runtime, "gcp.project.computeService.subnetwork", args)
+	res, err := CreateResource(runtime, "gcp.project.computeService.subnetwork", args)
+	if err != nil {
+		return nil, err
+	}
+	mqlSubnet := res.(*mqlGcpProjectComputeServiceSubnetwork)
+	mqlSubnet.cacheRegionUrl = subnetwork.GetRegion()
+	mqlSubnet.cacheNetworkUrl = subnetwork.GetNetwork()
+	return res, nil
 }
 
 func (g *mqlGcpProjectComputeService) subnetworks() ([]any, error) {
@@ -2671,11 +2660,6 @@ func newMqlRouter(projectId string, region *mqlGcpProjectComputeServiceRegion, r
 		return nil, err
 	}
 
-	nats, err := convert.JsonToDictSlice(router.Nats)
-	if err != nil {
-		return nil, err
-	}
-
 	routerId := strconv.FormatUint(router.Id, 10)
 	natResources := make([]any, 0, len(router.Nats))
 	for _, nat := range router.Nats {
@@ -2725,7 +2709,6 @@ func newMqlRouter(projectId string, region *mqlGcpProjectComputeServiceRegion, r
 		"bgp":                         llx.DictData(bgp),
 		"bgpPeers":                    llx.ArrayData(bgpPeers, types.Dict),
 		"encryptedInterconnectRouter": llx.BoolData(router.EncryptedInterconnectRouter),
-		"nats":                        llx.ArrayData(nats, types.Dict),
 		"natServices":                 llx.ArrayData(natResources, types.Resource("gcp.project.computeService.router.nat")),
 		"created":                     llx.TimeDataPtr(parseTime(router.CreationTimestamp)),
 	})
@@ -2848,7 +2831,6 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 						"capacityScaler":            llx.FloatData(backend.CapacityScaler),
 						"description":               llx.StringData(backend.Description),
 						"failover":                  llx.BoolData(backend.Failover),
-						"groupUrl":                  llx.StringData(backend.Group),
 						"maxConnections":            llx.IntData(backend.MaxConnections),
 						"maxConnectionsPerEndpoint": llx.IntData(backend.MaxConnectionsPerEndpoint),
 						"maxConnectionsPerInstance": llx.IntData(backend.MaxConnectionsPerInstance),
@@ -2860,6 +2842,8 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 					if err != nil {
 						return err
 					}
+					mqlRef := mqlBackend.(*mqlGcpProjectComputeServiceBackendServiceBackend)
+					mqlRef.cacheGroupUrl = backend.Group
 					mqlBackends = append(mqlBackends, mqlBackend)
 				}
 
@@ -3045,7 +3029,6 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 					"customRequestHeaders":            llx.ArrayData(convert.SliceAnyToInterface(b.CustomRequestHeaders), types.String),
 					"customResponseHeaders":           llx.ArrayData(convert.SliceAnyToInterface(b.CustomResponseHeaders), types.String),
 					"description":                     llx.StringData(b.Description),
-					"edgeSecurityPolicyUrl":           llx.StringData(b.EdgeSecurityPolicy),
 					"enableCDN":                       llx.BoolData(b.EnableCDN),
 					"failoverPolicy":                  llx.DictData(mqlFailoverPolicy),
 					"healthChecks":                    llx.ArrayData(convert.SliceAnyToInterface(b.HealthChecks), types.String),
@@ -3056,11 +3039,8 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 					"logConfig":                       llx.DictData(mqlLogConfig),
 					"maxStreamDuration":               llx.TimeDataPtr(maxStreamDuration),
 					"name":                            llx.StringData(b.Name),
-					"networkUrl":                      llx.StringData(b.Network),
 					"portName":                        llx.StringData(b.PortName),
 					"protocol":                        llx.StringData(b.Protocol),
-					"regionUrl":                       llx.StringData(b.Region),
-					"securityPolicyUrl":               llx.StringData(b.SecurityPolicy),
 					"securitySettings":                llx.DictData(mqlSecuritySettings),
 					"securitySettingsClientTlsPolicy": llx.StringData(securitySettingsClientTlsPolicy),
 					"securitySettingsSubjectAltNames": llx.ArrayData(convert.SliceAnyToInterface(securitySettingsSubjectAltNames), types.String),
@@ -3076,6 +3056,11 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlB.(*mqlGcpProjectComputeServiceBackendService)
+				mqlRef.cacheEdgeSecurityPolicyUrl = b.EdgeSecurityPolicy
+				mqlRef.cacheNetworkUrl = b.Network
+				mqlRef.cacheRegionUrl = b.Region
+				mqlRef.cacheSecurityPolicyUrl = b.SecurityPolicy
 				res = append(res, mqlB)
 			}
 		}
@@ -3154,18 +3139,19 @@ func (g *mqlGcpProjectComputeService) addresses() ([]any, error) {
 					"ipv6EndpointType": llx.StringData(a.Ipv6EndpointType),
 					"name":             llx.StringData(a.Name),
 					"labels":           llx.MapData(convert.MapToInterfaceMap(a.Labels), types.String),
-					"networkUrl":       llx.StringData(a.Network),
 					"networkTier":      llx.StringData(a.NetworkTier),
 					"prefixLength":     llx.IntData(a.PrefixLength),
 					"purpose":          llx.StringData(a.Purpose),
-					"regionUrl":        llx.StringData(a.Region),
 					"status":           llx.StringData(a.Status),
-					"subnetworkUrl":    llx.StringData(a.Subnetwork),
 					"resourceUrls":     llx.ArrayData(convert.SliceAnyToInterface(a.Users), types.String),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlA.(*mqlGcpProjectComputeServiceAddress)
+				mqlRef.cacheNetworkUrl = a.Network
+				mqlRef.cacheRegionUrl = a.Region
+				mqlRef.cacheSubnetworkUrl = a.Subnetwork
 				mqlAddresses = append(mqlAddresses, mqlA)
 			}
 		}
@@ -3177,10 +3163,7 @@ func (g *mqlGcpProjectComputeService) addresses() ([]any, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceAddress) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	networkUrl := g.NetworkUrl.Data
+	networkUrl := g.cacheNetworkUrl
 	net, err := getNetworkByUrl(networkUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
@@ -3192,10 +3175,7 @@ func (g *mqlGcpProjectComputeServiceAddress) network() (*mqlGcpProjectComputeSer
 }
 
 func (g *mqlGcpProjectComputeServiceAddress) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {
-	if g.SubnetworkUrl.Error != nil {
-		return nil, g.SubnetworkUrl.Error
-	}
-	subnetUrl := g.SubnetworkUrl.Data
+	subnetUrl := g.cacheSubnetworkUrl
 	subnet, err := getSubnetworkByUrl(subnetUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
@@ -3279,7 +3259,6 @@ func (g *mqlGcpProjectComputeService) forwardingRules() ([]any, error) {
 				"ipProtocol":                    llx.StringData(fwr.GetIPProtocol()),
 				"allPorts":                      llx.BoolData(fwr.GetAllPorts()),
 				"allowGlobalAccess":             llx.BoolData(fwr.GetAllowGlobalAccess()),
-				"backendServiceUrl":             llx.StringData(fwr.GetBackendService()),
 				"created":                       llx.TimeDataPtr(parseTime(fwr.GetCreationTimestamp())),
 				"description":                   llx.StringData(fwr.GetDescription()),
 				"ipVersion":                     llx.StringData(fwr.GetIpVersion()),
@@ -3288,16 +3267,13 @@ func (g *mqlGcpProjectComputeService) forwardingRules() ([]any, error) {
 				"loadBalancingScheme":           llx.StringData(fwr.GetLoadBalancingScheme()),
 				"metadataFilters":               llx.ArrayData(metadataFilters, types.Dict),
 				"name":                          llx.StringData(fwr.GetName()),
-				"networkUrl":                    llx.StringData(fwr.GetNetwork()),
 				"networkTier":                   llx.StringData(fwr.GetNetworkTier()),
 				"noAutomateDnsZone":             llx.BoolData(fwr.GetNoAutomateDnsZone()),
 				"portRange":                     llx.StringData(fwr.GetPortRange()),
 				"ports":                         llx.ArrayData(convert.SliceAnyToInterface(fwr.GetPorts()), types.String),
-				"regionUrl":                     llx.StringData(fwr.GetRegion()),
 				"serviceDirectoryRegistrations": llx.ArrayData(serviceDirRegs, types.Dict),
 				"serviceLabel":                  llx.StringData(fwr.GetServiceLabel()),
 				"serviceName":                   llx.StringData(fwr.GetServiceName()),
-				"subnetworkUrl":                 llx.StringData(fwr.GetSubnetwork()),
 				"targetUrl":                     llx.StringData(fwr.GetTarget()),
 				"allowPscGlobalAccess":          llx.BoolData(fwr.GetAllowPscGlobalAccess()),
 				"pscConnectionStatus":           llx.StringData(fwr.GetPscConnectionStatus()),
@@ -3309,6 +3285,11 @@ func (g *mqlGcpProjectComputeService) forwardingRules() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			mqlRef := mqlFwr.(*mqlGcpProjectComputeServiceForwardingRule)
+			mqlRef.cacheBackendServiceUrl = fwr.GetBackendService()
+			mqlRef.cacheNetworkUrl = fwr.GetNetwork()
+			mqlRef.cacheRegionUrl = fwr.GetRegion()
+			mqlRef.cacheSubnetworkUrl = fwr.GetSubnetwork()
 			fwRules = append(fwRules, mqlFwr)
 		}
 	}
@@ -3331,10 +3312,7 @@ func (g *mqlGcpProjectComputeServiceForwardingRule) isExternal() (bool, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceForwardingRule) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	networkUrl := g.NetworkUrl.Data
+	networkUrl := g.cacheNetworkUrl
 	if networkUrl == "" {
 		g.Network.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -3350,10 +3328,7 @@ func (g *mqlGcpProjectComputeServiceForwardingRule) network() (*mqlGcpProjectCom
 }
 
 func (g *mqlGcpProjectComputeServiceForwardingRule) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {
-	if g.SubnetworkUrl.Error != nil {
-		return nil, g.SubnetworkUrl.Error
-	}
-	subnetUrl := g.SubnetworkUrl.Data
+	subnetUrl := g.cacheSubnetworkUrl
 	if subnetUrl == "" {
 		g.Subnetwork.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -3385,6 +3360,7 @@ func (g *mqlGcpProjectComputeServiceRouterNat) id() (string, error) {
 type mqlGcpProjectComputeServiceSecurityPolicyInternal struct {
 	cacheProjectId string
 	cacheRegion    string
+	cacheRegionUrl string
 }
 
 func (g *mqlGcpProjectComputeServiceSecurityPolicy) id() (string, error) {
@@ -3466,13 +3442,14 @@ func (g *mqlGcpProjectComputeService) securityPolicies() ([]any, error) {
 					"recaptchaOptionsConfig":   llx.DictData(recaptchaOptionsConfig),
 					"fingerprint":              llx.StringData(policy.Fingerprint),
 					"userDefinedFields":        llx.ArrayData(userDefinedFields, types.Dict),
-					"regionUrl":                llx.StringData(policy.Region),
 					"selfLink":                 llx.StringData(policy.SelfLink),
 					"createdAt":                llx.TimeDataPtr(parseTime(policy.CreationTimestamp)),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlPolicy.(*mqlGcpProjectComputeServiceSecurityPolicy)
+				mqlRef.cacheRegionUrl = policy.Region
 				sp := mqlPolicy.(*mqlGcpProjectComputeServiceSecurityPolicy)
 				sp.cacheProjectId = projectId
 				sp.cacheRegion = RegionNameFromRegionUrl(policy.Region)
@@ -3653,7 +3630,6 @@ func (g *mqlGcpProjectComputeService) sslPolicies() ([]any, error) {
 					"minTlsVersion":   llx.StringData(policy.MinTlsVersion),
 					"customFeatures":  llx.ArrayData(convert.SliceAnyToInterface(policy.CustomFeatures), types.String),
 					"enabledFeatures": llx.ArrayData(convert.SliceAnyToInterface(policy.EnabledFeatures), types.String),
-					"regionUrl":       llx.StringData(policy.Region),
 					"selfLink":        llx.StringData(policy.SelfLink),
 					"warnings":        llx.ArrayData(warnings, types.Dict),
 					"createdAt":       llx.TimeDataPtr(parseTime(policy.CreationTimestamp)),
@@ -3661,6 +3637,8 @@ func (g *mqlGcpProjectComputeService) sslPolicies() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlPolicy.(*mqlGcpProjectComputeServiceSslPolicy)
+				mqlRef.cacheRegionUrl = policy.Region
 				res = append(res, mqlPolicy)
 			}
 		}
@@ -3741,7 +3719,6 @@ func (g *mqlGcpProjectComputeService) sslCertificates() ([]any, error) {
 					"subjectAlternativeNames": llx.ArrayData(convert.SliceAnyToInterface(cert.SubjectAlternativeNames), types.String),
 					"managed":                 llx.DictData(managed),
 					"managedStatus":           llx.StringData(managedStatus),
-					"regionUrl":               llx.StringData(cert.Region),
 					"selfLink":                llx.StringData(cert.SelfLink),
 					"expireTime":              llx.StringData(cert.ExpireTime),
 					"createdAt":               llx.TimeDataPtr(parseTime(cert.CreationTimestamp)),
@@ -3749,6 +3726,8 @@ func (g *mqlGcpProjectComputeService) sslCertificates() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlCert.(*mqlGcpProjectComputeServiceSslCertificate)
+				mqlRef.cacheRegionUrl = cert.Region
 				res = append(res, mqlCert)
 			}
 		}
@@ -3765,6 +3744,7 @@ func (g *mqlGcpProjectComputeServiceVpnGateway) id() (string, error) {
 
 type mqlGcpProjectComputeServiceVpnGatewayInternal struct {
 	cacheNetworkUrl string
+	cacheRegionUrl  string
 }
 
 func (g *mqlGcpProjectComputeServiceVpnGateway) network() (*mqlGcpProjectComputeServiceNetwork, error) {
@@ -3829,13 +3809,14 @@ func (g *mqlGcpProjectComputeService) vpnGateways() ([]any, error) {
 					"labels":              llx.MapData(convert.MapToInterfaceMap(gw.Labels), types.String),
 					"gatewayIpVersion":    llx.StringData(gw.GatewayIpVersion),
 					"stackType":           llx.StringData(gw.StackType),
-					"regionUrl":           llx.StringData(gw.Region),
 					"vpnInterfaces":       llx.ArrayData(vpnInterfaces, types.Dict),
 					"resourceManagerTags": llx.MapData(gwResourceManagerTags, types.String),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlGw.(*mqlGcpProjectComputeServiceVpnGateway)
+				mqlRef.cacheRegionUrl = gw.Region
 				mqlGw.(*mqlGcpProjectComputeServiceVpnGateway).cacheNetworkUrl = gw.Network
 				res = append(res, mqlGw)
 			}
@@ -3898,16 +3879,11 @@ func (g *mqlGcpProjectComputeService) vpnTunnels() ([]any, error) {
 					"ikeVersion":                   llx.IntData(t.IkeVersion),
 					"localTrafficSelector":         llx.ArrayData(convert.SliceAnyToInterface(t.LocalTrafficSelector), types.String),
 					"remoteTrafficSelector":        llx.ArrayData(convert.SliceAnyToInterface(t.RemoteTrafficSelector), types.String),
-					"peerExternalGateway":          llx.StringData(t.PeerExternalGateway),
 					"peerExternalGatewayInterface": llx.IntData(t.PeerExternalGatewayInterface),
-					"peerGcpGateway":               llx.StringData(t.PeerGcpGateway),
 					"peerIp":                       llx.StringData(t.PeerIp),
-					"regionUrl":                    llx.StringData(t.Region),
-					"routerUrl":                    llx.StringData(t.Router),
 					"sharedSecretHash":             llx.StringData(t.SharedSecretHash),
 					"status":                       llx.StringData(t.Status),
 					"targetVpnGateway":             llx.StringData(t.TargetVpnGateway),
-					"vpnGatewayUrl":                llx.StringData(t.VpnGateway),
 					"vpnGatewayInterface":          llx.IntData(int64(t.VpnGatewayInterface)),
 					"resourceManagerTags":          llx.MapData(tunnelResourceManagerTags, types.String),
 					"selfLink":                     llx.StringData(t.SelfLink),
@@ -3915,6 +3891,12 @@ func (g *mqlGcpProjectComputeService) vpnTunnels() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlTunnel.(*mqlGcpProjectComputeServiceVpnTunnel)
+				mqlRef.cachePeerExternalGateway = t.PeerExternalGateway
+				mqlRef.cachePeerGcpGateway = t.PeerGcpGateway
+				mqlRef.cacheRegionUrl = t.Region
+				mqlRef.cacheRouterUrl = t.Router
+				mqlRef.cacheVpnGatewayUrl = t.VpnGateway
 				res = append(res, mqlTunnel)
 			}
 		}
@@ -4065,20 +4047,20 @@ func (g *mqlGcpProjectComputeServiceImage) iamPolicy() ([]any, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceInstance) hasPublicIp() (bool, error) {
-	nics := g.GetNetworkInterfaces()
+	nics := g.GetNics()
 	if nics.Error != nil {
 		return false, nics.Error
 	}
-	for _, nic := range nics.Data {
-		nicMap, ok := nic.(map[string]any)
+	for _, n := range nics.Data {
+		nic, ok := n.(*mqlGcpProjectComputeServiceInstanceNetworkInterface)
 		if !ok {
 			continue
 		}
-		accessConfigs, ok := nicMap["accessConfigs"].([]any)
-		if !ok {
-			continue
+		accessConfigs := nic.GetAccessConfigs()
+		if accessConfigs.Error != nil {
+			return false, accessConfigs.Error
 		}
-		if len(accessConfigs) > 0 {
+		if len(accessConfigs.Data) > 0 {
 			return true, nil
 		}
 	}

--- a/providers/gcp/resources/compute_enrichments.go
+++ b/providers/gcp/resources/compute_enrichments.go
@@ -18,6 +18,26 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectComputeServiceHealthCheckInternal struct {
+	cacheRegionUrl string
+}
+
+type mqlGcpProjectComputeServiceTargetHttpProxyInternal struct {
+	cacheRegionUrl string
+	cacheUrlMapUrl string
+}
+
+type mqlGcpProjectComputeServiceTargetHttpsProxyInternal struct {
+	cacheRegionUrl    string
+	cacheSslPolicyUrl string
+	cacheUrlMapUrl    string
+}
+
+type mqlGcpProjectComputeServiceUrlMapInternal struct {
+	cacheDefaultServiceUrl string
+	cacheRegionUrl         string
+}
+
 // Health checks
 
 func (g *mqlGcpProjectComputeService) healthChecks() ([]any, error) {
@@ -77,11 +97,12 @@ func (g *mqlGcpProjectComputeService) healthChecks() ([]any, error) {
 					"http2HealthCheck":   llx.DictData(http2HC),
 					"grpcHealthCheck":    llx.DictData(grpcHC),
 					"logConfig":          llx.DictData(logCfg),
-					"regionUrl":          llx.StringData(hc.Region),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlHC.(*mqlGcpProjectComputeServiceHealthCheck)
+				mqlRef.cacheRegionUrl = hc.Region
 				res = append(res, mqlHC)
 			}
 		}
@@ -133,21 +154,22 @@ func (g *mqlGcpProjectComputeService) urlMaps() ([]any, error) {
 				tests, _ := convert.JsonToDictSlice(um.Tests)
 
 				mqlUM, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.urlMap", map[string]*llx.RawData{
-					"id":                llx.StringData(strconv.FormatUint(um.Id, 10)),
-					"projectId":         llx.StringData(projectId),
-					"name":              llx.StringData(um.Name),
-					"description":       llx.StringData(um.Description),
-					"defaultServiceUrl": llx.StringData(um.DefaultService),
-					"hostRules":         llx.ArrayData(hostRules, types.Dict),
-					"pathMatchers":      llx.ArrayData(pathMatchers, types.Dict),
-					"tests":             llx.ArrayData(tests, types.Dict),
-					"created":           llx.TimeDataPtr(parseTime(um.CreationTimestamp)),
-					"selfLink":          llx.StringData(um.SelfLink),
-					"regionUrl":         llx.StringData(um.Region),
+					"id":           llx.StringData(strconv.FormatUint(um.Id, 10)),
+					"projectId":    llx.StringData(projectId),
+					"name":         llx.StringData(um.Name),
+					"description":  llx.StringData(um.Description),
+					"hostRules":    llx.ArrayData(hostRules, types.Dict),
+					"pathMatchers": llx.ArrayData(pathMatchers, types.Dict),
+					"tests":        llx.ArrayData(tests, types.Dict),
+					"created":      llx.TimeDataPtr(parseTime(um.CreationTimestamp)),
+					"selfLink":     llx.StringData(um.SelfLink),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlUM.(*mqlGcpProjectComputeServiceUrlMap)
+				mqlRef.cacheDefaultServiceUrl = um.DefaultService
+				mqlRef.cacheRegionUrl = um.Region
 				res = append(res, mqlUM)
 			}
 		}
@@ -199,15 +221,16 @@ func (g *mqlGcpProjectComputeService) targetHttpProxies() ([]any, error) {
 					"projectId":   llx.StringData(projectId),
 					"name":        llx.StringData(proxy.Name),
 					"description": llx.StringData(proxy.Description),
-					"urlMapUrl":   llx.StringData(proxy.UrlMap),
 					"created":     llx.TimeDataPtr(parseTime(proxy.CreationTimestamp)),
 					"selfLink":    llx.StringData(proxy.SelfLink),
 					"proxyBind":   llx.BoolData(proxy.ProxyBind),
-					"regionUrl":   llx.StringData(proxy.Region),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlProxy.(*mqlGcpProjectComputeServiceTargetHttpProxy)
+				mqlRef.cacheUrlMapUrl = proxy.UrlMap
+				mqlRef.cacheRegionUrl = proxy.Region
 				res = append(res, mqlProxy)
 			}
 		}
@@ -223,10 +246,7 @@ func (g *mqlGcpProjectComputeServiceTargetHttpProxy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceTargetHttpProxy) urlMap() (*mqlGcpProjectComputeServiceUrlMap, error) {
-	if g.UrlMapUrl.Error != nil {
-		return nil, g.UrlMapUrl.Error
-	}
-	url := g.UrlMapUrl.Data
+	url := g.cacheUrlMapUrl
 	if url == "" {
 		g.UrlMap.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -278,9 +298,7 @@ func (g *mqlGcpProjectComputeService) targetHttpsProxies() ([]any, error) {
 					"projectId":           llx.StringData(projectId),
 					"name":                llx.StringData(proxy.Name),
 					"description":         llx.StringData(proxy.Description),
-					"urlMapUrl":           llx.StringData(proxy.UrlMap),
 					"sslCertificateUrls":  llx.ArrayData(convert.SliceAnyToInterface(proxy.SslCertificates), types.String),
-					"sslPolicyUrl":        llx.StringData(proxy.SslPolicy),
 					"quicOverride":        llx.StringData(proxy.QuicOverride),
 					"certificateMap":      llx.StringData(proxy.CertificateMap),
 					"serverTlsPolicy":     llx.StringData(proxy.ServerTlsPolicy),
@@ -289,11 +307,14 @@ func (g *mqlGcpProjectComputeService) targetHttpsProxies() ([]any, error) {
 					"created":             llx.TimeDataPtr(parseTime(proxy.CreationTimestamp)),
 					"selfLink":            llx.StringData(proxy.SelfLink),
 					"proxyBind":           llx.BoolData(proxy.ProxyBind),
-					"regionUrl":           llx.StringData(proxy.Region),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlProxy.(*mqlGcpProjectComputeServiceTargetHttpsProxy)
+				mqlRef.cacheUrlMapUrl = proxy.UrlMap
+				mqlRef.cacheSslPolicyUrl = proxy.SslPolicy
+				mqlRef.cacheRegionUrl = proxy.Region
 				res = append(res, mqlProxy)
 			}
 		}
@@ -309,10 +330,7 @@ func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) urlMap() (*mqlGcpProjectComputeServiceUrlMap, error) {
-	if g.UrlMapUrl.Error != nil {
-		return nil, g.UrlMapUrl.Error
-	}
-	url := g.UrlMapUrl.Data
+	url := g.cacheUrlMapUrl
 	if url == "" {
 		g.UrlMap.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -328,10 +346,7 @@ func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) urlMap() (*mqlGcpProjectCo
 }
 
 func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) sslPolicy() (*mqlGcpProjectComputeServiceSslPolicy, error) {
-	if g.SslPolicyUrl.Error != nil {
-		return nil, g.SslPolicyUrl.Error
-	}
-	url := g.SslPolicyUrl.Data
+	url := g.cacheSslPolicyUrl
 	if url == "" {
 		g.SslPolicy.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -59,8 +59,6 @@ func (g *mqlGcpProjectComputeService) instanceGroups() ([]any, error) {
 					"projectId":   llx.StringData(projectId),
 					"name":        llx.StringData(ig.Name),
 					"description": llx.StringData(ig.Description),
-					"zoneUrl":     llx.StringData(ig.Zone),
-					"networkUrl":  llx.StringData(ig.Network),
 					"size":        llx.IntData(ig.Size),
 					"namedPorts":  llx.ArrayData(namedPorts, types.Dict),
 					"created":     llx.TimeDataPtr(parseTime(ig.CreationTimestamp)),
@@ -69,6 +67,9 @@ func (g *mqlGcpProjectComputeService) instanceGroups() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlIG.(*mqlGcpProjectComputeServiceInstanceGroup)
+				mqlRef.cacheZoneUrl = ig.Zone
+				mqlRef.cacheNetworkUrl = ig.Network
 				mqlIG.(*mqlGcpProjectComputeServiceInstanceGroup).cacheSubnetworkUrl = ig.Subnetwork
 				res = append(res, mqlIG)
 			}
@@ -86,6 +87,8 @@ func (g *mqlGcpProjectComputeService) instanceGroups() ([]any, error) {
 
 type mqlGcpProjectComputeServiceInstanceGroupInternal struct {
 	cacheSubnetworkUrl string
+	cacheNetworkUrl    string
+	cacheZoneUrl       string
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroup) id() (string, error) {
@@ -93,10 +96,7 @@ func (g *mqlGcpProjectComputeServiceInstanceGroup) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroup) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	net, err := getNetworkByUrl(g.NetworkUrl.Data, g.MqlRuntime)
+	net, err := getNetworkByUrl(g.cacheNetworkUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -159,8 +159,6 @@ func (g *mqlGcpProjectComputeService) instanceGroupManagers() ([]any, error) {
 					"projectId":           llx.StringData(projectId),
 					"name":                llx.StringData(igm.Name),
 					"description":         llx.StringData(igm.Description),
-					"zoneUrl":             llx.StringData(igm.Zone),
-					"regionUrl":           llx.StringData(igm.Region),
 					"instanceTemplateUrl": llx.StringData(igm.InstanceTemplate),
 					"targetSize":          llx.IntData(igm.TargetSize),
 					"currentActions":      llx.DictData(currentActions),
@@ -175,6 +173,9 @@ func (g *mqlGcpProjectComputeService) instanceGroupManagers() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlIGM.(*mqlGcpProjectComputeServiceInstanceGroupManager)
+				mqlRef.cacheZoneUrl = igm.Zone
+				mqlRef.cacheRegionUrl = igm.Region
 				templateUrl := igm.InstanceTemplate
 				if templateUrl == "" {
 					for _, v := range igm.Versions {
@@ -201,6 +202,8 @@ func (g *mqlGcpProjectComputeService) instanceGroupManagers() ([]any, error) {
 
 type mqlGcpProjectComputeServiceInstanceGroupManagerInternal struct {
 	cacheInstanceTemplateUrl string
+	cacheRegionUrl           string
+	cacheZoneUrl             string
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroupManager) id() (string, error) {
@@ -289,12 +292,13 @@ func (g *mqlGcpProjectComputeService) firewallPolicies() ([]any, error) {
 				"selfLink":       llx.StringData(fp.SelfLink),
 				"ruleTupleCount": llx.IntData(fp.RuleTupleCount),
 				"created":        llx.TimeDataPtr(parseTime(fp.CreationTimestamp)),
-				"regionUrl":      llx.StringData(fp.Region),
 				"associations":   llx.ArrayData(associations, types.Dict),
 			})
 			if err != nil {
 				return err
 			}
+			mqlRef := mqlFP.(*mqlGcpProjectComputeServiceFirewallPolicy)
+			mqlRef.cacheRegionUrl = fp.Region
 			mqlPolicy := mqlFP.(*mqlGcpProjectComputeServiceFirewallPolicy)
 			mqlPolicy.cacheRules = fp.Rules
 			res = append(res, mqlFP)
@@ -311,7 +315,8 @@ func (g *mqlGcpProjectComputeService) firewallPolicies() ([]any, error) {
 }
 
 type mqlGcpProjectComputeServiceFirewallPolicyInternal struct {
-	cacheRules []*compute.FirewallPolicyRule
+	cacheRules     []*compute.FirewallPolicyRule
+	cacheRegionUrl string
 }
 
 func (g *mqlGcpProjectComputeServiceFirewallPolicy) id() (string, error) {

--- a/providers/gcp/resources/compute_network_children.go
+++ b/providers/gcp/resources/compute_network_children.go
@@ -162,10 +162,5 @@ func (g *mqlGcpProjectComputeServiceNetwork) firewalls() ([]any, error) {
 func (g *mqlGcpProjectComputeServiceNetwork) routes() ([]any, error) {
 	return networkChildren(g,
 		func(s *mqlGcpProjectComputeService) *plugin.TValue[[]any] { return s.GetRoutes() },
-		func(r *mqlGcpProjectComputeServiceRoute) string {
-			if r.NetworkUrl.Error != nil {
-				return ""
-			}
-			return r.NetworkUrl.Data
-		})
+		func(r *mqlGcpProjectComputeServiceRoute) string { return r.cacheNetworkUrl })
 }

--- a/providers/gcp/resources/compute_network_edges.go
+++ b/providers/gcp/resources/compute_network_edges.go
@@ -17,6 +17,27 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectComputeServiceBackendServiceBackendInternal struct {
+	cacheGroupUrl string
+}
+
+type mqlGcpProjectComputeServiceForwardingRuleInternal struct {
+	cacheBackendServiceUrl string
+	cacheNetworkUrl        string
+	cacheRegionUrl         string
+	cacheSubnetworkUrl     string
+}
+
+type mqlGcpProjectComputeServiceRouteInternal struct {
+	cacheNetworkUrl string
+}
+
+type mqlGcpProjectComputeServiceTargetPoolInternal struct {
+	cacheBackupPoolUrl     string
+	cacheRegionUrl         string
+	cacheSecurityPolicyUrl string
+}
+
 // ---------------------------------------------------------------
 // Shared URL helpers
 // ---------------------------------------------------------------
@@ -331,10 +352,7 @@ func resolveComputeRefs(urls plugin.TValue[[]any], runtime *plugin.Runtime, reso
 // ---------------------------------------------------------------
 
 func (g *mqlGcpProjectComputeServiceForwardingRule) backendService() (*mqlGcpProjectComputeServiceBackendService, error) {
-	if g.BackendServiceUrl.Error != nil {
-		return nil, g.BackendServiceUrl.Error
-	}
-	bs, err := getBackendServiceByUrl(g.BackendServiceUrl.Data, g.MqlRuntime)
+	bs, err := getBackendServiceByUrl(g.cacheBackendServiceUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -439,10 +457,7 @@ func (g *mqlGcpProjectComputeServiceForwardingRule) targetSslProxy() (*mqlGcpPro
 // ---------------------------------------------------------------
 
 func (g *mqlGcpProjectComputeServiceBackendService) edgeSecurityPolicy() (*mqlGcpProjectComputeServiceSecurityPolicy, error) {
-	if g.EdgeSecurityPolicyUrl.Error != nil {
-		return nil, g.EdgeSecurityPolicyUrl.Error
-	}
-	sp, err := getSecurityPolicyByUrl(g.EdgeSecurityPolicyUrl.Data, g.MqlRuntime)
+	sp, err := getSecurityPolicyByUrl(g.cacheEdgeSecurityPolicyUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -463,14 +478,11 @@ func (g *mqlGcpProjectComputeServiceBackendService) healthCheckRefs() ([]any, er
 }
 
 func (g *mqlGcpProjectComputeServiceBackendServiceBackend) instanceGroup() (*mqlGcpProjectComputeServiceInstanceGroup, error) {
-	if g.GroupUrl.Error != nil {
-		return nil, g.GroupUrl.Error
-	}
-	if computeURLCollection(g.GroupUrl.Data) != "instanceGroups" {
+	if computeURLCollection(g.cacheGroupUrl) != "instanceGroups" {
 		g.InstanceGroup.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	ig, err := getInstanceGroupByUrl(g.GroupUrl.Data, g.MqlRuntime)
+	ig, err := getInstanceGroupByUrl(g.cacheGroupUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -481,14 +493,11 @@ func (g *mqlGcpProjectComputeServiceBackendServiceBackend) instanceGroup() (*mql
 }
 
 func (g *mqlGcpProjectComputeServiceBackendServiceBackend) networkEndpointGroup() (*mqlGcpProjectComputeServiceNetworkEndpointGroup, error) {
-	if g.GroupUrl.Error != nil {
-		return nil, g.GroupUrl.Error
-	}
-	if computeURLCollection(g.GroupUrl.Data) != "networkEndpointGroups" {
+	if computeURLCollection(g.cacheGroupUrl) != "networkEndpointGroups" {
 		g.NetworkEndpointGroup.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	neg, err := getNetworkEndpointGroupByUrl(g.GroupUrl.Data, g.MqlRuntime)
+	neg, err := getNetworkEndpointGroupByUrl(g.cacheGroupUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -503,10 +512,7 @@ func (g *mqlGcpProjectComputeServiceBackendServiceBackend) networkEndpointGroup(
 // ---------------------------------------------------------------
 
 func (g *mqlGcpProjectComputeServiceUrlMap) defaultService() (*mqlGcpProjectComputeServiceBackendService, error) {
-	if g.DefaultServiceUrl.Error != nil {
-		return nil, g.DefaultServiceUrl.Error
-	}
-	bs, err := getBackendServiceByUrl(g.DefaultServiceUrl.Data, g.MqlRuntime)
+	bs, err := getBackendServiceByUrl(g.cacheDefaultServiceUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -517,10 +523,7 @@ func (g *mqlGcpProjectComputeServiceUrlMap) defaultService() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServiceTargetTcpProxy) service() (*mqlGcpProjectComputeServiceBackendService, error) {
-	if g.ServiceUrl.Error != nil {
-		return nil, g.ServiceUrl.Error
-	}
-	bs, err := getBackendServiceByUrl(g.ServiceUrl.Data, g.MqlRuntime)
+	bs, err := getBackendServiceByUrl(g.cacheServiceUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -531,10 +534,7 @@ func (g *mqlGcpProjectComputeServiceTargetTcpProxy) service() (*mqlGcpProjectCom
 }
 
 func (g *mqlGcpProjectComputeServiceTargetSslProxy) service() (*mqlGcpProjectComputeServiceBackendService, error) {
-	if g.ServiceUrl.Error != nil {
-		return nil, g.ServiceUrl.Error
-	}
-	bs, err := getBackendServiceByUrl(g.ServiceUrl.Data, g.MqlRuntime)
+	bs, err := getBackendServiceByUrl(g.cacheServiceUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -549,10 +549,7 @@ func (g *mqlGcpProjectComputeServiceTargetSslProxy) service() (*mqlGcpProjectCom
 // ---------------------------------------------------------------
 
 func (g *mqlGcpProjectComputeServiceTargetPool) backupPool() (*mqlGcpProjectComputeServiceTargetPool, error) {
-	if g.BackupPoolUrl.Error != nil {
-		return nil, g.BackupPoolUrl.Error
-	}
-	tp, err := getTargetPoolByUrl(g.BackupPoolUrl.Data, g.MqlRuntime)
+	tp, err := getTargetPoolByUrl(g.cacheBackupPoolUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -563,10 +560,7 @@ func (g *mqlGcpProjectComputeServiceTargetPool) backupPool() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServiceTargetPool) securityPolicy() (*mqlGcpProjectComputeServiceSecurityPolicy, error) {
-	if g.SecurityPolicyUrl.Error != nil {
-		return nil, g.SecurityPolicyUrl.Error
-	}
-	sp, err := getSecurityPolicyByUrl(g.SecurityPolicyUrl.Data, g.MqlRuntime)
+	sp, err := getSecurityPolicyByUrl(g.cacheSecurityPolicyUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/compute_networking.go
+++ b/providers/gcp/resources/compute_networking.go
@@ -20,6 +20,45 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectComputeServiceInterconnectAttachmentInternal struct {
+	cacheInterconnectUrl string
+	cacheRegionUrl       string
+	cacheRouterUrl       string
+}
+
+type mqlGcpProjectComputeServiceNetworkEndpointGroupInternal struct {
+	cacheNetworkUrl    string
+	cacheRegionUrl     string
+	cacheSubnetworkUrl string
+	cacheZoneUrl       string
+}
+
+type mqlGcpProjectComputeServicePacketMirroringInternal struct {
+	cacheRegionUrl string
+}
+
+type mqlGcpProjectComputeServiceServiceAttachmentInternal struct {
+	cacheRegionUrl string
+}
+
+type mqlGcpProjectComputeServiceTargetSslProxyInternal struct {
+	cacheServiceUrl   string
+	cacheSslPolicyUrl string
+}
+
+type mqlGcpProjectComputeServiceTargetTcpProxyInternal struct {
+	cacheRegionUrl  string
+	cacheServiceUrl string
+}
+
+type mqlGcpProjectComputeServiceVpnTunnelInternal struct {
+	cachePeerExternalGateway string
+	cachePeerGcpGateway      string
+	cacheRegionUrl           string
+	cacheRouterUrl           string
+	cacheVpnGatewayUrl       string
+}
+
 // ---------------------------------------------------------------
 // Cross-reference helper functions
 // ---------------------------------------------------------------
@@ -88,7 +127,7 @@ func getVpnGatewayByUrl(gwUrl string, runtime *plugin.Runtime) (*mqlGcpProjectCo
 	// VPN gateways are region-scoped and have regionUrl; match by name + region
 	for _, g := range gateways.Data {
 		gw := g.(*mqlGcpProjectComputeServiceVpnGateway)
-		if gw.GetName().Data == targetName && strings.HasSuffix(gw.RegionUrl.Data, "/"+targetRegion) {
+		if gw.GetName().Data == targetName && strings.HasSuffix(gw.cacheRegionUrl, "/"+targetRegion) {
 			return gw, nil
 		}
 	}
@@ -196,10 +235,7 @@ func getSecurityPolicyByUrl(policyUrl string, runtime *plugin.Runtime) (*mqlGcpP
 // vpnTunnel cross-references
 
 func (g *mqlGcpProjectComputeServiceVpnTunnel) router() (*mqlGcpProjectComputeServiceRouter, error) {
-	if g.RouterUrl.Error != nil {
-		return nil, g.RouterUrl.Error
-	}
-	routerUrl := g.RouterUrl.Data
+	routerUrl := g.cacheRouterUrl
 	if routerUrl == "" {
 		g.Router.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -215,10 +251,7 @@ func (g *mqlGcpProjectComputeServiceVpnTunnel) router() (*mqlGcpProjectComputeSe
 }
 
 func (g *mqlGcpProjectComputeServiceVpnTunnel) vpnGateway() (*mqlGcpProjectComputeServiceVpnGateway, error) {
-	if g.VpnGatewayUrl.Error != nil {
-		return nil, g.VpnGatewayUrl.Error
-	}
-	gwUrl := g.VpnGatewayUrl.Data
+	gwUrl := g.cacheVpnGatewayUrl
 	if gwUrl == "" {
 		g.VpnGateway.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -234,10 +267,7 @@ func (g *mqlGcpProjectComputeServiceVpnTunnel) vpnGateway() (*mqlGcpProjectCompu
 }
 
 func (g *mqlGcpProjectComputeServiceVpnTunnel) peerExternalVpnGateway() (*mqlGcpProjectComputeServiceExternalVpnGateway, error) {
-	if g.PeerExternalGateway.Error != nil {
-		return nil, g.PeerExternalGateway.Error
-	}
-	gwUrl := g.PeerExternalGateway.Data
+	gwUrl := g.cachePeerExternalGateway
 	if gwUrl == "" {
 		g.PeerExternalVpnGateway.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -253,10 +283,7 @@ func (g *mqlGcpProjectComputeServiceVpnTunnel) peerExternalVpnGateway() (*mqlGcp
 }
 
 func (g *mqlGcpProjectComputeServiceVpnTunnel) peerGcpVpnGateway() (*mqlGcpProjectComputeServiceVpnGateway, error) {
-	if g.PeerGcpGateway.Error != nil {
-		return nil, g.PeerGcpGateway.Error
-	}
-	gwUrl := g.PeerGcpGateway.Data
+	gwUrl := g.cachePeerGcpGateway
 	if gwUrl == "" {
 		g.PeerGcpVpnGateway.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -274,10 +301,7 @@ func (g *mqlGcpProjectComputeServiceVpnTunnel) peerGcpVpnGateway() (*mqlGcpProje
 // interconnectAttachment cross-references
 
 func (g *mqlGcpProjectComputeServiceInterconnectAttachment) interconnect() (*mqlGcpProjectComputeServiceInterconnect, error) {
-	if g.InterconnectUrl.Error != nil {
-		return nil, g.InterconnectUrl.Error
-	}
-	icUrl := g.InterconnectUrl.Data
+	icUrl := g.cacheInterconnectUrl
 	if icUrl == "" {
 		g.Interconnect.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -293,10 +317,7 @@ func (g *mqlGcpProjectComputeServiceInterconnectAttachment) interconnect() (*mql
 }
 
 func (g *mqlGcpProjectComputeServiceInterconnectAttachment) router() (*mqlGcpProjectComputeServiceRouter, error) {
-	if g.RouterUrl.Error != nil {
-		return nil, g.RouterUrl.Error
-	}
-	routerUrl := g.RouterUrl.Data
+	routerUrl := g.cacheRouterUrl
 	if routerUrl == "" {
 		g.Router.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -314,10 +335,7 @@ func (g *mqlGcpProjectComputeServiceInterconnectAttachment) router() (*mqlGcpPro
 // backendService cross-references
 
 func (g *mqlGcpProjectComputeServiceBackendService) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	networkUrl := g.NetworkUrl.Data
+	networkUrl := g.cacheNetworkUrl
 	if networkUrl == "" {
 		g.Network.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -333,10 +351,7 @@ func (g *mqlGcpProjectComputeServiceBackendService) network() (*mqlGcpProjectCom
 }
 
 func (g *mqlGcpProjectComputeServiceBackendService) securityPolicy() (*mqlGcpProjectComputeServiceSecurityPolicy, error) {
-	if g.SecurityPolicyUrl.Error != nil {
-		return nil, g.SecurityPolicyUrl.Error
-	}
-	policyUrl := g.SecurityPolicyUrl.Data
+	policyUrl := g.cacheSecurityPolicyUrl
 	if policyUrl == "" {
 		g.SecurityPolicy.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -360,10 +375,7 @@ func (g *mqlGcpProjectComputeServiceRoute) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceRoute) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	networkUrl := g.NetworkUrl.Data
+	networkUrl := g.cacheNetworkUrl
 	if networkUrl == "" {
 		g.Network.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -432,7 +444,6 @@ func (g *mqlGcpProjectComputeService) routes() ([]any, error) {
 				"description":      llx.StringData(r.Description),
 				"destRange":        llx.StringData(r.DestRange),
 				"priority":         llx.IntData(r.Priority),
-				"networkUrl":       llx.StringData(r.Network),
 				"nextHopGateway":   llx.StringData(r.NextHopGateway),
 				"nextHopInstance":  llx.StringData(r.NextHopInstance),
 				"nextHopIp":        llx.StringData(r.NextHopIp),
@@ -452,6 +463,8 @@ func (g *mqlGcpProjectComputeService) routes() ([]any, error) {
 			if err != nil {
 				return err
 			}
+			mqlRef := mqlRoute.(*mqlGcpProjectComputeServiceRoute)
+			mqlRef.cacheNetworkUrl = r.Network
 			res = append(res, mqlRoute)
 		}
 		return nil
@@ -532,7 +545,6 @@ func (g *mqlGcpProjectComputeService) serviceAttachments() ([]any, error) {
 					"producerForwardingRule": llx.StringData(sa.ProducerForwardingRule),
 					"targetService":          llx.StringData(sa.TargetService),
 					"reconcileConnections":   llx.BoolData(sa.ReconcileConnections),
-					"regionUrl":              llx.StringData(sa.Region),
 					"selfLink":               llx.StringData(sa.SelfLink),
 					"fingerprint":            llx.StringData(sa.Fingerprint),
 					"created":                llx.TimeDataPtr(parseTime(sa.CreationTimestamp)),
@@ -540,6 +552,8 @@ func (g *mqlGcpProjectComputeService) serviceAttachments() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlSA.(*mqlGcpProjectComputeServiceServiceAttachment)
+				mqlRef.cacheRegionUrl = sa.Region
 				res = append(res, mqlSA)
 			}
 		}
@@ -559,10 +573,7 @@ func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	networkUrl := g.NetworkUrl.Data
+	networkUrl := g.cacheNetworkUrl
 	if networkUrl == "" {
 		g.Network.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -578,10 +589,7 @@ func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) network() (*mqlGcpProj
 }
 
 func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {
-	if g.SubnetworkUrl.Error != nil {
-		return nil, g.SubnetworkUrl.Error
-	}
-	subnetUrl := g.SubnetworkUrl.Data
+	subnetUrl := g.cacheSubnetworkUrl
 	if subnetUrl == "" {
 		g.Subnetwork.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -657,10 +665,6 @@ func (g *mqlGcpProjectComputeService) networkEndpointGroups() ([]any, error) {
 					"networkEndpointType": llx.StringData(neg.NetworkEndpointType),
 					"defaultPort":         llx.IntData(neg.DefaultPort),
 					"size":                llx.IntData(neg.Size),
-					"networkUrl":          llx.StringData(neg.Network),
-					"subnetworkUrl":       llx.StringData(neg.Subnetwork),
-					"zoneUrl":             llx.StringData(neg.Zone),
-					"regionUrl":           llx.StringData(neg.Region),
 					"cloudRun":            llx.DictData(cloudRun),
 					"appEngine":           llx.DictData(appEngine),
 					"cloudFunction":       llx.DictData(cloudFunction),
@@ -673,6 +677,11 @@ func (g *mqlGcpProjectComputeService) networkEndpointGroups() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlNEG.(*mqlGcpProjectComputeServiceNetworkEndpointGroup)
+				mqlRef.cacheNetworkUrl = neg.Network
+				mqlRef.cacheSubnetworkUrl = neg.Subnetwork
+				mqlRef.cacheZoneUrl = neg.Zone
+				mqlRef.cacheRegionUrl = neg.Region
 				res = append(res, mqlNEG)
 			}
 		}
@@ -837,8 +846,6 @@ func (g *mqlGcpProjectComputeService) interconnectAttachments() ([]any, error) {
 					"type":                      llx.StringData(ia.Type),
 					"state":                     llx.StringData(ia.State),
 					"edgeAvailabilityDomain":    llx.StringData(ia.EdgeAvailabilityDomain),
-					"interconnectUrl":           llx.StringData(ia.Interconnect),
-					"routerUrl":                 llx.StringData(ia.Router),
 					"cloudRouterIpAddress":      llx.StringData(ia.CloudRouterIpAddress),
 					"customerRouterIpAddress":   llx.StringData(ia.CustomerRouterIpAddress),
 					"cloudRouterIpv6Address":    llx.StringData(ia.CloudRouterIpv6Address),
@@ -848,7 +855,6 @@ func (g *mqlGcpProjectComputeService) interconnectAttachments() ([]any, error) {
 					"vlanTag8021q":              llx.IntData(ia.VlanTag8021q),
 					"partnerMetadata":           llx.DictData(partnerMetadata),
 					"privateInterconnectInfo":   llx.DictData(privateInfo),
-					"regionUrl":                 llx.StringData(ia.Region),
 					"selfLink":                  llx.StringData(ia.SelfLink),
 					"dataplaneVersion":          llx.IntData(ia.DataplaneVersion),
 					"labels":                    llx.MapData(convert.MapToInterfaceMap(ia.Labels), types.String),
@@ -857,6 +863,10 @@ func (g *mqlGcpProjectComputeService) interconnectAttachments() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlIA.(*mqlGcpProjectComputeServiceInterconnectAttachment)
+				mqlRef.cacheInterconnectUrl = ia.Interconnect
+				mqlRef.cacheRouterUrl = ia.Router
+				mqlRef.cacheRegionUrl = ia.Region
 				res = append(res, mqlIA)
 			}
 		}
@@ -988,14 +998,15 @@ func (g *mqlGcpProjectComputeService) targetTcpProxies() ([]any, error) {
 					"description": llx.StringData(tp.Description),
 					"proxyHeader": llx.StringData(tp.ProxyHeader),
 					"proxyBind":   llx.BoolData(tp.ProxyBind),
-					"serviceUrl":  llx.StringData(tp.Service),
-					"regionUrl":   llx.StringData(tp.Region),
 					"selfLink":    llx.StringData(tp.SelfLink),
 					"created":     llx.TimeDataPtr(parseTime(tp.CreationTimestamp)),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlTP.(*mqlGcpProjectComputeServiceTargetTcpProxy)
+				mqlRef.cacheServiceUrl = tp.Service
+				mqlRef.cacheRegionUrl = tp.Region
 				res = append(res, mqlTP)
 			}
 		}
@@ -1015,10 +1026,7 @@ func (g *mqlGcpProjectComputeServiceTargetSslProxy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeServiceTargetSslProxy) sslPolicy() (*mqlGcpProjectComputeServiceSslPolicy, error) {
-	if g.SslPolicyUrl.Error != nil {
-		return nil, g.SslPolicyUrl.Error
-	}
-	sslPolicyUrl := g.SslPolicyUrl.Data
+	sslPolicyUrl := g.cacheSslPolicyUrl
 	if sslPolicyUrl == "" {
 		g.SslPolicy.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -1069,9 +1077,7 @@ func (g *mqlGcpProjectComputeService) targetSslProxies() ([]any, error) {
 				"name":               llx.StringData(sp.Name),
 				"description":        llx.StringData(sp.Description),
 				"proxyHeader":        llx.StringData(sp.ProxyHeader),
-				"serviceUrl":         llx.StringData(sp.Service),
 				"sslCertificateUrls": llx.ArrayData(convert.SliceAnyToInterface(sp.SslCertificates), types.String),
-				"sslPolicyUrl":       llx.StringData(sp.SslPolicy),
 				"certificateMap":     llx.StringData(sp.CertificateMap),
 				"selfLink":           llx.StringData(sp.SelfLink),
 				"created":            llx.TimeDataPtr(parseTime(sp.CreationTimestamp)),
@@ -1079,6 +1085,9 @@ func (g *mqlGcpProjectComputeService) targetSslProxies() ([]any, error) {
 			if err != nil {
 				return err
 			}
+			mqlRef := mqlSP.(*mqlGcpProjectComputeServiceTargetSslProxy)
+			mqlRef.cacheServiceUrl = sp.Service
+			mqlRef.cacheSslPolicyUrl = sp.SslPolicy
 			res = append(res, mqlSP)
 		}
 		return nil
@@ -1155,13 +1164,14 @@ func (g *mqlGcpProjectComputeService) packetMirrorings() ([]any, error) {
 					"collectorIlb":      llx.DictData(collectorIlb),
 					"mirroredResources": llx.DictData(mirroredResources),
 					"filter":            llx.DictData(filter),
-					"regionUrl":         llx.StringData(pm.Region),
 					"selfLink":          llx.StringData(pm.SelfLink),
 					"created":           llx.TimeDataPtr(parseTime(pm.CreationTimestamp)),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlPM.(*mqlGcpProjectComputeServicePacketMirroring)
+				mqlRef.cacheRegionUrl = pm.Region
 				res = append(res, mqlPM)
 			}
 		}
@@ -1282,22 +1292,23 @@ func (g *mqlGcpProjectComputeService) targetPools() ([]any, error) {
 		for _, scopedList := range page.Items {
 			for _, tp := range scopedList.TargetPools {
 				mqlTP, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.targetPool", map[string]*llx.RawData{
-					"id":                llx.StringData(fmt.Sprintf("%d", tp.Id)),
-					"name":              llx.StringData(tp.Name),
-					"description":       llx.StringData(tp.Description),
-					"sessionAffinity":   llx.StringData(tp.SessionAffinity),
-					"failoverRatio":     llx.FloatData(tp.FailoverRatio),
-					"backupPoolUrl":     llx.StringData(tp.BackupPool),
-					"healthCheckUrls":   llx.ArrayData(convert.SliceAnyToInterface(tp.HealthChecks), types.String),
-					"instanceUrls":      llx.ArrayData(convert.SliceAnyToInterface(tp.Instances), types.String),
-					"securityPolicyUrl": llx.StringData(tp.SecurityPolicy),
-					"regionUrl":         llx.StringData(tp.Region),
-					"selfLink":          llx.StringData(tp.SelfLink),
-					"created":           llx.TimeDataPtr(parseTime(tp.CreationTimestamp)),
+					"id":              llx.StringData(fmt.Sprintf("%d", tp.Id)),
+					"name":            llx.StringData(tp.Name),
+					"description":     llx.StringData(tp.Description),
+					"sessionAffinity": llx.StringData(tp.SessionAffinity),
+					"failoverRatio":   llx.FloatData(tp.FailoverRatio),
+					"healthCheckUrls": llx.ArrayData(convert.SliceAnyToInterface(tp.HealthChecks), types.String),
+					"instanceUrls":    llx.ArrayData(convert.SliceAnyToInterface(tp.Instances), types.String),
+					"selfLink":        llx.StringData(tp.SelfLink),
+					"created":         llx.TimeDataPtr(parseTime(tp.CreationTimestamp)),
 				})
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlTP.(*mqlGcpProjectComputeServiceTargetPool)
+				mqlRef.cacheBackupPoolUrl = tp.BackupPool
+				mqlRef.cacheSecurityPolicyUrl = tp.SecurityPolicy
+				mqlRef.cacheRegionUrl = tp.Region
 				res = append(res, mqlTP)
 			}
 		}

--- a/providers/gcp/resources/compute_typed_refs.go
+++ b/providers/gcp/resources/compute_typed_refs.go
@@ -5,16 +5,12 @@ package resources
 
 import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 
-// region/zone typed accessors. The matching `regionUrl`/`zoneUrl` string
-// fields remain populated for now and are marked @maturity("deprecated") in
-// the .lr schema. New audits should use the typed accessors so they can
-// traverse the region or zone resource directly.
+// region/zone typed accessors. The raw self-link URLs are held on each
+// resource's Internal struct (cacheRegionUrl/cacheZoneUrl) so the accessor can
+// resolve the region or zone resource without exposing the URL as a field.
 
 func (g *mqlGcpProjectComputeServiceAddress) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -25,10 +21,7 @@ func (g *mqlGcpProjectComputeServiceAddress) region() (*mqlGcpProjectComputeServ
 }
 
 func (g *mqlGcpProjectComputeServiceForwardingRule) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -39,10 +32,7 @@ func (g *mqlGcpProjectComputeServiceForwardingRule) region() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServiceBackendService) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -53,10 +43,7 @@ func (g *mqlGcpProjectComputeServiceBackendService) region() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServiceSecurityPolicy) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -67,10 +54,7 @@ func (g *mqlGcpProjectComputeServiceSecurityPolicy) region() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServiceSslPolicy) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -81,10 +65,7 @@ func (g *mqlGcpProjectComputeServiceSslPolicy) region() (*mqlGcpProjectComputeSe
 }
 
 func (g *mqlGcpProjectComputeServiceSslCertificate) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -95,10 +76,7 @@ func (g *mqlGcpProjectComputeServiceSslCertificate) region() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServiceVpnGateway) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -109,10 +87,7 @@ func (g *mqlGcpProjectComputeServiceVpnGateway) region() (*mqlGcpProjectComputeS
 }
 
 func (g *mqlGcpProjectComputeServiceVpnTunnel) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -123,10 +98,7 @@ func (g *mqlGcpProjectComputeServiceVpnTunnel) region() (*mqlGcpProjectComputeSe
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroup) zone() (*mqlGcpProjectComputeServiceZone, error) {
-	if g.ZoneUrl.Error != nil {
-		return nil, g.ZoneUrl.Error
-	}
-	z, err := getZoneByUrl(g.ZoneUrl.Data, g.MqlRuntime)
+	z, err := getZoneByUrl(g.cacheZoneUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -137,10 +109,7 @@ func (g *mqlGcpProjectComputeServiceInstanceGroup) zone() (*mqlGcpProjectCompute
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroupManager) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -151,10 +120,7 @@ func (g *mqlGcpProjectComputeServiceInstanceGroupManager) region() (*mqlGcpProje
 }
 
 func (g *mqlGcpProjectComputeServiceInstanceGroupManager) zone() (*mqlGcpProjectComputeServiceZone, error) {
-	if g.ZoneUrl.Error != nil {
-		return nil, g.ZoneUrl.Error
-	}
-	z, err := getZoneByUrl(g.ZoneUrl.Data, g.MqlRuntime)
+	z, err := getZoneByUrl(g.cacheZoneUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -165,10 +131,7 @@ func (g *mqlGcpProjectComputeServiceInstanceGroupManager) zone() (*mqlGcpProject
 }
 
 func (g *mqlGcpProjectComputeServiceFirewallPolicy) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -179,10 +142,7 @@ func (g *mqlGcpProjectComputeServiceFirewallPolicy) region() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServiceHealthCheck) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -193,10 +153,7 @@ func (g *mqlGcpProjectComputeServiceHealthCheck) region() (*mqlGcpProjectCompute
 }
 
 func (g *mqlGcpProjectComputeServiceUrlMap) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -207,10 +164,7 @@ func (g *mqlGcpProjectComputeServiceUrlMap) region() (*mqlGcpProjectComputeServi
 }
 
 func (g *mqlGcpProjectComputeServiceTargetHttpProxy) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -221,10 +175,7 @@ func (g *mqlGcpProjectComputeServiceTargetHttpProxy) region() (*mqlGcpProjectCom
 }
 
 func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -235,10 +186,7 @@ func (g *mqlGcpProjectComputeServiceTargetHttpsProxy) region() (*mqlGcpProjectCo
 }
 
 func (g *mqlGcpProjectComputeServiceServiceAttachment) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -249,10 +197,7 @@ func (g *mqlGcpProjectComputeServiceServiceAttachment) region() (*mqlGcpProjectC
 }
 
 func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -263,10 +208,7 @@ func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) region() (*mqlGcpProje
 }
 
 func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) zone() (*mqlGcpProjectComputeServiceZone, error) {
-	if g.ZoneUrl.Error != nil {
-		return nil, g.ZoneUrl.Error
-	}
-	z, err := getZoneByUrl(g.ZoneUrl.Data, g.MqlRuntime)
+	z, err := getZoneByUrl(g.cacheZoneUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -277,10 +219,7 @@ func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) zone() (*mqlGcpProject
 }
 
 func (g *mqlGcpProjectComputeServiceInterconnectAttachment) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -291,10 +230,7 @@ func (g *mqlGcpProjectComputeServiceInterconnectAttachment) region() (*mqlGcpPro
 }
 
 func (g *mqlGcpProjectComputeServiceTargetTcpProxy) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -305,10 +241,7 @@ func (g *mqlGcpProjectComputeServiceTargetTcpProxy) region() (*mqlGcpProjectComp
 }
 
 func (g *mqlGcpProjectComputeServicePacketMirroring) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -319,10 +252,7 @@ func (g *mqlGcpProjectComputeServicePacketMirroring) region() (*mqlGcpProjectCom
 }
 
 func (g *mqlGcpProjectComputeServiceTargetPool) region() (*mqlGcpProjectComputeServiceRegion, error) {
-	if g.RegionUrl.Error != nil {
-		return nil, g.RegionUrl.Error
-	}
-	r, err := getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)
+	r, err := getRegionByUrl(g.cacheRegionUrl, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/container_analysis.go
+++ b/providers/gcp/resources/container_analysis.go
@@ -223,11 +223,6 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 			return nil, err
 		}
 
-		vulnerability, err := protoToDict(occ.GetVulnerability())
-		if err != nil {
-			return nil, err
-		}
-
 		var (
 			vulnSeverity, vulnEffectiveSeverity       string
 			vulnCvssScore                             float64
@@ -257,11 +252,6 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 			}
 		}
 
-		build, err := protoToDict(occ.GetBuild())
-		if err != nil {
-			return nil, err
-		}
-
 		image, err := protoToDict(occ.GetImage())
 		if err != nil {
 			return nil, err
@@ -278,11 +268,6 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 		}
 
 		discovery, err := protoToDict(occ.GetDiscovery())
-		if err != nil {
-			return nil, err
-		}
-
-		attestation, err := protoToDict(occ.GetAttestation())
 		if err != nil {
 			return nil, err
 		}
@@ -341,7 +326,6 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 			"noteName":                       llx.StringData(occ.NoteName),
 			"kind":                           llx.StringData(occ.Kind.String()),
 			"remediation":                    llx.StringData(occ.Remediation),
-			"vulnerability":                  llx.DictData(vulnerability),
 			"vulnerabilitySeverity":          llx.StringData(vulnSeverity),
 			"vulnerabilityEffectiveSeverity": llx.StringData(vulnEffectiveSeverity),
 			"vulnerabilityCvssScore":         llx.FloatData(vulnCvssScore),
@@ -349,7 +333,6 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 			"vulnerabilityShortDescription":  llx.StringData(vulnShortDescription),
 			"vulnerabilityLongDescription":   llx.StringData(vulnLongDescription),
 			"vulnerabilityPackageIssues":     llx.ArrayData(vulnPackageIssues, types.Dict),
-			"build":                          llx.DictData(build),
 			"buildProvenanceId":              llx.StringData(buildProvenanceID),
 			"buildCreator":                   llx.StringData(buildCreator),
 			"buildCreateTime":                llx.TimeDataPtr(buildCreateTime),
@@ -364,7 +347,6 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 			"packageInfo":                    llx.DictData(packageInfo),
 			"deployment":                     llx.DictData(deployment),
 			"discovery":                      llx.DictData(discovery),
-			"attestation":                    llx.DictData(attestation),
 			"attestationSerializedPayload":   llx.StringData(attestationSerializedPayload),
 			"attestationSignatures":          llx.ArrayData(attestationSignatures, types.Dict),
 			"created":                        llx.TimeDataPtr(timestampAsTimePtr(occ.CreateTime)),

--- a/providers/gcp/resources/dataplex.go
+++ b/providers/gcp/resources/dataplex.go
@@ -19,6 +19,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectDataplexServiceLakeInternal struct {
+	cacheServiceAccount string
+}
+
 func (g *mqlGcpProjectDataplexService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -128,7 +132,6 @@ func (g *mqlGcpProjectDataplexService) lakes() ([]any, error) {
 				"created":                      llx.TimeDataPtr(parseTime(lake.CreateTime)),
 				"updated":                      llx.TimeDataPtr(parseTime(lake.UpdateTime)),
 				"labels":                       llx.MapData(convert.MapToInterfaceMap(lake.Labels), types.String),
-				"serviceAccount":               llx.StringData(lake.ServiceAccount),
 				"metastoreService":             llx.StringData(metastoreService),
 				"activeAssets":                 llx.IntData(activeAssets),
 				"securityPolicyApplyingAssets": llx.IntData(securityPolicyApplyingAssets),
@@ -137,6 +140,8 @@ func (g *mqlGcpProjectDataplexService) lakes() ([]any, error) {
 				log.Error().Err(err).Send()
 				continue
 			}
+			mqlRef := mqlLake.(*mqlGcpProjectDataplexServiceLake)
+			mqlRef.cacheServiceAccount = lake.ServiceAccount
 			mqlLakes = append(mqlLakes, mqlLake)
 		}
 		return nil
@@ -160,10 +165,7 @@ func dataplexLocation(name string) string {
 }
 
 func (g *mqlGcpProjectDataplexServiceLake) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.ServiceAccount.Error != nil {
-		return nil, g.ServiceAccount.Error
-	}
-	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.ServiceAccount.Data, g.ProjectId.Data)
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheServiceAccount, g.ProjectId.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -24,6 +24,11 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectDataprocServiceClusterConfigGceClusterInternal struct {
+	cacheNetworkUri    string
+	cacheSubnetworkUri string
+}
+
 type mqlGkeNodePoolAccelerator struct {
 	AcceleratorCount int64  `json:"acceleratorCount"`
 	AcceleratorType  string `json:"acceleratorType"`
@@ -315,20 +320,21 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]any, error) {
 								"confidentialInstance":    llx.DictData(mqlConfidentialInstanceCfg),
 								"internalIpOnly":          llx.BoolData(c.Config.GceClusterConfig.InternalIpOnly),
 								"metadata":                llx.MapData(convert.MapToInterfaceMap(c.Config.GceClusterConfig.Metadata), types.String),
-								"networkUri":              llx.StringData(c.Config.GceClusterConfig.NetworkUri),
 								"nodeGroupAffinity":       llx.DictData(mqlNodeGroupAffinityCfg),
 								"privateIpv6GoogleAccess": llx.StringData(c.Config.GceClusterConfig.PrivateIpv6GoogleAccess),
 								"reservationAffinity":     llx.ResourceData(mqlReservationAffinity, "gcp.project.dataprocService.cluster.config.gceCluster.reservationAffinity"),
 								"serviceAccountEmail":     llx.StringData(c.Config.GceClusterConfig.ServiceAccount),
 								"serviceAccountScopes":    llx.ArrayData(convert.SliceAnyToInterface(c.Config.GceClusterConfig.ServiceAccountScopes), types.String),
 								"shieldedInstanceConfig":  llx.ResourceData(mqlShieldedCfg, "gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig"),
-								"subnetworkUri":           llx.StringData(c.Config.GceClusterConfig.SubnetworkUri),
 								"tags":                    llx.ArrayData(convert.SliceAnyToInterface(c.Config.GceClusterConfig.Tags), types.String),
 								"zoneUri":                 llx.StringData(c.Config.GceClusterConfig.ZoneUri),
 							})
 							if err != nil {
 								log.Error().Err(err).Send()
 							}
+							mqlRef := mqlGceClusterCfg.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster)
+							mqlRef.cacheNetworkUri = c.Config.GceClusterConfig.NetworkUri
+							mqlRef.cacheSubnetworkUri = c.Config.GceClusterConfig.SubnetworkUri
 						}
 
 						var mqlGkeClusterCfg plugin.Resource
@@ -688,10 +694,7 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]any, error) {
 }
 
 func (g *mqlGcpProjectDataprocServiceClusterConfigGceCluster) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUri.Error != nil {
-		return nil, g.NetworkUri.Error
-	}
-	n, err := getNetworkByUrl(g.NetworkUri.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cacheNetworkUri, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -702,10 +705,7 @@ func (g *mqlGcpProjectDataprocServiceClusterConfigGceCluster) network() (*mqlGcp
 }
 
 func (g *mqlGcpProjectDataprocServiceClusterConfigGceCluster) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {
-	if g.SubnetworkUri.Error != nil {
-		return nil, g.SubnetworkUri.Error
-	}
-	s, err := getSubnetworkByUrl(g.SubnetworkUri.Data, g.MqlRuntime)
+	s, err := getSubnetworkByUrl(g.cacheSubnetworkUri, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -1100,13 +1100,9 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 			}
 			for i := range networks.Data {
 				network := networks.Data[i].(*mqlGcpProjectComputeServiceSubnetwork)
-				region := network.GetRegionUrl()
-				if region.Error != nil {
-					return region.Error
-				}
 				assetList = append(assetList, &inventory.Asset{
 					PlatformIds: []string{
-						connection.NewResourcePlatformID("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(region.Data), "subnetwork", network.Name.Data),
+						connection.NewResourcePlatformID("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(network.cacheRegionUrl), "subnetwork", network.Name.Data),
 					},
 					Name: network.Name.Data,
 					Platform: &inventory.Platform{
@@ -1115,7 +1111,7 @@ func discoverProject(conn *connection.GcpConnection, gcpProject *mqlGcpProject, 
 						Runtime:               "gcp",
 						Kind:                  "gcp-object",
 						Family:                []string{"google"},
-						TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(region.Data), "subnetwork", network.Name.Data),
+						TechnologyUrlSegments: connection.ResourceTechnologyUrl("compute", gcpProject.Id.Data, RegionNameFromRegionUrl(network.cacheRegionUrl), "subnetwork", network.Name.Data),
 					},
 					Labels:      map[string]string{},
 					Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.Conf.Id))}, // pass-in the parent connection config

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -167,6 +167,7 @@ func initGcpProjectDnsService(runtime *plugin.Runtime, args map[string]*llx.RawD
 
 type mqlGcpProjectDnsServiceManagedzoneInternal struct {
 	cacheAuthorizedNetworkUrls []string
+	cachePeeringNetwork        string
 }
 
 func (g *mqlGcpProjectDnsServiceManagedzone) authorizedNetworks() ([]any, error) {
@@ -188,10 +189,7 @@ func (g *mqlGcpProjectDnsServiceManagedzone) managedBy() (string, error) {
 }
 
 func (g *mqlGcpProjectDnsServiceManagedzone) peeringNetworkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.PeeringNetwork.Error != nil {
-		return nil, g.PeeringNetwork.Error
-	}
-	n, err := getNetworkByUrl(g.PeeringNetwork.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cachePeeringNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -329,11 +327,12 @@ func (g *mqlGcpProjectDnsService) managedZones() ([]any, error) {
 				"dnssecDefaultKeyAlgorithms": llx.ArrayData(dnssecAlgorithms, types.String),
 				"privateVisibilityConfig":    llx.DictData(mqlPrivateVisibilityCfg),
 				"forwardingTargets":          llx.ArrayData(forwardingTargets, types.String),
-				"peeringNetwork":             llx.StringData(peeringNetwork),
 			})
 			if err != nil {
 				return err
 			}
+			mqlRef := mqlManagedZone.(*mqlGcpProjectDnsServiceManagedzone)
+			mqlRef.cachePeeringNetwork = peeringNetwork
 			mqlManagedZone.(*mqlGcpProjectDnsServiceManagedzone).cacheAuthorizedNetworkUrls = authorizedNetworkUrls
 			res = append(res, mqlManagedZone)
 		}

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -20,6 +20,14 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectEventarcServiceChannelInternal struct {
+	cacheCryptoKeyName string
+}
+
+type mqlGcpProjectEventarcServiceTriggerInternal struct {
+	cacheServiceAccount string
+}
+
 type mqlGcpProjectEventarcServiceInternal struct {
 	serviceGate
 }
@@ -83,13 +91,10 @@ func (g *mqlGcpProjectEventarcServiceTrigger) id() (string, error) {
 }
 
 func (g *mqlGcpProjectEventarcServiceTrigger) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.ServiceAccount.Error != nil {
-		return nil, g.ServiceAccount.Error
-	}
 	if g.Name.Error != nil {
 		return nil, g.Name.Error
 	}
-	email := g.ServiceAccount.Data
+	email := g.cacheServiceAccount
 	projectId := projectFromResourceName(g.Name.Data)
 	if email == "" || projectId == "" {
 		g.ServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
@@ -202,7 +207,6 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 			"name":                 llx.StringData(trigger.Name),
 			"uid":                  llx.StringData(trigger.Uid),
 			"eventFilters":         llx.ArrayData(eventFilters, types.Resource("gcp.project.eventarcService.trigger.eventFilter")),
-			"serviceAccount":       llx.StringData(trigger.ServiceAccount),
 			"destination":          llx.DictData(destination),
 			"transport":            llx.DictData(transport),
 			"channelName":          llx.StringData(trigger.Channel),
@@ -215,6 +219,8 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlTrigger.(*mqlGcpProjectEventarcServiceTrigger)
+		mqlRef.cacheServiceAccount = trigger.ServiceAccount
 		res = append(res, mqlTrigger)
 	}
 
@@ -230,11 +236,7 @@ func (g *mqlGcpProjectEventarcServiceChannel) id() (string, error) {
 }
 
 func (g *mqlGcpProjectEventarcServiceChannel) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
-	keyName := g.GetCryptoKeyName()
-	if keyName.Error != nil {
-		return nil, keyName.Error
-	}
-	return newKmsCryptoKeyRef(g.MqlRuntime, &g.KmsKey, keyName.Data)
+	return newKmsCryptoKeyRef(g.MqlRuntime, &g.KmsKey, g.cacheCryptoKeyName)
 }
 
 func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
@@ -283,19 +285,20 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 		}
 
 		mqlChannel, err := CreateResource(g.MqlRuntime, "gcp.project.eventarcService.channel", map[string]*llx.RawData{
-			"name":          llx.StringData(channel.Name),
-			"uid":           llx.StringData(channel.Uid),
-			"provider":      llx.StringData(channel.Provider),
-			"pubsubTopic":   llx.StringData(channel.GetPubsubTopic()),
-			"state":         llx.StringData(channel.State.String()),
-			"cryptoKeyName": llx.StringData(channel.GetCryptoKeyName()),
-			"labels":        llx.MapData(convert.MapToInterfaceMap(channel.GetLabels()), types.String),
-			"created":       llx.TimeDataPtr(timestampAsTimePtr(channel.CreateTime)),
-			"updated":       llx.TimeDataPtr(timestampAsTimePtr(channel.UpdateTime)),
+			"name":        llx.StringData(channel.Name),
+			"uid":         llx.StringData(channel.Uid),
+			"provider":    llx.StringData(channel.Provider),
+			"pubsubTopic": llx.StringData(channel.GetPubsubTopic()),
+			"state":       llx.StringData(channel.State.String()),
+			"labels":      llx.MapData(convert.MapToInterfaceMap(channel.GetLabels()), types.String),
+			"created":     llx.TimeDataPtr(timestampAsTimePtr(channel.CreateTime)),
+			"updated":     llx.TimeDataPtr(timestampAsTimePtr(channel.UpdateTime)),
 		})
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlChannel.(*mqlGcpProjectEventarcServiceChannel)
+		mqlRef.cacheCryptoKeyName = channel.GetCryptoKeyName()
 		res = append(res, mqlChannel)
 	}
 

--- a/providers/gcp/resources/filestore.go
+++ b/providers/gcp/resources/filestore.go
@@ -19,6 +19,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectFilestoreServiceInstanceInternal struct {
+	cacheKmsKeyName string
+}
+
 func (g *mqlGcpProject) filestore() (*mqlGcpProjectFilestoreService, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -158,7 +162,6 @@ func (g *mqlGcpProjectFilestoreService) instances() ([]any, error) {
 			"labels":                    llx.MapData(convert.MapToInterfaceMap(instance.Labels), types.String),
 			"fileShares":                llx.ArrayData(fileShares, types.Resource("gcp.project.filestoreService.instance.fileShare")),
 			"networks":                  llx.ArrayData(networks, types.Resource("gcp.project.filestoreService.instance.network")),
-			"kmsKeyName":                llx.StringData(instance.KmsKeyName),
 			"satisfiesPzi":              llx.BoolData(instance.SatisfiesPzi),
 			"satisfiesPzs":              llx.BoolDataPtr(satisfiesPzs),
 			"deletionProtectionEnabled": llx.BoolData(instance.DeletionProtectionEnabled),
@@ -167,6 +170,8 @@ func (g *mqlGcpProjectFilestoreService) instances() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlInstance.(*mqlGcpProjectFilestoreServiceInstance)
+		mqlRef.cacheKmsKeyName = instance.KmsKeyName
 		res = append(res, mqlInstance)
 	}
 
@@ -181,11 +186,7 @@ func (g *mqlGcpProjectFilestoreServiceInstance) id() (string, error) {
 }
 
 func (g *mqlGcpProjectFilestoreServiceInstance) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
-	keyName := g.GetKmsKeyName()
-	if keyName.Error != nil {
-		return nil, keyName.Error
-	}
-	return newKmsCryptoKeyRef(g.MqlRuntime, &g.KmsKey, keyName.Data)
+	return newKmsCryptoKeyRef(g.MqlRuntime, &g.KmsKey, g.cacheKmsKeyName)
 }
 
 func (g *mqlGcpProjectFilestoreServiceInstanceFileShare) id() (string, error) {

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -500,13 +500,6 @@ private gcp.project.redisService.instance @defaults("name") {
   redisConfigs map[string]string
   // Redis memory size in GiB
   memorySizeGb int
-  // The full name of the Google Compute Engine network
-  //
-  // Deprecated in favor of `network`, which resolves the VPC network
-  // resource. The [VPC network](https://cloud.google.com/vpc/docs/vpc) to
-  // which the instance is connected; if left unspecified, the `default`
-  // network is used.
-  AuthorizedNetwork @maturity("deprecated") string
   // VPC network the instance is attached to (resolved from AuthorizedNetwork)
   network() gcp.project.computeService.network
   // Cloud IAM identity used by import / export operations to transfer data to/from Cloud Storage
@@ -525,10 +518,6 @@ private gcp.project.redisService.instance @defaults("name") {
   readEndpoint string
   // The port number of the exposed read-only Redis endpoint
   readEndpointPort int
-  // Customer-managed encryption key resource ID
-  //
-  // Deprecated in favor of `kmsKey()`.
-  customerManagedKey @maturity("deprecated") string
   // Customer-managed encryption key (CMEK) used to encrypt the at-rest data of the instance
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // The self service update maintenance version
@@ -636,10 +625,6 @@ private gcp.project.redisService.cluster @defaults("name") {
   preciseSizeGb float
   // Whether delete protection is enabled
   deletionProtectionEnabled bool
-  // Customer-managed encryption key resource ID
-  //
-  // Deprecated in favor of `cryptoKey()`.
-  kmsKey @maturity("deprecated") string
   // Customer-managed encryption key (CMEK) used to encrypt the at-rest data of the cluster
   cryptoKey() gcp.project.kmsService.keyring.cryptokey
   // The backup collection full resource name
@@ -1526,10 +1511,6 @@ private gcp.project.computeService.address @defaults("name address addressType")
   name string
   // Labels applied to this resource
   labels map[string]string
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network in which to reserve the address
   network() gcp.project.computeService.network
   // Network tier used for configuring this address
@@ -1538,18 +1519,10 @@ private gcp.project.computeService.address @defaults("name address addressType")
   prefixLength int
   // Address purpose
   purpose string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region where this address is reserved
   region() gcp.project.computeService.region
   // Address status
   status string
-  // Raw subnetwork self-link URL
-  //
-  // Deprecated in favor of `subnetwork`.
-  subnetworkUrl @maturity("deprecated") string
   // Subnetwork in which to reserve the address
   subnetwork() gcp.project.computeService.subnetwork
   // URLs of the resources that are using this address
@@ -1577,10 +1550,6 @@ private gcp.project.computeService.forwardingRule {
   allPorts bool
   // Whether to allow access to the load balancer from all regions
   allowGlobalAccess bool
-  // Raw backend-service self-link URL
-  //
-  // Deprecated in favor of `backendService`.
-  backendServiceUrl @maturity("deprecated") string
   // Backend service to which the forwarding rule sends traffic
   backendService() gcp.project.computeService.backendService
   // Creation timestamp
@@ -1601,10 +1570,6 @@ private gcp.project.computeService.forwardingRule {
   metadataFilters []dict
   // Forwarding rule name
   name string
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network used for internal load balancing
   network() gcp.project.computeService.network
   // Network tier used for configuring this load balancer
@@ -1615,10 +1580,6 @@ private gcp.project.computeService.forwardingRule {
   portRange string
   // Ports to forward
   ports []string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the forwarding rule lives in (empty for global forwarding rules)
   region() gcp.project.computeService.region
   // Service Directory resources with which to register this forwarding rule
@@ -1627,10 +1588,6 @@ private gcp.project.computeService.forwardingRule {
   serviceLabel string
   // Internal fully qualified service name for this forwarding rule
   serviceName string
-  // Raw subnetwork self-link URL
-  //
-  // Deprecated in favor of `subnetwork`.
-  subnetworkUrl @maturity("deprecated") string
   // Subnetwork to which the load balanced IP belongs
   subnetwork() gcp.project.computeService.subnetwork
   // URL of the target resource to receive the matched traffic
@@ -1755,11 +1712,6 @@ gcp.project.computeService.instance @defaults("name id") {
   name string
   // Optional description for this instance
   description string
-  // Raw confidential instance config dict
-  //
-  // Deprecated in favor of `confidentialCompute`, which exposes the same
-  // fields as a typed sub-resource plus the confidential VM type.
-  confidentialInstanceConfig @maturity("deprecated") dict
   // Confidential Compute configuration for this instance
   confidentialCompute gcp.project.computeService.instance.confidentialCompute
   // Whether the instance is allowed to send and receive packets with non-matching destination or source IPs
@@ -1794,10 +1746,6 @@ gcp.project.computeService.instance @defaults("name id") {
   metadata map[string]string
   // Minimum CPU platform for the VM instance
   minCpuPlatform string
-  // Raw network interface dicts
-  //
-  // Deprecated in favor of `nics`.
-  networkInterfaces @maturity("deprecated") []dict
   // Network interfaces attached to the instance
   nics []gcp.project.computeService.instance.networkInterface
   // Distinct network interface stack types across all interfaces (IPV4_ONLY, IPV4_IPV6)
@@ -1854,18 +1802,6 @@ gcp.project.computeService.instance @defaults("name id") {
   shieldedInstanceConfig gcp.project.computeService.instance.shieldedInstanceConfig
   // Shielded VM integrity monitoring auto-learn policy (updateAutoLearnPolicy)
   shieldedInstanceIntegrityPolicy dict
-  // Whether Shielded VM integrity monitoring is enabled
-  //
-  // Deprecated in favor of `shieldedInstanceConfig.enableIntegrityMonitoring`.
-  enableIntegrityMonitoring @maturity("deprecated") bool
-  // Whether Shielded VM secure boot is enabled
-  //
-  // Deprecated in favor of `shieldedInstanceConfig.enableSecureBoot`.
-  enableSecureBoot @maturity("deprecated") bool
-  // Whether Shielded VM vTPM is enabled
-  //
-  // Deprecated in favor of `shieldedInstanceConfig.enableVtpm`.
-  enableVtpm @maturity("deprecated") bool
   // Whether VM has been restricted from starting because Compute Engine has detected suspicious activity
   startRestricted bool
   // Instance status
@@ -2008,18 +1944,6 @@ private gcp.project.computeService.instance.networkInterface @defaults("name net
 private gcp.project.computeService.instance.osInventory @defaults("name updateTime") {
   // Full resource name of the inventory
   name string
-  // Operating system details reported by the OS Config agent
-  //
-  // Deprecated in favor of the os* and kernel* fields, which expose the
-  // same operating system details as scalars. Retained for backward
-  // compatibility.
-  osInfo @maturity("deprecated") dict
-  // Installed packages and available package updates, each keyed by its item id
-  //
-  // Deprecated in favor of inventoryItems, which exposes each package as a
-  // resource with its type, package manager, name, version, and
-  // architecture. Retained for backward compatibility.
-  items @maturity("deprecated") []dict
   // VM hostname reported by the OS Config agent
   osHostname string
   // Operating system long name (for example "Debian GNU/Linux 9")
@@ -2081,12 +2005,6 @@ private gcp.project.computeService.instance.osInventory.item @defaults("packageN
 private gcp.project.computeService.instance.vulnerabilityReport @defaults("name highestUpgradableCveSeverity updateTime") {
   // Full resource name of the vulnerability report
   name string
-  // Vulnerabilities affecting installed packages on the instance
-  //
-  // Deprecated in favor of vulnerabilityDetails, which exposes each
-  // vulnerability as a resource with its CVE, severity, score, and
-  // affected/fixed inventory items. Retained for backward compatibility.
-  vulnerabilities @maturity("deprecated") []dict
   // Vulnerabilities affecting installed packages on the instance
   //
   // Each entry records the CVE, the distro-assigned severity, the CVSS v3
@@ -2588,10 +2506,6 @@ gcp.project.computeService.network @defaults("name") {
   networkFirewallPolicyEnforcementOrder string
   // Creation timestamp
   created time
-  // Raw network peering dicts
-  //
-  // Deprecated in favor of `networkPeerings`.
-  peerings @maturity("deprecated") []dict
   // Network peerings for the resource
   networkPeerings() []gcp.project.computeService.network.peering
   // The network-wide routing mode to use
@@ -2625,12 +2539,6 @@ gcp.project.computeService.network @defaults("name") {
   firewallPolicyRef() gcp.project.computeService.firewallPolicy
   // URL of the network profile applied to this network
   networkProfile string
-  // Legacy single-region IPv4 range for non-subnetted networks
-  //
-  // Deprecated in favor of subnet-mode VPC networks. Only present on
-  // legacy (pre-subnet-mode) networks; a non-empty value flags a legacy
-  // network kept around for backward compatibility.
-  ipv4Range @maturity("deprecated") string
 }
 
 // Google Cloud VPC subnetwork
@@ -2679,10 +2587,6 @@ gcp.project.computeService.subnetwork @defaults("name") {
   purpose string
   // GCP compute region this resource belongs to
   region() gcp.project.computeService.region
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Role of subnetwork
   role string
   // Stack type for the subnet
@@ -2693,10 +2597,6 @@ gcp.project.computeService.subnetwork @defaults("name") {
   created time
   // The URL of the reserved internal range
   reservedInternalRange string
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Parent VPC network this subnetwork belongs to
   network() gcp.project.computeService.network
   // Whether subnet CIDR routes are allowed to overlap with routes installed by other subnets
@@ -2749,10 +2649,6 @@ private gcp.project.computeService.router @defaults("name")  {
   bgpPeers []dict
   // Whether a router is dedicated for use with encrypted VLAN attachments
   encryptedInterconnectRouter bool
-  // Raw NAT service dicts
-  //
-  // Deprecated in favor of `natServices`.
-  nats @maturity("deprecated") []dict
   // NAT services created in this router
   natServices []gcp.project.computeService.router.nat
   // Creation timestamp
@@ -2798,10 +2694,6 @@ private gcp.project.computeService.backendService @defaults("name") {
   customResponseHeaders []string
   // Backend service description
   description string
-  // Raw edge security policy self-link URL
-  //
-  // Deprecated in favor of `edgeSecurityPolicy`.
-  edgeSecurityPolicyUrl @maturity("deprecated") string
   // Cloud Armor edge security policy associated with this backend service
   edgeSecurityPolicy() gcp.project.computeService.securityPolicy
   // Whether to enable Cloud CDN
@@ -2826,26 +2718,14 @@ private gcp.project.computeService.backendService @defaults("name") {
   maxStreamDuration time
   // Backend service name
   name string
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network to which this backend service belongs
   network() gcp.project.computeService.network
   // Named port on a backend instance group representing the port for communication to the backend VMs in that group
   portName string
   // Protocol used for communication
   protocol string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the backend service lives in (empty for global services)
   region() gcp.project.computeService.region
-  // Raw security policy self-link URL
-  //
-  // Deprecated in favor of `securityPolicy`.
-  securityPolicyUrl @maturity("deprecated") string
   // Cloud Armor security policy
   securityPolicy() gcp.project.computeService.securityPolicy
   // Whether the backend service has a Cloud Armor security policy attached
@@ -2890,10 +2770,6 @@ private gcp.project.computeService.backendService.backend @defaults("description
   description string
   // Whether this is a failover backend
   failover bool
-  // Fully-qualified URL of an instance group or network endpoint group determining what types of backends a load balancer supports
-  //
-  // Deprecated in favor of `instanceGroup` and `networkEndpointGroup`.
-  groupUrl @maturity("deprecated") string
   // Instance group backing this backend (empty when the backend is a network endpoint group)
   instanceGroup() gcp.project.computeService.instanceGroup
   // Network endpoint group backing this backend (empty when the backend is an instance group)
@@ -3310,10 +3186,6 @@ private gcp.project.sqlService.instance @defaults("name") {
   // standby the primary fails over to for high availability. Null when the
   // instance has no failover replica.
   failoverReplicaRef() gcp.project.sqlService.instance
-  // Raw GCE zone name
-  //
-  // Deprecated in favor of `zone`.
-  gceZone @maturity("deprecated") string
   // Compute Engine zone that the instance is currently serviced from
   zone() gcp.project.computeService.zone
   // Instance type
@@ -3357,10 +3229,6 @@ private gcp.project.sqlService.instance @defaults("name") {
   hasBuiltInUsers() bool
   // Whether a built-in 'root' user exists (the most common SQL hardening finding)
   localRootEnabled() bool
-  // Service account email address
-  //
-  // Deprecated in favor of `serviceAccount`, which resolves the service account resource (the email is its `email`).
-  serviceAccountEmailAddress @maturity("deprecated") string
   // Service account identity the instance uses (resolved from serviceAccountEmailAddress)
   serviceAccount() gcp.project.iamService.serviceAccount
   // Instance state
@@ -3599,11 +3467,6 @@ private gcp.project.sqlService.instance.settings {
   instanceName string
   // When the instance is activated
   activationPolicy string
-  // Raw Active Directory config dict
-  //
-  // Deprecated in favor of `activeDirectory`, which exposes the same fields
-  // (domain, mode, and DNS servers) as a typed sub-resource.
-  activeDirectoryConfig @maturity("deprecated") dict
   // Entra ID (formerly Active Directory) configuration; relevant only for Cloud SQL for SQL Server
   activeDirectory gcp.project.sqlService.instance.settings.activeDirectory
   // Availability type
@@ -3774,10 +3637,6 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   hasOpenAuthorizedNetworks() bool
   // Whether the instance is assigned a public IP address
   ipv4Enabled bool
-  // Resource link for the VPC network from which the private IPs can access the Cloud SQL instance
-  //
-  // Deprecated in favor of `network`, which resolves the VPC network resource.
-  privateNetwork @maturity("deprecated") string
   // VPC network from which private IPs can reach the instance (resolved from privateNetwork)
   network() gcp.project.computeService.network
   // Whether SSL connections over IP are enforced
@@ -3903,10 +3762,6 @@ private gcp.project.bigqueryService.dataset @defaults("id name") {
   modified time
   // Tags associated with this dataset
   tags map[string]string
-  // Customer-managed KMS key resource name
-  //
-  // Deprecated in favor of `kmsKey()`.
-  kmsName @maturity("deprecated") string
   // Customer-managed KMS key used to protect tables in this dataset (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Access permissions
@@ -4025,10 +3880,6 @@ private gcp.project.bigqueryService.table @defaults("id") {
   type string
   // Time when this table expires
   expirationTime time
-  // Customer-managed KMS key resource name
-  //
-  // Deprecated in favor of `kmsKey()`.
-  kmsName @maturity("deprecated") string
   // Customer-managed KMS key used to protect this table (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Snapshot creation time
@@ -4110,10 +3961,6 @@ private gcp.project.bigqueryService.model @defaults("id") {
   type string
   // Expiration time of the model
   expirationTime time
-  // Customer-managed KMS key resource name
-  //
-  // Deprecated in favor of `kmsKey()`.
-  kmsName @maturity("deprecated") string
   // Customer-managed KMS key used to protect this model (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
 }
@@ -4387,10 +4234,6 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   authorizedNetworks() []gcp.project.computeService.network
   // IPv4 addresses of the name servers this private zone forwards outbound queries to (empty when forwarding is not configured)
   forwardingTargets []string
-  // Fully qualified URL of the VPC network this private zone peers with for DNS resolution (empty when peering is not configured)
-  //
-  // Deprecated in favor of `peeringNetworkRef`, which resolves the VPC network resource.
-  peeringNetwork @maturity("deprecated") string
   // VPC network this private zone peers with for DNS resolution (resolved from peeringNetwork)
   peeringNetworkRef() gcp.project.computeService.network
   // Cloud DNS record set in the zone
@@ -4511,19 +4354,8 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   name string
   // Optional description for the cluster
   description string
-  // Legacy logging service identifier
-  //
-  // Deprecated in favor of `loggingConfig`, which captures the per-component
-  // enable list (SYSTEM_COMPONENTS, WORKLOADS, APISERVER, SCHEDULER,
-  // CONTROLLER_MANAGER) used by modern GKE.
-  loggingService @maturity("deprecated") string
   // Whether cluster logging is enabled (loggingService is set and not "none")
   loggingEnabled() bool
-  // Legacy monitoring service identifier
-  //
-  // Deprecated in favor of `monitoringConfig`, which captures the per-component
-  // enable list plus the managed Prometheus configuration used by modern GKE.
-  monitoringService @maturity("deprecated") string
   // Whether cluster monitoring is enabled (monitoringService is set and not "none")
   monitoringEnabled() bool
   // The name of the Google Compute Engine network to which the cluster is connected
@@ -4581,17 +4413,6 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   ipAllocationPolicy gcp.project.gkeService.cluster.ipAllocationPolicy
   // Configuration for cluster networking
   networkConfig gcp.project.gkeService.cluster.networkConfig
-  // Legacy binary authorization configuration dict
-  //
-  // Deprecated in favor of `binaryAuthorizationEvaluationMode`, which is the
-  // single field GKE now uses to drive Binary Authorization policy evaluation.
-  binaryAuthorization @maturity("deprecated") dict
-  // Whether Binary Authorization is enabled for the cluster
-  //
-  // Deprecated in favor of `binaryAuthorizationEvaluationMode`. True when the
-  // legacy boolean is set or `evaluationMode` is anything other than
-  // `DISABLED`/`UNSPECIFIED`.
-  binaryAuthorizationEnabled @maturity("deprecated") bool
   // Binary Authorization policy evaluation mode
   //
   // One of `DISABLED` or `PROJECT_SINGLETON_POLICY_ENFORCE`.
@@ -4617,38 +4438,8 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   // security finding. Reads the deprecated MasterAuth.Username field purely
   // for the audit signal.
   basicAuthEnabled bool
-  // Legacy master authorized networks configuration
-  //
-  // Deprecated in favor of
-  // `controlPlaneEndpointsConfig.ipEndpointsConfig.authorizedNetworksConfig`,
-  // which is the modern home for restricting control plane access by source
-  // CIDR.
-  masterAuthorizedNetworksConfig @maturity("deprecated") dict
-  // Whether master authorized networks is enabled
-  //
-  // Deprecated in favor of
-  // `controlPlaneEndpointsConfig.ipEndpointsConfig.authorizedNetworksConfig.enabled`.
-  masterAuthorizedNetworksEnabled @maturity("deprecated") bool
   // Private cluster configuration
   privateClusterConfig dict
-  // Whether nodes have only private IPs
-  //
-  // Deprecated in favor of
-  // `controlPlaneEndpointsConfig.ipEndpointsConfig.enablePublicEndpoint`
-  // (which captures the modern equivalent inverted) and the broader private-node
-  // configuration on the cluster's node pool networking.
-  privateNodesEnabled @maturity("deprecated") bool
-  // Whether the cluster's control plane endpoint is private
-  //
-  // Deprecated in favor of
-  // `controlPlaneEndpointsConfig.ipEndpointsConfig.enablePublicEndpoint`
-  // (false means the public IP endpoint is disabled).
-  privateEndpointEnabled @maturity("deprecated") bool
-  // Whether the cluster's private control plane is reachable from any region
-  //
-  // Deprecated in favor of
-  // `controlPlaneEndpointsConfig.ipEndpointsConfig.enableGlobalAccess`.
-  masterGlobalAccessEnabled @maturity("deprecated") bool
   // Control plane endpoints configuration
   //
   // Structured access-control configuration for the cluster's control plane,
@@ -4793,10 +4584,6 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   confidentialNodesEnabled bool
   // Configuration for Identity Service component
   identityServiceConfig dict
-  // Raw network policy config dict
-  //
-  // Deprecated in favor of `networkPolicy`.
-  networkPolicyConfig @maturity("deprecated") dict
   // Network policy configuration
   networkPolicy() gcp.project.gkeService.cluster.networkPolicy
   // The release channel that the cluster is subscribed to
@@ -5415,17 +5202,13 @@ private gcp.project.pubsubService.topic @defaults("name") {
 // policy restricting which regions may persist messages, message
 // retention duration, topic lifecycle state, and the schema validation
 // settings that govern which message formats the topic accepts.
-private gcp.project.pubsubService.topic.config @defaults("kmsKeyName messageStoragePolicy") {
+private gcp.project.pubsubService.topic.config @defaults("kmsKey messageStoragePolicy") {
   // Project ID
   projectId string
   // Topic name
   topicName string
   // Labels associated with this topic
   labels map[string]string
-  // Customer-managed KMS key resource name
-  //
-  // Deprecated in favor of `kmsKey()`.
-  kmsKeyName @maturity("deprecated") string
   // Customer-managed KMS key used to protect topic messages (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Message storage policy
@@ -6186,10 +5969,6 @@ private gcp.project.loggingservice.bucket @defaults("name") {
   projectId string
   // Location where the bucket is stored
   location string
-  // Raw CMEK settings dict
-  //
-  // Deprecated in favor of `kmsKey`.
-  cmekSettings @maturity("deprecated") dict
   // Customer-managed KMS key used to encrypt log entries in this bucket (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // CMEK service-agent identity
@@ -6821,10 +6600,6 @@ private gcp.project.cloudFunction @defaults("name") {
   envVars map[string]string
   // Build environment variables that are available during build time
   buildEnvVars map[string]string
-  // VPC network that this cloud function can connect to
-  //
-  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
-  network @maturity("deprecated") string
   // VPC network this function can connect to (resolved from network)
   networkRef() gcp.project.computeService.network
   // Maximum number of function instances that may coexist at a given time
@@ -6872,11 +6647,6 @@ private gcp.project.cloudFunction @defaults("name") {
   // (a list of `{version, path}` objects mapping each mounted secret version
   // to its relative file path under the mount).
   secretVolumes []dict
-  // User-managed repository created in Artifact Registry
-  //
-  // Deprecated in favor of `dockerRepositoryRef`, which resolves the Artifact
-  // Registry repository resource.
-  dockerRepository @maturity("deprecated") string
   // Artifact Registry repository that stores the function's built image
   dockerRepositoryRef() gcp.project.artifactRegistryService.repository
   // Docker registry to use for this deployment
@@ -6962,17 +6732,8 @@ private gcp.project.cloudFunctionV2.buildConfig @defaults("runtime entryPoint") 
   buildWorkerPool string
   // Build environment variables
   environmentVariables map[string]string
-  // User-managed repository in Artifact Registry for storing built images
-  //
-  // Deprecated in favor of `dockerRepositoryRef`, which resolves the Artifact
-  // Registry repository resource.
-  dockerRepository @maturity("deprecated") string
   // Artifact Registry repository that stores the function's built images
   dockerRepositoryRef() gcp.project.artifactRegistryService.repository
-  // Service account to use for the build
-  //
-  // Deprecated in favor of `serviceAccountRef`, which resolves the service account resource.
-  serviceAccount @maturity("deprecated") string
   // Service account identity used for the build (resolved from serviceAccount)
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Cloud Build name of the latest successful deployment of this function
@@ -7125,10 +6886,6 @@ private gcp.project.dataplexService.lake @defaults("name state location") {
   updated time
   // User-provided labels
   labels map[string]string
-  // Service account associated with the lake, used to access managed resources
-  //
-  // Deprecated in favor of `serviceAccountRef`, which resolves the service account resource.
-  serviceAccount @maturity("deprecated") string
   // Service account identity associated with the lake (resolved from serviceAccount)
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Resource name of the attached Dataproc Metastore service, if any
@@ -7516,10 +7273,6 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   internalIpOnly bool
   // Compute Engine metadata entries
   metadata map[string]string
-  // Compute Engine network to be used for machine communications
-  //
-  // Deprecated in favor of `network`, which resolves the VPC network resource.
-  networkUri @maturity("deprecated") string
   // Compute Engine network used for machine communications (resolved from networkUri)
   network() gcp.project.computeService.network
   // Node group affinity for sole-tenant clusters
@@ -7542,10 +7295,6 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   serviceAccountScopes []string
   // Shielded instance config for clusters using Compute Engine Shielded VMs
   shieldedInstanceConfig gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig
-  // Compute Engine subnetwork to use for machine communications
-  //
-  // Deprecated in favor of `subnetwork`, which resolves the subnetwork resource.
-  subnetworkUri @maturity("deprecated") string
   // Compute Engine subnetwork used for machine communications (resolved from subnetworkUri)
   subnetwork() gcp.project.computeService.subnetwork
   // Compute Engine tags
@@ -7957,11 +7706,6 @@ private gcp.project.cloudRunService.service.revisionTemplate @defaults("name") {
   // bounds on the number of container instances Cloud Run runs for this
   // revision.
   scaling dict
-  // Raw VPC access dict
-  //
-  // Deprecated in favor of `vpcAccessConfig`, which exposes the same fields
-  // (connector, egress, networkInterfaces) as a typed sub-resource.
-  vpcAccess @maturity("deprecated") dict
   // VPC access configuration (Serverless VPC connector and egress policy)
   vpcAccessConfig gcp.project.cloudRunService.vpcAccessConfig
   // Maximum allowed time for an instance to respond to a request
@@ -8190,11 +7934,6 @@ private gcp.project.cloudRunService.job.executionTemplate.taskTemplate {
   id string
   // Project ID
   projectId string
-  // Raw VPC access dict
-  //
-  // Deprecated in favor of `vpcAccessConfig`, which exposes the same fields
-  // (connector, egress, networkInterfaces) as a typed sub-resource.
-  vpcAccess @maturity("deprecated") dict
   // VPC access configuration (Serverless VPC connector and egress policy)
   vpcAccessConfig gcp.project.cloudRunService.vpcAccessConfig
   // Maximum allowed time for an instance to respond to a request
@@ -8595,11 +8334,6 @@ private gcp.project.binaryAuthorizationControl.attestor @defaults("name") {
   name string
   // Human-readable description of the resource
   description string
-  // Raw user-owned Grafeas note dict
-  //
-  // Deprecated in favor of `noteReference`, `publicKeys`, and
-  // `delegationServiceAccountEmail`.
-  userOwnedGrafeasNote @maturity("deprecated") dict
   // Resource name of the Grafeas Attestation.Authority Note backing this attestor (format: `projects/*/notes/*`)
   noteReference string
   // Public keys that verify attestations signed by this attestor. An empty list means the attestor rejects every attestation.
@@ -8712,10 +8446,6 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   annotations map[string]string
   // Version destroy TTL duration
   versionDestroyTtl time
-  // Customer-managed KMS key resource names
-  //
-  // Deprecated in favor of `kmsKeys()`.
-  customerManagedEncryption @maturity("deprecated") []string
   // Customer-managed KMS keys protecting this secret across all replication locations (empty when Google-managed)
   kmsKeys() []gcp.project.kmsService.keyring.cryptokey
   // Whether customer-managed (CMEK) encryption is configured for this secret
@@ -9824,10 +9554,6 @@ private gcp.project.computeService.securityPolicy @defaults("name type") {
   fingerprint string
   // User-defined fields for custom rule tuning
   userDefinedFields []dict
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the policy lives in (empty for global policies)
   region() gcp.project.computeService.region
   // Self-link URL
@@ -9893,10 +9619,6 @@ private gcp.project.computeService.sslPolicy @defaults("name profile minTlsVersi
   customFeatures []string
   // Features enabled in the SSL policy
   enabledFeatures []string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the SSL policy lives in (empty for global policies)
   region() gcp.project.computeService.region
   // Self-link URL
@@ -9934,10 +9656,6 @@ private gcp.project.computeService.sslCertificate @defaults("name type") {
   // PROVISIONING_FAILED_PERMANENTLY, or RENEWAL_FAILED. Empty for
   // self-managed certificates.
   managedStatus string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the certificate lives in (empty for global certificates)
   region() gcp.project.computeService.region
   // Self-link URL
@@ -9975,10 +9693,6 @@ private gcp.project.computeService.vpnGateway @defaults("name") {
   gatewayIpVersion string
   // Stack type for this VPN gateway (IPV4_ONLY, IPV4_IPV6, IPV6_ONLY)
   stackType string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the VPN gateway lives in
   region() gcp.project.computeService.region
   // VPN interfaces associated with this VPN gateway
@@ -10014,32 +9728,16 @@ private gcp.project.computeService.vpnTunnel @defaults("name status") {
   localTrafficSelector []string
   // Remote traffic selector CIDRs
   remoteTrafficSelector []string
-  // Raw peer external VPN gateway URL
-  //
-  // Deprecated in favor of `peerExternalVpnGateway`.
-  peerExternalGateway @maturity("deprecated") string
   // Interface ID of the external VPN gateway
   peerExternalGatewayInterface int
   // Peer external VPN gateway resource
   peerExternalVpnGateway() gcp.project.computeService.externalVpnGateway
-  // Raw peer GCP VPN gateway URL
-  //
-  // Deprecated in favor of `peerGcpVpnGateway`.
-  peerGcpGateway @maturity("deprecated") string
   // Peer GCP HA VPN gateway resource
   peerGcpVpnGateway() gcp.project.computeService.vpnGateway
   // IP address of the peer VPN gateway
   peerIp string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the VPN tunnel lives in
   region() gcp.project.computeService.region
-  // Raw Cloud Router self-link URL
-  //
-  // Deprecated in favor of `router`.
-  routerUrl @maturity("deprecated") string
   // Cloud Router resource for dynamic routing
   router() gcp.project.computeService.router
   // Hash of the shared secret
@@ -10048,10 +9746,6 @@ private gcp.project.computeService.vpnTunnel @defaults("name status") {
   status string
   // URL of the Target VPN gateway (Classic VPN only)
   targetVpnGateway string
-  // Raw VPN gateway self-link URL
-  //
-  // Deprecated in favor of `vpnGateway`.
-  vpnGatewayUrl @maturity("deprecated") string
   // HA VPN gateway resource
   vpnGateway() gcp.project.computeService.vpnGateway
   // Interface ID of the VPN gateway
@@ -10918,16 +10612,8 @@ private gcp.project.computeService.instanceGroup @defaults("name size") {
   name string
   // Human-readable description of the resource
   description string
-  // Raw zone self-link URL
-  //
-  // Deprecated in favor of `zone`.
-  zoneUrl @maturity("deprecated") string
   // Zone the instance group lives in
   zone() gcp.project.computeService.zone
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
   // Subnetwork resource
@@ -10962,16 +10648,8 @@ private gcp.project.computeService.instanceGroupManager @defaults("name targetSi
   name string
   // Human-readable description of the resource
   description string
-  // Raw zone self-link URL
-  //
-  // Deprecated in favor of `zone`.
-  zoneUrl @maturity("deprecated") string
   // Zone the MIG lives in (empty for regional MIGs)
   zone() gcp.project.computeService.zone
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the MIG lives in (empty for zonal MIGs)
   region() gcp.project.computeService.region
   // Instance template URL
@@ -11024,10 +10702,6 @@ private gcp.project.computeService.firewallPolicy @defaults("name") {
   ruleTupleCount int
   // Creation timestamp
   created time
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the firewall policy lives in (empty for global policies)
   region() gcp.project.computeService.region
   // Rules associated with this firewall policy
@@ -11142,10 +10816,6 @@ private gcp.project.filestoreService.instance @defaults("name state tier") {
   fileShares []gcp.project.filestoreService.instance.fileShare
   // Network configurations
   networks []gcp.project.filestoreService.instance.network
-  // KMS key name used for data encryption
-  //
-  // Deprecated in favor of kmsKey().
-  kmsKeyName @maturity("deprecated") string
   // Customer-managed Cloud KMS key used to encrypt the instance's file shares at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Whether the instance satisfies zone separation (Pzi)
@@ -11278,16 +10948,8 @@ private gcp.project.cloudSchedulerService.job @defaults("name state schedule") {
   retryConfig gcp.retryConfig
   // Target type: "httpTarget", "pubsubTarget", or "appEngineHttpTarget"
   targetType string
-  // Service account email used to mint the OIDC token for HTTP target authentication (empty if not configured)
-  //
-  // Deprecated in favor of `oidcServiceAccount`, which resolves the service account resource.
-  oidcServiceAccountEmail @maturity("deprecated") string
   // Service account identity used to mint the OIDC token (resolved from oidcServiceAccountEmail)
   oidcServiceAccount() gcp.project.iamService.serviceAccount
-  // Service account email used to mint the OAuth token for HTTP target authentication (empty if not configured)
-  //
-  // Deprecated in favor of `oauthServiceAccount`, which resolves the service account resource.
-  oauthServiceAccountEmail @maturity("deprecated") string
   // Service account identity used to mint the OAuth token (resolved from oauthServiceAccountEmail)
   oauthServiceAccount() gcp.project.iamService.serviceAccount
 }
@@ -11518,10 +11180,6 @@ private gcp.project.apiGatewayService.apiConfig @defaults("name state") {
   state string
   // ID of the associated service config
   serviceConfigId string
-  // IAM service account that gateways serving this config use to authenticate to other services
-  //
-  // Deprecated in favor of `serviceAccount`, which resolves the service account resource.
-  gatewayServiceAccount @maturity("deprecated") string
   // Service account identity gateways serving this config authenticate as (resolved from gatewayServiceAccount)
   serviceAccount() gcp.project.iamService.serviceAccount
   // The time the API config was created
@@ -11957,10 +11615,6 @@ private gcp.project.computeService.healthCheck @defaults("name type") {
   grpcHealthCheck dict
   // Whether to enable logging
   logConfig dict
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the health check lives in (empty for global health checks)
   region() gcp.project.computeService.region
 }
@@ -11980,10 +11634,6 @@ private gcp.project.computeService.urlMap @defaults("name") {
   name string
   // Human-readable description of the resource
   description string
-  // Raw default backend-service self-link URL
-  //
-  // Deprecated in favor of `defaultService`.
-  defaultServiceUrl @maturity("deprecated") string
   // Default backend service traffic is routed to when no host or path rule matches
   defaultService() gcp.project.computeService.backendService
   // Host rules for the URL map
@@ -11996,10 +11646,6 @@ private gcp.project.computeService.urlMap @defaults("name") {
   created time
   // Server-defined URL for the resource
   selfLink string
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the URL map lives in (empty for global URL maps)
   region() gcp.project.computeService.region
 }
@@ -12018,10 +11664,6 @@ private gcp.project.computeService.targetHttpProxy @defaults("name") {
   name string
   // Human-readable description of the resource
   description string
-  // Raw URL map self-link URL
-  //
-  // Deprecated in favor of `urlMap`.
-  urlMapUrl @maturity("deprecated") string
   // URL map resource
   urlMap() gcp.project.computeService.urlMap
   // Creation timestamp
@@ -12030,10 +11672,6 @@ private gcp.project.computeService.targetHttpProxy @defaults("name") {
   selfLink string
   // Whether the proxy can be used by Cloud Armor
   proxyBind bool
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the proxy lives in (empty for global proxies)
   region() gcp.project.computeService.region
 }
@@ -12054,20 +11692,12 @@ private gcp.project.computeService.targetHttpsProxy @defaults("name") {
   name string
   // Human-readable description of the resource
   description string
-  // Raw URL map self-link URL
-  //
-  // Deprecated in favor of `urlMap`.
-  urlMapUrl @maturity("deprecated") string
   // URL map resource
   urlMap() gcp.project.computeService.urlMap
   // SSL certificate URLs
   sslCertificateUrls []string
   // SSL certificate resources presented by this proxy
   sslCertificates() []gcp.project.computeService.sslCertificate
-  // Raw SSL policy self-link URL
-  //
-  // Deprecated in favor of `sslPolicy`.
-  sslPolicyUrl @maturity("deprecated") string
   // SSL policy resource
   sslPolicy() gcp.project.computeService.sslPolicy
   // QUIC override setting (NONE, ENABLE, DISABLE)
@@ -12093,10 +11723,6 @@ private gcp.project.computeService.targetHttpsProxy @defaults("name") {
   selfLink string
   // Whether the proxy can be used by Cloud Armor
   proxyBind bool
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the proxy lives in (empty for global proxies)
   region() gcp.project.computeService.region
 }
@@ -12112,10 +11738,6 @@ private gcp.project.computeService.network.peering @defaults("name state") {
   id string
   // Name of the peering
   name string
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network resource of the peer
   network() gcp.project.computeService.network
   // State of the peering (ACTIVE, INACTIVE)
@@ -12155,10 +11777,6 @@ private gcp.project.computeService.route @defaults("name destRange") {
   destRange string
   // Route priority (0-65535)
   priority int
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
   // Next hop gateway URL
@@ -12235,10 +11853,6 @@ private gcp.project.computeService.serviceAttachment @defaults("name connectionP
   targetService string
   // Whether connection reconciliation is enabled
   reconcileConnections bool
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the service attachment lives in
   region() gcp.project.computeService.region
   // Self-link URL
@@ -12270,28 +11884,12 @@ private gcp.project.computeService.networkEndpointGroup @defaults("name networkE
   defaultPort int
   // Number of endpoints
   size int
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
-  // Raw subnetwork self-link URL
-  //
-  // Deprecated in favor of `subnetwork`.
-  subnetworkUrl @maturity("deprecated") string
   // Subnetwork resource
   subnetwork() gcp.project.computeService.subnetwork
-  // Raw zone self-link URL
-  //
-  // Deprecated in favor of `zone`.
-  zoneUrl @maturity("deprecated") string
   // Zone the NEG lives in (empty for regional NEGs)
   zone() gcp.project.computeService.zone
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the NEG lives in (empty for zonal NEGs)
   region() gcp.project.computeService.region
   // Cloud Run configuration
@@ -12403,16 +12001,8 @@ private gcp.project.computeService.interconnectAttachment @defaults("name type s
   state string
   // Edge availability domain
   edgeAvailabilityDomain string
-  // Raw interconnect self-link URL
-  //
-  // Deprecated in favor of `interconnect`.
-  interconnectUrl @maturity("deprecated") string
   // Interconnect resource
   interconnect() gcp.project.computeService.interconnect
-  // Raw Cloud Router self-link URL
-  //
-  // Deprecated in favor of `router`.
-  routerUrl @maturity("deprecated") string
   // Cloud Router resource
   router() gcp.project.computeService.router
   // Cloud Router IP address
@@ -12433,10 +12023,6 @@ private gcp.project.computeService.interconnectAttachment @defaults("name type s
   partnerMetadata dict
   // Private interconnect info
   privateInterconnectInfo dict
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the attachment lives in
   region() gcp.project.computeService.region
   // Self-link URL
@@ -12490,16 +12076,8 @@ private gcp.project.computeService.targetTcpProxy @defaults("name") {
   proxyHeader string
   // Whether proxy bind is enabled
   proxyBind bool
-  // Raw backend-service self-link URL
-  //
-  // Deprecated in favor of `service`.
-  serviceUrl @maturity("deprecated") string
   // Backend service this proxy forwards traffic to
   service() gcp.project.computeService.backendService
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the proxy lives in (empty for global proxies)
   region() gcp.project.computeService.region
   // Self-link URL
@@ -12523,20 +12101,12 @@ private gcp.project.computeService.targetSslProxy @defaults("name") {
   description string
   // Proxy header mode (NONE, PROXY_V1)
   proxyHeader string
-  // Raw backend-service self-link URL
-  //
-  // Deprecated in favor of `service`.
-  serviceUrl @maturity("deprecated") string
   // Backend service this proxy forwards traffic to
   service() gcp.project.computeService.backendService
   // SSL certificate URLs
   sslCertificateUrls []string
   // SSL certificate resources presented by this proxy
   sslCertificates() []gcp.project.computeService.sslCertificate
-  // Raw SSL policy self-link URL
-  //
-  // Deprecated in favor of `sslPolicy`.
-  sslPolicyUrl @maturity("deprecated") string
   // SSL policy
   sslPolicy() gcp.project.computeService.sslPolicy
   // Certificate map URL
@@ -12572,10 +12142,6 @@ private gcp.project.computeService.packetMirroring @defaults("name enable") {
   mirroredResources dict
   // Filter configuration
   filter dict
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the packet mirroring policy lives in
   region() gcp.project.computeService.region
   // Self-link URL
@@ -12632,10 +12198,6 @@ private gcp.project.computeService.targetPool @defaults("name") {
   sessionAffinity string
   // Failover ratio
   failoverRatio float
-  // Raw backup target-pool self-link URL
-  //
-  // Deprecated in favor of `backupPool`.
-  backupPoolUrl @maturity("deprecated") string
   // Backup target pool used when this pool's backends are unhealthy
   backupPool() gcp.project.computeService.targetPool
   // Health check URLs
@@ -12646,16 +12208,8 @@ private gcp.project.computeService.targetPool @defaults("name") {
   instanceUrls []string
   // Instances that receive traffic from this pool
   instanceRefs() []gcp.project.computeService.instance
-  // Raw security policy self-link URL
-  //
-  // Deprecated in favor of `securityPolicy`.
-  securityPolicyUrl @maturity("deprecated") string
   // Cloud Armor security policy attached to this target pool
   securityPolicy() gcp.project.computeService.securityPolicy
-  // Raw region self-link URL
-  //
-  // Deprecated in favor of `region`.
-  regionUrl @maturity("deprecated") string
   // Region the target pool lives in
   region() gcp.project.computeService.region
   // Self-link URL
@@ -12977,10 +12531,6 @@ private gcp.project.artifactRegistryService.repository @defaults("name format lo
   mode string
   // User-assigned labels
   labels map[string]string
-  // Cloud KMS encryption key name (empty means Google-managed encryption)
-  //
-  // Deprecated in favor of kmsKey().
-  kmsKeyName @maturity("deprecated") string
   // Customer-managed Cloud KMS key used to encrypt the repository's artifacts at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Creation time
@@ -13523,22 +13073,12 @@ private gcp.project.vertexaiService.endpoint @defaults("name displayName") {
   displayName string
   // Human-readable description of the resource
   description string
-  // Deployed models
-  //
-  // Deprecated in favor of deployments, which exposes each model deployment
-  // as a queryable gcp.project.vertexaiService.endpoint.deployment with a
-  // model() reference.
-  deployedModels @maturity("deprecated") []dict
   // Models deployed to this endpoint
   deployments []gcp.project.vertexaiService.endpoint.deployment
   // Encryption spec (CMEK)
   encryptionSpec dict
   // Customer-managed Cloud KMS key used to encrypt this resource at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
-  // Network for private endpoints
-  //
-  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
-  network @maturity("deprecated") string
   // VPC network used for private endpoints (resolved from network)
   networkRef() gcp.project.computeService.network
   // Whether private service connect is enabled
@@ -13631,20 +13171,8 @@ private gcp.project.vertexaiService.pipelineJob @defaults("name displayName stat
   pipelineSpec dict
   // Runtime config
   runtimeConfig dict
-  // Service account email used by the resource
-  //
-  // Deprecated in favor of `serviceAccountRef`, which resolves the identity
-  // to the service account resource (the email is available as its `email`).
-  // Note that `serviceAccountRef` is null when the service account has been
-  // deleted or lives in another project, whereas this field still holds the
-  // raw email.
-  serviceAccount @maturity("deprecated") string
   // Service account identity the pipeline job runs as
   serviceAccountRef() gcp.project.iamService.serviceAccount
-  // VPC network the resource is attached to
-  //
-  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
-  network @maturity("deprecated") string
   // VPC network the resource is attached to (resolved from network)
   networkRef() gcp.project.computeService.network
   // Encryption spec
@@ -13792,16 +13320,8 @@ private gcp.project.vertexaiService.customJob @defaults("displayName state") {
   state string
   // Job spec (worker pool specs, scheduling, etc.)
   jobSpec dict
-  // Email of the service account the job runs as (jobSpec.serviceAccount); empty when the default is used
-  //
-  // Deprecated in favor of `serviceAccountRef`.
-  serviceAccount @maturity("deprecated") string
   // The job's run-as service account, resolved to the typed resource
   serviceAccountRef() gcp.project.iamService.serviceAccount
-  // Resource name of the VPC network the job peers with (jobSpec.network); empty when none
-  //
-  // Deprecated in favor of `networkRef`.
-  network @maturity("deprecated") string
   // The job's peering VPC network, resolved to the typed resource
   networkRef() gcp.project.computeService.network
   // Whether interactive web access is enabled for the job (jobSpec.enableWebAccess)
@@ -13882,10 +13402,6 @@ private gcp.project.vertexaiService.indexEndpoint @defaults("displayName") {
   description string
   // Deployed indexes
   deployedIndexes []dict
-  // Network for private endpoints
-  //
-  // Deprecated in favor of `networkRef`, which resolves the VPC network resource.
-  network @maturity("deprecated") string
   // VPC network used for private endpoints (resolved from network)
   networkRef() gcp.project.computeService.network
   // Whether public endpoint is enabled
@@ -14069,11 +13585,6 @@ private gcp.project.vertexaiService.notebookExecutionJob @defaults("displayName 
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Runtime template that defines the execution environment
   notebookRuntimeTemplateRef() gcp.project.vertexaiService.notebookRuntimeTemplate
-  // Resource name of the schedule that triggered this job, if scheduled
-  //
-  // Deprecated in favor of scheduleRef, which resolves the schedule resource
-  // (its name is available as the resource's own name).
-  scheduleResourceName @maturity("deprecated") string
   // Schedule that triggered this job, if scheduled
   scheduleRef() gcp.project.vertexaiService.schedule
   // Configured execution timeout, in seconds
@@ -14851,14 +14362,6 @@ private gcp.accesscontextmanager.servicePerimeter @defaults("name title") {
   description string
   // Perimeter type (PERIMETER_TYPE_REGULAR, PERIMETER_TYPE_BRIDGE)
   perimeterType string
-  // Raw enforced perimeter config dict
-  //
-  // Deprecated in favor of `statusConfig`.
-  status @maturity("deprecated") dict
-  // Raw dry-run perimeter config dict
-  //
-  // Deprecated in favor of `specConfig`.
-  spec @maturity("deprecated") dict
   // Enforced perimeter configuration
   statusConfig() gcp.accesscontextmanager.servicePerimeter.config
   // Dry-run perimeter configuration (proposed changes)
@@ -15323,14 +14826,6 @@ private gcp.project.eventarcService.trigger @defaults("name") {
   uid string
   // Event filters
   eventFilters []gcp.project.eventarcService.trigger.eventFilter
-  // Service account email used by the trigger
-  //
-  // Deprecated in favor of `serviceAccountRef`, which resolves the identity
-  // to the service account resource (the email is available as its `email`).
-  // Note that `serviceAccountRef` is null when the service account has been
-  // deleted or lives in another project, whereas this field still holds the
-  // raw email.
-  serviceAccount @maturity("deprecated") string
   // Service account identity the trigger runs as
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Destination configuration
@@ -15394,10 +14889,6 @@ private gcp.project.eventarcService.channel @defaults("name state") {
   pubsubTopic string
   // Channel state (PENDING, ACTIVE, INACTIVE)
   state string
-  // Crypto key name for CMEK
-  //
-  // Deprecated in favor of `kmsKey`.
-  cryptoKeyName @maturity("deprecated") string
   // Customer-managed Cloud KMS key used to encrypt events flowing through the channel at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // User-provided labels for the channel
@@ -15936,10 +15427,6 @@ private gcp.project.idsService.endpoint @defaults("name severity state") {
   name string
   // Human-readable description of the resource
   description string
-  // Raw network self-link URL
-  //
-  // Deprecated in favor of `network`.
-  networkUrl @maturity("deprecated") string
   // Network resource
   network() gcp.project.computeService.network
   // Endpoint forwarding rule URL
@@ -16466,12 +15953,6 @@ private gcp.project.containerAnalysisService.occurrence @defaults("name kind") {
   kind string
   // Remediation details
   remediation string
-  // Vulnerability details (if kind is VULNERABILITY)
-  //
-  // Deprecated in favor of the vulnerability* fields, which expose the
-  // severity, CVSS score, fix availability, and descriptions as scalars.
-  // Retained for backward compatibility.
-  vulnerability @maturity("deprecated") dict
   // Note-provider severity of the vulnerability (when kind is VULNERABILITY)
   vulnerabilitySeverity string
   // Distro-assigned effective severity of the vulnerability (when kind is VULNERABILITY)
@@ -16486,12 +15967,6 @@ private gcp.project.containerAnalysisService.occurrence @defaults("name kind") {
   vulnerabilityLongDescription string
   // Affected locations and their fixes within the associated resource
   vulnerabilityPackageIssues []dict
-  // Build details (if kind is BUILD)
-  //
-  // Deprecated in favor of the build* fields, which expose the provenance
-  // ID, creator, timestamps, logs URI, trigger ID, built artifacts, and
-  // commands as scalars. Retained for backward compatibility.
-  build @maturity("deprecated") dict
   // Unique identifier of the build that produced the artifact (when kind is BUILD)
   buildProvenanceId string
   // Email address of the user who initiated the build (when kind is BUILD)
@@ -16538,13 +16013,6 @@ private gcp.project.containerAnalysisService.occurrence @defaults("name kind") {
   // `analysisStatus` (current scan status), `analysisStatusError`, `cpe`,
   // `lastScanTime`, `archiveTime`, and `sbomStatus`.
   discovery dict
-  // Attestation details (if kind is ATTESTATION)
-  //
-  // Deprecated in favor of attestationSerializedPayload and
-  // attestationSignatures, which expose the signed payload and the
-  // signatures with their public key IDs as scalars. Retained for backward
-  // compatibility.
-  attestation @maturity("deprecated") dict
   // Base64-encoded payload that the attestation signatures verify (when kind is ATTESTATION)
   attestationSerializedPayload string
   // Signatures over the attestation payload, each with its content and verifying public key ID (when kind is ATTESTATION)
@@ -16647,11 +16115,6 @@ private gcp.project.cloudBuildService.trigger @defaults("name description disabl
   filter string
   // Variable substitutions (key-value pairs)
   substitutions map[string]string
-  // Service account resource name used for builds from this trigger
-  //
-  // Deprecated in favor of `iamServiceAccount`, which resolves the identity to
-  // the service account resource (the resource name is its `name`).
-  serviceAccount @maturity("deprecated") string
   // IAM service account used for builds from this trigger
   iamServiceAccount() gcp.project.iamService.serviceAccount
   // GitHub event configuration
@@ -16822,10 +16285,6 @@ private gcp.project.cloudBuildService.workerPool.workerConfig @defaults("machine
 private gcp.project.cloudBuildService.workerPool.networkConfig @defaults("egressOption") {
   // Internal ID
   id string
-  // Peered VPC network name
-  //
-  // Deprecated in favor of `peeredNetworkRef`, which resolves the VPC network resource.
-  peeredNetwork @maturity("deprecated") string
   // Peered VPC network the worker pool connects through (resolved from peeredNetwork)
   peeredNetworkRef() gcp.project.computeService.network
   // Peered network IP range
@@ -16881,11 +16340,6 @@ private gcp.project.cloudBuildService.build @defaults("buildId status createTime
   logUrl string
   // Cloud Storage bucket where build logs are written
   logsBucket string
-  // Service account resource name used to run the build
-  //
-  // Deprecated in favor of `iamServiceAccount`, which resolves the identity to
-  // the service account resource (the resource name is its `name`).
-  serviceAccount @maturity("deprecated") string
   // IAM service account the build runs as
   iamServiceAccount() gcp.project.iamService.serviceAccount
   // Variable substitutions applied to the build

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2889,9 +2889,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.redisService.instance.memorySizeGb": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetMemorySizeGb()).ToDataRes(types.Int)
 	},
-	"gcp.project.redisService.instance.AuthorizedNetwork": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectRedisServiceInstance).GetAuthorizedNetwork()).ToDataRes(types.String)
-	},
 	"gcp.project.redisService.instance.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -2918,9 +2915,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.redisService.instance.readEndpointPort": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetReadEndpointPort()).ToDataRes(types.Int)
-	},
-	"gcp.project.redisService.instance.customerManagedKey": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectRedisServiceInstance).GetCustomerManagedKey()).ToDataRes(types.String)
 	},
 	"gcp.project.redisService.instance.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceInstance).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -3029,9 +3023,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.redisService.cluster.deletionProtectionEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceCluster).GetDeletionProtectionEnabled()).ToDataRes(types.Bool)
-	},
-	"gcp.project.redisService.cluster.kmsKey": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectRedisServiceCluster).GetKmsKey()).ToDataRes(types.String)
 	},
 	"gcp.project.redisService.cluster.cryptoKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectRedisServiceCluster).GetCryptoKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -3927,9 +3918,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.address.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
-	"gcp.project.computeService.address.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceAddress).GetNetworkUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.address.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -3942,17 +3930,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.address.purpose": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetPurpose()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.address.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceAddress).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.address.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
 	"gcp.project.computeService.address.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetStatus()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.address.subnetworkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceAddress).GetSubnetworkUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.address.subnetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAddress).GetSubnetwork()).ToDataRes(types.Resource("gcp.project.computeService.subnetwork"))
@@ -3974,9 +3956,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.forwardingRule.allowGlobalAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetAllowGlobalAccess()).ToDataRes(types.Bool)
-	},
-	"gcp.project.computeService.forwardingRule.backendServiceUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetBackendServiceUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.forwardingRule.backendService": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetBackendService()).ToDataRes(types.Resource("gcp.project.computeService.backendService"))
@@ -4008,9 +3987,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.forwardingRule.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetName()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.forwardingRule.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetNetworkUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.forwardingRule.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -4026,9 +4002,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.forwardingRule.ports": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetPorts()).ToDataRes(types.Array(types.String))
 	},
-	"gcp.project.computeService.forwardingRule.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.forwardingRule.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -4040,9 +4013,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.forwardingRule.serviceName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetServiceName()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.forwardingRule.subnetworkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetSubnetworkUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.forwardingRule.subnetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceForwardingRule).GetSubnetwork()).ToDataRes(types.Resource("gcp.project.computeService.subnetwork"))
@@ -4167,9 +4137,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.instance.confidentialInstanceConfig": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstance).GetConfidentialInstanceConfig()).ToDataRes(types.Dict)
-	},
 	"gcp.project.computeService.instance.confidentialCompute": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetConfidentialCompute()).ToDataRes(types.Resource("gcp.project.computeService.instance.confidentialCompute"))
 	},
@@ -4220,9 +4187,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instance.minCpuPlatform": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetMinCpuPlatform()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.instance.networkInterfaces": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstance).GetNetworkInterfaces()).ToDataRes(types.Array(types.Dict))
 	},
 	"gcp.project.computeService.instance.nics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetNics()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.instance.networkInterface")))
@@ -4277,15 +4241,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instance.shieldedInstanceIntegrityPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetShieldedInstanceIntegrityPolicy()).ToDataRes(types.Dict)
-	},
-	"gcp.project.computeService.instance.enableIntegrityMonitoring": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstance).GetEnableIntegrityMonitoring()).ToDataRes(types.Bool)
-	},
-	"gcp.project.computeService.instance.enableSecureBoot": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstance).GetEnableSecureBoot()).ToDataRes(types.Bool)
-	},
-	"gcp.project.computeService.instance.enableVtpm": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstance).GetEnableVtpm()).ToDataRes(types.Bool)
 	},
 	"gcp.project.computeService.instance.startRestricted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetStartRestricted()).ToDataRes(types.Bool)
@@ -4401,12 +4356,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.osInventory.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceOsInventory).GetName()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.instance.osInventory.osInfo": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceOsInventory).GetOsInfo()).ToDataRes(types.Dict)
-	},
-	"gcp.project.computeService.instance.osInventory.items": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceOsInventory).GetItems()).ToDataRes(types.Array(types.Dict))
-	},
 	"gcp.project.computeService.instance.osInventory.osHostname": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceOsInventory).GetOsHostname()).ToDataRes(types.String)
 	},
@@ -4460,9 +4409,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).GetName()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.instance.vulnerabilityReport.vulnerabilities": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).GetVulnerabilities()).ToDataRes(types.Array(types.Dict))
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport.vulnerabilityDetails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).GetVulnerabilityDetails()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.instance.vulnerabilityReport.vulnerability")))
@@ -4965,9 +4911,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.network.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetCreated()).ToDataRes(types.Time)
 	},
-	"gcp.project.computeService.network.peerings": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetwork).GetPeerings()).ToDataRes(types.Array(types.Dict))
-	},
 	"gcp.project.computeService.network.networkPeerings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetNetworkPeerings()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.network.peering")))
 	},
@@ -5000,9 +4943,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetNetworkProfile()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.network.ipv4Range": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetwork).GetIpv4Range()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.subnetwork.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetId()).ToDataRes(types.String)
@@ -5055,9 +4995,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.subnetwork.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
-	"gcp.project.computeService.subnetwork.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.subnetwork.role": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetRole()).ToDataRes(types.String)
 	},
@@ -5072,9 +5009,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.subnetwork.reservedInternalRange": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetReservedInternalRange()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.subnetwork.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetNetworkUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.subnetwork.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -5124,9 +5058,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.router.encryptedInterconnectRouter": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceRouter).GetEncryptedInterconnectRouter()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.router.nats": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceRouter).GetNats()).ToDataRes(types.Array(types.Dict))
-	},
 	"gcp.project.computeService.router.natServices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceRouter).GetNatServices()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.router.nat")))
 	},
@@ -5175,9 +5106,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.backendService.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.backendService.edgeSecurityPolicyUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceBackendService).GetEdgeSecurityPolicyUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.backendService.edgeSecurityPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetEdgeSecurityPolicy()).ToDataRes(types.Resource("gcp.project.computeService.securityPolicy"))
 	},
@@ -5214,9 +5142,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.backendService.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetName()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.backendService.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceBackendService).GetNetworkUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.backendService.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -5226,14 +5151,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.backendService.protocol": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetProtocol()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.backendService.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceBackendService).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.backendService.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
-	},
-	"gcp.project.computeService.backendService.securityPolicyUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceBackendService).GetSecurityPolicyUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.backendService.securityPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendService).GetSecurityPolicy()).ToDataRes(types.Resource("gcp.project.computeService.securityPolicy"))
@@ -5294,9 +5213,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.backendService.backend.failover": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendServiceBackend).GetFailover()).ToDataRes(types.Bool)
-	},
-	"gcp.project.computeService.backendService.backend.groupUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceBackendServiceBackend).GetGroupUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.backendService.backend.instanceGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceBackendServiceBackend).GetInstanceGroup()).ToDataRes(types.Resource("gcp.project.computeService.instanceGroup"))
@@ -5637,9 +5553,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.failoverReplicaRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetFailoverReplicaRef()).ToDataRes(types.Resource("gcp.project.sqlService.instance"))
 	},
-	"gcp.project.sqlService.instance.gceZone": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectSqlServiceInstance).GetGceZone()).ToDataRes(types.String)
-	},
 	"gcp.project.sqlService.instance.zone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
 	},
@@ -5696,9 +5609,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.localRootEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetLocalRootEnabled()).ToDataRes(types.Bool)
-	},
-	"gcp.project.sqlService.instance.serviceAccountEmailAddress": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectSqlServiceInstance).GetServiceAccountEmailAddress()).ToDataRes(types.String)
 	},
 	"gcp.project.sqlService.instance.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
@@ -5925,9 +5835,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.settings.activationPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetActivationPolicy()).ToDataRes(types.String)
 	},
-	"gcp.project.sqlService.instance.settings.activeDirectoryConfig": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetActiveDirectoryConfig()).ToDataRes(types.Dict)
-	},
 	"gcp.project.sqlService.instance.settings.activeDirectory": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettings).GetActiveDirectory()).ToDataRes(types.Resource("gcp.project.sqlService.instance.settings.activeDirectory"))
 	},
@@ -6093,9 +6000,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.settings.ipConfiguration.ipv4Enabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetIpv4Enabled()).ToDataRes(types.Bool)
 	},
-	"gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetPrivateNetwork()).ToDataRes(types.String)
-	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -6206,9 +6110,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.bigqueryService.dataset.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetTags()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"gcp.project.bigqueryService.dataset.kmsName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetKmsName()).ToDataRes(types.String)
 	},
 	"gcp.project.bigqueryService.dataset.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -6324,9 +6225,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.bigqueryService.table.expirationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTable).GetExpirationTime()).ToDataRes(types.Time)
 	},
-	"gcp.project.bigqueryService.table.kmsName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectBigqueryServiceTable).GetKmsName()).ToDataRes(types.String)
-	},
 	"gcp.project.bigqueryService.table.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTable).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
 	},
@@ -6404,9 +6302,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.bigqueryService.model.expirationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceModel).GetExpirationTime()).ToDataRes(types.Time)
-	},
-	"gcp.project.bigqueryService.model.kmsName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectBigqueryServiceModel).GetKmsName()).ToDataRes(types.String)
 	},
 	"gcp.project.bigqueryService.model.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceModel).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -6645,9 +6540,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dnsService.managedzone.forwardingTargets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetForwardingTargets()).ToDataRes(types.Array(types.String))
 	},
-	"gcp.project.dnsService.managedzone.peeringNetwork": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetPeeringNetwork()).ToDataRes(types.String)
-	},
 	"gcp.project.dnsService.managedzone.peeringNetworkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetPeeringNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -6747,14 +6639,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.gkeService.cluster.loggingService": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetLoggingService()).ToDataRes(types.String)
-	},
 	"gcp.project.gkeService.cluster.loggingEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetLoggingEnabled()).ToDataRes(types.Bool)
-	},
-	"gcp.project.gkeService.cluster.monitoringService": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetMonitoringService()).ToDataRes(types.String)
 	},
 	"gcp.project.gkeService.cluster.monitoringEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetMonitoringEnabled()).ToDataRes(types.Bool)
@@ -6834,12 +6720,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.networkConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetNetworkConfig()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.networkConfig"))
 	},
-	"gcp.project.gkeService.cluster.binaryAuthorization": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetBinaryAuthorization()).ToDataRes(types.Dict)
-	},
-	"gcp.project.gkeService.cluster.binaryAuthorizationEnabled": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetBinaryAuthorizationEnabled()).ToDataRes(types.Bool)
-	},
 	"gcp.project.gkeService.cluster.binaryAuthorizationEvaluationMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetBinaryAuthorizationEvaluationMode()).ToDataRes(types.String)
 	},
@@ -6858,23 +6738,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.gkeService.cluster.basicAuthEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetBasicAuthEnabled()).ToDataRes(types.Bool)
 	},
-	"gcp.project.gkeService.cluster.masterAuthorizedNetworksConfig": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterAuthorizedNetworksConfig()).ToDataRes(types.Dict)
-	},
-	"gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterAuthorizedNetworksEnabled()).ToDataRes(types.Bool)
-	},
 	"gcp.project.gkeService.cluster.privateClusterConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetPrivateClusterConfig()).ToDataRes(types.Dict)
-	},
-	"gcp.project.gkeService.cluster.privateNodesEnabled": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetPrivateNodesEnabled()).ToDataRes(types.Bool)
-	},
-	"gcp.project.gkeService.cluster.privateEndpointEnabled": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetPrivateEndpointEnabled()).ToDataRes(types.Bool)
-	},
-	"gcp.project.gkeService.cluster.masterGlobalAccessEnabled": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetMasterGlobalAccessEnabled()).ToDataRes(types.Bool)
 	},
 	"gcp.project.gkeService.cluster.controlPlaneEndpointsConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetControlPlaneEndpointsConfig()).ToDataRes(types.Dict)
@@ -6962,9 +6827,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.identityServiceConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetIdentityServiceConfig()).ToDataRes(types.Dict)
-	},
-	"gcp.project.gkeService.cluster.networkPolicyConfig": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectGkeServiceCluster).GetNetworkPolicyConfig()).ToDataRes(types.Dict)
 	},
 	"gcp.project.gkeService.cluster.networkPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetNetworkPolicy()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.networkPolicy"))
@@ -7559,9 +7421,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.pubsubService.topic.config.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceTopicConfig).GetLabels()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"gcp.project.pubsubService.topic.config.kmsKeyName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectPubsubServiceTopicConfig).GetKmsKeyName()).ToDataRes(types.String)
 	},
 	"gcp.project.pubsubService.topic.config.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectPubsubServiceTopicConfig).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -8163,9 +8022,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.loggingservice.bucket.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceBucket).GetLocation()).ToDataRes(types.String)
 	},
-	"gcp.project.loggingservice.bucket.cmekSettings": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectLoggingserviceBucket).GetCmekSettings()).ToDataRes(types.Dict)
-	},
 	"gcp.project.loggingservice.bucket.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceBucket).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
 	},
@@ -8724,9 +8580,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunction.buildEnvVars": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetBuildEnvVars()).ToDataRes(types.Map(types.String, types.String))
 	},
-	"gcp.project.cloudFunction.network": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudFunction).GetNetwork()).ToDataRes(types.String)
-	},
 	"gcp.project.cloudFunction.networkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -8765,9 +8618,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudFunction.secretVolumes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetSecretVolumes()).ToDataRes(types.Array(types.Dict))
-	},
-	"gcp.project.cloudFunction.dockerRepository": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudFunction).GetDockerRepository()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudFunction.dockerRepositoryRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunction).GetDockerRepositoryRef()).ToDataRes(types.Resource("gcp.project.artifactRegistryService.repository"))
@@ -8853,14 +8703,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudFunctionV2.buildConfig.environmentVariables": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetEnvironmentVariables()).ToDataRes(types.Map(types.String, types.String))
 	},
-	"gcp.project.cloudFunctionV2.buildConfig.dockerRepository": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetDockerRepository()).ToDataRes(types.String)
-	},
 	"gcp.project.cloudFunctionV2.buildConfig.dockerRepositoryRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetDockerRepositoryRef()).ToDataRes(types.Resource("gcp.project.artifactRegistryService.repository"))
-	},
-	"gcp.project.cloudFunctionV2.buildConfig.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetServiceAccount()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudFunctionV2BuildConfig).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
@@ -9005,9 +8849,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dataplexService.lake.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataplexServiceLake).GetLabels()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"gcp.project.dataplexService.lake.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectDataplexServiceLake).GetServiceAccount()).ToDataRes(types.String)
 	},
 	"gcp.project.dataplexService.lake.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataplexServiceLake).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
@@ -9339,9 +9180,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dataprocService.cluster.config.gceCluster.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
 	},
-	"gcp.project.dataprocService.cluster.config.gceCluster.networkUri": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetNetworkUri()).ToDataRes(types.String)
-	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -9365,9 +9203,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetShieldedInstanceConfig()).ToDataRes(types.Resource("gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig"))
-	},
-	"gcp.project.dataprocService.cluster.config.gceCluster.subnetworkUri": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetSubnetworkUri()).ToDataRes(types.String)
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.subnetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).GetSubnetwork()).ToDataRes(types.Resource("gcp.project.computeService.subnetwork"))
@@ -9738,9 +9573,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudRunService.service.revisionTemplate.scaling": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetScaling()).ToDataRes(types.Dict)
 	},
-	"gcp.project.cloudRunService.service.revisionTemplate.vpcAccess": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetVpcAccess()).ToDataRes(types.Dict)
-	},
 	"gcp.project.cloudRunService.service.revisionTemplate.vpcAccessConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).GetVpcAccessConfig()).ToDataRes(types.Resource("gcp.project.cloudRunService.vpcAccessConfig"))
 	},
@@ -9962,9 +9794,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).GetProjectId()).ToDataRes(types.String)
-	},
-	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccess": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).GetVpcAccess()).ToDataRes(types.Dict)
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccessConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).GetVpcAccessConfig()).ToDataRes(types.Resource("gcp.project.cloudRunService.vpcAccessConfig"))
@@ -10272,9 +10101,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.binaryAuthorizationControl.attestor.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBinaryAuthorizationControlAttestor).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.binaryAuthorizationControl.attestor.userOwnedGrafeasNote": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectBinaryAuthorizationControlAttestor).GetUserOwnedGrafeasNote()).ToDataRes(types.Dict)
-	},
 	"gcp.project.binaryAuthorizationControl.attestor.noteReference": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBinaryAuthorizationControlAttestor).GetNoteReference()).ToDataRes(types.String)
 	},
@@ -10367,9 +10193,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.secretmanagerService.secret.versionDestroyTtl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetVersionDestroyTtl()).ToDataRes(types.Time)
-	},
-	"gcp.project.secretmanagerService.secret.customerManagedEncryption": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetCustomerManagedEncryption()).ToDataRes(types.Array(types.String))
 	},
 	"gcp.project.secretmanagerService.secret.kmsKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetKmsKeys()).ToDataRes(types.Array(types.Resource("gcp.project.kmsService.keyring.cryptokey")))
@@ -11298,9 +11121,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.securityPolicy.userDefinedFields": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSecurityPolicy).GetUserDefinedFields()).ToDataRes(types.Array(types.Dict))
 	},
-	"gcp.project.computeService.securityPolicy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSecurityPolicy).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.securityPolicy.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSecurityPolicy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -11370,9 +11190,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.sslPolicy.enabledFeatures": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetEnabledFeatures()).ToDataRes(types.Array(types.String))
 	},
-	"gcp.project.computeService.sslPolicy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.sslPolicy.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslPolicy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -11405,9 +11222,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.sslCertificate.managedStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetManagedStatus()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.sslCertificate.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.sslCertificate.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSslCertificate).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -11448,9 +11262,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.vpnGateway.stackType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetStackType()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.vpnGateway.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.vpnGateway.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -11487,17 +11298,11 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.vpnTunnel.remoteTrafficSelector": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRemoteTrafficSelector()).ToDataRes(types.Array(types.String))
 	},
-	"gcp.project.computeService.vpnTunnel.peerExternalGateway": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetPeerExternalGateway()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.vpnTunnel.peerExternalGatewayInterface": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetPeerExternalGatewayInterface()).ToDataRes(types.Int)
 	},
 	"gcp.project.computeService.vpnTunnel.peerExternalVpnGateway": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetPeerExternalVpnGateway()).ToDataRes(types.Resource("gcp.project.computeService.externalVpnGateway"))
-	},
-	"gcp.project.computeService.vpnTunnel.peerGcpGateway": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetPeerGcpGateway()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.vpnTunnel.peerGcpVpnGateway": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetPeerGcpVpnGateway()).ToDataRes(types.Resource("gcp.project.computeService.vpnGateway"))
@@ -11505,14 +11310,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.vpnTunnel.peerIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetPeerIp()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.vpnTunnel.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.vpnTunnel.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
-	},
-	"gcp.project.computeService.vpnTunnel.routerUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRouterUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.vpnTunnel.router": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetRouter()).ToDataRes(types.Resource("gcp.project.computeService.router"))
@@ -11525,9 +11324,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.vpnTunnel.targetVpnGateway": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetTargetVpnGateway()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.vpnTunnel.vpnGatewayUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetVpnGatewayUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.vpnTunnel.vpnGateway": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetVpnGateway()).ToDataRes(types.Resource("gcp.project.computeService.vpnGateway"))
@@ -12267,14 +12063,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instanceGroup.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.instanceGroup.zoneUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetZoneUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.instanceGroup.zone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
-	},
-	"gcp.project.computeService.instanceGroup.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetNetworkUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.instanceGroup.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroup).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -12309,14 +12099,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instanceGroupManager.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.instanceGroupManager.zoneUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetZoneUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.instanceGroupManager.zone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
-	},
-	"gcp.project.computeService.instanceGroupManager.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.instanceGroupManager.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceGroupManager).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -12377,9 +12161,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.firewallPolicy.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewallPolicy).GetCreated()).ToDataRes(types.Time)
-	},
-	"gcp.project.computeService.firewallPolicy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceFirewallPolicy).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.firewallPolicy.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewallPolicy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -12501,9 +12282,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.filestoreService.instance.networks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFilestoreServiceInstance).GetNetworks()).ToDataRes(types.Array(types.Resource("gcp.project.filestoreService.instance.network")))
 	},
-	"gcp.project.filestoreService.instance.kmsKeyName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectFilestoreServiceInstance).GetKmsKeyName()).ToDataRes(types.String)
-	},
 	"gcp.project.filestoreService.instance.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFilestoreServiceInstance).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
 	},
@@ -12615,14 +12393,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudSchedulerService.job.targetType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetTargetType()).ToDataRes(types.String)
 	},
-	"gcp.project.cloudSchedulerService.job.oidcServiceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOidcServiceAccountEmail()).ToDataRes(types.String)
-	},
 	"gcp.project.cloudSchedulerService.job.oidcServiceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOidcServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
-	},
-	"gcp.project.cloudSchedulerService.job.oauthServiceAccountEmail": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOauthServiceAccountEmail()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudSchedulerService.job.oauthServiceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudSchedulerServiceJob).GetOauthServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
@@ -12800,9 +12572,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.apiGatewayService.apiConfig.serviceConfigId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiGatewayServiceApiConfig).GetServiceConfigId()).ToDataRes(types.String)
-	},
-	"gcp.project.apiGatewayService.apiConfig.gatewayServiceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectApiGatewayServiceApiConfig).GetGatewayServiceAccount()).ToDataRes(types.String)
 	},
 	"gcp.project.apiGatewayService.apiConfig.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiGatewayServiceApiConfig).GetServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
@@ -13170,9 +12939,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.healthCheck.logConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceHealthCheck).GetLogConfig()).ToDataRes(types.Dict)
 	},
-	"gcp.project.computeService.healthCheck.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceHealthCheck).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.healthCheck.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceHealthCheck).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -13187,9 +12953,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.urlMap.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetDescription()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.urlMap.defaultServiceUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetDefaultServiceUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.urlMap.defaultService": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetDefaultService()).ToDataRes(types.Resource("gcp.project.computeService.backendService"))
@@ -13209,9 +12972,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.urlMap.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetSelfLink()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.urlMap.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.urlMap.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceUrlMap).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -13227,9 +12987,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.targetHttpProxy.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.targetHttpProxy.urlMapUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetUrlMapUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.targetHttpProxy.urlMap": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetUrlMap()).ToDataRes(types.Resource("gcp.project.computeService.urlMap"))
 	},
@@ -13241,9 +12998,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetHttpProxy.proxyBind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetProxyBind()).ToDataRes(types.Bool)
-	},
-	"gcp.project.computeService.targetHttpProxy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.targetHttpProxy.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpProxy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -13260,9 +13014,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.targetHttpsProxy.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.targetHttpsProxy.urlMapUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetUrlMapUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.targetHttpsProxy.urlMap": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetUrlMap()).ToDataRes(types.Resource("gcp.project.computeService.urlMap"))
 	},
@@ -13271,9 +13022,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetHttpsProxy.sslCertificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetSslCertificates()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.sslCertificate")))
-	},
-	"gcp.project.computeService.targetHttpsProxy.sslPolicyUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetSslPolicyUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.targetHttpsProxy.sslPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetSslPolicy()).ToDataRes(types.Resource("gcp.project.computeService.sslPolicy"))
@@ -13302,9 +13050,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.targetHttpsProxy.proxyBind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetProxyBind()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.targetHttpsProxy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.targetHttpsProxy.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -13313,9 +13058,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.network.peering.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkPeering).GetName()).ToDataRes(types.String)
-	},
-	"gcp.project.computeService.network.peering.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkPeering).GetNetworkUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.network.peering.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkPeering).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -13358,9 +13100,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.route.priority": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceRoute).GetPriority()).ToDataRes(types.Int)
-	},
-	"gcp.project.computeService.route.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceRoute).GetNetworkUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.route.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceRoute).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -13461,9 +13200,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.serviceAttachment.reconcileConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceServiceAttachment).GetReconcileConnections()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.serviceAttachment.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceServiceAttachment).GetRegionUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.serviceAttachment.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceServiceAttachment).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
 	},
@@ -13494,26 +13230,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.networkEndpointGroup.size": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetSize()).ToDataRes(types.Int)
 	},
-	"gcp.project.computeService.networkEndpointGroup.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetNetworkUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.networkEndpointGroup.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
-	},
-	"gcp.project.computeService.networkEndpointGroup.subnetworkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetSubnetworkUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.networkEndpointGroup.subnetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetSubnetwork()).ToDataRes(types.Resource("gcp.project.computeService.subnetwork"))
 	},
-	"gcp.project.computeService.networkEndpointGroup.zoneUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetZoneUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.networkEndpointGroup.zone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetZone()).ToDataRes(types.Resource("gcp.project.computeService.zone"))
-	},
-	"gcp.project.computeService.networkEndpointGroup.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.networkEndpointGroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -13644,14 +13368,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.interconnectAttachment.edgeAvailabilityDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetEdgeAvailabilityDomain()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.interconnectAttachment.interconnectUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetInterconnectUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.interconnectAttachment.interconnect": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetInterconnect()).ToDataRes(types.Resource("gcp.project.computeService.interconnect"))
-	},
-	"gcp.project.computeService.interconnectAttachment.routerUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetRouterUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.interconnectAttachment.router": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetRouter()).ToDataRes(types.Resource("gcp.project.computeService.router"))
@@ -13682,9 +13400,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.interconnectAttachment.privateInterconnectInfo": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetPrivateInterconnectInfo()).ToDataRes(types.Dict)
-	},
-	"gcp.project.computeService.interconnectAttachment.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.interconnectAttachment.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -13740,14 +13455,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.targetTcpProxy.proxyBind": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetProxyBind()).ToDataRes(types.Bool)
 	},
-	"gcp.project.computeService.targetTcpProxy.serviceUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetServiceUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.targetTcpProxy.service": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetService()).ToDataRes(types.Resource("gcp.project.computeService.backendService"))
-	},
-	"gcp.project.computeService.targetTcpProxy.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.targetTcpProxy.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetTcpProxy).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -13770,9 +13479,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.targetSslProxy.proxyHeader": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetSslProxy).GetProxyHeader()).ToDataRes(types.String)
 	},
-	"gcp.project.computeService.targetSslProxy.serviceUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetSslProxy).GetServiceUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.targetSslProxy.service": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetSslProxy).GetService()).ToDataRes(types.Resource("gcp.project.computeService.backendService"))
 	},
@@ -13781,9 +13487,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetSslProxy.sslCertificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetSslProxy).GetSslCertificates()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.sslCertificate")))
-	},
-	"gcp.project.computeService.targetSslProxy.sslPolicyUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetSslProxy).GetSslPolicyUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.targetSslProxy.sslPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetSslProxy).GetSslPolicy()).ToDataRes(types.Resource("gcp.project.computeService.sslPolicy"))
@@ -13823,9 +13526,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.packetMirroring.filter": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServicePacketMirroring).GetFilter()).ToDataRes(types.Dict)
-	},
-	"gcp.project.computeService.packetMirroring.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServicePacketMirroring).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.packetMirroring.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServicePacketMirroring).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -13884,9 +13584,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.targetPool.failoverRatio": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetFailoverRatio()).ToDataRes(types.Float)
 	},
-	"gcp.project.computeService.targetPool.backupPoolUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetBackupPoolUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.targetPool.backupPool": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetBackupPool()).ToDataRes(types.Resource("gcp.project.computeService.targetPool"))
 	},
@@ -13902,14 +13599,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.targetPool.instanceRefs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetInstanceRefs()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.instance")))
 	},
-	"gcp.project.computeService.targetPool.securityPolicyUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetSecurityPolicyUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.computeService.targetPool.securityPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetSecurityPolicy()).ToDataRes(types.Resource("gcp.project.computeService.securityPolicy"))
-	},
-	"gcp.project.computeService.targetPool.regionUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetRegionUrl()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.targetPool.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetPool).GetRegion()).ToDataRes(types.Resource("gcp.project.computeService.region"))
@@ -14177,9 +13868,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.artifactRegistryService.repository.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectArtifactRegistryServiceRepository).GetLabels()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"gcp.project.artifactRegistryService.repository.kmsKeyName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectArtifactRegistryServiceRepository).GetKmsKeyName()).ToDataRes(types.String)
 	},
 	"gcp.project.artifactRegistryService.repository.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectArtifactRegistryServiceRepository).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -14727,9 +14415,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.vertexaiService.endpoint.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.vertexaiService.endpoint.deployedModels": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetDeployedModels()).ToDataRes(types.Array(types.Dict))
-	},
 	"gcp.project.vertexaiService.endpoint.deployments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetDeployments()).ToDataRes(types.Array(types.Resource("gcp.project.vertexaiService.endpoint.deployment")))
 	},
@@ -14738,9 +14423,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.vertexaiService.endpoint.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
-	},
-	"gcp.project.vertexaiService.endpoint.network": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetNetwork()).ToDataRes(types.String)
 	},
 	"gcp.project.vertexaiService.endpoint.networkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceEndpoint).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -14847,14 +14529,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.vertexaiService.pipelineJob.runtimeConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetRuntimeConfig()).ToDataRes(types.Dict)
 	},
-	"gcp.project.vertexaiService.pipelineJob.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetServiceAccount()).ToDataRes(types.String)
-	},
 	"gcp.project.vertexaiService.pipelineJob.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
-	},
-	"gcp.project.vertexaiService.pipelineJob.network": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetNetwork()).ToDataRes(types.String)
 	},
 	"gcp.project.vertexaiService.pipelineJob.networkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServicePipelineJob).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -15009,14 +14685,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.vertexaiService.customJob.jobSpec": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetJobSpec()).ToDataRes(types.Dict)
 	},
-	"gcp.project.vertexaiService.customJob.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetServiceAccount()).ToDataRes(types.String)
-	},
 	"gcp.project.vertexaiService.customJob.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
-	},
-	"gcp.project.vertexaiService.customJob.network": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetNetwork()).ToDataRes(types.String)
 	},
 	"gcp.project.vertexaiService.customJob.networkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceCustomJob).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -15101,9 +14771,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.vertexaiService.indexEndpoint.deployedIndexes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).GetDeployedIndexes()).ToDataRes(types.Array(types.Dict))
-	},
-	"gcp.project.vertexaiService.indexEndpoint.network": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).GetNetwork()).ToDataRes(types.String)
 	},
 	"gcp.project.vertexaiService.indexEndpoint.networkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).GetNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
@@ -15320,9 +14987,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.vertexaiService.notebookExecutionJob.notebookRuntimeTemplateRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceNotebookExecutionJob).GetNotebookRuntimeTemplateRef()).ToDataRes(types.Resource("gcp.project.vertexaiService.notebookRuntimeTemplate"))
-	},
-	"gcp.project.vertexaiService.notebookExecutionJob.scheduleResourceName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectVertexaiServiceNotebookExecutionJob).GetScheduleResourceName()).ToDataRes(types.String)
 	},
 	"gcp.project.vertexaiService.notebookExecutionJob.scheduleRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectVertexaiServiceNotebookExecutionJob).GetScheduleRef()).ToDataRes(types.Resource("gcp.project.vertexaiService.schedule"))
@@ -16017,12 +15681,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.accesscontextmanager.servicePerimeter.perimeterType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpAccesscontextmanagerServicePerimeter).GetPerimeterType()).ToDataRes(types.String)
 	},
-	"gcp.accesscontextmanager.servicePerimeter.status": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpAccesscontextmanagerServicePerimeter).GetStatus()).ToDataRes(types.Dict)
-	},
-	"gcp.accesscontextmanager.servicePerimeter.spec": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpAccesscontextmanagerServicePerimeter).GetSpec()).ToDataRes(types.Dict)
-	},
 	"gcp.accesscontextmanager.servicePerimeter.statusConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpAccesscontextmanagerServicePerimeter).GetStatusConfig()).ToDataRes(types.Resource("gcp.accesscontextmanager.servicePerimeter.config"))
 	},
@@ -16392,9 +16050,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.eventarcService.trigger.eventFilters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectEventarcServiceTrigger).GetEventFilters()).ToDataRes(types.Array(types.Resource("gcp.project.eventarcService.trigger.eventFilter")))
 	},
-	"gcp.project.eventarcService.trigger.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectEventarcServiceTrigger).GetServiceAccount()).ToDataRes(types.String)
-	},
 	"gcp.project.eventarcService.trigger.serviceAccountRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectEventarcServiceTrigger).GetServiceAccountRef()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
 	},
@@ -16448,9 +16103,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.eventarcService.channel.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectEventarcServiceChannel).GetState()).ToDataRes(types.String)
-	},
-	"gcp.project.eventarcService.channel.cryptoKeyName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectEventarcServiceChannel).GetCryptoKeyName()).ToDataRes(types.String)
 	},
 	"gcp.project.eventarcService.channel.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectEventarcServiceChannel).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
@@ -16929,9 +16581,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.idsService.endpoint.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIdsServiceEndpoint).GetDescription()).ToDataRes(types.String)
 	},
-	"gcp.project.idsService.endpoint.networkUrl": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectIdsServiceEndpoint).GetNetworkUrl()).ToDataRes(types.String)
-	},
 	"gcp.project.idsService.endpoint.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIdsServiceEndpoint).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -17319,9 +16968,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.containerAnalysisService.occurrence.remediation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetRemediation()).ToDataRes(types.String)
 	},
-	"gcp.project.containerAnalysisService.occurrence.vulnerability": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetVulnerability()).ToDataRes(types.Dict)
-	},
 	"gcp.project.containerAnalysisService.occurrence.vulnerabilitySeverity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetVulnerabilitySeverity()).ToDataRes(types.String)
 	},
@@ -17342,9 +16988,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.containerAnalysisService.occurrence.vulnerabilityPackageIssues": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetVulnerabilityPackageIssues()).ToDataRes(types.Array(types.Dict))
-	},
-	"gcp.project.containerAnalysisService.occurrence.build": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetBuild()).ToDataRes(types.Dict)
 	},
 	"gcp.project.containerAnalysisService.occurrence.buildProvenanceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetBuildProvenanceId()).ToDataRes(types.String)
@@ -17387,9 +17030,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.containerAnalysisService.occurrence.discovery": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetDiscovery()).ToDataRes(types.Dict)
-	},
-	"gcp.project.containerAnalysisService.occurrence.attestation": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetAttestation()).ToDataRes(types.Dict)
 	},
 	"gcp.project.containerAnalysisService.occurrence.attestationSerializedPayload": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).GetAttestationSerializedPayload()).ToDataRes(types.String)
@@ -17471,9 +17111,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudBuildService.trigger.substitutions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceTrigger).GetSubstitutions()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"gcp.project.cloudBuildService.trigger.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudBuildServiceTrigger).GetServiceAccount()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudBuildService.trigger.iamServiceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceTrigger).GetIamServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
@@ -17595,9 +17232,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudBuildService.workerPool.networkConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).GetId()).ToDataRes(types.String)
 	},
-	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetwork": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).GetPeeredNetwork()).ToDataRes(types.String)
-	},
 	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).GetPeeredNetworkRef()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
@@ -17651,9 +17285,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.cloudBuildService.build.logsBucket": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceBuild).GetLogsBucket()).ToDataRes(types.String)
-	},
-	"gcp.project.cloudBuildService.build.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGcpProjectCloudBuildServiceBuild).GetServiceAccount()).ToDataRes(types.String)
 	},
 	"gcp.project.cloudBuildService.build.iamServiceAccount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudBuildServiceBuild).GetIamServiceAccount()).ToDataRes(types.Resource("gcp.project.iamService.serviceAccount"))
@@ -19309,10 +18940,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectRedisServiceInstance).MemorySizeGb, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
-	"gcp.project.redisService.instance.AuthorizedNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectRedisServiceInstance).AuthorizedNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.redisService.instance.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceInstance).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -19347,10 +18974,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.redisService.instance.readEndpointPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceInstance).ReadEndpointPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"gcp.project.redisService.instance.customerManagedKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectRedisServiceInstance).CustomerManagedKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.redisService.instance.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19507,10 +19130,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.redisService.cluster.deletionProtectionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectRedisServiceCluster).DeletionProtectionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.redisService.cluster.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectRedisServiceCluster).KmsKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.redisService.cluster.cryptoKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20777,10 +20396,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceAddress).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.address.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceAddress).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.address.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAddress).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -20797,20 +20412,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceAddress).Purpose, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.address.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceAddress).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.address.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAddress).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.address.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAddress).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.address.subnetworkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceAddress).SubnetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.address.subnetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20843,10 +20450,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.forwardingRule.allowGlobalAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceForwardingRule).AllowGlobalAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.forwardingRule.backendServiceUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceForwardingRule).BackendServiceUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.forwardingRule.backendService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20889,10 +20492,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceForwardingRule).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.forwardingRule.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceForwardingRule).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.forwardingRule.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceForwardingRule).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -20913,10 +20512,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceForwardingRule).Ports, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.forwardingRule.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceForwardingRule).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.forwardingRule.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceForwardingRule).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -20931,10 +20526,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.forwardingRule.serviceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceForwardingRule).ServiceName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.forwardingRule.subnetworkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceForwardingRule).SubnetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.forwardingRule.subnetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21117,10 +20708,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.instance.confidentialInstanceConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstance).ConfidentialInstanceConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.instance.confidentialCompute": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).ConfidentialCompute, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInstanceConfidentialCompute](v.Value, v.Error)
 		return
@@ -21187,10 +20774,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.minCpuPlatform": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).MinCpuPlatform, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instance.networkInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstance).NetworkInterfaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.nics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21263,18 +20846,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.shieldedInstanceIntegrityPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstance).ShieldedInstanceIntegrityPolicy, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instance.enableIntegrityMonitoring": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstance).EnableIntegrityMonitoring, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instance.enableSecureBoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstance).EnableSecureBoot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instance.enableVtpm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstance).EnableVtpm, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.startRestricted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -21441,14 +21012,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstanceOsInventory).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.instance.osInventory.osInfo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceOsInventory).OsInfo, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instance.osInventory.items": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceOsInventory).Items, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.instance.osInventory.osHostname": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceOsInventory).OsHostname, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -21527,10 +21090,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instance.vulnerabilityReport.vulnerabilities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceVulnerabilityReport).Vulnerabilities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.vulnerabilityReport.vulnerabilityDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22241,10 +21800,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceNetwork).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.network.peerings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetwork).Peerings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.network.networkPeerings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetwork).NetworkPeerings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -22287,10 +21842,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetwork).NetworkProfile, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.network.ipv4Range": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetwork).Ipv4Range, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.subnetwork.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22365,10 +21916,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSubnetwork).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.subnetwork.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSubnetwork).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.subnetwork.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSubnetwork).Role, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -22387,10 +21934,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.subnetwork.reservedInternalRange": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSubnetwork).ReservedInternalRange, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.subnetwork.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSubnetwork).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.subnetwork.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22465,10 +22008,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceRouter).EncryptedInterconnectRouter, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.router.nats": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceRouter).Nats, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.router.natServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceRouter).NatServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -22537,10 +22076,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceBackendService).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.backendService.edgeSecurityPolicyUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceBackendService).EdgeSecurityPolicyUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.backendService.edgeSecurityPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceBackendService).EdgeSecurityPolicy, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSecurityPolicy](v.Value, v.Error)
 		return
@@ -22589,10 +22124,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceBackendService).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.backendService.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceBackendService).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.backendService.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceBackendService).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -22605,16 +22136,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceBackendService).Protocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.backendService.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceBackendService).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.backendService.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceBackendService).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.backendService.securityPolicyUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceBackendService).SecurityPolicyUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.backendService.securityPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -22699,10 +22222,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.backendService.backend.failover": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceBackendServiceBackend).Failover, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.backendService.backend.groupUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceBackendServiceBackend).GroupUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.backendService.backend.instanceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23193,10 +22712,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstance).FailoverReplicaRef, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstance](v.Value, v.Error)
 		return
 	},
-	"gcp.project.sqlService.instance.gceZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectSqlServiceInstance).GceZone, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.sqlService.instance.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
 		return
@@ -23271,10 +22786,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.localRootEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).LocalRootEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.sqlService.instance.serviceAccountEmailAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectSqlServiceInstance).ServiceAccountEmailAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23601,10 +23112,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstanceSettings).ActivationPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.sqlService.instance.settings.activeDirectoryConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectSqlServiceInstanceSettings).ActiveDirectoryConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.sqlService.instance.settings.activeDirectory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettings).ActiveDirectory, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory](v.Value, v.Error)
 		return
@@ -23841,10 +23348,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).Ipv4Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).PrivateNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.sqlService.instance.settings.ipConfiguration.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -24013,10 +23516,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBigqueryServiceDataset).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.bigqueryService.dataset.kmsName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectBigqueryServiceDataset).KmsName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.bigqueryService.dataset.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceDataset).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
@@ -24177,10 +23676,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBigqueryServiceTable).ExpirationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
-	"gcp.project.bigqueryService.table.kmsName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectBigqueryServiceTable).KmsName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.bigqueryService.table.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceTable).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
@@ -24287,10 +23782,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.bigqueryService.model.expirationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceModel).ExpirationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
-	"gcp.project.bigqueryService.model.kmsName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectBigqueryServiceModel).KmsName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.bigqueryService.model.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24637,10 +24128,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectDnsServiceManagedzone).ForwardingTargets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.dnsService.managedzone.peeringNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectDnsServiceManagedzone).PeeringNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.dnsService.managedzone.peeringNetworkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceManagedzone).PeeringNetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -24793,16 +24280,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.gkeService.cluster.loggingService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).LoggingService, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.gkeService.cluster.loggingEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).LoggingEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.gkeService.cluster.monitoringService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).MonitoringService, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.monitoringEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24909,14 +24388,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).NetworkConfig, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterNetworkConfig](v.Value, v.Error)
 		return
 	},
-	"gcp.project.gkeService.cluster.binaryAuthorization": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).BinaryAuthorization, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.gkeService.cluster.binaryAuthorizationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).BinaryAuthorizationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
 	"gcp.project.gkeService.cluster.binaryAuthorizationEvaluationMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).BinaryAuthorizationEvaluationMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -24941,28 +24412,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectGkeServiceCluster).BasicAuthEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.gkeService.cluster.masterAuthorizedNetworksConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).MasterAuthorizedNetworksConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).MasterAuthorizedNetworksEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
 	"gcp.project.gkeService.cluster.privateClusterConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).PrivateClusterConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.gkeService.cluster.privateNodesEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).PrivateNodesEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.gkeService.cluster.privateEndpointEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).PrivateEndpointEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.gkeService.cluster.masterGlobalAccessEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).MasterGlobalAccessEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.controlPlaneEndpointsConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25079,10 +24530,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.identityServiceConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).IdentityServiceConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.gkeService.cluster.networkPolicyConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectGkeServiceCluster).NetworkPolicyConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.networkPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25989,10 +25436,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectPubsubServiceTopicConfig).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.pubsubService.topic.config.kmsKeyName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectPubsubServiceTopicConfig).KmsKeyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.pubsubService.topic.config.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectPubsubServiceTopicConfig).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
@@ -26885,10 +26328,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectLoggingserviceBucket).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.loggingservice.bucket.cmekSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectLoggingserviceBucket).CmekSettings, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.loggingservice.bucket.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectLoggingserviceBucket).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
@@ -27693,10 +27132,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunction).BuildEnvVars, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.cloudFunction.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudFunction).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.cloudFunction.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).NetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -27747,10 +27182,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudFunction.secretVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunction).SecretVolumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.cloudFunction.dockerRepository": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudFunction).DockerRepository, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunction.dockerRepositoryRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27873,16 +27304,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).EnvironmentVariables, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.cloudFunctionV2.buildConfig.dockerRepository": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).DockerRepository, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.cloudFunctionV2.buildConfig.dockerRepositoryRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).DockerRepositoryRef, ok = plugin.RawToTValue[*mqlGcpProjectArtifactRegistryServiceRepository](v.Value, v.Error)
-		return
-	},
-	"gcp.project.cloudFunctionV2.buildConfig.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudFunctionV2BuildConfig).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28091,10 +27514,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dataplexService.lake.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDataplexServiceLake).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.dataplexService.lake.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectDataplexServiceLake).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dataplexService.lake.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28569,10 +27988,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).Metadata, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.dataprocService.cluster.config.gceCluster.networkUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).NetworkUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -28603,10 +28018,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).ShieldedInstanceConfig, ok = plugin.RawToTValue[*mqlGcpProjectDataprocServiceClusterConfigGceClusterShieldedInstanceConfig](v.Value, v.Error)
-		return
-	},
-	"gcp.project.dataprocService.cluster.config.gceCluster.subnetworkUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectDataprocServiceClusterConfigGceCluster).SubnetworkUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dataprocService.cluster.config.gceCluster.subnetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29157,10 +28568,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).Scaling, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.cloudRunService.service.revisionTemplate.vpcAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).VpcAccess, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.cloudRunService.service.revisionTemplate.vpcAccessConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceServiceRevisionTemplate).VpcAccessConfig, ok = plugin.RawToTValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig](v.Value, v.Error)
 		return
@@ -29483,10 +28890,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate).VpcAccess, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccessConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29949,10 +29352,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBinaryAuthorizationControlAttestor).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.binaryAuthorizationControl.attestor.userOwnedGrafeasNote": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectBinaryAuthorizationControlAttestor).UserOwnedGrafeasNote, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.binaryAuthorizationControl.attestor.noteReference": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBinaryAuthorizationControlAttestor).NoteReference, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -30087,10 +29486,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.secretmanagerService.secret.versionDestroyTtl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).VersionDestroyTtl, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
-	"gcp.project.secretmanagerService.secret.customerManagedEncryption": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectSecretmanagerServiceSecret).CustomerManagedEncryption, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.secretmanagerService.secret.kmsKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31429,10 +30824,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSecurityPolicy).UserDefinedFields, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.securityPolicy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSecurityPolicy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.securityPolicy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSecurityPolicy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -31533,10 +30924,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceSslPolicy).EnabledFeatures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.sslPolicy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSslPolicy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.sslPolicy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSslPolicy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -31583,10 +30970,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.sslCertificate.managedStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSslCertificate).ManagedStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.sslCertificate.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceSslCertificate).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.sslCertificate.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31645,10 +31028,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceVpnGateway).StackType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.vpnGateway.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceVpnGateway).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.vpnGateway.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnGateway).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -31701,20 +31080,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).RemoteTrafficSelector, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.vpnTunnel.peerExternalGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceVpnTunnel).PeerExternalGateway, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.vpnTunnel.peerExternalGatewayInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).PeerExternalGatewayInterface, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.vpnTunnel.peerExternalVpnGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).PeerExternalVpnGateway, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceExternalVpnGateway](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.vpnTunnel.peerGcpGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceVpnTunnel).PeerGcpGateway, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.vpnTunnel.peerGcpVpnGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31725,16 +31096,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).PeerIp, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.vpnTunnel.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceVpnTunnel).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.vpnTunnel.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.vpnTunnel.routerUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceVpnTunnel).RouterUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.vpnTunnel.router": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31751,10 +31114,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.vpnTunnel.targetVpnGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).TargetVpnGateway, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.vpnTunnel.vpnGatewayUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceVpnTunnel).VpnGatewayUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.vpnTunnel.vpnGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32829,16 +32188,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstanceGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.instanceGroup.zoneUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceGroup).ZoneUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.instanceGroup.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceGroup).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instanceGroup.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceGroup).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instanceGroup.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32889,16 +32240,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.instanceGroupManager.zoneUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).ZoneUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.instanceGroupManager.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.instanceGroupManager.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInstanceGroupManager).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instanceGroupManager.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32983,10 +32326,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.firewallPolicy.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewallPolicy).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.firewallPolicy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceFirewallPolicy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.firewallPolicy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33165,10 +32504,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectFilestoreServiceInstance).Networks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.filestoreService.instance.kmsKeyName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectFilestoreServiceInstance).KmsKeyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.filestoreService.instance.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectFilestoreServiceInstance).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
 		return
@@ -33341,16 +32676,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudSchedulerServiceJob).TargetType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.cloudSchedulerService.job.oidcServiceAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudSchedulerServiceJob).OidcServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.cloudSchedulerService.job.oidcServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudSchedulerServiceJob).OidcServiceAccount, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
-		return
-	},
-	"gcp.project.cloudSchedulerService.job.oauthServiceAccountEmail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudSchedulerServiceJob).OauthServiceAccountEmail, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudSchedulerService.job.oauthServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33619,10 +32946,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.apiGatewayService.apiConfig.serviceConfigId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectApiGatewayServiceApiConfig).ServiceConfigId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.apiGatewayService.apiConfig.gatewayServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectApiGatewayServiceApiConfig).GatewayServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.apiGatewayService.apiConfig.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34173,10 +33496,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceHealthCheck).LogConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.healthCheck.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceHealthCheck).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.healthCheck.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceHealthCheck).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -34199,10 +33518,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.urlMap.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceUrlMap).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.urlMap.defaultServiceUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceUrlMap).DefaultServiceUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.urlMap.defaultService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34229,10 +33544,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceUrlMap).SelfLink, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.urlMap.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceUrlMap).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.urlMap.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceUrlMap).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -34257,10 +33568,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.targetHttpProxy.urlMapUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).UrlMapUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.targetHttpProxy.urlMap": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).UrlMap, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceUrlMap](v.Value, v.Error)
 		return
@@ -34275,10 +33582,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetHttpProxy.proxyBind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).ProxyBind, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.targetHttpProxy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetHttpProxy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetHttpProxy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34305,10 +33608,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.targetHttpsProxy.urlMapUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).UrlMapUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.targetHttpsProxy.urlMap": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).UrlMap, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceUrlMap](v.Value, v.Error)
 		return
@@ -34319,10 +33618,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetHttpsProxy.sslCertificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).SslCertificates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.targetHttpsProxy.sslPolicyUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).SslPolicyUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetHttpsProxy.sslPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34361,10 +33656,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).ProxyBind, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.targetHttpsProxy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.targetHttpsProxy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -34379,10 +33670,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.network.peering.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetworkPeering).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.network.peering.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkPeering).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.network.peering.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34443,10 +33730,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.route.priority": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceRoute).Priority, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.route.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceRoute).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.route.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34585,10 +33868,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceServiceAttachment).ReconcileConnections, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.serviceAttachment.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceServiceAttachment).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.serviceAttachment.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceServiceAttachment).Region, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceRegion](v.Value, v.Error)
 		return
@@ -34633,32 +33912,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).Size, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.networkEndpointGroup.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.networkEndpointGroup.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.networkEndpointGroup.subnetworkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).SubnetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.networkEndpointGroup.subnetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).Subnetwork, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSubnetwork](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.networkEndpointGroup.zoneUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).ZoneUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.networkEndpointGroup.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).Zone, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceZone](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.networkEndpointGroup.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceNetworkEndpointGroup).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.networkEndpointGroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34841,16 +34104,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).EdgeAvailabilityDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.interconnectAttachment.interconnectUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).InterconnectUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.interconnectAttachment.interconnect": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).Interconnect, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceInterconnect](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.interconnectAttachment.routerUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).RouterUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.interconnectAttachment.router": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34891,10 +34146,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.interconnectAttachment.privateInterconnectInfo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).PrivateInterconnectInfo, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.interconnectAttachment.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.interconnectAttachment.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34977,16 +34228,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceTargetTcpProxy).ProxyBind, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.targetTcpProxy.serviceUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetTcpProxy).ServiceUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.targetTcpProxy.service": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetTcpProxy).Service, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceBackendService](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.targetTcpProxy.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetTcpProxy).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetTcpProxy.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35021,10 +34264,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceTargetSslProxy).ProxyHeader, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.targetSslProxy.serviceUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetSslProxy).ServiceUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.targetSslProxy.service": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetSslProxy).Service, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceBackendService](v.Value, v.Error)
 		return
@@ -35035,10 +34274,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetSslProxy.sslCertificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetSslProxy).SslCertificates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.targetSslProxy.sslPolicyUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetSslProxy).SslPolicyUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetSslProxy.sslPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35095,10 +34330,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.packetMirroring.filter": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServicePacketMirroring).Filter, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.packetMirroring.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServicePacketMirroring).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.packetMirroring.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35185,10 +34416,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceTargetPool).FailoverRatio, ok = plugin.RawToTValue[float64](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.targetPool.backupPoolUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetPool).BackupPoolUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.targetPool.backupPool": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetPool).BackupPool, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceTargetPool](v.Value, v.Error)
 		return
@@ -35209,16 +34436,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceTargetPool).InstanceRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.computeService.targetPool.securityPolicyUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetPool).SecurityPolicyUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.computeService.targetPool.securityPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetPool).SecurityPolicy, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceSecurityPolicy](v.Value, v.Error)
-		return
-	},
-	"gcp.project.computeService.targetPool.regionUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectComputeServiceTargetPool).RegionUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetPool.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35615,10 +34834,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.artifactRegistryService.repository.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectArtifactRegistryServiceRepository).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.artifactRegistryService.repository.kmsKeyName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectArtifactRegistryServiceRepository).KmsKeyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.artifactRegistryService.repository.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36421,10 +35636,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.vertexaiService.endpoint.deployedModels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServiceEndpoint).DeployedModels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.vertexaiService.endpoint.deployments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).Deployments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -36435,10 +35646,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.vertexaiService.endpoint.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceEndpoint).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
-		return
-	},
-	"gcp.project.vertexaiService.endpoint.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServiceEndpoint).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.endpoint.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36589,16 +35796,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectVertexaiServicePipelineJob).RuntimeConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.vertexaiService.pipelineJob.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServicePipelineJob).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.vertexaiService.pipelineJob.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServicePipelineJob).ServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
-		return
-	},
-	"gcp.project.vertexaiService.pipelineJob.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServicePipelineJob).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.pipelineJob.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36821,16 +36020,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectVertexaiServiceCustomJob).JobSpec, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.vertexaiService.customJob.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServiceCustomJob).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.vertexaiService.customJob.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceCustomJob).ServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
-		return
-	},
-	"gcp.project.vertexaiService.customJob.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServiceCustomJob).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.customJob.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36951,10 +36142,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.vertexaiService.indexEndpoint.deployedIndexes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).DeployedIndexes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.vertexaiService.indexEndpoint.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServiceIndexEndpoint).Network, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.indexEndpoint.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -37255,10 +36442,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.vertexaiService.notebookExecutionJob.notebookRuntimeTemplateRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectVertexaiServiceNotebookExecutionJob).NotebookRuntimeTemplateRef, ok = plugin.RawToTValue[*mqlGcpProjectVertexaiServiceNotebookRuntimeTemplate](v.Value, v.Error)
-		return
-	},
-	"gcp.project.vertexaiService.notebookExecutionJob.scheduleResourceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectVertexaiServiceNotebookExecutionJob).ScheduleResourceName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.vertexaiService.notebookExecutionJob.scheduleRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -38273,14 +37456,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpAccesscontextmanagerServicePerimeter).PerimeterType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.accesscontextmanager.servicePerimeter.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpAccesscontextmanagerServicePerimeter).Status, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.accesscontextmanager.servicePerimeter.spec": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpAccesscontextmanagerServicePerimeter).Spec, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"gcp.accesscontextmanager.servicePerimeter.statusConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpAccesscontextmanagerServicePerimeter).StatusConfig, ok = plugin.RawToTValue[*mqlGcpAccesscontextmanagerServicePerimeterConfig](v.Value, v.Error)
 		return
@@ -38833,10 +38008,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectEventarcServiceTrigger).EventFilters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"gcp.project.eventarcService.trigger.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectEventarcServiceTrigger).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.eventarcService.trigger.serviceAccountRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectEventarcServiceTrigger).ServiceAccountRef, ok = plugin.RawToTValue[*mqlGcpProjectIamServiceServiceAccount](v.Value, v.Error)
 		return
@@ -38915,10 +38086,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.eventarcService.channel.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectEventarcServiceChannel).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.eventarcService.channel.cryptoKeyName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectEventarcServiceChannel).CryptoKeyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.eventarcService.channel.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39625,10 +38792,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectIdsServiceEndpoint).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.idsService.endpoint.networkUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectIdsServiceEndpoint).NetworkUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.idsService.endpoint.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectIdsServiceEndpoint).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -40205,10 +39368,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).Remediation, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.containerAnalysisService.occurrence.vulnerability": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).Vulnerability, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"gcp.project.containerAnalysisService.occurrence.vulnerabilitySeverity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).VulnerabilitySeverity, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -40235,10 +39394,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.containerAnalysisService.occurrence.vulnerabilityPackageIssues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).VulnerabilityPackageIssues, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.containerAnalysisService.occurrence.build": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).Build, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.containerAnalysisService.occurrence.buildProvenanceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40295,10 +39450,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.containerAnalysisService.occurrence.discovery": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).Discovery, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.containerAnalysisService.occurrence.attestation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectContainerAnalysisServiceOccurrence).Attestation, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.containerAnalysisService.occurrence.attestationSerializedPayload": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40419,10 +39570,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudBuildService.trigger.substitutions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudBuildServiceTrigger).Substitutions, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
-		return
-	},
-	"gcp.project.cloudBuildService.trigger.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudBuildServiceTrigger).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudBuildService.trigger.iamServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40613,10 +39760,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).PeeredNetwork, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig).PeeredNetworkRef, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
@@ -40691,10 +39834,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.cloudBuildService.build.logsBucket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudBuildServiceBuild).LogsBucket, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"gcp.project.cloudBuildService.build.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGcpProjectCloudBuildServiceBuild).ServiceAccount, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.cloudBuildService.build.iamServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -43838,7 +42977,6 @@ type mqlGcpProjectRedisServiceInstance struct {
 	StatusMessage                plugin.TValue[string]
 	RedisConfigs                 plugin.TValue[map[string]any]
 	MemorySizeGb                 plugin.TValue[int64]
-	AuthorizedNetwork            plugin.TValue[string]
 	Network                      plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PersistenceIamIdentity       plugin.TValue[string]
 	PersistenceServiceAccount    plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
@@ -43848,7 +42986,6 @@ type mqlGcpProjectRedisServiceInstance struct {
 	Nodes                        plugin.TValue[[]any]
 	ReadEndpoint                 plugin.TValue[string]
 	ReadEndpointPort             plugin.TValue[int64]
-	CustomerManagedKey           plugin.TValue[string]
 	KmsKey                       plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	MaintenanceVersion           plugin.TValue[string]
 	AvailableMaintenanceVersions plugin.TValue[[]any]
@@ -43965,10 +43102,6 @@ func (c *mqlGcpProjectRedisServiceInstance) GetMemorySizeGb() *plugin.TValue[int
 	return &c.MemorySizeGb
 }
 
-func (c *mqlGcpProjectRedisServiceInstance) GetAuthorizedNetwork() *plugin.TValue[string] {
-	return &c.AuthorizedNetwork
-}
-
 func (c *mqlGcpProjectRedisServiceInstance) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -44027,10 +43160,6 @@ func (c *mqlGcpProjectRedisServiceInstance) GetReadEndpoint() *plugin.TValue[str
 
 func (c *mqlGcpProjectRedisServiceInstance) GetReadEndpointPort() *plugin.TValue[int64] {
 	return &c.ReadEndpointPort
-}
-
-func (c *mqlGcpProjectRedisServiceInstance) GetCustomerManagedKey() *plugin.TValue[string] {
-	return &c.CustomerManagedKey
 }
 
 func (c *mqlGcpProjectRedisServiceInstance) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -44251,7 +43380,6 @@ type mqlGcpProjectRedisServiceCluster struct {
 	SizeGb                               plugin.TValue[int64]
 	PreciseSizeGb                        plugin.TValue[float64]
 	DeletionProtectionEnabled            plugin.TValue[bool]
-	KmsKey                               plugin.TValue[string]
 	CryptoKey                            plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	BackupCollection                     plugin.TValue[string]
 	RedisConfigs                         plugin.TValue[map[string]any]
@@ -44364,10 +43492,6 @@ func (c *mqlGcpProjectRedisServiceCluster) GetPreciseSizeGb() *plugin.TValue[flo
 
 func (c *mqlGcpProjectRedisServiceCluster) GetDeletionProtectionEnabled() *plugin.TValue[bool] {
 	return &c.DeletionProtectionEnabled
-}
-
-func (c *mqlGcpProjectRedisServiceCluster) GetKmsKey() *plugin.TValue[string] {
-	return &c.KmsKey
 }
 
 func (c *mqlGcpProjectRedisServiceCluster) GetCryptoKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -48272,7 +47396,7 @@ func (c *mqlGcpProjectComputeService) GetSharedVpcServiceProjects() *plugin.TVal
 type mqlGcpProjectComputeServiceAddress struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceAddressInternal it will be used here
+	mqlGcpProjectComputeServiceAddressInternal
 	Id               plugin.TValue[string]
 	Address          plugin.TValue[string]
 	AddressType      plugin.TValue[string]
@@ -48282,15 +47406,12 @@ type mqlGcpProjectComputeServiceAddress struct {
 	Ipv6EndpointType plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Labels           plugin.TValue[map[string]any]
-	NetworkUrl       plugin.TValue[string]
 	Network          plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	NetworkTier      plugin.TValue[string]
 	PrefixLength     plugin.TValue[int64]
 	Purpose          plugin.TValue[string]
-	RegionUrl        plugin.TValue[string]
 	Region           plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	Status           plugin.TValue[string]
-	SubnetworkUrl    plugin.TValue[string]
 	Subnetwork       plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
 	ResourceUrls     plugin.TValue[[]any]
 }
@@ -48368,10 +47489,6 @@ func (c *mqlGcpProjectComputeServiceAddress) GetLabels() *plugin.TValue[map[stri
 	return &c.Labels
 }
 
-func (c *mqlGcpProjectComputeServiceAddress) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
-}
-
 func (c *mqlGcpProjectComputeServiceAddress) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -48400,10 +47517,6 @@ func (c *mqlGcpProjectComputeServiceAddress) GetPurpose() *plugin.TValue[string]
 	return &c.Purpose
 }
 
-func (c *mqlGcpProjectComputeServiceAddress) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceAddress) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -48422,10 +47535,6 @@ func (c *mqlGcpProjectComputeServiceAddress) GetRegion() *plugin.TValue[*mqlGcpP
 
 func (c *mqlGcpProjectComputeServiceAddress) GetStatus() *plugin.TValue[string] {
 	return &c.Status
-}
-
-func (c *mqlGcpProjectComputeServiceAddress) GetSubnetworkUrl() *plugin.TValue[string] {
-	return &c.SubnetworkUrl
 }
 
 func (c *mqlGcpProjectComputeServiceAddress) GetSubnetwork() *plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork] {
@@ -48452,13 +47561,12 @@ func (c *mqlGcpProjectComputeServiceAddress) GetResourceUrls() *plugin.TValue[[]
 type mqlGcpProjectComputeServiceForwardingRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceForwardingRuleInternal it will be used here
+	mqlGcpProjectComputeServiceForwardingRuleInternal
 	Id                            plugin.TValue[string]
 	IpAddress                     plugin.TValue[string]
 	IpProtocol                    plugin.TValue[string]
 	AllPorts                      plugin.TValue[bool]
 	AllowGlobalAccess             plugin.TValue[bool]
-	BackendServiceUrl             plugin.TValue[string]
 	BackendService                plugin.TValue[*mqlGcpProjectComputeServiceBackendService]
 	Created                       plugin.TValue[*time.Time]
 	Description                   plugin.TValue[string]
@@ -48469,18 +47577,15 @@ type mqlGcpProjectComputeServiceForwardingRule struct {
 	IsExternal                    plugin.TValue[bool]
 	MetadataFilters               plugin.TValue[[]any]
 	Name                          plugin.TValue[string]
-	NetworkUrl                    plugin.TValue[string]
 	Network                       plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	NetworkTier                   plugin.TValue[string]
 	NoAutomateDnsZone             plugin.TValue[bool]
 	PortRange                     plugin.TValue[string]
 	Ports                         plugin.TValue[[]any]
-	RegionUrl                     plugin.TValue[string]
 	Region                        plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	ServiceDirectoryRegistrations plugin.TValue[[]any]
 	ServiceLabel                  plugin.TValue[string]
 	ServiceName                   plugin.TValue[string]
-	SubnetworkUrl                 plugin.TValue[string]
 	Subnetwork                    plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
 	TargetUrl                     plugin.TValue[string]
 	TargetPool                    plugin.TValue[*mqlGcpProjectComputeServiceTargetPool]
@@ -48553,10 +47658,6 @@ func (c *mqlGcpProjectComputeServiceForwardingRule) GetAllowGlobalAccess() *plug
 	return &c.AllowGlobalAccess
 }
 
-func (c *mqlGcpProjectComputeServiceForwardingRule) GetBackendServiceUrl() *plugin.TValue[string] {
-	return &c.BackendServiceUrl
-}
-
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetBackendService() *plugin.TValue[*mqlGcpProjectComputeServiceBackendService] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceBackendService](&c.BackendService, func() (*mqlGcpProjectComputeServiceBackendService, error) {
 		if c.MqlRuntime.HasRecording {
@@ -48611,10 +47712,6 @@ func (c *mqlGcpProjectComputeServiceForwardingRule) GetName() *plugin.TValue[str
 	return &c.Name
 }
 
-func (c *mqlGcpProjectComputeServiceForwardingRule) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
-}
-
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -48647,10 +47744,6 @@ func (c *mqlGcpProjectComputeServiceForwardingRule) GetPorts() *plugin.TValue[[]
 	return &c.Ports
 }
 
-func (c *mqlGcpProjectComputeServiceForwardingRule) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -48677,10 +47770,6 @@ func (c *mqlGcpProjectComputeServiceForwardingRule) GetServiceLabel() *plugin.TV
 
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetServiceName() *plugin.TValue[string] {
 	return &c.ServiceName
-}
-
-func (c *mqlGcpProjectComputeServiceForwardingRule) GetSubnetworkUrl() *plugin.TValue[string] {
-	return &c.SubnetworkUrl
 }
 
 func (c *mqlGcpProjectComputeServiceForwardingRule) GetSubnetwork() *plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork] {
@@ -49068,7 +48157,6 @@ type mqlGcpProjectComputeServiceInstance struct {
 	ProjectId                       plugin.TValue[string]
 	Name                            plugin.TValue[string]
 	Description                     plugin.TValue[string]
-	ConfidentialInstanceConfig      plugin.TValue[any]
 	ConfidentialCompute             plugin.TValue[*mqlGcpProjectComputeServiceInstanceConfidentialCompute]
 	CanIpForward                    plugin.TValue[bool]
 	CpuPlatform                     plugin.TValue[string]
@@ -49086,7 +48174,6 @@ type mqlGcpProjectComputeServiceInstance struct {
 	LastSuspendedTimestamp          plugin.TValue[*time.Time]
 	Metadata                        plugin.TValue[map[string]any]
 	MinCpuPlatform                  plugin.TValue[string]
-	NetworkInterfaces               plugin.TValue[[]any]
 	Nics                            plugin.TValue[[]any]
 	NetworkStackTypes               plugin.TValue[[]any]
 	HasPublicIp                     plugin.TValue[bool]
@@ -49105,9 +48192,6 @@ type mqlGcpProjectComputeServiceInstance struct {
 	Scheduling                      plugin.TValue[any]
 	ShieldedInstanceConfig          plugin.TValue[*mqlGcpProjectComputeServiceInstanceShieldedInstanceConfig]
 	ShieldedInstanceIntegrityPolicy plugin.TValue[any]
-	EnableIntegrityMonitoring       plugin.TValue[bool]
-	EnableSecureBoot                plugin.TValue[bool]
-	EnableVtpm                      plugin.TValue[bool]
 	StartRestricted                 plugin.TValue[bool]
 	Status                          plugin.TValue[string]
 	StatusMessage                   plugin.TValue[string]
@@ -49185,10 +48269,6 @@ func (c *mqlGcpProjectComputeServiceInstance) GetDescription() *plugin.TValue[st
 	return &c.Description
 }
 
-func (c *mqlGcpProjectComputeServiceInstance) GetConfidentialInstanceConfig() *plugin.TValue[any] {
-	return &c.ConfidentialInstanceConfig
-}
-
 func (c *mqlGcpProjectComputeServiceInstance) GetConfidentialCompute() *plugin.TValue[*mqlGcpProjectComputeServiceInstanceConfidentialCompute] {
 	return &c.ConfidentialCompute
 }
@@ -49255,10 +48335,6 @@ func (c *mqlGcpProjectComputeServiceInstance) GetMetadata() *plugin.TValue[map[s
 
 func (c *mqlGcpProjectComputeServiceInstance) GetMinCpuPlatform() *plugin.TValue[string] {
 	return &c.MinCpuPlatform
-}
-
-func (c *mqlGcpProjectComputeServiceInstance) GetNetworkInterfaces() *plugin.TValue[[]any] {
-	return &c.NetworkInterfaces
 }
 
 func (c *mqlGcpProjectComputeServiceInstance) GetNics() *plugin.TValue[[]any] {
@@ -49359,18 +48435,6 @@ func (c *mqlGcpProjectComputeServiceInstance) GetShieldedInstanceConfig() *plugi
 
 func (c *mqlGcpProjectComputeServiceInstance) GetShieldedInstanceIntegrityPolicy() *plugin.TValue[any] {
 	return &c.ShieldedInstanceIntegrityPolicy
-}
-
-func (c *mqlGcpProjectComputeServiceInstance) GetEnableIntegrityMonitoring() *plugin.TValue[bool] {
-	return &c.EnableIntegrityMonitoring
-}
-
-func (c *mqlGcpProjectComputeServiceInstance) GetEnableSecureBoot() *plugin.TValue[bool] {
-	return &c.EnableSecureBoot
-}
-
-func (c *mqlGcpProjectComputeServiceInstance) GetEnableVtpm() *plugin.TValue[bool] {
-	return &c.EnableVtpm
 }
 
 func (c *mqlGcpProjectComputeServiceInstance) GetStartRestricted() *plugin.TValue[bool] {
@@ -49718,8 +48782,6 @@ type mqlGcpProjectComputeServiceInstanceOsInventory struct {
 	__id       string
 	// optional: if you define mqlGcpProjectComputeServiceInstanceOsInventoryInternal it will be used here
 	Name                 plugin.TValue[string]
-	OsInfo               plugin.TValue[any]
-	Items                plugin.TValue[[]any]
 	OsHostname           plugin.TValue[string]
 	OsLongName           plugin.TValue[string]
 	OsShortName          plugin.TValue[string]
@@ -49771,14 +48833,6 @@ func (c *mqlGcpProjectComputeServiceInstanceOsInventory) MqlID() string {
 
 func (c *mqlGcpProjectComputeServiceInstanceOsInventory) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlGcpProjectComputeServiceInstanceOsInventory) GetOsInfo() *plugin.TValue[any] {
-	return &c.OsInfo
-}
-
-func (c *mqlGcpProjectComputeServiceInstanceOsInventory) GetItems() *plugin.TValue[[]any] {
-	return &c.Items
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceOsInventory) GetOsHostname() *plugin.TValue[string] {
@@ -49901,7 +48955,6 @@ type mqlGcpProjectComputeServiceInstanceVulnerabilityReport struct {
 	__id       string
 	// optional: if you define mqlGcpProjectComputeServiceInstanceVulnerabilityReportInternal it will be used here
 	Name                         plugin.TValue[string]
-	Vulnerabilities              plugin.TValue[[]any]
 	VulnerabilityDetails         plugin.TValue[[]any]
 	HighestUpgradableCveSeverity plugin.TValue[string]
 	UpdateTime                   plugin.TValue[*time.Time]
@@ -49946,10 +48999,6 @@ func (c *mqlGcpProjectComputeServiceInstanceVulnerabilityReport) MqlID() string 
 
 func (c *mqlGcpProjectComputeServiceInstanceVulnerabilityReport) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlGcpProjectComputeServiceInstanceVulnerabilityReport) GetVulnerabilities() *plugin.TValue[[]any] {
-	return &c.Vulnerabilities
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceVulnerabilityReport) GetVulnerabilityDetails() *plugin.TValue[[]any] {
@@ -51351,7 +50400,6 @@ type mqlGcpProjectComputeServiceNetwork struct {
 	Mtu                                   plugin.TValue[int64]
 	NetworkFirewallPolicyEnforcementOrder plugin.TValue[string]
 	Created                               plugin.TValue[*time.Time]
-	Peerings                              plugin.TValue[[]any]
 	NetworkPeerings                       plugin.TValue[[]any]
 	RoutingMode                           plugin.TValue[string]
 	Mode                                  plugin.TValue[string]
@@ -51363,7 +50411,6 @@ type mqlGcpProjectComputeServiceNetwork struct {
 	FirewallPolicy                        plugin.TValue[string]
 	FirewallPolicyRef                     plugin.TValue[*mqlGcpProjectComputeServiceFirewallPolicy]
 	NetworkProfile                        plugin.TValue[string]
-	Ipv4Range                             plugin.TValue[string]
 }
 
 // createGcpProjectComputeServiceNetwork creates a new instance of this resource
@@ -51447,10 +50494,6 @@ func (c *mqlGcpProjectComputeServiceNetwork) GetNetworkFirewallPolicyEnforcement
 
 func (c *mqlGcpProjectComputeServiceNetwork) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
-}
-
-func (c *mqlGcpProjectComputeServiceNetwork) GetPeerings() *plugin.TValue[[]any] {
-	return &c.Peerings
 }
 
 func (c *mqlGcpProjectComputeServiceNetwork) GetNetworkPeerings() *plugin.TValue[[]any] {
@@ -51557,15 +50600,11 @@ func (c *mqlGcpProjectComputeServiceNetwork) GetNetworkProfile() *plugin.TValue[
 	return &c.NetworkProfile
 }
 
-func (c *mqlGcpProjectComputeServiceNetwork) GetIpv4Range() *plugin.TValue[string] {
-	return &c.Ipv4Range
-}
-
 // mqlGcpProjectComputeServiceSubnetwork for the gcp.project.computeService.subnetwork resource
 type mqlGcpProjectComputeServiceSubnetwork struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceSubnetworkInternal it will be used here
+	mqlGcpProjectComputeServiceSubnetworkInternal
 	Id                           plugin.TValue[string]
 	ProjectId                    plugin.TValue[string]
 	Name                         plugin.TValue[string]
@@ -51583,13 +50622,11 @@ type mqlGcpProjectComputeServiceSubnetwork struct {
 	PrivateIpv6GoogleAccess      plugin.TValue[string]
 	Purpose                      plugin.TValue[string]
 	Region                       plugin.TValue[*mqlGcpProjectComputeServiceRegion]
-	RegionUrl                    plugin.TValue[string]
 	Role                         plugin.TValue[string]
 	StackType                    plugin.TValue[string]
 	State                        plugin.TValue[string]
 	Created                      plugin.TValue[*time.Time]
 	ReservedInternalRange        plugin.TValue[string]
-	NetworkUrl                   plugin.TValue[string]
 	Network                      plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	AllowSubnetCidrRoutesOverlap plugin.TValue[bool]
 	SecondaryIpRanges            plugin.TValue[[]any]
@@ -51712,10 +50749,6 @@ func (c *mqlGcpProjectComputeServiceSubnetwork) GetRegion() *plugin.TValue[*mqlG
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceSubnetwork) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceSubnetwork) GetRole() *plugin.TValue[string] {
 	return &c.Role
 }
@@ -51734,10 +50767,6 @@ func (c *mqlGcpProjectComputeServiceSubnetwork) GetCreated() *plugin.TValue[*tim
 
 func (c *mqlGcpProjectComputeServiceSubnetwork) GetReservedInternalRange() *plugin.TValue[string] {
 	return &c.ReservedInternalRange
-}
-
-func (c *mqlGcpProjectComputeServiceSubnetwork) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
 }
 
 func (c *mqlGcpProjectComputeServiceSubnetwork) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -51854,7 +50883,6 @@ type mqlGcpProjectComputeServiceRouter struct {
 	Bgp                         plugin.TValue[any]
 	BgpPeers                    plugin.TValue[[]any]
 	EncryptedInterconnectRouter plugin.TValue[bool]
-	Nats                        plugin.TValue[[]any]
 	NatServices                 plugin.TValue[[]any]
 	Created                     plugin.TValue[*time.Time]
 	Network                     plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
@@ -51921,10 +50949,6 @@ func (c *mqlGcpProjectComputeServiceRouter) GetEncryptedInterconnectRouter() *pl
 	return &c.EncryptedInterconnectRouter
 }
 
-func (c *mqlGcpProjectComputeServiceRouter) GetNats() *plugin.TValue[[]any] {
-	return &c.Nats
-}
-
 func (c *mqlGcpProjectComputeServiceRouter) GetNatServices() *plugin.TValue[[]any] {
 	return &c.NatServices
 }
@@ -51953,7 +50977,7 @@ func (c *mqlGcpProjectComputeServiceRouter) GetNetwork() *plugin.TValue[*mqlGcpP
 type mqlGcpProjectComputeServiceBackendService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceBackendServiceInternal it will be used here
+	mqlGcpProjectComputeServiceBackendServiceInternal
 	Id                              plugin.TValue[string]
 	AffinityCookieTtlSec            plugin.TValue[int64]
 	Backends                        plugin.TValue[[]any]
@@ -51967,7 +50991,6 @@ type mqlGcpProjectComputeServiceBackendService struct {
 	CustomRequestHeaders            plugin.TValue[[]any]
 	CustomResponseHeaders           plugin.TValue[[]any]
 	Description                     plugin.TValue[string]
-	EdgeSecurityPolicyUrl           plugin.TValue[string]
 	EdgeSecurityPolicy              plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy]
 	EnableCDN                       plugin.TValue[bool]
 	FailoverPolicy                  plugin.TValue[any]
@@ -51980,13 +51003,10 @@ type mqlGcpProjectComputeServiceBackendService struct {
 	LogConfig                       plugin.TValue[any]
 	MaxStreamDuration               plugin.TValue[*time.Time]
 	Name                            plugin.TValue[string]
-	NetworkUrl                      plugin.TValue[string]
 	Network                         plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PortName                        plugin.TValue[string]
 	Protocol                        plugin.TValue[string]
-	RegionUrl                       plugin.TValue[string]
 	Region                          plugin.TValue[*mqlGcpProjectComputeServiceRegion]
-	SecurityPolicyUrl               plugin.TValue[string]
 	SecurityPolicy                  plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy]
 	CloudArmorEnabled               plugin.TValue[bool]
 	IapEnabled                      plugin.TValue[bool]
@@ -52093,10 +51113,6 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetDescription() *plugin.TVa
 	return &c.Description
 }
 
-func (c *mqlGcpProjectComputeServiceBackendService) GetEdgeSecurityPolicyUrl() *plugin.TValue[string] {
-	return &c.EdgeSecurityPolicyUrl
-}
-
 func (c *mqlGcpProjectComputeServiceBackendService) GetEdgeSecurityPolicy() *plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceSecurityPolicy](&c.EdgeSecurityPolicy, func() (*mqlGcpProjectComputeServiceSecurityPolicy, error) {
 		if c.MqlRuntime.HasRecording {
@@ -52169,10 +51185,6 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetName() *plugin.TValue[str
 	return &c.Name
 }
 
-func (c *mqlGcpProjectComputeServiceBackendService) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
-}
-
 func (c *mqlGcpProjectComputeServiceBackendService) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -52197,10 +51209,6 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetProtocol() *plugin.TValue
 	return &c.Protocol
 }
 
-func (c *mqlGcpProjectComputeServiceBackendService) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceBackendService) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -52215,10 +51223,6 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetRegion() *plugin.TValue[*
 
 		return c.region()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceBackendService) GetSecurityPolicyUrl() *plugin.TValue[string] {
-	return &c.SecurityPolicyUrl
 }
 
 func (c *mqlGcpProjectComputeServiceBackendService) GetSecurityPolicy() *plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy] {
@@ -52303,13 +51307,12 @@ func (c *mqlGcpProjectComputeServiceBackendService) GetSelfLink() *plugin.TValue
 type mqlGcpProjectComputeServiceBackendServiceBackend struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceBackendServiceBackendInternal it will be used here
+	mqlGcpProjectComputeServiceBackendServiceBackendInternal
 	Id                        plugin.TValue[string]
 	BalancingMode             plugin.TValue[string]
 	CapacityScaler            plugin.TValue[float64]
 	Description               plugin.TValue[string]
 	Failover                  plugin.TValue[bool]
-	GroupUrl                  plugin.TValue[string]
 	InstanceGroup             plugin.TValue[*mqlGcpProjectComputeServiceInstanceGroup]
 	NetworkEndpointGroup      plugin.TValue[*mqlGcpProjectComputeServiceNetworkEndpointGroup]
 	MaxConnections            plugin.TValue[int64]
@@ -52376,10 +51379,6 @@ func (c *mqlGcpProjectComputeServiceBackendServiceBackend) GetDescription() *plu
 
 func (c *mqlGcpProjectComputeServiceBackendServiceBackend) GetFailover() *plugin.TValue[bool] {
 	return &c.Failover
-}
-
-func (c *mqlGcpProjectComputeServiceBackendServiceBackend) GetGroupUrl() *plugin.TValue[string] {
-	return &c.GroupUrl
 }
 
 func (c *mqlGcpProjectComputeServiceBackendServiceBackend) GetInstanceGroup() *plugin.TValue[*mqlGcpProjectComputeServiceInstanceGroup] {
@@ -53368,7 +52367,6 @@ type mqlGcpProjectSqlServiceInstance struct {
 	KmsKey                                     plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	FailoverReplica                            plugin.TValue[any]
 	FailoverReplicaRef                         plugin.TValue[*mqlGcpProjectSqlServiceInstance]
-	GceZone                                    plugin.TValue[string]
 	Zone                                       plugin.TValue[*mqlGcpProjectComputeServiceZone]
 	InstanceType                               plugin.TValue[string]
 	IpAddresses                                plugin.TValue[[]any]
@@ -53388,7 +52386,6 @@ type mqlGcpProjectSqlServiceInstance struct {
 	PointInTimeRecoveryEnabled                 plugin.TValue[bool]
 	HasBuiltInUsers                            plugin.TValue[bool]
 	LocalRootEnabled                           plugin.TValue[bool]
-	ServiceAccountEmailAddress                 plugin.TValue[string]
 	ServiceAccount                             plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	State                                      plugin.TValue[string]
 	Databases                                  plugin.TValue[[]any]
@@ -53526,10 +52523,6 @@ func (c *mqlGcpProjectSqlServiceInstance) GetFailoverReplicaRef() *plugin.TValue
 	})
 }
 
-func (c *mqlGcpProjectSqlServiceInstance) GetGceZone() *plugin.TValue[string] {
-	return &c.GceZone
-}
-
 func (c *mqlGcpProjectSqlServiceInstance) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceZone](&c.Zone, func() (*mqlGcpProjectComputeServiceZone, error) {
 		if c.MqlRuntime.HasRecording {
@@ -53654,10 +52647,6 @@ func (c *mqlGcpProjectSqlServiceInstance) GetLocalRootEnabled() *plugin.TValue[b
 	return plugin.GetOrCompute[bool](&c.LocalRootEnabled, func() (bool, error) {
 		return c.localRootEnabled()
 	})
-}
-
-func (c *mqlGcpProjectSqlServiceInstance) GetServiceAccountEmailAddress() *plugin.TValue[string] {
-	return &c.ServiceAccountEmailAddress
 }
 
 func (c *mqlGcpProjectSqlServiceInstance) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
@@ -54308,7 +53297,6 @@ type mqlGcpProjectSqlServiceInstanceSettings struct {
 	ProjectId                   plugin.TValue[string]
 	InstanceName                plugin.TValue[string]
 	ActivationPolicy            plugin.TValue[string]
-	ActiveDirectoryConfig       plugin.TValue[any]
 	ActiveDirectory             plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory]
 	AvailabilityType            plugin.TValue[string]
 	BackupConfiguration         plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsBackupconfiguration]
@@ -54390,10 +53378,6 @@ func (c *mqlGcpProjectSqlServiceInstanceSettings) GetInstanceName() *plugin.TVal
 
 func (c *mqlGcpProjectSqlServiceInstanceSettings) GetActivationPolicy() *plugin.TValue[string] {
 	return &c.ActivationPolicy
-}
-
-func (c *mqlGcpProjectSqlServiceInstanceSettings) GetActiveDirectoryConfig() *plugin.TValue[any] {
-	return &c.ActiveDirectoryConfig
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceSettings) GetActiveDirectory() *plugin.TValue[*mqlGcpProjectSqlServiceInstanceSettingsActiveDirectory] {
@@ -54745,13 +53729,12 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsDenyMaintenancePeriod) GetTime()
 type mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationInternal it will be used here
+	mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationInternal
 	Id                                      plugin.TValue[string]
 	AllocatedIpRange                        plugin.TValue[string]
 	AuthorizedNetworks                      plugin.TValue[[]any]
 	HasOpenAuthorizedNetworks               plugin.TValue[bool]
 	Ipv4Enabled                             plugin.TValue[bool]
-	PrivateNetwork                          plugin.TValue[string]
 	Network                                 plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	RequireSsl                              plugin.TValue[bool]
 	SslMode                                 plugin.TValue[string]
@@ -54820,10 +53803,6 @@ func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetHasOpenAutho
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetIpv4Enabled() *plugin.TValue[bool] {
 	return &c.Ipv4Enabled
-}
-
-func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetPrivateNetwork() *plugin.TValue[string] {
-	return &c.PrivateNetwork
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -55195,7 +54174,6 @@ type mqlGcpProjectBigqueryServiceDataset struct {
 	Created                      plugin.TValue[*time.Time]
 	Modified                     plugin.TValue[*time.Time]
 	Tags                         plugin.TValue[map[string]any]
-	KmsName                      plugin.TValue[string]
 	KmsKey                       plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	Access                       plugin.TValue[[]any]
 	Public                       plugin.TValue[bool]
@@ -55283,10 +54261,6 @@ func (c *mqlGcpProjectBigqueryServiceDataset) GetModified() *plugin.TValue[*time
 
 func (c *mqlGcpProjectBigqueryServiceDataset) GetTags() *plugin.TValue[map[string]any] {
 	return &c.Tags
-}
-
-func (c *mqlGcpProjectBigqueryServiceDataset) GetKmsName() *plugin.TValue[string] {
-	return &c.KmsName
 }
 
 func (c *mqlGcpProjectBigqueryServiceDataset) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -55502,7 +54476,6 @@ type mqlGcpProjectBigqueryServiceTable struct {
 	NumRows                plugin.TValue[int64]
 	Type                   plugin.TValue[string]
 	ExpirationTime         plugin.TValue[*time.Time]
-	KmsName                plugin.TValue[string]
 	KmsKey                 plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	SnapshotTime           plugin.TValue[*time.Time]
 	SnapshotBaseTable      plugin.TValue[*mqlGcpProjectBigqueryServiceTable]
@@ -55619,10 +54592,6 @@ func (c *mqlGcpProjectBigqueryServiceTable) GetType() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectBigqueryServiceTable) GetExpirationTime() *plugin.TValue[*time.Time] {
 	return &c.ExpirationTime
-}
-
-func (c *mqlGcpProjectBigqueryServiceTable) GetKmsName() *plugin.TValue[string] {
-	return &c.KmsName
 }
 
 func (c *mqlGcpProjectBigqueryServiceTable) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -55763,7 +54732,6 @@ type mqlGcpProjectBigqueryServiceModel struct {
 	Modified       plugin.TValue[*time.Time]
 	Type           plugin.TValue[string]
 	ExpirationTime plugin.TValue[*time.Time]
-	KmsName        plugin.TValue[string]
 	KmsKey         plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 }
 
@@ -55846,10 +54814,6 @@ func (c *mqlGcpProjectBigqueryServiceModel) GetType() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectBigqueryServiceModel) GetExpirationTime() *plugin.TValue[*time.Time] {
 	return &c.ExpirationTime
-}
-
-func (c *mqlGcpProjectBigqueryServiceModel) GetKmsName() *plugin.TValue[string] {
-	return &c.KmsName
 }
 
 func (c *mqlGcpProjectBigqueryServiceModel) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -56494,7 +55458,6 @@ type mqlGcpProjectDnsServiceManagedzone struct {
 	PrivateVisibilityConfig    plugin.TValue[any]
 	AuthorizedNetworks         plugin.TValue[[]any]
 	ForwardingTargets          plugin.TValue[[]any]
-	PeeringNetwork             plugin.TValue[string]
 	PeeringNetworkRef          plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	RecordSets                 plugin.TValue[[]any]
 	IamPolicy                  plugin.TValue[[]any]
@@ -56626,10 +55589,6 @@ func (c *mqlGcpProjectDnsServiceManagedzone) GetAuthorizedNetworks() *plugin.TVa
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetForwardingTargets() *plugin.TValue[[]any] {
 	return &c.ForwardingTargets
-}
-
-func (c *mqlGcpProjectDnsServiceManagedzone) GetPeeringNetwork() *plugin.TValue[string] {
-	return &c.PeeringNetwork
 }
 
 func (c *mqlGcpProjectDnsServiceManagedzone) GetPeeringNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -57032,9 +55991,7 @@ type mqlGcpProjectGkeServiceCluster struct {
 	Id                                       plugin.TValue[string]
 	Name                                     plugin.TValue[string]
 	Description                              plugin.TValue[string]
-	LoggingService                           plugin.TValue[string]
 	LoggingEnabled                           plugin.TValue[bool]
-	MonitoringService                        plugin.TValue[string]
 	MonitoringEnabled                        plugin.TValue[bool]
 	Network                                  plugin.TValue[string]
 	ClusterIpv4Cidr                          plugin.TValue[string]
@@ -57061,20 +56018,13 @@ type mqlGcpProjectGkeServiceCluster struct {
 	WorkloadIdentityEnabled                  plugin.TValue[bool]
 	IpAllocationPolicy                       plugin.TValue[*mqlGcpProjectGkeServiceClusterIpAllocationPolicy]
 	NetworkConfig                            plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkConfig]
-	BinaryAuthorization                      plugin.TValue[any]
-	BinaryAuthorizationEnabled               plugin.TValue[bool]
 	BinaryAuthorizationEvaluationMode        plugin.TValue[string]
 	LegacyAbac                               plugin.TValue[any]
 	LegacyAbacEnabled                        plugin.TValue[bool]
 	MasterAuth                               plugin.TValue[any]
 	ClientCertificateEnabled                 plugin.TValue[bool]
 	BasicAuthEnabled                         plugin.TValue[bool]
-	MasterAuthorizedNetworksConfig           plugin.TValue[any]
-	MasterAuthorizedNetworksEnabled          plugin.TValue[bool]
 	PrivateClusterConfig                     plugin.TValue[any]
-	PrivateNodesEnabled                      plugin.TValue[bool]
-	PrivateEndpointEnabled                   plugin.TValue[bool]
-	MasterGlobalAccessEnabled                plugin.TValue[bool]
 	ControlPlaneEndpointsConfig              plugin.TValue[any]
 	ControlPlanePublicEndpointEnabled        plugin.TValue[bool]
 	MasterAuthorizedNetworksCidrs            plugin.TValue[[]any]
@@ -57104,7 +56054,6 @@ type mqlGcpProjectGkeServiceCluster struct {
 	ConfidentialNodesConfig                  plugin.TValue[any]
 	ConfidentialNodesEnabled                 plugin.TValue[bool]
 	IdentityServiceConfig                    plugin.TValue[any]
-	NetworkPolicyConfig                      plugin.TValue[any]
 	NetworkPolicy                            plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkPolicy]
 	ReleaseChannel                           plugin.TValue[string]
 	ReleaseChannelManaged                    plugin.TValue[bool]
@@ -57179,18 +56128,10 @@ func (c *mqlGcpProjectGkeServiceCluster) GetDescription() *plugin.TValue[string]
 	return &c.Description
 }
 
-func (c *mqlGcpProjectGkeServiceCluster) GetLoggingService() *plugin.TValue[string] {
-	return &c.LoggingService
-}
-
 func (c *mqlGcpProjectGkeServiceCluster) GetLoggingEnabled() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.LoggingEnabled, func() (bool, error) {
 		return c.loggingEnabled()
 	})
-}
-
-func (c *mqlGcpProjectGkeServiceCluster) GetMonitoringService() *plugin.TValue[string] {
-	return &c.MonitoringService
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetMonitoringEnabled() *plugin.TValue[bool] {
@@ -57299,14 +56240,6 @@ func (c *mqlGcpProjectGkeServiceCluster) GetNetworkConfig() *plugin.TValue[*mqlG
 	return &c.NetworkConfig
 }
 
-func (c *mqlGcpProjectGkeServiceCluster) GetBinaryAuthorization() *plugin.TValue[any] {
-	return &c.BinaryAuthorization
-}
-
-func (c *mqlGcpProjectGkeServiceCluster) GetBinaryAuthorizationEnabled() *plugin.TValue[bool] {
-	return &c.BinaryAuthorizationEnabled
-}
-
 func (c *mqlGcpProjectGkeServiceCluster) GetBinaryAuthorizationEvaluationMode() *plugin.TValue[string] {
 	return &c.BinaryAuthorizationEvaluationMode
 }
@@ -57331,28 +56264,8 @@ func (c *mqlGcpProjectGkeServiceCluster) GetBasicAuthEnabled() *plugin.TValue[bo
 	return &c.BasicAuthEnabled
 }
 
-func (c *mqlGcpProjectGkeServiceCluster) GetMasterAuthorizedNetworksConfig() *plugin.TValue[any] {
-	return &c.MasterAuthorizedNetworksConfig
-}
-
-func (c *mqlGcpProjectGkeServiceCluster) GetMasterAuthorizedNetworksEnabled() *plugin.TValue[bool] {
-	return &c.MasterAuthorizedNetworksEnabled
-}
-
 func (c *mqlGcpProjectGkeServiceCluster) GetPrivateClusterConfig() *plugin.TValue[any] {
 	return &c.PrivateClusterConfig
-}
-
-func (c *mqlGcpProjectGkeServiceCluster) GetPrivateNodesEnabled() *plugin.TValue[bool] {
-	return &c.PrivateNodesEnabled
-}
-
-func (c *mqlGcpProjectGkeServiceCluster) GetPrivateEndpointEnabled() *plugin.TValue[bool] {
-	return &c.PrivateEndpointEnabled
-}
-
-func (c *mqlGcpProjectGkeServiceCluster) GetMasterGlobalAccessEnabled() *plugin.TValue[bool] {
-	return &c.MasterGlobalAccessEnabled
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetControlPlaneEndpointsConfig() *plugin.TValue[any] {
@@ -57485,10 +56398,6 @@ func (c *mqlGcpProjectGkeServiceCluster) GetConfidentialNodesEnabled() *plugin.T
 
 func (c *mqlGcpProjectGkeServiceCluster) GetIdentityServiceConfig() *plugin.TValue[any] {
 	return &c.IdentityServiceConfig
-}
-
-func (c *mqlGcpProjectGkeServiceCluster) GetNetworkPolicyConfig() *plugin.TValue[any] {
-	return &c.NetworkPolicyConfig
 }
 
 func (c *mqlGcpProjectGkeServiceCluster) GetNetworkPolicy() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNetworkPolicy] {
@@ -59788,11 +58697,10 @@ func (c *mqlGcpProjectPubsubServiceTopic) GetPublic() *plugin.TValue[bool] {
 type mqlGcpProjectPubsubServiceTopicConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectPubsubServiceTopicConfigInternal it will be used here
+	mqlGcpProjectPubsubServiceTopicConfigInternal
 	ProjectId                   plugin.TValue[string]
 	TopicName                   plugin.TValue[string]
 	Labels                      plugin.TValue[map[string]any]
-	KmsKeyName                  plugin.TValue[string]
 	KmsKey                      plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	MessageStoragePolicy        plugin.TValue[*mqlGcpProjectPubsubServiceTopicConfigMessagestoragepolicy]
 	State                       plugin.TValue[string]
@@ -59851,10 +58759,6 @@ func (c *mqlGcpProjectPubsubServiceTopicConfig) GetTopicName() *plugin.TValue[st
 
 func (c *mqlGcpProjectPubsubServiceTopicConfig) GetLabels() *plugin.TValue[map[string]any] {
 	return &c.Labels
-}
-
-func (c *mqlGcpProjectPubsubServiceTopicConfig) GetKmsKeyName() *plugin.TValue[string] {
-	return &c.KmsKeyName
 }
 
 func (c *mqlGcpProjectPubsubServiceTopicConfig) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -62139,7 +61043,6 @@ type mqlGcpProjectLoggingserviceBucket struct {
 	mqlGcpProjectLoggingserviceBucketInternal
 	ProjectId            plugin.TValue[string]
 	Location             plugin.TValue[string]
-	CmekSettings         plugin.TValue[any]
 	KmsKey               plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	CmekServiceAccountId plugin.TValue[string]
 	CmekServiceAccount   plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
@@ -62199,10 +61102,6 @@ func (c *mqlGcpProjectLoggingserviceBucket) GetProjectId() *plugin.TValue[string
 
 func (c *mqlGcpProjectLoggingserviceBucket) GetLocation() *plugin.TValue[string] {
 	return &c.Location
-}
-
-func (c *mqlGcpProjectLoggingserviceBucket) GetCmekSettings() *plugin.TValue[any] {
-	return &c.CmekSettings
 }
 
 func (c *mqlGcpProjectLoggingserviceBucket) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -63870,7 +62769,6 @@ type mqlGcpProjectCloudFunction struct {
 	Labels                plugin.TValue[map[string]any]
 	EnvVars               plugin.TValue[map[string]any]
 	BuildEnvVars          plugin.TValue[map[string]any]
-	Network               plugin.TValue[string]
 	NetworkRef            plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	MaxInstances          plugin.TValue[int64]
 	MinInstances          plugin.TValue[int64]
@@ -63884,7 +62782,6 @@ type mqlGcpProjectCloudFunction struct {
 	BuildName             plugin.TValue[string]
 	SecretEnvVars         plugin.TValue[map[string]any]
 	SecretVolumes         plugin.TValue[[]any]
-	DockerRepository      plugin.TValue[string]
 	DockerRepositoryRef   plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository]
 	DockerRegistry        plugin.TValue[string]
 	IamPolicy             plugin.TValue[[]any]
@@ -64057,10 +62954,6 @@ func (c *mqlGcpProjectCloudFunction) GetBuildEnvVars() *plugin.TValue[map[string
 	return &c.BuildEnvVars
 }
 
-func (c *mqlGcpProjectCloudFunction) GetNetwork() *plugin.TValue[string] {
-	return &c.Network
-}
-
 func (c *mqlGcpProjectCloudFunction) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.NetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -64135,10 +63028,6 @@ func (c *mqlGcpProjectCloudFunction) GetSecretEnvVars() *plugin.TValue[map[strin
 
 func (c *mqlGcpProjectCloudFunction) GetSecretVolumes() *plugin.TValue[[]any] {
 	return &c.SecretVolumes
-}
-
-func (c *mqlGcpProjectCloudFunction) GetDockerRepository() *plugin.TValue[string] {
-	return &c.DockerRepository
 }
 
 func (c *mqlGcpProjectCloudFunction) GetDockerRepositoryRef() *plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository] {
@@ -64350,16 +63239,14 @@ func (c *mqlGcpProjectCloudFunctionV2) GetManagedBy() *plugin.TValue[string] {
 type mqlGcpProjectCloudFunctionV2BuildConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectCloudFunctionV2BuildConfigInternal it will be used here
+	mqlGcpProjectCloudFunctionV2BuildConfigInternal
 	Id                   plugin.TValue[string]
 	Runtime              plugin.TValue[string]
 	EntryPoint           plugin.TValue[string]
 	Source               plugin.TValue[any]
 	BuildWorkerPool      plugin.TValue[string]
 	EnvironmentVariables plugin.TValue[map[string]any]
-	DockerRepository     plugin.TValue[string]
 	DockerRepositoryRef  plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository]
-	ServiceAccount       plugin.TValue[string]
 	ServiceAccountRef    plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	Build                plugin.TValue[string]
 	SourceProvenance     plugin.TValue[any]
@@ -64427,10 +63314,6 @@ func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetEnvironmentVariables() *plu
 	return &c.EnvironmentVariables
 }
 
-func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetDockerRepository() *plugin.TValue[string] {
-	return &c.DockerRepository
-}
-
 func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetDockerRepositoryRef() *plugin.TValue[*mqlGcpProjectArtifactRegistryServiceRepository] {
 	return plugin.GetOrCompute[*mqlGcpProjectArtifactRegistryServiceRepository](&c.DockerRepositoryRef, func() (*mqlGcpProjectArtifactRegistryServiceRepository, error) {
 		if c.MqlRuntime.HasRecording {
@@ -64445,10 +63328,6 @@ func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetDockerRepositoryRef() *plug
 
 		return c.dockerRepositoryRef()
 	})
-}
-
-func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetServiceAccount() *plugin.TValue[string] {
-	return &c.ServiceAccount
 }
 
 func (c *mqlGcpProjectCloudFunctionV2BuildConfig) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
@@ -64840,7 +63719,7 @@ func (c *mqlGcpProjectDataplexService) GetLakes() *plugin.TValue[[]any] {
 type mqlGcpProjectDataplexServiceLake struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectDataplexServiceLakeInternal it will be used here
+	mqlGcpProjectDataplexServiceLakeInternal
 	Id                           plugin.TValue[string]
 	ProjectId                    plugin.TValue[string]
 	Location                     plugin.TValue[string]
@@ -64852,7 +63731,6 @@ type mqlGcpProjectDataplexServiceLake struct {
 	Created                      plugin.TValue[*time.Time]
 	Updated                      plugin.TValue[*time.Time]
 	Labels                       plugin.TValue[map[string]any]
-	ServiceAccount               plugin.TValue[string]
 	ServiceAccountRef            plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	MetastoreService             plugin.TValue[string]
 	ActiveAssets                 plugin.TValue[int64]
@@ -64934,10 +63812,6 @@ func (c *mqlGcpProjectDataplexServiceLake) GetUpdated() *plugin.TValue[*time.Tim
 
 func (c *mqlGcpProjectDataplexServiceLake) GetLabels() *plugin.TValue[map[string]any] {
 	return &c.Labels
-}
-
-func (c *mqlGcpProjectDataplexServiceLake) GetServiceAccount() *plugin.TValue[string] {
-	return &c.ServiceAccount
 }
 
 func (c *mqlGcpProjectDataplexServiceLake) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
@@ -65917,13 +64791,12 @@ func (c *mqlGcpProjectDataprocServiceClusterConfig) GetWorker() *plugin.TValue[*
 type mqlGcpProjectDataprocServiceClusterConfigGceCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectDataprocServiceClusterConfigGceClusterInternal it will be used here
+	mqlGcpProjectDataprocServiceClusterConfigGceClusterInternal
 	Id                      plugin.TValue[string]
 	ProjectId               plugin.TValue[string]
 	ConfidentialInstance    plugin.TValue[any]
 	InternalIpOnly          plugin.TValue[bool]
 	Metadata                plugin.TValue[map[string]any]
-	NetworkUri              plugin.TValue[string]
 	Network                 plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	NodeGroupAffinity       plugin.TValue[any]
 	PrivateIpv6GoogleAccess plugin.TValue[string]
@@ -65932,7 +64805,6 @@ type mqlGcpProjectDataprocServiceClusterConfigGceCluster struct {
 	ServiceAccount          plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	ServiceAccountScopes    plugin.TValue[[]any]
 	ShieldedInstanceConfig  plugin.TValue[*mqlGcpProjectDataprocServiceClusterConfigGceClusterShieldedInstanceConfig]
-	SubnetworkUri           plugin.TValue[string]
 	Subnetwork              plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
 	Tags                    plugin.TValue[[]any]
 	ZoneUri                 plugin.TValue[string]
@@ -65995,10 +64867,6 @@ func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetMetadata() *plu
 	return &c.Metadata
 }
 
-func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetNetworkUri() *plugin.TValue[string] {
-	return &c.NetworkUri
-}
-
 func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -66053,10 +64921,6 @@ func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetServiceAccountS
 
 func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetShieldedInstanceConfig() *plugin.TValue[*mqlGcpProjectDataprocServiceClusterConfigGceClusterShieldedInstanceConfig] {
 	return &c.ShieldedInstanceConfig
-}
-
-func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetSubnetworkUri() *plugin.TValue[string] {
-	return &c.SubnetworkUri
 }
 
 func (c *mqlGcpProjectDataprocServiceClusterConfigGceCluster) GetSubnetwork() *plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork] {
@@ -67316,7 +66180,6 @@ type mqlGcpProjectCloudRunServiceServiceRevisionTemplate struct {
 	Labels                        plugin.TValue[map[string]any]
 	Annotations                   plugin.TValue[map[string]any]
 	Scaling                       plugin.TValue[any]
-	VpcAccess                     plugin.TValue[any]
 	VpcAccessConfig               plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig]
 	Timeout                       plugin.TValue[*time.Time]
 	ServiceAccountEmail           plugin.TValue[string]
@@ -67387,10 +66250,6 @@ func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetAnnotations() *
 
 func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetScaling() *plugin.TValue[any] {
 	return &c.Scaling
-}
-
-func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetVpcAccess() *plugin.TValue[any] {
-	return &c.VpcAccess
 }
 
 func (c *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) GetVpcAccessConfig() *plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig] {
@@ -68060,7 +66919,6 @@ type mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate struct {
 	// optional: if you define mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplateInternal it will be used here
 	Id                   plugin.TValue[string]
 	ProjectId            plugin.TValue[string]
-	VpcAccess            plugin.TValue[any]
 	VpcAccessConfig      plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig]
 	Timeout              plugin.TValue[*time.Time]
 	ServiceAccountEmail  plugin.TValue[string]
@@ -68115,10 +66973,6 @@ func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetId() *
 
 func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetProjectId() *plugin.TValue[string] {
 	return &c.ProjectId
-}
-
-func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetVpcAccess() *plugin.TValue[any] {
-	return &c.VpcAccess
 }
 
 func (c *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) GetVpcAccessConfig() *plugin.TValue[*mqlGcpProjectCloudRunServiceVpcAccessConfig] {
@@ -69252,7 +68106,6 @@ type mqlGcpProjectBinaryAuthorizationControlAttestor struct {
 	// optional: if you define mqlGcpProjectBinaryAuthorizationControlAttestorInternal it will be used here
 	Name                          plugin.TValue[string]
 	Description                   plugin.TValue[string]
-	UserOwnedGrafeasNote          plugin.TValue[any]
 	NoteReference                 plugin.TValue[string]
 	PublicKeys                    plugin.TValue[[]any]
 	DelegationServiceAccountEmail plugin.TValue[string]
@@ -69302,10 +68155,6 @@ func (c *mqlGcpProjectBinaryAuthorizationControlAttestor) GetName() *plugin.TVal
 
 func (c *mqlGcpProjectBinaryAuthorizationControlAttestor) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlGcpProjectBinaryAuthorizationControlAttestor) GetUserOwnedGrafeasNote() *plugin.TValue[any] {
-	return &c.UserOwnedGrafeasNote
 }
 
 func (c *mqlGcpProjectBinaryAuthorizationControlAttestor) GetNoteReference() *plugin.TValue[string] {
@@ -69463,7 +68312,7 @@ func (c *mqlGcpProjectSecretmanagerService) GetSecrets() *plugin.TValue[[]any] {
 type mqlGcpProjectSecretmanagerServiceSecret struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectSecretmanagerServiceSecretInternal it will be used here
+	mqlGcpProjectSecretmanagerServiceSecretInternal
 	ProjectId                        plugin.TValue[string]
 	ResourcePath                     plugin.TValue[string]
 	Name                             plugin.TValue[string]
@@ -69483,7 +68332,6 @@ type mqlGcpProjectSecretmanagerServiceSecret struct {
 	VersionAliases                   plugin.TValue[map[string]any]
 	Annotations                      plugin.TValue[map[string]any]
 	VersionDestroyTtl                plugin.TValue[*time.Time]
-	CustomerManagedEncryption        plugin.TValue[[]any]
 	KmsKeys                          plugin.TValue[[]any]
 	CustomerManagedEncryptionEnabled plugin.TValue[bool]
 	Tags                             plugin.TValue[map[string]any]
@@ -69618,10 +68466,6 @@ func (c *mqlGcpProjectSecretmanagerServiceSecret) GetAnnotations() *plugin.TValu
 
 func (c *mqlGcpProjectSecretmanagerServiceSecret) GetVersionDestroyTtl() *plugin.TValue[*time.Time] {
 	return &c.VersionDestroyTtl
-}
-
-func (c *mqlGcpProjectSecretmanagerServiceSecret) GetCustomerManagedEncryption() *plugin.TValue[[]any] {
-	return &c.CustomerManagedEncryption
 }
 
 func (c *mqlGcpProjectSecretmanagerServiceSecret) GetKmsKeys() *plugin.TValue[[]any] {
@@ -72661,7 +71505,6 @@ type mqlGcpProjectComputeServiceSecurityPolicy struct {
 	RecaptchaOptionsConfig   plugin.TValue[any]
 	Fingerprint              plugin.TValue[string]
 	UserDefinedFields        plugin.TValue[[]any]
-	RegionUrl                plugin.TValue[string]
 	Region                   plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                 plugin.TValue[string]
 	CreatedAt                plugin.TValue[*time.Time]
@@ -72747,10 +71590,6 @@ func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetFingerprint() *plugin.TVa
 
 func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetUserDefinedFields() *plugin.TValue[[]any] {
 	return &c.UserDefinedFields
-}
-
-func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServiceSecurityPolicy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -72896,7 +71735,7 @@ func (c *mqlGcpProjectComputeServiceSecurityPolicyRule) GetPreconfiguredWafConfi
 type mqlGcpProjectComputeServiceSslPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceSslPolicyInternal it will be used here
+	mqlGcpProjectComputeServiceSslPolicyInternal
 	Id              plugin.TValue[string]
 	Name            plugin.TValue[string]
 	Description     plugin.TValue[string]
@@ -72905,7 +71744,6 @@ type mqlGcpProjectComputeServiceSslPolicy struct {
 	WeakTls         plugin.TValue[bool]
 	CustomFeatures  plugin.TValue[[]any]
 	EnabledFeatures plugin.TValue[[]any]
-	RegionUrl       plugin.TValue[string]
 	Region          plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink        plugin.TValue[string]
 	Warnings        plugin.TValue[[]any]
@@ -72983,10 +71821,6 @@ func (c *mqlGcpProjectComputeServiceSslPolicy) GetEnabledFeatures() *plugin.TVal
 	return &c.EnabledFeatures
 }
 
-func (c *mqlGcpProjectComputeServiceSslPolicy) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceSslPolicy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -73019,7 +71853,7 @@ func (c *mqlGcpProjectComputeServiceSslPolicy) GetCreatedAt() *plugin.TValue[*ti
 type mqlGcpProjectComputeServiceSslCertificate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceSslCertificateInternal it will be used here
+	mqlGcpProjectComputeServiceSslCertificateInternal
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
 	Description             plugin.TValue[string]
@@ -73027,7 +71861,6 @@ type mqlGcpProjectComputeServiceSslCertificate struct {
 	SubjectAlternativeNames plugin.TValue[[]any]
 	Managed                 plugin.TValue[any]
 	ManagedStatus           plugin.TValue[string]
-	RegionUrl               plugin.TValue[string]
 	Region                  plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                plugin.TValue[string]
 	ExpireTime              plugin.TValue[string]
@@ -73100,10 +71933,6 @@ func (c *mqlGcpProjectComputeServiceSslCertificate) GetManagedStatus() *plugin.T
 	return &c.ManagedStatus
 }
 
-func (c *mqlGcpProjectComputeServiceSslCertificate) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceSslCertificate) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -73151,7 +71980,6 @@ type mqlGcpProjectComputeServiceVpnGateway struct {
 	Network             plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	GatewayIpVersion    plugin.TValue[string]
 	StackType           plugin.TValue[string]
-	RegionUrl           plugin.TValue[string]
 	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	VpnInterfaces       plugin.TValue[[]any]
 	ResourceManagerTags plugin.TValue[map[string]any]
@@ -73238,10 +72066,6 @@ func (c *mqlGcpProjectComputeServiceVpnGateway) GetStackType() *plugin.TValue[st
 	return &c.StackType
 }
 
-func (c *mqlGcpProjectComputeServiceVpnGateway) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceVpnGateway) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -73270,7 +72094,7 @@ func (c *mqlGcpProjectComputeServiceVpnGateway) GetResourceManagerTags() *plugin
 type mqlGcpProjectComputeServiceVpnTunnel struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceVpnTunnelInternal it will be used here
+	mqlGcpProjectComputeServiceVpnTunnelInternal
 	Id                           plugin.TValue[string]
 	Name                         plugin.TValue[string]
 	Description                  plugin.TValue[string]
@@ -73280,20 +72104,15 @@ type mqlGcpProjectComputeServiceVpnTunnel struct {
 	IkeVersion                   plugin.TValue[int64]
 	LocalTrafficSelector         plugin.TValue[[]any]
 	RemoteTrafficSelector        plugin.TValue[[]any]
-	PeerExternalGateway          plugin.TValue[string]
 	PeerExternalGatewayInterface plugin.TValue[int64]
 	PeerExternalVpnGateway       plugin.TValue[*mqlGcpProjectComputeServiceExternalVpnGateway]
-	PeerGcpGateway               plugin.TValue[string]
 	PeerGcpVpnGateway            plugin.TValue[*mqlGcpProjectComputeServiceVpnGateway]
 	PeerIp                       plugin.TValue[string]
-	RegionUrl                    plugin.TValue[string]
 	Region                       plugin.TValue[*mqlGcpProjectComputeServiceRegion]
-	RouterUrl                    plugin.TValue[string]
 	Router                       plugin.TValue[*mqlGcpProjectComputeServiceRouter]
 	SharedSecretHash             plugin.TValue[string]
 	Status                       plugin.TValue[string]
 	TargetVpnGateway             plugin.TValue[string]
-	VpnGatewayUrl                plugin.TValue[string]
 	VpnGateway                   plugin.TValue[*mqlGcpProjectComputeServiceVpnGateway]
 	VpnGatewayInterface          plugin.TValue[int64]
 	ResourceManagerTags          plugin.TValue[map[string]any]
@@ -73373,10 +72192,6 @@ func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRemoteTrafficSelector() *plugi
 	return &c.RemoteTrafficSelector
 }
 
-func (c *mqlGcpProjectComputeServiceVpnTunnel) GetPeerExternalGateway() *plugin.TValue[string] {
-	return &c.PeerExternalGateway
-}
-
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetPeerExternalGatewayInterface() *plugin.TValue[int64] {
 	return &c.PeerExternalGatewayInterface
 }
@@ -73395,10 +72210,6 @@ func (c *mqlGcpProjectComputeServiceVpnTunnel) GetPeerExternalVpnGateway() *plug
 
 		return c.peerExternalVpnGateway()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceVpnTunnel) GetPeerGcpGateway() *plugin.TValue[string] {
-	return &c.PeerGcpGateway
 }
 
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetPeerGcpVpnGateway() *plugin.TValue[*mqlGcpProjectComputeServiceVpnGateway] {
@@ -73421,10 +72232,6 @@ func (c *mqlGcpProjectComputeServiceVpnTunnel) GetPeerIp() *plugin.TValue[string
 	return &c.PeerIp
 }
 
-func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -73439,10 +72246,6 @@ func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRegion() *plugin.TValue[*mqlGc
 
 		return c.region()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRouterUrl() *plugin.TValue[string] {
-	return &c.RouterUrl
 }
 
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetRouter() *plugin.TValue[*mqlGcpProjectComputeServiceRouter] {
@@ -73471,10 +72274,6 @@ func (c *mqlGcpProjectComputeServiceVpnTunnel) GetStatus() *plugin.TValue[string
 
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetTargetVpnGateway() *plugin.TValue[string] {
 	return &c.TargetVpnGateway
-}
-
-func (c *mqlGcpProjectComputeServiceVpnTunnel) GetVpnGatewayUrl() *plugin.TValue[string] {
-	return &c.VpnGatewayUrl
 }
 
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetVpnGateway() *plugin.TValue[*mqlGcpProjectComputeServiceVpnGateway] {
@@ -75837,9 +74636,7 @@ type mqlGcpProjectComputeServiceInstanceGroup struct {
 	ProjectId   plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
-	ZoneUrl     plugin.TValue[string]
 	Zone        plugin.TValue[*mqlGcpProjectComputeServiceZone]
-	NetworkUrl  plugin.TValue[string]
 	Network     plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	Subnetwork  plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
 	Size        plugin.TValue[int64]
@@ -75902,10 +74699,6 @@ func (c *mqlGcpProjectComputeServiceInstanceGroup) GetDescription() *plugin.TVal
 	return &c.Description
 }
 
-func (c *mqlGcpProjectComputeServiceInstanceGroup) GetZoneUrl() *plugin.TValue[string] {
-	return &c.ZoneUrl
-}
-
 func (c *mqlGcpProjectComputeServiceInstanceGroup) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceZone](&c.Zone, func() (*mqlGcpProjectComputeServiceZone, error) {
 		if c.MqlRuntime.HasRecording {
@@ -75920,10 +74713,6 @@ func (c *mqlGcpProjectComputeServiceInstanceGroup) GetZone() *plugin.TValue[*mql
 
 		return c.zone()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceInstanceGroup) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceGroup) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -75999,9 +74788,7 @@ type mqlGcpProjectComputeServiceInstanceGroupManager struct {
 	ProjectId           plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Description         plugin.TValue[string]
-	ZoneUrl             plugin.TValue[string]
 	Zone                plugin.TValue[*mqlGcpProjectComputeServiceZone]
-	RegionUrl           plugin.TValue[string]
 	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	InstanceTemplateUrl plugin.TValue[string]
 	InstanceTemplate    plugin.TValue[*mqlGcpProjectComputeServiceInstanceTemplate]
@@ -76069,10 +74856,6 @@ func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetDescription() *plug
 	return &c.Description
 }
 
-func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetZoneUrl() *plugin.TValue[string] {
-	return &c.ZoneUrl
-}
-
 func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceZone](&c.Zone, func() (*mqlGcpProjectComputeServiceZone, error) {
 		if c.MqlRuntime.HasRecording {
@@ -76087,10 +74870,6 @@ func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetZone() *plugin.TVal
 
 		return c.zone()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServiceInstanceGroupManager) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -76178,7 +74957,6 @@ type mqlGcpProjectComputeServiceFirewallPolicy struct {
 	SelfLink       plugin.TValue[string]
 	RuleTupleCount plugin.TValue[int64]
 	Created        plugin.TValue[*time.Time]
-	RegionUrl      plugin.TValue[string]
 	Region         plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	Rules          plugin.TValue[[]any]
 	Associations   plugin.TValue[[]any]
@@ -76251,10 +75029,6 @@ func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetRuleTupleCount() *plugin.
 
 func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
-}
-
-func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServiceFirewallPolicy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -76581,7 +75355,7 @@ func (c *mqlGcpProjectFilestoreService) GetInstances() *plugin.TValue[[]any] {
 type mqlGcpProjectFilestoreServiceInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectFilestoreServiceInstanceInternal it will be used here
+	mqlGcpProjectFilestoreServiceInstanceInternal
 	ProjectId                 plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Description               plugin.TValue[string]
@@ -76591,7 +75365,6 @@ type mqlGcpProjectFilestoreServiceInstance struct {
 	Labels                    plugin.TValue[map[string]any]
 	FileShares                plugin.TValue[[]any]
 	Networks                  plugin.TValue[[]any]
-	KmsKeyName                plugin.TValue[string]
 	KmsKey                    plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	SatisfiesPzi              plugin.TValue[bool]
 	SatisfiesPzs              plugin.TValue[bool]
@@ -76670,10 +75443,6 @@ func (c *mqlGcpProjectFilestoreServiceInstance) GetFileShares() *plugin.TValue[[
 
 func (c *mqlGcpProjectFilestoreServiceInstance) GetNetworks() *plugin.TValue[[]any] {
 	return &c.Networks
-}
-
-func (c *mqlGcpProjectFilestoreServiceInstance) GetKmsKeyName() *plugin.TValue[string] {
-	return &c.KmsKeyName
 }
 
 func (c *mqlGcpProjectFilestoreServiceInstance) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -77073,22 +75842,20 @@ func (c *mqlGcpProjectCloudSchedulerService) GetJobs() *plugin.TValue[[]any] {
 type mqlGcpProjectCloudSchedulerServiceJob struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectCloudSchedulerServiceJobInternal it will be used here
-	ProjectId                plugin.TValue[string]
-	Name                     plugin.TValue[string]
-	Schedule                 plugin.TValue[string]
-	TimeZone                 plugin.TValue[string]
-	State                    plugin.TValue[string]
-	Description              plugin.TValue[string]
-	LastAttemptTime          plugin.TValue[*time.Time]
-	ScheduleTime             plugin.TValue[*time.Time]
-	UserUpdateTime           plugin.TValue[*time.Time]
-	RetryConfig              plugin.TValue[*mqlGcpRetryConfig]
-	TargetType               plugin.TValue[string]
-	OidcServiceAccountEmail  plugin.TValue[string]
-	OidcServiceAccount       plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	OauthServiceAccountEmail plugin.TValue[string]
-	OauthServiceAccount      plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	mqlGcpProjectCloudSchedulerServiceJobInternal
+	ProjectId           plugin.TValue[string]
+	Name                plugin.TValue[string]
+	Schedule            plugin.TValue[string]
+	TimeZone            plugin.TValue[string]
+	State               plugin.TValue[string]
+	Description         plugin.TValue[string]
+	LastAttemptTime     plugin.TValue[*time.Time]
+	ScheduleTime        plugin.TValue[*time.Time]
+	UserUpdateTime      plugin.TValue[*time.Time]
+	RetryConfig         plugin.TValue[*mqlGcpRetryConfig]
+	TargetType          plugin.TValue[string]
+	OidcServiceAccount  plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	OauthServiceAccount plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 }
 
 // createGcpProjectCloudSchedulerServiceJob creates a new instance of this resource
@@ -77172,10 +75939,6 @@ func (c *mqlGcpProjectCloudSchedulerServiceJob) GetTargetType() *plugin.TValue[s
 	return &c.TargetType
 }
 
-func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOidcServiceAccountEmail() *plugin.TValue[string] {
-	return &c.OidcServiceAccountEmail
-}
-
 func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOidcServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
 	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.OidcServiceAccount, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
 		if c.MqlRuntime.HasRecording {
@@ -77190,10 +75953,6 @@ func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOidcServiceAccount() *plugin.
 
 		return c.oidcServiceAccount()
 	})
-}
-
-func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOauthServiceAccountEmail() *plugin.TValue[string] {
-	return &c.OauthServiceAccountEmail
 }
 
 func (c *mqlGcpProjectCloudSchedulerServiceJob) GetOauthServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
@@ -77868,18 +76627,17 @@ func (c *mqlGcpProjectApiGatewayServiceApi) GetConfigs() *plugin.TValue[[]any] {
 type mqlGcpProjectApiGatewayServiceApiConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectApiGatewayServiceApiConfigInternal it will be used here
-	ProjectId             plugin.TValue[string]
-	Name                  plugin.TValue[string]
-	DisplayName           plugin.TValue[string]
-	State                 plugin.TValue[string]
-	ServiceConfigId       plugin.TValue[string]
-	GatewayServiceAccount plugin.TValue[string]
-	ServiceAccount        plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	CreateTime            plugin.TValue[*time.Time]
-	UpdateTime            plugin.TValue[*time.Time]
-	Labels                plugin.TValue[map[string]any]
-	OpenapiDocuments      plugin.TValue[[]any]
+	mqlGcpProjectApiGatewayServiceApiConfigInternal
+	ProjectId        plugin.TValue[string]
+	Name             plugin.TValue[string]
+	DisplayName      plugin.TValue[string]
+	State            plugin.TValue[string]
+	ServiceConfigId  plugin.TValue[string]
+	ServiceAccount   plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
+	CreateTime       plugin.TValue[*time.Time]
+	UpdateTime       plugin.TValue[*time.Time]
+	Labels           plugin.TValue[map[string]any]
+	OpenapiDocuments plugin.TValue[[]any]
 }
 
 // createGcpProjectApiGatewayServiceApiConfig creates a new instance of this resource
@@ -77937,10 +76695,6 @@ func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetState() *plugin.TValue[stri
 
 func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetServiceConfigId() *plugin.TValue[string] {
 	return &c.ServiceConfigId
-}
-
-func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetGatewayServiceAccount() *plugin.TValue[string] {
-	return &c.GatewayServiceAccount
 }
 
 func (c *mqlGcpProjectApiGatewayServiceApiConfig) GetServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
@@ -79210,7 +77964,7 @@ func (c *mqlGcpProjectHealthcareServiceHl7v2Store) GetRejectDuplicateMessage() *
 type mqlGcpProjectComputeServiceHealthCheck struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceHealthCheckInternal it will be used here
+	mqlGcpProjectComputeServiceHealthCheckInternal
 	Id                 plugin.TValue[string]
 	ProjectId          plugin.TValue[string]
 	Name               plugin.TValue[string]
@@ -79229,7 +77983,6 @@ type mqlGcpProjectComputeServiceHealthCheck struct {
 	Http2HealthCheck   plugin.TValue[any]
 	GrpcHealthCheck    plugin.TValue[any]
 	LogConfig          plugin.TValue[any]
-	RegionUrl          plugin.TValue[string]
 	Region             plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
@@ -79342,10 +78095,6 @@ func (c *mqlGcpProjectComputeServiceHealthCheck) GetLogConfig() *plugin.TValue[a
 	return &c.LogConfig
 }
 
-func (c *mqlGcpProjectComputeServiceHealthCheck) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceHealthCheck) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79366,20 +78115,18 @@ func (c *mqlGcpProjectComputeServiceHealthCheck) GetRegion() *plugin.TValue[*mql
 type mqlGcpProjectComputeServiceUrlMap struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceUrlMapInternal it will be used here
-	Id                plugin.TValue[string]
-	ProjectId         plugin.TValue[string]
-	Name              plugin.TValue[string]
-	Description       plugin.TValue[string]
-	DefaultServiceUrl plugin.TValue[string]
-	DefaultService    plugin.TValue[*mqlGcpProjectComputeServiceBackendService]
-	HostRules         plugin.TValue[[]any]
-	PathMatchers      plugin.TValue[[]any]
-	Tests             plugin.TValue[[]any]
-	Created           plugin.TValue[*time.Time]
-	SelfLink          plugin.TValue[string]
-	RegionUrl         plugin.TValue[string]
-	Region            plugin.TValue[*mqlGcpProjectComputeServiceRegion]
+	mqlGcpProjectComputeServiceUrlMapInternal
+	Id             plugin.TValue[string]
+	ProjectId      plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Description    plugin.TValue[string]
+	DefaultService plugin.TValue[*mqlGcpProjectComputeServiceBackendService]
+	HostRules      plugin.TValue[[]any]
+	PathMatchers   plugin.TValue[[]any]
+	Tests          plugin.TValue[[]any]
+	Created        plugin.TValue[*time.Time]
+	SelfLink       plugin.TValue[string]
+	Region         plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
 // createGcpProjectComputeServiceUrlMap creates a new instance of this resource
@@ -79435,10 +78182,6 @@ func (c *mqlGcpProjectComputeServiceUrlMap) GetDescription() *plugin.TValue[stri
 	return &c.Description
 }
 
-func (c *mqlGcpProjectComputeServiceUrlMap) GetDefaultServiceUrl() *plugin.TValue[string] {
-	return &c.DefaultServiceUrl
-}
-
 func (c *mqlGcpProjectComputeServiceUrlMap) GetDefaultService() *plugin.TValue[*mqlGcpProjectComputeServiceBackendService] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceBackendService](&c.DefaultService, func() (*mqlGcpProjectComputeServiceBackendService, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79475,10 +78218,6 @@ func (c *mqlGcpProjectComputeServiceUrlMap) GetSelfLink() *plugin.TValue[string]
 	return &c.SelfLink
 }
 
-func (c *mqlGcpProjectComputeServiceUrlMap) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceUrlMap) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79499,17 +78238,15 @@ func (c *mqlGcpProjectComputeServiceUrlMap) GetRegion() *plugin.TValue[*mqlGcpPr
 type mqlGcpProjectComputeServiceTargetHttpProxy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceTargetHttpProxyInternal it will be used here
+	mqlGcpProjectComputeServiceTargetHttpProxyInternal
 	Id          plugin.TValue[string]
 	ProjectId   plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
-	UrlMapUrl   plugin.TValue[string]
 	UrlMap      plugin.TValue[*mqlGcpProjectComputeServiceUrlMap]
 	Created     plugin.TValue[*time.Time]
 	SelfLink    plugin.TValue[string]
 	ProxyBind   plugin.TValue[bool]
-	RegionUrl   plugin.TValue[string]
 	Region      plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
@@ -79566,10 +78303,6 @@ func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetDescription() *plugin.TV
 	return &c.Description
 }
 
-func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetUrlMapUrl() *plugin.TValue[string] {
-	return &c.UrlMapUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetUrlMap() *plugin.TValue[*mqlGcpProjectComputeServiceUrlMap] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceUrlMap](&c.UrlMap, func() (*mqlGcpProjectComputeServiceUrlMap, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79598,10 +78331,6 @@ func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetProxyBind() *plugin.TVal
 	return &c.ProxyBind
 }
 
-func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79622,16 +78351,14 @@ func (c *mqlGcpProjectComputeServiceTargetHttpProxy) GetRegion() *plugin.TValue[
 type mqlGcpProjectComputeServiceTargetHttpsProxy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceTargetHttpsProxyInternal it will be used here
+	mqlGcpProjectComputeServiceTargetHttpsProxyInternal
 	Id                  plugin.TValue[string]
 	ProjectId           plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Description         plugin.TValue[string]
-	UrlMapUrl           plugin.TValue[string]
 	UrlMap              plugin.TValue[*mqlGcpProjectComputeServiceUrlMap]
 	SslCertificateUrls  plugin.TValue[[]any]
 	SslCertificates     plugin.TValue[[]any]
-	SslPolicyUrl        plugin.TValue[string]
 	SslPolicy           plugin.TValue[*mqlGcpProjectComputeServiceSslPolicy]
 	QuicOverride        plugin.TValue[string]
 	CertificateMap      plugin.TValue[string]
@@ -79641,7 +78368,6 @@ type mqlGcpProjectComputeServiceTargetHttpsProxy struct {
 	Created             plugin.TValue[*time.Time]
 	SelfLink            plugin.TValue[string]
 	ProxyBind           plugin.TValue[bool]
-	RegionUrl           plugin.TValue[string]
 	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
@@ -79698,10 +78424,6 @@ func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetDescription() *plugin.T
 	return &c.Description
 }
 
-func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetUrlMapUrl() *plugin.TValue[string] {
-	return &c.UrlMapUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetUrlMap() *plugin.TValue[*mqlGcpProjectComputeServiceUrlMap] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceUrlMap](&c.UrlMap, func() (*mqlGcpProjectComputeServiceUrlMap, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79736,10 +78458,6 @@ func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetSslCertificates() *plug
 
 		return c.sslCertificates()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetSslPolicyUrl() *plugin.TValue[string] {
-	return &c.SslPolicyUrl
 }
 
 func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetSslPolicy() *plugin.TValue[*mqlGcpProjectComputeServiceSslPolicy] {
@@ -79790,10 +78508,6 @@ func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetProxyBind() *plugin.TVa
 	return &c.ProxyBind
 }
 
-func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79814,10 +78528,9 @@ func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetRegion() *plugin.TValue
 type mqlGcpProjectComputeServiceNetworkPeering struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceNetworkPeeringInternal it will be used here
+	mqlGcpProjectComputeServiceNetworkPeeringInternal
 	Id                             plugin.TValue[string]
 	Name                           plugin.TValue[string]
-	NetworkUrl                     plugin.TValue[string]
 	Network                        plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	State                          plugin.TValue[string]
 	StateDetails                   plugin.TValue[string]
@@ -79874,10 +78587,6 @@ func (c *mqlGcpProjectComputeServiceNetworkPeering) GetName() *plugin.TValue[str
 	return &c.Name
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkPeering) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
-}
-
 func (c *mqlGcpProjectComputeServiceNetworkPeering) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -79930,13 +78639,12 @@ func (c *mqlGcpProjectComputeServiceNetworkPeering) GetImportSubnetRoutesWithPub
 type mqlGcpProjectComputeServiceRoute struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceRouteInternal it will be used here
+	mqlGcpProjectComputeServiceRouteInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Description         plugin.TValue[string]
 	DestRange           plugin.TValue[string]
 	Priority            plugin.TValue[int64]
-	NetworkUrl          plugin.TValue[string]
 	Network             plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	NextHopGateway      plugin.TValue[string]
 	NextHopInstance     plugin.TValue[string]
@@ -80014,10 +78722,6 @@ func (c *mqlGcpProjectComputeServiceRoute) GetDestRange() *plugin.TValue[string]
 
 func (c *mqlGcpProjectComputeServiceRoute) GetPriority() *plugin.TValue[int64] {
 	return &c.Priority
-}
-
-func (c *mqlGcpProjectComputeServiceRoute) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
 }
 
 func (c *mqlGcpProjectComputeServiceRoute) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -80164,7 +78868,7 @@ func (c *mqlGcpProjectComputeServiceRoute) GetSelfLink() *plugin.TValue[string] 
 type mqlGcpProjectComputeServiceServiceAttachment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceServiceAttachmentInternal it will be used here
+	mqlGcpProjectComputeServiceServiceAttachmentInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Description            plugin.TValue[string]
@@ -80178,7 +78882,6 @@ type mqlGcpProjectComputeServiceServiceAttachment struct {
 	ProducerForwardingRule plugin.TValue[string]
 	TargetService          plugin.TValue[string]
 	ReconcileConnections   plugin.TValue[bool]
-	RegionUrl              plugin.TValue[string]
 	Region                 plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink               plugin.TValue[string]
 	Fingerprint            plugin.TValue[string]
@@ -80274,10 +78977,6 @@ func (c *mqlGcpProjectComputeServiceServiceAttachment) GetReconcileConnections()
 	return &c.ReconcileConnections
 }
 
-func (c *mqlGcpProjectComputeServiceServiceAttachment) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
-}
-
 func (c *mqlGcpProjectComputeServiceServiceAttachment) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceRegion](&c.Region, func() (*mqlGcpProjectComputeServiceRegion, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80310,20 +79009,16 @@ func (c *mqlGcpProjectComputeServiceServiceAttachment) GetCreated() *plugin.TVal
 type mqlGcpProjectComputeServiceNetworkEndpointGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceNetworkEndpointGroupInternal it will be used here
+	mqlGcpProjectComputeServiceNetworkEndpointGroupInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Description         plugin.TValue[string]
 	NetworkEndpointType plugin.TValue[string]
 	DefaultPort         plugin.TValue[int64]
 	Size                plugin.TValue[int64]
-	NetworkUrl          plugin.TValue[string]
 	Network             plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
-	SubnetworkUrl       plugin.TValue[string]
 	Subnetwork          plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork]
-	ZoneUrl             plugin.TValue[string]
 	Zone                plugin.TValue[*mqlGcpProjectComputeServiceZone]
-	RegionUrl           plugin.TValue[string]
 	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	CloudRun            plugin.TValue[any]
 	AppEngine           plugin.TValue[any]
@@ -80396,10 +79091,6 @@ func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetSize() *plugin.TVal
 	return &c.Size
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
-}
-
 func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.Network, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80414,10 +79105,6 @@ func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetNetwork() *plugin.T
 
 		return c.network()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetSubnetworkUrl() *plugin.TValue[string] {
-	return &c.SubnetworkUrl
 }
 
 func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetSubnetwork() *plugin.TValue[*mqlGcpProjectComputeServiceSubnetwork] {
@@ -80436,10 +79123,6 @@ func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetSubnetwork() *plugi
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetZoneUrl() *plugin.TValue[string] {
-	return &c.ZoneUrl
-}
-
 func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetZone() *plugin.TValue[*mqlGcpProjectComputeServiceZone] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceZone](&c.Zone, func() (*mqlGcpProjectComputeServiceZone, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80454,10 +79137,6 @@ func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetZone() *plugin.TVal
 
 		return c.zone()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServiceNetworkEndpointGroup) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -80686,7 +79365,7 @@ func (c *mqlGcpProjectComputeServiceInterconnect) GetCreated() *plugin.TValue[*t
 type mqlGcpProjectComputeServiceInterconnectAttachment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceInterconnectAttachmentInternal it will be used here
+	mqlGcpProjectComputeServiceInterconnectAttachmentInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Description               plugin.TValue[string]
@@ -80695,9 +79374,7 @@ type mqlGcpProjectComputeServiceInterconnectAttachment struct {
 	Type                      plugin.TValue[string]
 	State                     plugin.TValue[string]
 	EdgeAvailabilityDomain    plugin.TValue[string]
-	InterconnectUrl           plugin.TValue[string]
 	Interconnect              plugin.TValue[*mqlGcpProjectComputeServiceInterconnect]
-	RouterUrl                 plugin.TValue[string]
 	Router                    plugin.TValue[*mqlGcpProjectComputeServiceRouter]
 	CloudRouterIpAddress      plugin.TValue[string]
 	CustomerRouterIpAddress   plugin.TValue[string]
@@ -80708,7 +79385,6 @@ type mqlGcpProjectComputeServiceInterconnectAttachment struct {
 	VlanTag8021q              plugin.TValue[int64]
 	PartnerMetadata           plugin.TValue[any]
 	PrivateInterconnectInfo   plugin.TValue[any]
-	RegionUrl                 plugin.TValue[string]
 	Region                    plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                  plugin.TValue[string]
 	DataplaneVersion          plugin.TValue[int64]
@@ -80785,10 +79461,6 @@ func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetEdgeAvailabilityD
 	return &c.EdgeAvailabilityDomain
 }
 
-func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetInterconnectUrl() *plugin.TValue[string] {
-	return &c.InterconnectUrl
-}
-
 func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetInterconnect() *plugin.TValue[*mqlGcpProjectComputeServiceInterconnect] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceInterconnect](&c.Interconnect, func() (*mqlGcpProjectComputeServiceInterconnect, error) {
 		if c.MqlRuntime.HasRecording {
@@ -80803,10 +79475,6 @@ func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetInterconnect() *p
 
 		return c.interconnect()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetRouterUrl() *plugin.TValue[string] {
-	return &c.RouterUrl
 }
 
 func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetRouter() *plugin.TValue[*mqlGcpProjectComputeServiceRouter] {
@@ -80859,10 +79527,6 @@ func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetPartnerMetadata()
 
 func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetPrivateInterconnectInfo() *plugin.TValue[any] {
 	return &c.PrivateInterconnectInfo
-}
-
-func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -80985,15 +79649,13 @@ func (c *mqlGcpProjectComputeServiceExternalVpnGateway) GetCreated() *plugin.TVa
 type mqlGcpProjectComputeServiceTargetTcpProxy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceTargetTcpProxyInternal it will be used here
+	mqlGcpProjectComputeServiceTargetTcpProxyInternal
 	Id          plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
 	ProxyHeader plugin.TValue[string]
 	ProxyBind   plugin.TValue[bool]
-	ServiceUrl  plugin.TValue[string]
 	Service     plugin.TValue[*mqlGcpProjectComputeServiceBackendService]
-	RegionUrl   plugin.TValue[string]
 	Region      plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink    plugin.TValue[string]
 	Created     plugin.TValue[*time.Time]
@@ -81056,10 +79718,6 @@ func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetProxyBind() *plugin.TValu
 	return &c.ProxyBind
 }
 
-func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetServiceUrl() *plugin.TValue[string] {
-	return &c.ServiceUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetService() *plugin.TValue[*mqlGcpProjectComputeServiceBackendService] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceBackendService](&c.Service, func() (*mqlGcpProjectComputeServiceBackendService, error) {
 		if c.MqlRuntime.HasRecording {
@@ -81074,10 +79732,6 @@ func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetService() *plugin.TValue[
 
 		return c.service()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -81108,16 +79762,14 @@ func (c *mqlGcpProjectComputeServiceTargetTcpProxy) GetCreated() *plugin.TValue[
 type mqlGcpProjectComputeServiceTargetSslProxy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceTargetSslProxyInternal it will be used here
+	mqlGcpProjectComputeServiceTargetSslProxyInternal
 	Id                 plugin.TValue[string]
 	Name               plugin.TValue[string]
 	Description        plugin.TValue[string]
 	ProxyHeader        plugin.TValue[string]
-	ServiceUrl         plugin.TValue[string]
 	Service            plugin.TValue[*mqlGcpProjectComputeServiceBackendService]
 	SslCertificateUrls plugin.TValue[[]any]
 	SslCertificates    plugin.TValue[[]any]
-	SslPolicyUrl       plugin.TValue[string]
 	SslPolicy          plugin.TValue[*mqlGcpProjectComputeServiceSslPolicy]
 	CertificateMap     plugin.TValue[string]
 	SelfLink           plugin.TValue[string]
@@ -81177,10 +79829,6 @@ func (c *mqlGcpProjectComputeServiceTargetSslProxy) GetProxyHeader() *plugin.TVa
 	return &c.ProxyHeader
 }
 
-func (c *mqlGcpProjectComputeServiceTargetSslProxy) GetServiceUrl() *plugin.TValue[string] {
-	return &c.ServiceUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetSslProxy) GetService() *plugin.TValue[*mqlGcpProjectComputeServiceBackendService] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceBackendService](&c.Service, func() (*mqlGcpProjectComputeServiceBackendService, error) {
 		if c.MqlRuntime.HasRecording {
@@ -81217,10 +79865,6 @@ func (c *mqlGcpProjectComputeServiceTargetSslProxy) GetSslCertificates() *plugin
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceTargetSslProxy) GetSslPolicyUrl() *plugin.TValue[string] {
-	return &c.SslPolicyUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetSslProxy) GetSslPolicy() *plugin.TValue[*mqlGcpProjectComputeServiceSslPolicy] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceSslPolicy](&c.SslPolicy, func() (*mqlGcpProjectComputeServiceSslPolicy, error) {
 		if c.MqlRuntime.HasRecording {
@@ -81253,7 +79897,7 @@ func (c *mqlGcpProjectComputeServiceTargetSslProxy) GetCreated() *plugin.TValue[
 type mqlGcpProjectComputeServicePacketMirroring struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServicePacketMirroringInternal it will be used here
+	mqlGcpProjectComputeServicePacketMirroringInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Description       plugin.TValue[string]
@@ -81263,7 +79907,6 @@ type mqlGcpProjectComputeServicePacketMirroring struct {
 	CollectorIlb      plugin.TValue[any]
 	MirroredResources plugin.TValue[any]
 	Filter            plugin.TValue[any]
-	RegionUrl         plugin.TValue[string]
 	Region            plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink          plugin.TValue[string]
 	Created           plugin.TValue[*time.Time]
@@ -81340,10 +79983,6 @@ func (c *mqlGcpProjectComputeServicePacketMirroring) GetMirroredResources() *plu
 
 func (c *mqlGcpProjectComputeServicePacketMirroring) GetFilter() *plugin.TValue[any] {
 	return &c.Filter
-}
-
-func (c *mqlGcpProjectComputeServicePacketMirroring) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServicePacketMirroring) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -81473,24 +80112,21 @@ func (c *mqlGcpProjectComputeServiceBackendBucket) GetCreated() *plugin.TValue[*
 type mqlGcpProjectComputeServiceTargetPool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceTargetPoolInternal it will be used here
-	Id                plugin.TValue[string]
-	Name              plugin.TValue[string]
-	Description       plugin.TValue[string]
-	SessionAffinity   plugin.TValue[string]
-	FailoverRatio     plugin.TValue[float64]
-	BackupPoolUrl     plugin.TValue[string]
-	BackupPool        plugin.TValue[*mqlGcpProjectComputeServiceTargetPool]
-	HealthCheckUrls   plugin.TValue[[]any]
-	HealthCheckRefs   plugin.TValue[[]any]
-	InstanceUrls      plugin.TValue[[]any]
-	InstanceRefs      plugin.TValue[[]any]
-	SecurityPolicyUrl plugin.TValue[string]
-	SecurityPolicy    plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy]
-	RegionUrl         plugin.TValue[string]
-	Region            plugin.TValue[*mqlGcpProjectComputeServiceRegion]
-	SelfLink          plugin.TValue[string]
-	Created           plugin.TValue[*time.Time]
+	mqlGcpProjectComputeServiceTargetPoolInternal
+	Id              plugin.TValue[string]
+	Name            plugin.TValue[string]
+	Description     plugin.TValue[string]
+	SessionAffinity plugin.TValue[string]
+	FailoverRatio   plugin.TValue[float64]
+	BackupPool      plugin.TValue[*mqlGcpProjectComputeServiceTargetPool]
+	HealthCheckUrls plugin.TValue[[]any]
+	HealthCheckRefs plugin.TValue[[]any]
+	InstanceUrls    plugin.TValue[[]any]
+	InstanceRefs    plugin.TValue[[]any]
+	SecurityPolicy  plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy]
+	Region          plugin.TValue[*mqlGcpProjectComputeServiceRegion]
+	SelfLink        plugin.TValue[string]
+	Created         plugin.TValue[*time.Time]
 }
 
 // createGcpProjectComputeServiceTargetPool creates a new instance of this resource
@@ -81550,10 +80186,6 @@ func (c *mqlGcpProjectComputeServiceTargetPool) GetFailoverRatio() *plugin.TValu
 	return &c.FailoverRatio
 }
 
-func (c *mqlGcpProjectComputeServiceTargetPool) GetBackupPoolUrl() *plugin.TValue[string] {
-	return &c.BackupPoolUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetPool) GetBackupPool() *plugin.TValue[*mqlGcpProjectComputeServiceTargetPool] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceTargetPool](&c.BackupPool, func() (*mqlGcpProjectComputeServiceTargetPool, error) {
 		if c.MqlRuntime.HasRecording {
@@ -81610,10 +80242,6 @@ func (c *mqlGcpProjectComputeServiceTargetPool) GetInstanceRefs() *plugin.TValue
 	})
 }
 
-func (c *mqlGcpProjectComputeServiceTargetPool) GetSecurityPolicyUrl() *plugin.TValue[string] {
-	return &c.SecurityPolicyUrl
-}
-
 func (c *mqlGcpProjectComputeServiceTargetPool) GetSecurityPolicy() *plugin.TValue[*mqlGcpProjectComputeServiceSecurityPolicy] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceSecurityPolicy](&c.SecurityPolicy, func() (*mqlGcpProjectComputeServiceSecurityPolicy, error) {
 		if c.MqlRuntime.HasRecording {
@@ -81628,10 +80256,6 @@ func (c *mqlGcpProjectComputeServiceTargetPool) GetSecurityPolicy() *plugin.TVal
 
 		return c.securityPolicy()
 	})
-}
-
-func (c *mqlGcpProjectComputeServiceTargetPool) GetRegionUrl() *plugin.TValue[string] {
-	return &c.RegionUrl
 }
 
 func (c *mqlGcpProjectComputeServiceTargetPool) GetRegion() *plugin.TValue[*mqlGcpProjectComputeServiceRegion] {
@@ -82532,7 +81156,7 @@ func (c *mqlGcpProjectArtifactRegistryService) GetRepositories() *plugin.TValue[
 type mqlGcpProjectArtifactRegistryServiceRepository struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectArtifactRegistryServiceRepositoryInternal it will be used here
+	mqlGcpProjectArtifactRegistryServiceRepositoryInternal
 	ProjectId                   plugin.TValue[string]
 	ResourcePath                plugin.TValue[string]
 	Name                        plugin.TValue[string]
@@ -82541,7 +81165,6 @@ type mqlGcpProjectArtifactRegistryServiceRepository struct {
 	Format                      plugin.TValue[string]
 	Mode                        plugin.TValue[string]
 	Labels                      plugin.TValue[map[string]any]
-	KmsKeyName                  plugin.TValue[string]
 	KmsKey                      plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
 	CreateTime                  plugin.TValue[*time.Time]
 	UpdateTime                  plugin.TValue[*time.Time]
@@ -82627,10 +81250,6 @@ func (c *mqlGcpProjectArtifactRegistryServiceRepository) GetMode() *plugin.TValu
 
 func (c *mqlGcpProjectArtifactRegistryServiceRepository) GetLabels() *plugin.TValue[map[string]any] {
 	return &c.Labels
-}
-
-func (c *mqlGcpProjectArtifactRegistryServiceRepository) GetKmsKeyName() *plugin.TValue[string] {
-	return &c.KmsKeyName
 }
 
 func (c *mqlGcpProjectArtifactRegistryServiceRepository) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -84742,11 +83361,9 @@ type mqlGcpProjectVertexaiServiceEndpoint struct {
 	Name                                 plugin.TValue[string]
 	DisplayName                          plugin.TValue[string]
 	Description                          plugin.TValue[string]
-	DeployedModels                       plugin.TValue[[]any]
 	Deployments                          plugin.TValue[[]any]
 	EncryptionSpec                       plugin.TValue[any]
 	KmsKey                               plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	Network                              plugin.TValue[string]
 	NetworkRef                           plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	EnablePrivateServiceConnect          plugin.TValue[bool]
 	PscProjectAllowlist                  plugin.TValue[[]any]
@@ -84815,10 +83432,6 @@ func (c *mqlGcpProjectVertexaiServiceEndpoint) GetDescription() *plugin.TValue[s
 	return &c.Description
 }
 
-func (c *mqlGcpProjectVertexaiServiceEndpoint) GetDeployedModels() *plugin.TValue[[]any] {
-	return &c.DeployedModels
-}
-
 func (c *mqlGcpProjectVertexaiServiceEndpoint) GetDeployments() *plugin.TValue[[]any] {
 	return &c.Deployments
 }
@@ -84841,10 +83454,6 @@ func (c *mqlGcpProjectVertexaiServiceEndpoint) GetKmsKey() *plugin.TValue[*mqlGc
 
 		return c.kmsKey()
 	})
-}
-
-func (c *mqlGcpProjectVertexaiServiceEndpoint) GetNetwork() *plugin.TValue[string] {
-	return &c.Network
 }
 
 func (c *mqlGcpProjectVertexaiServiceEndpoint) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -85065,9 +83674,7 @@ type mqlGcpProjectVertexaiServicePipelineJob struct {
 	State             plugin.TValue[string]
 	PipelineSpec      plugin.TValue[any]
 	RuntimeConfig     plugin.TValue[any]
-	ServiceAccount    plugin.TValue[string]
 	ServiceAccountRef plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	Network           plugin.TValue[string]
 	NetworkRef        plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	EncryptionSpec    plugin.TValue[any]
 	KmsKey            plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
@@ -85141,10 +83748,6 @@ func (c *mqlGcpProjectVertexaiServicePipelineJob) GetRuntimeConfig() *plugin.TVa
 	return &c.RuntimeConfig
 }
 
-func (c *mqlGcpProjectVertexaiServicePipelineJob) GetServiceAccount() *plugin.TValue[string] {
-	return &c.ServiceAccount
-}
-
 func (c *mqlGcpProjectVertexaiServicePipelineJob) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
 	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccountRef, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
 		if c.MqlRuntime.HasRecording {
@@ -85159,10 +83762,6 @@ func (c *mqlGcpProjectVertexaiServicePipelineJob) GetServiceAccountRef() *plugin
 
 		return c.serviceAccountRef()
 	})
-}
-
-func (c *mqlGcpProjectVertexaiServicePipelineJob) GetNetwork() *plugin.TValue[string] {
-	return &c.Network
 }
 
 func (c *mqlGcpProjectVertexaiServicePipelineJob) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -85601,9 +84200,7 @@ type mqlGcpProjectVertexaiServiceCustomJob struct {
 	DisplayName       plugin.TValue[string]
 	State             plugin.TValue[string]
 	JobSpec           plugin.TValue[any]
-	ServiceAccount    plugin.TValue[string]
 	ServiceAccountRef plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
-	Network           plugin.TValue[string]
 	NetworkRef        plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	EnableWebAccess   plugin.TValue[bool]
 	Labels            plugin.TValue[map[string]any]
@@ -85670,10 +84267,6 @@ func (c *mqlGcpProjectVertexaiServiceCustomJob) GetJobSpec() *plugin.TValue[any]
 	return &c.JobSpec
 }
 
-func (c *mqlGcpProjectVertexaiServiceCustomJob) GetServiceAccount() *plugin.TValue[string] {
-	return &c.ServiceAccount
-}
-
 func (c *mqlGcpProjectVertexaiServiceCustomJob) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
 	return plugin.GetOrCompute[*mqlGcpProjectIamServiceServiceAccount](&c.ServiceAccountRef, func() (*mqlGcpProjectIamServiceServiceAccount, error) {
 		if c.MqlRuntime.HasRecording {
@@ -85688,10 +84281,6 @@ func (c *mqlGcpProjectVertexaiServiceCustomJob) GetServiceAccountRef() *plugin.T
 
 		return c.serviceAccountRef()
 	})
-}
-
-func (c *mqlGcpProjectVertexaiServiceCustomJob) GetNetwork() *plugin.TValue[string] {
-	return &c.Network
 }
 
 func (c *mqlGcpProjectVertexaiServiceCustomJob) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -85894,7 +84483,6 @@ type mqlGcpProjectVertexaiServiceIndexEndpoint struct {
 	DisplayName              plugin.TValue[string]
 	Description              plugin.TValue[string]
 	DeployedIndexes          plugin.TValue[[]any]
-	Network                  plugin.TValue[string]
 	NetworkRef               plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PublicEndpointEnabled    plugin.TValue[bool]
 	PublicEndpointDomainName plugin.TValue[string]
@@ -85956,10 +84544,6 @@ func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetDescription() *plugin.TVa
 
 func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetDeployedIndexes() *plugin.TValue[[]any] {
 	return &c.DeployedIndexes
-}
-
-func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetNetwork() *plugin.TValue[string] {
-	return &c.Network
 }
 
 func (c *mqlGcpProjectVertexaiServiceIndexEndpoint) GetNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -86513,7 +85097,6 @@ type mqlGcpProjectVertexaiServiceNotebookExecutionJob struct {
 	ExecutionUser              plugin.TValue[string]
 	ServiceAccountRef          plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	NotebookRuntimeTemplateRef plugin.TValue[*mqlGcpProjectVertexaiServiceNotebookRuntimeTemplate]
-	ScheduleResourceName       plugin.TValue[string]
 	ScheduleRef                plugin.TValue[*mqlGcpProjectVertexaiServiceSchedule]
 	ExecutionTimeoutSeconds    plugin.TValue[int64]
 	Labels                     plugin.TValue[map[string]any]
@@ -86611,10 +85194,6 @@ func (c *mqlGcpProjectVertexaiServiceNotebookExecutionJob) GetNotebookRuntimeTem
 
 		return c.notebookRuntimeTemplateRef()
 	})
-}
-
-func (c *mqlGcpProjectVertexaiServiceNotebookExecutionJob) GetScheduleResourceName() *plugin.TValue[string] {
-	return &c.ScheduleResourceName
 }
 
 func (c *mqlGcpProjectVertexaiServiceNotebookExecutionJob) GetScheduleRef() *plugin.TValue[*mqlGcpProjectVertexaiServiceSchedule] {
@@ -88999,8 +87578,6 @@ type mqlGcpAccesscontextmanagerServicePerimeter struct {
 	Title                 plugin.TValue[string]
 	Description           plugin.TValue[string]
 	PerimeterType         plugin.TValue[string]
-	Status                plugin.TValue[any]
-	Spec                  plugin.TValue[any]
 	StatusConfig          plugin.TValue[*mqlGcpAccesscontextmanagerServicePerimeterConfig]
 	SpecConfig            plugin.TValue[*mqlGcpAccesscontextmanagerServicePerimeterConfig]
 	UseExplicitDryRunSpec plugin.TValue[bool]
@@ -89059,14 +87636,6 @@ func (c *mqlGcpAccesscontextmanagerServicePerimeter) GetDescription() *plugin.TV
 
 func (c *mqlGcpAccesscontextmanagerServicePerimeter) GetPerimeterType() *plugin.TValue[string] {
 	return &c.PerimeterType
-}
-
-func (c *mqlGcpAccesscontextmanagerServicePerimeter) GetStatus() *plugin.TValue[any] {
-	return &c.Status
-}
-
-func (c *mqlGcpAccesscontextmanagerServicePerimeter) GetSpec() *plugin.TValue[any] {
-	return &c.Spec
 }
 
 func (c *mqlGcpAccesscontextmanagerServicePerimeter) GetStatusConfig() *plugin.TValue[*mqlGcpAccesscontextmanagerServicePerimeterConfig] {
@@ -90495,11 +89064,10 @@ func (c *mqlGcpProjectEventarcService) GetChannels() *plugin.TValue[[]any] {
 type mqlGcpProjectEventarcServiceTrigger struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectEventarcServiceTriggerInternal it will be used here
+	mqlGcpProjectEventarcServiceTriggerInternal
 	Name                 plugin.TValue[string]
 	Uid                  plugin.TValue[string]
 	EventFilters         plugin.TValue[[]any]
-	ServiceAccount       plugin.TValue[string]
 	ServiceAccountRef    plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	Destination          plugin.TValue[any]
 	Transport            plugin.TValue[any]
@@ -90558,10 +89126,6 @@ func (c *mqlGcpProjectEventarcServiceTrigger) GetUid() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectEventarcServiceTrigger) GetEventFilters() *plugin.TValue[[]any] {
 	return &c.EventFilters
-}
-
-func (c *mqlGcpProjectEventarcServiceTrigger) GetServiceAccount() *plugin.TValue[string] {
-	return &c.ServiceAccount
 }
 
 func (c *mqlGcpProjectEventarcServiceTrigger) GetServiceAccountRef() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
@@ -90680,17 +89244,16 @@ func (c *mqlGcpProjectEventarcServiceTriggerEventFilter) GetOperator() *plugin.T
 type mqlGcpProjectEventarcServiceChannel struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectEventarcServiceChannelInternal it will be used here
-	Name          plugin.TValue[string]
-	Uid           plugin.TValue[string]
-	Provider      plugin.TValue[string]
-	PubsubTopic   plugin.TValue[string]
-	State         plugin.TValue[string]
-	CryptoKeyName plugin.TValue[string]
-	KmsKey        plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
-	Labels        plugin.TValue[map[string]any]
-	Created       plugin.TValue[*time.Time]
-	Updated       plugin.TValue[*time.Time]
+	mqlGcpProjectEventarcServiceChannelInternal
+	Name        plugin.TValue[string]
+	Uid         plugin.TValue[string]
+	Provider    plugin.TValue[string]
+	PubsubTopic plugin.TValue[string]
+	State       plugin.TValue[string]
+	KmsKey      plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	Labels      plugin.TValue[map[string]any]
+	Created     plugin.TValue[*time.Time]
+	Updated     plugin.TValue[*time.Time]
 }
 
 // createGcpProjectEventarcServiceChannel creates a new instance of this resource
@@ -90748,10 +89311,6 @@ func (c *mqlGcpProjectEventarcServiceChannel) GetPubsubTopic() *plugin.TValue[st
 
 func (c *mqlGcpProjectEventarcServiceChannel) GetState() *plugin.TValue[string] {
 	return &c.State
-}
-
-func (c *mqlGcpProjectEventarcServiceChannel) GetCryptoKeyName() *plugin.TValue[string] {
-	return &c.CryptoKeyName
 }
 
 func (c *mqlGcpProjectEventarcServiceChannel) GetKmsKey() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey] {
@@ -92435,10 +90994,9 @@ func (c *mqlGcpProjectIdsService) GetEndpoints() *plugin.TValue[[]any] {
 type mqlGcpProjectIdsServiceEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectIdsServiceEndpointInternal it will be used here
+	mqlGcpProjectIdsServiceEndpointInternal
 	Name                   plugin.TValue[string]
 	Description            plugin.TValue[string]
-	NetworkUrl             plugin.TValue[string]
 	Network                plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	EndpointForwardingRule plugin.TValue[string]
 	EndpointIp             plugin.TValue[string]
@@ -92493,10 +91051,6 @@ func (c *mqlGcpProjectIdsServiceEndpoint) GetName() *plugin.TValue[string] {
 
 func (c *mqlGcpProjectIdsServiceEndpoint) GetDescription() *plugin.TValue[string] {
 	return &c.Description
-}
-
-func (c *mqlGcpProjectIdsServiceEndpoint) GetNetworkUrl() *plugin.TValue[string] {
-	return &c.NetworkUrl
 }
 
 func (c *mqlGcpProjectIdsServiceEndpoint) GetNetwork() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
@@ -93904,7 +92458,6 @@ type mqlGcpProjectContainerAnalysisServiceOccurrence struct {
 	NoteName                       plugin.TValue[string]
 	Kind                           plugin.TValue[string]
 	Remediation                    plugin.TValue[string]
-	Vulnerability                  plugin.TValue[any]
 	VulnerabilitySeverity          plugin.TValue[string]
 	VulnerabilityEffectiveSeverity plugin.TValue[string]
 	VulnerabilityCvssScore         plugin.TValue[float64]
@@ -93912,7 +92465,6 @@ type mqlGcpProjectContainerAnalysisServiceOccurrence struct {
 	VulnerabilityShortDescription  plugin.TValue[string]
 	VulnerabilityLongDescription   plugin.TValue[string]
 	VulnerabilityPackageIssues     plugin.TValue[[]any]
-	Build                          plugin.TValue[any]
 	BuildProvenanceId              plugin.TValue[string]
 	BuildCreator                   plugin.TValue[string]
 	BuildCreateTime                plugin.TValue[*time.Time]
@@ -93927,7 +92479,6 @@ type mqlGcpProjectContainerAnalysisServiceOccurrence struct {
 	PackageInfo                    plugin.TValue[any]
 	Deployment                     plugin.TValue[any]
 	Discovery                      plugin.TValue[any]
-	Attestation                    plugin.TValue[any]
 	AttestationSerializedPayload   plugin.TValue[string]
 	AttestationSignatures          plugin.TValue[[]any]
 	Created                        plugin.TValue[*time.Time]
@@ -93991,10 +92542,6 @@ func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetRemediation() *plug
 	return &c.Remediation
 }
 
-func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetVulnerability() *plugin.TValue[any] {
-	return &c.Vulnerability
-}
-
 func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetVulnerabilitySeverity() *plugin.TValue[string] {
 	return &c.VulnerabilitySeverity
 }
@@ -94021,10 +92568,6 @@ func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetVulnerabilityLongDe
 
 func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetVulnerabilityPackageIssues() *plugin.TValue[[]any] {
 	return &c.VulnerabilityPackageIssues
-}
-
-func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetBuild() *plugin.TValue[any] {
-	return &c.Build
 }
 
 func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetBuildProvenanceId() *plugin.TValue[string] {
@@ -94081,10 +92624,6 @@ func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetDeployment() *plugi
 
 func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetDiscovery() *plugin.TValue[any] {
 	return &c.Discovery
-}
-
-func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetAttestation() *plugin.TValue[any] {
-	return &c.Attestation
 }
 
 func (c *mqlGcpProjectContainerAnalysisServiceOccurrence) GetAttestationSerializedPayload() *plugin.TValue[string] {
@@ -94311,7 +92850,6 @@ type mqlGcpProjectCloudBuildServiceTrigger struct {
 	Filename              plugin.TValue[string]
 	Filter                plugin.TValue[string]
 	Substitutions         plugin.TValue[map[string]any]
-	ServiceAccount        plugin.TValue[string]
 	IamServiceAccount     plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	Github                plugin.TValue[*mqlGcpProjectCloudBuildServiceTriggerGithubEventsConfig]
 	PubsubConfig          plugin.TValue[*mqlGcpProjectCloudBuildServiceTriggerPubsubConfig]
@@ -94391,10 +92929,6 @@ func (c *mqlGcpProjectCloudBuildServiceTrigger) GetFilter() *plugin.TValue[strin
 
 func (c *mqlGcpProjectCloudBuildServiceTrigger) GetSubstitutions() *plugin.TValue[map[string]any] {
 	return &c.Substitutions
-}
-
-func (c *mqlGcpProjectCloudBuildServiceTrigger) GetServiceAccount() *plugin.TValue[string] {
-	return &c.ServiceAccount
 }
 
 func (c *mqlGcpProjectCloudBuildServiceTrigger) GetIamServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {
@@ -94890,9 +93424,8 @@ func (c *mqlGcpProjectCloudBuildServiceWorkerPoolWorkerConfig) GetEnableNestedVi
 type mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfigInternal it will be used here
+	mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfigInternal
 	Id                   plugin.TValue[string]
-	PeeredNetwork        plugin.TValue[string]
 	PeeredNetworkRef     plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
 	PeeredNetworkIpRange plugin.TValue[string]
 	EgressOption         plugin.TValue[string]
@@ -94939,10 +93472,6 @@ func (c *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) GetId() *plugin.
 	return &c.Id
 }
 
-func (c *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) GetPeeredNetwork() *plugin.TValue[string] {
-	return &c.PeeredNetwork
-}
-
 func (c *mqlGcpProjectCloudBuildServiceWorkerPoolNetworkConfig) GetPeeredNetworkRef() *plugin.TValue[*mqlGcpProjectComputeServiceNetwork] {
 	return plugin.GetOrCompute[*mqlGcpProjectComputeServiceNetwork](&c.PeeredNetworkRef, func() (*mqlGcpProjectComputeServiceNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -94987,7 +93516,6 @@ type mqlGcpProjectCloudBuildServiceBuild struct {
 	Trigger           plugin.TValue[*mqlGcpProjectCloudBuildServiceTrigger]
 	LogUrl            plugin.TValue[string]
 	LogsBucket        plugin.TValue[string]
-	ServiceAccount    plugin.TValue[string]
 	IamServiceAccount plugin.TValue[*mqlGcpProjectIamServiceServiceAccount]
 	Substitutions     plugin.TValue[map[string]any]
 	Tags              plugin.TValue[[]any]
@@ -95100,10 +93628,6 @@ func (c *mqlGcpProjectCloudBuildServiceBuild) GetLogUrl() *plugin.TValue[string]
 
 func (c *mqlGcpProjectCloudBuildServiceBuild) GetLogsBucket() *plugin.TValue[string] {
 	return &c.LogsBucket
-}
-
-func (c *mqlGcpProjectCloudBuildServiceBuild) GetServiceAccount() *plugin.TValue[string] {
-	return &c.ServiceAccount
 }
 
 func (c *mqlGcpProjectCloudBuildServiceBuild) GetIamServiceAccount() *plugin.TValue[*mqlGcpProjectIamServiceServiceAccount] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -42,9 +42,7 @@ gcp.accesscontextmanager.servicePerimeter.createTime 13.3.4
 gcp.accesscontextmanager.servicePerimeter.description 13.3.4
 gcp.accesscontextmanager.servicePerimeter.name 13.3.4
 gcp.accesscontextmanager.servicePerimeter.perimeterType 13.3.4
-gcp.accesscontextmanager.servicePerimeter.spec 13.3.4
 gcp.accesscontextmanager.servicePerimeter.specConfig 13.6.1
-gcp.accesscontextmanager.servicePerimeter.status 13.3.4
 gcp.accesscontextmanager.servicePerimeter.statusConfig 13.6.1
 gcp.accesscontextmanager.servicePerimeter.title 13.3.4
 gcp.accesscontextmanager.servicePerimeter.updateTime 13.3.4
@@ -429,7 +427,6 @@ gcp.project.apiGatewayService.api.updateTime 13.15.1
 gcp.project.apiGatewayService.apiConfig 13.15.1
 gcp.project.apiGatewayService.apiConfig.createTime 13.15.1
 gcp.project.apiGatewayService.apiConfig.displayName 13.15.1
-gcp.project.apiGatewayService.apiConfig.gatewayServiceAccount 13.15.1
 gcp.project.apiGatewayService.apiConfig.labels 13.15.1
 gcp.project.apiGatewayService.apiConfig.name 13.15.1
 gcp.project.apiGatewayService.apiConfig.openapiDocuments 13.15.1
@@ -555,7 +552,6 @@ gcp.project.artifactRegistryService.repository.formatConfig.immutableTags 11.6.1
 gcp.project.artifactRegistryService.repository.formatConfig.mavenVersionPolicy 11.6.1
 gcp.project.artifactRegistryService.repository.iamPolicy 11.6.1
 gcp.project.artifactRegistryService.repository.kmsKey 13.19.2
-gcp.project.artifactRegistryService.repository.kmsKeyName 11.6.1
 gcp.project.artifactRegistryService.repository.labels 11.6.1
 gcp.project.artifactRegistryService.repository.location 11.6.1
 gcp.project.artifactRegistryService.repository.managedBy 13.27.2
@@ -761,7 +757,6 @@ gcp.project.bigqueryService.dataset.externalDatasetReference 13.16.3
 gcp.project.bigqueryService.dataset.id 9.0.0
 gcp.project.bigqueryService.dataset.isCaseInsensitive 13.1.2
 gcp.project.bigqueryService.dataset.kmsKey 13.12.2
-gcp.project.bigqueryService.dataset.kmsName 9.0.0
 gcp.project.bigqueryService.dataset.labels 9.0.0
 gcp.project.bigqueryService.dataset.location 9.0.0
 gcp.project.bigqueryService.dataset.managedBy 13.27.2
@@ -783,7 +778,6 @@ gcp.project.bigqueryService.model.description 9.0.0
 gcp.project.bigqueryService.model.expirationTime 9.0.0
 gcp.project.bigqueryService.model.id 9.0.0
 gcp.project.bigqueryService.model.kmsKey 13.12.2
-gcp.project.bigqueryService.model.kmsName 9.0.0
 gcp.project.bigqueryService.model.labels 9.0.0
 gcp.project.bigqueryService.model.location 9.0.0
 gcp.project.bigqueryService.model.modified 9.0.0
@@ -830,7 +824,6 @@ gcp.project.bigqueryService.table.externalDataConfig 9.0.0
 gcp.project.bigqueryService.table.iamPolicy 13.21.2
 gcp.project.bigqueryService.table.id 9.0.0
 gcp.project.bigqueryService.table.kmsKey 13.12.2
-gcp.project.bigqueryService.table.kmsName 9.0.0
 gcp.project.bigqueryService.table.labels 9.0.0
 gcp.project.bigqueryService.table.location 9.0.0
 gcp.project.bigqueryService.table.materializedView 9.0.0
@@ -930,7 +923,6 @@ gcp.project.binaryAuthorizationControl.attestor.publicKey.pkixSignatureAlgorithm
 gcp.project.binaryAuthorizationControl.attestor.publicKey.type 13.13.4
 gcp.project.binaryAuthorizationControl.attestor.publicKeys 13.13.4
 gcp.project.binaryAuthorizationControl.attestor.updated 13.6.1
-gcp.project.binaryAuthorizationControl.attestor.userOwnedGrafeasNote 13.6.1
 gcp.project.binaryAuthorizationControl.attestors 13.6.1
 gcp.project.binaryAuthorizationControl.policy 11.0.15
 gcp.project.binaryAuthorizationControl.policy.admissionWhitelistPatterns 11.0.15
@@ -1133,7 +1125,6 @@ gcp.project.cloudBuildService.build.logUrl 13.23.2
 gcp.project.cloudBuildService.build.logsBucket 13.23.2
 gcp.project.cloudBuildService.build.projectId 13.23.2
 gcp.project.cloudBuildService.build.results 13.23.2
-gcp.project.cloudBuildService.build.serviceAccount 13.23.2
 gcp.project.cloudBuildService.build.source 13.23.2
 gcp.project.cloudBuildService.build.sourceProvenance 13.23.2
 gcp.project.cloudBuildService.build.startTime 13.23.2
@@ -1175,7 +1166,6 @@ gcp.project.cloudBuildService.trigger.repositoryEventConfig.pullRequest 13.7.2
 gcp.project.cloudBuildService.trigger.repositoryEventConfig.push 13.7.2
 gcp.project.cloudBuildService.trigger.repositoryEventConfig.repository 13.7.2
 gcp.project.cloudBuildService.trigger.repositoryEventConfig.repositoryType 13.7.2
-gcp.project.cloudBuildService.trigger.serviceAccount 13.7.2
 gcp.project.cloudBuildService.trigger.substitutions 13.7.2
 gcp.project.cloudBuildService.trigger.tags 13.7.2
 gcp.project.cloudBuildService.trigger.triggerId 13.7.2
@@ -1191,7 +1181,6 @@ gcp.project.cloudBuildService.workerPool.name 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig.egressOption 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig.id 13.7.2
-gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetwork 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkIpRange 13.7.2
 gcp.project.cloudBuildService.workerPool.networkConfig.peeredNetworkRef 13.21.2
 gcp.project.cloudBuildService.workerPool.projectId 13.7.2
@@ -1284,7 +1273,6 @@ gcp.project.cloudFunction.buildServiceAccount 13.25.2
 gcp.project.cloudFunction.buildWorkerPool 9.0.0
 gcp.project.cloudFunction.description 9.0.0
 gcp.project.cloudFunction.dockerRegistry 9.0.0
-gcp.project.cloudFunction.dockerRepository 9.0.0
 gcp.project.cloudFunction.dockerRepositoryRef 13.27.2
 gcp.project.cloudFunction.egressSettings 9.0.0
 gcp.project.cloudFunction.entryPoint 9.0.0
@@ -1302,7 +1290,6 @@ gcp.project.cloudFunction.managedBy 13.27.2
 gcp.project.cloudFunction.maxInstances 9.0.0
 gcp.project.cloudFunction.minInstances 9.0.0
 gcp.project.cloudFunction.name 9.0.0
-gcp.project.cloudFunction.network 9.0.0
 gcp.project.cloudFunction.networkRef 13.21.2
 gcp.project.cloudFunction.projectId 9.0.0
 gcp.project.cloudFunction.runtime 9.0.0
@@ -1323,14 +1310,12 @@ gcp.project.cloudFunctionV2.allowsUnauthenticated 13.19.2
 gcp.project.cloudFunctionV2.buildConfig 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.build 13.25.2
 gcp.project.cloudFunctionV2.buildConfig.buildWorkerPool 13.7.2
-gcp.project.cloudFunctionV2.buildConfig.dockerRepository 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.dockerRepositoryRef 13.27.2
 gcp.project.cloudFunctionV2.buildConfig.entryPoint 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.environmentVariables 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.gitUri 13.25.2
 gcp.project.cloudFunctionV2.buildConfig.id 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.runtime 13.7.2
-gcp.project.cloudFunctionV2.buildConfig.serviceAccount 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.serviceAccountRef 13.21.2
 gcp.project.cloudFunctionV2.buildConfig.source 13.7.2
 gcp.project.cloudFunctionV2.buildConfig.sourceProvenance 13.25.2
@@ -1440,7 +1425,6 @@ gcp.project.cloudRunService.job.executionTemplate.taskTemplate.serviceAccount 9.
 gcp.project.cloudRunService.job.executionTemplate.taskTemplate.serviceAccountEmail 9.0.0
 gcp.project.cloudRunService.job.executionTemplate.taskTemplate.timeout 9.0.0
 gcp.project.cloudRunService.job.executionTemplate.taskTemplate.volumes 9.0.0
-gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccess 9.0.0
 gcp.project.cloudRunService.job.executionTemplate.taskTemplate.vpcAccessConfig 13.16.3
 gcp.project.cloudRunService.job.executionTemplate.template 9.0.0
 gcp.project.cloudRunService.job.expired 9.0.0
@@ -1519,7 +1503,6 @@ gcp.project.cloudRunService.service.revisionTemplate.serviceAccount 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate.serviceAccountEmail 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate.timeout 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate.volumes 9.0.0
-gcp.project.cloudRunService.service.revisionTemplate.vpcAccess 9.0.0
 gcp.project.cloudRunService.service.revisionTemplate.vpcAccessConfig 13.16.3
 gcp.project.cloudRunService.service.satisfiesPzs 13.1.2
 gcp.project.cloudRunService.service.template 9.0.0
@@ -1542,9 +1525,7 @@ gcp.project.cloudSchedulerService.job.description 11.6.6
 gcp.project.cloudSchedulerService.job.lastAttemptTime 11.6.6
 gcp.project.cloudSchedulerService.job.name 11.6.6
 gcp.project.cloudSchedulerService.job.oauthServiceAccount 13.21.2
-gcp.project.cloudSchedulerService.job.oauthServiceAccountEmail 13.18.1
 gcp.project.cloudSchedulerService.job.oidcServiceAccount 13.21.2
-gcp.project.cloudSchedulerService.job.oidcServiceAccountEmail 13.18.1
 gcp.project.cloudSchedulerService.job.projectId 11.6.6
 gcp.project.cloudSchedulerService.job.retryConfig 11.6.6
 gcp.project.cloudSchedulerService.job.schedule 11.6.6
@@ -1599,15 +1580,12 @@ gcp.project.computeService.address.labels 11.6.6
 gcp.project.computeService.address.name 9.0.0
 gcp.project.computeService.address.network 9.0.0
 gcp.project.computeService.address.networkTier 9.0.0
-gcp.project.computeService.address.networkUrl 9.0.0
 gcp.project.computeService.address.prefixLength 9.0.0
 gcp.project.computeService.address.purpose 9.0.0
 gcp.project.computeService.address.region 13.16.3
-gcp.project.computeService.address.regionUrl 9.0.0
 gcp.project.computeService.address.resourceUrls 9.0.0
 gcp.project.computeService.address.status 9.0.0
 gcp.project.computeService.address.subnetwork 9.0.0
-gcp.project.computeService.address.subnetworkUrl 9.0.0
 gcp.project.computeService.addresses 9.0.0
 gcp.project.computeService.attachedDisk 9.0.0
 gcp.project.computeService.attachedDisk.architecture 9.0.0
@@ -1646,7 +1624,6 @@ gcp.project.computeService.backendService.backend.balancingMode 9.0.0
 gcp.project.computeService.backendService.backend.capacityScaler 9.0.0
 gcp.project.computeService.backendService.backend.description 9.0.0
 gcp.project.computeService.backendService.backend.failover 9.0.0
-gcp.project.computeService.backendService.backend.groupUrl 9.0.0
 gcp.project.computeService.backendService.backend.id 9.0.0
 gcp.project.computeService.backendService.backend.instanceGroup 13.29.1
 gcp.project.computeService.backendService.backend.maxConnections 9.0.0
@@ -1683,7 +1660,6 @@ gcp.project.computeService.backendService.customRequestHeaders 9.0.0
 gcp.project.computeService.backendService.customResponseHeaders 9.0.0
 gcp.project.computeService.backendService.description 9.0.0
 gcp.project.computeService.backendService.edgeSecurityPolicy 9.0.0
-gcp.project.computeService.backendService.edgeSecurityPolicyUrl 13.29.1
 gcp.project.computeService.backendService.enableCDN 9.0.0
 gcp.project.computeService.backendService.failoverPolicy 9.0.0
 gcp.project.computeService.backendService.fingerprint 13.1.2
@@ -1701,14 +1677,11 @@ gcp.project.computeService.backendService.loggingEnabled 13.21.2
 gcp.project.computeService.backendService.maxStreamDuration 9.0.0
 gcp.project.computeService.backendService.name 9.0.0
 gcp.project.computeService.backendService.network 13.6.1
-gcp.project.computeService.backendService.networkUrl 9.0.0
 gcp.project.computeService.backendService.port 11.6.6
 gcp.project.computeService.backendService.portName 9.0.0
 gcp.project.computeService.backendService.protocol 9.0.0
 gcp.project.computeService.backendService.region 13.16.3
-gcp.project.computeService.backendService.regionUrl 9.0.0
 gcp.project.computeService.backendService.securityPolicy 13.6.1
-gcp.project.computeService.backendService.securityPolicyUrl 9.0.0
 gcp.project.computeService.backendService.securitySettings 9.0.0
 gcp.project.computeService.backendService.securitySettingsClientTlsPolicy 13.18.1
 gcp.project.computeService.backendService.securitySettingsSubjectAltNames 13.18.1
@@ -1806,7 +1779,6 @@ gcp.project.computeService.firewallPolicy.id 11.6.6
 gcp.project.computeService.firewallPolicy.name 11.6.6
 gcp.project.computeService.firewallPolicy.projectId 11.6.6
 gcp.project.computeService.firewallPolicy.region 13.16.3
-gcp.project.computeService.firewallPolicy.regionUrl 11.6.6
 gcp.project.computeService.firewallPolicy.rule 11.6.6
 gcp.project.computeService.firewallPolicy.rule.action 11.6.6
 gcp.project.computeService.firewallPolicy.rule.description 11.6.6
@@ -1837,7 +1809,6 @@ gcp.project.computeService.forwardingRule.allPorts 9.0.0
 gcp.project.computeService.forwardingRule.allowGlobalAccess 9.0.0
 gcp.project.computeService.forwardingRule.allowPscGlobalAccess 11.6.6
 gcp.project.computeService.forwardingRule.backendService 9.0.0
-gcp.project.computeService.forwardingRule.backendServiceUrl 13.29.1
 gcp.project.computeService.forwardingRule.created 9.0.0
 gcp.project.computeService.forwardingRule.description 9.0.0
 gcp.project.computeService.forwardingRule.fingerprint 13.1.2
@@ -1854,20 +1825,17 @@ gcp.project.computeService.forwardingRule.metadataFilters 9.0.0
 gcp.project.computeService.forwardingRule.name 9.0.0
 gcp.project.computeService.forwardingRule.network 9.0.0
 gcp.project.computeService.forwardingRule.networkTier 9.0.0
-gcp.project.computeService.forwardingRule.networkUrl 9.0.0
 gcp.project.computeService.forwardingRule.noAutomateDnsZone 9.0.0
 gcp.project.computeService.forwardingRule.portRange 9.0.0
 gcp.project.computeService.forwardingRule.ports 9.0.0
 gcp.project.computeService.forwardingRule.pscConnectionStatus 11.6.6
 gcp.project.computeService.forwardingRule.region 13.16.3
-gcp.project.computeService.forwardingRule.regionUrl 9.0.0
 gcp.project.computeService.forwardingRule.selfLink 13.29.1
 gcp.project.computeService.forwardingRule.serviceDirectoryRegistrations 9.0.0
 gcp.project.computeService.forwardingRule.serviceLabel 9.0.0
 gcp.project.computeService.forwardingRule.serviceName 9.0.0
 gcp.project.computeService.forwardingRule.sourceIpRanges 11.6.6
 gcp.project.computeService.forwardingRule.subnetwork 9.0.0
-gcp.project.computeService.forwardingRule.subnetworkUrl 9.0.0
 gcp.project.computeService.forwardingRule.targetHttpProxy 13.29.1
 gcp.project.computeService.forwardingRule.targetHttpsProxy 13.29.1
 gcp.project.computeService.forwardingRule.targetPool 13.29.1
@@ -1890,7 +1858,6 @@ gcp.project.computeService.healthCheck.logConfig 11.6.6
 gcp.project.computeService.healthCheck.name 11.6.6
 gcp.project.computeService.healthCheck.projectId 11.6.6
 gcp.project.computeService.healthCheck.region 13.16.3
-gcp.project.computeService.healthCheck.regionUrl 11.6.6
 gcp.project.computeService.healthCheck.selfLink 11.6.6
 gcp.project.computeService.healthCheck.sslHealthCheck 11.6.6
 gcp.project.computeService.healthCheck.tcpHealthCheck 11.6.6
@@ -1932,16 +1899,12 @@ gcp.project.computeService.instance.canIpForward 9.0.0
 gcp.project.computeService.instance.confidentialCompute 13.16.3
 gcp.project.computeService.instance.confidentialCompute.enabled 13.16.3
 gcp.project.computeService.instance.confidentialCompute.instanceType 13.16.3
-gcp.project.computeService.instance.confidentialInstanceConfig 9.0.0
 gcp.project.computeService.instance.cpuPlatform 9.0.0
 gcp.project.computeService.instance.created 9.0.0
 gcp.project.computeService.instance.deletionProtection 9.0.0
 gcp.project.computeService.instance.description 9.0.0
 gcp.project.computeService.instance.disks 9.0.0
 gcp.project.computeService.instance.enableDisplay 9.0.0
-gcp.project.computeService.instance.enableIntegrityMonitoring 9.0.0
-gcp.project.computeService.instance.enableSecureBoot 9.0.0
-gcp.project.computeService.instance.enableVtpm 9.0.0
 gcp.project.computeService.instance.exposure 13.24.1
 gcp.project.computeService.instance.exposure.firewallAllowsIngress 13.24.1
 gcp.project.computeService.instance.exposure.hasPublicIp 13.24.1
@@ -1979,7 +1942,6 @@ gcp.project.computeService.instance.networkInterface.nicType 13.29.1
 gcp.project.computeService.instance.networkInterface.queueCount 13.29.1
 gcp.project.computeService.instance.networkInterface.stackType 13.29.1
 gcp.project.computeService.instance.networkInterface.subnetwork 13.29.1
-gcp.project.computeService.instance.networkInterfaces 9.0.0
 gcp.project.computeService.instance.networkStackTypes 13.18.1
 gcp.project.computeService.instance.networks 13.27.2
 gcp.project.computeService.instance.nics 13.29.1
@@ -1993,14 +1955,12 @@ gcp.project.computeService.instance.osInventory.item.packageType 13.18.1
 gcp.project.computeService.instance.osInventory.item.packageVersion 13.18.1
 gcp.project.computeService.instance.osInventory.item.type 13.18.1
 gcp.project.computeService.instance.osInventory.item.updateTime 13.18.1
-gcp.project.computeService.instance.osInventory.items 13.15.1
 gcp.project.computeService.instance.osInventory.kernelRelease 13.18.1
 gcp.project.computeService.instance.osInventory.kernelVersion 13.18.1
 gcp.project.computeService.instance.osInventory.name 13.15.1
 gcp.project.computeService.instance.osInventory.osArchitecture 13.18.1
 gcp.project.computeService.instance.osInventory.osConfigAgentVersion 13.18.1
 gcp.project.computeService.instance.osInventory.osHostname 13.18.1
-gcp.project.computeService.instance.osInventory.osInfo 13.15.1
 gcp.project.computeService.instance.osInventory.osLongName 13.18.1
 gcp.project.computeService.instance.osInventory.osShortName 13.18.1
 gcp.project.computeService.instance.osInventory.osVersion 13.18.1
@@ -2037,7 +1997,6 @@ gcp.project.computeService.instance.vulnerabilityReport 13.15.1
 gcp.project.computeService.instance.vulnerabilityReport.highestUpgradableCveSeverity 13.15.1
 gcp.project.computeService.instance.vulnerabilityReport.name 13.15.1
 gcp.project.computeService.instance.vulnerabilityReport.updateTime 13.15.1
-gcp.project.computeService.instance.vulnerabilityReport.vulnerabilities 13.15.1
 gcp.project.computeService.instance.vulnerabilityReport.vulnerability 13.18.1
 gcp.project.computeService.instance.vulnerabilityReport.vulnerability.availableInventoryItemIds 13.18.1
 gcp.project.computeService.instance.vulnerabilityReport.vulnerability.cve 13.18.1
@@ -2060,13 +2019,11 @@ gcp.project.computeService.instanceGroup.instances 13.29.1
 gcp.project.computeService.instanceGroup.name 11.6.6
 gcp.project.computeService.instanceGroup.namedPorts 11.6.6
 gcp.project.computeService.instanceGroup.network 11.6.6
-gcp.project.computeService.instanceGroup.networkUrl 11.6.6
 gcp.project.computeService.instanceGroup.projectId 11.6.6
 gcp.project.computeService.instanceGroup.selfLink 11.6.6
 gcp.project.computeService.instanceGroup.size 11.6.6
 gcp.project.computeService.instanceGroup.subnetwork 11.6.6
 gcp.project.computeService.instanceGroup.zone 13.16.3
-gcp.project.computeService.instanceGroup.zoneUrl 11.6.6
 gcp.project.computeService.instanceGroupManager 11.6.6
 gcp.project.computeService.instanceGroupManager.autoHealingPolicies 11.6.6
 gcp.project.computeService.instanceGroupManager.baseInstanceName 11.6.6
@@ -2080,13 +2037,11 @@ gcp.project.computeService.instanceGroupManager.instanceTemplateUrl 11.6.6
 gcp.project.computeService.instanceGroupManager.name 11.6.6
 gcp.project.computeService.instanceGroupManager.projectId 11.6.6
 gcp.project.computeService.instanceGroupManager.region 13.16.3
-gcp.project.computeService.instanceGroupManager.regionUrl 11.6.6
 gcp.project.computeService.instanceGroupManager.selfLink 11.6.6
 gcp.project.computeService.instanceGroupManager.statefulPolicy 11.6.6
 gcp.project.computeService.instanceGroupManager.status 11.6.6
 gcp.project.computeService.instanceGroupManager.targetSize 11.6.6
 gcp.project.computeService.instanceGroupManager.zone 13.16.3
-gcp.project.computeService.instanceGroupManager.zoneUrl 11.6.6
 gcp.project.computeService.instanceGroupManagers 11.6.6
 gcp.project.computeService.instanceGroups 11.6.6
 gcp.project.computeService.instanceTemplate 13.7.2
@@ -2141,15 +2096,12 @@ gcp.project.computeService.interconnectAttachment.edgeAvailabilityDomain 13.6.1
 gcp.project.computeService.interconnectAttachment.encryption 13.6.1
 gcp.project.computeService.interconnectAttachment.id 13.6.1
 gcp.project.computeService.interconnectAttachment.interconnect 13.6.1
-gcp.project.computeService.interconnectAttachment.interconnectUrl 13.6.1
 gcp.project.computeService.interconnectAttachment.labels 13.35.1
 gcp.project.computeService.interconnectAttachment.name 13.6.1
 gcp.project.computeService.interconnectAttachment.partnerMetadata 13.6.1
 gcp.project.computeService.interconnectAttachment.privateInterconnectInfo 13.6.1
 gcp.project.computeService.interconnectAttachment.region 13.16.3
-gcp.project.computeService.interconnectAttachment.regionUrl 13.6.1
 gcp.project.computeService.interconnectAttachment.router 13.6.1
-gcp.project.computeService.interconnectAttachment.routerUrl 13.6.1
 gcp.project.computeService.interconnectAttachment.selfLink 13.6.1
 gcp.project.computeService.interconnectAttachment.stackType 13.6.1
 gcp.project.computeService.interconnectAttachment.state 13.6.1
@@ -2183,7 +2135,6 @@ gcp.project.computeService.network.firewalls 13.34.2
 gcp.project.computeService.network.gatewayIPv4 9.0.0
 gcp.project.computeService.network.id 9.0.0
 gcp.project.computeService.network.internalIpv6Range 11.6.6
-gcp.project.computeService.network.ipv4Range 13.16.3
 gcp.project.computeService.network.legacy 13.12.2
 gcp.project.computeService.network.mode 9.0.0
 gcp.project.computeService.network.mtu 9.0.0
@@ -2201,10 +2152,8 @@ gcp.project.computeService.network.peering.importCustomRoutes 11.6.6
 gcp.project.computeService.network.peering.importSubnetRoutesWithPublicIp 11.6.6
 gcp.project.computeService.network.peering.name 11.6.6
 gcp.project.computeService.network.peering.network 11.6.6
-gcp.project.computeService.network.peering.networkUrl 11.6.6
 gcp.project.computeService.network.peering.state 11.6.6
 gcp.project.computeService.network.peering.stateDetails 11.6.6
-gcp.project.computeService.network.peerings 9.0.0
 gcp.project.computeService.network.projectId 9.0.0
 gcp.project.computeService.network.routes 13.34.2
 gcp.project.computeService.network.routingMode 9.0.0
@@ -2222,17 +2171,13 @@ gcp.project.computeService.networkEndpointGroup.id 13.6.1
 gcp.project.computeService.networkEndpointGroup.name 13.6.1
 gcp.project.computeService.networkEndpointGroup.network 13.6.1
 gcp.project.computeService.networkEndpointGroup.networkEndpointType 13.6.1
-gcp.project.computeService.networkEndpointGroup.networkUrl 13.6.1
 gcp.project.computeService.networkEndpointGroup.pscData 13.6.1
 gcp.project.computeService.networkEndpointGroup.pscTargetService 13.6.1
 gcp.project.computeService.networkEndpointGroup.region 13.16.3
-gcp.project.computeService.networkEndpointGroup.regionUrl 13.6.1
 gcp.project.computeService.networkEndpointGroup.selfLink 13.6.1
 gcp.project.computeService.networkEndpointGroup.size 13.6.1
 gcp.project.computeService.networkEndpointGroup.subnetwork 13.6.1
-gcp.project.computeService.networkEndpointGroup.subnetworkUrl 13.6.1
 gcp.project.computeService.networkEndpointGroup.zone 13.16.3
-gcp.project.computeService.networkEndpointGroup.zoneUrl 13.6.1
 gcp.project.computeService.networkEndpointGroups 13.6.1
 gcp.project.computeService.networks 9.0.0
 gcp.project.computeService.packetMirroring 13.6.1
@@ -2247,7 +2192,6 @@ gcp.project.computeService.packetMirroring.name 13.6.1
 gcp.project.computeService.packetMirroring.network 13.6.1
 gcp.project.computeService.packetMirroring.priority 13.6.1
 gcp.project.computeService.packetMirroring.region 13.16.3
-gcp.project.computeService.packetMirroring.regionUrl 13.6.1
 gcp.project.computeService.packetMirroring.selfLink 13.6.1
 gcp.project.computeService.packetMirrorings 13.6.1
 gcp.project.computeService.projectBlockProjectSshKeys 13.18.1
@@ -2286,7 +2230,6 @@ gcp.project.computeService.route.destRange 13.6.1
 gcp.project.computeService.route.id 13.6.1
 gcp.project.computeService.route.name 13.6.1
 gcp.project.computeService.route.network 13.6.1
-gcp.project.computeService.route.networkUrl 13.6.1
 gcp.project.computeService.route.nextHopGateway 13.6.1
 gcp.project.computeService.route.nextHopHub 13.6.1
 gcp.project.computeService.route.nextHopIlb 13.6.1
@@ -2334,7 +2277,6 @@ gcp.project.computeService.router.nat.tcpTimeWaitTimeoutSec 11.5.1
 gcp.project.computeService.router.nat.tcpTransitoryIdleTimeoutSec 11.5.1
 gcp.project.computeService.router.nat.udpIdleTimeoutSec 11.5.1
 gcp.project.computeService.router.natServices 11.5.1
-gcp.project.computeService.router.nats 9.0.0
 gcp.project.computeService.router.network 11.6.6
 gcp.project.computeService.routers 9.0.0
 gcp.project.computeService.routes 13.6.1
@@ -2351,7 +2293,6 @@ gcp.project.computeService.securityPolicy.labels 11.5.1
 gcp.project.computeService.securityPolicy.name 11.5.1
 gcp.project.computeService.securityPolicy.recaptchaOptionsConfig 11.5.1
 gcp.project.computeService.securityPolicy.region 13.16.3
-gcp.project.computeService.securityPolicy.regionUrl 11.5.1
 gcp.project.computeService.securityPolicy.rule 11.5.1
 gcp.project.computeService.securityPolicy.rule.action 11.5.1
 gcp.project.computeService.securityPolicy.rule.description 11.5.1
@@ -2384,7 +2325,6 @@ gcp.project.computeService.serviceAttachment.natSubnets 13.6.1
 gcp.project.computeService.serviceAttachment.producerForwardingRule 13.6.1
 gcp.project.computeService.serviceAttachment.reconcileConnections 13.6.1
 gcp.project.computeService.serviceAttachment.region 13.16.3
-gcp.project.computeService.serviceAttachment.regionUrl 13.6.1
 gcp.project.computeService.serviceAttachment.selfLink 13.6.1
 gcp.project.computeService.serviceAttachment.targetService 13.6.1
 gcp.project.computeService.serviceAttachments 13.6.1
@@ -2435,7 +2375,6 @@ gcp.project.computeService.sslCertificate.managed 11.5.1
 gcp.project.computeService.sslCertificate.managedStatus 13.18.1
 gcp.project.computeService.sslCertificate.name 11.5.1
 gcp.project.computeService.sslCertificate.region 13.16.3
-gcp.project.computeService.sslCertificate.regionUrl 11.5.1
 gcp.project.computeService.sslCertificate.selfLink 11.5.1
 gcp.project.computeService.sslCertificate.subjectAlternativeNames 11.5.1
 gcp.project.computeService.sslCertificate.type 11.5.1
@@ -2451,7 +2390,6 @@ gcp.project.computeService.sslPolicy.minTlsVersion 11.5.1
 gcp.project.computeService.sslPolicy.name 11.5.1
 gcp.project.computeService.sslPolicy.profile 11.5.1
 gcp.project.computeService.sslPolicy.region 13.16.3
-gcp.project.computeService.sslPolicy.regionUrl 11.5.1
 gcp.project.computeService.sslPolicy.selfLink 11.5.1
 gcp.project.computeService.sslPolicy.warnings 11.5.1
 gcp.project.computeService.sslPolicy.weakTls 13.12.2
@@ -2494,13 +2432,11 @@ gcp.project.computeService.subnetwork.logConfig.metadata 9.0.0
 gcp.project.computeService.subnetwork.logConfig.metadataFields 9.0.0
 gcp.project.computeService.subnetwork.name 9.0.0
 gcp.project.computeService.subnetwork.network 13.9.1
-gcp.project.computeService.subnetwork.networkUrl 13.9.1
 gcp.project.computeService.subnetwork.privateIpGoogleAccess 9.0.0
 gcp.project.computeService.subnetwork.privateIpv6GoogleAccess 9.0.0
 gcp.project.computeService.subnetwork.projectId 9.0.0
 gcp.project.computeService.subnetwork.purpose 9.0.0
 gcp.project.computeService.subnetwork.region 9.0.0
-gcp.project.computeService.subnetwork.regionUrl 9.0.0
 gcp.project.computeService.subnetwork.reservedInternalRange 11.6.6
 gcp.project.computeService.subnetwork.role 9.0.0
 gcp.project.computeService.subnetwork.secondaryIpRanges 13.16.3
@@ -2516,10 +2452,8 @@ gcp.project.computeService.targetHttpProxy.name 11.6.6
 gcp.project.computeService.targetHttpProxy.projectId 11.6.6
 gcp.project.computeService.targetHttpProxy.proxyBind 11.6.6
 gcp.project.computeService.targetHttpProxy.region 13.16.3
-gcp.project.computeService.targetHttpProxy.regionUrl 11.6.6
 gcp.project.computeService.targetHttpProxy.selfLink 11.6.6
 gcp.project.computeService.targetHttpProxy.urlMap 11.6.6
-gcp.project.computeService.targetHttpProxy.urlMapUrl 11.6.6
 gcp.project.computeService.targetHttpsProxies 11.6.6
 gcp.project.computeService.targetHttpsProxy 11.6.6
 gcp.project.computeService.targetHttpsProxy.authorizationPolicy 13.32.1
@@ -2532,19 +2466,15 @@ gcp.project.computeService.targetHttpsProxy.projectId 11.6.6
 gcp.project.computeService.targetHttpsProxy.proxyBind 11.6.6
 gcp.project.computeService.targetHttpsProxy.quicOverride 11.6.6
 gcp.project.computeService.targetHttpsProxy.region 13.16.3
-gcp.project.computeService.targetHttpsProxy.regionUrl 11.6.6
 gcp.project.computeService.targetHttpsProxy.selfLink 11.6.6
 gcp.project.computeService.targetHttpsProxy.serverTlsPolicy 13.32.1
 gcp.project.computeService.targetHttpsProxy.sslCertificateUrls 11.6.6
 gcp.project.computeService.targetHttpsProxy.sslCertificates 13.21.2
 gcp.project.computeService.targetHttpsProxy.sslPolicy 11.6.6
-gcp.project.computeService.targetHttpsProxy.sslPolicyUrl 11.6.6
 gcp.project.computeService.targetHttpsProxy.tlsEarlyData 13.32.1
 gcp.project.computeService.targetHttpsProxy.urlMap 11.6.6
-gcp.project.computeService.targetHttpsProxy.urlMapUrl 11.6.6
 gcp.project.computeService.targetPool 13.6.1
 gcp.project.computeService.targetPool.backupPool 13.6.1
-gcp.project.computeService.targetPool.backupPoolUrl 13.29.1
 gcp.project.computeService.targetPool.created 13.6.1
 gcp.project.computeService.targetPool.description 13.6.1
 gcp.project.computeService.targetPool.failoverRatio 13.6.1
@@ -2555,9 +2485,7 @@ gcp.project.computeService.targetPool.instanceRefs 13.29.1
 gcp.project.computeService.targetPool.instanceUrls 13.6.1
 gcp.project.computeService.targetPool.name 13.6.1
 gcp.project.computeService.targetPool.region 13.16.3
-gcp.project.computeService.targetPool.regionUrl 13.6.1
 gcp.project.computeService.targetPool.securityPolicy 13.6.1
-gcp.project.computeService.targetPool.securityPolicyUrl 13.29.1
 gcp.project.computeService.targetPool.selfLink 13.6.1
 gcp.project.computeService.targetPool.sessionAffinity 13.6.1
 gcp.project.computeService.targetPools 13.6.1
@@ -2571,11 +2499,9 @@ gcp.project.computeService.targetSslProxy.name 13.6.1
 gcp.project.computeService.targetSslProxy.proxyHeader 13.6.1
 gcp.project.computeService.targetSslProxy.selfLink 13.6.1
 gcp.project.computeService.targetSslProxy.service 13.29.1
-gcp.project.computeService.targetSslProxy.serviceUrl 13.6.1
 gcp.project.computeService.targetSslProxy.sslCertificateUrls 13.6.1
 gcp.project.computeService.targetSslProxy.sslCertificates 13.21.2
 gcp.project.computeService.targetSslProxy.sslPolicy 13.6.1
-gcp.project.computeService.targetSslProxy.sslPolicyUrl 13.6.1
 gcp.project.computeService.targetTcpProxies 13.6.1
 gcp.project.computeService.targetTcpProxy 13.6.1
 gcp.project.computeService.targetTcpProxy.created 13.6.1
@@ -2585,14 +2511,11 @@ gcp.project.computeService.targetTcpProxy.name 13.6.1
 gcp.project.computeService.targetTcpProxy.proxyBind 13.6.1
 gcp.project.computeService.targetTcpProxy.proxyHeader 13.6.1
 gcp.project.computeService.targetTcpProxy.region 13.16.3
-gcp.project.computeService.targetTcpProxy.regionUrl 13.6.1
 gcp.project.computeService.targetTcpProxy.selfLink 13.6.1
 gcp.project.computeService.targetTcpProxy.service 13.29.1
-gcp.project.computeService.targetTcpProxy.serviceUrl 13.6.1
 gcp.project.computeService.urlMap 11.6.6
 gcp.project.computeService.urlMap.created 11.6.6
 gcp.project.computeService.urlMap.defaultService 11.6.6
-gcp.project.computeService.urlMap.defaultServiceUrl 13.29.1
 gcp.project.computeService.urlMap.description 11.6.6
 gcp.project.computeService.urlMap.hostRules 11.6.6
 gcp.project.computeService.urlMap.id 11.6.6
@@ -2600,7 +2523,6 @@ gcp.project.computeService.urlMap.name 11.6.6
 gcp.project.computeService.urlMap.pathMatchers 11.6.6
 gcp.project.computeService.urlMap.projectId 11.6.6
 gcp.project.computeService.urlMap.region 13.16.3
-gcp.project.computeService.urlMap.regionUrl 11.6.6
 gcp.project.computeService.urlMap.selfLink 11.6.6
 gcp.project.computeService.urlMap.tests 11.6.6
 gcp.project.computeService.urlMaps 11.6.6
@@ -2613,7 +2535,6 @@ gcp.project.computeService.vpnGateway.labels 11.6.6
 gcp.project.computeService.vpnGateway.name 11.6.6
 gcp.project.computeService.vpnGateway.network 11.6.6
 gcp.project.computeService.vpnGateway.region 13.16.3
-gcp.project.computeService.vpnGateway.regionUrl 11.6.6
 gcp.project.computeService.vpnGateway.resourceManagerTags 13.5.0
 gcp.project.computeService.vpnGateway.stackType 11.6.6
 gcp.project.computeService.vpnGateway.vpnInterfaces 11.6.6
@@ -2627,25 +2548,20 @@ gcp.project.computeService.vpnTunnel.ikeVersion 11.6.6
 gcp.project.computeService.vpnTunnel.labels 11.6.6
 gcp.project.computeService.vpnTunnel.localTrafficSelector 11.6.6
 gcp.project.computeService.vpnTunnel.name 11.6.6
-gcp.project.computeService.vpnTunnel.peerExternalGateway 11.6.6
 gcp.project.computeService.vpnTunnel.peerExternalGatewayInterface 11.6.6
 gcp.project.computeService.vpnTunnel.peerExternalVpnGateway 13.6.1
-gcp.project.computeService.vpnTunnel.peerGcpGateway 11.6.6
 gcp.project.computeService.vpnTunnel.peerGcpVpnGateway 13.6.1
 gcp.project.computeService.vpnTunnel.peerIp 11.6.6
 gcp.project.computeService.vpnTunnel.region 13.16.3
-gcp.project.computeService.vpnTunnel.regionUrl 11.6.6
 gcp.project.computeService.vpnTunnel.remoteTrafficSelector 11.6.6
 gcp.project.computeService.vpnTunnel.resourceManagerTags 13.5.0
 gcp.project.computeService.vpnTunnel.router 13.6.1
-gcp.project.computeService.vpnTunnel.routerUrl 11.6.6
 gcp.project.computeService.vpnTunnel.selfLink 13.29.1
 gcp.project.computeService.vpnTunnel.sharedSecretHash 11.6.6
 gcp.project.computeService.vpnTunnel.status 11.6.6
 gcp.project.computeService.vpnTunnel.targetVpnGateway 11.6.6
 gcp.project.computeService.vpnTunnel.vpnGateway 13.6.1
 gcp.project.computeService.vpnTunnel.vpnGatewayInterface 11.6.6
-gcp.project.computeService.vpnTunnel.vpnGatewayUrl 11.6.6
 gcp.project.computeService.vpnTunnels 11.6.6
 gcp.project.computeService.zone 9.0.0
 gcp.project.computeService.zone.created 9.0.0
@@ -2669,10 +2585,8 @@ gcp.project.containerAnalysisService.note.updated 13.21.2
 gcp.project.containerAnalysisService.note.vulnerability 13.21.2
 gcp.project.containerAnalysisService.notes 13.21.2
 gcp.project.containerAnalysisService.occurrence 13.6.1
-gcp.project.containerAnalysisService.occurrence.attestation 13.6.1
 gcp.project.containerAnalysisService.occurrence.attestationSerializedPayload 13.23.2
 gcp.project.containerAnalysisService.occurrence.attestationSignatures 13.23.2
-gcp.project.containerAnalysisService.occurrence.build 13.6.1
 gcp.project.containerAnalysisService.occurrence.buildArtifacts 13.23.2
 gcp.project.containerAnalysisService.occurrence.buildBuilderVersion 13.23.2
 gcp.project.containerAnalysisService.occurrence.buildCommands 13.23.2
@@ -2694,7 +2608,6 @@ gcp.project.containerAnalysisService.occurrence.packageInfo 13.6.1
 gcp.project.containerAnalysisService.occurrence.remediation 13.6.1
 gcp.project.containerAnalysisService.occurrence.resourceUri 13.6.1
 gcp.project.containerAnalysisService.occurrence.updated 13.6.1
-gcp.project.containerAnalysisService.occurrence.vulnerability 13.6.1
 gcp.project.containerAnalysisService.occurrence.vulnerabilityCvssScore 13.18.1
 gcp.project.containerAnalysisService.occurrence.vulnerabilityEffectiveSeverity 13.18.1
 gcp.project.containerAnalysisService.occurrence.vulnerabilityFixAvailable 13.18.1
@@ -2739,7 +2652,6 @@ gcp.project.dataplexService.lake.metastoreService 13.18.1
 gcp.project.dataplexService.lake.name 13.18.1
 gcp.project.dataplexService.lake.projectId 13.18.1
 gcp.project.dataplexService.lake.securityPolicyApplyingAssets 13.18.1
-gcp.project.dataplexService.lake.serviceAccount 13.18.1
 gcp.project.dataplexService.lake.serviceAccountRef 13.21.2
 gcp.project.dataplexService.lake.state 13.18.1
 gcp.project.dataplexService.lake.uid 13.18.1
@@ -2809,7 +2721,6 @@ gcp.project.dataprocService.cluster.config.gceCluster.id 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.internalIpOnly 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.metadata 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.network 13.21.2
-gcp.project.dataprocService.cluster.config.gceCluster.networkUri 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.nodeGroupAffinity 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.privateIpv6GoogleAccess 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.projectId 9.0.0
@@ -2827,7 +2738,6 @@ gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig.ena
 gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig.enableVtpm 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.shieldedInstanceConfig.id 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.subnetwork 13.21.2
-gcp.project.dataprocService.cluster.config.gceCluster.subnetworkUri 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.tags 9.0.0
 gcp.project.dataprocService.cluster.config.gceCluster.zoneUri 9.0.0
 gcp.project.dataprocService.cluster.config.gkeCluster 9.0.0
@@ -3173,7 +3083,6 @@ gcp.project.dnsService.managedzone.managedBy 13.27.2
 gcp.project.dnsService.managedzone.name 9.0.0
 gcp.project.dnsService.managedzone.nameServerSet 9.0.0
 gcp.project.dnsService.managedzone.nameServers 9.0.0
-gcp.project.dnsService.managedzone.peeringNetwork 13.18.1
 gcp.project.dnsService.managedzone.peeringNetworkRef 13.21.2
 gcp.project.dnsService.managedzone.privateVisibilityConfig 13.9.1
 gcp.project.dnsService.managedzone.projectId 9.0.0
@@ -3249,7 +3158,6 @@ gcp.project.eventarc 13.6.1
 gcp.project.eventarcService 13.6.1
 gcp.project.eventarcService.channel 13.6.1
 gcp.project.eventarcService.channel.created 13.6.1
-gcp.project.eventarcService.channel.cryptoKeyName 13.6.1
 gcp.project.eventarcService.channel.kmsKey 13.19.2
 gcp.project.eventarcService.channel.labels 13.35.1
 gcp.project.eventarcService.channel.name 13.6.1
@@ -3274,7 +3182,6 @@ gcp.project.eventarcService.trigger.eventFilter.value 13.6.1
 gcp.project.eventarcService.trigger.eventFilters 13.6.1
 gcp.project.eventarcService.trigger.labels 13.6.1
 gcp.project.eventarcService.trigger.name 13.6.1
-gcp.project.eventarcService.trigger.serviceAccount 13.6.1
 gcp.project.eventarcService.trigger.serviceAccountRef 13.21.2
 gcp.project.eventarcService.trigger.transport 13.6.1
 gcp.project.eventarcService.trigger.uid 13.6.1
@@ -3293,7 +3200,6 @@ gcp.project.filestoreService.instance.fileShare.name 11.6.6
 gcp.project.filestoreService.instance.fileShare.nfsExportOptions 13.32.1
 gcp.project.filestoreService.instance.fileShares 11.6.6
 gcp.project.filestoreService.instance.kmsKey 13.19.2
-gcp.project.filestoreService.instance.kmsKeyName 11.6.6
 gcp.project.filestoreService.instance.labels 11.6.6
 gcp.project.filestoreService.instance.name 11.6.6
 gcp.project.filestoreService.instance.network 11.6.6
@@ -3407,8 +3313,6 @@ gcp.project.gkeService.cluster.authenticatorGroupsSecurityGroup 13.32.1
 gcp.project.gkeService.cluster.autopilotEnabled 9.0.0
 gcp.project.gkeService.cluster.autopilotWorkloadPolicyAllowNetAdmin 13.21.2
 gcp.project.gkeService.cluster.basicAuthEnabled 13.18.1
-gcp.project.gkeService.cluster.binaryAuthorization 9.0.0
-gcp.project.gkeService.cluster.binaryAuthorizationEnabled 13.12.2
 gcp.project.gkeService.cluster.binaryAuthorizationEvaluationMode 13.16.3
 gcp.project.gkeService.cluster.clientCertificateEnabled 13.18.1
 gcp.project.gkeService.cluster.clusterIpv4Cidr 9.0.0
@@ -3463,7 +3367,6 @@ gcp.project.gkeService.cluster.location 9.0.0
 gcp.project.gkeService.cluster.locations 9.0.0
 gcp.project.gkeService.cluster.loggingConfig 13.16.3
 gcp.project.gkeService.cluster.loggingEnabled 13.12.2
-gcp.project.gkeService.cluster.loggingService 9.0.0
 gcp.project.gkeService.cluster.maintenancePolicy 11.6.6
 gcp.project.gkeService.cluster.maintenancePolicy.dailyMaintenanceWindowDuration 11.6.6
 gcp.project.gkeService.cluster.maintenancePolicy.dailyMaintenanceWindowStartTime 11.6.6
@@ -3477,13 +3380,9 @@ gcp.project.gkeService.cluster.managedBy 13.27.2
 gcp.project.gkeService.cluster.masterAuth 9.0.0
 gcp.project.gkeService.cluster.masterAuthorizedNetworksAllowed 13.18.1
 gcp.project.gkeService.cluster.masterAuthorizedNetworksCidrs 13.18.1
-gcp.project.gkeService.cluster.masterAuthorizedNetworksConfig 9.0.0
-gcp.project.gkeService.cluster.masterAuthorizedNetworksEnabled 13.12.2
-gcp.project.gkeService.cluster.masterGlobalAccessEnabled 13.12.2
 gcp.project.gkeService.cluster.meshCertificates 13.7.2
 gcp.project.gkeService.cluster.monitoringConfig 13.16.3
 gcp.project.gkeService.cluster.monitoringEnabled 13.12.2
-gcp.project.gkeService.cluster.monitoringService 9.0.0
 gcp.project.gkeService.cluster.name 9.0.0
 gcp.project.gkeService.cluster.network 9.0.0
 gcp.project.gkeService.cluster.networkConfig 9.0.0
@@ -3506,7 +3405,6 @@ gcp.project.gkeService.cluster.networkPolicy 13.6.1
 gcp.project.gkeService.cluster.networkPolicy.enabled 13.6.1
 gcp.project.gkeService.cluster.networkPolicy.id 13.6.1
 gcp.project.gkeService.cluster.networkPolicy.provider 13.6.1
-gcp.project.gkeService.cluster.networkPolicyConfig 9.0.0
 gcp.project.gkeService.cluster.nodeIpv4CidrSize 13.1.2
 gcp.project.gkeService.cluster.nodePools 9.0.0
 gcp.project.gkeService.cluster.nodepool 9.0.0
@@ -3625,8 +3523,6 @@ gcp.project.gkeService.cluster.notificationConfig.pubsubEnabled 13.7.2
 gcp.project.gkeService.cluster.notificationConfig.pubsubTopic 13.7.2
 gcp.project.gkeService.cluster.notificationConfig.topic 13.7.2
 gcp.project.gkeService.cluster.privateClusterConfig 9.0.0
-gcp.project.gkeService.cluster.privateEndpointEnabled 13.12.2
-gcp.project.gkeService.cluster.privateNodesEnabled 13.12.2
 gcp.project.gkeService.cluster.projectId 9.0.0
 gcp.project.gkeService.cluster.rbacBindingConfig 13.16.3
 gcp.project.gkeService.cluster.rbacBindingInsecureSystemAuthenticated 13.22.2
@@ -3855,7 +3751,6 @@ gcp.project.idsService.endpoint.endpointIp 13.6.1
 gcp.project.idsService.endpoint.labels 13.6.1
 gcp.project.idsService.endpoint.name 13.6.1
 gcp.project.idsService.endpoint.network 13.6.1
-gcp.project.idsService.endpoint.networkUrl 13.6.1
 gcp.project.idsService.endpoint.severity 13.6.1
 gcp.project.idsService.endpoint.state 13.6.1
 gcp.project.idsService.endpoint.trafficLogs 13.6.1
@@ -3974,7 +3869,6 @@ gcp.project.loggingservice 9.0.0
 gcp.project.loggingservice.bucket 9.0.0
 gcp.project.loggingservice.bucket.cmekServiceAccount 13.27.2
 gcp.project.loggingservice.bucket.cmekServiceAccountId 13.27.2
-gcp.project.loggingservice.bucket.cmekSettings 9.0.0
 gcp.project.loggingservice.bucket.created 9.0.0
 gcp.project.loggingservice.bucket.description 9.0.0
 gcp.project.loggingservice.bucket.indexConfig 9.0.0
@@ -4553,7 +4447,6 @@ gcp.project.pubsubService.topic 9.0.0
 gcp.project.pubsubService.topic.config 9.0.0
 gcp.project.pubsubService.topic.config.ingestionDataSourceSettings 13.16.3
 gcp.project.pubsubService.topic.config.kmsKey 13.12.2
-gcp.project.pubsubService.topic.config.kmsKeyName 9.0.0
 gcp.project.pubsubService.topic.config.labels 9.0.0
 gcp.project.pubsubService.topic.config.managedBy 13.27.2
 gcp.project.pubsubService.topic.config.messageStoragePolicy 9.0.0
@@ -4641,7 +4534,6 @@ gcp.project.redisService.cluster.discoveryEndpoint.port 11.1.0
 gcp.project.redisService.cluster.discoveryEndpoint.projectId 11.1.0
 gcp.project.redisService.cluster.discoveryEndpoints 11.1.0
 gcp.project.redisService.cluster.encryptionInfo 11.1.0
-gcp.project.redisService.cluster.kmsKey 11.1.0
 gcp.project.redisService.cluster.maintenancePolicy 11.1.0
 gcp.project.redisService.cluster.maintenanceSchedule 11.1.0
 gcp.project.redisService.cluster.name 11.1.0
@@ -4682,14 +4574,12 @@ gcp.project.redisService.cluster.uid 11.1.0
 gcp.project.redisService.cluster.zoneDistributionConfig 11.1.0
 gcp.project.redisService.clusters 11.0.79
 gcp.project.redisService.instance 11.0.79
-gcp.project.redisService.instance.AuthorizedNetwork 11.0.79
 gcp.project.redisService.instance.alternativeLocationId 11.0.79
 gcp.project.redisService.instance.authEnabled 11.0.79
 gcp.project.redisService.instance.availableMaintenanceVersions 11.0.79
 gcp.project.redisService.instance.connectMode 11.0.79
 gcp.project.redisService.instance.createTime 11.0.79
 gcp.project.redisService.instance.currentLocationId 11.0.79
-gcp.project.redisService.instance.customerManagedKey 11.0.79
 gcp.project.redisService.instance.displayName 11.0.79
 gcp.project.redisService.instance.host 11.0.79
 gcp.project.redisService.instance.kmsKey 13.12.2
@@ -4742,7 +4632,6 @@ gcp.project.secretmanagerService.projectId 11.1.0
 gcp.project.secretmanagerService.secret 11.1.0
 gcp.project.secretmanagerService.secret.annotations 11.1.0
 gcp.project.secretmanagerService.secret.createTime 11.1.0
-gcp.project.secretmanagerService.secret.customerManagedEncryption 11.1.0
 gcp.project.secretmanagerService.secret.customerManagedEncryptionEnabled 13.21.2
 gcp.project.secretmanagerService.secret.etag 11.1.0
 gcp.project.secretmanagerService.secret.expireTime 11.1.0
@@ -4956,7 +4845,6 @@ gcp.project.sqlService.instance.drReplica 13.27.2
 gcp.project.sqlService.instance.etag 13.1.2
 gcp.project.sqlService.instance.failoverReplica 9.0.0
 gcp.project.sqlService.instance.failoverReplicaRef 13.27.2
-gcp.project.sqlService.instance.gceZone 9.0.0
 gcp.project.sqlService.instance.hasBuiltInUsers 13.12.2
 gcp.project.sqlService.instance.iamAuthenticationEnabled 13.21.2
 gcp.project.sqlService.instance.instanceType 9.0.0
@@ -4991,7 +4879,6 @@ gcp.project.sqlService.instance.scheduledMaintenance 13.16.3
 gcp.project.sqlService.instance.secondaryZone 11.6.6
 gcp.project.sqlService.instance.serverCaCertExpiration 13.18.1
 gcp.project.sqlService.instance.serviceAccount 13.21.2
-gcp.project.sqlService.instance.serviceAccountEmailAddress 9.0.0
 gcp.project.sqlService.instance.settings 9.0.0
 gcp.project.sqlService.instance.settings.activationPolicy 9.0.0
 gcp.project.sqlService.instance.settings.activeDirectory 13.16.3
@@ -4999,7 +4886,6 @@ gcp.project.sqlService.instance.settings.activeDirectory.adminCredentialSecretNa
 gcp.project.sqlService.instance.settings.activeDirectory.dnsServers 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectory.domain 13.16.3
 gcp.project.sqlService.instance.settings.activeDirectory.mode 13.16.3
-gcp.project.sqlService.instance.settings.activeDirectoryConfig 9.0.0
 gcp.project.sqlService.instance.settings.availabilityType 9.0.0
 gcp.project.sqlService.instance.settings.backupConfiguration 9.0.0
 gcp.project.sqlService.instance.settings.backupconfiguration 9.0.0
@@ -5044,7 +4930,6 @@ gcp.project.sqlService.instance.settings.ipConfiguration.hasOpenAuthorizedNetwor
 gcp.project.sqlService.instance.settings.ipConfiguration.id 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.ipv4Enabled 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.network 13.21.2
-gcp.project.sqlService.instance.settings.ipConfiguration.privateNetwork 9.0.0
 gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig 13.10.1
 gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.allowedConsumerProjects 13.10.1
 gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig.id 13.10.1
@@ -5245,9 +5130,7 @@ gcp.project.vertexaiService.customJob.kmsKey 13.19.2
 gcp.project.vertexaiService.customJob.labels 13.6.1
 gcp.project.vertexaiService.customJob.managedBy 13.27.2
 gcp.project.vertexaiService.customJob.name 13.6.1
-gcp.project.vertexaiService.customJob.network 13.22.2
 gcp.project.vertexaiService.customJob.networkRef 13.22.2
-gcp.project.vertexaiService.customJob.serviceAccount 13.22.2
 gcp.project.vertexaiService.customJob.serviceAccountRef 13.22.2
 gcp.project.vertexaiService.customJob.startTime 13.6.1
 gcp.project.vertexaiService.customJob.state 13.6.1
@@ -5279,7 +5162,6 @@ gcp.project.vertexaiService.endpoint 13.1.2
 gcp.project.vertexaiService.endpoint.createdAt 13.1.2
 gcp.project.vertexaiService.endpoint.dedicatedEndpointDns 13.31.3
 gcp.project.vertexaiService.endpoint.dedicatedEndpointEnabled 13.31.3
-gcp.project.vertexaiService.endpoint.deployedModels 13.1.2
 gcp.project.vertexaiService.endpoint.deployment 13.20.2
 gcp.project.vertexaiService.endpoint.deployment.createdAt 13.20.2
 gcp.project.vertexaiService.endpoint.deployment.disableContainerLogging 13.20.2
@@ -5303,7 +5185,6 @@ gcp.project.vertexaiService.endpoint.etag 13.1.2
 gcp.project.vertexaiService.endpoint.kmsKey 13.19.2
 gcp.project.vertexaiService.endpoint.labels 13.1.2
 gcp.project.vertexaiService.endpoint.name 13.1.2
-gcp.project.vertexaiService.endpoint.network 13.1.2
 gcp.project.vertexaiService.endpoint.networkRef 13.21.2
 gcp.project.vertexaiService.endpoint.predictionLoggingBigqueryDestination 13.31.3
 gcp.project.vertexaiService.endpoint.predictionLoggingEnabled 13.31.3
@@ -5383,7 +5264,6 @@ gcp.project.vertexaiService.indexEndpoint.encryptionSpec 13.6.1
 gcp.project.vertexaiService.indexEndpoint.kmsKey 13.19.2
 gcp.project.vertexaiService.indexEndpoint.labels 13.6.1
 gcp.project.vertexaiService.indexEndpoint.name 13.6.1
-gcp.project.vertexaiService.indexEndpoint.network 13.6.1
 gcp.project.vertexaiService.indexEndpoint.networkRef 13.21.2
 gcp.project.vertexaiService.indexEndpoint.publicEndpointDomainName 13.6.1
 gcp.project.vertexaiService.indexEndpoint.publicEndpointEnabled 13.6.1
@@ -5457,7 +5337,6 @@ gcp.project.vertexaiService.notebookExecutionJob.managedBy 13.27.2
 gcp.project.vertexaiService.notebookExecutionJob.name 13.20.2
 gcp.project.vertexaiService.notebookExecutionJob.notebookRuntimeTemplateRef 13.27.2
 gcp.project.vertexaiService.notebookExecutionJob.scheduleRef 13.27.2
-gcp.project.vertexaiService.notebookExecutionJob.scheduleResourceName 13.20.2
 gcp.project.vertexaiService.notebookExecutionJob.serviceAccountRef 13.27.2
 gcp.project.vertexaiService.notebookExecutionJob.updatedAt 13.20.2
 gcp.project.vertexaiService.notebookExecutionJobs 13.20.2
@@ -5547,13 +5426,11 @@ gcp.project.vertexaiService.pipelineJob.kmsKey 13.19.2
 gcp.project.vertexaiService.pipelineJob.labels 13.1.2
 gcp.project.vertexaiService.pipelineJob.managedBy 13.27.2
 gcp.project.vertexaiService.pipelineJob.name 13.1.2
-gcp.project.vertexaiService.pipelineJob.network 13.1.2
 gcp.project.vertexaiService.pipelineJob.networkRef 13.21.2
 gcp.project.vertexaiService.pipelineJob.pipelineSpec 13.1.2
 gcp.project.vertexaiService.pipelineJob.reservedIpRanges 13.31.3
 gcp.project.vertexaiService.pipelineJob.runtimeConfig 13.1.2
 gcp.project.vertexaiService.pipelineJob.scheduleRef 13.31.3
-gcp.project.vertexaiService.pipelineJob.serviceAccount 13.1.2
 gcp.project.vertexaiService.pipelineJob.serviceAccountRef 13.21.2
 gcp.project.vertexaiService.pipelineJob.startTime 13.1.2
 gcp.project.vertexaiService.pipelineJob.state 13.1.2

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -149,18 +149,18 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 	}
 
 	// Networks the instance is attached to.
-	nics := g.GetNetworkInterfaces()
+	nics := g.GetNics()
 	if nics.Error != nil {
 		return nil, nics.Error
 	}
 	instanceNetworks := map[string]bool{}
 	for _, n := range nics.Data {
-		nic, ok := n.(map[string]any)
+		nic, ok := n.(*mqlGcpProjectComputeServiceInstanceNetworkInterface)
 		if !ok {
 			continue
 		}
-		if network, ok := nic["network"].(string); ok && network != "" {
-			instanceNetworks[networkNameFromUrl(network)] = true
+		if nic.cacheNetworkUrl != "" {
+			instanceNetworks[networkNameFromUrl(nic.cacheNetworkUrl)] = true
 		}
 	}
 

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -251,6 +251,9 @@ func (g *mqlGcpProjectGkeServiceClusterNetworkConfig) id() (string, error) {
 
 type mqlGcpProjectGkeServiceClusterInternal struct {
 	cacheDatabaseEncryptionKeyName string
+	cacheLoggingService            string
+	cacheMonitoringService         string
+	cacheNetworkPolicyConfig       any
 }
 
 func (g *mqlGcpProjectGkeServiceCluster) databaseEncryptionKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -279,10 +282,7 @@ func (g *mqlGcpProjectGkeServiceClusterNodepoolConfig) bootDiskKmsKeyRef() (*mql
 }
 
 func (g *mqlGcpProjectGkeServiceCluster) networkPolicy() (*mqlGcpProjectGkeServiceClusterNetworkPolicy, error) {
-	if g.NetworkPolicyConfig.Error != nil {
-		return nil, g.NetworkPolicyConfig.Error
-	}
-	npConfig := g.NetworkPolicyConfig.Data
+	npConfig := g.cacheNetworkPolicyConfig
 	if npConfig == nil {
 		g.NetworkPolicy.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
@@ -568,20 +568,9 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			}
 		}
 
-		var binAuth map[string]any
-		var binaryAuthorizationEnabled bool
 		var binaryAuthorizationEvaluationMode string
 		if c.BinaryAuthorization != nil {
-			binAuth = map[string]any{
-				"enabled":        c.BinaryAuthorization.Enabled,
-				"evaluationMode": c.BinaryAuthorization.EvaluationMode.String(),
-			}
-			// Binary Auth is "enabled" when evaluationMode is anything other than
-			// DISABLED/UNSPECIFIED, or when the legacy boolean Enabled field is set.
-			mode := c.BinaryAuthorization.EvaluationMode
-			binaryAuthorizationEnabled = c.BinaryAuthorization.Enabled ||
-				(mode != containerpb.BinaryAuthorization_EVALUATION_MODE_UNSPECIFIED && mode != containerpb.BinaryAuthorization_DISABLED)
-			binaryAuthorizationEvaluationMode = mode.String()
+			binaryAuthorizationEvaluationMode = c.BinaryAuthorization.EvaluationMode.String()
 		}
 
 		var legacyAbac map[string]any
@@ -619,27 +608,15 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			}
 		}
 
-		var masterAuthorizedNetworksCfg map[string]any
-		var masterAuthorizedNetworksEnabled bool
 		// Derived: the CIDR allowlist and enablement read from the modern
 		// ControlPlaneEndpointsConfig when present, otherwise the legacy
 		// MasterAuthorizedNetworksConfig.
 		var masterAuthorizedNetworksCidrs []any
 		var masterAuthorizedNetworksAllowed bool
 		if c.MasterAuthorizedNetworksConfig != nil {
-			masterAuthorizedNetworksEnabled = c.MasterAuthorizedNetworksConfig.Enabled
 			masterAuthorizedNetworksAllowed = c.MasterAuthorizedNetworksConfig.Enabled
-			cidrBlocks := make([]any, 0, len(c.MasterAuthorizedNetworksConfig.CidrBlocks))
 			for _, cidrBlock := range c.MasterAuthorizedNetworksConfig.CidrBlocks {
-				cidrBlocks = append(cidrBlocks, map[string]any{
-					"displayName": cidrBlock.DisplayName,
-					"cidrBlock":   cidrBlock.CidrBlock,
-				})
 				masterAuthorizedNetworksCidrs = append(masterAuthorizedNetworksCidrs, cidrBlock.CidrBlock)
-			}
-			masterAuthorizedNetworksCfg = map[string]any{
-				"enabled":    c.MasterAuthorizedNetworksConfig.Enabled,
-				"cidrBlocks": cidrBlocks,
 			}
 		}
 
@@ -678,13 +655,9 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 
 		var privateClusterCfg map[string]any
-		var privateNodesEnabled, privateEndpointEnabled, masterGlobalAccessEnabled bool
 		if c.PrivateClusterConfig != nil {
-			privateNodesEnabled = c.PrivateClusterConfig.EnablePrivateNodes
-			privateEndpointEnabled = c.PrivateClusterConfig.EnablePrivateEndpoint
 			var masterGlobalAccessCfg map[string]any
 			if c.PrivateClusterConfig.MasterGlobalAccessConfig != nil {
-				masterGlobalAccessEnabled = c.PrivateClusterConfig.MasterGlobalAccessConfig.Enabled
 				masterGlobalAccessCfg = map[string]any{
 					"enabled": c.PrivateClusterConfig.MasterGlobalAccessConfig.Enabled,
 				}
@@ -903,8 +876,6 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			"id":                                       llx.StringData(c.Id),
 			"name":                                     llx.StringData(c.Name),
 			"description":                              llx.StringData(c.Description),
-			"loggingService":                           llx.StringData(c.LoggingService),
-			"monitoringService":                        llx.StringData(c.MonitoringService),
 			"network":                                  llx.StringData(c.Network),
 			"clusterIpv4Cidr":                          llx.StringData(c.ClusterIpv4Cidr),
 			"subnetwork":                               llx.StringData(c.Subnetwork),
@@ -930,20 +901,13 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			"workloadIdentityEnabled":                  llx.BoolData(workloadIdentityEnabled),
 			"ipAllocationPolicy":                       llx.ResourceData(ipAllocPolicy, "gcp.project.gkeService.cluster.ipAllocationPolicy"),
 			"networkConfig":                            llx.ResourceData(networkConfig, "gcp.project.gkeService.cluster.networkConfig"),
-			"binaryAuthorization":                      llx.DictData(binAuth),
-			"binaryAuthorizationEnabled":               llx.BoolData(binaryAuthorizationEnabled),
 			"binaryAuthorizationEvaluationMode":        llx.StringData(binaryAuthorizationEvaluationMode),
 			"legacyAbac":                               llx.DictData(legacyAbac),
 			"legacyAbacEnabled":                        llx.BoolData(legacyAbacEnabled),
 			"masterAuth":                               llx.DictData(masterAuth),
 			"clientCertificateEnabled":                 llx.BoolData(clientCertificateEnabled),
 			"basicAuthEnabled":                         llx.BoolData(basicAuthEnabled),
-			"masterAuthorizedNetworksConfig":           llx.DictData(masterAuthorizedNetworksCfg),
-			"masterAuthorizedNetworksEnabled":          llx.BoolData(masterAuthorizedNetworksEnabled),
 			"privateClusterConfig":                     llx.DictData(privateClusterCfg),
-			"privateNodesEnabled":                      llx.BoolData(privateNodesEnabled),
-			"privateEndpointEnabled":                   llx.BoolData(privateEndpointEnabled),
-			"masterGlobalAccessEnabled":                llx.BoolData(masterGlobalAccessEnabled),
 			"databaseEncryption":                       llx.DictData(databaseEncryption),
 			"databaseEncryptionState":                  llx.StringData(databaseEncryptionState),
 			"shieldedNodesConfig":                      llx.DictData(shieldedNodesConfig),
@@ -952,7 +916,6 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			"confidentialNodesConfig":                  llx.DictData(confidentialNodesConfig),
 			"confidentialNodesEnabled":                 llx.BoolData(confidentialNodesEnabled),
 			"identityServiceConfig":                    llx.DictData(identityServiceConfig),
-			"networkPolicyConfig":                      llx.DictData(networkPolicyConfig),
 			"releaseChannel":                           llx.StringData(strings.ToLower(c.ReleaseChannel.GetChannel().String())),
 			"enableTpu":                                llx.BoolData(c.EnableTpu),
 			"currentNodeCount":                         llx.IntData(int64(c.CurrentNodeCount)),
@@ -998,6 +961,9 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 		}
 		mqlC := mqlCluster.(*mqlGcpProjectGkeServiceCluster)
 		mqlC.cacheDatabaseEncryptionKeyName = databaseEncryptionKeyName
+		mqlC.cacheLoggingService = c.LoggingService
+		mqlC.cacheMonitoringService = c.MonitoringService
+		mqlC.cacheNetworkPolicyConfig = networkPolicyConfig
 		if notificationConfig == nil {
 			mqlC.NotificationConfig.State = plugin.StateIsNull | plugin.StateIsSet
 		}
@@ -1512,18 +1478,12 @@ func (g *mqlGcpProjectGkeServiceClusterNotificationConfig) topic() (*mqlGcpProje
 }
 
 func (g *mqlGcpProjectGkeServiceCluster) loggingEnabled() (bool, error) {
-	if g.LoggingService.Error != nil {
-		return false, g.LoggingService.Error
-	}
-	v := strings.ToLower(g.LoggingService.Data)
+	v := strings.ToLower(g.cacheLoggingService)
 	return v != "" && v != "none", nil
 }
 
 func (g *mqlGcpProjectGkeServiceCluster) monitoringEnabled() (bool, error) {
-	if g.MonitoringService.Error != nil {
-		return false, g.MonitoringService.Error
-	}
-	v := strings.ToLower(g.MonitoringService.Data)
+	v := strings.ToLower(g.cacheMonitoringService)
 	return v != "" && v != "none", nil
 }
 

--- a/providers/gcp/resources/ids.go
+++ b/providers/gcp/resources/ids.go
@@ -20,6 +20,10 @@ import (
 	"google.golang.org/api/option"
 )
 
+type mqlGcpProjectIdsServiceEndpointInternal struct {
+	cacheNetworkUrl string
+}
+
 type mqlGcpProjectIdsServiceInternal struct {
 	serviceGate
 }
@@ -126,7 +130,6 @@ func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
 		mqlEp, err := CreateResource(g.MqlRuntime, "gcp.project.idsService.endpoint", map[string]*llx.RawData{
 			"name":                   llx.StringData(ep.Name),
 			"description":            llx.StringData(ep.Description),
-			"networkUrl":             llx.StringData(ep.Network),
 			"endpointForwardingRule": llx.StringData(ep.EndpointForwardingRule),
 			"endpointIp":             llx.StringData(ep.EndpointIp),
 			"severity":               llx.StringData(ep.Severity.String()),
@@ -139,6 +142,8 @@ func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlEp.(*mqlGcpProjectIdsServiceEndpoint)
+		mqlRef.cacheNetworkUrl = ep.Network
 		res = append(res, mqlEp)
 	}
 
@@ -146,10 +151,7 @@ func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
 }
 
 func (g *mqlGcpProjectIdsServiceEndpoint) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.NetworkUrl.Error != nil {
-		return nil, g.NetworkUrl.Error
-	}
-	networkUrl := g.NetworkUrl.Data
+	networkUrl := g.cacheNetworkUrl
 	if networkUrl == "" {
 		g.Network.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -115,25 +115,6 @@ func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 	if err := req.Pages(ctx, func(page *logging.ListBucketsResponse) error {
 		for _, bucket := range page.Buckets {
 
-			var mqlCmekSettingsDict map[string]any
-			if bucket.CmekSettings != nil {
-				type mqlCmekSettings struct {
-					KmsKeyName        string `json:"kmsKeyName"`
-					KmsKeyVersionName string `json:"kmsKeyVersionName"`
-					Name              string `json:"name"`
-					ServiceAccountId  string `json:"serviceAccountId"`
-				}
-				mqlCmekSettingsDict, err = convert.JsonToDict(mqlCmekSettings{
-					KmsKeyName:        bucket.CmekSettings.KmsKeyName,
-					KmsKeyVersionName: bucket.CmekSettings.KmsKeyVersionName,
-					Name:              bucket.CmekSettings.Name,
-					ServiceAccountId:  bucket.CmekSettings.ServiceAccountId,
-				})
-				if err != nil {
-					return err
-				}
-			}
-
 			indexConfigs := make([]any, 0, len(bucket.IndexConfigs))
 			for _, cfg := range bucket.IndexConfigs {
 				mqlIndexConfig, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket.indexConfig", map[string]*llx.RawData{
@@ -157,7 +138,6 @@ func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 			mqlBucket, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket", map[string]*llx.RawData{
 				"projectId":            llx.StringData(projectId),
 				"location":             llx.StringData(parseLocationFromPath(bucket.Name)),
-				"cmekSettings":         llx.DictData(mqlCmekSettingsDict),
 				"cmekServiceAccountId": llx.StringData(cmekServiceAccountId),
 				"created":              llx.TimeDataPtr(parseTime(bucket.CreateTime)),
 				"description":          llx.StringData(bucket.Description),

--- a/providers/gcp/resources/osconfig.go
+++ b/providers/gcp/resources/osconfig.go
@@ -352,19 +352,8 @@ func (g *mqlGcpProjectComputeServiceInstance) inventory() (*mqlGcpProjectCompute
 		return nil, err
 	}
 
-	osInfo, err := convert.JsonToDict(inv.OsInfo)
-	if err != nil {
-		return nil, err
-	}
-	items := make([]any, 0, len(inv.Items))
 	inventoryItems := make([]any, 0, len(inv.Items))
 	for _, item := range inv.Items {
-		dict, err := convert.JsonToDict(item)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, dict)
-
 		mqlItem, err := newMqlOsInventoryItem(g.MqlRuntime, inv.Name, &item)
 		if err != nil {
 			return nil, err
@@ -386,8 +375,6 @@ func (g *mqlGcpProjectComputeServiceInstance) inventory() (*mqlGcpProjectCompute
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.instance.osInventory", map[string]*llx.RawData{
 		"name":                 llx.StringData(inv.Name),
-		"osInfo":               llx.DictData(osInfo),
-		"items":                llx.ArrayData(items, types.Dict),
 		"osHostname":           llx.StringData(osHostname),
 		"osLongName":           llx.StringData(osLongName),
 		"osShortName":          llx.StringData(osShortName),
@@ -489,11 +476,6 @@ func (g *mqlGcpProjectComputeServiceInstance) vulnerabilityReport() (*mqlGcpProj
 		return nil, err
 	}
 
-	vulnerabilities, err := convert.JsonToDictSlice(report.Vulnerabilities)
-	if err != nil {
-		return nil, err
-	}
-
 	vulnDetails := make([]any, 0, len(report.Vulnerabilities))
 	for i, v := range report.Vulnerabilities {
 		mqlVuln, err := newMqlVulnerabilityReportVulnerability(g.MqlRuntime, report.Name, i, v)
@@ -505,7 +487,6 @@ func (g *mqlGcpProjectComputeServiceInstance) vulnerabilityReport() (*mqlGcpProj
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.instance.vulnerabilityReport", map[string]*llx.RawData{
 		"name":                         llx.StringData(report.Name),
-		"vulnerabilities":              llx.ArrayData(vulnerabilities, types.Dict),
 		"vulnerabilityDetails":         llx.ArrayData(vulnDetails, types.Resource("gcp.project.computeService.instance.vulnerabilityReport.vulnerability")),
 		"highestUpgradableCveSeverity": llx.StringData(report.HighestUpgradableCveSeverity),
 		"updateTime":                   llx.TimeDataPtr(parseTime(report.UpdateTime)),

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -27,6 +27,10 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+type mqlGcpProjectPubsubServiceTopicConfigInternal struct {
+	cacheKmsKeyName string
+}
+
 func (g *mqlGcpProjectPubsubService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -439,7 +443,6 @@ func (g *mqlGcpProjectPubsubServiceTopic) config() (*mqlGcpProjectPubsubServiceT
 		"projectId":                   llx.StringData(projectId),
 		"topicName":                   llx.StringData(name),
 		"labels":                      llx.MapData(convert.MapToInterfaceMap(cfg.Labels), types.String),
-		"kmsKeyName":                  llx.StringData(cfg.KmsKeyName),
 		"messageStoragePolicy":        llx.ResourceData(messageStoragePolicy, "gcp.project.pubsubService.topic.config.messagestoragepolicy"),
 		"state":                       llx.StringData(topicStateToString(cfg.State)),
 		"retentionDuration":           llx.TimeData(pbDurationToTime(cfg.MessageRetentionDuration)),
@@ -455,6 +458,7 @@ func (g *mqlGcpProjectPubsubServiceTopic) config() (*mqlGcpProjectPubsubServiceT
 		return nil, err
 	}
 	tc := res.(*mqlGcpProjectPubsubServiceTopicConfig)
+	tc.cacheKmsKeyName = cfg.KmsKeyName
 	if schemaSettings == nil {
 		tc.SchemaSettings.State = plugin.StateIsNull | plugin.StateIsSet
 	}
@@ -1227,15 +1231,12 @@ func (g *mqlGcpProjectPubsubServiceSnapshot) managedBy() (string, error) {
 }
 
 func (g *mqlGcpProjectPubsubServiceTopicConfig) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
-	if g.KmsKeyName.Error != nil {
-		return nil, g.KmsKeyName.Error
-	}
-	if g.KmsKeyName.Data == "" {
+	if g.cacheKmsKeyName == "" {
 		g.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
 	res, err := NewResource(g.MqlRuntime, "gcp.project.kmsService.keyring.cryptokey",
-		map[string]*llx.RawData{"resourcePath": llx.StringData(g.KmsKeyName.Data)})
+		map[string]*llx.RawData{"resourcePath": llx.StringData(g.cacheKmsKeyName)})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -29,7 +29,8 @@ type mqlGcpProjectRedisServiceInternal struct {
 }
 
 type mqlGcpProjectRedisServiceInstanceInternal struct {
-	cacheKmsKey string
+	cacheKmsKey            string
+	cacheAuthorizedNetwork string
 }
 
 func (g *mqlGcpProjectRedisServiceInstance) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -150,10 +151,7 @@ func (g *mqlGcpProjectRedisService) id() (string, error) {
 }
 
 func (g *mqlGcpProjectRedisServiceInstance) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.AuthorizedNetwork.Error != nil {
-		return nil, g.AuthorizedNetwork.Error
-	}
-	n, err := getNetworkByUrl(g.AuthorizedNetwork.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cacheAuthorizedNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -264,11 +262,9 @@ func (g *mqlGcpProjectRedisService) instances() ([]any, error) {
 			"redisVersion":           llx.StringData(instance.RedisVersion),
 			"reservedIpRange":        llx.StringData(instance.ReservedIpRange),
 			"secondaryIpRange":       llx.StringData(instance.SecondaryIpRange),
-			"AuthorizedNetwork":      llx.StringData(instance.AuthorizedNetwork),
 			"persistenceIamIdentity": llx.StringData(instance.PersistenceIamIdentity),
 			"connectMode":            llx.StringData(instance.ConnectMode.String()),
 			"readEndpoint":           llx.StringData(instance.ReadEndpoint),
-			"customerManagedKey":     llx.StringData(instance.CustomerManagedKey),
 			"maintenanceVersion":     llx.StringData(instance.MaintenanceVersion),
 			"host":                   llx.StringData(instance.Host),
 			"currentLocationId":      llx.StringData(instance.CurrentLocationId),
@@ -304,6 +300,8 @@ func (g *mqlGcpProjectRedisService) instances() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlRedisInstance.(*mqlGcpProjectRedisServiceInstance)
+		mqlRef.cacheAuthorizedNetwork = instance.AuthorizedNetwork
 		mqlRedisInstance.(*mqlGcpProjectRedisServiceInstance).cacheKmsKey = instance.CustomerManagedKey
 		res = append(res, mqlRedisInstance)
 	}
@@ -704,7 +702,6 @@ func (g *mqlGcpProjectRedisService) clusters() ([]any, error) {
 			"sizeGb":                        llx.IntData(sizeGb),
 			"preciseSizeGb":                 llx.FloatData(preciseSizeGb),
 			"deletionProtectionEnabled":     llx.BoolData(deletionProtection),
-			"kmsKey":                        llx.StringData(kmsKey),
 			"backupCollection":              llx.StringData(backupCollection),
 			"redisConfigs":                  llx.MapData(convert.MapToInterfaceMap(cluster.RedisConfigs), types.String),
 			"persistenceConfig":             llx.DictData(persistenceConfig),

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -27,6 +27,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+type mqlGcpProjectSecretmanagerServiceSecretInternal struct {
+	cacheCustomerManagedEncryption []any
+}
+
 func (g *mqlGcpProjectSecretmanagerService) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
@@ -178,29 +182,30 @@ func (g *mqlGcpProjectSecretmanagerService) secrets() ([]any, error) {
 		cmeKeys := extractCustomerManagedEncryptionKeys(s)
 
 		mqlSecret, err := CreateResource(g.MqlRuntime, "gcp.project.secretmanagerService.secret", map[string]*llx.RawData{
-			"projectId":                 llx.StringData(projectId),
-			"resourcePath":              llx.StringData(s.Name),
-			"name":                      llx.StringData(parseResourceName(s.Name)),
-			"createTime":                llx.TimeDataPtr(timestampAsTimePtr(s.CreateTime)),
-			"labels":                    llx.MapData(convert.MapToInterfaceMap(s.Labels), types.String),
-			"replication":               llx.DictData(replicationDict),
-			"replicationType":           llx.StringData(replicationType),
-			"topics":                    llx.ArrayData(topicNames, types.String),
-			"expireTime":                llx.TimeDataPtr(timestampAsTimePtr(s.GetExpireTime())),
-			"ttl":                       llx.StringData(ttl),
-			"etag":                      llx.StringData(s.Etag),
-			"rotation":                  llx.DictData(rotationDict),
-			"rotationPeriod":            llx.StringData(rotationPeriod),
-			"nextRotationTime":          llx.TimeDataPtr(nextRotationTime),
-			"versionAliases":            llx.MapData(versionAliasesMap, types.Int),
-			"annotations":               llx.MapData(convert.MapToInterfaceMap(s.Annotations), types.String),
-			"versionDestroyTtl":         llx.TimeDataPtr(mqlVersionDestroyTtl),
-			"customerManagedEncryption": llx.ArrayData(cmeKeys, types.String),
-			"tags":                      llx.MapData(convert.MapToInterfaceMap(s.Tags), types.String),
+			"projectId":         llx.StringData(projectId),
+			"resourcePath":      llx.StringData(s.Name),
+			"name":              llx.StringData(parseResourceName(s.Name)),
+			"createTime":        llx.TimeDataPtr(timestampAsTimePtr(s.CreateTime)),
+			"labels":            llx.MapData(convert.MapToInterfaceMap(s.Labels), types.String),
+			"replication":       llx.DictData(replicationDict),
+			"replicationType":   llx.StringData(replicationType),
+			"topics":            llx.ArrayData(topicNames, types.String),
+			"expireTime":        llx.TimeDataPtr(timestampAsTimePtr(s.GetExpireTime())),
+			"ttl":               llx.StringData(ttl),
+			"etag":              llx.StringData(s.Etag),
+			"rotation":          llx.DictData(rotationDict),
+			"rotationPeriod":    llx.StringData(rotationPeriod),
+			"nextRotationTime":  llx.TimeDataPtr(nextRotationTime),
+			"versionAliases":    llx.MapData(versionAliasesMap, types.Int),
+			"annotations":       llx.MapData(convert.MapToInterfaceMap(s.Annotations), types.String),
+			"versionDestroyTtl": llx.TimeDataPtr(mqlVersionDestroyTtl),
+			"tags":              llx.MapData(convert.MapToInterfaceMap(s.Tags), types.String),
 		})
 		if err != nil {
 			return nil, err
 		}
+		mqlRef := mqlSecret.(*mqlGcpProjectSecretmanagerServiceSecret)
+		mqlRef.cacheCustomerManagedEncryption = cmeKeys
 		secrets = append(secrets, mqlSecret)
 	}
 	return secrets, nil
@@ -361,10 +366,7 @@ func (g *mqlGcpProjectSecretmanagerServiceSecret) public() (bool, error) {
 }
 
 func (g *mqlGcpProjectSecretmanagerServiceSecret) kmsKeys() ([]any, error) {
-	if g.CustomerManagedEncryption.Error != nil {
-		return nil, g.CustomerManagedEncryption.Error
-	}
-	keys := g.CustomerManagedEncryption.Data
+	keys := g.cacheCustomerManagedEncryption
 	if len(keys) == 0 {
 		return []any{}, nil
 	}
@@ -419,10 +421,7 @@ func (g *mqlGcpProjectSecretmanagerServiceSecret) managedBy() (string, error) {
 }
 
 func (g *mqlGcpProjectSecretmanagerServiceSecret) customerManagedEncryptionEnabled() (bool, error) {
-	if g.CustomerManagedEncryption.Error != nil {
-		return false, g.CustomerManagedEncryption.Error
-	}
-	return len(g.CustomerManagedEncryption.Data) > 0, nil
+	return len(g.cacheCustomerManagedEncryption) > 0, nil
 }
 
 func (g *mqlGcpProjectSecretmanagerServiceSecret) iamPolicy() ([]any, error) {

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -26,6 +26,10 @@ import (
 	"google.golang.org/api/sqladmin/v1"
 )
 
+type mqlGcpProjectSqlServiceInstanceSettingsIpConfigurationInternal struct {
+	cachePrivateNetwork string
+}
+
 func initGcpProjectSqlService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 0 {
 		return args, nil, nil
@@ -393,18 +397,8 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				dbFlags[f.Name] = f.Value
 			}
 
-			type mqlActiveDirectoryCfg struct {
-				Domain string `json:"domain,omitempty"`
-			}
-			var mqlADCfg map[string]any
 			var mqlActiveDirectory plugin.Resource
 			if s.ActiveDirectoryConfig != nil {
-				mqlADCfg, err = convert.JsonToDict(mqlActiveDirectoryCfg{
-					Domain: s.ActiveDirectoryConfig.Domain,
-				})
-				if err != nil {
-					return err
-				}
 				mqlActiveDirectory, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.activeDirectory", map[string]*llx.RawData{
 					"__id":                      llx.StringData(fmt.Sprintf("%s/settings/activeDirectory", instanceId)),
 					"domain":                    llx.StringData(s.ActiveDirectoryConfig.Domain),
@@ -534,7 +528,6 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 					"enablePrivatePathForGoogleCloudServices": llx.BoolData(s.IpConfiguration.EnablePrivatePathForGoogleCloudServices),
 					"id":                            llx.StringData(fmt.Sprintf("%s/settings/ipConfiguration", instanceId)),
 					"ipv4Enabled":                   llx.BoolData(s.IpConfiguration.Ipv4Enabled),
-					"privateNetwork":                llx.StringData(s.IpConfiguration.PrivateNetwork),
 					"requireSsl":                    llx.BoolData(s.IpConfiguration.RequireSsl),
 					"sslMode":                       llx.StringData(s.IpConfiguration.SslMode),
 					"serverCaMode":                  llx.StringData(s.IpConfiguration.ServerCaMode),
@@ -545,6 +538,8 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				mqlRef := mqlIpCfg.(*mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration)
+				mqlRef.cachePrivateNetwork = s.IpConfiguration.PrivateNetwork
 			}
 
 			type mqlLocationPref struct {
@@ -640,7 +635,6 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 
 			mqlSettings, err := CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings", map[string]*llx.RawData{
 				"activationPolicy":            llx.StringData(s.ActivationPolicy),
-				"activeDirectoryConfig":       llx.DictData(mqlADCfg),
 				"activeDirectory":             llx.ResourceData(mqlActiveDirectory, "gcp.project.sqlService.instance.settings.activeDirectory"),
 				"availabilityType":            llx.StringData(s.AvailabilityType),
 				"backupConfiguration":         llx.DictData(mqlBackupCfg),
@@ -780,7 +774,6 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				"diskEncryptionConfiguration":  llx.DictData(mqlEncCfg),
 				"diskEncryptionStatus":         llx.DictData(mqlEncStatus),
 				"failoverReplica":              llx.DictData(mqlFailoverReplica),
-				"gceZone":                      llx.StringData(instance.GceZone),
 				"instanceType":                 llx.StringData(instance.InstanceType),
 				"ipAddresses":                  llx.ArrayData(mqlIpAddresses, types.Resource("gcp.project.sqlService.instance.ipMapping")),
 				"maintenanceVersion":           llx.StringData(instance.MaintenanceVersion),
@@ -790,7 +783,6 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				"projectId":                    llx.StringData(projectId),
 				"region":                       llx.StringData(instance.Region),
 				"replicaNames":                 llx.ArrayData(convert.SliceAnyToInterface(instance.ReplicaNames), types.String),
-				"serviceAccountEmailAddress":   llx.StringData(instance.ServiceAccountEmailAddress),
 				"settings":                     llx.ResourceData(mqlSettings, "gcp.project.sqlService.instance.settings"),
 				"state":                        llx.StringData(instance.State),
 				"satisfiesPzi":                 llx.BoolData(instance.SatisfiesPzi),
@@ -814,6 +806,9 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 			if err != nil {
 				return err
 			}
+			mqlRef := mqlInstance.(*mqlGcpProjectSqlServiceInstance)
+			mqlRef.cacheGceZone = instance.GceZone
+			mqlRef.cacheServiceAccountEmailAddress = instance.ServiceAccountEmailAddress
 			mqlSqlInstance := mqlInstance.(*mqlGcpProjectSqlServiceInstance)
 			mqlSqlInstance.cacheSecondaryGceZone = instance.SecondaryGceZone
 			if instance.DiskEncryptionConfiguration != nil {
@@ -906,10 +901,12 @@ func (g *mqlGcpProjectSqlServiceInstance) databases() ([]any, error) {
 }
 
 type mqlGcpProjectSqlServiceInstanceInternal struct {
-	cacheSecondaryGceZone    string
-	cacheKmsKeyName          string
-	cacheFailoverReplicaName string
-	cacheDrReplicaName       string
+	cacheSecondaryGceZone           string
+	cacheKmsKeyName                 string
+	cacheFailoverReplicaName        string
+	cacheDrReplicaName              string
+	cacheGceZone                    string
+	cacheServiceAccountEmailAddress string
 }
 
 func (g *mqlGcpProjectSqlServiceInstance) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -926,10 +923,7 @@ func (g *mqlGcpProjectSqlServiceInstance) kmsKey() (*mqlGcpProjectKmsServiceKeyr
 }
 
 func (g *mqlGcpProjectSqlServiceInstance) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.ServiceAccountEmailAddress.Error != nil {
-		return nil, g.ServiceAccountEmailAddress.Error
-	}
-	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.ServiceAccountEmailAddress.Data, g.ProjectId.Data)
+	sa, err := resolveServiceAccountRef(g.MqlRuntime, g.cacheServiceAccountEmailAddress, g.ProjectId.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -940,10 +934,7 @@ func (g *mqlGcpProjectSqlServiceInstance) serviceAccount() (*mqlGcpProjectIamSer
 }
 
 func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) network() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.PrivateNetwork.Error != nil {
-		return nil, g.PrivateNetwork.Error
-	}
-	n, err := getNetworkByUrl(g.PrivateNetwork.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cachePrivateNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -966,10 +957,7 @@ func (g *mqlGcpProjectSqlServiceInstance) id() (string, error) {
 }
 
 func (g *mqlGcpProjectSqlServiceInstance) zone() (*mqlGcpProjectComputeServiceZone, error) {
-	if g.GceZone.Error != nil {
-		return nil, g.GceZone.Error
-	}
-	zoneName := g.GceZone.Data
+	zoneName := g.cacheGceZone
 	if zoneName == "" {
 		g.Zone.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -457,10 +457,8 @@ func newMqlVertexaiEndpoint(runtime *plugin.Runtime, projectId string, ep *aipla
 		"name":                                 llx.StringData(ep.Name),
 		"displayName":                          llx.StringData(ep.DisplayName),
 		"description":                          llx.StringData(ep.Description),
-		"deployedModels":                       llx.ArrayData(deployedModels, types.Dict),
 		"deployments":                          llx.ArrayData(deployments, types.Resource("gcp.project.vertexaiService.endpoint.deployment")),
 		"encryptionSpec":                       llx.DictData(encryptionSpec),
-		"network":                              llx.StringData(ep.Network),
 		"enablePrivateServiceConnect":          llx.BoolData(ep.EnablePrivateServiceConnect),
 		"pscProjectAllowlist":                  llx.ArrayData(pscProjectAllowlist, types.String),
 		"pscServiceAttachment":                 llx.StringData(pscServiceAttachment),
@@ -481,6 +479,8 @@ func newMqlVertexaiEndpoint(runtime *plugin.Runtime, projectId string, ep *aipla
 	if err != nil {
 		return nil, err
 	}
+	mqlRef := mqlEndpoint.(*mqlGcpProjectVertexaiServiceEndpoint)
+	mqlRef.cacheNetwork = ep.Network
 	res := mqlEndpoint.(*mqlGcpProjectVertexaiServiceEndpoint)
 	res.cacheKmsKeyName = ep.GetEncryptionSpec().GetKmsKeyName()
 	return res, nil
@@ -530,10 +530,7 @@ func (g *mqlGcpProjectVertexaiServiceEndpoint) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiServiceEndpoint) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.Network.Error != nil {
-		return nil, g.Network.Error
-	}
-	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cacheNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -725,8 +722,6 @@ func newMqlVertexaiPipelineJob(runtime *plugin.Runtime, job *aiplatformpb.Pipeli
 		"state":            llx.StringData(job.State.String()),
 		"pipelineSpec":     llx.DictData(pipelineSpec),
 		"runtimeConfig":    llx.DictData(runtimeConfig),
-		"serviceAccount":   llx.StringData(job.ServiceAccount),
-		"network":          llx.StringData(job.Network),
 		"encryptionSpec":   llx.DictData(encryptionSpec),
 		"templateUri":      llx.StringData(job.TemplateUri),
 		"templateMetadata": llx.DictData(templateMetadata),
@@ -741,6 +736,9 @@ func newMqlVertexaiPipelineJob(runtime *plugin.Runtime, job *aiplatformpb.Pipeli
 	if err != nil {
 		return nil, err
 	}
+	mqlRef := mqlJob.(*mqlGcpProjectVertexaiServicePipelineJob)
+	mqlRef.cacheServiceAccount = job.ServiceAccount
+	mqlRef.cacheNetwork = job.Network
 	res := mqlJob.(*mqlGcpProjectVertexaiServicePipelineJob)
 	res.cacheKmsKeyName = job.GetEncryptionSpec().GetKmsKeyName()
 	res.cacheScheduleName = job.ScheduleName
@@ -752,13 +750,10 @@ func (g *mqlGcpProjectVertexaiServicePipelineJob) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiServicePipelineJob) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.ServiceAccount.Error != nil {
-		return nil, g.ServiceAccount.Error
-	}
 	if g.Name.Error != nil {
 		return nil, g.Name.Error
 	}
-	email := g.ServiceAccount.Data
+	email := g.cacheServiceAccount
 	projectId := projectFromResourceName(g.Name.Data)
 	if email == "" || projectId == "" {
 		g.ServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
@@ -776,10 +771,7 @@ func (g *mqlGcpProjectVertexaiServicePipelineJob) serviceAccountRef() (*mqlGcpPr
 }
 
 func (g *mqlGcpProjectVertexaiServicePipelineJob) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.Network.Error != nil {
-		return nil, g.Network.Error
-	}
-	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cacheNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -790,10 +782,7 @@ func (g *mqlGcpProjectVertexaiServicePipelineJob) networkRef() (*mqlGcpProjectCo
 }
 
 func (g *mqlGcpProjectVertexaiServiceIndexEndpoint) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.Network.Error != nil {
-		return nil, g.Network.Error
-	}
-	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cacheNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -1053,13 +1042,10 @@ func (g *mqlGcpProjectVertexaiServiceCustomJob) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiServiceCustomJob) serviceAccountRef() (*mqlGcpProjectIamServiceServiceAccount, error) {
-	if g.ServiceAccount.Error != nil {
-		return nil, g.ServiceAccount.Error
-	}
 	if g.Name.Error != nil {
 		return nil, g.Name.Error
 	}
-	email := g.ServiceAccount.Data
+	email := g.cacheServiceAccount
 	projectId := projectFromResourceName(g.Name.Data)
 	if email == "" || projectId == "" {
 		g.ServiceAccountRef.State = plugin.StateIsSet | plugin.StateIsNull
@@ -1076,14 +1062,11 @@ func (g *mqlGcpProjectVertexaiServiceCustomJob) serviceAccountRef() (*mqlGcpProj
 }
 
 func (g *mqlGcpProjectVertexaiServiceCustomJob) networkRef() (*mqlGcpProjectComputeServiceNetwork, error) {
-	if g.Network.Error != nil {
-		return nil, g.Network.Error
-	}
-	if g.Network.Data == "" {
+	if g.cacheNetwork == "" {
 		g.NetworkRef.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	n, err := getNetworkByUrl(g.Network.Data, g.MqlRuntime)
+	n, err := getNetworkByUrl(g.cacheNetwork, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -1371,8 +1354,6 @@ func mqlVertexAICustomJobFromProto(runtime *plugin.Runtime, job *aiplatformpb.Cu
 		"displayName":     llx.StringData(job.DisplayName),
 		"state":           llx.StringData(job.State.String()),
 		"jobSpec":         llx.DictData(jobSpec),
-		"serviceAccount":  llx.StringData(serviceAccount),
-		"network":         llx.StringData(network),
 		"enableWebAccess": llx.BoolData(enableWebAccess),
 		"labels":          llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
 		"encryptionSpec":  llx.DictData(encryptionSpec),
@@ -1385,6 +1366,9 @@ func mqlVertexAICustomJobFromProto(runtime *plugin.Runtime, job *aiplatformpb.Cu
 	if err != nil {
 		return nil, err
 	}
+	mqlRef := res.(*mqlGcpProjectVertexaiServiceCustomJob)
+	mqlRef.cacheServiceAccount = serviceAccount
+	mqlRef.cacheNetwork = network
 	res.(*mqlGcpProjectVertexaiServiceCustomJob).cacheKmsKeyName = job.GetEncryptionSpec().GetKmsKeyName()
 	return res.(*mqlGcpProjectVertexaiServiceCustomJob), nil
 }
@@ -1606,7 +1590,6 @@ func (g *mqlGcpProjectVertexaiService) indexEndpoints() ([]any, error) {
 				"displayName":              llx.StringData(ep.DisplayName),
 				"description":              llx.StringData(ep.Description),
 				"deployedIndexes":          llx.ArrayData(deployedIndexes, types.Dict),
-				"network":                  llx.StringData(ep.Network),
 				"publicEndpointEnabled":    llx.BoolData(ep.PublicEndpointEnabled),
 				"publicEndpointDomainName": llx.StringData(ep.PublicEndpointDomainName),
 				"labels":                   llx.MapData(convert.MapToInterfaceMap(ep.Labels), types.String),
@@ -1617,6 +1600,8 @@ func (g *mqlGcpProjectVertexaiService) indexEndpoints() ([]any, error) {
 			if err != nil {
 				return nil, false, err
 			}
+			mqlRef := mqlEP.(*mqlGcpProjectVertexaiServiceIndexEndpoint)
+			mqlRef.cacheNetwork = ep.Network
 			mqlEP.(*mqlGcpProjectVertexaiServiceIndexEndpoint).cacheKmsKeyName = ep.GetEncryptionSpec().GetKmsKeyName()
 			items = append(items, mqlEP)
 		}
@@ -2007,7 +1992,6 @@ func (g *mqlGcpProjectVertexaiService) notebookExecutionJobs() ([]any, error) {
 				"jobState":                llx.StringData(job.JobState.String()),
 				"kernelName":              llx.StringData(job.KernelName),
 				"executionUser":           llx.StringData(job.GetExecutionUser()),
-				"scheduleResourceName":    llx.StringData(job.ScheduleResourceName),
 				"executionTimeoutSeconds": llx.IntData(timeoutSeconds),
 				"labels":                  llx.MapData(convert.MapToInterfaceMap(job.Labels), types.String),
 				"encryptionSpec":          llx.DictData(encryptionSpec),
@@ -2017,6 +2001,8 @@ func (g *mqlGcpProjectVertexaiService) notebookExecutionJobs() ([]any, error) {
 			if err != nil {
 				return nil, false, err
 			}
+			mqlRef := mqlJob.(*mqlGcpProjectVertexaiServiceNotebookExecutionJob)
+			mqlRef.cacheScheduleResourceName = job.ScheduleResourceName
 			mqlNotebookJob := mqlJob.(*mqlGcpProjectVertexaiServiceNotebookExecutionJob)
 			mqlNotebookJob.cacheKmsKeyName = job.GetEncryptionSpec().GetKmsKeyName()
 			mqlNotebookJob.cacheServiceAccountEmail = job.GetServiceAccount()
@@ -3146,6 +3132,7 @@ func (a *mqlGcpProjectVertexaiServiceModel) pipelineJob() (*mqlGcpProjectVertexa
 
 type mqlGcpProjectVertexaiServiceEndpointInternal struct {
 	cacheKmsKeyName string
+	cacheNetwork    string
 }
 
 func (a *mqlGcpProjectVertexaiServiceEndpoint) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -3153,8 +3140,10 @@ func (a *mqlGcpProjectVertexaiServiceEndpoint) kmsKey() (*mqlGcpProjectKmsServic
 }
 
 type mqlGcpProjectVertexaiServicePipelineJobInternal struct {
-	cacheKmsKeyName   string
-	cacheScheduleName string
+	cacheKmsKeyName     string
+	cacheScheduleName   string
+	cacheNetwork        string
+	cacheServiceAccount string
 }
 
 func (a *mqlGcpProjectVertexaiServicePipelineJob) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -3204,7 +3193,9 @@ func (a *mqlGcpProjectVertexaiServiceTensorboard) kmsKey() (*mqlGcpProjectKmsSer
 }
 
 type mqlGcpProjectVertexaiServiceCustomJobInternal struct {
-	cacheKmsKeyName string
+	cacheKmsKeyName     string
+	cacheNetwork        string
+	cacheServiceAccount string
 }
 
 func (a *mqlGcpProjectVertexaiServiceCustomJob) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -3225,6 +3216,7 @@ func (a *mqlGcpProjectVertexaiServiceIndex) kmsKey() (*mqlGcpProjectKmsServiceKe
 
 type mqlGcpProjectVertexaiServiceIndexEndpointInternal struct {
 	cacheKmsKeyName string
+	cacheNetwork    string
 }
 
 func (a *mqlGcpProjectVertexaiServiceIndexEndpoint) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -3395,6 +3387,7 @@ type mqlGcpProjectVertexaiServiceNotebookExecutionJobInternal struct {
 	cacheServiceAccountEmail         string
 	cacheProjectId                   string
 	cacheNotebookRuntimeTemplateName string
+	cacheScheduleResourceName        string
 }
 
 func (a *mqlGcpProjectVertexaiServiceNotebookExecutionJob) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -3420,10 +3413,7 @@ func (a *mqlGcpProjectVertexaiServiceNotebookExecutionJob) notebookRuntimeTempla
 }
 
 func (a *mqlGcpProjectVertexaiServiceNotebookExecutionJob) scheduleRef() (*mqlGcpProjectVertexaiServiceSchedule, error) {
-	if a.ScheduleResourceName.Error != nil {
-		return nil, a.ScheduleResourceName.Error
-	}
-	name := a.ScheduleResourceName.Data
+	name := a.cacheScheduleResourceName
 	if name == "" {
 		a.ScheduleRef.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil


### PR DESCRIPTION
## What

Removes **123** fields marked `@maturity("deprecated")` in the GCP provider, across 38 files.

Every removed field already had a shipped replacement in the schema, so this is the removal half of migrations staged in earlier PRs. No capability is lost.

## What was removed

| Shape | Fields | Replaced by |
|---|---|---|
| Raw self-link URLs | `regionUrl`, `zoneUrl`, `networkUrl`, `subnetworkUrl`, `routerUrl`, `urlMapUrl`, `sslPolicyUrl`, `securityPolicyUrl`, `interconnectUrl`, `vpnGatewayUrl`, `groupUrl`, `serviceUrl`, `backendServiceUrl`, `defaultServiceUrl`, `backupPoolUrl`, `edgeSecurityPolicyUrl` | typed accessors (`region`, `zone`, `network`, `subnetwork`, `router`, `urlMap`, …) |
| Raw KMS / SA / network ids | `kmsName`, `kmsKeyName`, `kmsKey`, `cryptoKeyName`, `customerManagedKey`, `serviceAccount`, `serviceAccountEmailAddress`, `gatewayServiceAccount`, `oidcServiceAccountEmail`, `oauthServiceAccountEmail`, `AuthorizedNetwork`, `privateNetwork`, `peeringNetwork`, `peeredNetwork`, `networkUri`, `subnetworkUri` | typed refs |
| dict / `[]dict` blobs | `confidentialInstanceConfig`, `networkInterfaces`, `osInfo`, `items`, `vulnerabilities`, `peerings`, `nats`, `activeDirectoryConfig`, `cmekSettings`, `binaryAuthorization`, `masterAuthorizedNetworksConfig`, `networkPolicyConfig`, `vpcAccess`, `userOwnedGrafeasNote`, `deployedModels`, `vulnerability`, `build`, `attestation`, `spec`, `status` | typed sub-resources / flattened scalars |
| Derived booleans | `enableSecureBoot`, `enableVtpm`, `enableIntegrityMonitoring`, `binaryAuthorizationEnabled`, `masterAuthorizedNetworksEnabled`, `privateNodesEnabled`, `privateEndpointEnabled`, `masterGlobalAccessEnabled` | their config resources (e.g. `shieldedInstanceConfig`) |
| GKE / network | `loggingService`, `monitoringService`, `ipv4Range` | `loggingConfig`, `monitoringConfig`, `mode == "legacy"` |

## The interesting part: accessor migration

Many typed accessors were implemented by reading the very field they deprecated:

```go
func (g *mqlGcpProjectComputeServiceAddress) region() (*mqlGcpProjectComputeServiceRegion, error) {
    if g.RegionUrl.Error != nil { return nil, g.RegionUrl.Error }
    return getRegionByUrl(g.RegionUrl.Data, g.MqlRuntime)   // <- reads the deprecated field
}
```

So removing the field would have broken its own replacement. Those read sites now use a `cache*` field on the resource's `Internal` struct, primed from the SDK object at creation time — the pattern already used by `cacheNetworkUrl` in `compute_network_edges.go`. **88 cache fields across 51 resources.**

`instance.hasPublicIp` and the network-exposure analysis moved off the `networkInterfaces` dict onto the typed `nics` collection.

Local variables and helpers that only fed removed fields are gone too (`mqlVpcAccess`, several `protoToDict` / `JsonToDict` computations), so no dead API-shaping work remains on the hot path.

## Compatibility

- **Breaking** for any query referencing a removed field — hence the `v14` label.
- cnspec's shipped policies were checked against every removed `resource.field` path: **no policy references any of them.** The apparent hits (`shieldedInstanceConfig.enableSecureBoot`, `addonsConfig.networkPolicyConfig`, `topic.config.kmsKey`) are all on different resources or already-migrated paths.
- `.lr.versions` entries for removed fields are dropped, matching the openstack precedent (cc6173ac6).
- `config.go` `Version` intentionally untouched.

## Verification

- `go build ./...` clean; `go test ./...` passes.
- `gofmt` clean; `mqlr generate` reruns with no diff.
- **Four** `@maturity("deprecated")` markers remain, deliberately: `gcp.project.computeService.firewall.allowed` / `.denied`, `gcp.project.apiKey.keyString`, and the hierarchical firewall rule's `layer4Configs`. All four were marked deprecated on 2026-08-07 by #9607 and #9636, ten days *after* this branch enumerated its removal set, and arrived here via a rebase. Removing them now would give users no migration window, so they come out in the next major instead. Their replacements (`allowedProtocols`, `deniedProtocols`, `layer4Protocols`) already ship; `keyString` has no replacement by design (it is a live API credential an inventory resource deliberately does not carry). This mirrors the same call made on oci #9481.
- Swept for stale `CreateResource` map keys naming a removed field (these are runtime-only errors, invisible to the compiler) — none remain. This caught two real cases the naive check missed, where the args map is built as a variable: GKE `clusterArgs` and pubsub `topic.config`.
- Verified every `cache*` field is primed **for its own type**, so no accessor silently returns a zero value. This caught `subnetwork.cacheRegionUrl` / `cacheNetworkUrl`, which were declared but never set.
- Checked for `@defaults(...)` clauses left pointing at a removed field — fixed one on `pubsubService.topic.config`.

Not yet validated against live GCP infrastructure.

---

**Rebased onto current `v14-pre`** (2026-08-13), which had moved 17 commits ahead — including oci #9481 and aws #9520. None touched `providers/gcp`, so the rebase was clean.

The `golangci-lint` failure on the previous run was **infrastructure, not code**: `golangci-lint config verify` timed out fetching its JSON schema from `golangci-lint.run` and the action aborted before linting anything. A second `golangci-lint` job and both `golangci-lint-providers / lint` jobs in the same run passed. Since that job never actually linted, it was re-verified locally: `golangci-lint run ./...` in `providers/gcp` reports **0 issues**, and `go build` / `go vet` / `go test ./...` are clean.
