### PR TITLE
🐛 gcp: keep partial results across the remaining truncating listers

### DIFF
--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -61,7 +61,7 @@ func (g *mqlGcpOrganization) gcpUserAccessBindings() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -118,7 +118,7 @@ func (g *mqlGcpOrganization) accessPolicies() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -165,7 +165,7 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) accessLevels() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -223,7 +223,7 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) servicePerimeters() ([]any, err
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -85,7 +85,7 @@ func (g *mqlGcpProjectAlloydbService) clusters() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB clusters")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -339,7 +339,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) users() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB users")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -488,7 +488,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) instances() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB instances")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -649,7 +649,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) backups() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB backups")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -127,7 +127,7 @@ func (g *mqlGcpProjectAssetService) resources() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not search Cloud Asset Inventory resources")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -203,7 +203,7 @@ func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not search Cloud Asset Inventory IAM policies")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/backupdr.go
+++ b/providers/gcp/resources/backupdr.go
@@ -98,7 +98,7 @@ func (g *mqlGcpProjectBackupdrService) managementServers() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR management servers")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -175,7 +175,7 @@ func (g *mqlGcpProjectBackupdrService) backupVaults() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR backup vaults")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -242,7 +242,7 @@ func (g *mqlGcpProjectBackupdrServiceBackupVault) dataSources() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR data sources")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -313,7 +313,7 @@ func (g *mqlGcpProjectBackupdrService) backupPlans() ([]any, error) {
 		if err != nil {
 			if isBackupDRSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR backup plans")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/batch.go
+++ b/providers/gcp/resources/batch.go
@@ -125,7 +125,7 @@ func (g *mqlGcpProjectBatchService) jobs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Batch jobs")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -532,7 +532,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) appProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Bigtable app profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -119,7 +119,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificates() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -232,7 +232,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateMaps() ([]any, error
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -299,7 +299,7 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificateMap) entries() ([]any,
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (g *mqlGcpProjectCertificateManagerService) dnsAuthorizations() ([]any, err
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -449,7 +449,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateIssuanceConfigs() ([
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -527,7 +527,7 @@ func (g *mqlGcpProjectCertificateManagerService) trustConfigs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/container_analysis.go
+++ b/providers/gcp/resources/container_analysis.go
@@ -156,7 +156,7 @@ func (g *mqlGcpProjectContainerAnalysisService) notes() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Container Analysis notes")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -243,7 +243,7 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Container Analysis occurrences")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -126,7 +126,7 @@ func (g *mqlGcpProjectDlpService) inspectTemplates() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP inspect templates")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -201,7 +201,7 @@ func (g *mqlGcpProjectDlpService) deidentifyTemplates() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP deidentify templates")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -276,7 +276,7 @@ func (g *mqlGcpProjectDlpService) jobTriggers() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP job triggers")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -372,7 +372,7 @@ func (g *mqlGcpProjectDlpService) storedInfoTypes() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP stored info types")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -501,7 +501,7 @@ func (g *mqlGcpProjectDlpService) dlpJobs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP jobs")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -768,7 +768,7 @@ func (g *mqlGcpProjectDlpService) projectDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP project data profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -843,7 +843,7 @@ func (g *mqlGcpProjectDlpService) tableDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP table data profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -981,7 +981,7 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP table data profiles for column profile enumeration")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -1089,7 +1089,7 @@ func (g *mqlGcpProjectDlpService) fileStoreDataProfiles() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP file-store data profiles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -161,7 +161,7 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Eventarc triggers")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -280,7 +280,7 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Eventarc channels")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -274,7 +274,7 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) indexes() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Firestore indexes")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/gke_backup.go
+++ b/providers/gcp/resources/gke_backup.go
@@ -125,7 +125,7 @@ func (g *mqlGcpProjectGkeBackupService) backupPlans() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list GKE Backup backup plans")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -219,7 +219,7 @@ func (g *mqlGcpProjectGkeBackupService) restorePlans() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list GKE Backup restore plans")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/ids.go
+++ b/providers/gcp/resources/ids.go
@@ -121,7 +121,7 @@ func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Cloud IDS endpoints")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -101,7 +101,7 @@ func (g *mqlGcpProjectCertificateAuthorityService) caPools() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -240,7 +240,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificateAuthorities(
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -373,7 +373,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificates() ([]any, 
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -491,7 +491,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCertificateAuthority) certifica
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -568,7 +568,7 @@ func (g *mqlGcpProjectCertificateAuthorityService) certificateTemplates() ([]any
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -147,7 +147,7 @@ func (g *mqlGcpProjectSpannerService) instances() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instances")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -259,7 +259,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) databases() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner databases")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -561,7 +561,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) backups() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner backups")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -681,7 +681,7 @@ func (g *mqlGcpProjectSpannerService) instanceConfigs() ([]any, error) {
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instance configs")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -922,7 +922,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) databaseRoles() ([]any, er
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner database roles")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}
@@ -1092,7 +1092,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) instancePartitions() ([]any, error
 		if err != nil {
 			if isGRPCSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instance partitions")
-				return nil, nil
+				break
 			}
 			return nil, err
 		}


### PR DESCRIPTION
Follow-up requested in review on #9584, which this stacks on. Review #9584 first.

That PR fixed 5 listers that discarded already-fetched results when a skippable error arrived partway through pagination. This applies the same fix to every remaining one.

## Scope

50 sites across 15 files:

| file | sites | | file | sites |
|---|---|---|---|---|
| dlp.go | 9 | | eventarc.go | 2 |
| certificatemanager.go | 6 | | gke_backup.go | 2 |
| spanner.go | 6 | | batch.go | 1 |
| privateca.go | 5 | | bigtable.go | 1 |
| accesscontextmanager.go | 4 | | firestore.go | 1 |
| alloydb.go | 4 | | ids.go | 1 |
| backupdr.go | 4 | | | |
| asset.go | 2 | | | |
| container_analysis.go | 2 | | | |

Two corrections to the review's estimate: the count is 50 rather than ~22, and `cloudbuild.go` was cited but already used `break` — it's the file I pointed at as the existing convention.

## How the sites were chosen

Mechanically, then verified. A site qualifies only when it is a bare `for { it.Next() }` iterator loop that appends to a result slice, and the `return nil, nil` is guarded by an `is*Skippable(err)` check. All nine skip helpers count, not just `isGRPCSkippable` — `backupdr.go` uses `isBackupDRSkippable`, and restricting to the two common ones would have silently missed its 4 sites.

Every one of the 50 turned out to share a single shape:

```go
if err != nil {
    if isGRPCSkippable(err) {
        log.Warn().Err(err).Msg("could not list X")
        return nil, nil   // ← now: break
    }
    return nil, err
}
```

Loops with no accumulation were deliberately left alone (2 sites): there is nothing to lose there, and `break` would only obscure the intent.

## What the diff is

Exactly 50 lines, nothing else:

```
$ git diff | grep '^-' | grep -v '^---' | sed 's/^-\s*//' | sort | uniq -c
  50 return nil, nil
$ git diff | grep '^+' | grep -v '^+++' | sed 's/^+\s*//' | sort | uniq -c
  50 break
```

Log messages are untouched to keep the diff reviewable — they already report the failure, and rewording 50 of them across files owned by other areas would bury the behavioral change in noise.

`go build`, `go vet`, `gofmt` clean; GCP provider suite passes.
