### PR TITLE
✨ azure: bump Front Door and management groups SDKs to v2 and expose new WAF settings

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault/v2 v2.0.2
@@ -39,7 +39,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -104,8 +104,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0/go.mod h1:NOM/LtCJfoU69VkmxPxV6PMxDm/MsOvmsao/5V5Rhgs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0 h1:4hGvxD72TluuFIXVr8f4XkKZfqAa7Pj61t0jmQ7+kes=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0/go.mod h1:TSH7DcFItwAufy0Lz+Ft2cyopExCpxbOxI5SkH4dRNo=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0 h1:dz5II+dFuMkrdpIkO9f/Ht3f8hnRUURiQdLj1hwKO5Q=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0/go.mod h1:0tuwjeZbMwLV7h1bcyfTlnXUH6GBKkPml8ukX6EoS3o=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor/v2 v2.0.0 h1:hllt77imY438iao+x/FatjViqGMq9JUuCrlq6+sLxgk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor/v2 v2.0.0/go.mod h1:oSOL1euXyQO4Cp3x4cr3G40q3NCd80zn46XNEfac2CU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0 h1:VvSZmyJEBvdzQXbs1Ued+iaapfSze5+rawR0EFFzyVw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0/go.mod h1:6BoXNi4OfvyyIdP4vl4fEGt8CWHFFDMHgiUtNLHl1/0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
@@ -124,8 +124,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachine
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0/go.mod h1:nivJvZio5SHpEASAk8LKIueqs7zEHU+iRLKWbx3Xi10=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0 h1:dwmV8G0tLD17J+LcTirpFmNKvZBLLuErtGR0h6h8n2c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0/go.mod h1:UmV8UnyCQ+05EvopWqF6CQsFWI5FWcp/AXGVkJguv9E=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 h1:akP6VpxJGgQRpDR1P462piz/8OhYLRCreDj48AyNabc=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0/go.mod h1:8wzvopPfyZYPaQUoKW87Zfdul7jmJMDfp/k7YY3oJyA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups/v2 v2.0.0 h1:cS5VjOdxqyldaMld1AGGbVQ8gobVgcXoHT/Zwucl88E=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups/v2 v2.0.0/go.mod h1:D+hzHqoUiFABfnTuCvm3Dn5MQ1eW1NVQDvjQ6mABnNQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.2.0 h1:CRwl8O5YMdbQQ1MJ2ojHtTxaqesztdoBfFFcYVfv+Nc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.2.0/go.mod h1:3AVoXQskcMH6BK+RamT0WKc6x3HJxvm05J3N61hOySs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.13.0 h1:c7r8eBbYWf2JbQFinuEbHsqq+ukY1tVIgAxt0uND2Fo=

--- a/providers/azure/resources/azure.go
+++ b/providers/azure/resources/azure.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"sync"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups/v2"
 )
 
 // TODO: we should look into restructuring resources for v11.

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -13695,10 +13695,21 @@ azure.subscription.frontDoorService.wafPolicy @defaults("name mode enabled sku")
   requestBodyCheck bool
   // Status code returned when the policy blocks a request
   customBlockResponseStatusCode int
+  // Response body returned when the policy blocks a request
+  //
+  // Base64-encoded, as Azure stores it. Empty when the policy returns the
+  // default block page instead of an authored one.
+  customBlockResponseBody string
   // URL clients are redirected to when a rule's action is redirect
   redirectUrl string
   // JavaScript challenge cookie lifetime, in minutes (Premium tier)
   javascriptChallengeExpirationInMinutes int
+  // CAPTCHA cookie lifetime, in minutes (Premium tier)
+  //
+  // How long a client stays exempt after solving a CAPTCHA challenge. A
+  // long lifetime widens the window in which a solved challenge can be
+  // replayed from a stolen cookie.
+  captchaExpirationInMinutes int
   // Log scrubbing state, which removes matched fields from firewall logs
   //
   // One of "Enabled" or "Disabled", or empty when no scrubbing is
@@ -13796,9 +13807,16 @@ private azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOv
   enabledState string
   // Action that replaces the rule's own when it matches
   //
-  // One of "Allow", "Block", "Log", "Redirect", or "AnomalyScoring", or
-  // empty to keep the rule's own action.
+  // One of "Allow", "Block", "Log", "Redirect", "AnomalyScoring",
+  // "CAPTCHA", or "JSChallenge", or empty to keep the rule's own action.
   action string
+  // Detection sensitivity applied to the rule
+  //
+  // One of "High", "Medium", or "Low", or empty to keep the rule's own
+  // default. A higher sensitivity trips the rule on smaller traffic
+  // spikes, so an override that lowers it weakens the rule while
+  // enabledState still reports "Enabled".
+  sensitivity string
   // Request parts excluded from this rule only
   exclusions []dict
 }
@@ -13820,9 +13838,9 @@ private azure.subscription.frontDoorService.wafPolicy.customRule @defaults("name
   ruleType string
   // Action taken when every match condition holds
   //
-  // One of "Allow", "Block", "Log", "Redirect", or "AnomalyScoring". An
-  // "Allow" rule short-circuits the managed rule sets for matching
-  // requests.
+  // One of "Allow", "Block", "Log", "Redirect", "AnomalyScoring",
+  // "CAPTCHA", or "JSChallenge". An "Allow" rule short-circuits the
+  // managed rule sets for matching requests.
   action string
   // Whether the rule is evaluated
   //
@@ -13861,7 +13879,8 @@ private azure.subscription.frontDoorService.wafPolicy.customRule.matchCondition 
   //
   // One of "Any", "IPMatch", "GeoMatch", "Equal", "Contains",
   // "LessThan", "GreaterThan", "LessThanOrEqual", "GreaterThanOrEqual",
-  // "BeginsWith", "EndsWith", or "RegEx". "Any" matches unconditionally.
+  // "BeginsWith", "EndsWith", "RegEx", or "ServiceTagMatch". "Any"
+  // matches unconditionally.
   operator string
   // Whether the condition's result is inverted
   negate bool

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -16721,11 +16721,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.frontDoorService.wafPolicy.customBlockResponseStatusCode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).GetCustomBlockResponseStatusCode()).ToDataRes(types.Int)
 	},
+	"azure.subscription.frontDoorService.wafPolicy.customBlockResponseBody": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).GetCustomBlockResponseBody()).ToDataRes(types.String)
+	},
 	"azure.subscription.frontDoorService.wafPolicy.redirectUrl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).GetRedirectUrl()).ToDataRes(types.String)
 	},
 	"azure.subscription.frontDoorService.wafPolicy.javascriptChallengeExpirationInMinutes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).GetJavascriptChallengeExpirationInMinutes()).ToDataRes(types.Int)
+	},
+	"azure.subscription.frontDoorService.wafPolicy.captchaExpirationInMinutes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).GetCaptchaExpirationInMinutes()).ToDataRes(types.Int)
 	},
 	"azure.subscription.frontDoorService.wafPolicy.logScrubbingState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).GetLogScrubbingState()).ToDataRes(types.String)
@@ -16789,6 +16795,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.action": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule).GetAction()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.sensitivity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule).GetSensitivity()).ToDataRes(types.String)
 	},
 	"azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.exclusions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule).GetExclusions()).ToDataRes(types.Array(types.Dict))
@@ -40787,12 +40796,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).CustomBlockResponseStatusCode, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.frontDoorService.wafPolicy.customBlockResponseBody": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).CustomBlockResponseBody, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.frontDoorService.wafPolicy.redirectUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).RedirectUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.wafPolicy.javascriptChallengeExpirationInMinutes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).JavascriptChallengeExpirationInMinutes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.wafPolicy.captchaExpirationInMinutes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicy).CaptchaExpirationInMinutes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.wafPolicy.logScrubbingState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40889,6 +40906,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.action": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule).Action, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.sensitivity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule).Sensitivity, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.exclusions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -96286,8 +96307,10 @@ type mqlAzureSubscriptionFrontDoorServiceWafPolicy struct {
 	Enabled                                plugin.TValue[bool]
 	RequestBodyCheck                       plugin.TValue[bool]
 	CustomBlockResponseStatusCode          plugin.TValue[int64]
+	CustomBlockResponseBody                plugin.TValue[string]
 	RedirectUrl                            plugin.TValue[string]
 	JavascriptChallengeExpirationInMinutes plugin.TValue[int64]
+	CaptchaExpirationInMinutes             plugin.TValue[int64]
 	LogScrubbingState                      plugin.TValue[string]
 	LogScrubbingRules                      plugin.TValue[[]any]
 	ProvisioningState                      plugin.TValue[string]
@@ -96367,12 +96390,20 @@ func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicy) GetCustomBlockResponseSt
 	return &c.CustomBlockResponseStatusCode
 }
 
+func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicy) GetCustomBlockResponseBody() *plugin.TValue[string] {
+	return &c.CustomBlockResponseBody
+}
+
 func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicy) GetRedirectUrl() *plugin.TValue[string] {
 	return &c.RedirectUrl
 }
 
 func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicy) GetJavascriptChallengeExpirationInMinutes() *plugin.TValue[int64] {
 	return &c.JavascriptChallengeExpirationInMinutes
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicy) GetCaptchaExpirationInMinutes() *plugin.TValue[int64] {
+	return &c.CaptchaExpirationInMinutes
 }
 
 func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicy) GetLogScrubbingState() *plugin.TValue[string] {
@@ -96590,6 +96621,7 @@ type mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrid
 	RuleId       plugin.TValue[string]
 	EnabledState plugin.TValue[string]
 	Action       plugin.TValue[string]
+	Sensitivity  plugin.TValue[string]
 	Exclusions   plugin.TValue[[]any]
 }
 
@@ -96635,6 +96667,10 @@ func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOve
 
 func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule) GetAction() *plugin.TValue[string] {
 	return &c.Action
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule) GetSensitivity() *plugin.TValue[string] {
+	return &c.Sensitivity
 }
 
 func (c *mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOverrideRule) GetExclusions() *plugin.TValue[[]any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2598,6 +2598,8 @@ azure.subscription.frontDoorService.profiles 13.3.3
 azure.subscription.frontDoorService.subscriptionId 13.3.3
 azure.subscription.frontDoorService.wafPolicies 13.33.8
 azure.subscription.frontDoorService.wafPolicy 13.33.8
+azure.subscription.frontDoorService.wafPolicy.captchaExpirationInMinutes 13.33.8
+azure.subscription.frontDoorService.wafPolicy.customBlockResponseBody 13.33.8
 azure.subscription.frontDoorService.wafPolicy.customBlockResponseStatusCode 13.33.8
 azure.subscription.frontDoorService.wafPolicy.customRule 13.33.8
 azure.subscription.frontDoorService.wafPolicy.customRule.action 13.33.8
@@ -2634,6 +2636,7 @@ azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.r
 azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.enabledState 13.33.8
 azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.exclusions 13.33.8
 azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.ruleId 13.33.8
+azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rule.sensitivity 13.33.8
 azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.ruleGroupName 13.33.8
 azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverride.rules 13.33.8
 azure.subscription.frontDoorService.wafPolicy.managedRuleSet.ruleGroupOverrides 13.33.8

--- a/providers/azure/resources/frontdoor_waf.go
+++ b/providers/azure/resources/frontdoor_waf.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/frontdoor_waf.go
+++ b/providers/azure/resources/frontdoor_waf.go
@@ -146,10 +146,10 @@ func frontDoorWafPolicyToMql(runtime *plugin.Runtime, policy armfrontdoor.WebApp
 		sku = string(convert.ToValue(policy.SKU.Name))
 	}
 
-	var mode, redirectURL, logScrubbingState, provisioningState, resourceState string
+	var mode, redirectURL, customBlockResponseBody, logScrubbingState, provisioningState, resourceState string
 	enabled := true
 	requestBodyCheck := false
-	var customBlockResponseStatusCode, jsChallengeExpiration *int64
+	var customBlockResponseStatusCode, jsChallengeExpiration, captchaExpiration *int64
 	logScrubbingRules := []any{}
 
 	if props := policy.Properties; props != nil {
@@ -165,6 +165,7 @@ func frontDoorWafPolicyToMql(runtime *plugin.Runtime, policy armfrontdoor.WebApp
 			// Likewise the request body check defaults to Enabled.
 			requestBodyCheck = ps.RequestBodyCheck == nil || *ps.RequestBodyCheck == armfrontdoor.PolicyRequestBodyCheckEnabled
 			redirectURL = convert.ToValue(ps.RedirectURL)
+			customBlockResponseBody = convert.ToValue(ps.CustomBlockResponseBody)
 			if ps.CustomBlockResponseStatusCode != nil {
 				v := int64(*ps.CustomBlockResponseStatusCode)
 				customBlockResponseStatusCode = &v
@@ -172,6 +173,10 @@ func frontDoorWafPolicyToMql(runtime *plugin.Runtime, policy armfrontdoor.WebApp
 			if ps.JavascriptChallengeExpirationInMinutes != nil {
 				v := int64(*ps.JavascriptChallengeExpirationInMinutes)
 				jsChallengeExpiration = &v
+			}
+			if ps.CaptchaExpirationInMinutes != nil {
+				v := int64(*ps.CaptchaExpirationInMinutes)
+				captchaExpiration = &v
 			}
 			if ls := ps.LogScrubbing; ls != nil {
 				logScrubbingState = string(convert.ToValue(ls.State))
@@ -217,8 +222,10 @@ func frontDoorWafPolicyToMql(runtime *plugin.Runtime, policy armfrontdoor.WebApp
 			"enabled":                                llx.BoolData(enabled),
 			"requestBodyCheck":                       llx.BoolData(requestBodyCheck),
 			"customBlockResponseStatusCode":          llx.IntDataPtr(customBlockResponseStatusCode),
+			"customBlockResponseBody":                llx.StringData(customBlockResponseBody),
 			"redirectUrl":                            llx.StringData(redirectURL),
 			"javascriptChallengeExpirationInMinutes": llx.IntDataPtr(jsChallengeExpiration),
+			"captchaExpirationInMinutes":             llx.IntDataPtr(captchaExpiration),
 			"logScrubbingState":                      llx.StringData(logScrubbingState),
 			"logScrubbingRules":                      llx.ArrayData(logScrubbingRules, types.Dict),
 			"provisioningState":                      llx.StringData(provisioningState),
@@ -342,6 +349,7 @@ func (a *mqlAzureSubscriptionFrontDoorServiceWafPolicyManagedRuleSetRuleGroupOve
 				"ruleId":       llx.StringData(ruleID),
 				"enabledState": llx.StringData(string(convert.ToValue(rule.EnabledState))),
 				"action":       llx.StringData(string(convert.ToValue(rule.Action))),
+				"sensitivity":  llx.StringData(string(convert.ToValue(rule.Sensitivity))),
 				"exclusions":   llx.ArrayData(exclusions, types.Dict),
 			})
 		if err != nil {

--- a/providers/azure/resources/managementgroups.go
+++ b/providers/azure/resources/managementgroups.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	authorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups/v2"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/azure/resources/managementgroups_test.go
+++ b/providers/azure/resources/managementgroups_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups/v2"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Two commits: a stable-only Azure SDK dependency sweep, then the schema additions that sweep unlocked.

## 1. Dependency sweep

All 71 `github.com/Azure/...` and `github.com/AzureAD/...` dependencies in `providers/azure/go.mod` were probed against the module proxy. 48 were already current; 21 have a newer major published only as a beta or pseudo-version and were left alone. Two stable upgrades applied:

| Module | From | To |
|---|---|---|
| `managementgroups/armmanagementgroups` | `v1.2.0` | `/v2` `v2.0.0` |
| `frontdoor/armfrontdoor` | `v1.4.0` | `/v2` `v2.0.0` |

Both majors are the same Azure SDK change: a regeneration onto the modern codegen that deletes the hand-rolled `*ListResult`, `*UpdateParameters`, and `Error*` scaffolding structs and adds `SystemData`.

**No breaking change reaches this provider.** All 26 symbols removed across the two CHANGELOGs were checked against `providers/azure` and none are referenced. Neither module has a silent (non-compile-visible) break: no date field changing from `*string` to `*time.Time`, no capacity enum narrowing to `int32`, no `Identity` to `ManagedServiceIdentity` rename, no operation flipping from sync to LRO. The only call-site change is the `/v2` import path suffix in four files.

## 2. New Front Door WAF fields

| Field | Notes |
|---|---|
| `wafPolicy.captchaExpirationInMinutes` | New in armfrontdoor v2. Sibling of the existing `javascriptChallengeExpirationInMinutes`. |
| `...managedRuleSet.ruleGroupOverride.rule.sensitivity` | New in armfrontdoor v2. `High` / `Medium` / `Low`. |
| `wafPolicy.customBlockResponseBody` | Predates the bump; was the last unexposed `PolicySettings` field. |

`sensitivity` is the one worth calling out. It decides how large a traffic spike has to be before a managed rule trips, so an override that lowers it weakens the rule while `enabledState` still reports `"Enabled"` and `action` is unchanged. Nothing else in the schema surfaced that, which makes it a blind spot for any check reading only the enabled state.

All three fields ride responses the provider already fetches, so `azure.permissions.json` is unchanged at 330 permissions and no new API call is introduced.

## 3. Enum documentation corrections

Three `.lr` enum lists were under-reporting valid values. Doc-only, no schema or version change:

- `wafPolicy.customRule.action` and `...ruleGroupOverride.rule.action` were missing **`CAPTCHA`** (added in v2) and **`JSChallenge`** (absent since the fields were written).
- `wafPolicy.customRule.matchCondition.operator` was missing **`ServiceTagMatch`**.

`JSChallenge` is not in either CHANGELOG; it surfaced from reading `constants.go` directly rather than trusting the release delta.

## Not included

The provider's `Version` in `config/config.go` is untouched, per the release flow.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes across the whole provider
- [x] `gofmt -l` clean on all changed files
- [x] `make providers/build/azure` reports `330 permissions (unchanged)`
- [x] Codegen re-run; `azure.lr.versions` gains exactly the 3 new field entries, all at `13.33.8` (next patch after the provider's current `13.33.7`)

Not yet exercised against live Azure infrastructure; the three new fields need a Premium Front Door policy with a CAPTCHA action and a sensitivity override to observe non-empty.
