### PR TITLE
🛑 together: remove deprecated cluster storageVolumes accessor

### DIFF
--- a/providers/together/resources/together.go
+++ b/providers/together/resources/together.go
@@ -232,9 +232,6 @@ func (r *mqlTogether) clusters() ([]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		cluster := mqlCluster.(*mqlTogetherCluster)
-		cluster.clusterId = c.ClusterID
-		cluster.projectId = c.ProjectID
 		res = append(res, mqlCluster)
 	}
 
@@ -282,30 +279,14 @@ func (r *mqlTogether) secrets() ([]interface{}, error) {
 
 func (r *mqlTogether) clusterStorageVolumes() ([]interface{}, error) {
 	conn := togetherConn(r.MqlRuntime)
-	return listClusterStorageVolumes(r.MqlRuntime, conn.Client(), conn.Project(), "")
-}
-
-type mqlTogetherClusterInternal struct {
-	clusterId string
-	projectId string
-}
-
-// storageVolumes is deprecated in favor of the top-level
-// together.clusterStorageVolumes. The Together storage API is project-scoped
-// and returns no cluster association, so this lists the cluster's project-wide
-// volumes rather than volumes owned by this specific cluster. Retained for
-// backward compatibility with its original project filter and __id.
-func (r *mqlTogetherCluster) storageVolumes() ([]interface{}, error) {
-	conn := togetherConn(r.MqlRuntime)
-	return listClusterStorageVolumes(r.MqlRuntime, conn.Client(), r.projectId, r.clusterId+"/")
+	return listClusterStorageVolumes(r.MqlRuntime, conn.Client(), conn.Project())
 }
 
 // listClusterStorageVolumes lists project-scoped cluster storage volumes. The
 // list endpoint accepts only a project filter and the returned volumes carry no
 // cluster reference, so they belong to the account's project and are shared
-// across its clusters. idPrefix is prepended to each volume's __id to preserve
-// the deprecated per-cluster accessor's cache keys.
-func listClusterStorageVolumes(runtime *plugin.Runtime, client *together.Client, project, idPrefix string) ([]interface{}, error) {
+// across its clusters.
+func listClusterStorageVolumes(runtime *plugin.Runtime, client *together.Client, project string) ([]interface{}, error) {
 	params := together.BetaClusterStorageListParams{}
 	if project != "" {
 		params.ProjectID = together.Opt(project)
@@ -325,7 +306,7 @@ func listClusterStorageVolumes(runtime *plugin.Runtime, client *together.Client,
 	res := make([]interface{}, 0, len(resp.Volumes))
 	for _, v := range resp.Volumes {
 		mqlVol, err := CreateResource(runtime, "together.clusterStorageVolume", map[string]*llx.RawData{
-			"__id":       llx.StringData(idPrefix + v.VolumeID),
+			"__id":       llx.StringData(v.VolumeID),
 			"volumeId":   llx.StringData(v.VolumeID),
 			"volumeName": llx.StringData(v.VolumeName),
 			"sizeTib":    llx.IntData(v.SizeTib),

--- a/providers/together/resources/together.lr
+++ b/providers/together/resources/together.lr
@@ -231,13 +231,6 @@ together.cluster @defaults("name gpuType numGpus region status") @maturity("prev
   reservationStartTime time
   // Reservation end time
   reservationEndTime time
-  // Storage volumes reachable from this cluster
-  //
-  // Deprecated in favor of the top-level together.clusterStorageVolumes.
-  // The Together storage API is project-scoped and returns no cluster
-  // association, so the volumes listed here are the account's project-wide
-  // volumes rather than volumes owned by this specific cluster.
-  storageVolumes() @maturity("deprecated") []together.clusterStorageVolume
 }
 
 // Together AI managed secret

--- a/providers/together/resources/together.lr.go
+++ b/providers/together/resources/together.lr.go
@@ -363,9 +363,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"together.cluster.reservationEndTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogetherCluster).GetReservationEndTime()).ToDataRes(types.Time)
 	},
-	"together.cluster.storageVolumes": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlTogetherCluster).GetStorageVolumes()).ToDataRes(types.Array(types.Resource("together.clusterStorageVolume")))
-	},
 	"together.secret.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogetherSecret).GetId()).ToDataRes(types.String)
 	},
@@ -848,10 +845,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"together.cluster.reservationEndTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTogetherCluster).ReservationEndTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
-	"together.cluster.storageVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlTogetherCluster).StorageVolumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"together.secret.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1757,7 +1750,7 @@ func (c *mqlTogetherFile) GetCreatedAt() *plugin.TValue[*time.Time] {
 type mqlTogetherCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlTogetherClusterInternal
+	// optional: if you define mqlTogetherClusterInternal it will be used here
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
 	ClusterType          plugin.TValue[string]
@@ -1775,7 +1768,6 @@ type mqlTogetherCluster struct {
 	CreatedAt            plugin.TValue[*time.Time]
 	ReservationStartTime plugin.TValue[*time.Time]
 	ReservationEndTime   plugin.TValue[*time.Time]
-	StorageVolumes       plugin.TValue[[]any]
 }
 
 // createTogetherCluster creates a new instance of this resource
@@ -1881,22 +1873,6 @@ func (c *mqlTogetherCluster) GetReservationStartTime() *plugin.TValue[*time.Time
 
 func (c *mqlTogetherCluster) GetReservationEndTime() *plugin.TValue[*time.Time] {
 	return &c.ReservationEndTime
-}
-
-func (c *mqlTogetherCluster) GetStorageVolumes() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.StorageVolumes, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("together.cluster", c.__id, "storageVolumes")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.storageVolumes()
-	})
 }
 
 // mqlTogetherSecret for the together.secret resource

--- a/providers/together/resources/together.lr.versions
+++ b/providers/together/resources/together.lr.versions
@@ -35,7 +35,6 @@ together.cluster.region 13.0.0
 together.cluster.reservationEndTime 13.0.0
 together.cluster.reservationStartTime 13.0.0
 together.cluster.status 13.0.0
-together.cluster.storageVolumes 13.0.0
 together.clusterStorageVolume 13.0.0
 together.clusterStorageVolume.sizeTib 13.0.0
 together.clusterStorageVolume.status 13.0.0


### PR DESCRIPTION
## What

Removes `together.cluster.storageVolumes` as part of the v14 breaking-change cleanup.

## Why

The accessor was misleading. Together's storage list endpoint accepts only a project filter, and the volumes it returns carry no cluster reference:

```go
params := together.BetaClusterStorageListParams{}
if project != "" { params.ProjectID = together.Opt(project) }
```

So reading `storageVolumes` from a cluster returned the account's **project-wide** volumes, not volumes owned by that cluster. Querying two clusters in the same project produced identical lists, which invites exactly the wrong conclusion about which workload a volume belongs to.

## Migration

| Removed | Use instead |
| --- | --- |
| `together.cluster.storageVolumes` | `together.clusterStorageVolumes` |

The top-level resource returns the same set, without implying a cluster association that the API does not provide.

## Changes

- `together.lr` — removed the field and its doc comment
- `together.lr.versions` — dropped the `together.cluster.storageVolumes 13.0.0` entry
- `together.go` — removed the accessor, plus the code that existed only to feed it:
  - `mqlTogetherClusterInternal` (both `clusterId` and `projectId` became write-only — the Go compiler does not flag unused struct fields, so these had to be found by hand)
  - the two assignments in the cluster creator
  - the `idPrefix` parameter on `listClusterStorageVolumes`, which existed only to preserve the deprecated accessor's cache keys and is now always `""`
- `together.lr.go` — regenerated

Dropping `idPrefix` does not change `__id` for the surviving path: the top-level accessor already passed `""`.

## Policy impact

None. No query in the cnspec content bundles or enterprise policies references this field.

## Verification

- `./mqlr generate providers/together/resources/together.lr` — clean
- `go build -gcflags=-e ./...` — clean
- `go test ./...` — passing
- `gofmt -l .` — clean
