### PR TITLE
🛑 arista: remove deprecated boundaryType field

### DIFF
--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -498,12 +498,6 @@ arista.eos.spt.mstInterface @defaults("name") {
   // designated bridge and port; `regionalRootAddress` and
   // `regionalRootPriority` identify the MST regional root.
   detail dict
-  // Interface boundary type
-  //
-  // Deprecated, please use state. This field never carried a distinct
-  // boundary type: it returns the same value as state. It will be removed in
-  // a future major release once a real boundary source is wired up.
-  boundaryType @maturity("deprecated") string
   // BPDU transaction counters for the interface
   //
   // Keys `bpduSent`, `bpduReceived`, `bpduTaggedError`, `bpduOtherError`,

--- a/providers/arista/resources/arista.lr.go
+++ b/providers/arista/resources/arista.lr.go
@@ -763,9 +763,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"arista.eos.spt.mstInterface.detail": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAristaEosSptMstInterface).GetDetail()).ToDataRes(types.Dict)
 	},
-	"arista.eos.spt.mstInterface.boundaryType": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAristaEosSptMstInterface).GetBoundaryType()).ToDataRes(types.String)
-	},
 	"arista.eos.spt.mstInterface.counters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAristaEosSptMstInterface).GetCounters()).ToDataRes(types.Dict)
 	},
@@ -2291,10 +2288,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"arista.eos.spt.mstInterface.detail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAristaEosSptMstInterface).Detail, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"arista.eos.spt.mstInterface.boundaryType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAristaEosSptMstInterface).BoundaryType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"arista.eos.spt.mstInterface.counters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5442,7 +5435,6 @@ type mqlAristaEosSptMstInterface struct {
 	PortNumber           plugin.TValue[int64]
 	IsEdgePort           plugin.TValue[bool]
 	Detail               plugin.TValue[any]
-	BoundaryType         plugin.TValue[string]
 	Counters             plugin.TValue[any]
 	Features             plugin.TValue[any]
 }
@@ -5530,10 +5522,6 @@ func (c *mqlAristaEosSptMstInterface) GetIsEdgePort() *plugin.TValue[bool] {
 
 func (c *mqlAristaEosSptMstInterface) GetDetail() *plugin.TValue[any] {
 	return &c.Detail
-}
-
-func (c *mqlAristaEosSptMstInterface) GetBoundaryType() *plugin.TValue[string] {
-	return &c.BoundaryType
 }
 
 func (c *mqlAristaEosSptMstInterface) GetCounters() *plugin.TValue[any] {

--- a/providers/arista/resources/arista.lr.versions
+++ b/providers/arista/resources/arista.lr.versions
@@ -403,7 +403,6 @@ arista.eos.snmpSetting 9.0.0
 arista.eos.snmpSetting.enabled 9.0.0
 arista.eos.snmpSetting.notifications 9.0.0
 arista.eos.spt.mstInterface 9.0.0
-arista.eos.spt.mstInterface.boundaryType 9.0.0
 arista.eos.spt.mstInterface.cost 9.0.0
 arista.eos.spt.mstInterface.counters 9.0.0
 arista.eos.spt.mstInterface.detail 9.0.0

--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -575,9 +575,6 @@ func (a *mqlAristaEosStp) mstInstances() ([]any, error) {
 				"portNumber":           llx.IntData(int64(iface.PortNumber)),
 				"isEdgePort":           llx.BoolData(iface.IsEdgePort),
 				"detail":               llx.DictData(detail),
-				// Deprecated: duplicates state; no real boundary source exists
-				// in the SDK response yet.
-				"boundaryType": llx.StringData(iface.State),
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## What

Removes the deprecated `arista.eos.spt.mstInterface.boundaryType` field as part of the v14 breaking-change cleanup.

## Why

`boundaryType` was deprecated in favor of `state`. It never carried a distinct boundary type — the creator in `arista_eos.go` passed `iface.State` straight through:

```go
"boundaryType": llx.StringData(iface.State),
```

So every query returned the same value as `state`. The eAPI response exposes no real boundary source, so there was nothing to wire it up to.

## Changes

- `arista.lr` — removed the field and its doc comment
- `arista.lr.versions` — dropped the `arista.eos.spt.mstInterface.boundaryType 9.0.0` entry
- `arista_eos.go` — removed the stale `"boundaryType":` `CreateResource` arg key (invisible to the Go compiler; would have become an invalid-field error at query time)
- `arista.lr.go` — regenerated

The `boundaryType` keys remaining under `resources/eos/testdata/` are raw eAPI fixtures (the device's own output), not our schema, so they are left untouched.

## Migration

| Removed | Use instead |
| --- | --- |
| `arista.eos.spt.mstInterface.boundaryType` | `arista.eos.spt.mstInterface.state` |

## Policy impact

None. No query in the cnspec content bundles or enterprise policies references this field.

## Verification

- `./mqlr generate providers/arista/resources/arista.lr` — clean
- `go build -gcflags=-e ./...` — clean
- `go test ./...` — passing
