### PR TITLE
🧹 okta: fix deferred audit papercuts and consolidate raw HTTP paths

### DIFF
--- a/providers/okta/resources/apiTokens.go
+++ b/providers/okta/resources/apiTokens.go
@@ -24,7 +24,12 @@ func (o *mqlOkta) apiTokens() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	tokens, err := sdk.ListApiTokens(ctx, conn.OrganizationID(), conn.Token())
+	apiSupplement := &sdk.ApiExtension{
+		Host:  conn.OrganizationID(),
+		Token: conn.Token(),
+	}
+
+	tokens, err := apiSupplement.ListApiTokens(ctx, queryLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/okta/resources/customRoles.go
+++ b/providers/okta/resources/customRoles.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -72,6 +73,9 @@ func initOktaCustomRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	role, _, err := client.RoleAPI.GetRole(ctx, id).Execute()
 	if err != nil {
 		return nil, nil, err
+	}
+	if role == nil {
+		return nil, nil, fmt.Errorf("okta.customRole with id %q not found", id)
 	}
 
 	args["id"] = llx.StringData(oktaStr(role.Id))

--- a/providers/okta/resources/logStreams.go
+++ b/providers/okta/resources/logStreams.go
@@ -67,18 +67,30 @@ func (o *mqlOkta) logStreams() ([]any, error) {
 	return list, nil
 }
 
-func newMqlOktaLogStream(runtime *plugin.Runtime, entry *okta.ListLogStreams200ResponseInner) (any, error) {
+// decodeOktaLogStream flattens one entry of the polymorphic listing into the
+// shared fields plus its type-specific settings, dropping the Splunk token.
+// Kept separate from resource construction so the redaction is testable.
+func decodeOktaLogStream(entry *okta.ListLogStreams200ResponseInner) (*oktaLogStreamRaw, error) {
 	raw, err := json.Marshal(entry.GetActualInstance())
 	if err != nil {
 		return nil, err
 	}
-	var stream oktaLogStreamRaw
-	if err := json.Unmarshal(raw, &stream); err != nil {
+	stream := &oktaLogStreamRaw{}
+	if err := json.Unmarshal(raw, stream); err != nil {
 		return nil, err
 	}
 
 	// The Splunk token is a secret; never expose it.
 	delete(stream.Settings, "token")
+	return stream, nil
+}
+
+func newMqlOktaLogStream(runtime *plugin.Runtime, entry *okta.ListLogStreams200ResponseInner) (any, error) {
+	stream, err := decodeOktaLogStream(entry)
+	if err != nil {
+		return nil, err
+	}
+
 	settings, err := convert.JsonToDict(stream.Settings)
 	if err != nil {
 		return nil, err

--- a/providers/okta/resources/logStreams.go
+++ b/providers/okta/resources/logStreams.go
@@ -34,7 +34,7 @@ func (o *mqlOkta) logStreams() ([]any, error) {
 	client := conn.Client()
 
 	ctx := context.Background()
-	slice, resp, err := client.LogStreamAPI.ListLogStreams(ctx).Execute()
+	slice, resp, err := client.LogStreamAPI.ListLogStreams(ctx).Limit(queryLimit).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/okta/resources/logStreams_test.go
+++ b/providers/okta/resources/logStreams_test.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/v5/okta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecodeOktaLogStreamAws covers the AWS EventBridge variant of the log
+// stream union.
+func TestDecodeOktaLogStreamAws(t *testing.T) {
+	t.Parallel()
+	wire := `{
+		"id": "ls1",
+		"name": "eventbridge",
+		"type": "aws_eventbridge",
+		"status": "ACTIVE",
+		"created": "2026-01-02T03:04:05.000Z",
+		"lastUpdated": "2026-02-03T04:05:06.000Z",
+		"settings": {"accountId": "123456789012", "eventSourceName": "okta", "region": "us-east-1"}
+	}`
+
+	stream, err := decodeOktaLogStream(unmarshalLogStream(t, wire))
+	require.NoError(t, err)
+
+	assert.Equal(t, "ls1", stream.Id)
+	assert.Equal(t, "eventbridge", stream.Name)
+	assert.Equal(t, "aws_eventbridge", stream.Type)
+	assert.Equal(t, "ACTIVE", stream.Status)
+	assert.Equal(t, "123456789012", stream.Settings["accountId"])
+	assert.Equal(t, "us-east-1", stream.Settings["region"])
+	require.NotNil(t, stream.Created)
+	assert.Equal(t, 2026, stream.Created.Year())
+}
+
+// TestDecodeOktaLogStreamSplunkRedactsToken is the one that matters: the Splunk
+// HEC token is a credential capable of writing into the customer's Splunk
+// index, and it must never reach a resource field.
+func TestDecodeOktaLogStreamSplunkRedactsToken(t *testing.T) {
+	t.Parallel()
+	wire := `{
+		"id": "ls2",
+		"name": "splunk",
+		"type": "splunk_cloud_logstreaming",
+		"status": "ACTIVE",
+		"settings": {
+			"host": "acme.splunkcloud.com",
+			"edition": "gcp",
+			"token": "super-secret-hec-token"
+		}
+	}`
+
+	stream, err := decodeOktaLogStream(unmarshalLogStream(t, wire))
+	require.NoError(t, err)
+
+	assert.Equal(t, "acme.splunkcloud.com", stream.Settings["host"])
+	assert.Equal(t, "gcp", stream.Settings["edition"])
+	assert.NotContains(t, stream.Settings, "token", "the Splunk HEC token must never be exposed")
+
+	// Belt and braces: the token value must not survive anywhere in settings.
+	encoded, err := json.Marshal(stream.Settings)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "super-secret-hec-token")
+}
+
+// TestDecodeOktaLogStreamNoSettings documents what the SDK's union decoder does
+// with a response that omits `settings` and the timestamps. It does not produce
+// an absent settings block: it selects a variant and zero-fills that variant's
+// typed fields, so the keys are present with empty values, and the non-pointer
+// `created`/`lastUpdated` come back as the zero time rather than null.
+//
+// The decode must not fail or panic on that shape. Okta always sends these
+// fields for a real log stream, so no coercion is applied; this test exists to
+// make the behavior visible if that ever stops being true.
+func TestDecodeOktaLogStreamNoSettings(t *testing.T) {
+	t.Parallel()
+	stream, err := decodeOktaLogStream(unmarshalLogStream(t,
+		`{"id":"ls3","name":"bare","type":"aws_eventbridge","status":"INACTIVE"}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "ls3", stream.Id)
+	assert.Equal(t, "INACTIVE", stream.Status)
+	assert.Equal(t, "", stream.Settings["accountId"], "zero-filled by the union decoder")
+	assert.NotContains(t, stream.Settings, "token")
+	require.NotNil(t, stream.Created)
+	assert.True(t, stream.Created.IsZero(), "omitted timestamps decode to the zero time")
+}
+
+func unmarshalLogStream(t *testing.T, wire string) *okta.ListLogStreams200ResponseInner {
+	t.Helper()
+	entry := &okta.ListLogStreams200ResponseInner{}
+	require.NoError(t, json.Unmarshal([]byte(wire), entry))
+	return entry
+}

--- a/providers/okta/resources/organization.go
+++ b/providers/okta/resources/organization.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -31,6 +33,9 @@ func initOktaOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	settings, _, err := client.OrgSettingAPI.GetOrgSettings(ctx).Execute()
 	if err != nil {
 		return nil, nil, err
+	}
+	if settings == nil {
+		return nil, nil, errors.New("failed to read Okta org settings: empty response")
 	}
 
 	args["id"] = llx.StringData(oktaStr(settings.Id))
@@ -72,27 +77,58 @@ func (o *mqlOktaOrganization) optOutCommunicationEmails() (bool, error) {
 }
 
 func (o *mqlOktaOrganization) billingContact() (*mqlOktaUser, error) {
-	return o.contactUser("BILLING")
+	usr, err := o.contactUser("BILLING")
+	if err != nil {
+		return nil, err
+	}
+	if usr == nil {
+		o.BillingContact.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return usr, nil
 }
 
 func (o *mqlOktaOrganization) technicalContact() (*mqlOktaUser, error) {
-	return o.contactUser("TECHNICAL")
+	usr, err := o.contactUser("TECHNICAL")
+	if err != nil {
+		return nil, err
+	}
+	if usr == nil {
+		o.TechnicalContact.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return usr, nil
 }
 
+// contactUser resolves the okta.user behind one of the org's contact slots.
+// Designating a contact is optional: Okta answers 404 when the slot is empty
+// and can answer 200 with no user id at all. Both mean "no contact", reported
+// as a null field rather than failing the whole okta.organization query.
 func (o *mqlOktaOrganization) contactUser(contactType string) (*mqlOktaUser, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 	client := conn.Client()
 
 	ctx := context.Background()
-	contactUser, _, err := client.OrgSettingAPI.GetOrgContactUser(ctx, contactType).Execute()
+	contact, resp, err := client.OrgSettingAPI.GetOrgContactUser(ctx, contactType).Execute()
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
 		return nil, err
 	}
-	uid := oktaStr(contactUser.UserId)
+	if contact == nil {
+		return nil, nil
+	}
+
+	uid := oktaStr(contact.UserId)
+	if uid == "" {
+		return nil, nil
+	}
 
 	usr, _, err := client.UserAPI.GetUser(ctx, uid).Execute()
 	if err != nil {
 		return nil, err
+	}
+	if usr == nil {
+		return nil, nil
 	}
 
 	return newMqlOktaUser(o.MqlRuntime, usr)

--- a/providers/okta/resources/policies.go
+++ b/providers/okta/resources/policies.go
@@ -147,7 +147,7 @@ func (o *mqlOktaPolicy) id() (string, error) {
 	return "okta.policy/" + o.Id.Data, o.Id.Error
 }
 
-func (o mqlOktaPolicy) rules() ([]any, error) {
+func (o *mqlOktaPolicy) rules() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 	client := conn.Client()
 

--- a/providers/okta/resources/roles_test.go
+++ b/providers/okta/resources/roles_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/v5/okta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// oktaRoleTypedRefs reads the custom-role and resource-set ids out of a role
+// assignment's HAL `_links`. The v5 SDK types only the `self` link, so the rest
+// come from an untyped map keyed by link name. Nothing fails loudly if those
+// key names are wrong: the accessors just resolve to null, which is
+// indistinguishable from a standard admin role that legitimately has neither.
+// These tests pin the wire shape so a rename cannot silently empty the
+// admin-privilege graph.
+func TestOktaRoleTypedRefs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		wire            string
+		wantCustomRole  string
+		wantResourceSet string
+	}{
+		{
+			name: "custom role scoped to a resource set",
+			wire: `{
+				"id": "ra1",
+				"type": "CUSTOM",
+				"_links": {
+					"self":         {"href": "https://x.okta.com/api/v1/users/00u1/roles/ra1"},
+					"permissions":  {"href": "https://x.okta.com/api/v1/iam/roles/cr1/permissions"},
+					"resource-set": {"href": "https://x.okta.com/api/v1/iam/resource-sets/rs1"}
+				}
+			}`,
+			wantCustomRole:  "cr1",
+			wantResourceSet: "rs1",
+		},
+		{
+			name: "custom role without a permissions link falls back to role",
+			wire: `{
+				"id": "ra2",
+				"type": "CUSTOM",
+				"_links": {
+					"role":         {"href": "https://x.okta.com/api/v1/iam/roles/cr2"},
+					"resource-set": {"href": "https://x.okta.com/api/v1/iam/resource-sets/rs2"}
+				}
+			}`,
+			wantCustomRole:  "cr2",
+			wantResourceSet: "rs2",
+		},
+		{
+			name: "standard admin role carries neither",
+			wire: `{
+				"id": "ra3",
+				"type": "SUPER_ADMIN",
+				"_links": {"self": {"href": "https://x.okta.com/api/v1/users/00u1/roles/ra3"}}
+			}`,
+			wantCustomRole:  "",
+			wantResourceSet: "",
+		},
+		{
+			name: "standard role is never treated as custom even with a permissions link",
+			wire: `{
+				"id": "ra4",
+				"type": "READ_ONLY_ADMIN",
+				"_links": {"permissions": {"href": "https://x.okta.com/api/v1/iam/roles/cr4/permissions"}}
+			}`,
+			wantCustomRole:  "",
+			wantResourceSet: "",
+		},
+		{
+			name:            "no links at all",
+			wire:            `{"id": "ra5", "type": "CUSTOM"}`,
+			wantCustomRole:  "",
+			wantResourceSet: "",
+		},
+		{
+			name: "malformed link entries are ignored, not fatal",
+			wire: `{
+				"id": "ra6",
+				"type": "CUSTOM",
+				"_links": {"permissions": "not-an-object", "resource-set": {"nothref": 1}}
+			}`,
+			wantCustomRole:  "",
+			wantResourceSet: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var role okta.Role
+			require.NoError(t, json.Unmarshal([]byte(tc.wire), &role))
+
+			customRole, resourceSet := oktaRoleTypedRefs(&role)
+			assert.Equal(t, tc.wantCustomRole, customRole, "custom role id")
+			assert.Equal(t, tc.wantResourceSet, resourceSet, "resource set id")
+		})
+	}
+}

--- a/providers/okta/resources/sdk/apiTokens.go
+++ b/providers/okta/resources/sdk/apiTokens.go
@@ -37,7 +37,7 @@ func (m *ApiExtension) ListApiTokens(ctx context.Context, limit int) ([]*ApiToke
 	if limit > 0 {
 		params.Set("limit", strconv.Itoa(limit))
 	}
-	nextURL := m.url("/api/v1/api-tokens") + "?" + params.Encode()
+	nextURL := m.urlWithParams("/api/v1/api-tokens", params)
 
 	result := []*ApiToken{}
 	for i := 0; i < maxPages && nextURL != ""; i++ {

--- a/providers/okta/resources/sdk/apiTokens.go
+++ b/providers/okta/resources/sdk/apiTokens.go
@@ -5,10 +5,8 @@ package sdk
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -28,47 +26,30 @@ type ApiToken struct {
 	TokenWindow string     `json:"tokenWindow,omitempty"`
 }
 
-// ListApiTokens fetches all API tokens for the org. The endpoint requires Super Admin
-// privileges. We use raw HTTP because the Okta golang SDK v2 does not include this resource.
+// ListApiTokens fetches all API tokens for the org. The endpoint requires Super
+// Admin privileges. We issue it ourselves because the Okta golang SDK does not
+// include this resource.
 //
-// Pagination follows Okta's `Link: <url>; rel="next"` response header convention until
-// no `next` link is returned.
-func ListApiTokens(ctx context.Context, host, token string) ([]*ApiToken, error) {
-	client := http.Client{}
+// Pagination follows Okta's `Link: <url>; rel="next"` response header convention
+// until no `next` link is returned.
+func (m *ApiExtension) ListApiTokens(ctx context.Context, limit int) ([]*ApiToken, error) {
+	params := url.Values{}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	nextURL := m.url("/api/v1/api-tokens") + "?" + params.Encode()
+
 	result := []*ApiToken{}
-	nextURL := fmt.Sprintf("https://%s/api/v1/api-tokens?limit=200", host)
-
-	for nextURL != "" {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", fmt.Sprintf("SSWS %s", token))
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
-			return nil, fmt.Errorf("failed to fetch API tokens from %s: %s", nextURL, resp.Status)
-		}
-
-		raw, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-
+	for i := 0; i < maxPages && nextURL != ""; i++ {
 		page := []*ApiToken{}
-		if err := json.Unmarshal(raw, &page); err != nil {
+		resp, err := m.get(ctx, nextURL, &page)
+		if err != nil {
 			return nil, err
 		}
 		result = append(result, page...)
-
+		if resp == nil {
+			break
+		}
 		nextURL = nextLinkURL(resp.Header.Values("Link"))
 	}
 

--- a/providers/okta/resources/sdk/apiTokens_test.go
+++ b/providers/okta/resources/sdk/apiTokens_test.go
@@ -1,0 +1,95 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListApiTokensFollowsPagination covers the API token listing now that it
+// runs through ApiExtension: the transport is injectable, so the previously
+// untestable `Link: rel="next"` loop is exercised here.
+func TestListApiTokensFollowsPagination(t *testing.T) {
+	t.Parallel()
+	rt := &pagedRoundTripper{
+		page1:     `[{"id":"t1","name":"one"},{"id":"t2","name":"two"}]`,
+		page2:     `[{"id":"t3","name":"three"}]`,
+		nextQuery: "after=p2",
+	}
+
+	m := fakeClient(rt)
+	tokens, err := m.ListApiTokens(context.Background(), 200)
+	require.NoError(t, err)
+	require.Len(t, tokens, 3, "expected tokens from both pages, not just the first")
+	assert.Equal(t, 2, rt.calls, "expected the client to follow the next-page link once")
+	assert.Equal(t, "t3", tokens[2].Id)
+}
+
+// singlePageRoundTripper serves one page with no `Link` header at all.
+type singlePageRoundTripper struct {
+	body  string
+	calls int
+}
+
+func (rt *singlePageRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString(rt.body)),
+		Request:    req,
+	}, nil
+}
+
+// TestListUserFactorsDecodesProfile proves the factors fetch keeps the
+// per-factorType `profile` object, which is the whole reason we bypass the
+// generated SDK's UserFactor union.
+func TestListUserFactorsDecodesProfile(t *testing.T) {
+	t.Parallel()
+	rt := &singlePageRoundTripper{
+		body: `[{"id":"f1","factorType":"sms","profile":{"phoneNumber":"+15551234567"}}]`,
+	}
+
+	m := fakeClient(rt)
+	factors, err := m.ListUserFactors(context.Background(), "user1")
+	require.NoError(t, err)
+	require.Len(t, factors, 1)
+	assert.Equal(t, 1, rt.calls, "the factors endpoint is not paginated")
+	assert.Contains(t, string(factors[0]), `"phoneNumber":"+15551234567"`)
+}
+
+// TestListUserFactorsEscapesUserId guards against a user id with URL-unsafe
+// characters breaking out of the path segment.
+func TestListUserFactorsEscapesUserId(t *testing.T) {
+	t.Parallel()
+	rt := &pathCapturingRoundTripper{body: `[]`}
+
+	m := fakeClient(rt)
+	_, err := m.ListUserFactors(context.Background(), "a/b c")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/users/a%2Fb%20c/factors", rt.path)
+}
+
+// pathCapturingRoundTripper records the escaped request path.
+type pathCapturingRoundTripper struct {
+	body string
+	path string
+}
+
+func (rt *pathCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.path = req.URL.EscapedPath()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewBufferString(rt.body)),
+		Request:    req,
+	}, nil
+}

--- a/providers/okta/resources/sdk/policies.go
+++ b/providers/okta/resources/sdk/policies.go
@@ -46,7 +46,7 @@ func (m *ApiExtension) ListPolicies(ctx context.Context, policyType string, limi
 	if limit > 0 {
 		params.Set("limit", strconv.Itoa(limit))
 	}
-	nextURL := m.url("/api/v1/policies") + "?" + params.Encode()
+	nextURL := m.urlWithParams("/api/v1/policies", params)
 
 	policies := []*PolicyWrapper{}
 	var firstResp *http.Response
@@ -79,7 +79,7 @@ func (m *ApiExtension) ListPolicyRules(ctx context.Context, policyId string, lim
 	if limit > 0 {
 		params.Set("limit", strconv.Itoa(limit))
 	}
-	nextURL := m.url("/api/v1/policies/"+url.PathEscape(policyId)+"/rules") + "?" + params.Encode()
+	nextURL := m.urlWithParams("/api/v1/policies/"+url.PathEscape(policyId)+"/rules", params)
 
 	rules := []json.RawMessage{}
 	for i := 0; i < maxPages && nextURL != ""; i++ {

--- a/providers/okta/resources/sdk/sdk.go
+++ b/providers/okta/resources/sdk/sdk.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 // ApiExtension handles cases where Okta's SDK doesn't expose a particular API.
@@ -72,4 +73,15 @@ func (m *ApiExtension) get(ctx context.Context, url string, out any) (*http.Resp
 // url builds an absolute org URL for the given API path (e.g. "/api/v1/zones").
 func (m *ApiExtension) url(path string) string {
 	return fmt.Sprintf("https://%s%s", m.Host, path)
+}
+
+// urlWithParams builds an absolute org URL with a query string, omitting the
+// "?" entirely when there are no parameters so the URL does not end in a bare
+// separator.
+func (m *ApiExtension) urlWithParams(path string, params url.Values) string {
+	u := m.url(path)
+	if len(params) == 0 {
+		return u
+	}
+	return u + "?" + params.Encode()
 }

--- a/providers/okta/resources/sdk/sdk_test.go
+++ b/providers/okta/resources/sdk/sdk_test.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUrlWithParams(t *testing.T) {
+	t.Parallel()
+	m := &ApiExtension{Host: "x.okta.com"}
+
+	tests := []struct {
+		name   string
+		path   string
+		params url.Values
+		expect string
+	}{
+		{
+			name:   "no params leaves off the separator",
+			path:   "/api/v1/api-tokens",
+			params: url.Values{},
+			expect: "https://x.okta.com/api/v1/api-tokens",
+		},
+		{
+			name:   "nil params leaves off the separator",
+			path:   "/api/v1/api-tokens",
+			params: nil,
+			expect: "https://x.okta.com/api/v1/api-tokens",
+		},
+		{
+			name:   "single param",
+			path:   "/api/v1/api-tokens",
+			params: url.Values{"limit": []string{"200"}},
+			expect: "https://x.okta.com/api/v1/api-tokens?limit=200",
+		},
+		{
+			name:   "values are escaped",
+			path:   "/api/v1/policies",
+			params: url.Values{"type": []string{"ACCESS POLICY"}},
+			expect: "https://x.okta.com/api/v1/policies?type=ACCESS+POLICY",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, m.urlWithParams(tc.path, tc.params))
+		})
+	}
+}

--- a/providers/okta/resources/sdk/userFactors.go
+++ b/providers/okta/resources/sdk/userFactors.go
@@ -18,7 +18,7 @@ import (
 // The endpoint returns every enrolled factor in a single response, so there is
 // no `Link: rel="next"` loop here.
 func (m *ApiExtension) ListUserFactors(ctx context.Context, userId string) ([]json.RawMessage, error) {
-	factors := []json.RawMessage{}
+	var factors []json.RawMessage
 	_, err := m.get(ctx, m.url("/api/v1/users/"+url.PathEscape(userId)+"/factors"), &factors)
 	if err != nil {
 		return nil, err

--- a/providers/okta/resources/sdk/userFactors.go
+++ b/providers/okta/resources/sdk/userFactors.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+)
+
+// ListUserFactors returns the MFA factors enrolled by a user as raw JSON
+// objects. We decode them in the caller rather than through the generated SDK's
+// UserFactor type: that type is a discriminated union which drops the
+// per-factorType `profile` object, and the profile is where the enrollment
+// detail (phone number, credential id, authenticator name) lives.
+//
+// The endpoint returns every enrolled factor in a single response, so there is
+// no `Link: rel="next"` loop here.
+func (m *ApiExtension) ListUserFactors(ctx context.Context, userId string) ([]json.RawMessage, error) {
+	factors := []json.RawMessage{}
+	_, err := m.get(ctx, m.url("/api/v1/users/"+url.PathEscape(userId)+"/factors"), &factors)
+	if err != nil {
+		return nil, err
+	}
+	return factors, nil
+}

--- a/providers/okta/resources/trustedorigin.go
+++ b/providers/okta/resources/trustedorigin.go
@@ -79,5 +79,5 @@ func newMqlOktaTrustedOrigin(runtime *plugin.Runtime, entry *okta.TrustedOrigin)
 }
 
 func (o *mqlOktaTrustedOrigin) id() (string, error) {
-	return "okta.trustedOriogin/" + o.Id.Data, o.Id.Error
+	return "okta.trustedOrigin/" + o.Id.Data, o.Id.Error
 }

--- a/providers/okta/resources/userFactors.go
+++ b/providers/okta/resources/userFactors.go
@@ -6,15 +6,12 @@ package resources
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
+	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
 
 // mqlOktaUserFactorInternal caches the owning user's id so the typed user()
@@ -47,42 +44,23 @@ func (o *mqlOktaUser) factors() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
+	apiSupplement := &sdk.ApiExtension{
+		Host:  conn.OrganizationID(),
+		Token: conn.Token(),
+	}
 
-	// The factors endpoint returns all enrolled factors in a single response;
-	// we issue the request directly (rather than client.UserFactorAPI.ListFactors)
-	// to capture the per-factorType `profile` object that the SDK's typed
-	// UserFactor union discards.
-	endpoint := fmt.Sprintf("https://%s/api/v1/users/%s/factors", conn.OrganizationID(), url.PathEscape(o.Id.Data))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	raw, err := apiSupplement.ListUserFactors(ctx, o.Id.Data)
 	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "SSWS "+conn.Token())
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch user factors: %s: %s", resp.Status, string(body))
-	}
-
-	var page []userFactorRaw
-	if err := json.Unmarshal(body, &page); err != nil {
 		return nil, err
 	}
 
 	list := []any{}
-	for i := range page {
-		r, err := newMqlOktaUserFactor(o.MqlRuntime, o.Id.Data, &page[i])
+	for i := range raw {
+		var entry userFactorRaw
+		if err := json.Unmarshal(raw[i], &entry); err != nil {
+			return nil, err
+		}
+		r, err := newMqlOktaUserFactor(o.MqlRuntime, o.Id.Data, &entry)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Clears the low-severity findings deferred from the okta provider logic audit, and routes the two remaining ad-hoc HTTP call sites through the shared `sdk.ApiExtension`.

## Fixes

- **`okta.organization` contact users** — `billingContact`/`technicalContact` dereferenced the contact response without a nil check, and a missing contact failed the *entire* `okta.organization` query. Designating a contact is optional; Okta answers `404` for an empty slot. Both slots now report a null field (`StateIsSet | StateIsNull`) instead of erroring.
- **Unguarded response derefs** — `initOktaOrganization` and `initOktaCustomRole` now check their responses before reading them, matching their siblings.
- **`okta.trustedOrigin` `__id` typo** — the prefix read `okta.trustedOriogin/`. Unique and stable either way, so caching was never broken, but it leaked into debug output.
- **`okta.policy.rules()` receiver** — was the only accessor in the provider on a value receiver.
- **`okta.logStreams` page size** — was requesting Okta's default page size rather than `queryLimit`.

## Consolidation

- `sdk.ListApiTokens` becomes an `ApiExtension` method, dropping its own private `http.Client` and a second copy of the `Link: rel="next"` pagination loop. As a free function with a hardcoded client it could not be tested; it now has pagination coverage.
- `okta.user.factors()` fetches through a new `ApiExtension.ListUserFactors` instead of hand-building a request against `http.DefaultClient`. The raw-JSON decode is deliberately preserved — the generated SDK's `UserFactor` union drops the per-`factorType` `profile` object, which is where the enrollment detail lives.

This leaves `ApiExtension` as the single raw-HTTP path in the provider, so the rate-limit and timeout handling it currently lacks becomes a one-place fix.

## A correction to the audit backlog

The deferred list flagged ~12 paginated calls as "missing `.Limit(queryLimit)`". That was overstated. Checking the v5 SDK, only `ListLogStreams` among them exposes a `Limit` method at all:

```
ListApiServiceIntegrationInstances, ListApplicationKeys, ListScopeConsentGrants,
ListAuthorizationServerPolicies, ListAuthenticators, ListDeviceAssurancePolicies,
ListDeviceUsers, ListGroupAssignedRoles, ListIdentityProviderSigningKeys,
ListEventHooks, ListInlineHooks, ListHookKeys, ListPolicyRules, ListRiskProviders,
ListSecurityEventsProviderInstances, ListAssignedRolesForUser, ListResourceSets,
ListResourceSetResources, ListBindings, ListMembersOfBinding   -> no Limit()
```

The rest are already requesting everything the API offers. Only the `logStreams` change was actionable.

## Testing

`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test ./resources/...` passes. New tests cover `ListApiTokens` pagination, `ListUserFactors` profile decoding, and user-id path escaping.

Not live-verified against an org — the behavior changes are on error/empty paths (missing org contact, absent custom role) that the trial org used for earlier okta verification does not exercise.
