### PR TITLE
🛑 alicloud: remove deprecated kmsKeyId and encryptionKey fields

### DIFF
--- a/providers/alicloud/resources/alicloud.lr
+++ b/providers/alicloud/resources/alicloud.lr
@@ -557,10 +557,6 @@ alicloud.ecs.disk @defaults("diskId diskName category size status") {
   status string
   // Whether the disk is encrypted
   encrypted bool
-  // KMS key ID used to encrypt the disk
-  //
-  // Deprecated in favor of kmsKey.
-  kmsKeyId @maturity("deprecated") string
   // KMS key used to encrypt the disk, null when the disk is not encrypted
   kmsKey() alicloud.kms.key
   // Instance the disk is attached to
@@ -2106,10 +2102,6 @@ alicloud.mongodb.instance {
   maintainEndTime() string
   // Whether disk encryption is enabled for the instance
   encrypted() bool
-  // KMS key ID used for disk encryption, empty when disk encryption is disabled
-  //
-  // Deprecated in favor of kmsKey.
-  encryptionKey() @maturity("deprecated") string
   // KMS key used for disk encryption, null when disk encryption is disabled
   kmsKey() alicloud.kms.key
   // Whether release protection is enabled for the instance

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -1029,9 +1029,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.ecs.disk.encrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsDisk).GetEncrypted()).ToDataRes(types.Bool)
 	},
-	"alicloud.ecs.disk.kmsKeyId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAlicloudEcsDisk).GetKmsKeyId()).ToDataRes(types.String)
-	},
 	"alicloud.ecs.disk.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsDisk).GetKmsKey()).ToDataRes(types.Resource("alicloud.kms.key"))
 	},
@@ -2381,9 +2378,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.mongodb.instance.encrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudMongodbInstance).GetEncrypted()).ToDataRes(types.Bool)
-	},
-	"alicloud.mongodb.instance.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlAlicloudMongodbInstance).GetEncryptionKey()).ToDataRes(types.String)
 	},
 	"alicloud.mongodb.instance.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudMongodbInstance).GetKmsKey()).ToDataRes(types.Resource("alicloud.kms.key"))
@@ -5584,10 +5578,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudEcsDisk).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"alicloud.ecs.disk.kmsKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAlicloudEcsDisk).KmsKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"alicloud.ecs.disk.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudEcsDisk).KmsKey, ok = plugin.RawToTValue[*mqlAlicloudKmsKey](v.Value, v.Error)
 		return
@@ -7486,10 +7476,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.mongodb.instance.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudMongodbInstance).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
-		return
-	},
-	"alicloud.mongodb.instance.encryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlAlicloudMongodbInstance).EncryptionKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"alicloud.mongodb.instance.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12674,7 +12660,6 @@ type mqlAlicloudEcsDisk struct {
 	Size               plugin.TValue[int64]
 	Status             plugin.TValue[string]
 	Encrypted          plugin.TValue[bool]
-	KmsKeyId           plugin.TValue[string]
 	KmsKey             plugin.TValue[*mqlAlicloudKmsKey]
 	Instance           plugin.TValue[*mqlAlicloudEcsInstance]
 	Device             plugin.TValue[string]
@@ -12759,10 +12744,6 @@ func (c *mqlAlicloudEcsDisk) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAlicloudEcsDisk) GetEncrypted() *plugin.TValue[bool] {
 	return &c.Encrypted
-}
-
-func (c *mqlAlicloudEcsDisk) GetKmsKeyId() *plugin.TValue[string] {
-	return &c.KmsKeyId
 }
 
 func (c *mqlAlicloudEcsDisk) GetKmsKey() *plugin.TValue[*mqlAlicloudKmsKey] {
@@ -16649,7 +16630,6 @@ type mqlAlicloudMongodbInstance struct {
 	MaintainStartTime     plugin.TValue[string]
 	MaintainEndTime       plugin.TValue[string]
 	Encrypted             plugin.TValue[bool]
-	EncryptionKey         plugin.TValue[string]
 	KmsKey                plugin.TValue[*mqlAlicloudKmsKey]
 	ReleaseProtection     plugin.TValue[bool]
 	CurrentKernelVersion  plugin.TValue[string]
@@ -16876,12 +16856,6 @@ func (c *mqlAlicloudMongodbInstance) GetMaintainEndTime() *plugin.TValue[string]
 func (c *mqlAlicloudMongodbInstance) GetEncrypted() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.Encrypted, func() (bool, error) {
 		return c.encrypted()
-	})
-}
-
-func (c *mqlAlicloudMongodbInstance) GetEncryptionKey() *plugin.TValue[string] {
-	return plugin.GetOrCompute[string](&c.EncryptionKey, func() (string, error) {
-		return c.encryptionKey()
 	})
 }
 

--- a/providers/alicloud/resources/alicloud.lr.versions
+++ b/providers/alicloud/resources/alicloud.lr.versions
@@ -407,7 +407,6 @@ alicloud.ecs.disk.enableAutoSnapshot 13.0.0
 alicloud.ecs.disk.encrypted 13.0.0
 alicloud.ecs.disk.instance 13.0.0
 alicloud.ecs.disk.kmsKey 13.0.1
-alicloud.ecs.disk.kmsKeyId 13.0.0
 alicloud.ecs.disk.performanceLevel 13.0.0
 alicloud.ecs.disk.portable 13.0.0
 alicloud.ecs.disk.regionId 13.0.0
@@ -736,7 +735,6 @@ alicloud.mongodb.instance.dbInstanceStorage 13.0.0
 alicloud.mongodb.instance.dbInstanceType 13.0.0
 alicloud.mongodb.instance.destroyTime 13.0.0
 alicloud.mongodb.instance.encrypted 13.0.0
-alicloud.mongodb.instance.encryptionKey 13.0.0
 alicloud.mongodb.instance.engine 13.0.0
 alicloud.mongodb.instance.engineVersion 13.0.0
 alicloud.mongodb.instance.expireTime 13.0.0

--- a/providers/alicloud/resources/ecs.go
+++ b/providers/alicloud/resources/ecs.go
@@ -90,10 +90,11 @@ type mqlAlicloudEcsInstanceInternal struct {
 }
 
 // mqlAlicloudEcsDiskInternal caches the identifiers needed to resolve the
-// disk's typed instance reference without a repeat API call.
+// disk's typed instance and KMS key references without a repeat API call.
 type mqlAlicloudEcsDiskInternal struct {
 	cacheRegion     string
 	cacheInstanceID string
+	cacheKmsKeyID   string
 }
 
 // mqlAlicloudEcsSecuritygroupPermissionInternal caches the identifiers needed
@@ -564,7 +565,6 @@ func (r *mqlAlicloudEcs) disks() ([]any, error) {
 					"size":               llx.IntDataPtr(disk.Size),
 					"status":             llx.StringDataPtr(disk.Status),
 					"encrypted":          llx.BoolDataPtr(disk.Encrypted),
-					"kmsKeyId":           llx.StringDataPtr(disk.KMSKeyId),
 					"device":             llx.StringDataPtr(disk.Device),
 					"deleteWithInstance": llx.BoolDataPtr(disk.DeleteWithInstance),
 					"deleteAutoSnapshot": llx.BoolDataPtr(disk.DeleteAutoSnapshot),
@@ -585,6 +585,7 @@ func (r *mqlAlicloudEcs) disks() ([]any, error) {
 				mqlDisk := resource.(*mqlAlicloudEcsDisk)
 				mqlDisk.cacheRegion = region
 				mqlDisk.cacheInstanceID = strDeref(disk.InstanceId)
+				mqlDisk.cacheKmsKeyID = strDeref(disk.KMSKeyId)
 				res = append(res, mqlDisk)
 			}
 
@@ -613,11 +614,11 @@ func (r *mqlAlicloudEcsDisk) instance() (*mqlAlicloudEcsInstance, error) {
 // kmsKey resolves the KMS key that encrypts the disk, or null when the disk is
 // not encrypted.
 func (r *mqlAlicloudEcsDisk) kmsKey() (*mqlAlicloudKmsKey, error) {
-	if r.KmsKeyId.Data == "" {
+	if r.cacheKmsKeyID == "" {
 		r.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	key, err := resolveKmsKey(r.MqlRuntime, r.RegionId.Data, r.KmsKeyId.Data)
+	key, err := resolveKmsKey(r.MqlRuntime, r.cacheRegion, r.cacheKmsKeyID)
 	if err != nil || key == nil {
 		r.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil

--- a/providers/alicloud/resources/mongodb.go
+++ b/providers/alicloud/resources/mongodb.go
@@ -276,14 +276,6 @@ func (r *mqlAlicloudMongodbInstance) encrypted() (bool, error) {
 	return tea.BoolValue(attr.Encrypted), nil
 }
 
-func (r *mqlAlicloudMongodbInstance) encryptionKey() (string, error) {
-	attr, err := r.attribute()
-	if err != nil || attr == nil {
-		return "", err
-	}
-	return tea.StringValue(attr.EncryptionKey), nil
-}
-
 // kmsKey resolves the KMS key used for disk encryption, or null when disk
 // encryption is disabled.
 func (r *mqlAlicloudMongodbInstance) kmsKey() (*mqlAlicloudKmsKey, error) {


### PR DESCRIPTION
## What

Removes `alicloud.ecs.disk.kmsKeyId` and `alicloud.mongodb.instance.encryptionKey` as part of the v14 breaking-change cleanup. Both were deprecated in favor of the typed `kmsKey` reference, which resolves to an `alicloud.kms.key` and lets you traverse into the key's rotation state, protection level, and deletion protection instead of just holding an opaque id string.

## Why this one needed care

`ecs.disk.kmsKey()` read the deprecated field as its own input:

```go
if r.KmsKeyId.Data == "" { ... }
key, err := resolveKmsKey(r.MqlRuntime, r.RegionId.Data, r.KmsKeyId.Data)
```

Deleting `kmsKeyId` from the schema deletes the generated `KmsKeyId` struct field, so the **replacement** would have stopped resolving. The raw id is therefore migrated onto the resource's internal cache:

```go
type mqlAlicloudEcsDiskInternal struct {
	cacheRegion     string
	cacheInstanceID string
	cacheKmsKeyID   string   // <- added
}
```

primed in the disk creator alongside the existing cache fields (`strDeref` is nil-safe), and read by the accessor. The accessor also moves from `r.RegionId.Data` to `r.cacheRegion` to match the sibling `instance()` accessor.

`mongodb.instance.kmsKey()` already resolved from the fetched attribute struct rather than from `encryptionKey`, so that removal is self-contained — just the dead accessor.

## Migration

| Removed | Use instead |
| --- | --- |
| `alicloud.ecs.disk.kmsKeyId` | `alicloud.ecs.disk.kmsKey` (→ `alicloud.kms.key`) |
| `alicloud.mongodb.instance.encryptionKey` | `alicloud.mongodb.instance.kmsKey` (→ `alicloud.kms.key`) |

To keep an id-only comparison, use `kmsKey.keyId`. Note `kmsKey` is null when the resource is unencrypted, where the old field was `""`.

## Explicitly not touched

- `alicloud.kms.secret.encryptionKey` and `alicloud.log.logstore.encryptionKey` — same field name, different resources, already typed `alicloud.kms.key`, not deprecated.
- `cs.go` still builds a `"kmsKeyId"` key inside the `dataDisks` `[]dict` value. That is a plain `map[string]any` dict element, not a `CreateResource` arg, so it is unaffected by the schema change.

## Changes

- `alicloud.lr` — removed both fields and their doc comments
- `alicloud.lr.versions` — dropped the 2 entries
- `ecs.go` — added `cacheKmsKeyID` to the internal struct, primed it in the creator, re-pointed `kmsKey()`, removed the stale `"kmsKeyId":` arg key
- `mongodb.go` — removed the `encryptionKey()` accessor
- `alicloud.lr.go` — regenerated

## Policy impact

None. The `kmsKeyId` / `encryptionKey` hits in the content bundles are all on other providers (`oci.objectStorage.bucket.kmsKeyId`, `aws.backup.vaults`, `azure...cosmosDb`), not alicloud.

## Verification

- `./mqlr generate providers/alicloud/resources/alicloud.lr` — clean
- `go build -gcflags=-e ./...` — clean
- `go test ./...` — passing
- `gofmt -l .` — clean
