### PR TITLE
🐛 gcp: keep partial results when a listing is truncated mid-pagination

### DIFF
--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -61,7 +61,7 @@ func (g *mqlGcpOrganization) gcpUserAccessBindings() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -118,7 +118,7 @@ func (g *mqlGcpOrganization) accessPolicies() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -165,7 +165,7 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) accessLevels() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -223,7 +223,7 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) servicePerimeters() ([]any, err
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -85,7 +85,7 @@ func (g *mqlGcpProjectAlloydbService) clusters() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB clusters")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -339,7 +339,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) users() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB users")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -488,7 +488,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) instances() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB instances")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -649,7 +649,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) backups() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB backups")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -127,7 +127,7 @@ func (g *mqlGcpProjectAssetService) resources() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not search Cloud Asset Inventory resources")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -203,7 +203,7 @@ func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not search Cloud Asset Inventory IAM policies")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/backupdr.go
+++ b/providers/gcp/resources/backupdr.go
@@ -98,7 +98,7 @@ func (g *mqlGcpProjectBackupdrService) managementServers() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR management servers")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -175,7 +175,7 @@ func (g *mqlGcpProjectBackupdrService) backupVaults() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR backup vaults")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -242,7 +242,7 @@ func (g *mqlGcpProjectBackupdrServiceBackupVault) dataSources() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR data sources")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -313,7 +313,7 @@ func (g *mqlGcpProjectBackupdrService) backupPlans() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR backup plans")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/batch.go
+++ b/providers/gcp/resources/batch.go
@@ -125,7 +125,7 @@ func (g *mqlGcpProjectBatchService) jobs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Batch jobs")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -532,7 +532,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) appProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Bigtable app profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -119,7 +119,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificates() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -232,7 +232,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateMaps() ([]any, error
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -299,7 +299,7 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificateMap) entries() ([]any,
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (g *mqlGcpProjectCertificateManagerService) dnsAuthorizations() ([]any, err
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateIssuanceConfigs() ([
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -527,7 +527,7 @@ func (g *mqlGcpProjectCertificateManagerService) trustConfigs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/container_analysis.go
+++ b/providers/gcp/resources/container_analysis.go
@@ -156,7 +156,7 @@ func (g *mqlGcpProjectContainerAnalysisService) notes() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Container Analysis notes")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -243,7 +243,7 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Container Analysis occurrences")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -126,7 +126,7 @@ func (g *mqlGcpProjectDlpService) inspectTemplates() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP inspect templates")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -201,7 +201,7 @@ func (g *mqlGcpProjectDlpService) deidentifyTemplates() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP deidentify templates")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -276,7 +276,7 @@ func (g *mqlGcpProjectDlpService) jobTriggers() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP job triggers")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (g *mqlGcpProjectDlpService) storedInfoTypes() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP stored info types")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -501,7 +501,7 @@ func (g *mqlGcpProjectDlpService) dlpJobs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP jobs")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -768,7 +768,7 @@ func (g *mqlGcpProjectDlpService) projectDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP project data profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -843,7 +843,7 @@ func (g *mqlGcpProjectDlpService) tableDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP table data profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -981,7 +981,7 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP table data profiles for column profile enumeration")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -1089,7 +1089,7 @@ func (g *mqlGcpProjectDlpService) fileStoreDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP file-store data profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -161,7 +161,7 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Eventarc triggers")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -280,7 +280,7 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Eventarc channels")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -274,7 +274,7 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) indexes() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Firestore indexes")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/gke_backup.go
+++ b/providers/gcp/resources/gke_backup.go
@@ -125,7 +125,7 @@ func (g *mqlGcpProjectGkeBackupService) backupPlans() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list GKE Backup backup plans")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -219,7 +219,7 @@ func (g *mqlGcpProjectGkeBackupService) restorePlans() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list GKE Backup restore plans")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/ids.go
+++ b/providers/gcp/resources/ids.go
@@ -121,7 +121,7 @@ func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Cloud IDS endpoints")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/network_connectivity.go
+++ b/providers/gcp/resources/network_connectivity.go
@@ -174,8 +174,10 @@ func (g *mqlGcpProjectNetworkConnectivityService) hubs() ([]any, error) {
 		}
 		if err != nil {
 			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Str("project", projectId).Msg("could not list Network Connectivity hubs")
-				return nil, nil
+				// break rather than discard: an error partway through pagination
+				// should not throw away the hubs the API already returned.
+				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Network Connectivity hubs")
+				break
 			}
 			return nil, err
 		}
@@ -279,8 +281,9 @@ func (g *mqlGcpProjectNetworkConnectivityService) spokes() ([]any, error) {
 		}
 		if err != nil {
 			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Str("project", projectId).Msg("could not list Network Connectivity spokes")
-				return nil, nil
+				// break rather than discard: keep the spokes already returned.
+				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Network Connectivity spokes")
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/network_management.go
+++ b/providers/gcp/resources/network_management.go
@@ -163,8 +163,9 @@ func (g *mqlGcpProjectNetworkManagementService) connectivityTests() ([]any, erro
 		}
 		if err != nil {
 			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Str("project", projectId).Msg("could not list connectivity tests")
-				return nil, nil
+				// break rather than discard: keep the tests already returned.
+				log.Warn().Err(err).Str("project", projectId).Msg("could not list all connectivity tests")
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -101,7 +101,7 @@ func (g *mqlGcpProjectCertificateAuthorityService) caPools() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -240,7 +240,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificateAuthorities(
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -373,7 +373,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificates() ([]any, 
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCertificateAuthority) certifica
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -568,7 +568,7 @@ func (g *mqlGcpProjectCertificateAuthorityService) certificateTemplates() ([]any
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/privileged_access_manager.go
+++ b/providers/gcp/resources/privileged_access_manager.go
@@ -169,8 +169,9 @@ func (g *mqlGcpProjectPrivilegedAccessManagerService) entitlements() ([]any, err
 		}
 		if err != nil {
 			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Str("project", projectId).Msg("could not list Privileged Access Manager entitlements")
-				return nil, nil
+				// break rather than discard: keep the entitlements already returned.
+				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Privileged Access Manager entitlements")
+				break
 			}
 			return nil, err
 		}
@@ -301,8 +302,9 @@ func (g *mqlGcpProjectPrivilegedAccessManagerService) grants() ([]any, error) {
 		}
 		if err != nil {
 			if isGRPCSkippable(err) {
-				log.Warn().Err(err).Str("project", projectId).Msg("could not list Privileged Access Manager grants")
-				return nil, nil
+				// break rather than discard: keep the grants already returned.
+				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Privileged Access Manager grants")
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -147,7 +147,7 @@ func (g *mqlGcpProjectSpannerService) instances() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instances")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -259,7 +259,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) databases() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner databases")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -561,7 +561,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) backups() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner backups")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -681,7 +681,7 @@ func (g *mqlGcpProjectSpannerService) instanceConfigs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instance configs")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -922,7 +922,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) databaseRoles() ([]any, er
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner database roles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -1092,7 +1092,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) instancePartitions() ([]any, error
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instance partitions")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}


### PR DESCRIPTION
Follow-up to #9568, which merged before this last piece of review feedback could land on it.

Five listers discarded everything already accumulated when a skippable error arrived partway through pagination:

- Network Connectivity hubs and spokes
- Network Management connectivity tests
- Privileged Access Manager entitlements and grants

They now `break`, keeping what the API returned, which matches the treatment the principal-access-boundary listers already got in #9566 and the existing convention in `cloudbuild.go`.

Two of the five (`privileged_access_manager.go`) shipped with #9567 and the other three with #9568, both merged, so the fix lands on its own branch rather than being tacked onto an unrelated PR.

For the record on why `break` rather than `return nil, nil`: the realistic failure is a `PermissionDenied` or "API not enabled" on the *first* page, where both forms produce an empty list. They differ only when a page fails partway through, and there discarding data the API already returned has no upside — the warning is logged either way.

`go build`, `go vet`, `gofmt` clean; GCP provider suite passes.
