### PR TITLE
🛑 openstack: remove 11 deprecated projectId and zoneId fields

### DIFF
--- a/providers/openstack/resources/compute.go
+++ b/providers/openstack/resources/compute.go
@@ -912,8 +912,11 @@ func (o *mqlOpenstack) aggregates() ([]any, error) {
 
 // ---- openstack.compute.limits ----
 
-func (r *mqlOpenstackComputeLimits) id() (string, error) {
-	return "openstack.compute.limits/" + r.ProjectId.Data, nil
+// mqlOpenstackComputeLimitsInternal holds the project id the limits report
+// applies to, which project() resolves. The __id is supplied explicitly by the
+// creator, so this resource needs no id() function.
+type mqlOpenstackComputeLimitsInternal struct {
+	cacheProjectID string
 }
 
 func (o *mqlOpenstack) computeLimits() (*mqlOpenstackComputeLimits, error) {
@@ -938,7 +941,6 @@ func (o *mqlOpenstack) computeLimits() (*mqlOpenstackComputeLimits, error) {
 	projectId := c.ProjectID()
 	res, err := CreateResource(o.MqlRuntime, "openstack.compute.limits", map[string]*llx.RawData{
 		"__id":                    llx.StringData("openstack.compute.limits/" + projectId),
-		"projectId":               llx.StringData(projectId),
 		"maxTotalCores":           llx.IntData(int64(abs.MaxTotalCores)),
 		"totalCoresUsed":          llx.IntData(int64(abs.TotalCoresUsed)),
 		"maxTotalInstances":       llx.IntData(int64(abs.MaxTotalInstances)),
@@ -962,9 +964,11 @@ func (o *mqlOpenstack) computeLimits() (*mqlOpenstackComputeLimits, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlOpenstackComputeLimits), nil
+	mqlLimits := res.(*mqlOpenstackComputeLimits)
+	mqlLimits.cacheProjectID = projectId
+	return mqlLimits, nil
 }
 
 func (r *mqlOpenstackComputeLimits) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }

--- a/providers/openstack/resources/compute_quotaset.go
+++ b/providers/openstack/resources/compute_quotaset.go
@@ -30,7 +30,6 @@ func (o *mqlOpenstack) computeQuotaSet() (*mqlOpenstackComputeQuotaSet, error) {
 	}
 	res, err := CreateResource(o.MqlRuntime, "openstack.compute.quotaSet", map[string]*llx.RawData{
 		"__id":                     llx.StringData("openstack.compute.quotaSet/" + projectId),
-		"projectId":                llx.StringData(projectId),
 		"instances":                llx.IntData(int64(q.Instances)),
 		"cores":                    llx.IntData(int64(q.Cores)),
 		"ram":                      llx.IntData(int64(q.RAM)),
@@ -49,9 +48,17 @@ func (o *mqlOpenstack) computeQuotaSet() (*mqlOpenstackComputeQuotaSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlOpenstackComputeQuotaSet), nil
+	mqlQuota := res.(*mqlOpenstackComputeQuotaSet)
+	mqlQuota.cacheProjectID = projectId
+	return mqlQuota, nil
+}
+
+// mqlOpenstackComputeQuotaSetInternal holds the project id the quota applies
+// to, which project() resolves.
+type mqlOpenstackComputeQuotaSetInternal struct {
+	cacheProjectID string
 }
 
 func (r *mqlOpenstackComputeQuotaSet) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }

--- a/providers/openstack/resources/dns.go
+++ b/providers/openstack/resources/dns.go
@@ -74,7 +74,6 @@ func (o *mqlOpenstack) dnsZones() ([]any, error) {
 			"action":        llx.StringData(z.Action),
 			"type":          llx.StringData(z.Type),
 			"masters":       stringSliceData(z.Masters),
-			"projectId":     llx.StringData(z.ProjectID),
 			"createdAt":     llx.TimeDataPtr(timePtr(z.CreatedAt)),
 			"updatedAt":     llx.TimeDataPtr(timePtr(z.UpdatedAt)),
 			"transferredAt": llx.TimeDataPtr(timePtr(z.TransferredAt)),
@@ -82,18 +81,25 @@ func (o *mqlOpenstack) dnsZones() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlOpenstackDnsZone).cacheProjectID = z.ProjectID
 		out = append(out, res)
 	}
 	return out, nil
 }
 
+// mqlOpenstackDnsZoneInternal holds the owning project id that project()
+// resolves.
+type mqlOpenstackDnsZoneInternal struct {
+	cacheProjectID string
+}
+
 func (r *mqlOpenstackDnsZone) project() (*mqlOpenstackProject, error) {
-	if r.ProjectId.Data == "" {
+	if r.cacheProjectID == "" {
 		r.Project.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(r.MqlRuntime, "openstack.project", map[string]*llx.RawData{
-		"id": llx.StringData(r.ProjectId.Data),
+		"id": llx.StringData(r.cacheProjectID),
 	})
 	if err != nil {
 		return nil, err
@@ -128,7 +134,6 @@ func (r *mqlOpenstackDnsZone) recordsets() ([]any, error) {
 			"__id":        llx.StringData("openstack.dns.recordset/" + rs.ID),
 			"id":          llx.StringData(rs.ID),
 			"name":        llx.StringData(rs.Name),
-			"zoneId":      llx.StringData(rs.ZoneID),
 			"type":        llx.StringData(rs.Type),
 			"ttl":         llx.IntData(int64(rs.TTL)),
 			"records":     stringSliceData(rs.Records),
@@ -141,9 +146,16 @@ func (r *mqlOpenstackDnsZone) recordsets() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlOpenstackDnsRecordset).cacheZoneID = rs.ZoneID
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// mqlOpenstackDnsRecordsetInternal holds the owning zone id that zone()
+// resolves.
+type mqlOpenstackDnsRecordsetInternal struct {
+	cacheZoneID string
 }
 
 // ---- openstack.dns.recordset ----
@@ -162,12 +174,12 @@ func initOpenstackDnsRecordset(runtime *plugin.Runtime, args map[string]*llx.Raw
 }
 
 func (r *mqlOpenstackDnsRecordset) zone() (*mqlOpenstackDnsZone, error) {
-	if r.ZoneId.Data == "" {
+	if r.cacheZoneID == "" {
 		r.Zone.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(r.MqlRuntime, "openstack.dns.zone", map[string]*llx.RawData{
-		"id": llx.StringData(r.ZoneId.Data),
+		"id": llx.StringData(r.cacheZoneID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/openstack/resources/magnum.go
+++ b/providers/openstack/resources/magnum.go
@@ -16,6 +16,7 @@ import (
 // ---- openstack.containerinfra.cluster ----
 
 type mqlOpenstackContainerinfraClusterInternal struct {
+	cacheProjectID         string
 	cacheClusterTemplateID string
 	cacheKeyPair           string
 	cacheFlavorID          string
@@ -101,7 +102,6 @@ func (o *mqlOpenstack) clusters() ([]any, error) {
 			"masterLbEnabled":   llx.BoolData(cl.MasterLBEnabled),
 			"discoveryUrl":      llx.StringData(cl.DiscoveryURL),
 			"labels":            stringMapData(cl.Labels),
-			"projectId":         llx.StringData(cl.ProjectID),
 			"createdAt":         llx.TimeDataPtr(timePtr(cl.CreatedAt)),
 			"updatedAt":         llx.TimeDataPtr(timePtr(cl.UpdatedAt)),
 		})
@@ -109,6 +109,7 @@ func (o *mqlOpenstack) clusters() ([]any, error) {
 			return nil, err
 		}
 		mqlCluster := res.(*mqlOpenstackContainerinfraCluster)
+		mqlCluster.cacheProjectID = cl.ProjectID
 		mqlCluster.cacheClusterTemplateID = cl.ClusterTemplateID
 		mqlCluster.cacheKeyPair = cl.KeyPair
 		mqlCluster.cacheFlavorID = cl.FlavorID
@@ -149,7 +150,7 @@ func (r *mqlOpenstackContainerinfraCluster) masterFlavor() (*mqlOpenstackCompute
 }
 
 func (r *mqlOpenstackContainerinfraCluster) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }
 
 func (r *mqlOpenstackContainerinfraCluster) user() (*mqlOpenstackUser, error) {

--- a/providers/openstack/resources/manila.go
+++ b/providers/openstack/resources/manila.go
@@ -34,6 +34,7 @@ func translateManilaError(err error) error {
 
 type mqlOpenstackSharedfilesystemShareInternal struct {
 	cacheShareNetworkID string
+	cacheProjectID      string
 }
 
 func (r *mqlOpenstackSharedfilesystemShare) id() (string, error) {
@@ -104,7 +105,6 @@ func (o *mqlOpenstack) shares() ([]any, error) {
 			"replicationType":  llx.StringData(s.ReplicationType),
 			"snapshotSupport":  llx.BoolData(s.SnapshotSupport),
 			"snapshotId":       llx.StringData(s.SnapshotID),
-			"projectId":        llx.StringData(s.ProjectID),
 			"metadata":         stringMapData(s.Metadata),
 			"createdAt":        llx.TimeDataPtr(timePtr(s.CreatedAt)),
 			"updatedAt":        llx.TimeDataPtr(timePtr(s.UpdatedAt)),
@@ -114,6 +114,7 @@ func (o *mqlOpenstack) shares() ([]any, error) {
 		}
 		mqlShare := res.(*mqlOpenstackSharedfilesystemShare)
 		mqlShare.cacheShareNetworkID = s.ShareNetworkID
+		mqlShare.cacheProjectID = s.ProjectID
 		out = append(out, mqlShare)
 	}
 	return out, nil
@@ -134,7 +135,7 @@ func (r *mqlOpenstackSharedfilesystemShare) shareNetwork() (*mqlOpenstackSharedf
 }
 
 func (r *mqlOpenstackSharedfilesystemShare) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }
 
 func (r *mqlOpenstackSharedfilesystemShare) accessRules() ([]any, error) {
@@ -263,20 +264,26 @@ func (o *mqlOpenstack) securityServices() ([]any, error) {
 			"ou":          llx.StringData(s.OU),
 			"user":        llx.StringData(s.User),
 			"server":      llx.StringData(s.Server),
-			"projectId":   llx.StringData(s.ProjectID),
 			"createdAt":   llx.TimeDataPtr(timePtr(s.CreatedAt)),
 			"updatedAt":   llx.TimeDataPtr(timePtr(s.UpdatedAt)),
 		})
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlOpenstackSharedfilesystemSecurityService).cacheProjectID = s.ProjectID
 		out = append(out, res)
 	}
 	return out, nil
 }
 
+// mqlOpenstackSharedfilesystemSecurityServiceInternal holds the owning project
+// id that project() resolves.
+type mqlOpenstackSharedfilesystemSecurityServiceInternal struct {
+	cacheProjectID string
+}
+
 func (r *mqlOpenstackSharedfilesystemSecurityService) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }
 
 // ---- openstack.sharedfilesystem.shareNetwork ----
@@ -343,16 +350,22 @@ func (o *mqlOpenstack) shareNetworks() ([]any, error) {
 			"segmentationId":  llx.IntData(int64(n.SegmentationID)),
 			"cidr":            llx.StringData(n.CIDR),
 			"ipVersion":       llx.IntData(int64(n.IPVersion)),
-			"projectId":       llx.StringData(n.ProjectID),
 			"createdAt":       llx.TimeDataPtr(timePtr(n.CreatedAt)),
 			"updatedAt":       llx.TimeDataPtr(timePtr(n.UpdatedAt)),
 		})
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlOpenstackSharedfilesystemShareNetwork).cacheProjectID = n.ProjectID
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// mqlOpenstackSharedfilesystemShareNetworkInternal holds the owning project id
+// that project() resolves.
+type mqlOpenstackSharedfilesystemShareNetworkInternal struct {
+	cacheProjectID string
 }
 
 func (r *mqlOpenstackSharedfilesystemShareNetwork) network() (*mqlOpenstackNetwork, error) {
@@ -384,5 +397,5 @@ func (r *mqlOpenstackSharedfilesystemShareNetwork) subnet() (*mqlOpenstackSubnet
 }
 
 func (r *mqlOpenstackSharedfilesystemShareNetwork) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -1190,8 +1190,11 @@ func lookupSecurityGroupIDByName(runtime *plugin.Runtime, name string) (string, 
 
 // ---- openstack.network.quotaSet ----
 
-func (r *mqlOpenstackNetworkQuotaSet) id() (string, error) {
-	return "openstack.network.quotaSet/" + r.ProjectId.Data, nil
+// mqlOpenstackNetworkQuotaSetInternal holds the project id the quota applies
+// to, which project() resolves. The __id is supplied explicitly by the creator,
+// so this resource needs no id() function.
+type mqlOpenstackNetworkQuotaSetInternal struct {
+	cacheProjectID string
 }
 
 func (o *mqlOpenstack) networkQuotaSet() (*mqlOpenstackNetworkQuotaSet, error) {
@@ -1215,7 +1218,6 @@ func (o *mqlOpenstack) networkQuotaSet() (*mqlOpenstackNetworkQuotaSet, error) {
 	}
 	res, err := CreateResource(o.MqlRuntime, "openstack.network.quotaSet", map[string]*llx.RawData{
 		"__id":              llx.StringData("openstack.network.quotaSet/" + projectId),
-		"projectId":         llx.StringData(projectId),
 		"network":           llx.IntData(int64(q.Network)),
 		"subnet":            llx.IntData(int64(q.Subnet)),
 		"port":              llx.IntData(int64(q.Port)),
@@ -1230,9 +1232,11 @@ func (o *mqlOpenstack) networkQuotaSet() (*mqlOpenstackNetworkQuotaSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlOpenstackNetworkQuotaSet), nil
+	mqlQuota := res.(*mqlOpenstackNetworkQuotaSet)
+	mqlQuota.cacheProjectID = projectId
+	return mqlQuota, nil
 }
 
 func (r *mqlOpenstackNetworkQuotaSet) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -2165,10 +2165,6 @@ private openstack.dns.zone @defaults("id name type ttl status") {
   type string
   // Master nameservers for SECONDARY zones (empty for PRIMARY zones)
   masters []string
-  // Owning project ID
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Creation timestamp
   createdAt time
   // Last update timestamp
@@ -2197,10 +2193,6 @@ private openstack.dns.recordset @defaults("id name type ttl") {
   id string
   // Recordset name (FQDN, e.g. "www.example.com.")
   name string
-  // Owning zone ID
-  //
-  // Deprecated in favor of zone.
-  zoneId @maturity("deprecated") string
   // Record type (A, AAAA, MX, CNAME, TXT, SRV, NS, PTR, SPF, SSHFP, CAA, ...)
   type string
   // TTL in seconds; null when the zone default applies
@@ -2373,10 +2365,6 @@ private openstack.blockstorage.backup @defaults("id name status size createdAt")
   availabilityZone string
   // Free-form backup metadata (requires Cinder microversion >= 3.43)
   metadata map[string]string
-  // Owning project ID (admin-only attribute; empty for non-admin tokens)
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Timestamp when the data on the source volume was first saved (matches the source's data, not the backup's creation)
   dataTimestamp time
   // Backup creation timestamp
@@ -2613,10 +2601,6 @@ private openstack.compute.aggregate @defaults("id name availabilityZone hostCoun
 //
 // Reports both the configured maximum (`max*`) and the current usage (`*Used`) for each tracked resource. Limits without a usage counter are admin-set caps only.
 private openstack.compute.limits @defaults("maxTotalInstances totalInstancesUsed maxTotalCores totalCoresUsed maxTotalRAMSize totalRAMUsed") {
-  // Project ID the limits report applies to
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Project the limits report applies to
   project() openstack.project
   // Maximum number of vCPU cores
@@ -2694,10 +2678,6 @@ private openstack.placement.resourceProvider @defaults("id name generation") {
 
 // OpenStack Cinder block-storage quota for the scoped project (configured maximums; usage values are not exposed by the default API path).
 private openstack.blockstorage.quotaSet @defaults("volumes snapshots gigabytes backups") {
-  // Project ID the quota applies to
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Project the quota applies to
   project() openstack.project
   // Maximum number of volumes
@@ -2725,10 +2705,6 @@ private openstack.blockstorage.quotaSet @defaults("volumes snapshots gigabytes b
 // the default API path. The quota applies to the scoped project,
 // reachable through project.
 private openstack.network.quotaSet @defaults("network subnet port floatingIp router") {
-  // Project ID the quota applies to
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Project the quota applies to
   project() openstack.project
   // Maximum number of networks
@@ -2804,10 +2780,6 @@ private openstack.sharedfilesystem.share @defaults("id name shareProto status si
   snapshotSupport bool
   // Snapshot ID the share was created from; empty when not created from a snapshot
   snapshotId string
-  // Owning project ID
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // User-defined metadata
   metadata map[string]string
   // Creation timestamp
@@ -2882,10 +2854,6 @@ private openstack.sharedfilesystem.securityService @defaults("id name type statu
   user string
   // Directory server hostname or IP address
   server string
-  // Owning project ID
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Creation timestamp
   createdAt time
   // Last update timestamp
@@ -2920,10 +2888,6 @@ private openstack.sharedfilesystem.shareNetwork @defaults("id name networkType c
   cidr string
   // IP version (4 or 6)
   ipVersion int
-  // Owning project ID
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Creation timestamp
   createdAt time
   // Last update timestamp
@@ -2978,10 +2942,6 @@ private openstack.containerinfra.cluster @defaults("id name status nodeCount mas
   discoveryUrl string
   // Labels (key/value tuning and feature flags) applied to the cluster
   labels map[string]string
-  // Owning project ID
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Creation timestamp
   createdAt time
   // Last update timestamp
@@ -3286,10 +3246,6 @@ private openstack.orchestration.stack @defaults("id name status") {
 // openstack.compute.limits) surfaces projects near capacity or with
 // overly permissive quotas.
 private openstack.compute.quotaSet @defaults("instances cores ram") {
-  // Project ID the quota applies to
-  //
-  // Deprecated in favor of project.
-  projectId @maturity("deprecated") string
   // Project the quota applies to
   project() openstack.project
   // Maximum number of instances

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -2796,9 +2796,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.dns.zone.masters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackDnsZone).GetMasters()).ToDataRes(types.Array(types.String))
 	},
-	"openstack.dns.zone.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackDnsZone).GetProjectId()).ToDataRes(types.String)
-	},
 	"openstack.dns.zone.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackDnsZone).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -2819,9 +2816,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.dns.recordset.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackDnsRecordset).GetName()).ToDataRes(types.String)
-	},
-	"openstack.dns.recordset.zoneId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackDnsRecordset).GetZoneId()).ToDataRes(types.String)
 	},
 	"openstack.dns.recordset.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackDnsRecordset).GetType()).ToDataRes(types.String)
@@ -3005,9 +2999,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.blockstorage.backup.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBlockstorageBackup).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"openstack.blockstorage.backup.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackBlockstorageBackup).GetProjectId()).ToDataRes(types.String)
 	},
 	"openstack.blockstorage.backup.dataTimestamp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBlockstorageBackup).GetDataTimestamp()).ToDataRes(types.Time)
@@ -3207,9 +3198,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.compute.aggregate.deleted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackComputeAggregate).GetDeleted()).ToDataRes(types.Bool)
 	},
-	"openstack.compute.limits.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackComputeLimits).GetProjectId()).ToDataRes(types.String)
-	},
 	"openstack.compute.limits.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackComputeLimits).GetProject()).ToDataRes(types.Resource("openstack.project"))
 	},
@@ -3294,9 +3282,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.placement.resourceProvider.root": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackPlacementResourceProvider).GetRoot()).ToDataRes(types.Resource("openstack.placement.resourceProvider"))
 	},
-	"openstack.blockstorage.quotaSet.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackBlockstorageQuotaSet).GetProjectId()).ToDataRes(types.String)
-	},
 	"openstack.blockstorage.quotaSet.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBlockstorageQuotaSet).GetProject()).ToDataRes(types.Resource("openstack.project"))
 	},
@@ -3320,9 +3305,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.blockstorage.quotaSet.groups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBlockstorageQuotaSet).GetGroups()).ToDataRes(types.Int)
-	},
-	"openstack.network.quotaSet.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackNetworkQuotaSet).GetProjectId()).ToDataRes(types.String)
 	},
 	"openstack.network.quotaSet.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackNetworkQuotaSet).GetProject()).ToDataRes(types.Resource("openstack.project"))
@@ -3405,9 +3387,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.sharedfilesystem.share.snapshotId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSharedfilesystemShare).GetSnapshotId()).ToDataRes(types.String)
 	},
-	"openstack.sharedfilesystem.share.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackSharedfilesystemShare).GetProjectId()).ToDataRes(types.String)
-	},
 	"openstack.sharedfilesystem.share.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSharedfilesystemShare).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -3483,9 +3462,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.sharedfilesystem.securityService.server": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSharedfilesystemSecurityService).GetServer()).ToDataRes(types.String)
 	},
-	"openstack.sharedfilesystem.securityService.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackSharedfilesystemSecurityService).GetProjectId()).ToDataRes(types.String)
-	},
 	"openstack.sharedfilesystem.securityService.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSharedfilesystemSecurityService).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -3521,9 +3497,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.sharedfilesystem.shareNetwork.ipVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSharedfilesystemShareNetwork).GetIpVersion()).ToDataRes(types.Int)
-	},
-	"openstack.sharedfilesystem.shareNetwork.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackSharedfilesystemShareNetwork).GetProjectId()).ToDataRes(types.String)
 	},
 	"openstack.sharedfilesystem.shareNetwork.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSharedfilesystemShareNetwork).GetCreatedAt()).ToDataRes(types.Time)
@@ -3587,9 +3560,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.containerinfra.cluster.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackContainerinfraCluster).GetLabels()).ToDataRes(types.Map(types.String, types.String))
-	},
-	"openstack.containerinfra.cluster.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackContainerinfraCluster).GetProjectId()).ToDataRes(types.String)
 	},
 	"openstack.containerinfra.cluster.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackContainerinfraCluster).GetCreatedAt()).ToDataRes(types.Time)
@@ -3920,9 +3890,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.orchestration.stack.template": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOrchestrationStack).GetTemplate()).ToDataRes(types.Dict)
-	},
-	"openstack.compute.quotaSet.projectId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOpenstackComputeQuotaSet).GetProjectId()).ToDataRes(types.String)
 	},
 	"openstack.compute.quotaSet.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackComputeQuotaSet).GetProject()).ToDataRes(types.Resource("openstack.project"))
@@ -7599,10 +7566,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackDnsZone).Masters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"openstack.dns.zone.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackDnsZone).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"openstack.dns.zone.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackDnsZone).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -7633,10 +7596,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.dns.recordset.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackDnsRecordset).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"openstack.dns.recordset.zoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackDnsRecordset).ZoneId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openstack.dns.recordset.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7897,10 +7856,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.blockstorage.backup.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackBlockstorageBackup).Metadata, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
-		return
-	},
-	"openstack.blockstorage.backup.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackBlockstorageBackup).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openstack.blockstorage.backup.dataTimestamp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8207,10 +8162,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackComputeLimits).__id, ok = v.Value.(string)
 		return
 	},
-	"openstack.compute.limits.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackComputeLimits).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"openstack.compute.limits.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackComputeLimits).Project, ok = plugin.RawToTValue[*mqlOpenstackProject](v.Value, v.Error)
 		return
@@ -8331,10 +8282,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackBlockstorageQuotaSet).__id, ok = v.Value.(string)
 		return
 	},
-	"openstack.blockstorage.quotaSet.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackBlockstorageQuotaSet).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"openstack.blockstorage.quotaSet.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackBlockstorageQuotaSet).Project, ok = plugin.RawToTValue[*mqlOpenstackProject](v.Value, v.Error)
 		return
@@ -8369,10 +8316,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.network.quotaSet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackNetworkQuotaSet).__id, ok = v.Value.(string)
-		return
-	},
-	"openstack.network.quotaSet.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackNetworkQuotaSet).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openstack.network.quotaSet.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8491,10 +8434,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackSharedfilesystemShare).SnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"openstack.sharedfilesystem.share.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackSharedfilesystemShare).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"openstack.sharedfilesystem.share.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackSharedfilesystemShare).Metadata, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -8603,10 +8542,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackSharedfilesystemSecurityService).Server, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"openstack.sharedfilesystem.securityService.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackSharedfilesystemSecurityService).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"openstack.sharedfilesystem.securityService.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackSharedfilesystemSecurityService).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -8657,10 +8592,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.sharedfilesystem.shareNetwork.ipVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackSharedfilesystemShareNetwork).IpVersion, ok = plugin.RawToTValue[int64](v.Value, v.Error)
-		return
-	},
-	"openstack.sharedfilesystem.shareNetwork.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackSharedfilesystemShareNetwork).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openstack.sharedfilesystem.shareNetwork.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8749,10 +8680,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.containerinfra.cluster.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackContainerinfraCluster).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
-		return
-	},
-	"openstack.containerinfra.cluster.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackContainerinfraCluster).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openstack.containerinfra.cluster.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9217,10 +9144,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.compute.quotaSet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackComputeQuotaSet).__id, ok = v.Value.(string)
-		return
-	},
-	"openstack.compute.quotaSet.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOpenstackComputeQuotaSet).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openstack.compute.quotaSet.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -18573,7 +18496,7 @@ func (c *mqlOpenstackObjectstorageObject) GetContainer() *plugin.TValue[*mqlOpen
 type mqlOpenstackDnsZone struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackDnsZoneInternal it will be used here
+	mqlOpenstackDnsZoneInternal
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	Email         plugin.TValue[string]
@@ -18584,7 +18507,6 @@ type mqlOpenstackDnsZone struct {
 	Action        plugin.TValue[string]
 	Type          plugin.TValue[string]
 	Masters       plugin.TValue[[]any]
-	ProjectId     plugin.TValue[string]
 	CreatedAt     plugin.TValue[*time.Time]
 	UpdatedAt     plugin.TValue[*time.Time]
 	TransferredAt plugin.TValue[*time.Time]
@@ -18669,10 +18591,6 @@ func (c *mqlOpenstackDnsZone) GetMasters() *plugin.TValue[[]any] {
 	return &c.Masters
 }
 
-func (c *mqlOpenstackDnsZone) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
-}
-
 func (c *mqlOpenstackDnsZone) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
@@ -18721,10 +18639,9 @@ func (c *mqlOpenstackDnsZone) GetRecordsets() *plugin.TValue[[]any] {
 type mqlOpenstackDnsRecordset struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackDnsRecordsetInternal it will be used here
+	mqlOpenstackDnsRecordsetInternal
 	Id          plugin.TValue[string]
 	Name        plugin.TValue[string]
-	ZoneId      plugin.TValue[string]
 	Type        plugin.TValue[string]
 	Ttl         plugin.TValue[int64]
 	Records     plugin.TValue[[]any]
@@ -18779,10 +18696,6 @@ func (c *mqlOpenstackDnsRecordset) GetId() *plugin.TValue[string] {
 
 func (c *mqlOpenstackDnsRecordset) GetName() *plugin.TValue[string] {
 	return &c.Name
-}
-
-func (c *mqlOpenstackDnsRecordset) GetZoneId() *plugin.TValue[string] {
-	return &c.ZoneId
 }
 
 func (c *mqlOpenstackDnsRecordset) GetType() *plugin.TValue[string] {
@@ -19228,7 +19141,6 @@ type mqlOpenstackBlockstorageBackup struct {
 	FailReason          plugin.TValue[string]
 	AvailabilityZone    plugin.TValue[string]
 	Metadata            plugin.TValue[map[string]any]
-	ProjectId           plugin.TValue[string]
 	DataTimestamp       plugin.TValue[*time.Time]
 	CreatedAt           plugin.TValue[*time.Time]
 	UpdatedAt           plugin.TValue[*time.Time]
@@ -19320,10 +19232,6 @@ func (c *mqlOpenstackBlockstorageBackup) GetAvailabilityZone() *plugin.TValue[st
 
 func (c *mqlOpenstackBlockstorageBackup) GetMetadata() *plugin.TValue[map[string]any] {
 	return &c.Metadata
-}
-
-func (c *mqlOpenstackBlockstorageBackup) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
 }
 
 func (c *mqlOpenstackBlockstorageBackup) GetDataTimestamp() *plugin.TValue[*time.Time] {
@@ -20278,8 +20186,7 @@ func (c *mqlOpenstackComputeAggregate) GetDeleted() *plugin.TValue[bool] {
 type mqlOpenstackComputeLimits struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackComputeLimitsInternal it will be used here
-	ProjectId               plugin.TValue[string]
+	mqlOpenstackComputeLimitsInternal
 	Project                 plugin.TValue[*mqlOpenstackProject]
 	MaxTotalCores           plugin.TValue[int64]
 	TotalCoresUsed          plugin.TValue[int64]
@@ -20313,12 +20220,7 @@ func createOpenstackComputeLimits(runtime *plugin.Runtime, args map[string]*llx.
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("openstack.compute.limits", res.__id)
@@ -20337,10 +20239,6 @@ func (c *mqlOpenstackComputeLimits) MqlName() string {
 
 func (c *mqlOpenstackComputeLimits) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlOpenstackComputeLimits) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
 }
 
 func (c *mqlOpenstackComputeLimits) GetProject() *plugin.TValue[*mqlOpenstackProject] {
@@ -20553,8 +20451,7 @@ func (c *mqlOpenstackPlacementResourceProvider) GetRoot() *plugin.TValue[*mqlOpe
 type mqlOpenstackBlockstorageQuotaSet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackBlockstorageQuotaSetInternal it will be used here
-	ProjectId          plugin.TValue[string]
+	mqlOpenstackBlockstorageQuotaSetInternal
 	Project            plugin.TValue[*mqlOpenstackProject]
 	Volumes            plugin.TValue[int64]
 	Snapshots          plugin.TValue[int64]
@@ -20576,12 +20473,7 @@ func createOpenstackBlockstorageQuotaSet(runtime *plugin.Runtime, args map[strin
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("openstack.blockstorage.quotaSet", res.__id)
@@ -20600,10 +20492,6 @@ func (c *mqlOpenstackBlockstorageQuotaSet) MqlName() string {
 
 func (c *mqlOpenstackBlockstorageQuotaSet) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlOpenstackBlockstorageQuotaSet) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
 }
 
 func (c *mqlOpenstackBlockstorageQuotaSet) GetProject() *plugin.TValue[*mqlOpenstackProject] {
@@ -20654,8 +20542,7 @@ func (c *mqlOpenstackBlockstorageQuotaSet) GetGroups() *plugin.TValue[int64] {
 type mqlOpenstackNetworkQuotaSet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackNetworkQuotaSetInternal it will be used here
-	ProjectId         plugin.TValue[string]
+	mqlOpenstackNetworkQuotaSetInternal
 	Project           plugin.TValue[*mqlOpenstackProject]
 	Network           plugin.TValue[int64]
 	Subnet            plugin.TValue[int64]
@@ -20680,12 +20567,7 @@ func createOpenstackNetworkQuotaSet(runtime *plugin.Runtime, args map[string]*ll
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("openstack.network.quotaSet", res.__id)
@@ -20704,10 +20586,6 @@ func (c *mqlOpenstackNetworkQuotaSet) MqlName() string {
 
 func (c *mqlOpenstackNetworkQuotaSet) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlOpenstackNetworkQuotaSet) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
 }
 
 func (c *mqlOpenstackNetworkQuotaSet) GetProject() *plugin.TValue[*mqlOpenstackProject] {
@@ -20835,7 +20713,6 @@ type mqlOpenstackSharedfilesystemShare struct {
 	ReplicationType  plugin.TValue[string]
 	SnapshotSupport  plugin.TValue[bool]
 	SnapshotId       plugin.TValue[string]
-	ProjectId        plugin.TValue[string]
 	Metadata         plugin.TValue[map[string]any]
 	CreatedAt        plugin.TValue[*time.Time]
 	UpdatedAt        plugin.TValue[*time.Time]
@@ -20939,10 +20816,6 @@ func (c *mqlOpenstackSharedfilesystemShare) GetSnapshotSupport() *plugin.TValue[
 
 func (c *mqlOpenstackSharedfilesystemShare) GetSnapshotId() *plugin.TValue[string] {
 	return &c.SnapshotId
-}
-
-func (c *mqlOpenstackSharedfilesystemShare) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
 }
 
 func (c *mqlOpenstackSharedfilesystemShare) GetMetadata() *plugin.TValue[map[string]any] {
@@ -21110,7 +20983,7 @@ func (c *mqlOpenstackSharedfilesystemShareAccessRule) GetShare() *plugin.TValue[
 type mqlOpenstackSharedfilesystemSecurityService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackSharedfilesystemSecurityServiceInternal it will be used here
+	mqlOpenstackSharedfilesystemSecurityServiceInternal
 	Id          plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
@@ -21121,7 +20994,6 @@ type mqlOpenstackSharedfilesystemSecurityService struct {
 	Ou          plugin.TValue[string]
 	User        plugin.TValue[string]
 	Server      plugin.TValue[string]
-	ProjectId   plugin.TValue[string]
 	CreatedAt   plugin.TValue[*time.Time]
 	UpdatedAt   plugin.TValue[*time.Time]
 	Project     plugin.TValue[*mqlOpenstackProject]
@@ -21204,10 +21076,6 @@ func (c *mqlOpenstackSharedfilesystemSecurityService) GetServer() *plugin.TValue
 	return &c.Server
 }
 
-func (c *mqlOpenstackSharedfilesystemSecurityService) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
-}
-
 func (c *mqlOpenstackSharedfilesystemSecurityService) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
@@ -21236,7 +21104,7 @@ func (c *mqlOpenstackSharedfilesystemSecurityService) GetProject() *plugin.TValu
 type mqlOpenstackSharedfilesystemShareNetwork struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackSharedfilesystemShareNetworkInternal it will be used here
+	mqlOpenstackSharedfilesystemShareNetworkInternal
 	Id              plugin.TValue[string]
 	Name            plugin.TValue[string]
 	Description     plugin.TValue[string]
@@ -21246,7 +21114,6 @@ type mqlOpenstackSharedfilesystemShareNetwork struct {
 	SegmentationId  plugin.TValue[int64]
 	Cidr            plugin.TValue[string]
 	IpVersion       plugin.TValue[int64]
-	ProjectId       plugin.TValue[string]
 	CreatedAt       plugin.TValue[*time.Time]
 	UpdatedAt       plugin.TValue[*time.Time]
 	Network         plugin.TValue[*mqlOpenstackNetwork]
@@ -21327,10 +21194,6 @@ func (c *mqlOpenstackSharedfilesystemShareNetwork) GetIpVersion() *plugin.TValue
 	return &c.IpVersion
 }
 
-func (c *mqlOpenstackSharedfilesystemShareNetwork) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
-}
-
 func (c *mqlOpenstackSharedfilesystemShareNetwork) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
@@ -21408,7 +21271,6 @@ type mqlOpenstackContainerinfraCluster struct {
 	MasterLbEnabled        plugin.TValue[bool]
 	DiscoveryUrl           plugin.TValue[string]
 	Labels                 plugin.TValue[map[string]any]
-	ProjectId              plugin.TValue[string]
 	CreatedAt              plugin.TValue[*time.Time]
 	UpdatedAt              plugin.TValue[*time.Time]
 	ClusterTemplate        plugin.TValue[*mqlOpenstackContainerinfraClusterTemplate]
@@ -21524,10 +21386,6 @@ func (c *mqlOpenstackContainerinfraCluster) GetDiscoveryUrl() *plugin.TValue[str
 
 func (c *mqlOpenstackContainerinfraCluster) GetLabels() *plugin.TValue[map[string]any] {
 	return &c.Labels
-}
-
-func (c *mqlOpenstackContainerinfraCluster) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
 }
 
 func (c *mqlOpenstackContainerinfraCluster) GetCreatedAt() *plugin.TValue[*time.Time] {
@@ -22594,8 +22452,7 @@ func (c *mqlOpenstackOrchestrationStack) GetTemplate() *plugin.TValue[any] {
 type mqlOpenstackComputeQuotaSet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOpenstackComputeQuotaSetInternal it will be used here
-	ProjectId                plugin.TValue[string]
+	mqlOpenstackComputeQuotaSetInternal
 	Project                  plugin.TValue[*mqlOpenstackProject]
 	Instances                plugin.TValue[int64]
 	Cores                    plugin.TValue[int64]
@@ -22643,10 +22500,6 @@ func (c *mqlOpenstackComputeQuotaSet) MqlName() string {
 
 func (c *mqlOpenstackComputeQuotaSet) MqlID() string {
 	return c.__id
-}
-
-func (c *mqlOpenstackComputeQuotaSet) GetProjectId() *plugin.TValue[string] {
-	return &c.ProjectId
 }
 
 func (c *mqlOpenstackComputeQuotaSet) GetProject() *plugin.TValue[*mqlOpenstackProject] {

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -76,7 +76,6 @@ openstack.blockstorage.backup.metadata 13.0.1
 openstack.blockstorage.backup.name 13.0.1
 openstack.blockstorage.backup.objectCount 13.0.1
 openstack.blockstorage.backup.project 13.0.1
-openstack.blockstorage.backup.projectId 13.0.1
 openstack.blockstorage.backup.size 13.0.1
 openstack.blockstorage.backup.sourceSnapshot 13.0.1
 openstack.blockstorage.backup.status 13.0.1
@@ -94,7 +93,6 @@ openstack.blockstorage.quotaSet.gigabytes 13.0.1
 openstack.blockstorage.quotaSet.groups 13.0.1
 openstack.blockstorage.quotaSet.perVolumeGigabytes 13.0.1
 openstack.blockstorage.quotaSet.project 13.4.2
-openstack.blockstorage.quotaSet.projectId 13.0.1
 openstack.blockstorage.quotaSet.snapshots 13.0.1
 openstack.blockstorage.quotaSet.volumes 13.0.1
 openstack.blockstorage.snapshot 13.0.1
@@ -220,7 +218,6 @@ openstack.compute.limits.maxTotalInstances 13.0.1
 openstack.compute.limits.maxTotalKeypairs 13.0.1
 openstack.compute.limits.maxTotalRAMSize 13.0.1
 openstack.compute.limits.project 13.4.2
-openstack.compute.limits.projectId 13.0.1
 openstack.compute.limits.totalCoresUsed 13.0.1
 openstack.compute.limits.totalFloatingIpsUsed 13.0.1
 openstack.compute.limits.totalInstancesUsed 13.0.1
@@ -238,7 +235,6 @@ openstack.compute.quotaSet.instances 13.5.2
 openstack.compute.quotaSet.keyPairs 13.5.2
 openstack.compute.quotaSet.metadataItems 13.5.2
 openstack.compute.quotaSet.project 13.5.2
-openstack.compute.quotaSet.projectId 13.5.2
 openstack.compute.quotaSet.ram 13.5.2
 openstack.compute.quotaSet.securityGroupRules 13.5.2
 openstack.compute.quotaSet.securityGroups 13.5.2
@@ -359,7 +355,6 @@ openstack.containerinfra.cluster.nodeGroup.status 13.7.6
 openstack.containerinfra.cluster.nodeGroup.statusReason 13.7.6
 openstack.containerinfra.cluster.nodeGroups 13.7.6
 openstack.containerinfra.cluster.project 13.1.4
-openstack.containerinfra.cluster.projectId 13.1.4
 openstack.containerinfra.cluster.stack 13.2.1
 openstack.containerinfra.cluster.status 13.1.4
 openstack.containerinfra.cluster.statusReason 13.1.4
@@ -440,7 +435,6 @@ openstack.dns.recordset.ttl 13.0.1
 openstack.dns.recordset.type 13.0.1
 openstack.dns.recordset.updatedAt 13.0.1
 openstack.dns.recordset.zone 13.0.1
-openstack.dns.recordset.zoneId 13.0.1
 openstack.dns.transferAccept 13.7.6
 openstack.dns.transferAccept.createdAt 13.7.6
 openstack.dns.transferAccept.id 13.7.6
@@ -477,7 +471,6 @@ openstack.dns.zone.id 13.0.1
 openstack.dns.zone.masters 13.0.1
 openstack.dns.zone.name 13.0.1
 openstack.dns.zone.project 13.0.1
-openstack.dns.zone.projectId 13.0.1
 openstack.dns.zone.recordsets 13.0.1
 openstack.dns.zone.serial 13.0.1
 openstack.dns.zone.status 13.0.1
@@ -764,7 +757,6 @@ openstack.network.quotaSet.floatingIp 13.0.1
 openstack.network.quotaSet.network 13.0.1
 openstack.network.quotaSet.port 13.0.1
 openstack.network.quotaSet.project 13.4.2
-openstack.network.quotaSet.projectId 13.0.1
 openstack.network.quotaSet.rbacPolicy 13.0.1
 openstack.network.quotaSet.router 13.0.1
 openstack.network.quotaSet.securityGroup 13.0.1
@@ -1159,7 +1151,6 @@ openstack.sharedfilesystem.securityService.id 13.1.4
 openstack.sharedfilesystem.securityService.name 13.1.4
 openstack.sharedfilesystem.securityService.ou 13.1.4
 openstack.sharedfilesystem.securityService.project 13.1.4
-openstack.sharedfilesystem.securityService.projectId 13.1.4
 openstack.sharedfilesystem.securityService.server 13.1.4
 openstack.sharedfilesystem.securityService.status 13.1.4
 openstack.sharedfilesystem.securityService.type 13.1.4
@@ -1187,7 +1178,6 @@ openstack.sharedfilesystem.share.isPublic 13.1.4
 openstack.sharedfilesystem.share.metadata 13.1.4
 openstack.sharedfilesystem.share.name 13.1.4
 openstack.sharedfilesystem.share.project 13.1.4
-openstack.sharedfilesystem.share.projectId 13.1.4
 openstack.sharedfilesystem.share.replicationType 13.1.4
 openstack.sharedfilesystem.share.shareNetwork 13.1.4
 openstack.sharedfilesystem.share.shareProto 13.1.4
@@ -1210,7 +1200,6 @@ openstack.sharedfilesystem.shareNetwork.networkType 13.1.4
 openstack.sharedfilesystem.shareNetwork.neutronNetId 13.1.4
 openstack.sharedfilesystem.shareNetwork.neutronSubnetId 13.1.4
 openstack.sharedfilesystem.shareNetwork.project 13.1.4
-openstack.sharedfilesystem.shareNetwork.projectId 13.1.4
 openstack.sharedfilesystem.shareNetwork.segmentationId 13.1.4
 openstack.sharedfilesystem.shareNetwork.subnet 13.1.4
 openstack.sharedfilesystem.shareNetwork.updatedAt 13.1.4

--- a/providers/openstack/resources/volumes.go
+++ b/providers/openstack/resources/volumes.go
@@ -658,7 +658,6 @@ func (o *mqlOpenstack) backups() ([]any, error) {
 			"failReason":          llx.StringData(b.FailReason),
 			"availabilityZone":    llx.StringData(az),
 			"metadata":            stringMapData(meta),
-			"projectId":           llx.StringData(b.ProjectID),
 			"dataTimestamp":       llx.TimeDataPtr(timePtr(b.DataTimestamp)),
 			"createdAt":           llx.TimeDataPtr(timePtr(b.CreatedAt)),
 			"updatedAt":           llx.TimeDataPtr(timePtr(b.UpdatedAt)),
@@ -719,8 +718,11 @@ func (r *mqlOpenstackBlockstorageBackup) project() (*mqlOpenstackProject, error)
 
 // ---- openstack.blockstorage.quotaSet ----
 
-func (r *mqlOpenstackBlockstorageQuotaSet) id() (string, error) {
-	return "openstack.blockstorage.quotaSet/" + r.ProjectId.Data, nil
+// mqlOpenstackBlockstorageQuotaSetInternal holds the project id the quota
+// applies to, which project() resolves. The __id is supplied explicitly by the
+// creator, so this resource needs no id() function.
+type mqlOpenstackBlockstorageQuotaSetInternal struct {
+	cacheProjectID string
 }
 
 func (o *mqlOpenstack) blockStorageQuotaSet() (*mqlOpenstackBlockstorageQuotaSet, error) {
@@ -744,7 +746,6 @@ func (o *mqlOpenstack) blockStorageQuotaSet() (*mqlOpenstackBlockstorageQuotaSet
 	}
 	res, err := CreateResource(o.MqlRuntime, "openstack.blockstorage.quotaSet", map[string]*llx.RawData{
 		"__id":               llx.StringData("openstack.blockstorage.quotaSet/" + projectId),
-		"projectId":          llx.StringData(projectId),
 		"volumes":            llx.IntData(int64(q.Volumes)),
 		"snapshots":          llx.IntData(int64(q.Snapshots)),
 		"gigabytes":          llx.IntData(int64(q.Gigabytes)),
@@ -756,9 +757,11 @@ func (o *mqlOpenstack) blockStorageQuotaSet() (*mqlOpenstackBlockstorageQuotaSet
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlOpenstackBlockstorageQuotaSet), nil
+	mqlQuota := res.(*mqlOpenstackBlockstorageQuotaSet)
+	mqlQuota.cacheProjectID = projectId
+	return mqlQuota, nil
 }
 
 func (r *mqlOpenstackBlockstorageQuotaSet) project() (*mqlOpenstackProject, error) {
-	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
 }


### PR DESCRIPTION
## What

Removes 11 deprecated raw owner-id fields from the openstack provider as part of the v14 breaking-change cleanup: `projectId` on ten resources, plus `zoneId` on `openstack.dns.recordset`. All were deprecated in favor of the typed `project` / `zone` references.

## Why this one needed care

**Each removed field was the input to the accessor that replaced it:**

```go
func (r *mqlOpenstackComputeQuotaSet) project() (*mqlOpenstackProject, error) {
	return resolveProject(r.MqlRuntime, r.ProjectId.Data, &r.Project)
}
```

So each raw id moves onto the resource's `Internal` struct as `cacheProjectID` (or `cacheZoneID`) — the convention this provider already uses at roughly 40 other sites — primed in each creator.

### The `id()` trap

Three resources — `compute.limits`, `blockstorage.quotaSet`, `network.quotaSet` — built their cache key from the field inside an `id()` function:

```go
func (r *mqlOpenstackBlockstorageQuotaSet) id() (string, error) {
	return "openstack.blockstorage.quotaSet/" + r.ProjectId.Data, nil
}
```

An `Internal` cache **cannot** serve `id()`: `id()` runs *during* `CreateResource`, before the creator primes the cache, so it would have read `""`. Every project would then have collapsed onto the same cache key `openstack.blockstorage.quotaSet/` — one project's quota silently returned for another, with no error.

Fortunately all three creators **already** pass `__id` explicitly:

```go
"__id": llx.StringData("openstack.blockstorage.quotaSet/" + projectId),
```

so the `id()` functions were redundant on the only construction path (verified: no `NewResource` call targets any of the three). They are removed rather than re-pointed, and `__id` values are unchanged.

### The live field that had to survive

The **top-level** `openstack.projectId` is a separate, non-deprecated field, and it is used by shipped content:

```
bundles/cnspec/mondoo-openstack-security.mql.yaml:2230
  openstack.images.where(owner.id == openstack.projectId).all(visibility != "public")
```

Only the 11 sub-resource fields are removed; a guard in the edit script asserts the top-level field survives.

`openstack.blockstorage.backup.projectId` turned out to be genuinely inert — its `project()` accessor already read a pre-existing `cacheProjectID` — so only the field and its arg key were dropped there.

## Migration

| Removed | Use instead |
| --- | --- |
| `openstack.dns.zone.projectId` | `openstack.dns.zone.project` |
| `openstack.dns.recordset.zoneId` | `openstack.dns.recordset.zone` |
| `openstack.blockstorage.backup.projectId` | `openstack.blockstorage.backup.project` |
| `openstack.blockstorage.quotaSet.projectId` | `openstack.blockstorage.quotaSet.project` |
| `openstack.compute.limits.projectId` | `openstack.compute.limits.project` |
| `openstack.compute.quotaSet.projectId` | `openstack.compute.quotaSet.project` |
| `openstack.network.quotaSet.projectId` | `openstack.network.quotaSet.project` |
| `openstack.sharedfilesystem.share.projectId` | `openstack.sharedfilesystem.share.project` |
| `openstack.sharedfilesystem.securityService.projectId` | `openstack.sharedfilesystem.securityService.project` |
| `openstack.sharedfilesystem.shareNetwork.projectId` | `openstack.sharedfilesystem.shareNetwork.project` |
| `openstack.containerinfra.cluster.projectId` | `openstack.containerinfra.cluster.project` |

For an id-only comparison use `project.id` / `zone.id`. The reference is **null** where the old field was `""` — notably `blockstorage.backup`, whose `projectId` is an admin-only attribute and empty for non-admin tokens.

## Changes

- `openstack.lr` — removed 11 fields and their doc comments
- `openstack.lr.versions` — dropped the 11 entries
- `dns.go` — new `Internal` structs for zone (`cacheProjectID`) and recordset (`cacheZoneID`)
- `compute.go`, `compute_quotaset.go`, `volumes.go`, `network.go` — new `Internal` structs; `id()` removed on the three that built `__id` from the field
- `magnum.go`, `manila.go` — extended existing `Internal` structs
- `manila.go` — three `project()` accessors with byte-identical bodies, disambiguated by receiver signature rather than field name
- `openstack.lr.go` — regenerated (two passes, for the new `Internal` structs)

## Policy impact

**None.** The only openstack hit in the content bundles is the top-level `openstack.projectId`, which is preserved.

## Verification

- `./mqlr generate providers/openstack/resources/openstack.lr` — run twice; all 10 `Internal` structs confirmed embedded
- `go build -gcflags=-e ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — passing
- `gofmt -l .` — clean
- Confirmed no `.ProjectId.Data` / `.ZoneId.Data` reads remain, and `openstack.projectId 13.0.1` is still in `.lr.versions`
