### PR TITLE
🧹 ms365: fetch Power BI over REST instead of PowerShell

### DIFF
--- a/providers/ms365/README.md
+++ b/providers/ms365/README.md
@@ -11,6 +11,8 @@ __NOTE__
 
 At the moment some of the resources within this provider require the use of PowerShell. Please ensure `pwsh` is in your PATH. For example, `pwsh -c 'Get-Date'` should return a timestamp.
 
+The resources that still need PowerShell are `ms365.exchangeonline`, `ms365.sharepointonline`, `ms365.teams` and `microsoft.security.exchange`. Everything else, including `microsoft.powerbi`, is served directly from the REST APIs and works without `pwsh`.
+
 Also it's recommended that you use certificate based authentication with this provider, especially with the resources that need to use powershell, this is due to the way those cmdlets authenticate.  Certificate auth is more reliable when testing.
 
 ### Mac

--- a/providers/ms365/resources/powerbi.go
+++ b/providers/ms365/resources/powerbi.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/rs/zerolog/log"
@@ -44,7 +45,19 @@ const (
 	// powerBiMaxPages bounds continuation following so a service that keeps
 	// handing back a link cannot spin forever.
 	powerBiMaxPages = 512
+
+	// powerBiHTTPTimeout bounds a single request. powerBiMaxPages caps how many
+	// requests a walk makes but says nothing about how long one may hang, and
+	// these requests do not go through an SDK pipeline that would impose a
+	// deadline of its own. Without it a stalled connection blocks the section
+	// forever, and the sections are collected concurrently, so one hung endpoint
+	// holds the whole report.
+	powerBiHTTPTimeout = 60 * time.Second
 )
+
+// powerBiHTTPClient is shared by the admin API requests so they all get the
+// timeout. http.Client is safe for concurrent use.
+var powerBiHTTPClient = &http.Client{Timeout: powerBiHTTPTimeout}
 
 // powerBiSection is one report section: its payload as raw JSON plus any error
 // captured while collecting it. Each section is collected independently: the
@@ -271,7 +284,7 @@ func powerBiRequest(ctx context.Context, token string, url string) ([]byte, erro
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := powerBiHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/ms365/resources/powerbi.go
+++ b/providers/ms365/resources/powerbi.go
@@ -11,9 +11,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -38,6 +40,10 @@ const (
 	// powerBiWorkspacePageSize is the maximum page size the admin groups
 	// endpoint accepts.
 	powerBiWorkspacePageSize = 5000
+
+	// powerBiMaxPages bounds continuation following so a service that keeps
+	// handing back a link cannot spin forever.
+	powerBiMaxPages = 512
 )
 
 // powerBiSection is one report section: its payload as raw JSON plus any error
@@ -185,21 +191,23 @@ func (r *mqlMicrosoftPowerbi) fetchReport() (*powerBiReportRaw, error) {
 		}
 		return powerBiSection{Data: data}
 	}
-	get := func(url, envelope string) func() (json.RawMessage, error) {
+	get := func(url string, envelope ...string) func() (json.RawMessage, error) {
 		return func() (json.RawMessage, error) {
-			return powerBiGet(ctx, token, url, envelope)
+			return powerBiGet(ctx, token, url, envelope...)
 		}
 	}
 
 	raw := &powerBiReportRaw{
-		TenantSettings: collect(get(fabricTenantSettingsUrl, "tenantSettings")),
+		// the documented envelope is "value"; "tenantSettings" is accepted as a
+		// fallback because that is the name the previous collection looked for
+		TenantSettings: collect(get(fabricTenantSettingsUrl, "value", "tenantSettings")),
 		Workspaces: collect(func() (json.RawMessage, error) {
 			return fetchPowerBiWorkspaces(ctx, token)
 		}),
 		Capacities:     collect(get(powerBiApiBase+"admin/capacities", "value")),
-		PublishedToWeb: collect(get(powerBiApiBase+"admin/widelySharedArtifacts/publishedToWeb", "ArtifactAccessEntities")),
+		PublishedToWeb: collect(get(powerBiApiBase+"admin/widelySharedArtifacts/publishedToWeb", "artifactAccessEntities")),
 		SharedToWholeOrganization: collect(get(powerBiApiBase+"admin/widelySharedArtifacts/linksSharedToWholeOrganization",
-			"ArtifactAccessEntities")),
+			"artifactAccessEntities")),
 	}
 
 	if dump, err := json.Marshal(raw); err == nil {
@@ -209,8 +217,53 @@ func (r *mqlMicrosoftPowerbi) fetchReport() (*powerBiReportRaw, error) {
 }
 
 // powerBiGet issues an authenticated GET and returns the collection named by
-// envelope from the response body.
-func powerBiGet(ctx context.Context, token string, url string, envelope string) (json.RawMessage, error) {
+// envelope, following continuation links so a large collection is not
+// truncated at the service chunk size.
+func powerBiGet(ctx context.Context, token string, url string, envelope ...string) (json.RawMessage, error) {
+	all := []json.RawMessage{}
+	next := url
+	seen := map[string]struct{}{}
+
+	for page := 0; next != ""; page++ {
+		if page >= powerBiMaxPages {
+			return nil, fmt.Errorf("power bi request to %s returned more than %d pages", url, powerBiMaxPages)
+		}
+		// a service that echoes the same continuation would otherwise loop
+		if _, repeated := seen[next]; repeated {
+			return nil, fmt.Errorf("power bi request to %s repeated the same continuation link", url)
+		}
+		seen[next] = struct{}{}
+
+		body, err := powerBiRequest(ctx, token, next)
+		if err != nil {
+			return nil, err
+		}
+
+		raw, err := extractPowerBiEnvelope(body, envelope...)
+		if err != nil {
+			return nil, err
+		}
+		if len(raw) > 0 {
+			var chunk []json.RawMessage
+			if err := json.Unmarshal(raw, &chunk); err != nil {
+				// a single object rather than a collection ends the walk
+				if page == 0 {
+					return raw, nil
+				}
+				return nil, err
+			}
+			all = append(all, chunk...)
+		}
+
+		if next, err = powerBiContinuation(body); err != nil {
+			return nil, err
+		}
+	}
+
+	return json.Marshal(all)
+}
+
+func powerBiRequest(ctx context.Context, token string, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -236,18 +289,56 @@ func powerBiGet(ctx context.Context, token string, url string, envelope string) 
 		return nil, fmt.Errorf("power bi request to %s failed with status %d: %s", url, resp.StatusCode, string(body))
 	}
 
-	return extractPowerBiEnvelope(body, envelope)
+	return body, nil
 }
 
-// extractPowerBiEnvelope pulls the named collection out of a response body. A
-// response that omits the property carries nothing to report, which yields a
-// nil payload rather than an error.
-func extractPowerBiEnvelope(body []byte, envelope string) (json.RawMessage, error) {
+// extractPowerBiEnvelope pulls the first of the named collections out of a
+// response body. Several names are accepted because the endpoints do not agree
+// on one: collections arrive under "value", "artifactAccessEntities" or
+// "tenantSettings" depending on the API.
+//
+// The match is case-insensitive. PowerShell property access was, so a name
+// whose casing differs from the response (the widely-shared-artifacts
+// endpoints answer with "artifactAccessEntities") must still resolve.
+//
+// A response that carries none of the names has nothing to report, which
+// yields a nil payload rather than an error.
+func extractPowerBiEnvelope(body []byte, envelope ...string) (json.RawMessage, error) {
 	var wrapper map[string]json.RawMessage
 	if err := json.Unmarshal(body, &wrapper); err != nil {
 		return nil, err
 	}
-	return wrapper[envelope], nil
+
+	for _, name := range envelope {
+		if raw, ok := wrapper[name]; ok {
+			return raw, nil
+		}
+		for key, raw := range wrapper {
+			if strings.EqualFold(key, name) {
+				return raw, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// powerBiContinuation returns the link to the next chunk, or an empty string
+// when the response is the last one. Both the Power BI admin endpoints and the
+// Fabric admin API chunk their results this way.
+func powerBiContinuation(body []byte) (string, error) {
+	var wrapper struct {
+		ContinuationUri   string `json:"continuationUri"`
+		ContinuationToken string `json:"continuationToken"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		return "", err
+	}
+	// the service hands back a ready-made uri; the token alone is ambiguous to
+	// re-encode, so it only signals that a uri was expected
+	if wrapper.ContinuationUri == "" && wrapper.ContinuationToken != "" {
+		log.Warn().Msg("power bi returned a continuation token without a uri, results may be incomplete")
+	}
+	return wrapper.ContinuationUri, nil
 }
 
 // fetchPowerBiWorkspaces pages the admin groups endpoint so tenants with more

--- a/providers/ms365/resources/powerbi.go
+++ b/providers/ms365/resources/powerbi.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
+	"net/http"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -24,69 +24,27 @@ import (
 
 const (
 	powerbiScope = "https://analysis.windows.net/powerbi/api/.default"
+
+	// powerBiApiBase is the Power BI REST API root. The admin endpoints below
+	// are the same ones the MicrosoftPowerBIMgmt module reaches through
+	// Invoke-PowerBIRestMethod, so the payloads are unchanged.
+	powerBiApiBase = "https://api.powerbi.com/v1.0/myorg/"
+
+	// fabricTenantSettingsUrl serves tenant settings. They live on the Fabric
+	// admin API rather than the Power BI REST API, but accept the same bearer
+	// token.
+	fabricTenantSettingsUrl = "https://api.fabric.microsoft.com/v1/admin/tenantsettings"
+
+	// powerBiWorkspacePageSize is the maximum page size the admin groups
+	// endpoint accepts.
+	powerBiWorkspacePageSize = 5000
 )
 
-// powerbiReport connects to the Power BI service with the tenant credential and
-// dumps the admin endpoints we model as a single JSON document. Each section is
-// collected independently: the Power BI admin REST endpoints and the Fabric
-// admin API have separate authorization requirements, so a permission gap in
-// one section (for example tenant settings) must not blank the others. The
-// PowerShell module emits a connection banner before any output, so the Go side
-// strips everything up to the first '{'.
-var powerbiReport = `
-$ErrorActionPreference = "Stop"
-$pbiToken = '%s'
-
-if (-not (Get-Module -ListAvailable -Name MicrosoftPowerBIMgmt)) {
-  Install-Module -Name MicrosoftPowerBIMgmt -Scope CurrentUser -Force
-}
-Import-Module MicrosoftPowerBIMgmt
-
-Connect-PowerBIServiceAccount -Token $pbiToken | Out-Null
-
-# Tenant settings live on the Fabric admin API, not the Power BI REST API, but
-# accept the same Power BI bearer token.
-$fabricHeaders = @{ Authorization = "Bearer $pbiToken" }
-
-function Get-PbiSection([scriptblock]$call) {
-  try {
-    return [PSCustomObject]@{ data = (& $call); error = $null }
-  } catch {
-    return [PSCustomObject]@{ data = $null; error = $_.Exception.Message }
-  }
-}
-
-# Get-PbiWorkspaces pages the admin groups endpoint (max 5000 per page) so
-# tenants with more than 5000 workspaces are not silently truncated.
-function Get-PbiWorkspaces() {
-  $all = @()
-  $skip = 0
-  while ($true) {
-    $url = 'admin/groups?$top=5000&$expand=users&$skip=' + $skip
-    $page = @((Invoke-PowerBIRestMethod -Url $url -Method Get | ConvertFrom-Json).value)
-    if ($page.Count -eq 0) { break }
-    $all += $page
-    if ($page.Count -lt 5000) { break }
-    $skip += 5000
-  }
-  return $all
-}
-
-$report = [PSCustomObject]@{
-  TenantSettings            = (Get-PbiSection { (Invoke-RestMethod -Uri 'https://api.fabric.microsoft.com/v1/admin/tenantsettings' -Headers $fabricHeaders -Method Get).tenantSettings })
-  Workspaces                = (Get-PbiSection { Get-PbiWorkspaces })
-  Capacities                = (Get-PbiSection { (Invoke-PowerBIRestMethod -Url 'admin/capacities' -Method Get | ConvertFrom-Json).value })
-  PublishedToWeb            = (Get-PbiSection { (Invoke-PowerBIRestMethod -Url 'admin/widelySharedArtifacts/publishedToWeb' -Method Get | ConvertFrom-Json).ArtifactAccessEntities })
-  SharedToWholeOrganization = (Get-PbiSection { (Invoke-PowerBIRestMethod -Url 'admin/widelySharedArtifacts/linksSharedToWholeOrganization' -Method Get | ConvertFrom-Json).ArtifactAccessEntities })
-}
-
-Disconnect-PowerBIServiceAccount | Out-Null
-
-ConvertTo-Json -Depth 8 $report
-`
-
 // powerBiSection is one report section: its payload as raw JSON plus any error
-// PowerShell captured while collecting it. A non-nil error is surfaced by the
+// captured while collecting it. Each section is collected independently: the
+// Power BI admin endpoints and the Fabric admin API have separate authorization
+// requirements, so a permission gap in one section (for example tenant
+// settings) must not blank the others. A non-nil error is surfaced by the
 // section's getter so callers see the real cause (for example missing admin API
 // access) instead of an empty result.
 type powerBiSection struct {
@@ -154,8 +112,9 @@ type powerBiArtifactAccess struct {
 }
 
 // unmarshalPowerBiSection returns the section error when present, otherwise
-// decodes the payload into a slice. PowerShell's ConvertTo-Json collapses a
-// single-element array into a bare object, so both forms are accepted.
+// decodes the payload into a slice. Both the array and the bare-object form are
+// accepted so an endpoint that returns a single object instead of a collection
+// still decodes.
 func unmarshalPowerBiSection[T any](s powerBiSection) ([]T, error) {
 	if s.Error != nil && *s.Error != "" {
 		return nil, errors.New(*s.Error)
@@ -214,42 +173,114 @@ func (r *mqlMicrosoftPowerbi) fetchReport() (*powerBiReportRaw, error) {
 	if err != nil {
 		return nil, err
 	}
+	token := pbiToken.Token
 
-	// The token is interpolated into a single-quoted PowerShell string; double
-	// any single quote so a token value can never break out of the quoting.
-	escapedToken := strings.ReplaceAll(pbiToken.Token, "'", "''")
-	script := fmt.Sprintf(powerbiReport, escapedToken)
-	res, err := conn.CheckAndRunPowershellScript(script)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.ExitStatus != 0 {
-		data, _ := io.ReadAll(res.Stderr)
-		str := strings.ToLower(string(data))
-		if strings.Contains(str, "access denied") || strings.Contains(str, "unauthorized") || strings.Contains(str, "powerbinotlicensed") {
-			return nil, errors.New("access denied; ensure the service principal is granted read-only admin API access in the Power BI tenant settings")
+	// collect runs one section and converts a failure into a section error, so
+	// a permission gap on one endpoint leaves the other sections intact.
+	collect := func(fetch func() (json.RawMessage, error)) powerBiSection {
+		data, err := fetch()
+		if err != nil {
+			msg := err.Error()
+			return powerBiSection{Error: &msg}
 		}
-		return nil, fmt.Errorf("failed to connect to Power BI (exit code %d): %s", res.ExitStatus, string(data))
+		return powerBiSection{Data: data}
+	}
+	get := func(url, envelope string) func() (json.RawMessage, error) {
+		return func() (json.RawMessage, error) {
+			return powerBiGet(ctx, token, url, envelope)
+		}
 	}
 
-	data, err := io.ReadAll(res.Stdout)
-	if err != nil {
-		return nil, err
+	raw := &powerBiReportRaw{
+		TenantSettings: collect(get(fabricTenantSettingsUrl, "tenantSettings")),
+		Workspaces: collect(func() (json.RawMessage, error) {
+			return fetchPowerBiWorkspaces(ctx, token)
+		}),
+		Capacities:     collect(get(powerBiApiBase+"admin/capacities", "value")),
+		PublishedToWeb: collect(get(powerBiApiBase+"admin/widelySharedArtifacts/publishedToWeb", "ArtifactAccessEntities")),
+		SharedToWholeOrganization: collect(get(powerBiApiBase+"admin/widelySharedArtifacts/linksSharedToWholeOrganization",
+			"ArtifactAccessEntities")),
 	}
-	str := string(data)
-	idx := strings.IndexByte(str, '{')
-	if idx == -1 {
-		return nil, errors.New("invalid JSON format in Power BI report")
-	}
-	jsonBytes := []byte(str[idx:])
-	logger.DebugDumpJSON("ms-powerbi-report", string(jsonBytes))
 
-	raw := &powerBiReportRaw{}
-	if err := json.Unmarshal(jsonBytes, raw); err != nil {
-		return nil, err
+	if dump, err := json.Marshal(raw); err == nil {
+		logger.DebugDumpJSON("ms-powerbi-report", string(dump))
 	}
 	return raw, nil
+}
+
+// powerBiGet issues an authenticated GET and returns the collection named by
+// envelope from the response body.
+func powerBiGet(ctx context.Context, token string, url string, envelope string) (json.RawMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, errors.New("access denied; ensure the service principal is granted read-only admin API access in the Power BI tenant settings")
+		}
+		return nil, fmt.Errorf("power bi request to %s failed with status %d: %s", url, resp.StatusCode, string(body))
+	}
+
+	return extractPowerBiEnvelope(body, envelope)
+}
+
+// extractPowerBiEnvelope pulls the named collection out of a response body. A
+// response that omits the property carries nothing to report, which yields a
+// nil payload rather than an error.
+func extractPowerBiEnvelope(body []byte, envelope string) (json.RawMessage, error) {
+	var wrapper map[string]json.RawMessage
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper[envelope], nil
+}
+
+// fetchPowerBiWorkspaces pages the admin groups endpoint so tenants with more
+// than one page of workspaces are not silently truncated.
+func fetchPowerBiWorkspaces(ctx context.Context, token string) (json.RawMessage, error) {
+	return fetchPowerBiWorkspacePages(ctx, token, powerBiApiBase, powerBiWorkspacePageSize)
+}
+
+// fetchPowerBiWorkspacePages walks the admin groups endpoint until a short page
+// signals the end of the collection. The pages are concatenated into a single
+// array so the section decodes like any other.
+func fetchPowerBiWorkspacePages(ctx context.Context, token string, baseUrl string, pageSize int) (json.RawMessage, error) {
+	all := []json.RawMessage{}
+	for skip := 0; ; skip += pageSize {
+		url := fmt.Sprintf("%sadmin/groups?$top=%d&$expand=users&$skip=%d", baseUrl, pageSize, skip)
+		raw, err := powerBiGet(ctx, token, url, "value")
+		if err != nil {
+			return nil, err
+		}
+
+		var page []json.RawMessage
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &page); err != nil {
+				return nil, err
+			}
+		}
+		all = append(all, page...)
+
+		if len(page) < pageSize {
+			break
+		}
+	}
+	return json.Marshal(all)
 }
 
 func (r *mqlMicrosoftPowerbi) tenantSettings() ([]any, error) {

--- a/providers/ms365/resources/powerbi_test.go
+++ b/providers/ms365/resources/powerbi_test.go
@@ -84,6 +84,107 @@ func TestExtractPowerBiEnvelope(t *testing.T) {
 	}
 }
 
+func TestExtractPowerBiEnvelopeIsCaseInsensitive(t *testing.T) {
+	// the widely-shared-artifacts endpoints answer with a lower-case
+	// "artifactAccessEntities". PowerShell property access was case-insensitive,
+	// so a Go map lookup that is not would silently return an empty list.
+	tests := []struct {
+		name     string
+		body     string
+		envelope string
+	}{
+		{name: "documented casing", body: `{"artifactAccessEntities":[{"artifactId":"1"}]}`, envelope: "artifactAccessEntities"},
+		{name: "asking with other casing", body: `{"artifactAccessEntities":[{"artifactId":"1"}]}`, envelope: "ArtifactAccessEntities"},
+		{name: "service using other casing", body: `{"ArtifactAccessEntities":[{"artifactId":"1"}]}`, envelope: "artifactAccessEntities"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw, err := extractPowerBiEnvelope([]byte(test.body), test.envelope)
+			require.NoError(t, err)
+			assert.Equal(t, `[{"artifactId":"1"}]`, string(raw))
+		})
+	}
+}
+
+func TestExtractPowerBiEnvelopeFallbackOrder(t *testing.T) {
+	// tenant settings are documented under "value"; "tenantSettings" is only a
+	// fallback and must not win when both are present
+	body := []byte(`{"value":[{"settingName":"right"}],"tenantSettings":[{"settingName":"wrong"}]}`)
+	raw, err := extractPowerBiEnvelope(body, "value", "tenantSettings")
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "right")
+	assert.NotContains(t, string(raw), "wrong")
+
+	// and the fallback still resolves when the first name is absent
+	raw, err = extractPowerBiEnvelope([]byte(`{"tenantSettings":[{"settingName":"only"}]}`), "value", "tenantSettings")
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "only")
+
+	// none present is an empty result, not an error
+	raw, err = extractPowerBiEnvelope([]byte(`{"@odata.context":"ctx"}`), "value", "tenantSettings")
+	require.NoError(t, err)
+	assert.Empty(t, raw)
+}
+
+func TestPowerBiGetFollowsContinuation(t *testing.T) {
+	// both the Fabric tenant settings endpoint and the widely-shared-artifacts
+	// endpoints chunk their results; taking only the first chunk reports a
+	// partial list as the whole tenant
+	var srv *httptest.Server
+	var calls int
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		switch calls {
+		case 1:
+			fmt.Fprintf(w, `{"value":[{"settingName":"s1"}],"continuationToken":"t1","continuationUri":%q}`, srv.URL+"/chunk2")
+		case 2:
+			fmt.Fprintf(w, `{"value":[{"settingName":"s2"}],"continuationToken":"t2","continuationUri":%q}`, srv.URL+"/chunk3")
+		default:
+			fmt.Fprint(w, `{"value":[{"settingName":"s3"}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	raw, err := powerBiGet(context.Background(), "tok", srv.URL, "value")
+	require.NoError(t, err)
+
+	var got []powerBiTenantSetting
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Len(t, got, 3)
+	assert.Equal(t, "s1", got[0].SettingName)
+	assert.Equal(t, "s3", got[2].SettingName)
+	assert.Equal(t, 3, calls)
+}
+
+func TestPowerBiGetRejectsRepeatedContinuation(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"value":[{"id":"a"}],"continuationUri":%q}`, srv.URL+"/same")
+	}))
+	defer srv.Close()
+
+	_, err := powerBiGet(context.Background(), "tok", srv.URL, "value")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same continuation link")
+}
+
+func TestPowerBiGetStopsWithoutContinuation(t *testing.T) {
+	// a continuation token with no uri cannot be re-encoded reliably, so the
+	// walk stops rather than looping on the same chunk
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		fmt.Fprint(w, `{"value":[{"id":"a"}],"continuationToken":"t1"}`)
+	}))
+	defer srv.Close()
+
+	raw, err := powerBiGet(context.Background(), "tok", srv.URL, "value")
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.JSONEq(t, `[{"id":"a"}]`, string(raw))
+}
+
 func TestPowerBiGet(t *testing.T) {
 	t.Run("sends bearer token and extracts envelope", func(t *testing.T) {
 		var gotAuth, gotAccept string

--- a/providers/ms365/resources/powerbi_test.go
+++ b/providers/ms365/resources/powerbi_test.go
@@ -1,0 +1,323 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPowerBiEnvelope(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		envelope string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "collection under value",
+			body:     `{"@odata.context":"ctx","value":[{"id":"a"},{"id":"b"}]}`,
+			envelope: "value",
+			expected: `[{"id":"a"},{"id":"b"}]`,
+		},
+		{
+			name:     "artifact access entities envelope",
+			body:     `{"ArtifactAccessEntities":[{"artifactId":"1"}]}`,
+			envelope: "ArtifactAccessEntities",
+			expected: `[{"artifactId":"1"}]`,
+		},
+		{
+			name:     "fabric tenant settings envelope",
+			body:     `{"tenantSettings":[{"settingName":"s"}]}`,
+			envelope: "tenantSettings",
+			expected: `[{"settingName":"s"}]`,
+		},
+		{
+			// an endpoint with nothing to report omits the property; that is an
+			// empty result, not a failure
+			name:     "missing envelope yields nil",
+			body:     `{"@odata.context":"ctx"}`,
+			envelope: "value",
+			expected: "",
+		},
+		{
+			name:     "empty collection",
+			body:     `{"value":[]}`,
+			envelope: "value",
+			expected: `[]`,
+		},
+		{
+			name:     "malformed json",
+			body:     `not json`,
+			envelope: "value",
+			wantErr:  true,
+		},
+		{
+			name:     "top level array is not an envelope",
+			body:     `[{"id":"a"}]`,
+			envelope: "value",
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw, err := extractPowerBiEnvelope([]byte(test.body), test.envelope)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, string(raw))
+		})
+	}
+}
+
+func TestPowerBiGet(t *testing.T) {
+	t.Run("sends bearer token and extracts envelope", func(t *testing.T) {
+		var gotAuth, gotAccept string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			gotAccept = r.Header.Get("Accept")
+			fmt.Fprint(w, `{"value":[{"id":"cap-1"}]}`)
+		}))
+		defer srv.Close()
+
+		raw, err := powerBiGet(context.Background(), "tok-123", srv.URL, "value")
+		require.NoError(t, err)
+		assert.Equal(t, `[{"id":"cap-1"}]`, string(raw))
+		assert.Equal(t, "Bearer tok-123", gotAuth)
+		assert.Equal(t, "application/json", gotAccept)
+	})
+
+	// 401 and 403 are the shapes a tenant hits when the service principal is
+	// not allowed on the admin APIs, so both must produce the actionable
+	// message rather than a bare status code
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run("access denied on "+strconv.Itoa(status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				fmt.Fprint(w, `{"error":"PowerBINotLicensed"}`)
+			}))
+			defer srv.Close()
+
+			_, err := powerBiGet(context.Background(), "tok", srv.URL, "value")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "read-only admin API access")
+		})
+	}
+
+	t.Run("other status carries code and body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "backend exploded")
+		}))
+		defer srv.Close()
+
+		_, err := powerBiGet(context.Background(), "tok", srv.URL, "value")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+		assert.Contains(t, err.Error(), "backend exploded")
+	})
+
+	t.Run("malformed success body errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"value":`)
+		}))
+		defer srv.Close()
+
+		_, err := powerBiGet(context.Background(), "tok", srv.URL, "value")
+		require.Error(t, err)
+	})
+
+	t.Run("unreachable host errors", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+
+		_, err := powerBiGet(context.Background(), "tok", url, "value")
+		require.Error(t, err)
+	})
+}
+
+// workspacePageServer serves `total` workspaces through the admin groups
+// endpoint, honouring $top and $skip the way the real API does.
+func workspacePageServer(t *testing.T, total int, requests *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*requests = append(*requests, r.URL.RequestURI())
+
+		top, err := strconv.Atoi(r.URL.Query().Get("$top"))
+		require.NoError(t, err)
+		skip, err := strconv.Atoi(r.URL.Query().Get("$skip"))
+		require.NoError(t, err)
+		assert.Equal(t, "users", r.URL.Query().Get("$expand"))
+
+		items := []string{}
+		for i := skip; i < skip+top && i < total; i++ {
+			items = append(items, fmt.Sprintf(`{"id":"ws-%d"}`, i))
+		}
+		fmt.Fprintf(w, `{"value":[%s]}`, strings.Join(items, ","))
+	}))
+}
+
+func TestFetchPowerBiWorkspacePages(t *testing.T) {
+	// the boundary cases are what a truncation bug hides behind: a tenant whose
+	// workspace count is an exact multiple of the page size only reveals the
+	// bug on the follow-up empty page
+	tests := []struct {
+		name          string
+		total         int
+		pageSize      int
+		wantRequests  int
+		wantWorkspace int
+	}{
+		{name: "no workspaces", total: 0, pageSize: 2, wantRequests: 1, wantWorkspace: 0},
+		{name: "single short page", total: 1, pageSize: 2, wantRequests: 1, wantWorkspace: 1},
+		{name: "exact single page", total: 2, pageSize: 2, wantRequests: 2, wantWorkspace: 2},
+		{name: "spills to second page", total: 3, pageSize: 2, wantRequests: 2, wantWorkspace: 3},
+		{name: "exact two pages", total: 4, pageSize: 2, wantRequests: 3, wantWorkspace: 4},
+		{name: "many pages", total: 11, pageSize: 2, wantRequests: 6, wantWorkspace: 11},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var requests []string
+			srv := workspacePageServer(t, test.total, &requests)
+			defer srv.Close()
+
+			raw, err := fetchPowerBiWorkspacePages(context.Background(), "tok", srv.URL+"/", test.pageSize)
+			require.NoError(t, err)
+
+			var got []powerBiWorkspace
+			require.NoError(t, json.Unmarshal(raw, &got))
+			assert.Len(t, got, test.wantWorkspace)
+			assert.Len(t, requests, test.wantRequests)
+
+			// every workspace is present exactly once and in order
+			for i := range got {
+				assert.Equal(t, fmt.Sprintf("ws-%d", i), got[i].Id)
+			}
+		})
+	}
+}
+
+func TestFetchPowerBiWorkspacePagesRequestShape(t *testing.T) {
+	var requests []string
+	srv := workspacePageServer(t, 3, &requests)
+	defer srv.Close()
+
+	_, err := fetchPowerBiWorkspacePages(context.Background(), "tok", srv.URL+"/", 2)
+	require.NoError(t, err)
+
+	require.Len(t, requests, 2)
+	assert.Contains(t, requests[0], "admin/groups")
+	assert.Contains(t, requests[0], "$skip=0")
+	assert.Contains(t, requests[1], "$skip=2")
+}
+
+func TestFetchPowerBiWorkspacePagesPropagatesError(t *testing.T) {
+	// a failure on a later page must not silently return the pages already
+	// collected, which would report a partial workspace list as complete
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if page > 0 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		page++
+		fmt.Fprint(w, `{"value":[{"id":"ws-0"},{"id":"ws-1"}]}`)
+	}))
+	defer srv.Close()
+
+	_, err := fetchPowerBiWorkspacePages(context.Background(), "tok", srv.URL+"/", 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read-only admin API access")
+}
+
+func TestUnmarshalPowerBiSection(t *testing.T) {
+	t.Run("section error takes precedence", func(t *testing.T) {
+		msg := "insufficient privileges"
+		_, err := unmarshalPowerBiSection[powerBiCapacity](powerBiSection{
+			Data:  json.RawMessage(`[{"id":"c1"}]`),
+			Error: &msg,
+		})
+		require.Error(t, err)
+		assert.Equal(t, msg, err.Error())
+	})
+
+	t.Run("empty error string is not an error", func(t *testing.T) {
+		empty := ""
+		out, err := unmarshalPowerBiSection[powerBiCapacity](powerBiSection{
+			Data:  json.RawMessage(`[{"id":"c1"}]`),
+			Error: &empty,
+		})
+		require.NoError(t, err)
+		assert.Len(t, out, 1)
+	})
+
+	t.Run("nil payload", func(t *testing.T) {
+		out, err := unmarshalPowerBiSection[powerBiCapacity](powerBiSection{})
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("json null payload", func(t *testing.T) {
+		out, err := unmarshalPowerBiSection[powerBiCapacity](powerBiSection{Data: json.RawMessage(`null`)})
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("array payload", func(t *testing.T) {
+		out, err := unmarshalPowerBiSection[powerBiCapacity](powerBiSection{
+			Data: json.RawMessage(`[{"id":"c1","sku":"A1"},{"id":"c2","sku":"A2"}]`),
+		})
+		require.NoError(t, err)
+		require.Len(t, out, 2)
+		assert.Equal(t, "c1", out[0].Id)
+		assert.Equal(t, "A2", out[1].Sku)
+	})
+
+	t.Run("bare object payload", func(t *testing.T) {
+		out, err := unmarshalPowerBiSection[powerBiCapacity](powerBiSection{
+			Data: json.RawMessage(`{"id":"c1","sku":"A1"}`),
+		})
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "c1", out[0].Id)
+	})
+
+	t.Run("decode failure surfaces", func(t *testing.T) {
+		_, err := unmarshalPowerBiSection[powerBiCapacity](powerBiSection{
+			Data: json.RawMessage(`{"id":`),
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestPowerBiWorkspaceDecodesUsers(t *testing.T) {
+	// $expand=users nests the access list inside each workspace; losing it
+	// would blank microsoft.powerbi.workspace.users without any error
+	raw := `[{"id":"ws-1","name":"Finance","isOnDedicatedCapacity":true,"capacityId":"cap-1",
+	  "users":[{"emailAddress":"a@contoso.com","groupUserAccessRight":"Admin","principalType":"User"}]}]`
+
+	out, err := unmarshalPowerBiSection[powerBiWorkspace](powerBiSection{Data: json.RawMessage(raw)})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "Finance", out[0].Name)
+	assert.True(t, out[0].IsOnDedicatedCapacity)
+	assert.Equal(t, "cap-1", out[0].CapacityId)
+	require.Len(t, out[0].Users, 1)
+	assert.Equal(t, "Admin", out[0].Users[0].GroupUserAccessRight)
+}


### PR DESCRIPTION
## What

Replaces the PowerShell collection behind `microsoft.powerbi` with direct calls to the Power BI and Fabric admin REST APIs, and fixes three envelope/pagination defects found while checking those endpoints against the REST reference.

## Why

The Power BI script never used a cmdlet that did any real work. Every section was already an `Invoke-PowerBIRestMethod` or `Invoke-RestMethod` call:

```powershell
Capacities = (Invoke-PowerBIRestMethod -Url 'admin/capacities' -Method Get | ConvertFrom-Json).value
```

`Invoke-PowerBIRestMethod -Url 'admin/capacities'` is `GET https://api.powerbi.com/v1.0/myorg/admin/capacities`. So `MicrosoftPowerBIMgmt` was acting as an HTTP client for a bearer token we already acquire in Go (`powerbiScope`), at the cost of a `pwsh` dependency, a PowerShell Gallery module install, and a `ConvertTo-Json` round-trip.

## Endpoints called

| Section | Endpoint | Envelope |
|---|---|---|
| `tenantSettings` | `https://api.fabric.microsoft.com/v1/admin/tenantsettings` | `value` |
| `workspaces` | `admin/groups?$top=5000&$expand=users&$skip=N` | `value` |
| `capacities` | `admin/capacities` | `value` |
| `publishedToWeb` | `admin/widelySharedArtifacts/publishedToWeb` | `artifactAccessEntities` |
| `sharedToWholeOrganization` | `admin/widelySharedArtifacts/linksSharedToWholeOrganization` | `artifactAccessEntities` |

All five are on Microsoft's [documented read-only admin API list](https://learn.microsoft.com/fabric/admin/enable-service-principal-admin-apis) with service-principal support.

## Bugs fixed

Second commit. These are worth reading as the substantive part of the PR:

1. **`tenantSettings` read the wrong envelope.** The [Fabric reference](https://learn.microsoft.com/rest/api/fabric/admin/tenants/list-tenant-settings) returns the collection under **`value`**; the PowerShell script asked for `.tenantSettings`, a name that appears only *nested* inside `delegatedTenantSettingOverrides`. `microsoft.powerbi.tenantSettings` has therefore been returning nothing. Now reads `value`, with `tenantSettings` kept as a fallback.

2. **Envelope matching had to be case-insensitive.** The [widely-shared-artifacts reference](https://learn.microsoft.com/en-us/rest/api/power-bi/admin/widely-shared-artifacts-published-to-web) shows `artifactAccessEntities` (lower-case `a`), while the script asked for `ArtifactAccessEntities`. PowerShell property access is case-insensitive so it worked; a Go map lookup is not. Caught before merge — a naive port would have regressed both artifact lists to empty. Matching now behaves the way the code it replaces did.

3. **Three endpoints were truncating.** Tenant settings and both widely-shared-artifacts endpoints chunk results and return a `continuationUri`; only the first chunk was ever read. Continuation links are now followed, with repeat-link and page-count guards. `admin/capacities` is genuinely unpaginated and the `admin/groups` `$top`/`$skip` loop was already correct.

## Backwards compatibility

- **No schema change.** No `.lr` edit, so no `.lr.versions` entries.
- **No permission change.** Same token, same scope, same endpoints, same "Service principals can access read-only admin APIs" tenant setting.
- **Same payloads.** The module returned the API's JSON verbatim, so every `microsoft.powerbi.*` field keeps its shape and property names. The `powerBiSection` / `powerBiReportRaw` types and all five getters are untouched.
- **Same error isolation.** A permission gap on one endpoint still surfaces on that section's getter instead of blanking the report — previously via PowerShell `try`/`catch`, now via a per-request error captured into the same section struct. 401/403 still map to the actionable "grant read-only admin API access" message.

The fixes do change output, in the direction of correctness only: `tenantSettings` goes from empty to populated, and the two artifact lists go from first-chunk to complete. Nothing that returned data before returns different data.

## What this removes

Three workarounds that existed only to cope with PowerShell: stripping the connection banner with `strings.IndexByte(str, '{')`; doubling single quotes in the bearer token so it could not escape a single-quoted string; and accepting a bare object where `ConvertTo-Json` collapsed a single-element array.

`microsoft.powerbi` no longer requires `pwsh`. `ms365.exchangeonline`, `ms365.sharepointonline`, `ms365.teams` and `microsoft.security.exchange` still do — README updated to say which. (#9594 moves Exchange off it.)

## Tests

New `powerbi_test.go`, 41 subtests:

- `extractPowerBiEnvelope` — the three envelope keys, **case-insensitive matching in both directions** (the regression above), fallback ordering so `value` beats `tenantSettings` when both are present, a missing envelope as an empty result rather than an error, malformed bodies
- `powerBiGet` — bearer/accept headers, envelope extraction, **continuation following across three chunks**, repeat-link rejection, a token-without-uri stopping rather than looping, 401 and 403 both mapping to the access-denied message, other statuses carrying code and body, unreachable host
- `fetchPowerBiWorkspacePages` — paging boundaries including the exact-multiple cases (`total == pageSize`, `total == 2*pageSize`) where an off-by-one silently truncates, request shape (`$top`/`$skip`/`$expand`), and error propagation on a later page so a partial list is never reported as complete
- `unmarshalPowerBiSection` — section error precedence, nil/null payloads, array and bare-object forms, decode failures
- workspace decoding with `$expand=users` nested access lists

## Verification

- `go build ./...` clean
- `go test ./resources/` passes
- `gofmt` clean, `go mod tidy` no-op (stdlib only, no new dependencies)

Live verification is still owed and will be batched with #9594. Note that the `tenantSettings` fix in particular has never been exercised against a tenant with admin-API access enabled, so that section is the one to watch.

## Follow-ups not taken here

- `TenantSetting` has six unmodeled fields, all security-relevant: `excludedSecurityGroups` (which inverts the meaning of an "enabled" setting), `properties[]`, `delegateToCapacity`, `delegateToDomain`, `delegateToWorkspace`. Adding them is a `.lr` change and belongs in its own PR.
- The Fabric endpoint is called with the `analysis.windows.net/powerbi/api` token on the assumption of identifier-URI aliasing. That is unchanged from today's behaviour, but a Fabric-scoped token would be the safer form if it ever 401s.
