### PR TITLE
🛑 portainer: remove deprecated enableHostManagementFeatures field

### DIFF
--- a/providers/portainer/resources/portainer.lr
+++ b/providers/portainer/resources/portainer.lr
@@ -80,12 +80,6 @@ portainer.settings @defaults("authenticationMethod requiredPasswordLength") {
   disableKubeShell bool
   // Whether kubeconfig download is disabled
   disableKubeconfigDownload bool
-  // Host-management features
-  //
-  // Deprecated in favor of the per-environment securitySettings override of
-  // the same name. Portainer stopped maintaining this instance-wide flag, so
-  // it reads false regardless of how individual environments are configured.
-  enableHostManagementFeatures @maturity("deprecated") bool
   // Whether syncing of built-in Kubernetes roles is disabled
   disableKubeRolesSync bool
   // Custom kubectl shell image used for the Kubernetes web console

--- a/providers/portainer/resources/portainer.lr.go
+++ b/providers/portainer/resources/portainer.lr.go
@@ -221,9 +221,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"portainer.settings.disableKubeconfigDownload": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerSettings).GetDisableKubeconfigDownload()).ToDataRes(types.Bool)
 	},
-	"portainer.settings.enableHostManagementFeatures": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlPortainerSettings).GetEnableHostManagementFeatures()).ToDataRes(types.Bool)
-	},
 	"portainer.settings.disableKubeRolesSync": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerSettings).GetDisableKubeRolesSync()).ToDataRes(types.Bool)
 	},
@@ -559,10 +556,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"portainer.settings.disableKubeconfigDownload": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPortainerSettings).DisableKubeconfigDownload, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"portainer.settings.enableHostManagementFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlPortainerSettings).EnableHostManagementFeatures, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"portainer.settings.disableKubeRolesSync": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1136,7 +1129,6 @@ type mqlPortainerSettings struct {
 	AllowVolumeBrowserForRegularUsers         plugin.TValue[bool]
 	DisableKubeShell                          plugin.TValue[bool]
 	DisableKubeconfigDownload                 plugin.TValue[bool]
-	EnableHostManagementFeatures              plugin.TValue[bool]
 	DisableKubeRolesSync                      plugin.TValue[bool]
 	KubectlShellImage                         plugin.TValue[string]
 	KubeconfigExpiry                          plugin.TValue[string]
@@ -1241,10 +1233,6 @@ func (c *mqlPortainerSettings) GetDisableKubeShell() *plugin.TValue[bool] {
 
 func (c *mqlPortainerSettings) GetDisableKubeconfigDownload() *plugin.TValue[bool] {
 	return &c.DisableKubeconfigDownload
-}
-
-func (c *mqlPortainerSettings) GetEnableHostManagementFeatures() *plugin.TValue[bool] {
-	return &c.EnableHostManagementFeatures
 }
 
 func (c *mqlPortainerSettings) GetDisableKubeRolesSync() *plugin.TValue[bool] {

--- a/providers/portainer/resources/portainer.lr.versions
+++ b/providers/portainer/resources/portainer.lr.versions
@@ -76,7 +76,6 @@ portainer.settings.displayExternalContributors 13.0.0
 portainer.settings.edgeAgentCheckinInterval 13.0.0
 portainer.settings.edgePortainerUrl 13.0.0
 portainer.settings.enableEdgeComputeFeatures 13.0.0
-portainer.settings.enableHostManagementFeatures 13.0.0
 portainer.settings.enableTelemetry 13.0.0
 portainer.settings.enforceEdgeId 13.0.0
 portainer.settings.helmRepositoryUrl 13.0.0

--- a/providers/portainer/resources/settings.go
+++ b/providers/portainer/resources/settings.go
@@ -66,7 +66,6 @@ func (r *mqlPortainer) settings() (*mqlPortainerSettings, error) {
 		"allowVolumeBrowserForRegularUsers":         llx.BoolData(settings.AllowVolumeBrowserForRegularUsers),
 		"disableKubeShell":                          llx.BoolData(settings.DisableKubeShell),
 		"disableKubeconfigDownload":                 llx.BoolData(settings.DisableKubeconfigDownload),
-		"enableHostManagementFeatures":              llx.BoolData(settings.EnableHostManagementFeatures),
 		"disableKubeRolesSync":                      llx.BoolData(settings.DisableKubeRolesSync),
 		"kubectlShellImage":                         llx.StringData(settings.KubectlShellImage),
 		"kubeconfigExpiry":                          llx.StringData(settings.KubeconfigExpiry),


### PR DESCRIPTION
## What

Removes the deprecated `portainer.settings.enableHostManagementFeatures` field as part of the v14 breaking-change cleanup.

## Why

Portainer stopped maintaining this instance-wide flag. It read `false` regardless of how individual environments were actually configured, so any audit built on it was silently wrong. The live setting is the per-environment override of the same name.

## Changes

- `portainer.lr` — removed the field and its doc comment
- `portainer.lr.versions` — dropped the `portainer.settings.enableHostManagementFeatures 13.0.0` entry
- `settings.go` — removed the stale `"enableHostManagementFeatures":` `CreateResource` arg key (a string map key, so invisible to the Go compiler; it would have surfaced as an invalid-field error at query time)
- `portainer.lr.go` — regenerated

Deliberately **not** touched: `environments.go` still sets `"enableHostManagementFeatures"` in the `securitySettings` map, and `portainer.lr` still names it in that field's dict-shape doc comment. That is the replacement, on a different resource.

## Migration

| Removed | Use instead |
| --- | --- |
| `portainer.settings.enableHostManagementFeatures` | `portainer.environment.securitySettings['enableHostManagementFeatures']` |

## Policy impact

None. No query in the cnspec content bundles or enterprise policies references this field.

## Verification

- `./mqlr generate providers/portainer/resources/portainer.lr` — clean
- `go build -gcflags=-e ./...` — clean
- `gofmt -l providers/portainer/` — clean
