### PR TITLE
🟢 fix tests that only pass on Linux, or only pass once

### DIFF
--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -20,9 +20,15 @@ var (
 	homeConfigDir = filepath.Join(home, ".config", "mondoo")
 	homeConfig    = filepath.Join(homeConfigDir, DefaultConfigFile)
 
-	systemConfigDir = filepath.Join("/etc", "opt", "mondoo")
-	systemConfig    = filepath.Join(systemConfigDir, DefaultConfigFile)
-	systemInventory = filepath.Join(systemConfigDir, "inventory.yml")
+	// Derived from SystemConfigPath rather than hardcoded: the system config
+	// directory is platform-specific (/etc/opt/mondoo on Linux,
+	// /Library/Mondoo/etc on macOS, C:\ProgramData\Mondoo on Windows). Writing
+	// fixtures to a hardcoded Linux path made every test that expects the
+	// system config to be found fail anywhere but Linux, because
+	// autodetectConfig probed a path the test never wrote to.
+	systemConfigDir = SystemConfigPath()
+	systemConfig    = SystemConfigPath(DefaultConfigFile)
+	systemInventory = SystemConfigPath("inventory.yml")
 
 	oldConfig = filepath.Join(home, "."+DefaultConfigFile)
 

--- a/cli/selfupdate/inplace.go
+++ b/cli/selfupdate/inplace.go
@@ -49,18 +49,32 @@ func swapBinaryInPlace(stagedBinaryPath string) (string, error) {
 	return swapBinaryInPlaceFrom(stagedBinaryPath, originalPath)
 }
 
+// resolvePathForCompare normalizes a path for identity comparison: absolute,
+// with symlinks resolved. Each step is best-effort, so a path that cannot be
+// resolved (it may not exist yet) degrades to the closest form available
+// rather than failing.
+func resolvePathForCompare(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
+}
+
 // swapBinaryInPlaceFrom is the testable core of swapBinaryInPlace. It takes
-// the resolved original path explicitly instead of calling os.Executable().
+// the original path explicitly instead of calling os.Executable().
 func swapBinaryInPlaceFrom(stagedBinaryPath, originalPath string) (string, error) {
-	// If already running from the same path, no swap needed.
-	stagedAbs, err := filepath.Abs(stagedBinaryPath)
-	if err == nil {
-		if resolved, err2 := filepath.EvalSymlinks(stagedAbs); err2 == nil {
-			stagedAbs = resolved
-		}
-		if stagedAbs == originalPath {
-			return originalPath, nil
-		}
+	// If already running from the same path, no swap needed. Both sides are
+	// resolved the same way: comparing a symlink-resolved staged path against an
+	// unresolved original would miss the match and fall through to renaming the
+	// binary out of the way, then failing to copy it back from a path that no
+	// longer exists. That is exactly what happens where TMPDIR is itself a
+	// symlink, as it is on macOS (/var/folders -> /private/var/folders).
+	if resolvePathForCompare(stagedBinaryPath) == resolvePathForCompare(originalPath) {
+		return originalPath, nil
 	}
 
 	oldPath := originalPath + ".old"

--- a/providers/os/connection/container/image_connection_test.go
+++ b/providers/os/connection/container/image_connection_test.go
@@ -60,6 +60,10 @@ func cacheImageToTar(source string, filename string) error {
 	// every subsequent run. The failure that produces is "unexpected EOF" from
 	// whatever later tries to read the tar, which points nowhere near the
 	// download that actually failed.
+	//
+	// The temporary file deliberately sits next to its destination rather than
+	// in os.TempDir(): a same-directory rename is atomic and cannot land
+	// cross-volume, which is what would make os.Rename fail on Windows.
 	tmp := filename + ".partial"
 	if err := tarball.WriteToFile(tmp, tag, img); err != nil {
 		os.Remove(tmp)

--- a/providers/os/connection/container/image_connection_test.go
+++ b/providers/os/connection/container/image_connection_test.go
@@ -53,7 +53,19 @@ func cacheImageToTar(source string, filename string) error {
 		return err
 	}
 
-	return tarball.WriteToFile(filename, tag, img)
+	// Download to a temporary file and only move it into place once it is
+	// complete. Writing straight to filename means an interrupted pull (a
+	// truncated layer, a killed run) leaves a partial tar behind, and the
+	// os.Stat check above then treats that corrupt file as a valid cache on
+	// every subsequent run. The failure that produces is "unexpected EOF" from
+	// whatever later tries to read the tar, which points nowhere near the
+	// download that actually failed.
+	tmp := filename + ".partial"
+	if err := tarball.WriteToFile(tmp, tag, img); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, filename)
 }
 
 func cacheAlpine() error {
@@ -292,7 +304,10 @@ func TestTarSymlinkFile(t *testing.T) {
 			tar.OPTION_FILE: alpineContainerPath,
 		},
 	}, &inventory.Asset{})
-	assert.Equal(t, nil, err, "should create tar without error")
+	// require, not assert: c is dereferenced immediately below, so continuing
+	// past a failure here segfaults the whole package rather than failing this
+	// one test.
+	require.NoError(t, err, "should create tar without error")
 
 	f, err := c.FileSystem().Open("/bin/cat")
 	assert.Nil(t, err)
@@ -324,7 +339,10 @@ func TestTarRelativeSymlinkFileCentos(t *testing.T) {
 			tar.OPTION_FILE: centosContainerPath,
 		},
 	}, &inventory.Asset{})
-	assert.Equal(t, nil, err, "should create tar without error")
+	// require, not assert: c is dereferenced immediately below, so continuing
+	// past a failure here segfaults the whole package rather than failing this
+	// one test.
+	require.NoError(t, err, "should create tar without error")
 
 	f, err := c.FileSystem().Open("/etc/redhat-release")
 	require.NoError(t, err)

--- a/providers/os/connection/ssh/sftp/sftp_test.go
+++ b/providers/os/connection/ssh/sftp/sftp_test.go
@@ -232,6 +232,11 @@ func TestSftpCreate(t *testing.T) {
 	// first and remove it afterwards: without this the directory survives the
 	// run, and every subsequent invocation in the same working tree fails at
 	// the Mkdir below with "file exists" before testing anything.
+	//
+	// That fixed path is shared state, so this test must not become parallel:
+	// do not add t.Parallel() here, and do not add it to any other test in this
+	// package that touches ./testdata. The RemoveAll below would delete the
+	// directory out from under a concurrent test.
 	require.NoError(t, os.RemoveAll("./testdata"))
 	require.NoError(t, os.Mkdir("./testdata", 0o777))
 	t.Cleanup(func() { _ = os.RemoveAll("./testdata") })

--- a/providers/os/connection/ssh/sftp/sftp_test.go
+++ b/providers/os/connection/ssh/sftp/sftp_test.go
@@ -227,7 +227,14 @@ func MakeSSHKeyPair(bits int, pubKeyPath, privateKeyPath string) error {
 }
 
 func TestSftpCreate(t *testing.T) {
+	// The sftp server under test serves from the package directory, so testdata
+	// has to live at a fixed relative path rather than in t.TempDir(). Clear it
+	// first and remove it afterwards: without this the directory survives the
+	// run, and every subsequent invocation in the same working tree fails at
+	// the Mkdir below with "file exists" before testing anything.
+	require.NoError(t, os.RemoveAll("./testdata"))
 	require.NoError(t, os.Mkdir("./testdata", 0o777))
+	t.Cleanup(func() { _ = os.RemoveAll("./testdata") })
 	require.NoError(t, MakeSSHKeyPair(1024, "./testdata/id_rsa.pub", "./testdata/id_rsa"))
 
 	go RunSftpServer()


### PR DESCRIPTION
Ran the full suite locally on macOS and found four failures. All four are real. None required changing what the code under test does, with one exception where the test exposed a genuine asymmetry in the implementation.

Two themes: **tests that only pass on Linux**, and **tests that only pass once**.

## 1. `cli/config` — hardcoded Linux system path

`config_test.go` hardcoded `/etc/opt/mondoo`, but `SystemConfigPath` is platform-specific:

| OS | System config dir |
|---|---|
| linux | `/etc/opt/mondoo` |
| darwin | `/Library/Mondoo/etc` |
| windows | `C:\ProgramData\Mondoo` |

The test wrote its fixture to a path `autodetectConfig` never probes, so `autodetectConfig` fell through to the home config and `test systemConfig returned` failed anywhere but Linux. Now derived from `SystemConfigPath`.

## 2. `cli/selfupdate` — asymmetric symlink resolution

`swapBinaryInPlaceFrom` resolved symlinks on the staged path but compared it against an unresolved `originalPath`:

```go
if resolved, err2 := filepath.EvalSymlinks(stagedAbs); err2 == nil {
    stagedAbs = resolved
}
if stagedAbs == originalPath {   // originalPath never resolved
```

Where `TMPDIR` is itself a symlink — as on macOS, `/var/folders` → `/private/var/folders` — the already-in-place short circuit misses. The function then renames the binary to `.old` and fails copying it back from a path that no longer exists. It does roll back, so nothing is lost, but it returns an error where a no-op was correct.

Production callers pass an already-resolved path (`swapBinaryInPlace` calls `EvalSymlinks` first), so only the test hit this. The function shouldn't depend on that, so both sides now go through one `resolvePathForCompare`.

## 3. `providers/os` container — a panic that poisoned the image cache

Two tests asserted the connection error and then dereferenced the connection:

```go
c, err := container.NewFromTar(...)
assert.Equal(t, nil, err, "should create tar without error")
f, err := c.FileSystem().Open("/etc/redhat-release")   // c is nil -> SIGSEGV
```

A failed image pull therefore segfaulted the entire package rather than failing one test, taking every later test in it down too. Now `require`.

That panic had a second-order effect worth fixing on its own. `cacheImageToTar` treats **any** existing file as a valid cache:

```go
_, err := os.Stat(filename)
if err == nil { return nil }
```

The interrupted download left a truncated 36MB `centos-container.tar`, which every subsequent run happily reused — failing instantly with `unexpected EOF` and never re-downloading. That error points nowhere near the download that actually failed, and the only cure was knowing to delete the file by hand.

Now the download goes to `<name>.partial` and is renamed into place only on success. Verified end-to-end: deleting the truncated file and re-running downloads the full 76MB tar in ~86s and the test passes.

## 4. `providers/os` sftp — non-idempotent

`TestSftpCreate` did `require.NoError(t, os.Mkdir("./testdata", 0o777))` and never removed the directory. It passed exactly once per working tree; every run after that failed at the `Mkdir` with `file exists`, before testing anything. It can't move to `t.TempDir()` because the sftp server under test serves from the package directory, so it now clears the path up front and registers cleanup. Confirmed by running it twice in a row.

## Testing

Full `go test ./...` after the fixes. The only remaining failure is `TestRpmPackages`, which needs a running Docker daemon and says so itself — it lives under `test/` and is excluded from `test/go/plain`.

Worth noting for anyone else running the suite locally: `go test ./...` on its own fails to build several packages with `undefined: NewMockProviderPlugin` and friends. Those mocks are generated and gitignored, so `make test/generate` (or `make test/go`, which runs it) is required first. Not a defect, just a sharp edge.
