### PR TITLE
🛑 google-workspace: remove 3 deprecated raw dict fields

### DIFF
--- a/providers/google-workspace/resources/google-workspace.lr
+++ b/providers/google-workspace/resources/google-workspace.lr
@@ -517,11 +517,6 @@ private googleworkspace.group @defaults("email") {
   adminCreated bool
   // Retrieve members of the group
   members() []googleworkspace.member
-  // Group settings as a raw dict
-  //
-  // Deprecated in favor of groupSettings, which exposes the same Groups
-  // Settings API data as typed, queryable fields.
-  settings() @maturity("deprecated") dict
   // Group security settings
   //
   // Membership restrictions from the Cloud Identity Groups API. The
@@ -807,18 +802,6 @@ private googleworkspace.report.usage {
   // are also promoted to the typed fields on this resource (isDisabled,
   // is2svEnrolled, usedQuotaInMb, and so on).
   parameters []dict
-  // Account Settings as a raw dict
-  //
-  // Deprecated in favor of the typed isDisabled, isSuperAdmin, is2svEnrolled,
-  // is2svEnforced, passwordStrength, passwordLengthCompliance, and quota
-  // fields on this resource.
-  account() @maturity("deprecated") dict
-  // Security Settings as a raw dict
-  //
-  // Deprecated in favor of the typed is2svEnrolled, is2svEnforced,
-  // isLessSecureAppsAccessAllowed, numAuthorizedApps, and numSecurityKeys
-  // fields on this resource.
-  security() @maturity("deprecated") dict
   // Per-application usage counters for the account
   //
   // Keys include `gmailUsedQuotaInMb`, `driveUsedQuotaInMb`,

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -701,9 +701,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"googleworkspace.group.members": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceGroup).GetMembers()).ToDataRes(types.Array(types.Resource("googleworkspace.member")))
 	},
-	"googleworkspace.group.settings": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGoogleworkspaceGroup).GetSettings()).ToDataRes(types.Dict)
-	},
 	"googleworkspace.group.securitySettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceGroup).GetSecuritySettings()).ToDataRes(types.Dict)
 	},
@@ -898,12 +895,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"googleworkspace.report.usage.parameters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceReportUsage).GetParameters()).ToDataRes(types.Array(types.Dict))
-	},
-	"googleworkspace.report.usage.account": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGoogleworkspaceReportUsage).GetAccount()).ToDataRes(types.Dict)
-	},
-	"googleworkspace.report.usage.security": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlGoogleworkspaceReportUsage).GetSecurity()).ToDataRes(types.Dict)
 	},
 	"googleworkspace.report.usage.appUsage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceReportUsage).GetAppUsage()).ToDataRes(types.Dict)
@@ -1952,10 +1943,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGoogleworkspaceGroup).Members, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"googleworkspace.group.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGoogleworkspaceGroup).Settings, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
 	"googleworkspace.group.securitySettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspaceGroup).SecuritySettings, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -2250,14 +2237,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"googleworkspace.report.usage.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspaceReportUsage).Parameters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"googleworkspace.report.usage.account": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGoogleworkspaceReportUsage).Account, ok = plugin.RawToTValue[any](v.Value, v.Error)
-		return
-	},
-	"googleworkspace.report.usage.security": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlGoogleworkspaceReportUsage).Security, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"googleworkspace.report.usage.appUsage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4398,7 +4377,6 @@ type mqlGoogleworkspaceGroup struct {
 	DirectMembersCount plugin.TValue[int64]
 	AdminCreated       plugin.TValue[bool]
 	Members            plugin.TValue[[]any]
-	Settings           plugin.TValue[any]
 	SecuritySettings   plugin.TValue[any]
 	GroupSettings      plugin.TValue[*mqlGoogleworkspaceGroupSettingsConfig]
 }
@@ -4485,12 +4463,6 @@ func (c *mqlGoogleworkspaceGroup) GetMembers() *plugin.TValue[[]any] {
 		}
 
 		return c.members()
-	})
-}
-
-func (c *mqlGoogleworkspaceGroup) GetSettings() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.Settings, func() (any, error) {
-		return c.settings()
 	})
 }
 
@@ -5239,8 +5211,6 @@ type mqlGoogleworkspaceReportUsage struct {
 	UserEmail                     plugin.TValue[string]
 	Date                          plugin.TValue[*time.Time]
 	Parameters                    plugin.TValue[[]any]
-	Account                       plugin.TValue[any]
-	Security                      plugin.TValue[any]
 	AppUsage                      plugin.TValue[any]
 	IsDisabled                    plugin.TValue[bool]
 	IsSuperAdmin                  plugin.TValue[bool]
@@ -5319,18 +5289,6 @@ func (c *mqlGoogleworkspaceReportUsage) GetDate() *plugin.TValue[*time.Time] {
 
 func (c *mqlGoogleworkspaceReportUsage) GetParameters() *plugin.TValue[[]any] {
 	return &c.Parameters
-}
-
-func (c *mqlGoogleworkspaceReportUsage) GetAccount() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.Account, func() (any, error) {
-		return c.account()
-	})
-}
-
-func (c *mqlGoogleworkspaceReportUsage) GetSecurity() *plugin.TValue[any] {
-	return plugin.GetOrCompute[any](&c.Security, func() (any, error) {
-		return c.security()
-	})
 }
 
 func (c *mqlGoogleworkspaceReportUsage) GetAppUsage() *plugin.TValue[any] {

--- a/providers/google-workspace/resources/google-workspace.lr.versions
+++ b/providers/google-workspace/resources/google-workspace.lr.versions
@@ -121,7 +121,6 @@ googleworkspace.group.members 9.0.0
 googleworkspace.group.name 9.0.0
 googleworkspace.group.nonEditableAliases 11.1.122
 googleworkspace.group.securitySettings 9.0.0
-googleworkspace.group.settings 9.0.0
 googleworkspace.group.settingsConfig 13.1.5
 googleworkspace.group.settingsConfig.allowExternalMembers 13.1.5
 googleworkspace.group.settingsConfig.allowWebPosting 13.1.5
@@ -214,7 +213,6 @@ googleworkspace.report.apps 9.0.0
 googleworkspace.report.apps.admin 9.0.0
 googleworkspace.report.apps.drive 9.0.0
 googleworkspace.report.usage 9.0.0
-googleworkspace.report.usage.account 9.0.0
 googleworkspace.report.usage.appUsage 9.0.0
 googleworkspace.report.usage.customerId 9.0.0
 googleworkspace.report.usage.date 9.0.0
@@ -232,7 +230,6 @@ googleworkspace.report.usage.parameters 9.0.0
 googleworkspace.report.usage.passwordLengthCompliance 13.1.5
 googleworkspace.report.usage.passwordStrength 13.1.5
 googleworkspace.report.usage.profileId 9.0.0
-googleworkspace.report.usage.security 9.0.0
 googleworkspace.report.usage.type 9.0.0
 googleworkspace.report.usage.usedQuotaInMb 13.1.5
 googleworkspace.report.usage.userEmail 9.0.0

--- a/providers/google-workspace/resources/group.go
+++ b/providers/google-workspace/resources/group.go
@@ -157,26 +157,6 @@ func (g *mqlGoogleworkspaceMember) user() (*mqlGoogleworkspaceUser, error) {
 	return user, nil
 }
 
-func (g *mqlGoogleworkspaceGroup) settings() (any, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GoogleWorkspaceConnection)
-	service, err := groupSettingsService(conn, groupssettings.AppsGroupsSettingsScope)
-	if err != nil {
-		return nil, err
-	}
-
-	if g.Email.Error != nil {
-		return nil, g.Email.Error
-	}
-	email := g.Email.Data
-
-	settings, err := service.Groups.Get(email).Do()
-	if err != nil {
-		return nil, err
-	}
-
-	return convert.JsonToDict(settings)
-}
-
 // parseGroupSettingBool converts a Groups Settings API boolean, which the API
 // encodes as the string "true"/"false", into a typed bool.
 func parseGroupSettingBool(s string) bool {

--- a/providers/google-workspace/resources/reports.go
+++ b/providers/google-workspace/resources/reports.go
@@ -303,16 +303,6 @@ func newMqlGoogleWorkspaceUsageReport(runtime *plugin.Runtime, entry *reports.Us
 
 	r := parseUserReports(entry.Parameters)
 
-	accountUsage, err := convert.JsonToDict(r.Account)
-	if err != nil {
-		return nil, err
-	}
-
-	securityUsage, err := convert.JsonToDict(r.Security)
-	if err != nil {
-		return nil, err
-	}
-
 	appUsage, err := convert.JsonToDict(r.AppUsage)
 	if err != nil {
 		return nil, err
@@ -335,8 +325,6 @@ func newMqlGoogleWorkspaceUsageReport(runtime *plugin.Runtime, entry *reports.Us
 		"userEmail":  llx.StringData(userEmail),
 		"date":       llx.TimeDataPtr(date),
 		"parameters": llx.ArrayData(parameters, types.Any),
-		"account":    llx.MapData(accountUsage, types.Any),
-		"security":   llx.MapData(securityUsage, types.Any),
 		"appUsage":   llx.MapData(appUsage, types.Any),
 		// Typed promotions of the account/security dicts (already parsed into
 		// r above) so audits can assert on them directly.
@@ -502,16 +490,6 @@ func parseUserReports(params []*reports.UsageReportParameters) *userReport {
 	}
 
 	return r
-}
-
-func (g *mqlGoogleworkspaceReportUsage) account() (any, error) {
-	// is auto-computed during creation time
-	return nil, errors.New("not implemented")
-}
-
-func (g *mqlGoogleworkspaceReportUsage) security() (any, error) {
-	// is auto-computed during creation time
-	return nil, errors.New("not implemented")
 }
 
 func (g *mqlGoogleworkspaceReportUsage) appUsage() (any, error) {


### PR DESCRIPTION
## What

Removes 3 deprecated raw `dict` fields from the google-workspace provider as part of the v14 breaking-change cleanup.

## Why

All three were raw `convert.JsonToDict` dumps that have since been replaced by typed, queryable fields carrying the same API data. A `dict` forces consumers into untyped key lookups with no schema and no compile-time checking; the typed fields are directly assertable.

`googleworkspace.report.usage.account` and `.security` were additionally **stubs**:

```go
func (g *mqlGoogleworkspaceReportUsage) account() (any, error) {
	// is auto-computed during creation time
	return nil, errors.New("not implemented")
}
```

The values arrived as `CreateResource` args, and the same underlying structs are already promoted to typed fields on that resource, so nothing is lost.

## Migration

| Removed | Use instead |
| --- | --- |
| `googleworkspace.group.settings` | `googleworkspace.group.groupSettings` (typed) |
| `googleworkspace.report.usage.account` | `isDisabled`, `isSuperAdmin`, `is2svEnrolled`, `is2svEnforced`, `passwordStrength`, `passwordLengthCompliance`, `quota` |
| `googleworkspace.report.usage.security` | `is2svEnrolled`, `is2svEnforced`, `isLessSecureAppsAccessAllowed`, `numAuthorizedApps`, `numSecurityKeys` |

## Changes

- `google-workspace.lr` — removed 3 fields and their doc comments
- `google-workspace.lr.versions` — dropped the 3 entries
- `group.go` — removed the `settings()` accessor
- `reports.go` — removed the `"account":` / `"security":` arg keys, the now-dead `accountUsage` / `securityUsage` dict conversions, and the two stub methods
- `google-workspace.lr.go` — regenerated

`groupSettingsService` is deliberately retained: the typed `groupSettings` accessor calls the same Groups Settings API, so the helper and the `groupssettings` import are still live.

## Policy impact

None. No query in the cnspec content bundles or enterprise policies references these fields.

## Verification

- `./mqlr generate providers/google-workspace/resources/google-workspace.lr` — clean
- `go build -gcflags=-e ./...` — clean
- `go test ./...` — passing
- `gofmt -l providers/google-workspace/` — clean
