### PR TITLE
🛑 proxmox: remove deprecated user groups field

### DIFF
--- a/providers/proxmox/resources/access.go
+++ b/providers/proxmox/resources/access.go
@@ -14,10 +14,22 @@ import (
 
 // mqlProxmoxUserInternal caches the inline token list from
 // /access/users?full=1 so `proxmox.users { tokens }` doesn't fan out
-// into a per-user /access/users/<id>/token fetch (N+1).
+// into a per-user /access/users/<id>/token fetch (N+1). It also holds the
+// raw group-membership names that groupRefs() resolves, since /access/users
+// returns them inline and GetUsers() is not cached.
 type mqlProxmoxUserInternal struct {
 	cachedTokens    []any
 	cachedTokensSet bool
+	cachedGroups    []string
+}
+
+// splitProxmoxGroups splits the comma-separated group list that
+// /access/users returns inline. Returns nil for an empty list.
+func splitProxmoxGroups(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, ",")
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/proxmox/resources/init.go
+++ b/providers/proxmox/resources/init.go
@@ -33,12 +33,6 @@ func initProxmoxUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		if u.UserID != userID {
 			continue
 		}
-		var groups []any
-		if u.Groups != "" {
-			for _, g := range strings.Split(u.Groups, ",") {
-				groups = append(groups, g)
-			}
-		}
 		realm := ""
 		if parts := strings.SplitN(u.UserID, "@", 2); len(parts) == 2 {
 			realm = parts[1]
@@ -48,11 +42,19 @@ func initProxmoxUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		args["expire"] = llx.IntData(u.Expire)
 		args["firstname"] = llx.StringData(u.Firstname)
 		args["lastname"] = llx.StringData(u.Lastname)
-		args["groups"] = llx.ArrayData(groups, "\x02")
 		args["realm"] = llx.StringData(realm)
 		args["realmType"] = llx.StringData(u.RealmType)
 		args["tfaLockedUntil"] = llx.IntData(u.TFALockedUntil)
-		return args, nil, nil
+		// Build the resource here rather than returning args: group membership
+		// arrives inline on /access/users and groupRefs() reads it from the
+		// internal cache, which can only be set on a resource we hold.
+		res, err := CreateResource(runtime, "proxmox.user", args)
+		if err != nil {
+			return nil, nil, err
+		}
+		mqlUser := res.(*mqlProxmoxUser)
+		mqlUser.cachedGroups = splitProxmoxGroups(u.Groups)
+		return nil, res, nil
 	}
 	// User referenced by ACL no longer exists — return the bare resource
 	// so audits can still see the dangling reference rather than erroring.

--- a/providers/proxmox/resources/proxmox.go
+++ b/providers/proxmox/resources/proxmox.go
@@ -139,12 +139,7 @@ func (r *mqlProxmox) users() ([]any, error) {
 	}
 	list := make([]any, len(users))
 	for i, u := range users {
-		var groups []any
-		if u.Groups != "" {
-			for _, g := range strings.Split(u.Groups, ",") {
-				groups = append(groups, g)
-			}
-		}
+		groups := splitProxmoxGroups(u.Groups)
 		realm := ""
 		if parts := strings.SplitN(u.UserID, "@", 2); len(parts) == 2 {
 			realm = parts[1]
@@ -156,7 +151,6 @@ func (r *mqlProxmox) users() ([]any, error) {
 			"expire":         llx.IntData(u.Expire),
 			"firstname":      llx.StringData(u.Firstname),
 			"lastname":       llx.StringData(u.Lastname),
-			"groups":         llx.ArrayData(groups, "\x02"),
 			"realm":          llx.StringData(realm),
 			"realmType":      llx.StringData(u.RealmType),
 			"tfaLockedUntil": llx.IntData(u.TFALockedUntil),
@@ -184,6 +178,7 @@ func (r *mqlProxmox) users() ([]any, error) {
 		}
 		mqlUser.cachedTokens = tokens
 		mqlUser.cachedTokensSet = true
+		mqlUser.cachedGroups = groups
 		list[i] = res
 	}
 	return list, nil

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -1400,10 +1400,6 @@ proxmox.user @defaults("id enable realm") {
   firstname string
   // Last name
   lastname string
-  // Raw group membership names
-  //
-  // Deprecated in favor of `groupRefs`.
-  groups @maturity("deprecated") []string
   // Resolved group memberships
   groupRefs() []proxmox.group
   // Authentication realm (pam, pve, ldap, ad)

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -1578,9 +1578,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.user.lastname": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxUser).GetLastname()).ToDataRes(types.String)
 	},
-	"proxmox.user.groups": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlProxmoxUser).GetGroups()).ToDataRes(types.Array(types.String))
-	},
 	"proxmox.user.groupRefs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxUser).GetGroupRefs()).ToDataRes(types.Array(types.Resource("proxmox.group")))
 	},
@@ -4296,10 +4293,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.user.lastname": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxUser).Lastname, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"proxmox.user.groups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlProxmoxUser).Groups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"proxmox.user.groupRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10214,7 +10207,6 @@ type mqlProxmoxUser struct {
 	Expire         plugin.TValue[int64]
 	Firstname      plugin.TValue[string]
 	Lastname       plugin.TValue[string]
-	Groups         plugin.TValue[[]any]
 	GroupRefs      plugin.TValue[[]any]
 	Realm          plugin.TValue[string]
 	RealmType      plugin.TValue[string]
@@ -10282,10 +10274,6 @@ func (c *mqlProxmoxUser) GetFirstname() *plugin.TValue[string] {
 
 func (c *mqlProxmoxUser) GetLastname() *plugin.TValue[string] {
 	return &c.Lastname
-}
-
-func (c *mqlProxmoxUser) GetGroups() *plugin.TValue[[]any] {
-	return &c.Groups
 }
 
 func (c *mqlProxmoxUser) GetGroupRefs() *plugin.TValue[[]any] {

--- a/providers/proxmox/resources/proxmox.lr.versions
+++ b/providers/proxmox/resources/proxmox.lr.versions
@@ -683,7 +683,6 @@ proxmox.user.enable 0.1.1
 proxmox.user.expire 0.1.1
 proxmox.user.firstname 0.1.1
 proxmox.user.groupRefs 0.1.9
-proxmox.user.groups 0.1.1
 proxmox.user.id 0.1.1
 proxmox.user.lastname 0.1.1
 proxmox.user.realm 0.1.1

--- a/providers/proxmox/resources/xrefs.go
+++ b/providers/proxmox/resources/xrefs.go
@@ -64,10 +64,9 @@ func (r *mqlProxmoxToken) owner() (*mqlProxmoxUser, error) {
 // ---------------------------------------------------------------------------
 
 func (r *mqlProxmoxUser) groupRefs() ([]any, error) {
-	out := make([]any, 0, len(r.Groups.Data))
-	for _, raw := range r.Groups.Data {
-		g, ok := raw.(string)
-		if !ok || g == "" {
+	out := make([]any, 0, len(r.cachedGroups))
+	for _, g := range r.cachedGroups {
+		if g == "" {
 			continue
 		}
 		res, err := NewResource(r.MqlRuntime, "proxmox.group", map[string]*llx.RawData{


### PR DESCRIPTION
## What

Removes `proxmox.user.groups` as part of the v14 breaking-change cleanup. It was deprecated in favor of `groupRefs`, which resolves each membership to a real `proxmox.group` you can traverse into.

## Why this one needed care

`groupRefs()` built its references *by reading the field being removed*:

```go
out := make([]any, 0, len(r.Groups.Data))
for _, raw := range r.Groups.Data { ... }
```

Deleting `groups` from the schema deletes the generated `Groups` struct field, so the replacement would have stopped resolving. The raw names move to the resource's internal cache instead:

```go
type mqlProxmoxUserInternal struct {
	cachedTokens    []any
	cachedTokensSet bool
	cachedGroups    []string   // <- added
}
```

`/access/users?full=1` returns membership inline and `PveConnection.GetUsers()` is **not** cached, so having `groupRefs()` re-derive it would have meant a full user-list fetch per user (N+1). Caching avoids that.

### The init path was the real trap

`proxmox.user` is reachable two ways: the `proxmox.users` listing, and `initProxmoxUser` when an ACL entry resolves a user by id. An `init` that ends in `return args, nil, nil` hands the args back and lets the runtime construct the resource — which means **there is no resource instance to set an internal cache field on**. Priming only the listing path would have left `groupRefs` silently returning `[]` for any ACL-resolved user: no error, no null, just wrong.

So the init now constructs the resource itself and returns it:

```go
res, err := CreateResource(runtime, "proxmox.user", args)
...
mqlUser.cachedGroups = splitProxmoxGroups(u.Groups)
return nil, res, nil
```

The "user referenced by an ACL no longer exists" fallthrough still returns the bare resource, so dangling references stay visible rather than erroring.

## Migration

| Removed | Use instead |
| --- | --- |
| `proxmox.user.groups` (`[]string`) | `proxmox.user.groupRefs` (`[]proxmox.group`) |

For a name-only check: `groupRefs.map(id)`.

## Changes

- `proxmox.lr` — removed the field and its doc comment
- `proxmox.lr.versions` — dropped the `proxmox.user.groups` entry
- `access.go` — added `cachedGroups` to the internal struct, plus `splitProxmoxGroups` so both producers parse the comma-separated string identically
- `proxmox.go` — primed `cachedGroups` in the users listing, removed the stale `"groups":` arg key
- `init.go` — returns a built resource so the cache can be primed
- `xrefs.go` — `groupRefs()` reads `cachedGroups`
- `proxmox.lr.go` — regenerated

## Policy impact

None. No query in the cnspec content bundles or enterprise policies references `proxmox.user.groups`.

## Verification

- `./mqlr generate providers/proxmox/resources/proxmox.lr` — clean
- `go build -gcflags=-e ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — passing
- `gofmt -l .` — clean
