### PR TITLE
🛑 cloudflare: remove deprecated zone fields and legacy resources

### DIFF
--- a/providers/cloudflare/resources/cloudflare.go
+++ b/providers/cloudflare/resources/cloudflare.go
@@ -40,32 +40,15 @@ func (c *mqlCloudflare) zones() ([]any, error) {
 		acc, err := NewResource(c.MqlRuntime, "cloudflare.zone.account", map[string]*llx.RawData{
 			"id":   llx.StringData(zone.Account.ID),
 			"name": llx.StringData(zone.Account.Name),
-			// v6 ZoneAccount has no Type field; surface empty for schema compatibility.
-			"type": llx.StringData(""),
 		})
 		if err != nil {
 			return nil, err
 		}
 
 		owner, err := NewResource(c.MqlRuntime, "cloudflare.zone.owner", map[string]*llx.RawData{
-			"id": llx.StringData(zone.Owner.ID),
-			// v6 ZoneOwner has no Email field — the OpenAPI spec doesn't expose
-			// it at the zone level. Surface empty for schema compatibility.
-			"email":     llx.StringData(""),
+			"id":        llx.StringData(zone.Owner.ID),
 			"name":      llx.StringData(zone.Owner.Name),
 			"ownerType": llx.StringData(zone.Owner.Type),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		plan, err := NewResource(c.MqlRuntime, "cloudflare.zone.plan", map[string]*llx.RawData{
-			"id":           llx.StringData(zone.Plan.ID),
-			"name":         llx.StringData(zone.Plan.Name),
-			"price":        llx.IntData(int64(zone.Plan.Price)),
-			"currency":     llx.StringData(zone.Plan.Currency),
-			"frequency":    llx.StringData(zone.Plan.Frequency),
-			"isSubscribed": llx.BoolData(zone.Plan.IsSubscribed),
 		})
 		if err != nil {
 			return nil, err
@@ -84,7 +67,6 @@ func (c *mqlCloudflare) zones() ([]any, error) {
 
 			"account": llx.ResourceData(acc, acc.MqlName()),
 			"owner":   llx.ResourceData(owner, owner.MqlName()),
-			"plan":    llx.ResourceData(plan, plan.MqlName()),
 
 			"createdOn":  llx.TimeData(zone.CreatedOn),
 			"modifiedOn": llx.TimeData(zone.ModifiedOn),

--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -62,8 +62,6 @@ private cloudflare.zone @defaults("name account.name") {
   account cloudflare.zone.account
 	// Zone owner
 	owner cloudflare.zone.owner
-	// Zone plan. Deprecated and will be removed in the next major release.
-	plan @maturity("deprecated") cloudflare.zone.plan
 
 	// Zone security settings
 	settings() cloudflare.zone.settings
@@ -75,58 +73,7 @@ private cloudflare.zone @defaults("name account.name") {
 	// DNS records associated with the zone
 	dns() cloudflare.dns
 
-	// Stream live inputs
-	//
-	// Deprecated in favor of cloudflare.account.liveInputs. Stream is
-	// account-scoped, so a zone returned the same account-wide live inputs
-	// regardless of which zone it was read from.
-	liveInputs() @maturity("deprecated") []cloudflare.streams.liveInput
 
-	// Stream video assets
-	//
-	// Deprecated in favor of cloudflare.account.videos. Stream is
-	// account-scoped, so a zone returned the same account-wide videos
-	// regardless of which zone it was read from.
-	videos() @maturity("deprecated") []cloudflare.streams.video
-
-	// Cloudflare R2 storage
-	//
-	// Deprecated in favor of cloudflare.account.r2. R2 is account-scoped,
-	// so a zone returned the same account-wide buckets regardless of which
-	// zone it was read from.
-	r2() @maturity("deprecated") cloudflare.r2
-
-	// Cloudflare Workers configuration and deployments
-	//
-	// Deprecated in favor of cloudflare.account.workers. Workers are
-	// account-scoped, so a zone returned the same account-wide scripts
-	// regardless of which zone it was read from.
-	workers() @maturity("deprecated") cloudflare.workers
-
-	// Cloudflare One (Zero Trust)
-	//
-	// Deprecated in favor of cloudflare.account.one. Zero Trust is
-	// account-scoped, so a zone returned the same account-wide
-	// configuration regardless of which zone it was read from.
-	one() @maturity("deprecated") cloudflare.one
-
-	// Cloudflare tunnels
-	//
-	// Deprecated in favor of cloudflare.account.tunnels. Tunnels are
-	// account-scoped, so a zone returned the same account-wide tunnels
-	// regardless of which zone it was read from.
-	tunnels() @maturity("deprecated") []cloudflare.tunnel
-	// Tunnel routes
-	//
-	// Deprecated in favor of cloudflare.account.tunnelRoutes.
-	tunnelRoutes() @maturity("deprecated") []cloudflare.tunnel.route
-	// Tunnel virtual networks
-	//
-	// Deprecated in favor of cloudflare.account.tunnelVirtualNetworks.
-	tunnelVirtualNetworks() @maturity("deprecated") []cloudflare.tunnel.virtualNetwork
-
-	// Firewall rules (legacy)
-	firewallRules() []cloudflare.zone.firewallRule
 	// Managed and custom rulesets evaluated for this zone
 	rulesets() []cloudflare.zone.ruleset
 	// Page rules
@@ -173,42 +120,16 @@ private cloudflare.zone.account @defaults("name") {
 	id string
 	// Account name
 	name string
-	// Account type. Deprecated and will be removed in the next major release.
-	type @maturity("deprecated") string
-	// Account email. Deprecated and will be removed in the next major release.
-	email @maturity("deprecated") string
 }
 
 // Cloudflare zone owner
 private cloudflare.zone.owner @defaults("name") {
 	// Owner identifier
 	id string
-	// Owner email. Deprecated and will be removed in the next major release.
-	email @maturity("deprecated") string
 	// Owner name
 	name string
 	// Owner type
 	ownerType string
-}
-
-// Cloudflare zone plan
-//
-// Cloudflare service plan attached to a zone (plan name, price, billing
-// frequency, and subscription state). Will be removed in the next major
-// release.
-private cloudflare.zone.plan @defaults("name") @maturity("deprecated") {
-	// Plan identifier
-	id string
-	// Plan name
-	name string
-	// Plan price
-	price int
-	// Plan currency
-	currency string
-	// Plan frequency
-	frequency string
-	// Whether the zone is subscribed to this plan
-	isSubscribed bool
 }
 
 // Cloudflare zone security settings
@@ -1228,30 +1149,6 @@ private cloudflare.tunnel.virtualNetwork @defaults("name") {
 	createdAt time
 	// Time the virtual network was deleted
 	deletedAt time
-}
-
-// Legacy Cloudflare zone firewall rule
-//
-// Deprecated in favor of `cloudflare.zone.ruleset`.
-private cloudflare.zone.firewallRule @defaults("id action") @maturity("deprecated") {
-	// Rule identifier
-	id string
-	// Rule description
-	description string
-	// Rule action (block, challenge, js_challenge, managed_challenge, allow, log, bypass)
-	action string
-	// Rule reference tag
-	ref string
-	// Whether the rule is paused
-	paused bool
-	// Filter expression
-	filterExpression string
-	// Products this rule applies to
-	products []string
-	// Time the rule was created
-	createdAt time
-	// Time the rule was last modified
-	updatedAt time
 }
 
 // Cloudflare zone ruleset

--- a/providers/cloudflare/resources/cloudflare.lr.go
+++ b/providers/cloudflare/resources/cloudflare.lr.go
@@ -20,7 +20,6 @@ const (
 	ResourceCloudflareZone                                            string = "cloudflare.zone"
 	ResourceCloudflareZoneAccount                                     string = "cloudflare.zone.account"
 	ResourceCloudflareZoneOwner                                       string = "cloudflare.zone.owner"
-	ResourceCloudflareZonePlan                                        string = "cloudflare.zone.plan"
 	ResourceCloudflareZoneSettings                                    string = "cloudflare.zone.settings"
 	ResourceCloudflareZoneCustomCertificate                           string = "cloudflare.zone.customCertificate"
 	ResourceCloudflareZoneCertificatePack                             string = "cloudflare.zone.certificatePack"
@@ -56,7 +55,6 @@ const (
 	ResourceCloudflareTunnelConnection                                string = "cloudflare.tunnel.connection"
 	ResourceCloudflareTunnelRoute                                     string = "cloudflare.tunnel.route"
 	ResourceCloudflareTunnelVirtualNetwork                            string = "cloudflare.tunnel.virtualNetwork"
-	ResourceCloudflareZoneFirewallRule                                string = "cloudflare.zone.firewallRule"
 	ResourceCloudflareZoneRuleset                                     string = "cloudflare.zone.ruleset"
 	ResourceCloudflareZonePageRule                                    string = "cloudflare.zone.pageRule"
 	ResourceCloudflareZoneLoadBalancer                                string = "cloudflare.zone.loadBalancer"
@@ -108,10 +106,6 @@ func init() {
 		"cloudflare.zone.owner": {
 			// to override args, implement: initCloudflareZoneOwner(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCloudflareZoneOwner,
-		},
-		"cloudflare.zone.plan": {
-			// to override args, implement: initCloudflareZonePlan(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createCloudflareZonePlan,
 		},
 		"cloudflare.zone.settings": {
 			// to override args, implement: initCloudflareZoneSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -252,10 +246,6 @@ func init() {
 		"cloudflare.tunnel.virtualNetwork": {
 			// to override args, implement: initCloudflareTunnelVirtualNetwork(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCloudflareTunnelVirtualNetwork,
-		},
-		"cloudflare.zone.firewallRule": {
-			// to override args, implement: initCloudflareZoneFirewallRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createCloudflareZoneFirewallRule,
 		},
 		"cloudflare.zone.ruleset": {
 			// to override args, implement: initCloudflareZoneRuleset(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -490,9 +480,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudflare.zone.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZone).GetOwner()).ToDataRes(types.Resource("cloudflare.zone.owner"))
 	},
-	"cloudflare.zone.plan": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetPlan()).ToDataRes(types.Resource("cloudflare.zone.plan"))
-	},
 	"cloudflare.zone.settings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZone).GetSettings()).ToDataRes(types.Resource("cloudflare.zone.settings"))
 	},
@@ -504,33 +491,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"cloudflare.zone.dns": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZone).GetDns()).ToDataRes(types.Resource("cloudflare.dns"))
-	},
-	"cloudflare.zone.liveInputs": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetLiveInputs()).ToDataRes(types.Array(types.Resource("cloudflare.streams.liveInput")))
-	},
-	"cloudflare.zone.videos": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetVideos()).ToDataRes(types.Array(types.Resource("cloudflare.streams.video")))
-	},
-	"cloudflare.zone.r2": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetR2()).ToDataRes(types.Resource("cloudflare.r2"))
-	},
-	"cloudflare.zone.workers": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetWorkers()).ToDataRes(types.Resource("cloudflare.workers"))
-	},
-	"cloudflare.zone.one": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetOne()).ToDataRes(types.Resource("cloudflare.one"))
-	},
-	"cloudflare.zone.tunnels": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetTunnels()).ToDataRes(types.Array(types.Resource("cloudflare.tunnel")))
-	},
-	"cloudflare.zone.tunnelRoutes": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetTunnelRoutes()).ToDataRes(types.Array(types.Resource("cloudflare.tunnel.route")))
-	},
-	"cloudflare.zone.tunnelVirtualNetworks": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetTunnelVirtualNetworks()).ToDataRes(types.Array(types.Resource("cloudflare.tunnel.virtualNetwork")))
-	},
-	"cloudflare.zone.firewallRules": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZone).GetFirewallRules()).ToDataRes(types.Array(types.Resource("cloudflare.zone.firewallRule")))
 	},
 	"cloudflare.zone.rulesets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZone).GetRulesets()).ToDataRes(types.Array(types.Resource("cloudflare.zone.ruleset")))
@@ -589,41 +549,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudflare.zone.account.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZoneAccount).GetName()).ToDataRes(types.String)
 	},
-	"cloudflare.zone.account.type": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneAccount).GetType()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.account.email": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneAccount).GetEmail()).ToDataRes(types.String)
-	},
 	"cloudflare.zone.owner.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZoneOwner).GetId()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.owner.email": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneOwner).GetEmail()).ToDataRes(types.String)
 	},
 	"cloudflare.zone.owner.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZoneOwner).GetName()).ToDataRes(types.String)
 	},
 	"cloudflare.zone.owner.ownerType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZoneOwner).GetOwnerType()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.plan.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZonePlan).GetId()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.plan.name": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZonePlan).GetName()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.plan.price": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZonePlan).GetPrice()).ToDataRes(types.Int)
-	},
-	"cloudflare.zone.plan.currency": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZonePlan).GetCurrency()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.plan.frequency": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZonePlan).GetFrequency()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.plan.isSubscribed": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZonePlan).GetIsSubscribed()).ToDataRes(types.Bool)
 	},
 	"cloudflare.zone.settings.ssl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZoneSettings).GetSsl()).ToDataRes(types.String)
@@ -1552,33 +1485,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudflare.tunnel.virtualNetwork.deletedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareTunnelVirtualNetwork).GetDeletedAt()).ToDataRes(types.Time)
 	},
-	"cloudflare.zone.firewallRule.id": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetId()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.firewallRule.description": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetDescription()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.firewallRule.action": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetAction()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.firewallRule.ref": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetRef()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.firewallRule.paused": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetPaused()).ToDataRes(types.Bool)
-	},
-	"cloudflare.zone.firewallRule.filterExpression": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetFilterExpression()).ToDataRes(types.String)
-	},
-	"cloudflare.zone.firewallRule.products": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetProducts()).ToDataRes(types.Array(types.String))
-	},
-	"cloudflare.zone.firewallRule.createdAt": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetCreatedAt()).ToDataRes(types.Time)
-	},
-	"cloudflare.zone.firewallRule.updatedAt": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlCloudflareZoneFirewallRule).GetUpdatedAt()).ToDataRes(types.Time)
-	},
 	"cloudflare.zone.ruleset.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareZoneRuleset).GetId()).ToDataRes(types.String)
 	},
@@ -2402,10 +2308,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudflareZone).Owner, ok = plugin.RawToTValue[*mqlCloudflareZoneOwner](v.Value, v.Error)
 		return
 	},
-	"cloudflare.zone.plan": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).Plan, ok = plugin.RawToTValue[*mqlCloudflareZonePlan](v.Value, v.Error)
-		return
-	},
 	"cloudflare.zone.settings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareZone).Settings, ok = plugin.RawToTValue[*mqlCloudflareZoneSettings](v.Value, v.Error)
 		return
@@ -2420,42 +2322,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cloudflare.zone.dns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareZone).Dns, ok = plugin.RawToTValue[*mqlCloudflareDns](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.liveInputs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).LiveInputs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.videos": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).Videos, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.r2": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).R2, ok = plugin.RawToTValue[*mqlCloudflareR2](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.workers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).Workers, ok = plugin.RawToTValue[*mqlCloudflareWorkers](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.one": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).One, ok = plugin.RawToTValue[*mqlCloudflareOne](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.tunnels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).Tunnels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.tunnelRoutes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).TunnelRoutes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.tunnelVirtualNetworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).TunnelVirtualNetworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZone).FirewallRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"cloudflare.zone.rulesets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2538,14 +2404,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudflareZoneAccount).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"cloudflare.zone.account.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneAccount).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.account.email": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneAccount).Email, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"cloudflare.zone.owner.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareZoneOwner).__id, ok = v.Value.(string)
 		return
@@ -2554,44 +2412,12 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudflareZoneOwner).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"cloudflare.zone.owner.email": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneOwner).Email, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"cloudflare.zone.owner.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareZoneOwner).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"cloudflare.zone.owner.ownerType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareZoneOwner).OwnerType, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.plan.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZonePlan).__id, ok = v.Value.(string)
-		return
-	},
-	"cloudflare.zone.plan.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZonePlan).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.plan.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZonePlan).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.plan.price": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZonePlan).Price, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.plan.currency": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZonePlan).Currency, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.plan.frequency": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZonePlan).Frequency, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.plan.isSubscribed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZonePlan).IsSubscribed, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"cloudflare.zone.settings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3970,46 +3796,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCloudflareTunnelVirtualNetwork).DeletedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
-	"cloudflare.zone.firewallRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).__id, ok = v.Value.(string)
-		return
-	},
-	"cloudflare.zone.firewallRule.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.action": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).Action, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.ref": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).Ref, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.paused": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).Paused, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.filterExpression": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).FilterExpression, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.products": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).Products, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
-	"cloudflare.zone.firewallRule.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlCloudflareZoneFirewallRule).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
 	"cloudflare.zone.ruleset.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareZoneRuleset).__id, ok = v.Value.(string)
 		return
@@ -5261,20 +5047,10 @@ type mqlCloudflareZone struct {
 	ModifiedOn               plugin.TValue[*time.Time]
 	Account                  plugin.TValue[*mqlCloudflareZoneAccount]
 	Owner                    plugin.TValue[*mqlCloudflareZoneOwner]
-	Plan                     plugin.TValue[*mqlCloudflareZonePlan]
 	Settings                 plugin.TValue[*mqlCloudflareZoneSettings]
 	CustomCertificates       plugin.TValue[[]any]
 	CertificatePacks         plugin.TValue[[]any]
 	Dns                      plugin.TValue[*mqlCloudflareDns]
-	LiveInputs               plugin.TValue[[]any]
-	Videos                   plugin.TValue[[]any]
-	R2                       plugin.TValue[*mqlCloudflareR2]
-	Workers                  plugin.TValue[*mqlCloudflareWorkers]
-	One                      plugin.TValue[*mqlCloudflareOne]
-	Tunnels                  plugin.TValue[[]any]
-	TunnelRoutes             plugin.TValue[[]any]
-	TunnelVirtualNetworks    plugin.TValue[[]any]
-	FirewallRules            plugin.TValue[[]any]
 	Rulesets                 plugin.TValue[[]any]
 	PageRules                plugin.TValue[[]any]
 	LoadBalancers            plugin.TValue[[]any]
@@ -5375,10 +5151,6 @@ func (c *mqlCloudflareZone) GetOwner() *plugin.TValue[*mqlCloudflareZoneOwner] {
 	return &c.Owner
 }
 
-func (c *mqlCloudflareZone) GetPlan() *plugin.TValue[*mqlCloudflareZonePlan] {
-	return &c.Plan
-}
-
 func (c *mqlCloudflareZone) GetSettings() *plugin.TValue[*mqlCloudflareZoneSettings] {
 	return plugin.GetOrCompute[*mqlCloudflareZoneSettings](&c.Settings, func() (*mqlCloudflareZoneSettings, error) {
 		if c.MqlRuntime.HasRecording {
@@ -5440,150 +5212,6 @@ func (c *mqlCloudflareZone) GetDns() *plugin.TValue[*mqlCloudflareDns] {
 		}
 
 		return c.dns()
-	})
-}
-
-func (c *mqlCloudflareZone) GetLiveInputs() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.LiveInputs, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "liveInputs")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.liveInputs()
-	})
-}
-
-func (c *mqlCloudflareZone) GetVideos() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.Videos, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "videos")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.videos()
-	})
-}
-
-func (c *mqlCloudflareZone) GetR2() *plugin.TValue[*mqlCloudflareR2] {
-	return plugin.GetOrCompute[*mqlCloudflareR2](&c.R2, func() (*mqlCloudflareR2, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "r2")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.(*mqlCloudflareR2), nil
-			}
-		}
-
-		return c.r2()
-	})
-}
-
-func (c *mqlCloudflareZone) GetWorkers() *plugin.TValue[*mqlCloudflareWorkers] {
-	return plugin.GetOrCompute[*mqlCloudflareWorkers](&c.Workers, func() (*mqlCloudflareWorkers, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "workers")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.(*mqlCloudflareWorkers), nil
-			}
-		}
-
-		return c.workers()
-	})
-}
-
-func (c *mqlCloudflareZone) GetOne() *plugin.TValue[*mqlCloudflareOne] {
-	return plugin.GetOrCompute[*mqlCloudflareOne](&c.One, func() (*mqlCloudflareOne, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "one")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.(*mqlCloudflareOne), nil
-			}
-		}
-
-		return c.one()
-	})
-}
-
-func (c *mqlCloudflareZone) GetTunnels() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.Tunnels, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "tunnels")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.tunnels()
-	})
-}
-
-func (c *mqlCloudflareZone) GetTunnelRoutes() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.TunnelRoutes, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "tunnelRoutes")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.tunnelRoutes()
-	})
-}
-
-func (c *mqlCloudflareZone) GetTunnelVirtualNetworks() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.TunnelVirtualNetworks, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "tunnelVirtualNetworks")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.tunnelVirtualNetworks()
-	})
-}
-
-func (c *mqlCloudflareZone) GetFirewallRules() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.FirewallRules, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.zone", c.__id, "firewallRules")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.firewallRules()
 	})
 }
 
@@ -5864,10 +5492,8 @@ type mqlCloudflareZoneAccount struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudflareZoneAccountInternal it will be used here
-	Id    plugin.TValue[string]
-	Name  plugin.TValue[string]
-	Type  plugin.TValue[string]
-	Email plugin.TValue[string]
+	Id   plugin.TValue[string]
+	Name plugin.TValue[string]
 }
 
 // createCloudflareZoneAccount creates a new instance of this resource
@@ -5915,21 +5541,12 @@ func (c *mqlCloudflareZoneAccount) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
-func (c *mqlCloudflareZoneAccount) GetType() *plugin.TValue[string] {
-	return &c.Type
-}
-
-func (c *mqlCloudflareZoneAccount) GetEmail() *plugin.TValue[string] {
-	return &c.Email
-}
-
 // mqlCloudflareZoneOwner for the cloudflare.zone.owner resource
 type mqlCloudflareZoneOwner struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudflareZoneOwnerInternal it will be used here
 	Id        plugin.TValue[string]
-	Email     plugin.TValue[string]
 	Name      plugin.TValue[string]
 	OwnerType plugin.TValue[string]
 }
@@ -5975,90 +5592,12 @@ func (c *mqlCloudflareZoneOwner) GetId() *plugin.TValue[string] {
 	return &c.Id
 }
 
-func (c *mqlCloudflareZoneOwner) GetEmail() *plugin.TValue[string] {
-	return &c.Email
-}
-
 func (c *mqlCloudflareZoneOwner) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
 
 func (c *mqlCloudflareZoneOwner) GetOwnerType() *plugin.TValue[string] {
 	return &c.OwnerType
-}
-
-// mqlCloudflareZonePlan for the cloudflare.zone.plan resource
-type mqlCloudflareZonePlan struct {
-	MqlRuntime *plugin.Runtime
-	__id       string
-	// optional: if you define mqlCloudflareZonePlanInternal it will be used here
-	Id           plugin.TValue[string]
-	Name         plugin.TValue[string]
-	Price        plugin.TValue[int64]
-	Currency     plugin.TValue[string]
-	Frequency    plugin.TValue[string]
-	IsSubscribed plugin.TValue[bool]
-}
-
-// createCloudflareZonePlan creates a new instance of this resource
-func createCloudflareZonePlan(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlCloudflareZonePlan{
-		MqlRuntime: runtime,
-	}
-
-	err := SetAllData(res, args)
-	if err != nil {
-		return res, err
-	}
-
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("cloudflare.zone.plan", res.__id)
-		if err != nil || args == nil {
-			return res, err
-		}
-		return res, SetAllData(res, args)
-	}
-
-	return res, nil
-}
-
-func (c *mqlCloudflareZonePlan) MqlName() string {
-	return "cloudflare.zone.plan"
-}
-
-func (c *mqlCloudflareZonePlan) MqlID() string {
-	return c.__id
-}
-
-func (c *mqlCloudflareZonePlan) GetId() *plugin.TValue[string] {
-	return &c.Id
-}
-
-func (c *mqlCloudflareZonePlan) GetName() *plugin.TValue[string] {
-	return &c.Name
-}
-
-func (c *mqlCloudflareZonePlan) GetPrice() *plugin.TValue[int64] {
-	return &c.Price
-}
-
-func (c *mqlCloudflareZonePlan) GetCurrency() *plugin.TValue[string] {
-	return &c.Currency
-}
-
-func (c *mqlCloudflareZonePlan) GetFrequency() *plugin.TValue[string] {
-	return &c.Frequency
-}
-
-func (c *mqlCloudflareZonePlan) GetIsSubscribed() *plugin.TValue[bool] {
-	return &c.IsSubscribed
 }
 
 // mqlCloudflareZoneSettings for the cloudflare.zone.settings resource
@@ -9506,95 +9045,6 @@ func (c *mqlCloudflareTunnelVirtualNetwork) GetCreatedAt() *plugin.TValue[*time.
 
 func (c *mqlCloudflareTunnelVirtualNetwork) GetDeletedAt() *plugin.TValue[*time.Time] {
 	return &c.DeletedAt
-}
-
-// mqlCloudflareZoneFirewallRule for the cloudflare.zone.firewallRule resource
-type mqlCloudflareZoneFirewallRule struct {
-	MqlRuntime *plugin.Runtime
-	__id       string
-	// optional: if you define mqlCloudflareZoneFirewallRuleInternal it will be used here
-	Id               plugin.TValue[string]
-	Description      plugin.TValue[string]
-	Action           plugin.TValue[string]
-	Ref              plugin.TValue[string]
-	Paused           plugin.TValue[bool]
-	FilterExpression plugin.TValue[string]
-	Products         plugin.TValue[[]any]
-	CreatedAt        plugin.TValue[*time.Time]
-	UpdatedAt        plugin.TValue[*time.Time]
-}
-
-// createCloudflareZoneFirewallRule creates a new instance of this resource
-func createCloudflareZoneFirewallRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlCloudflareZoneFirewallRule{
-		MqlRuntime: runtime,
-	}
-
-	err := SetAllData(res, args)
-	if err != nil {
-		return res, err
-	}
-
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("cloudflare.zone.firewallRule", res.__id)
-		if err != nil || args == nil {
-			return res, err
-		}
-		return res, SetAllData(res, args)
-	}
-
-	return res, nil
-}
-
-func (c *mqlCloudflareZoneFirewallRule) MqlName() string {
-	return "cloudflare.zone.firewallRule"
-}
-
-func (c *mqlCloudflareZoneFirewallRule) MqlID() string {
-	return c.__id
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetId() *plugin.TValue[string] {
-	return &c.Id
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetDescription() *plugin.TValue[string] {
-	return &c.Description
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetAction() *plugin.TValue[string] {
-	return &c.Action
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetRef() *plugin.TValue[string] {
-	return &c.Ref
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetPaused() *plugin.TValue[bool] {
-	return &c.Paused
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetFilterExpression() *plugin.TValue[string] {
-	return &c.FilterExpression
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetProducts() *plugin.TValue[[]any] {
-	return &c.Products
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetCreatedAt() *plugin.TValue[*time.Time] {
-	return &c.CreatedAt
-}
-
-func (c *mqlCloudflareZoneFirewallRule) GetUpdatedAt() *plugin.TValue[*time.Time] {
-	return &c.UpdatedAt
 }
 
 // mqlCloudflareZoneRuleset for the cloudflare.zone.ruleset resource

--- a/providers/cloudflare/resources/cloudflare.lr.versions
+++ b/providers/cloudflare/resources/cloudflare.lr.versions
@@ -388,10 +388,8 @@ cloudflare.workers.worker.size 11.0.0
 cloudflare.workers.workers 11.0.0
 cloudflare.zone 11.0.0
 cloudflare.zone.account 11.0.0
-cloudflare.zone.account.email 11.0.0
 cloudflare.zone.account.id 11.0.0
 cloudflare.zone.account.name 11.0.0
-cloudflare.zone.account.type 11.0.0
 cloudflare.zone.authenticatedOriginPulls 13.6.8
 cloudflare.zone.authenticatedOriginPulls.certificate 13.6.8
 cloudflare.zone.authenticatedOriginPulls.certificate.enabled 13.6.8
@@ -520,17 +518,6 @@ cloudflare.zone.emailRouting.mxConfigured 13.1.1
 cloudflare.zone.emailRouting.name 13.1.1
 cloudflare.zone.emailRouting.spfConfigured 13.1.1
 cloudflare.zone.emailRouting.status 13.1.1
-cloudflare.zone.firewallRule 13.1.0
-cloudflare.zone.firewallRule.action 13.1.0
-cloudflare.zone.firewallRule.createdAt 13.1.0
-cloudflare.zone.firewallRule.description 13.1.0
-cloudflare.zone.firewallRule.filterExpression 13.1.0
-cloudflare.zone.firewallRule.id 13.1.0
-cloudflare.zone.firewallRule.paused 13.1.0
-cloudflare.zone.firewallRule.products 13.1.0
-cloudflare.zone.firewallRule.ref 13.1.0
-cloudflare.zone.firewallRule.updatedAt 13.1.0
-cloudflare.zone.firewallRules 13.1.0
 cloudflare.zone.id 11.0.0
 cloudflare.zone.leakedCredentialChecks 13.6.8
 cloudflare.zone.leakedCredentialChecks.detection 13.6.8
@@ -539,7 +526,6 @@ cloudflare.zone.leakedCredentialChecks.detection.password 13.6.8
 cloudflare.zone.leakedCredentialChecks.detection.username 13.6.8
 cloudflare.zone.leakedCredentialChecks.detections 13.6.8
 cloudflare.zone.leakedCredentialChecks.enabled 13.6.8
-cloudflare.zone.liveInputs 11.0.0
 cloudflare.zone.loadBalancer 13.3.6
 cloudflare.zone.loadBalancer.countryPools 13.3.6
 cloudflare.zone.loadBalancer.createdOn 13.3.6
@@ -576,7 +562,6 @@ cloudflare.zone.modifiedOn 11.0.0
 cloudflare.zone.mtlsCertificates 13.1.0
 cloudflare.zone.name 11.0.0
 cloudflare.zone.nameServers 11.0.0
-cloudflare.zone.one 11.0.0
 cloudflare.zone.originCACertificate 13.1.0
 cloudflare.zone.originCACertificate.expiresAt 13.1.0
 cloudflare.zone.originCACertificate.hostnames 13.1.0
@@ -587,7 +572,6 @@ cloudflare.zone.originCACertificate.revokedAt 13.1.0
 cloudflare.zone.originCACertificates 13.1.0
 cloudflare.zone.originalNameServers 11.0.0
 cloudflare.zone.owner 11.1.0
-cloudflare.zone.owner.email 11.1.0
 cloudflare.zone.owner.id 11.1.0
 cloudflare.zone.owner.name 11.1.0
 cloudflare.zone.owner.ownerType 11.1.0
@@ -599,14 +583,6 @@ cloudflare.zone.pageRule.status 13.1.0
 cloudflare.zone.pageRule.updatedAt 13.1.0
 cloudflare.zone.pageRules 13.1.0
 cloudflare.zone.paused 11.0.0
-cloudflare.zone.plan 11.1.0
-cloudflare.zone.plan.currency 11.1.0
-cloudflare.zone.plan.frequency 11.1.0
-cloudflare.zone.plan.id 11.1.0
-cloudflare.zone.plan.isSubscribed 11.1.0
-cloudflare.zone.plan.name 11.1.0
-cloudflare.zone.plan.price 11.1.0
-cloudflare.zone.r2 11.0.0
 cloudflare.zone.rateLimitRule 13.1.1
 cloudflare.zone.rateLimitRule.action 13.1.1
 cloudflare.zone.rateLimitRule.description 13.1.1
@@ -663,11 +639,7 @@ cloudflare.zone.settings.waf 11.1.0
 cloudflare.zone.settings.websockets 13.3.6
 cloudflare.zone.settings.zeroRtt 13.3.6
 cloudflare.zone.status 11.0.0
-cloudflare.zone.tunnelRoutes 13.1.0
-cloudflare.zone.tunnelVirtualNetworks 13.1.0
-cloudflare.zone.tunnels 13.1.0
 cloudflare.zone.type 11.0.0
-cloudflare.zone.videos 11.0.0
 cloudflare.zone.wafRule 13.1.1
 cloudflare.zone.wafRule.action 13.1.1
 cloudflare.zone.wafRule.description 13.1.1
@@ -683,5 +655,4 @@ cloudflare.zone.wafRule.rulesetPhase 13.1.1
 cloudflare.zone.wafRule.scoreThreshold 13.1.1
 cloudflare.zone.wafRule.version 13.1.1
 cloudflare.zone.wafRules 13.1.1
-cloudflare.zone.workers 11.0.0
 cloudflare.zones 11.0.0

--- a/providers/cloudflare/resources/cloudflare_test.go
+++ b/providers/cloudflare/resources/cloudflare_test.go
@@ -56,16 +56,8 @@ func TestZones(t *testing.T) {
 	assert.Equal(t, "Test Account", z1.Account.Data.Name.Data)
 
 	require.NotNil(t, z1.Owner.Data)
-	// cloudflare-go v6 ZoneOwner has no Email field (Cloudflare's OpenAPI
-	// spec doesn't expose it at the zone level), so the migrated provider
-	// always surfaces "". Field is preserved in the MQL schema to keep the
-	// existing query surface, just always empty post-v6.
-	assert.Equal(t, "", z1.Owner.Data.Email.Data)
-
-	require.NotNil(t, z1.Plan.Data)
-	assert.Equal(t, "Free Website", z1.Plan.Data.Name.Data)
-	assert.Equal(t, int64(0), z1.Plan.Data.Price.Data)
-	assert.True(t, z1.Plan.Data.IsSubscribed.Data)
+	assert.Equal(t, "owner-001", z1.Owner.Data.Id.Data)
+	assert.Equal(t, "user", z1.Owner.Data.OwnerType.Data)
 
 	z2 := result[1].(*mqlCloudflareZone)
 	assert.Equal(t, "abcdef1234567890abcdef1234567890", z2.Id.Data)

--- a/providers/cloudflare/resources/firewall.go
+++ b/providers/cloudflare/resources/firewall.go
@@ -4,94 +4,13 @@ package resources
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/page_rules"
 	"github.com/cloudflare/cloudflare-go/v6/rulesets"
 	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
-	"go.mondoo.com/mql/v13/types"
 )
-
-func (c *mqlCloudflareZoneFirewallRule) id() (string, error) {
-	if c.Id.Error != nil {
-		return "", c.Id.Error
-	}
-	return c.Id.Data, nil
-}
-
-// firewallRule is the response shape of the legacy zone firewall-rules endpoint
-// (`/zones/{id}/firewall/rules`). cloudflare-go v6 marks its typed
-// firewall.RuleService as deprecated and its typed response drops the
-// created/modified timestamps we expose, so we read the endpoint via the
-// client's generic Get and decode the full payload ourselves to preserve the
-// MQL schema.
-type firewallRule struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
-	Action      string `json:"action"`
-	Ref         string `json:"ref"`
-	Paused      bool   `json:"paused"`
-	Filter      struct {
-		Expression string `json:"expression"`
-	} `json:"filter"`
-	Products   []string  `json:"products"`
-	CreatedOn  time.Time `json:"created_on"`
-	ModifiedOn time.Time `json:"modified_on"`
-}
-
-func (c *mqlCloudflareZone) firewallRules() ([]any, error) {
-	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
-
-	var result []any
-	page := 1
-	for {
-		var env struct {
-			Result     []firewallRule `json:"result"`
-			ResultInfo struct {
-				Page       int `json:"page"`
-				TotalPages int `json:"total_pages"`
-			} `json:"result_info"`
-		}
-		uri := fmt.Sprintf("zones/%s/firewall/rules?page=%d&per_page=100", c.Id.Data, page)
-		if err := conn.Cf.Get(context.TODO(), uri, nil, &env); err != nil {
-			return nil, err
-		}
-
-		for i := range env.Result {
-			rec := env.Result[i]
-
-			res, err := NewResource(c.MqlRuntime, "cloudflare.zone.firewallRule", map[string]*llx.RawData{
-				"id":               llx.StringData(rec.ID),
-				"description":      llx.StringData(rec.Description),
-				"action":           llx.StringData(rec.Action),
-				"ref":              llx.StringData(rec.Ref),
-				"paused":           llx.BoolData(rec.Paused),
-				"filterExpression": llx.StringData(rec.Filter.Expression),
-				"products":         llx.ArrayData(convert.SliceAnyToInterface(rec.Products), types.String),
-				"createdAt":        llx.TimeData(rec.CreatedOn),
-				"updatedAt":        llx.TimeData(rec.ModifiedOn),
-			})
-			if err != nil {
-				return nil, err
-			}
-
-			result = append(result, res)
-		}
-
-		// Terminate on the local page counter, not the server-echoed
-		// ResultInfo.Page, so a page:0 echo with total_pages>0 can't loop forever.
-		if env.ResultInfo.TotalPages == 0 || page >= env.ResultInfo.TotalPages {
-			break
-		}
-		page++
-	}
-
-	return result, nil
-}
 
 func (c *mqlCloudflareZoneRuleset) id() (string, error) {
 	if c.Id.Error != nil {

--- a/providers/cloudflare/resources/firewall_test.go
+++ b/providers/cloudflare/resources/firewall_test.go
@@ -12,30 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFirewallRules(t *testing.T) {
-	env := setupTestEnv(t)
-	zone := createTestZone(t, env)
-
-	env.Mux.HandleFunc(fmt.Sprintf("/zones/%s/firewall/rules", testZoneID), func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		jsonResponse(w, loadFixture("firewall_rules"))
-	})
-
-	result, err := zone.firewallRules()
-	require.NoError(t, err)
-	require.Len(t, result, 1)
-
-	rule := result[0].(*mqlCloudflareZoneFirewallRule)
-	assert.Equal(t, "fw-rule-1", rule.Id.Data)
-	assert.Equal(t, "Block bad bots", rule.Description.Data)
-	assert.Equal(t, "block", rule.Action.Data)
-	assert.False(t, rule.Paused.Data)
-	assert.Equal(t, "(cf.client.bot)", rule.FilterExpression.Data)
-	assert.Len(t, rule.Products.Data, 2)
-	assert.False(t, rule.CreatedAt.Data.IsZero())
-	assert.False(t, rule.UpdatedAt.Data.IsZero())
-}
-
 func TestRulesets(t *testing.T) {
 	env := setupTestEnv(t)
 	zone := createTestZone(t, env)

--- a/providers/cloudflare/resources/helper_test.go
+++ b/providers/cloudflare/resources/helper_test.go
@@ -96,11 +96,9 @@ func createTestZone(t *testing.T, env *testEnv) *mqlCloudflareZone {
 
 	// First create the account resource (needed by zone methods that call c.GetAccount())
 	acc, err := CreateResource(env.Runtime, "cloudflare.zone.account", map[string]*llx.RawData{
-		"__id":  llx.StringData("cloudflare.zone.account@" + testAccountID),
-		"id":    llx.StringData(testAccountID),
-		"name":  llx.StringData("Test Account"),
-		"type":  llx.StringData("standard"),
-		"email": llx.StringData(""),
+		"__id": llx.StringData("cloudflare.zone.account@" + testAccountID),
+		"id":   llx.StringData(testAccountID),
+		"name": llx.StringData("Test Account"),
 	})
 	if err != nil {
 		t.Fatalf("failed to create test account: %v", err)
@@ -118,7 +116,6 @@ func createTestZone(t *testing.T, env *testEnv) *mqlCloudflareZone {
 		"modifiedOn":          llx.TimeData(llx.DurationToTime(0)),
 		"account":             llx.ResourceData(acc, acc.MqlName()),
 		"owner":               llx.NilData,
-		"plan":                llx.NilData,
 	})
 	if err != nil {
 		t.Fatalf("failed to create test zone: %v", err)

--- a/providers/cloudflare/resources/one.go
+++ b/providers/cloudflare/resources/one.go
@@ -171,17 +171,6 @@ func (c *mqlCloudflareAccount) one() (*mqlCloudflareOne, error) {
 	return newOne(c.MqlRuntime, c.Id.Data, "")
 }
 
-// Deprecated: Zero Trust is account-scoped. Use cloudflare.account.one.
-// Retained so existing queries keep working; resolves the parent account and
-// delegates, keeping the zone id so apps/identityProviders stay zone-scoped.
-func (c *mqlCloudflareZone) one() (*mqlCloudflareOne, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return newOne(c.MqlRuntime, accountID, c.Id.Data)
-}
-
 type mqlCloudflareOneAppInternal struct {
 	// appPolicies caches the access policies embedded in the application
 	// record so the policies() accessor needs no extra API call.

--- a/providers/cloudflare/resources/r2.go
+++ b/providers/cloudflare/resources/r2.go
@@ -4,7 +4,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -14,20 +13,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 )
-
-// zoneAccountID returns the parent account id, guarding the nullable account
-// field so the R2/Workers/Stream accessors don't nil-deref on a zone whose
-// account wasn't resolved (e.g. a zone reached by id without discovery).
-func (c *mqlCloudflareZone) zoneAccountID() (string, error) {
-	acc := c.GetAccount()
-	if acc.Error != nil {
-		return "", acc.Error
-	}
-	if acc.Data == nil {
-		return "", errors.New("cloudflare zone has no associated account")
-	}
-	return acc.Data.GetId().Data, nil
-}
 
 func (c *mqlCloudflareR2) id() (string, error) {
 	return "cloudflare.r2", nil
@@ -74,16 +59,6 @@ func initCloudflareR2(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 
 func (c *mqlCloudflareAccount) r2() (*mqlCloudflareR2, error) {
 	return newR2(c.MqlRuntime, c.Id.Data)
-}
-
-// Deprecated: R2 is account-scoped. Use cloudflare.account.r2. Retained so
-// existing queries keep working; resolves the parent account and delegates.
-func (c *mqlCloudflareZone) r2() (*mqlCloudflareR2, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return newR2(c.MqlRuntime, accountID)
 }
 
 type mqlCloudflareR2BucketInternal struct {

--- a/providers/cloudflare/resources/stream.go
+++ b/providers/cloudflare/resources/stream.go
@@ -55,14 +55,6 @@ func (c *mqlCloudflareStreamsVideo) id() (string, error) {
 	return v.Data, nil
 }
 
-func (c *mqlCloudflareZone) liveInputs() ([]any, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return fetchLiveInputs(c.MqlRuntime, accountID)
-}
-
 func (c *mqlCloudflareAccount) liveInputs() ([]any, error) {
 	return fetchLiveInputs(c.MqlRuntime, c.Id.Data)
 }
@@ -103,14 +95,6 @@ func fetchLiveInputs(runtime *plugin.Runtime, accountID string) ([]any, error) {
 	}
 
 	return res, nil
-}
-
-func (c *mqlCloudflareZone) videos() ([]any, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return fetchVideos(c.MqlRuntime, accountID)
 }
 
 func (c *mqlCloudflareAccount) videos() ([]any, error) {

--- a/providers/cloudflare/resources/stream_test.go
+++ b/providers/cloudflare/resources/stream_test.go
@@ -18,7 +18,7 @@ import (
 // metadata, so all three shapes are realistic.
 func TestStreamLiveInputsNilMeta(t *testing.T) {
 	env := setupTestEnv(t)
-	zone := createTestZone(t, env)
+	acc := createTestAccount(t, env)
 
 	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/stream/live_inputs", testAccountID), func(w http.ResponseWriter, r *http.Request) {
 		jsonResponse(w, `{
@@ -32,7 +32,7 @@ func TestStreamLiveInputsNilMeta(t *testing.T) {
 		}`)
 	})
 
-	result, err := zone.liveInputs()
+	result, err := acc.liveInputs()
 	require.NoError(t, err)
 	require.Len(t, result, 4)
 

--- a/providers/cloudflare/resources/tunnels.go
+++ b/providers/cloudflare/resources/tunnels.go
@@ -32,17 +32,6 @@ func (c *mqlCloudflareAccount) tunnels() ([]any, error) {
 	return fetchTunnels(c.MqlRuntime, c.Id.Data)
 }
 
-// Deprecated: tunnels are account-scoped. Use cloudflare.account.tunnels.
-// Retained so existing queries keep working; resolves the parent account and
-// delegates.
-func (c *mqlCloudflareZone) tunnels() ([]any, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return fetchTunnels(c.MqlRuntime, accountID)
-}
-
 func fetchTunnels(runtime *plugin.Runtime, accountID string) ([]any, error) {
 	conn := runtime.Connection.(*connection.CloudflareConnection)
 
@@ -177,16 +166,6 @@ func (c *mqlCloudflareAccount) tunnelRoutes() ([]any, error) {
 	return fetchTunnelRoutes(c.MqlRuntime, c.Id.Data)
 }
 
-// Deprecated: tunnel routes are account-scoped. Use
-// cloudflare.account.tunnelRoutes. Retained so existing queries keep working.
-func (c *mqlCloudflareZone) tunnelRoutes() ([]any, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return fetchTunnelRoutes(c.MqlRuntime, accountID)
-}
-
 func fetchTunnelRoutes(runtime *plugin.Runtime, accountID string) ([]any, error) {
 	conn := runtime.Connection.(*connection.CloudflareConnection)
 
@@ -240,16 +219,6 @@ func (c *mqlCloudflareTunnelVirtualNetwork) id() (string, error) {
 
 func (c *mqlCloudflareAccount) tunnelVirtualNetworks() ([]any, error) {
 	return fetchTunnelVirtualNetworks(c.MqlRuntime, c.Id.Data)
-}
-
-// Deprecated: tunnel virtual networks are account-scoped. Use
-// cloudflare.account.tunnelVirtualNetworks. Retained for existing queries.
-func (c *mqlCloudflareZone) tunnelVirtualNetworks() ([]any, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return fetchTunnelVirtualNetworks(c.MqlRuntime, accountID)
 }
 
 func fetchTunnelVirtualNetworks(runtime *plugin.Runtime, accountID string) ([]any, error) {

--- a/providers/cloudflare/resources/tunnels_test.go
+++ b/providers/cloudflare/resources/tunnels_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestTunnels(t *testing.T) {
 	env := setupTestEnv(t)
-	zone := createTestZone(t, env)
+	acc := createTestAccount(t, env)
 
 	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/cfd_tunnel", testAccountID), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -34,7 +34,7 @@ func TestTunnels(t *testing.T) {
 		jsonResponse(w, loadFixture("tunnel_connections"))
 	})
 
-	result, err := zone.tunnels()
+	result, err := acc.tunnels()
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 
@@ -64,7 +64,7 @@ func TestTunnels(t *testing.T) {
 
 func TestTunnelRoutes(t *testing.T) {
 	env := setupTestEnv(t)
-	zone := createTestZone(t, env)
+	acc := createTestAccount(t, env)
 
 	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/teamnet/routes", testAccountID), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -75,7 +75,7 @@ func TestTunnelRoutes(t *testing.T) {
 		jsonResponse(w, loadFixture("tunnel_routes"))
 	})
 
-	result, err := zone.tunnelRoutes()
+	result, err := acc.tunnelRoutes()
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -88,14 +88,14 @@ func TestTunnelRoutes(t *testing.T) {
 
 func TestTunnelVirtualNetworks(t *testing.T) {
 	env := setupTestEnv(t)
-	zone := createTestZone(t, env)
+	acc := createTestAccount(t, env)
 
 	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/teamnet/virtual_networks", testAccountID), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		jsonResponse(w, loadFixture("tunnel_virtual_networks"))
 	})
 
-	result, err := zone.tunnelVirtualNetworks()
+	result, err := acc.tunnelVirtualNetworks()
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -112,7 +112,7 @@ func TestTunnelVirtualNetworks(t *testing.T) {
 // The previous __id `tunnelRoute@<network>@<tunnelId>` collided in this case.
 func TestTunnelRoutesVnetIDInCacheKey(t *testing.T) {
 	env := setupTestEnv(t)
-	zone := createTestZone(t, env)
+	acc := createTestAccount(t, env)
 
 	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/teamnet/routes", testAccountID), func(w http.ResponseWriter, r *http.Request) {
 		jsonResponse(w, `{
@@ -124,7 +124,7 @@ func TestTunnelRoutesVnetIDInCacheKey(t *testing.T) {
 		}`)
 	})
 
-	result, err := zone.tunnelRoutes()
+	result, err := acc.tunnelRoutes()
 	require.NoError(t, err)
 	require.Len(t, result, 2, "routes with distinct virtual_network_id must not collapse into one")
 
@@ -144,7 +144,7 @@ func TestTunnelRoutesVnetIDInCacheKey(t *testing.T) {
 // three pages and bumped page numbers monotonically.
 func TestTunnelRoutesPagination(t *testing.T) {
 	env := setupTestEnv(t)
-	zone := createTestZone(t, env)
+	acc := createTestAccount(t, env)
 
 	const perPage = 50
 	var calls int32
@@ -170,7 +170,7 @@ func TestTunnelRoutesPagination(t *testing.T) {
 		fmt.Fprint(w, `]}`)
 	})
 
-	result, err := zone.tunnelRoutes()
+	result, err := acc.tunnelRoutes()
 	require.NoError(t, err)
 	require.Equal(t, perPage*2+7, len(result), "all three pages must be consumed")
 	require.Equal(t, int32(3), atomic.LoadInt32(&calls), "exactly three calls (page=1,2,3)")

--- a/providers/cloudflare/resources/workers.go
+++ b/providers/cloudflare/resources/workers.go
@@ -54,17 +54,6 @@ func (c *mqlCloudflareAccount) workers() (*mqlCloudflareWorkers, error) {
 	return newWorkers(c.MqlRuntime, c.Id.Data)
 }
 
-// Deprecated: Workers are account-scoped. Use cloudflare.account.workers.
-// Retained so existing queries keep working; resolves the parent account and
-// delegates.
-func (c *mqlCloudflareZone) workers() (*mqlCloudflareWorkers, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	return newWorkers(c.MqlRuntime, accountID)
-}
-
 // workerScript mirrors the account workers-scripts list entry. We decode it via
 // the client's generic Get to preserve fields (size, deployment_id,
 // pipeline_hash) that the typed cloudflare-go v6 script struct no longer

--- a/providers/cloudflare/resources/zones.go
+++ b/providers/cloudflare/resources/zones.go
@@ -59,10 +59,3 @@ func (c *mqlCloudflareZoneOwner) id() (string, error) {
 	}
 	return c.Id.Data, nil
 }
-
-func (c *mqlCloudflareZonePlan) id() (string, error) {
-	if c.Id.Error != nil {
-		return "", c.Id.Error
-	}
-	return c.Id.Data, nil
-}


### PR DESCRIPTION
## What

Removes 12 deprecated fields plus 2 deprecated resources from the cloudflare provider, as part of the v14 breaking-change cleanup.

## Why

**The zone-scoped accessors were misleading.** Stream, R2, Workers, Zero Trust, and Tunnels are all *account*-scoped in Cloudflare's API. Each zone accessor was a thin wrapper that resolved the parent account and delegated:

```go
// Deprecated: R2 is account-scoped. Use cloudflare.account.r2.
func (c *mqlCloudflareZone) r2() (*mqlCloudflareR2, error) {
	accountID, err := c.zoneAccountID()
	...
	return newR2(c.MqlRuntime, accountID)
}
```

So reading `r2` from two different zones in one account returned identical buckets — inviting the conclusion that a bucket belongs to a zone, which it does not.

**Three fields were structurally always empty.** `cloudflare.zone.account.type`, `cloudflare.zone.account.email`, and `cloudflare.zone.owner.email` were hardcoded to `llx.StringData("")` because cloudflare-go v6 (and Cloudflare's OpenAPI spec) does not expose them at the zone level.

**Two resources are superseded.** `cloudflare.zone.plan` is billing metadata, not a security surface. `cloudflare.zone.firewallRule` is the legacy firewall-rules API, replaced by `cloudflare.zone.ruleset`; cloudflare-go v6 already marks its typed `firewall.RuleService` deprecated.

## Migration

| Removed | Use instead |
| --- | --- |
| `cloudflare.zone.liveInputs` | `cloudflare.account.liveInputs` |
| `cloudflare.zone.videos` | `cloudflare.account.videos` |
| `cloudflare.zone.r2` | `cloudflare.account.r2` |
| `cloudflare.zone.workers` | `cloudflare.account.workers` |
| `cloudflare.zone.one` | `cloudflare.account.one` |
| `cloudflare.zone.tunnels` | `cloudflare.account.tunnels` |
| `cloudflare.zone.tunnelRoutes` | `cloudflare.account.tunnelRoutes` |
| `cloudflare.zone.tunnelVirtualNetworks` | `cloudflare.account.tunnelVirtualNetworks` |
| `cloudflare.zone.firewallRules` / `cloudflare.zone.firewallRule` | `cloudflare.zone.rulesets` / `cloudflare.zone.ruleset` |
| `cloudflare.zone.plan` | — (removed; billing metadata) |
| `cloudflare.zone.account.type` / `.email` | — (always empty) |
| `cloudflare.zone.owner.email` | — (always empty) |

## ⚠️ Policy impact — content changes required

`bundles/cnquery/mondoo-cloudflare-inventory.mql.yaml` in `cnspec-enterprise-policies` reads several of these from `cloudflare.zones`. All are filtered on `asset.platform == "cloudflare-zone"`, so they need re-pointing at the account asset:

| Query uid | Line | Current | Replace with |
| --- | --- | --- | --- |
| `mondoo-cloudflare-inventory-live-inputs` | 334 | `cloudflare.zones { liveInputs {...} }` | `cloudflare.account.liveInputs { ... }` |
| `mondoo-cloudflare-inventory-videos` | 350 | `videos {...}` | `cloudflare.account.videos { ... }` |
| `mondoo-cloudflare-inventory-r2-buckets` | 315 | `r2.buckets {...}` | `cloudflare.account.r2.buckets { ... }` |
| `mondoo-cloudflare-inventory-workers` | 270, 291 | `workers.workers {...}`, `workers.pages {...}` | `cloudflare.account.workers.workers`, `...workers.pages` |
| `mondoo-cloudflare-inventory-one-apps` | 378 | `one.apps {...}` | `cloudflare.account.one.apps { ... }` |
| `mondoo-cloudflare-inventory-one-idps` | 415 | `one.identityProviders {...}` | `cloudflare.account.one.identityProviders { ... }` |
| `mondoo-cloudflare-inventory-zone-plan` | 147 | `plan {...}` | remove the query |

These also need their `filters:` switched from `cloudflare-zone` to the account platform, since the data no longer hangs off a zone.

No other removed field appears in any content bundle or enterprise policy.

## Changes

- `cloudflare.lr` — removed 12 fields and the `cloudflare.zone.plan` / `cloudflare.zone.firewallRule` resource blocks
- `cloudflare.lr.versions` — dropped 29 entries
- `cloudflare.go` — removed the plan `NewResource` block, the `"plan":` arg key, and the two always-empty `"type"` / `"email"` arg keys
- `stream.go`, `r2.go`, `workers.go`, `one.go`, `tunnels.go` — removed the 8 zone wrappers; the account accessors and shared `fetch*` helpers are untouched
- `r2.go` — removed `zoneAccountID()`, which existed only to serve those wrappers and is now unreferenced
- `firewall.go` — removed `firewallRules()`, the resource's `id()`, and the now-dead `firewallRule` response struct; trimmed 4 newly-unused imports
- `zones.go` — removed `mqlCloudflareZonePlan.id()`
- `stream_test.go`, `tunnels_test.go` — re-pointed from `createTestZone` to `createTestAccount` and the account accessors. Coverage of the shared fetch/pagination logic is preserved; the mock endpoints were already `accounts/...`-scoped.
- `firewall_test.go` — removed `TestFirewallRules`
- `cloudflare_test.go`, `helper_test.go` — dropped assertions and args for the removed fields

## Follow-up (not in this PR)

`cloudflare.one` still carries zone-scoping machinery (`ZoneID` on the internal struct, the zone branch in `accessScope()`, the `zoneID` parameter on `newOne`) that only `cloudflare.zone.one` ever populated. With that accessor gone, no production path sets it, so the zone branch is now unreachable. Left in place deliberately: `cloudflare.one` is not itself deprecated and its tests still exercise that path, so collapsing it to account-only is a separate refactor rather than part of this removal.

## Verification

- `./mqlr generate providers/cloudflare/resources/cloudflare.lr` — clean
- `go build -gcflags=-e ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — passing
- `gofmt -l providers/cloudflare/` — clean
