### PR TITLE
🐛 aws/gcp: populate aws.organization and stop Shared VPC erroring on non-hosts

### DIFF
--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1014,7 +1014,7 @@ func init() {
 			Create: createAwsBillingBudget,
 		},
 		"aws.organization": {
-			// to override args, implement: initAwsOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsOrganization,
 			Create: createAwsOrganization,
 		},
 		"aws.organization.serviceControlPolicy": {

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -79,15 +79,25 @@ func (a *mqlAwsAccount) aliases() ([]any, error) {
 	return result, nil
 }
 
-func (a *mqlAwsAccount) organization() (*mqlAwsOrganization, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+// fetchOrganization describes the caller's AWS organization and maps it onto a
+// new aws.organization resource. Both aws.account.organization and the
+// aws.organization init go through here so the two paths cannot drift apart.
+func fetchOrganization(runtime *plugin.Runtime) (*mqlAwsOrganization, error) {
+	conn, ok := runtime.Connection.(*connection.AwsConnection)
+	if !ok {
+		return nil, errors.New("aws.organization requires an AWS connection")
+	}
 	client := conn.Organizations("") // no region for orgs, use configured region
 
 	org, err := client.DescribeOrganization(context.TODO(), &organizations.DescribeOrganizationInput{})
 	if err != nil {
 		return nil, err
 	}
-	res, err := CreateResource(a.MqlRuntime, ResourceAwsOrganization,
+	if org.Organization == nil {
+		return nil, errors.New("aws.organization: no organization returned for this account")
+	}
+
+	res, err := CreateResource(runtime, ResourceAwsOrganization,
 		map[string]*llx.RawData{
 			"arn":                llx.StringDataPtr(org.Organization.Arn),
 			"id":                 llx.StringDataPtr(org.Organization.Id),
@@ -102,6 +112,10 @@ func (a *mqlAwsAccount) organization() (*mqlAwsOrganization, error) {
 	return res.(*mqlAwsOrganization), nil
 }
 
+func (a *mqlAwsAccount) organization() (*mqlAwsOrganization, error) {
+	return fetchOrganization(a.MqlRuntime)
+}
+
 // initAwsOrganization populates the organization from the API when it is
 // reached directly rather than through aws.account.organization. Without this,
 // a bare `aws.organization` query creates the resource with every field unset,
@@ -111,29 +125,7 @@ func initAwsOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		return args, nil, nil
 	}
 
-	conn, ok := runtime.Connection.(*connection.AwsConnection)
-	if !ok {
-		return nil, nil, errors.New("aws.organization requires an AWS connection")
-	}
-	client := conn.Organizations("") // no region for orgs, use configured region
-
-	org, err := client.DescribeOrganization(context.TODO(), &organizations.DescribeOrganizationInput{})
-	if err != nil {
-		return nil, nil, err
-	}
-	if org.Organization == nil {
-		return nil, nil, errors.New("aws.organization: no organization returned for this account")
-	}
-
-	res, err := CreateResource(runtime, ResourceAwsOrganization,
-		map[string]*llx.RawData{
-			"arn":                llx.StringDataPtr(org.Organization.Arn),
-			"id":                 llx.StringDataPtr(org.Organization.Id),
-			"featureSet":         llx.StringData(string(org.Organization.FeatureSet)),
-			"masterAccountId":    llx.StringDataPtr(org.Organization.MasterAccountId),
-			"masterAccountArn":   llx.StringDataPtr(org.Organization.MasterAccountArn),
-			"masterAccountEmail": llx.StringDataPtr(org.Organization.MasterAccountEmail),
-		})
+	res, err := fetchOrganization(runtime)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -102,6 +102,44 @@ func (a *mqlAwsAccount) organization() (*mqlAwsOrganization, error) {
 	return res.(*mqlAwsOrganization), nil
 }
 
+// initAwsOrganization populates the organization from the API when it is
+// reached directly rather than through aws.account.organization. Without this,
+// a bare `aws.organization` query creates the resource with every field unset,
+// which surfaces client-side as null values with no attribution.
+func initAwsOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) >= 2 {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.AwsConnection)
+	if !ok {
+		return nil, nil, errors.New("aws.organization requires an AWS connection")
+	}
+	client := conn.Organizations("") // no region for orgs, use configured region
+
+	org, err := client.DescribeOrganization(context.TODO(), &organizations.DescribeOrganizationInput{})
+	if err != nil {
+		return nil, nil, err
+	}
+	if org.Organization == nil {
+		return nil, nil, errors.New("aws.organization: no organization returned for this account")
+	}
+
+	res, err := CreateResource(runtime, ResourceAwsOrganization,
+		map[string]*llx.RawData{
+			"arn":                llx.StringDataPtr(org.Organization.Arn),
+			"id":                 llx.StringDataPtr(org.Organization.Id),
+			"featureSet":         llx.StringData(string(org.Organization.FeatureSet)),
+			"masterAccountId":    llx.StringDataPtr(org.Organization.MasterAccountId),
+			"masterAccountArn":   llx.StringDataPtr(org.Organization.MasterAccountArn),
+			"masterAccountEmail": llx.StringDataPtr(org.Organization.MasterAccountEmail),
+		})
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
+}
+
 func (a *mqlAwsOrganization) accounts() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	client := conn.Organizations("") // no region for orgs, use configured region

--- a/providers/gcp/resources/compute_shared_vpc.go
+++ b/providers/gcp/resources/compute_shared_vpc.go
@@ -6,6 +6,8 @@ package resources
 import (
 	"context"
 	"errors"
+	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -15,6 +17,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -118,13 +121,34 @@ func (g *mqlGcpProjectComputeService) fetchSharedVpc() (*sharedVpcTopology, erro
 		}
 		return nil
 	}); err != nil {
-		if !isHTTPSkippable(err) {
+		if !isHTTPSkippable(err) && !isNotSharedVpcHost(err) {
 			return nil, err
 		}
 		log.Debug().Err(err).Str("project", projectId).Msg("could not read Shared VPC service projects")
 	}
 
 	return out, nil
+}
+
+// isNotSharedVpcHost reports whether the error is Compute's way of saying the
+// project simply is not a Shared VPC host. GetXpnResources answers that case
+// with HTTP 400 invalidResourceUsage rather than an empty list, so without this
+// the common case (a project that hosts nothing) fails every Shared VPC
+// accessor instead of reporting false.
+func isNotSharedVpcHost(err error) bool {
+	gerr, ok := err.(*googleapi.Error)
+	if !ok || gerr.Code != http.StatusBadRequest {
+		return false
+	}
+	if strings.Contains(gerr.Message, "is not a shared VPC host project") {
+		return true
+	}
+	for _, e := range gerr.Errors {
+		if e.Reason == "invalidResourceUsage" {
+			return true
+		}
+	}
+	return false
 }
 
 // isSharedVpcHost reports whether other projects run workloads on this project's


### PR DESCRIPTION
Two defects found while verifying the resources added between `b7b8543..main` against live AWS and GCP accounts.

## `aws.organization` returned an empty husk

`aws.organization` is a public, top-level resource, and `discovery.go` also constructs it with `NewResource(runtime, "aws.organization", {})`. Neither path worked, because **no `initAwsOrganization` existed** — only the generated comment offering one. Every field came back unset:

```
> aws.organization { id arn featureSet masterAccountId }
x provider returned no data and no error for a field; the field was never set on the resource (provider bug) field=arn resource=aws.organization
x llx: encountered a primitive with no type information, coercing to null
aws.organization: { id: null, masterAccountId: null, arn: null, featureSet: null }
```

Only the indirect path `aws.account.organization` ever populated it, and that one worked fine — which is what isolated the cause.

`initAwsOrganization` now calls `DescribeOrganization` and fills the same six fields that accessor does. It returns the API error rather than falling through to a blank resource, per the init guidance in CLAUDE.md.

**After:**
```
aws.organization: {
  id: "o-6ee55t8zdf"
  arn: "arn:aws:organizations::<redacted>:organization/o-6ee55t8zdf"
  featureSet: "ALL"
  ...
}
```

## Shared VPC accessors errored on every non-host project

`isSharedVpcHost()`, `isSharedVpcServiceProject()`, `sharedVpcHost()` and `sharedVpcServiceProjects()` all failed on a project that is not a Shared VPC host — the common case:

```
googleapi: Error 400: Invalid resource usage: ''projects/<p>' is not a shared VPC host project.'., invalidResourceUsage
```

Compute answers `GetXpnResources` for a non-host with **HTTP 400 `invalidResourceUsage`** rather than an empty list. `fetchSharedVpc` already guards with `isHTTPSkippable`, but that only covers 403/404 and the "not enabled" / "has not been used" messages, so the 400 propagated and took all four accessors down with it.

A scoped `isNotSharedVpcHost` guard treats that single response as "hosts nothing". It is deliberately narrow rather than widening `isHTTPSkippable` to all 400s, so genuine bad requests still surface.

**After:** `isSharedVpcHost: false`, `isSharedVpcServiceProject: false`, `sharedVpcServiceProjects: []`, no error.

## Verification

Both fixes were confirmed against live accounts before and after, using the exact failing queries. `aws.permissions.json` and `gcp.permissions.json` are unchanged (no new API calls); no `.lr` or `.lr.versions` changes, since neither fix adds schema.

## Related finding, not fixed here

The same run surfaced a third issue with no confident fix: `azure.subscription.networkService.applicationFirewallPolicies` fails to list entirely when any WAF policy has rule-group overrides, because `armnetwork/v10` types `ManagedRuleSetRuleGroup.Rules` as `[]*string` while Azure returns numbers at api-version `2025-07-01`:

```
struct field ComputedDisabledRules: ... struct field Rules: json: cannot unmarshal number into Go value of type string
```

That is an upstream SDK typing bug, so it is left out of this PR and tracked separately.
