### PR TITLE
🧹 ms365: fetch Exchange Online over REST, keep PowerShell as fallback

### DIFF
--- a/providers/ms365/resources/exchange_restapi.go
+++ b/providers/ms365/resources/exchange_restapi.go
@@ -1,0 +1,545 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+const (
+	// exchangeAdminApiHost serves Exchange Online cmdlets. It is the host the
+	// ExchangeOnlineManagement module connects to, and it accepts the token this
+	// provider already acquires for outlookScope.
+	//
+	// Security & Compliance cmdlets are deliberately not served from here. That
+	// workload sits behind a per-tenant regional host that has to be discovered
+	// through a redirect before any cmdlet can run, so it stays on PowerShell.
+	exchangeAdminApiHost = "https://outlook.office365.com"
+
+	// exchangeSystemMailboxGuid is the organization system mailbox. The value is
+	// the same in every organization and is the routing key app-only callers use
+	// for operations that do not target a specific mailbox.
+	exchangeSystemMailboxGuid = "bb558c35-97f1-4cb9-8ff7-d53741dc928c"
+
+	// exchangeMaxPages bounds nextLink following so a service that keeps
+	// handing back a continuation cannot spin forever.
+	exchangeMaxPages = 512
+)
+
+// exchangeRestClient runs Exchange Online and Security & Compliance cmdlets
+// over HTTPS instead of through a PowerShell session. Since EXO V3 every cmdlet
+// is served by this endpoint and the module is only a client for it, so the
+// rows returned here are the same objects the cmdlets emit, with their property
+// names unchanged.
+type exchangeRestClient struct {
+	host         string
+	tenantId     string
+	organization string
+	token        string
+	httpClient   *http.Client
+}
+
+func newExchangeRestClient(host string, tenantId string, organization string, token string) *exchangeRestClient {
+	return &exchangeRestClient{
+		host:         host,
+		tenantId:     tenantId,
+		organization: organization,
+		token:        token,
+		httpClient:   http.DefaultClient,
+	}
+}
+
+type exchangeCmdletInput struct {
+	CmdletName string         `json:"CmdletName"`
+	Parameters map[string]any `json:"Parameters,omitempty"`
+}
+
+type exchangeCmdletRequest struct {
+	CmdletInput exchangeCmdletInput `json:"CmdletInput"`
+}
+
+type exchangeCmdletResponse struct {
+	Value    []json.RawMessage `json:"value"`
+	NextLink string            `json:"@odata.nextLink"`
+}
+
+// anchorMailbox is the routing hint the service uses to reach the right backend.
+// App-only callers with no specific mailbox target address the organization
+// system mailbox.
+func (c *exchangeRestClient) anchorMailbox() string {
+	return fmt.Sprintf("APP:SystemMailbox{%s}@%s", exchangeSystemMailboxGuid, c.organization)
+}
+
+func (c *exchangeRestClient) invokeUrl(selects []string) string {
+	u := fmt.Sprintf("%s/adminapi/beta/%s/InvokeCommand", c.host, c.tenantId)
+	if len(selects) > 0 {
+		u += "?$select=" + url.QueryEscape(strings.Join(selects, ","))
+	}
+	return u
+}
+
+// invoke runs one cmdlet and returns every row it produced. Results that arrive
+// in pages are followed through @odata.nextLink so a large collection is never
+// silently truncated at the service page limit.
+func (c *exchangeRestClient) invoke(ctx context.Context, cmdlet string, params map[string]any, selects ...string) ([]json.RawMessage, error) {
+	body, err := json.Marshal(exchangeCmdletRequest{
+		CmdletInput: exchangeCmdletInput{CmdletName: cmdlet, Parameters: params},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	rows := []json.RawMessage{}
+	next := c.invokeUrl(selects)
+	seen := map[string]struct{}{}
+
+	for page := 0; next != ""; page++ {
+		if page >= exchangeMaxPages {
+			return nil, fmt.Errorf("%s returned more than %d pages", cmdlet, exchangeMaxPages)
+		}
+		// a service that echoes the same continuation would otherwise loop
+		if _, repeated := seen[next]; repeated {
+			return nil, fmt.Errorf("%s repeated the same continuation link", cmdlet)
+		}
+		seen[next] = struct{}{}
+
+		resp, err := c.post(ctx, next, body, cmdlet)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, resp.Value...)
+		next = resp.NextLink
+	}
+
+	return rows, nil
+}
+
+func (c *exchangeRestClient) post(ctx context.Context, url string, body []byte, cmdlet string) (*exchangeCmdletResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-AnchorMailbox", c.anchorMailbox())
+	// ask for the largest page the service serves, so a big collection costs
+	// fewer round trips
+	req.Header.Set("Prefer", "odata.maxpagesize=1000")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("access denied running %s, please ensure the credentials have the right permissions and Exchange RBAC roles (status %d)", cmdlet, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("%s failed with status %d: %s", cmdlet, resp.StatusCode, string(raw))
+	}
+
+	out := &exchangeCmdletResponse{}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return nil, fmt.Errorf("cannot decode %s response: %w", cmdlet, err)
+	}
+	return out, nil
+}
+
+// decodeRows decodes cmdlet rows into a typed slice. An empty result decodes to
+// an empty (non-nil) slice, which is how a cmdlet that ran but matched nothing
+// is represented.
+func decodeRows[T any](rows []json.RawMessage) ([]T, error) {
+	out := make([]T, 0, len(rows))
+	for _, row := range rows {
+		var item T
+		if err := json.Unmarshal(row, &item); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+// decodeSingle decodes the first row of a cmdlet that describes one object.
+// Get-OrganizationConfig and friends are single-object cmdlets whose value the
+// PowerShell report stored unwrapped, so the same unwrapping happens here to
+// keep the field shape identical.
+func decodeSingle(rows []json.RawMessage) (any, error) {
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	var item any
+	if err := json.Unmarshal(rows[0], &item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+// exchangeSection is one cmdlet call and the report field it fills.
+type exchangeSection struct {
+	// name identifies the section in error messages
+	name string
+	// cmdlet is the Exchange cmdlet to run
+	cmdlet string
+	// params are the cmdlet parameters, matching what the PowerShell report passed
+	params map[string]any
+	// selects restricts the returned properties, standing in for Select-Object
+	selects []string
+	// assign decodes the rows into the report
+	assign func(rows []json.RawMessage, report *ExchangeOnlineReport) error
+}
+
+// exchangeReportSections mirrors the cmdlets the PowerShell report ran, in the
+// same order, with the same parameters.
+//
+// Get-EXOMailbox is the one substitution: it is implemented by the
+// ExchangeOnlineManagement module rather than by the service, so the shared
+// mailbox list comes from Get-Mailbox with the same filter. Both cmdlets return
+// Identity and ExternalDirectoryObjectId, which are the only properties the
+// report consumes.
+func exchangeReportSections() []exchangeSection {
+	unlimited := map[string]any{"ResultSize": "Unlimited"}
+
+	return []exchangeSection{
+		{
+			name: "MailboxAuditBypassAssociation", cmdlet: "Get-MailboxAuditBypassAssociation", params: unlimited,
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[MailboxAuditBypassAssociation](rows)
+				r.MailboxAuditBypassAssociation = out
+				return err
+			},
+		},
+		{
+			name: "MalwareFilterPolicy", cmdlet: "Get-MalwareFilterPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.MalwareFilterPolicy = out
+				return err
+			},
+		},
+		{
+			name: "HostedOutboundSpamFilterPolicy", cmdlet: "Get-HostedOutboundSpamFilterPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.HostedOutboundSpamFilterPolicy = out
+				return err
+			},
+		},
+		{
+			name: "HostedContentFilterPolicy", cmdlet: "Get-HostedContentFilterPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.HostedContentFilterPolicy = out
+				return err
+			},
+		},
+		{
+			name: "TransportRule", cmdlet: "Get-TransportRule",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.TransportRule = out
+				return err
+			},
+		},
+		{
+			// the PowerShell report asked for the Default remote domain only
+			name: "RemoteDomain", cmdlet: "Get-RemoteDomain", params: map[string]any{"Identity": "Default"},
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.RemoteDomain = out
+				return err
+			},
+		},
+		{
+			name: "SafeLinksPolicy", cmdlet: "Get-SafeLinksPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.SafeLinksPolicy = out
+				return err
+			},
+		},
+		{
+			name: "SafeAttachmentPolicy", cmdlet: "Get-SafeAttachmentPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.SafeAttachmentPolicy = out
+				return err
+			},
+		},
+		{
+			name: "OrganizationConfig", cmdlet: "Get-OrganizationConfig",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeSingle(rows)
+				r.OrganizationConfig = out
+				return err
+			},
+		},
+		{
+			name: "AuthenticationPolicy", cmdlet: "Get-AuthenticationPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.AuthenticationPolicy = out
+				return err
+			},
+		},
+		{
+			name: "AntiPhishPolicy", cmdlet: "Get-AntiPhishPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.AntiPhishPolicy = out
+				return err
+			},
+		},
+		{
+			name: "DkimSigningConfig", cmdlet: "Get-DkimSigningConfig",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.DkimSigningConfig = out
+				return err
+			},
+		},
+		{
+			name: "OwaMailboxPolicy", cmdlet: "Get-OwaMailboxPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.OwaMailboxPolicy = out
+				return err
+			},
+		},
+		{
+			name: "AdminAuditLogConfig", cmdlet: "Get-AdminAuditLogConfig",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeSingle(rows)
+				r.AdminAuditLogConfig = out
+				return err
+			},
+		},
+		{
+			name: "PhishFilterPolicy", cmdlet: "Get-PhishFilterPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.PhishFilterPolicy = out
+				return err
+			},
+		},
+		{
+			name: "QuarantinePolicy", cmdlet: "Get-QuarantinePolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.QuarantinePolicy = out
+				return err
+			},
+		},
+		{
+			name: "JournalRule", cmdlet: "Get-JournalRule",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[JournalRule](rows)
+				r.JournalRules = out
+				return err
+			},
+		},
+		{
+			name: "MailboxPlan", cmdlet: "Get-MailboxPlan",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[MailboxPlan](rows)
+				r.MailboxPlans = out
+				return err
+			},
+		},
+		{
+			name: "RetentionPolicy", cmdlet: "Get-RetentionPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[RetentionPolicy](rows)
+				r.RetentionPolicies = out
+				return err
+			},
+		},
+		{
+			name: "Mailbox", cmdlet: "Get-Mailbox", params: unlimited,
+			selects: []string{
+				"Identity", "DisplayName", "PrimarySmtpAddress", "RecipientTypeDetails",
+				"AuditEnabled", "AuditAdmin", "AuditDelegate", "AuditOwner", "AuditLogAgeLimit",
+			},
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[MailboxWithAudit](rows)
+				r.Mailbox = out
+				return err
+			},
+		},
+		{
+			name: "AtpPolicyForO365", cmdlet: "Get-AtpPolicyForO365",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.AtpPolicyForO365 = out
+				return err
+			},
+		},
+		{
+			name: "SharingPolicy", cmdlet: "Get-SharingPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.SharingPolicy = out
+				return err
+			},
+		},
+		{
+			name: "RoleAssignmentPolicy", cmdlet: "Get-RoleAssignmentPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[any](rows)
+				r.RoleAssignmentPolicy = out
+				return err
+			},
+		},
+		{
+			name: "ExternalInOutlook", cmdlet: "Get-ExternalInOutlook",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[*ExternalSender](rows)
+				r.ExternalInOutlook = out
+				return err
+			},
+		},
+		{
+			name:    "ExoMailbox",
+			cmdlet:  "Get-Mailbox",
+			params:  map[string]any{"ResultSize": "Unlimited", "RecipientTypeDetails": "SharedMailbox"},
+			selects: []string{"Identity", "ExternalDirectoryObjectId"},
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[*ExoMailbox](rows)
+				r.ExoMailbox = out
+				return err
+			},
+		},
+		{
+			name: "TeamsProtectionPolicy", cmdlet: "Get-TeamsProtectionPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[*TeamsProtectionPolicy](rows)
+				r.TeamsProtectionPolicy = out
+				return err
+			},
+		},
+		{
+			name: "ReportSubmissionPolicy", cmdlet: "Get-ReportSubmissionPolicy",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				out, err := decodeRows[*ReportSubmissionPolicy](rows)
+				r.ReportSubmissionPolicy = out
+				return err
+			},
+		},
+		{
+			name: "TransportConfig", cmdlet: "Get-TransportConfig",
+			assign: func(rows []json.RawMessage, r *ExchangeOnlineReport) error {
+				if len(rows) == 0 {
+					return nil
+				}
+				out := &TransportConfig{}
+				if err := json.Unmarshal(rows[0], out); err != nil {
+					return err
+				}
+				r.TransportConfig = out
+				return nil
+			},
+		},
+	}
+}
+
+// exchangeSectionConcurrency bounds how many cmdlets run at once. The single
+// PowerShell session ran them one after another; a small pool keeps the
+// wall-clock cost down without hammering the service into throttling.
+const exchangeSectionConcurrency = 6
+
+// runExchangeSections executes every section and returns the sections that
+// failed keyed by name. A cmdlet failure leaves its report field unset, which
+// matches the PowerShell report: it did not stop on error, so a cmdlet that
+// failed left its variable null and the corresponding MQL field null.
+func runExchangeSections(ctx context.Context, client *exchangeRestClient, sections []exchangeSection, report *ExchangeOnlineReport) map[string]error {
+	var (
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+		failures = map[string]error{}
+		sem      = make(chan struct{}, exchangeSectionConcurrency)
+	)
+
+	for i := range sections {
+		section := sections[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			rows, err := client.invoke(ctx, section.cmdlet, section.params, section.selects...)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				failures[section.name] = err
+				return
+			}
+			if err := section.assign(rows, report); err != nil {
+				failures[section.name] = err
+			}
+		}()
+	}
+	wg.Wait()
+
+	return failures
+}
+
+// fetchExchangeReportViaRest builds the Exchange Online report from the admin
+// endpoint. It fails only when no section succeeded, which is the signal that
+// the endpoint or the credential is unusable and the PowerShell path should be
+// tried instead. A partial result is returned as-is so one unavailable cmdlet
+// does not cost the whole report.
+func fetchExchangeReportViaRest(ctx context.Context, client *exchangeRestClient) (*ExchangeOnlineReport, map[string]error, error) {
+	report := &ExchangeOnlineReport{}
+	sections := exchangeReportSections()
+	failures := runExchangeSections(ctx, client, sections, report)
+
+	if len(failures) == len(sections) {
+		return nil, failures, fmt.Errorf("every exchange cmdlet failed, first error: %w", anyError(failures))
+	}
+	return report, failures, nil
+}
+
+// fetchHostedConnectionFilterPolicyViaRest reads the default connection filter
+// policy, the IP allow and block lists used for mail flow.
+func fetchHostedConnectionFilterPolicyViaRest(ctx context.Context, client *exchangeRestClient) (*HostedConnectionFilterPolicyReport, error) {
+	rows, err := client.invoke(ctx, "Get-HostedConnectionFilterPolicy", map[string]any{"Identity": "Default"})
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("no hosted connection filter policy returned")
+	}
+
+	policy := &HostedConnectionFilterPolicyData{}
+	if err := json.Unmarshal(rows[0], policy); err != nil {
+		return nil, err
+	}
+	return &HostedConnectionFilterPolicyReport{HostedConnectionFilterPolicy: policy}, nil
+}
+
+// anyError returns one error from the map so a caller can report a cause. Map
+// iteration order is unspecified, so the name is included to keep the message
+// self-explanatory.
+func anyError(failures map[string]error) error {
+	for name, err := range failures {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	return nil
+}

--- a/providers/ms365/resources/exchange_restapi.go
+++ b/providers/ms365/resources/exchange_restapi.go
@@ -7,12 +7,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -29,6 +32,15 @@ const (
 	// the same in every organization and is the routing key app-only callers use
 	// for operations that do not target a specific mailbox.
 	exchangeSystemMailboxGuid = "bb558c35-97f1-4cb9-8ff7-d53741dc928c"
+
+	// exchangeHTTPTimeout bounds a single cmdlet request. exchangeMaxPages caps
+	// how many requests a walk makes but says nothing about how long one may
+	// hang, and these requests do not go through an SDK pipeline that would
+	// impose a deadline of its own. Sections run concurrently, so a stalled
+	// connection to the admin host would otherwise hold the whole collection
+	// rather than just its own section. Generous because some cmdlets are slow
+	// on large tenants.
+	exchangeHTTPTimeout = 2 * time.Minute
 
 	// exchangeMaxPages bounds nextLink following so a service that keeps
 	// handing back a continuation cannot spin forever.
@@ -54,8 +66,42 @@ func newExchangeRestClient(host string, tenantId string, organization string, to
 		tenantId:     tenantId,
 		organization: organization,
 		token:        token,
-		httpClient:   http.DefaultClient,
+		httpClient:   &http.Client{Timeout: exchangeHTTPTimeout},
 	}
+}
+
+// exchangeHTTPError is a non-2xx response from the admin endpoint, carrying the
+// status so a caller can tell why the request failed rather than only that it
+// did.
+type exchangeHTTPError struct {
+	StatusCode int
+	msg        string
+}
+
+func (e *exchangeHTTPError) Error() string { return e.msg }
+
+// exchangeErrorIsTransient reports whether err is the service asking to be
+// tried again later rather than saying it cannot serve this caller at all.
+//
+// It decides whether the PowerShell fallback is worth taking. The
+// ExchangeOnlineManagement module is a client for this same endpoint, so
+// falling back on a throttle or an outage does not route around anything: it
+// reissues the same request over a slower transport, gets throttled again, and
+// reports it as a PowerShell failure with the original status lost. Falling
+// back is only meaningful when the endpoint or the credential cannot serve the
+// request at all, which is what the remaining statuses mean.
+func exchangeErrorIsTransient(err error) bool {
+	var httpErr *exchangeHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == http.StatusRequestTimeout ||
+			httpErr.StatusCode == http.StatusTooManyRequests ||
+			httpErr.StatusCode >= 500
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 type exchangeCmdletInput struct {
@@ -149,9 +195,15 @@ func (c *exchangeRestClient) post(ctx context.Context, url string, body []byte, 
 
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-			return nil, fmt.Errorf("access denied running %s, please ensure the credentials have the right permissions and Exchange RBAC roles (status %d)", cmdlet, resp.StatusCode)
+			return nil, &exchangeHTTPError{
+				StatusCode: resp.StatusCode,
+				msg:        fmt.Sprintf("access denied running %s, please ensure the credentials have the right permissions and Exchange RBAC roles (status %d)", cmdlet, resp.StatusCode),
+			}
 		}
-		return nil, fmt.Errorf("%s failed with status %d: %s", cmdlet, resp.StatusCode, string(raw))
+		return nil, &exchangeHTTPError{
+			StatusCode: resp.StatusCode,
+			msg:        fmt.Sprintf("%s failed with status %d: %s", cmdlet, resp.StatusCode, string(raw)),
+		}
 	}
 
 	out := &exchangeCmdletResponse{}

--- a/providers/ms365/resources/exchange_restapi_test.go
+++ b/providers/ms365/resources/exchange_restapi_test.go
@@ -1,0 +1,423 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testClient(host string) *exchangeRestClient {
+	return newExchangeRestClient(host, "tenant-guid", "contoso.onmicrosoft.com", "tok-123")
+}
+
+func TestExchangeAnchorMailbox(t *testing.T) {
+	// app-only callers with no specific mailbox target address the organization
+	// system mailbox, whose guid is the same in every organization
+	c := testClient("https://outlook.office365.com")
+	assert.Equal(t,
+		"APP:SystemMailbox{bb558c35-97f1-4cb9-8ff7-d53741dc928c}@contoso.onmicrosoft.com",
+		c.anchorMailbox())
+}
+
+func TestExchangeInvokeUrl(t *testing.T) {
+	c := testClient("https://outlook.office365.com")
+
+	assert.Equal(t,
+		"https://outlook.office365.com/adminapi/beta/tenant-guid/InvokeCommand",
+		c.invokeUrl(nil))
+
+	assert.Equal(t,
+		"https://outlook.office365.com/adminapi/beta/tenant-guid/InvokeCommand?$select=Identity%2CDisplayName",
+		c.invokeUrl([]string{"Identity", "DisplayName"}))
+}
+
+func TestExchangeInvokeRequestShape(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotQuery  string
+		gotHeader http.Header
+		gotBody   exchangeCmdletRequest
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotHeader = r.Header.Clone()
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		fmt.Fprint(w, `{"value":[]}`)
+	}))
+	defer srv.Close()
+
+	_, err := testClient(srv.URL).invoke(context.Background(), "Get-Mailbox",
+		map[string]any{"ResultSize": "Unlimited"}, "Identity")
+	require.NoError(t, err)
+
+	// every cmdlet, including Get-*, is a POST
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/adminapi/beta/tenant-guid/InvokeCommand", gotPath)
+	assert.Contains(t, gotQuery, "select=Identity")
+
+	assert.Equal(t, "Bearer tok-123", gotHeader.Get("Authorization"))
+	assert.Equal(t, "application/json", gotHeader.Get("Content-Type"))
+	// routing hint is mandatory; without it the service can fail the request
+	assert.Contains(t, gotHeader.Get("X-AnchorMailbox"), "APP:SystemMailbox{")
+	assert.Equal(t, "odata.maxpagesize=1000", gotHeader.Get("Prefer"))
+
+	assert.Equal(t, "Get-Mailbox", gotBody.CmdletInput.CmdletName)
+	assert.Equal(t, "Unlimited", gotBody.CmdletInput.Parameters["ResultSize"])
+}
+
+func TestExchangeInvokeSinglePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"value":[{"Name":"a"},{"Name":"b"}]}`)
+	}))
+	defer srv.Close()
+
+	rows, err := testClient(srv.URL).invoke(context.Background(), "Get-JournalRule", nil)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.JSONEq(t, `{"Name":"a"}`, string(rows[0]))
+}
+
+func TestExchangeInvokeFollowsNextLink(t *testing.T) {
+	// Get-Mailbox on a large tenant pages; dropping the continuation would
+	// silently report a truncated mailbox list as the whole tenant
+	var srv *httptest.Server
+	var calls int32
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		switch n {
+		case 1:
+			fmt.Fprintf(w, `{"value":[{"Identity":"m1"}],"@odata.nextLink":%q}`, srv.URL+"/page2")
+		case 2:
+			fmt.Fprintf(w, `{"value":[{"Identity":"m2"}],"@odata.nextLink":%q}`, srv.URL+"/page3")
+		default:
+			fmt.Fprint(w, `{"value":[{"Identity":"m3"}]}`)
+		}
+	}))
+	defer srv.Close()
+
+	rows, err := testClient(srv.URL).invoke(context.Background(), "Get-Mailbox", nil)
+	require.NoError(t, err)
+
+	got, err := decodeRows[MailboxWithAudit](rows)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "m1", got[0].Identity)
+	assert.Equal(t, "m3", got[2].Identity)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
+func TestExchangeInvokeRejectsRepeatedContinuation(t *testing.T) {
+	// a service that echoes the same continuation would otherwise spin forever
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"value":[{"Name":"a"}],"@odata.nextLink":%q}`, srv.URL+"/same")
+	}))
+	defer srv.Close()
+
+	_, err := testClient(srv.URL).invoke(context.Background(), "Get-TransportRule", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same continuation")
+}
+
+func TestExchangeInvokeErrors(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(fmt.Sprintf("access denied on %d", status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			_, err := testClient(srv.URL).invoke(context.Background(), "Get-OrganizationConfig", nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "access denied")
+			assert.Contains(t, err.Error(), "Get-OrganizationConfig")
+		})
+	}
+
+	t.Run("other status carries cmdlet, code and body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, "unsupported parameter")
+		}))
+		defer srv.Close()
+
+		_, err := testClient(srv.URL).invoke(context.Background(), "Get-RemoteDomain", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Get-RemoteDomain")
+		assert.Contains(t, err.Error(), "400")
+		assert.Contains(t, err.Error(), "unsupported parameter")
+	})
+
+	t.Run("malformed body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"value":`)
+		}))
+		defer srv.Close()
+
+		_, err := testClient(srv.URL).invoke(context.Background(), "Get-TransportConfig", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot decode")
+	})
+}
+
+func TestDecodeRows(t *testing.T) {
+	t.Run("empty is non-nil", func(t *testing.T) {
+		// a cmdlet that ran but matched nothing must produce an empty list, not
+		// a null one: the report distinguishes the two
+		out, err := decodeRows[JournalRule](nil)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Empty(t, out)
+	})
+
+	t.Run("typed decode keeps cmdlet property names", func(t *testing.T) {
+		rows := []json.RawMessage{
+			json.RawMessage(`{"Name":"jr1","JournalEmailAddress":"j@contoso.com","Scope":"Global","Enabled":true}`),
+		}
+		out, err := decodeRows[JournalRule](rows)
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "jr1", out[0].Name)
+		assert.Equal(t, "j@contoso.com", out[0].JournalEmailAddress)
+		assert.True(t, out[0].Enabled)
+	})
+
+	t.Run("decode failure surfaces", func(t *testing.T) {
+		_, err := decodeRows[JournalRule]([]json.RawMessage{json.RawMessage(`{"Name":`)})
+		require.Error(t, err)
+	})
+}
+
+func TestDecodeSingle(t *testing.T) {
+	t.Run("no rows is nil", func(t *testing.T) {
+		out, err := decodeSingle(nil)
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("unwraps the first row", func(t *testing.T) {
+		// Get-OrganizationConfig is a single-object cmdlet; the report stored it
+		// unwrapped, so an array here would change the field shape
+		out, err := decodeSingle([]json.RawMessage{json.RawMessage(`{"Name":"contoso"}`)})
+		require.NoError(t, err)
+		obj, ok := out.(map[string]any)
+		require.True(t, ok, "expected a bare object, not a list")
+		assert.Equal(t, "contoso", obj["Name"])
+	})
+}
+
+func TestExchangeReportSectionsSpec(t *testing.T) {
+	sections := map[string]exchangeSection{}
+	for _, s := range exchangeReportSections() {
+		require.NotContains(t, sections, s.name, "duplicate section name")
+		sections[s.name] = s
+	}
+
+	t.Run("remote domain asks for the default domain", func(t *testing.T) {
+		assert.Equal(t, "Default", sections["RemoteDomain"].params["Identity"])
+	})
+
+	t.Run("mailbox is unlimited and selects the audit properties", func(t *testing.T) {
+		s := sections["Mailbox"]
+		assert.Equal(t, "Unlimited", s.params["ResultSize"])
+		assert.ElementsMatch(t, []string{
+			"Identity", "DisplayName", "PrimarySmtpAddress", "RecipientTypeDetails",
+			"AuditEnabled", "AuditAdmin", "AuditDelegate", "AuditOwner", "AuditLogAgeLimit",
+		}, s.selects)
+	})
+
+	t.Run("shared mailboxes come from Get-Mailbox with the same filter", func(t *testing.T) {
+		// Get-EXOMailbox is a module cmdlet rather than a service one, so the
+		// shared mailbox list is filtered server side instead
+		s := sections["ExoMailbox"]
+		assert.Equal(t, "Get-Mailbox", s.cmdlet)
+		assert.Equal(t, "SharedMailbox", s.params["RecipientTypeDetails"])
+		assert.Equal(t, "Unlimited", s.params["ResultSize"])
+		assert.ElementsMatch(t, []string{"Identity", "ExternalDirectoryObjectId"}, s.selects)
+	})
+
+	t.Run("audit bypass association is unlimited", func(t *testing.T) {
+		assert.Equal(t, "Unlimited", sections["MailboxAuditBypassAssociation"].params["ResultSize"])
+	})
+
+	t.Run("covers every cmdlet the powershell report ran", func(t *testing.T) {
+		for _, name := range []string{
+			"MalwareFilterPolicy", "HostedOutboundSpamFilterPolicy", "HostedContentFilterPolicy",
+			"TransportRule", "RemoteDomain", "SafeLinksPolicy", "SafeAttachmentPolicy",
+			"OrganizationConfig", "AuthenticationPolicy", "AntiPhishPolicy", "DkimSigningConfig",
+			"OwaMailboxPolicy", "AdminAuditLogConfig", "PhishFilterPolicy", "QuarantinePolicy",
+			"JournalRule", "MailboxPlan", "RetentionPolicy", "Mailbox", "AtpPolicyForO365",
+			"SharingPolicy", "RoleAssignmentPolicy", "ExternalInOutlook", "ExoMailbox",
+			"TeamsProtectionPolicy", "ReportSubmissionPolicy", "TransportConfig",
+			"MailboxAuditBypassAssociation",
+		} {
+			assert.Contains(t, sections, name)
+		}
+	})
+}
+
+// exchangeRowServer answers every InvokeCommand with the rows registered for
+// the requested cmdlet, and fails the cmdlets listed in broken.
+func exchangeRowServer(t *testing.T, rows map[string]string, broken map[string]bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req exchangeCmdletRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		if broken[req.CmdletInput.CmdletName] {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if body, ok := rows[req.CmdletInput.CmdletName]; ok {
+			fmt.Fprintf(w, `{"value":%s}`, body)
+			return
+		}
+		fmt.Fprint(w, `{"value":[]}`)
+	}))
+}
+
+func TestFetchExchangeReportViaRest(t *testing.T) {
+	t.Run("builds the report and keeps single objects unwrapped", func(t *testing.T) {
+		srv := exchangeRowServer(t, map[string]string{
+			"Get-OrganizationConfig": `[{"Name":"contoso","MailTipsAllTipsEnabled":true}]`,
+			"Get-TransportConfig":    `[{"SmtpClientAuthenticationDisabled":true}]`,
+			"Get-JournalRule":        `[{"Name":"jr1","Enabled":true}]`,
+			"Get-TransportRule":      `[{"Name":"tr1"},{"Name":"tr2"}]`,
+		}, nil)
+		defer srv.Close()
+
+		report, failures, err := fetchExchangeReportViaRest(context.Background(), testClient(srv.URL))
+		require.NoError(t, err)
+		assert.Empty(t, failures)
+
+		// single-object cmdlets stay bare, matching the powershell report
+		orgConfig, ok := report.OrganizationConfig.(map[string]any)
+		require.True(t, ok, "OrganizationConfig must be an object, not a list")
+		assert.Equal(t, "contoso", orgConfig["Name"])
+
+		require.NotNil(t, report.TransportConfig)
+		assert.True(t, report.TransportConfig.SmtpClientAuthenticationDisabled)
+
+		require.Len(t, report.JournalRules, 1)
+		assert.Equal(t, "jr1", report.JournalRules[0].Name)
+		assert.Len(t, report.TransportRule, 2)
+	})
+
+	t.Run("a failing cmdlet leaves its field null and spares the others", func(t *testing.T) {
+		// the powershell report did not stop on error either: a cmdlet that
+		// failed left its variable null and the matching field null
+		srv := exchangeRowServer(t,
+			map[string]string{"Get-TransportRule": `[{"Name":"tr1"}]`},
+			map[string]bool{"Get-AntiPhishPolicy": true})
+		defer srv.Close()
+
+		report, failures, err := fetchExchangeReportViaRest(context.Background(), testClient(srv.URL))
+		require.NoError(t, err)
+
+		require.Contains(t, failures, "AntiPhishPolicy")
+		assert.Nil(t, report.AntiPhishPolicy)
+		assert.Len(t, report.TransportRule, 1)
+	})
+
+	t.Run("every cmdlet failing is a report failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		_, _, err := fetchExchangeReportViaRest(context.Background(), testClient(srv.URL))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "every exchange cmdlet failed")
+	})
+
+	t.Run("a cmdlet that matched nothing yields an empty, non-null list", func(t *testing.T) {
+		srv := exchangeRowServer(t, nil, nil)
+		defer srv.Close()
+
+		report, _, err := fetchExchangeReportViaRest(context.Background(), testClient(srv.URL))
+		require.NoError(t, err)
+		require.NotNil(t, report.TransportRule)
+		assert.Empty(t, report.TransportRule)
+	})
+}
+
+func TestFetchHostedConnectionFilterPolicyViaRest(t *testing.T) {
+	t.Run("reads the default policy", func(t *testing.T) {
+		var got exchangeCmdletRequest
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+			fmt.Fprint(w, `{"value":[{"Identity":"Default","EnableSafeList":true,
+			  "IPAllowList":["1.2.3.4"],"IPBlockList":["5.6.7.8"]}]}`)
+		}))
+		defer srv.Close()
+
+		report, err := fetchHostedConnectionFilterPolicyViaRest(context.Background(), testClient(srv.URL))
+		require.NoError(t, err)
+
+		assert.Equal(t, "Get-HostedConnectionFilterPolicy", got.CmdletInput.CmdletName)
+		assert.Equal(t, "Default", got.CmdletInput.Parameters["Identity"])
+
+		policy := report.HostedConnectionFilterPolicy
+		require.NotNil(t, policy)
+		assert.Equal(t, "Default", policy.Identity)
+		assert.True(t, policy.EnableSafeList)
+		assert.Equal(t, []string{"1.2.3.4"}, policy.IPAllowList)
+		assert.Equal(t, []string{"5.6.7.8"}, policy.IPBlockList)
+	})
+
+	t.Run("no policy is an error rather than a blank policy", func(t *testing.T) {
+		// a zero-value policy would report an empty IP allow list as fact
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"value":[]}`)
+		}))
+		defer srv.Close()
+
+		_, err := fetchHostedConnectionFilterPolicyViaRest(context.Background(), testClient(srv.URL))
+		require.Error(t, err)
+	})
+}
+
+// The REST rows and the PowerShell JSON must land in the same report shape, or
+// a policy reading these dict fields would see different data depending on
+// which transport served the scan.
+func TestRestAndPowershellReportsAgree(t *testing.T) {
+	powershellJson := `{
+	  "OrganizationConfig": {"Name":"contoso","MailTipsAllTipsEnabled":true},
+	  "TransportRule": [{"Name":"tr1","State":"Enabled"}],
+	  "JournalRule": [{"Name":"jr1","Enabled":true,"Scope":"Global"}],
+	  "TransportConfig": {"SmtpClientAuthenticationDisabled":true}
+	}`
+
+	fromPowershell := &ExchangeOnlineReport{}
+	require.NoError(t, json.Unmarshal([]byte(powershellJson), fromPowershell))
+
+	srv := exchangeRowServer(t, map[string]string{
+		"Get-OrganizationConfig": `[{"Name":"contoso","MailTipsAllTipsEnabled":true}]`,
+		"Get-TransportRule":      `[{"Name":"tr1","State":"Enabled"}]`,
+		"Get-JournalRule":        `[{"Name":"jr1","Enabled":true,"Scope":"Global"}]`,
+		"Get-TransportConfig":    `[{"SmtpClientAuthenticationDisabled":true}]`,
+	}, nil)
+	defer srv.Close()
+
+	fromRest, _, err := fetchExchangeReportViaRest(context.Background(), testClient(srv.URL))
+	require.NoError(t, err)
+
+	assert.Equal(t, fromPowershell.OrganizationConfig, fromRest.OrganizationConfig)
+	assert.Equal(t, fromPowershell.TransportRule, fromRest.TransportRule)
+	assert.Equal(t, fromPowershell.JournalRules, fromRest.JournalRules)
+	assert.Equal(t, fromPowershell.TransportConfig, fromRest.TransportConfig)
+}

--- a/providers/ms365/resources/exchange_restapi_test.go
+++ b/providers/ms365/resources/exchange_restapi_test.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -420,4 +421,55 @@ func TestRestAndPowershellReportsAgree(t *testing.T) {
 	assert.Equal(t, fromPowershell.TransportRule, fromRest.TransportRule)
 	assert.Equal(t, fromPowershell.JournalRules, fromRest.JournalRules)
 	assert.Equal(t, fromPowershell.TransportConfig, fromRest.TransportConfig)
+}
+
+// TestExchangeErrorIsTransient pins which failures take the PowerShell
+// fallback. PowerShell reaches the same endpoint, so falling back on a
+// throttle repeats the throttle over a slower transport and reports it as a
+// PowerShell failure; the fallback is only worth taking when the endpoint or
+// the credential cannot serve the request at all.
+func TestExchangeErrorIsTransient(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"throttled", &exchangeHTTPError{StatusCode: http.StatusTooManyRequests}, true},
+		{"request timeout", &exchangeHTTPError{StatusCode: http.StatusRequestTimeout}, true},
+		{"internal server error", &exchangeHTTPError{StatusCode: http.StatusInternalServerError}, true},
+		{"bad gateway", &exchangeHTTPError{StatusCode: http.StatusBadGateway}, true},
+		{"service unavailable", &exchangeHTTPError{StatusCode: http.StatusServiceUnavailable}, true},
+		{"context deadline", context.DeadlineExceeded, true},
+		{"wrapped deadline", fmt.Errorf("get org config: %w", context.DeadlineExceeded), true},
+
+		{"unauthorized", &exchangeHTTPError{StatusCode: http.StatusUnauthorized}, false},
+		{"forbidden", &exchangeHTTPError{StatusCode: http.StatusForbidden}, false},
+		{"not found", &exchangeHTTPError{StatusCode: http.StatusNotFound}, false},
+		{"bad request", &exchangeHTTPError{StatusCode: http.StatusBadRequest}, false},
+		{"wrapped forbidden", fmt.Errorf("run cmdlet: %w", &exchangeHTTPError{StatusCode: http.StatusForbidden}), false},
+		{"a plain error is not assumed transient", errors.New("boom"), false},
+		{"no error", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, exchangeErrorIsTransient(tc.err))
+		})
+	}
+}
+
+// A non-2xx response has to carry its status out of post, or the caller cannot
+// tell a throttle from a permission problem and falls back on both.
+func TestPostReturnsATypedStatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"error":"throttled"}`)
+	}))
+	defer srv.Close()
+
+	_, err := testClient(srv.URL).invoke(context.Background(), "Get-OrganizationConfig", nil)
+	require.Error(t, err)
+
+	var httpErr *exchangeHTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusTooManyRequests, httpErr.StatusCode)
+	assert.True(t, exchangeErrorIsTransient(err), "a 429 must not take the powershell fallback")
 }

--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -393,6 +393,63 @@ func convertRetentionPolicies(r *mqlMs365Exchangeonline, data []RetentionPolicy)
 	return result, nil
 }
 
+// fetchExchangeReport prefers the Exchange admin endpoint and falls back to the
+// PowerShell module when that endpoint cannot serve the tenant, so a scan that
+// works today keeps working. Both paths produce the same report: the module is
+// a client for the same endpoint, so the cmdlet objects and their property
+// names are identical either way.
+func (r *mqlMs365Exchangeonline) fetchExchangeReport(ctx context.Context, conn *connection.Ms365Connection, organization string, token string) (*ExchangeOnlineReport, error) {
+	client := newExchangeRestClient(exchangeAdminApiHost, conn.TenantId(), organization, token)
+
+	report, failures, err := fetchExchangeReportViaRest(ctx, client)
+	if err == nil {
+		// a cmdlet that failed leaves its field null, which is what the
+		// PowerShell report did with a cmdlet that errored mid-script
+		for name, failure := range failures {
+			log.Warn().Err(failure).Str("section", name).
+				Msg("unable to collect exchange online section, the matching field will be null")
+		}
+		return report, nil
+	}
+
+	log.Warn().Err(err).Msg("exchange online admin endpoint unavailable, falling back to powershell")
+	return r.fetchExchangeReportViaPowershell(conn, organization, token)
+}
+
+func (r *mqlMs365Exchangeonline) fetchExchangeReportViaPowershell(conn *connection.Ms365Connection, organization string, token string) (*ExchangeOnlineReport, error) {
+	fmtScript := fmt.Sprintf(exchangeReport, conn.ClientId(), organization, conn.TenantId(), token)
+	res, err := conn.CheckAndRunPowershellScript(fmtScript)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.ExitStatus != 0 {
+		data, err := io.ReadAll(res.Stderr)
+		if err != nil {
+			return nil, err
+		}
+
+		if strings.Contains(strings.ToLower(string(data)), "unauthorized") {
+			return nil, errors.New("access denied, please ensure the credentials have the right permissions in Azure AD")
+		}
+
+		logger.DebugDumpJSON("exchange-online-report", data)
+		return nil, fmt.Errorf("failed to generate exchange online report (exit code %d): %s", res.ExitStatus, string(data))
+	}
+
+	data, err := io.ReadAll(res.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	logger.DebugDumpJSON("exchange-online-report", data)
+
+	report := &ExchangeOnlineReport{}
+	if err := json.Unmarshal(data, report); err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
 func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 	conn := r.MqlRuntime.Connection.(*connection.Ms365Connection)
 
@@ -424,36 +481,8 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 		return errHandler(err)
 	}
 
-	fmtScript := fmt.Sprintf(exchangeReport, conn.ClientId(), organization, conn.TenantId(), outlookToken.Token)
-	res, err := conn.CheckAndRunPowershellScript(fmtScript)
+	report, err := r.fetchExchangeReport(ctx, conn, organization, outlookToken.Token)
 	if err != nil {
-		return errHandler(err)
-	}
-	report := &ExchangeOnlineReport{}
-	if res.ExitStatus == 0 {
-		data, err := io.ReadAll(res.Stdout)
-		if err != nil {
-			return errHandler(err)
-		}
-		logger.DebugDumpJSON("exchange-online-report", data)
-
-		err = json.Unmarshal(data, report)
-		if err != nil {
-			return errHandler(err)
-		}
-	} else {
-		data, err := io.ReadAll(res.Stderr)
-		if err != nil {
-			return errHandler(err)
-		}
-
-		str := string(data)
-		if strings.Contains(strings.ToLower(str), "unauthorized") {
-			return errHandler(errors.New("access denied, please ensure the credentials have the right permissions in Azure AD"))
-		}
-
-		logger.DebugDumpJSON("exchange-online-report", data)
-		err = fmt.Errorf("failed to generate exchange online report (exit code %d): %s", res.ExitStatus, string(data))
 		return errHandler(err)
 	}
 

--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -412,6 +412,13 @@ func (r *mqlMs365Exchangeonline) fetchExchangeReport(ctx context.Context, conn *
 		return report, nil
 	}
 
+	// PowerShell is a client for this same endpoint, so a throttle or an outage
+	// would only repeat itself over a slower transport and be reported as a
+	// PowerShell failure. Surface the real cause instead.
+	if exchangeErrorIsTransient(err) {
+		return nil, err
+	}
+
 	log.Warn().Err(err).Msg("exchange online admin endpoint unavailable, falling back to powershell")
 	return r.fetchExchangeReportViaPowershell(conn, organization, token)
 }

--- a/providers/ms365/resources/security_exchange.go
+++ b/providers/ms365/resources/security_exchange.go
@@ -177,6 +177,12 @@ func (r *mqlMicrosoftSecurityExchange) getHostedConnectionFilterPolicyReport() (
 	client := newExchangeRestClient(exchangeAdminApiHost, conn.TenantId(), organization, outlookToken.Token)
 	report, err := fetchHostedConnectionFilterPolicyViaRest(ctx, client)
 	if err != nil {
+		// PowerShell is a client for this same endpoint, so a throttle or an
+		// outage would only repeat itself over a slower transport and be
+		// reported as a PowerShell failure. Surface the real cause instead.
+		if exchangeErrorIsTransient(err) {
+			return errHandler(err)
+		}
 		log.Warn().Err(err).Msg("exchange online admin endpoint unavailable, falling back to powershell")
 		report, err = fetchHostedConnectionFilterPolicyViaPowershell(conn, organization, outlookToken.Token)
 		if err != nil {

--- a/providers/ms365/resources/security_exchange.go
+++ b/providers/ms365/resources/security_exchange.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -173,35 +174,45 @@ func (r *mqlMicrosoftSecurityExchange) getHostedConnectionFilterPolicyReport() (
 		return errHandler(err)
 	}
 
-	fmtScript := fmt.Sprintf(hostedConnectionFilterPolicyScript, conn.ClientId(), organization, conn.TenantId(), outlookToken.Token)
-	res, err := conn.CheckAndRunPowershellScript(fmtScript)
+	client := newExchangeRestClient(exchangeAdminApiHost, conn.TenantId(), organization, outlookToken.Token)
+	report, err := fetchHostedConnectionFilterPolicyViaRest(ctx, client)
 	if err != nil {
-		return errHandler(err)
-	}
-
-	report := &HostedConnectionFilterPolicyReport{}
-	if res.ExitStatus == 0 {
-		data, err := io.ReadAll(res.Stdout)
+		log.Warn().Err(err).Msg("exchange online admin endpoint unavailable, falling back to powershell")
+		report, err = fetchHostedConnectionFilterPolicyViaPowershell(conn, organization, outlookToken.Token)
 		if err != nil {
 			return errHandler(err)
 		}
-		logger.DebugDumpJSON("hosted-connection-filter-policy-report", data)
-
-		err = json.Unmarshal(data, report)
-		if err != nil {
-			return errHandler(err)
-		}
-	} else {
-		data, err := io.ReadAll(res.Stderr)
-		if err != nil {
-			return errHandler(err)
-		}
-
-		err = fmt.Errorf("failed to generate hosted connection filter policy report (exit code %d): %s", res.ExitStatus, string(data))
-		return errHandler(err)
 	}
 
 	r.report = report
 	r.fetched = true
+	return report, nil
+}
+
+func fetchHostedConnectionFilterPolicyViaPowershell(conn *connection.Ms365Connection, organization string, token string) (*HostedConnectionFilterPolicyReport, error) {
+	fmtScript := fmt.Sprintf(hostedConnectionFilterPolicyScript, conn.ClientId(), organization, conn.TenantId(), token)
+	res, err := conn.CheckAndRunPowershellScript(fmtScript)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.ExitStatus != 0 {
+		data, err := io.ReadAll(res.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to generate hosted connection filter policy report (exit code %d): %s", res.ExitStatus, string(data))
+	}
+
+	data, err := io.ReadAll(res.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	logger.DebugDumpJSON("hosted-connection-filter-policy-report", data)
+
+	report := &HostedConnectionFilterPolicyReport{}
+	if err := json.Unmarshal(data, report); err != nil {
+		return nil, err
+	}
 	return report, nil
 }


### PR DESCRIPTION
## What

Fetches the Exchange Online report and the hosted connection filter policy over HTTPS instead of through a PowerShell session, keeping the PowerShell path as an automatic fallback.

Covers two of the six PowerShell call sites in the provider:

- `ms365_exchange.go` — the ~28-cmdlet `exchangeReport`, backing ~24 `ms365.exchangeonline.*` resources
- `security_exchange.go` — `Get-HostedConnectionFilterPolicy`, backing `microsoft.security.exchange.antispam.*`

## Why this endpoint and not Graph

Since EXO V3 the `ExchangeOnlineManagement` module is itself a REST client. Every cmdlet is served by an admin endpoint that takes the cmdlet name and parameters as JSON:

```
POST https://outlook.office365.com/adminapi/beta/<tenantId>/InvokeCommand
X-AnchorMailbox: APP:SystemMailbox{bb558c35-97f1-4cb9-8ff7-d53741dc928c}@<org>

{"CmdletInput":{"CmdletName":"Get-OrganizationConfig","Parameters":{}}}
```

The rows come back as the cmdlets' own objects with PascalCase property names. **That property-for-property match is the whole point.** Most of these fields are raw `dict` passthroughs of `ConvertTo-Json` output, so a policy reads `transportRule.First.Name` or `organizationConfig.MailTipsAllTipsEnabled` today. Graph returns camelCase with renamed properties and recased enums (`ExternalUserAndGuestSharing` → `externalUserAndGuestSharing`), so a Graph swap could not be backwards compatible here no matter how it was written. Cutting out the middleman can be.

There is also **no Graph API at all** for the EOP/MDO threat policies that make up the bulk of this report — `Get-MalwareFilterPolicy`, `Get-HostedContentFilterPolicy`, `Get-SafeLinksPolicy`, `Get-AntiPhishPolicy`, `Get-TransportRule` and the rest are Defender-portal-or-Exchange-PowerShell only.

## The risk, and how it is contained

⚠️ **Microsoft documents only a six-endpoint v2.0 subset** of this API (`OrganizationConfig`, `AcceptedDomain`, `Mailbox`, `MailboxFolderPermission`, `DistributionGroupMember`, `DynamicDistributionGroupMember`). The generic `beta/InvokeCommand` route used here covers every cmdlet but is undocumented — it is the mechanism Microsoft's own shipping module uses, not third-party reverse engineering, but it is still undocumented. **This is worth an explicit call rather than an assumption**, and it is the main thing to review.

Containment:

- **Automatic fallback.** If the REST report cannot be built at all, the original PowerShell script runs and the scan behaves exactly as it does today. Nothing that works now stops working.
- **Per-cmdlet failures are not fatal.** A cmdlet that fails leaves its field null and logs a warning. That matches the old script, which did not set `$ErrorActionPreference` and so left a failed cmdlet's variable null.
- **Single objects stay unwrapped.** `Get-OrganizationConfig`, `Get-AdminAuditLogConfig` and `Get-TransportConfig` were stored bare by the PowerShell report (no `@(...)` wrapper); the REST path unwraps `value[0]` to keep the field shape identical. There is a test asserting a PowerShell-shaped report and a REST-shaped report decode equal.

## Two behaviour changes

- **`Get-Mailbox` is now paged** through `@odata.nextLink`. The old script relied on `-ResultSize Unlimited` returning everything in one response; the REST endpoint defaults to 1,000 rows per page. This is a latent-truncation fix, not just a port.
- **Shared mailboxes come from `Get-Mailbox`, not `Get-EXOMailbox`.** `Get-EXOMailbox` is implemented by the module rather than the service, so it is not available through `InvokeCommand`. The substitute uses the same `RecipientTypeDetails: SharedMailbox` filter, and both cmdlets return the `Identity` and `ExternalDirectoryObjectId` that are the only two properties the report consumes. This is the one place the cmdlet changes.

## Out of scope

**Security & Compliance stays on PowerShell.** `Get-DlpCompliancePolicy` / `Get-DlpComplianceRule` live behind a per-tenant *regional* host that has to be discovered through a redirect (`EXOBanner('AutogenSession')` → read `Location` → rebuild as `<region>.ps.compliance.protection.outlook.com`) and uses a `UPN:` rather than `APP:` anchor. That is not something to ship without verifying against a real tenant, so `ms365.exchangeonline.securityAndCompliance` is untouched. Graph has no DLP policy read API, so PowerShell remains the only route there for now.

SharePoint and Teams are also untouched — see the analysis; Graph covers 6 of 21 SharePoint tenant fields and 2 of 10 site fields, and Teams has no synchronous Graph read at all.

## Tests

New `exchange_restapi_test.go`, 43 subtests:

- **Request shape** — POST for `Get-*` cmdlets, `X-AnchorMailbox` present and correctly formed, `Prefer: odata.maxpagesize=1000`, `$select` encoding, `CmdletInput` body
- **Paging** — follows `@odata.nextLink` across three pages; rejects a repeated continuation link so a service echoing the same link cannot spin forever; page cap
- **Errors** — 401/403 → access-denied naming the cmdlet, other statuses carrying cmdlet + code + body, malformed bodies
- **Decoding** — empty results decode to an empty *non-nil* list (the report distinguishes empty from null), single-object unwrapping, typed decode preserving cmdlet property names
- **Section spec** — `Get-RemoteDomain` asks for `Identity: Default`, `Get-Mailbox` selects the nine audit properties, shared mailboxes use the `SharedMailbox` filter, and all 28 sections from the old script are present
- **Failure isolation** — one failing cmdlet leaves its field null while the others populate; all cmdlets failing is a report failure that triggers the fallback
- **Transport agreement** — a report built from PowerShell JSON and one built from REST rows compare equal

## Verification

- `go build ./...` clean, `go test ./resources/` passes, `gofmt` clean, `go mod tidy` no-op (stdlib only)
- No `.lr` change, so no `.lr.versions` entries

**Live verification against a real tenant is owed before merge** — that is the only way to confirm cmdlet-by-cmdlet payload equivalence, particularly `AuditLogAgeLimit` serialization and whether every cmdlet in the list is exposed through `InvokeCommand` for a given tenant. Happy to hold this until that runs.

The README's PowerShell note is left alone here; it needs one update once this and #9591 have both landed.
