### PR TITLE
🛑 stackit: remove deprecated serviceAccountMails and nics fields

### DIFF
--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -11,7 +11,6 @@ import (
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/types"
 )
 
 // ------------------------- servers -------------------------
@@ -41,6 +40,16 @@ func (r *mqlStackit) servers() ([]any, error) {
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// mqlStackitServerInternal caches data the server GET returns inline that is no
+// longer exposed as schema fields: the service-account mail addresses that
+// serviceAccounts() resolves into typed references, and the per-interface
+// summaries that securityGroups() and exposure() read. Keeping the summaries
+// here avoids a ListServerNICs call per server just to answer those two.
+type mqlStackitServerInternal struct {
+	cacheServiceAccountMails []string
+	cacheNics                []any
 }
 
 func buildServer(runtime *plugin.Runtime, s *iaas.Server) (plugin.Resource, error) {
@@ -79,29 +88,34 @@ func buildServer(runtime *plugin.Runtime, s *iaas.Server) (plugin.Resource, erro
 	const vtpmEnabled = false
 
 	args := map[string]*llx.RawData{
-		"id":                  llx.StringData(s.GetId()),
-		"name":                llx.StringData(s.GetName()),
-		"status":              llx.StringData(s.GetStatus()),
-		"powerStatus":         llx.StringData(s.GetPowerStatus()),
-		"machineType":         llx.StringData(s.GetMachineType()),
-		"availabilityZone":    llx.StringData(s.GetAvailabilityZone()),
-		"createdAt":           llx.TimeDataPtr(timeOrNil(createdAt, ok1)),
-		"launchedAt":          llx.TimeDataPtr(timeOrNil(launchedAt, ok2)),
-		"updatedAt":           llx.TimeDataPtr(timeOrNil(updatedAt, ok3)),
-		"errorMessage":        llx.StringData(s.GetErrorMessage()),
-		"configDrive":         llx.BoolData(s.GetConfigDrive()),
-		"vtpmEnabled":         llx.BoolData(vtpmEnabled),
-		"keypairName":         llx.StringData(s.GetKeypairName()),
-		"imageId":             llx.StringData(s.GetImageId()),
-		"volumeIds":           strSliceData(s.GetVolumes()),
-		"securityGroupIds":    strSliceData(s.GetSecurityGroups()),
-		"serviceAccountMails": strSliceData(s.GetServiceAccountMails()),
-		"nics":                llx.ArrayData(nics, types.Dict),
-		"userData":            llx.StringData(string(s.GetUserData())),
-		"labels":              labelData(s.GetLabels()),
-		"metadata":            metadataData(s.GetMetadata()),
+		"id":               llx.StringData(s.GetId()),
+		"name":             llx.StringData(s.GetName()),
+		"status":           llx.StringData(s.GetStatus()),
+		"powerStatus":      llx.StringData(s.GetPowerStatus()),
+		"machineType":      llx.StringData(s.GetMachineType()),
+		"availabilityZone": llx.StringData(s.GetAvailabilityZone()),
+		"createdAt":        llx.TimeDataPtr(timeOrNil(createdAt, ok1)),
+		"launchedAt":       llx.TimeDataPtr(timeOrNil(launchedAt, ok2)),
+		"updatedAt":        llx.TimeDataPtr(timeOrNil(updatedAt, ok3)),
+		"errorMessage":     llx.StringData(s.GetErrorMessage()),
+		"configDrive":      llx.BoolData(s.GetConfigDrive()),
+		"vtpmEnabled":      llx.BoolData(vtpmEnabled),
+		"keypairName":      llx.StringData(s.GetKeypairName()),
+		"imageId":          llx.StringData(s.GetImageId()),
+		"volumeIds":        strSliceData(s.GetVolumes()),
+		"securityGroupIds": strSliceData(s.GetSecurityGroups()),
+		"userData":         llx.StringData(string(s.GetUserData())),
+		"labels":           labelData(s.GetLabels()),
+		"metadata":         metadataData(s.GetMetadata()),
 	}
-	return CreateResource(runtime, "stackit.server", args)
+	res, err := CreateResource(runtime, "stackit.server", args)
+	if err != nil {
+		return nil, err
+	}
+	mqlServer := res.(*mqlStackitServer)
+	mqlServer.cacheServiceAccountMails = s.GetServiceAccountMails()
+	mqlServer.cacheNics = nics
+	return res, nil
 }
 
 func (r *mqlStackitServer) id() (string, error) {
@@ -197,21 +211,18 @@ func (r *mqlStackitServer) securityGroups() ([]any, error) {
 			add(id)
 		}
 	}
-	nics := r.GetNics()
-	if nics.Error == nil {
-		for _, raw := range nics.Data {
-			nic, ok := raw.(map[string]any)
-			if !ok {
-				continue
-			}
-			sgs, ok := nic["securityGroups"].([]any)
-			if !ok {
-				continue
-			}
-			for _, s := range sgs {
-				if id, ok := s.(string); ok {
-					add(id)
-				}
+	for _, raw := range r.cacheNics {
+		nic, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		sgs, ok := nic["securityGroups"].([]any)
+		if !ok {
+			continue
+		}
+		for _, s := range sgs {
+			if id, ok := s.(string); ok {
+				add(id)
 			}
 		}
 	}
@@ -232,10 +243,9 @@ func (r *mqlStackitServer) securityGroups() ([]any, error) {
 // serviceAccounts resolves the service accounts attached to the server from
 // the mail addresses carried on the server object.
 func (r *mqlStackitServer) serviceAccounts() ([]any, error) {
-	out := make([]any, 0, len(r.ServiceAccountMails.Data))
-	for _, raw := range r.ServiceAccountMails.Data {
-		mail, ok := raw.(string)
-		if !ok || mail == "" {
+	out := make([]any, 0, len(r.cacheServiceAccountMails))
+	for _, mail := range r.cacheServiceAccountMails {
+		if mail == "" {
 			continue
 		}
 		sa, err := NewResource(r.MqlRuntime, "stackit.serviceAccount", map[string]*llx.RawData{

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -178,20 +178,8 @@ private stackit.server @defaults("id name status machineType") {
   securityGroups() []stackit.securityGroup
   // Internet-exposure breakdown (public IP combined with security group ingress)
   exposure() stackit.network.exposure
-  // Service account mail addresses
-  //
-  // Deprecated in favor of serviceAccounts, which resolves each mail to a
-  // resource exposing the service account's email and project.
-  serviceAccountMails @maturity("deprecated") []string
   // Service accounts attached to the server
   serviceAccounts() []stackit.serviceAccount
-  // Network interface summaries
-  //
-  // Deprecated in favor of networkInterfaces, which exposes each interface
-  // as a resource with network and security-group references. Each entry
-  // has {nicId, networkId, networkName, ipv4, ipv6, mac, securityGroups,
-  // allowedAddresses, publicIp, nicSecurity}.
-  nics @maturity("deprecated") []dict
   // Network interfaces attached to the server
   networkInterfaces() []stackit.nic
   // Point-in-time backups taken from the server by the Server Backup service

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -752,14 +752,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.server.exposure": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetExposure()).ToDataRes(types.Resource("stackit.network.exposure"))
 	},
-	"stackit.server.serviceAccountMails": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlStackitServer).GetServiceAccountMails()).ToDataRes(types.Array(types.String))
-	},
 	"stackit.server.serviceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetServiceAccounts()).ToDataRes(types.Array(types.Resource("stackit.serviceAccount")))
-	},
-	"stackit.server.nics": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlStackitServer).GetNics()).ToDataRes(types.Array(types.Dict))
 	},
 	"stackit.server.networkInterfaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetNetworkInterfaces()).ToDataRes(types.Array(types.Resource("stackit.nic")))
@@ -3299,16 +3293,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitServer).Exposure, ok = plugin.RawToTValue[*mqlStackitNetworkExposure](v.Value, v.Error)
 		return
 	},
-	"stackit.server.serviceAccountMails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlStackitServer).ServiceAccountMails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"stackit.server.serviceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitServer).ServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"stackit.server.nics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlStackitServer).Nics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"stackit.server.networkInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7439,39 +7425,37 @@ func (c *mqlStackitProject) GetLabels() *plugin.TValue[map[string]any] {
 type mqlStackitServer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitServerInternal it will be used here
-	Id                  plugin.TValue[string]
-	Name                plugin.TValue[string]
-	Status              plugin.TValue[string]
-	PowerStatus         plugin.TValue[string]
-	MachineType         plugin.TValue[string]
-	AvailabilityZone    plugin.TValue[string]
-	CreatedAt           plugin.TValue[*time.Time]
-	LaunchedAt          plugin.TValue[*time.Time]
-	UpdatedAt           plugin.TValue[*time.Time]
-	ErrorMessage        plugin.TValue[string]
-	ConfigDrive         plugin.TValue[bool]
-	VtpmEnabled         plugin.TValue[bool]
-	KeypairName         plugin.TValue[string]
-	KeyPair             plugin.TValue[*mqlStackitKeyPair]
-	ImageId             plugin.TValue[string]
-	Image               plugin.TValue[*mqlStackitImage]
-	VolumeIds           plugin.TValue[[]any]
-	Volumes             plugin.TValue[[]any]
-	SecurityGroupIds    plugin.TValue[[]any]
-	SecurityGroups      plugin.TValue[[]any]
-	Exposure            plugin.TValue[*mqlStackitNetworkExposure]
-	ServiceAccountMails plugin.TValue[[]any]
-	ServiceAccounts     plugin.TValue[[]any]
-	Nics                plugin.TValue[[]any]
-	NetworkInterfaces   plugin.TValue[[]any]
-	Backups             plugin.TValue[[]any]
-	BackupSchedules     plugin.TValue[[]any]
-	Updates             plugin.TValue[[]any]
-	UpdateSchedules     plugin.TValue[[]any]
-	UserData            plugin.TValue[string]
-	Labels              plugin.TValue[map[string]any]
-	Metadata            plugin.TValue[map[string]any]
+	mqlStackitServerInternal
+	Id                plugin.TValue[string]
+	Name              plugin.TValue[string]
+	Status            plugin.TValue[string]
+	PowerStatus       plugin.TValue[string]
+	MachineType       plugin.TValue[string]
+	AvailabilityZone  plugin.TValue[string]
+	CreatedAt         plugin.TValue[*time.Time]
+	LaunchedAt        plugin.TValue[*time.Time]
+	UpdatedAt         plugin.TValue[*time.Time]
+	ErrorMessage      plugin.TValue[string]
+	ConfigDrive       plugin.TValue[bool]
+	VtpmEnabled       plugin.TValue[bool]
+	KeypairName       plugin.TValue[string]
+	KeyPair           plugin.TValue[*mqlStackitKeyPair]
+	ImageId           plugin.TValue[string]
+	Image             plugin.TValue[*mqlStackitImage]
+	VolumeIds         plugin.TValue[[]any]
+	Volumes           plugin.TValue[[]any]
+	SecurityGroupIds  plugin.TValue[[]any]
+	SecurityGroups    plugin.TValue[[]any]
+	Exposure          plugin.TValue[*mqlStackitNetworkExposure]
+	ServiceAccounts   plugin.TValue[[]any]
+	NetworkInterfaces plugin.TValue[[]any]
+	Backups           plugin.TValue[[]any]
+	BackupSchedules   plugin.TValue[[]any]
+	Updates           plugin.TValue[[]any]
+	UpdateSchedules   plugin.TValue[[]any]
+	UserData          plugin.TValue[string]
+	Labels            plugin.TValue[map[string]any]
+	Metadata          plugin.TValue[map[string]any]
 }
 
 // createStackitServer creates a new instance of this resource
@@ -7655,10 +7639,6 @@ func (c *mqlStackitServer) GetExposure() *plugin.TValue[*mqlStackitNetworkExposu
 	})
 }
 
-func (c *mqlStackitServer) GetServiceAccountMails() *plugin.TValue[[]any] {
-	return &c.ServiceAccountMails
-}
-
 func (c *mqlStackitServer) GetServiceAccounts() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ServiceAccounts, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -7673,10 +7653,6 @@ func (c *mqlStackitServer) GetServiceAccounts() *plugin.TValue[[]any] {
 
 		return c.serviceAccounts()
 	})
-}
-
-func (c *mqlStackitServer) GetNics() *plugin.TValue[[]any] {
-	return &c.Nics
 }
 
 func (c *mqlStackitServer) GetNetworkInterfaces() *plugin.TValue[[]any] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -600,11 +600,9 @@ stackit.server.machineType 13.0.0
 stackit.server.metadata 13.0.0
 stackit.server.name 13.0.0
 stackit.server.networkInterfaces 13.4.2
-stackit.server.nics 13.0.0
 stackit.server.powerStatus 13.0.0
 stackit.server.securityGroupIds 13.0.0
 stackit.server.securityGroups 13.0.0
-stackit.server.serviceAccountMails 13.0.0
 stackit.server.serviceAccounts 13.4.2
 stackit.server.status 13.0.0
 stackit.server.update 13.4.2

--- a/providers/stackit/resources/stackit_exposure.go
+++ b/providers/stackit/resources/stackit_exposure.go
@@ -52,11 +52,7 @@ func (s *mqlStackitServer) exposure() (*mqlStackitNetworkExposure, error) {
 		return nil, id.Error
 	}
 
-	nics := s.GetNics()
-	if nics.Error != nil {
-		return nil, nics.Error
-	}
-	hasPublicIp := nicsHavePublicIp(nics.Data)
+	hasPublicIp := nicsHavePublicIp(s.cacheNics)
 
 	openRules := []any{}
 	sgs := s.GetSecurityGroups()


### PR DESCRIPTION
## What

Removes `stackit.server.serviceAccountMails` and `stackit.server.nics` as part of the v14 breaking-change cleanup. Both were deprecated in favor of typed replacements: `serviceAccounts` (each mail resolved to a `stackit.serviceAccount`) and `networkInterfaces` (each interface a `stackit.nic` with network and security-group references).

## Why this one needed care

Both fields were **load-bearing for three different accessors**:

| Accessor | Read |
| --- | --- |
| `serviceAccounts()` | `r.ServiceAccountMails.Data` |
| `securityGroups()` | `r.GetNics()` — nic-level `securityGroups` |
| `exposure()` | `s.GetNics()` — nic-level `publicIp` |

The two `nics` consumers used the generated **`GetNics()`** accessor, so a grep for `.Nics` found neither. They only surfaced as compile errors after the schema field was deleted — which is exactly why the edits here were driven off `go build -gcflags=-e` rather than find/replace.

All three now read a new internal cache:

```go
type mqlStackitServerInternal struct {
	cacheServiceAccountMails []string
	cacheNics                []any
}
```

primed in `buildServer`. That single site covers **both** construction paths, because `initStackitServer` already delegates to `buildServer` and returns the built resource (`return nil, res, nil`) — so a server reached by id gets the same cache as one from the listing.

### Why the nic summaries stay cached rather than re-derived

`securityGroups()` and `exposure()` could have been re-pointed at `networkInterfaces()`, but that accessor issues a `ListServerNICs` call, whereas the server GET already returns the summaries inline. Re-pointing would have added one API call per server just to answer those two accessors. The summaries therefore move from a public schema field to the internal cache — same data, same call count, field gone from the schema.

## Migration

| Removed | Use instead |
| --- | --- |
| `stackit.server.serviceAccountMails` (`[]string`) | `stackit.server.serviceAccounts` (`[]stackit.serviceAccount`) |
| `stackit.server.nics` (`[]dict`) | `stackit.server.networkInterfaces` (`[]stackit.nic`) |

For mail-only checks: `serviceAccounts.map(email)`. The `nics` dict keys map onto `stackit.nic` fields of the same names, with `securityGroups` now typed references rather than id strings.

## Changes

- `stackit.lr` — removed both fields and their doc comments
- `stackit.lr.versions` — dropped the 2 entries
- `iaas.go` — added `mqlStackitServerInternal`, primed both cache fields in `buildServer`, re-pointed `serviceAccounts()` and `securityGroups()`, removed both stale arg keys (which lived in a **variable-form** args map — `args := map[...]{...}` then `CreateResource(runtime, "stackit.server", args)` — the form that inline-only checkers miss), dropped the now-unused `types` import
- `stackit_exposure.go` — `exposure()` reads `cacheNics`
- `stackit.lr.go` — regenerated (two passes, so the generator picks up the new `Internal` struct)

## Policy impact

None. No query in the cnspec content bundles or enterprise policies references either field.

## Verification

- `./mqlr generate providers/stackit/resources/stackit.lr` — run twice; `mqlStackitServerInternal` confirmed embedded in the generated struct
- `go build -gcflags=-e ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — passing
- `gofmt -l .` — clean
