### PR TITLE
🐛 oci: stop reporting fabricated data as fact

### DIFF
--- a/providers/oci/connection/clients.go
+++ b/providers/oci/connection/clients.go
@@ -80,7 +80,23 @@ func (c *OciConnection) Tenant(ctx context.Context) (*identity.Tenancy, error) {
 	return &resp.Tenancy, nil
 }
 
+// GetCompartments returns the tenancy root plus every active compartment
+// beneath it.
+//
+// The result is memoized for the lifetime of the connection. A dozen listers
+// fan out over the compartment tree, and each one asking for it separately
+// meant walking the same paginated ListCompartments a dozen times per scan.
+//
+// A failure is not cached: an Identity call that fails on a throttle should be
+// retried by the next lister rather than turning one bad moment into a scan
+// with no compartments at all.
 func (c *OciConnection) GetCompartments(ctx context.Context) ([]identity.Compartment, error) {
+	c.compartmentLock.Lock()
+	defer c.compartmentLock.Unlock()
+	if c.compartmentsDone {
+		return c.compartmentList, nil
+	}
+
 	oClient, err := c.IdentityClient()
 	if err != nil {
 		return nil, err
@@ -122,6 +138,8 @@ func (c *OciConnection) GetCompartments(ctx context.Context) ([]identity.Compart
 		}
 	}
 
+	c.compartmentList = compartments
+	c.compartmentsDone = true
 	return compartments, nil
 }
 

--- a/providers/oci/connection/connection.go
+++ b/providers/oci/connection/connection.go
@@ -5,8 +5,10 @@ package connection
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identity"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
@@ -18,6 +20,16 @@ type OciConnection struct {
 	asset       *inventory.Asset
 	config      common.ConfigurationProvider
 	tenancyOcid string
+
+	// The compartment tree, resolved once per connection. Every
+	// compartment-scoped lister needs the full list to fan out over, and there
+	// are a dozen of them, so without this a scan re-walked the paginated
+	// ListCompartments for each one. The tree does not change mid-scan, and on
+	// a large tenancy those repeats are both slow and a good way to run into
+	// Identity rate limits.
+	compartmentLock  sync.Mutex
+	compartmentList  []identity.Compartment
+	compartmentsDone bool
 }
 
 func NewOciConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*OciConnection, error) {

--- a/providers/oci/resources/audit.go
+++ b/providers/oci/resources/audit.go
@@ -76,7 +76,11 @@ func (o *mqlOciAudit) events() ([]any, error) {
 
 	// Audit events are recorded per region and per compartment, and the API
 	// offers no subtree flag, so both dimensions have to be walked.
-	endTime := time.Now().UTC()
+	// Truncated to the minute because the Audit API requires it: both bounds
+	// are documented as accepting minute granularity only, with seconds and
+	// milliseconds set to zero. The SDK serializes an SDKTime with RFC3339Nano,
+	// so an untruncated time.Now() puts seconds and nanoseconds on the wire.
+	endTime := time.Now().UTC().Truncate(time.Minute)
 	startTime := endTime.Add(-ociAuditEventWindow)
 
 	return ociRunCompartmentRegionPool(conn, regions.Data,

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -37,21 +37,15 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getCertificates(conn, list.Data))
-}
+	// Certificates are issued into the compartment of the load balancer or
+	// gateway that terminates TLS, and ListCertificates cannot look below the
+	// compartment it is given. A root-only listing reported no certificates at
+	// all, so expiry and renewal checks silently had nothing to inspect.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci certificates with region %s", region)
 
-func (o *mqlOciCertificates) getCertificates(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci certificates with region %s", regionResource.Id.Data)
-
-			svc, err := conn.CertificatesManagementClient(regionResource.Id.Data)
+			svc, err := conn.CertificatesManagementClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -60,7 +54,7 @@ func (o *mqlOciCertificates) getCertificates(conn *connection.OciConnection, reg
 			var page *string
 			for {
 				response, err := svc.ListCertificates(ctx, certificatesmanagement.ListCertificatesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -145,11 +139,8 @@ func (o *mqlOciCertificates) getCertificates(conn *connection.OciConnection, reg
 				mqlCert.cacheIssuerCaId = stringValue(c.IssuerCertificateAuthorityId)
 				res = append(res, mqlCert)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciCertificatesCertificateInternal struct {

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -34,6 +34,24 @@ type mqlOciCloudGuardInternal struct {
 	homeRegion     string
 }
 
+// ociCloudGuardProblemWindow is how far back the problem listing reaches.
+//
+// The service defaults this to 30 days when the caller leaves it unset, which
+// is short enough to hide the remediation history the resource exists to
+// expose: a finding resolved six weeks ago simply vanishes, and "was this ever
+// raised?" answers no. 90 days matches the shortest Audit retention period, so
+// the two detection-side resources cover a comparable span.
+const ociCloudGuardProblemWindow = 90 * 24 * time.Hour
+
+// ociCloudGuardProblemStates are the lifecycle states a problem listing has to
+// ask for. The filter takes one value at a time and defaults to ACTIVE, so
+// every state has to be requested explicitly or the resolved ones never
+// appear.
+var ociCloudGuardProblemStates = []cloudguard.ListProblemsLifecycleStateEnum{
+	cloudguard.ListProblemsLifecycleStateActive,
+	cloudguard.ListProblemsLifecycleStateInactive,
+}
+
 func (o *mqlOciCloudGuard) id() (string, error) {
 	return "oci.cloudGuard", nil
 }
@@ -72,6 +90,10 @@ func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 
 	// Resolve the home region before taking configLock: getHomeRegion takes its
 	// own lock, and nesting it inside this critical section would deadlock.
+	//
+	// This is the one caller that must not use getServiceRegion. The reporting
+	// region is read *from* this configuration, so asking for it here would
+	// recurse back into getConfig and never terminate.
 	homeRegion, err := o.getHomeRegion()
 	if err != nil {
 		return nil, err
@@ -102,6 +124,23 @@ func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 	return o.config, nil
 }
 
+// getServiceRegion returns the region Cloud Guard actually serves data from.
+//
+// Cloud Guard aggregates findings from every monitored region into a single
+// reporting region, chosen when the service is enabled. That is usually the
+// tenancy's home region but is not required to be, and querying the wrong one
+// returns nothing - a Cloud Guard posture check that reports no problems at
+// all while the console shows hundreds. The home region is the fallback,
+// because it is also what getConfig has to use to discover the reporting
+// region in the first place.
+func (o *mqlOciCloudGuard) getServiceRegion() (string, error) {
+	cfg, err := o.getConfig()
+	if err == nil && cfg != nil && stringValue(cfg.ReportingRegion) != "" {
+		return *cfg.ReportingRegion, nil
+	}
+	return o.getHomeRegion()
+}
+
 func (o *mqlOciCloudGuard) status() (bool, error) {
 	cfg, err := o.getConfig()
 	if err != nil {
@@ -129,12 +168,12 @@ func (o *mqlOciCloudGuard) selfManageResources() (bool, error) {
 func (o *mqlOciCloudGuard) targets() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -191,48 +230,63 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 	return res, nil
 }
 
-// problems lists every finding Cloud Guard has raised. The listing is
-// deliberately unfiltered: `lifecycleDetail` is exposed as a field so callers
-// decide whether they care about OPEN findings only or also want the
-// RESOLVED and DISMISSED history. Filtering to OPEN here would make a
-// dismissed-but-unfixed finding indistinguishable from one that never existed.
+// problems lists the findings Cloud Guard has raised.
+//
+// Leaving the request's filters unset does not mean "everything": the service
+// applies its own defaults, narrowing the result to problems whose lifecycle
+// state is ACTIVE and that were last detected within the past 30 days. Both
+// bounds are set explicitly here instead, so the scope is what this code says
+// it is rather than whatever the service currently defaults to.
+//
+// The window is deliberately wider than the default. `lifecycleDetail` is
+// exposed as a field so callers decide whether they care about OPEN findings
+// only or also want the RESOLVED and DISMISSED history, and that history is
+// the point - a dismissed-but-unfixed finding should be distinguishable from
+// one that never existed, which a 30-day cutoff quietly prevents.
 func (o *mqlOciCloudGuard) problems() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	ctx := context.Background()
+	since := common.SDKTime{Time: time.Now().UTC().Add(-ociCloudGuardProblemWindow)}
 	problems := []cloudguard.ProblemSummary{}
-	var page *string
-	for {
-		response, err := client.ListProblems(ctx, cloudguard.ListProblemsRequest{
-			CompartmentId: common.String(conn.TenantID()),
-			// Problems are raised against resources in sub-compartments, so
-			// without the subtree flag the tenancy root reports almost none.
-			CompartmentIdInSubtree: common.Bool(true),
-			// ACCESSIBLE degrades to the compartments the caller can read
-			// instead of failing the whole listing on the first one it cannot.
-			AccessLevel: cloudguard.ListProblemsAccessLevelAccessible,
-			Page:        page,
-		})
-		if err != nil {
-			return nil, err
-		}
+	// One pass per lifecycle state: the filter accepts a single value, and
+	// leaving it unset is not the union - the service falls back to ACTIVE.
+	for _, state := range ociCloudGuardProblemStates {
+		var page *string
+		for {
+			response, err := client.ListProblems(ctx, cloudguard.ListProblemsRequest{
+				CompartmentId: common.String(conn.TenantID()),
+				// Problems are raised against resources in sub-compartments, so
+				// without the subtree flag the tenancy root reports almost none.
+				CompartmentIdInSubtree: common.Bool(true),
+				// ACCESSIBLE degrades to the compartments the caller can read
+				// instead of failing the whole listing on the first one it cannot.
+				AccessLevel:                          cloudguard.ListProblemsAccessLevelAccessible,
+				LifecycleState:                       state,
+				TimeLastDetectedGreaterThanOrEqualTo: &since,
+				Page:                                 page,
+			})
+			if err != nil {
+				return nil, err
+			}
 
-		problems = append(problems, response.Items...)
+			problems = append(problems, response.Items...)
 
-		if response.OpcNextPage == nil {
-			break
+			if response.OpcNextPage == nil {
+				break
+			}
+			page = response.OpcNextPage
 		}
-		page = response.OpcNextPage
 	}
 
 	res := make([]any, 0, len(problems))
@@ -322,12 +376,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	homeRegion, err := obj.(*mqlOciCloudGuard).getHomeRegion()
+	serviceRegion, err := obj.(*mqlOciCloudGuard).getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -423,12 +477,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -486,12 +540,12 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -553,12 +607,12 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -616,12 +670,12 @@ func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/compartments.go
+++ b/providers/oci/resources/compartments.go
@@ -20,6 +20,21 @@ import (
 // limits.
 const ociCompartmentPoolConcurrency = 10
 
+// ociRegionsByID indexes an oci.regions collection by region key so a
+// compartment lister, which only receives the region as a string, can still set
+// a typed oci.region field on the resources it builds.
+func ociRegionsByID(regions []any) (map[string]*mqlOciRegion, error) {
+	res := make(map[string]*mqlOciRegion, len(regions))
+	for _, region := range regions {
+		regionResource, ok := region.(*mqlOciRegion)
+		if !ok {
+			return nil, errors.New("invalid region type")
+		}
+		res[regionResource.Id.Data] = regionResource
+	}
+	return res, nil
+}
+
 // ociCompartmentLister lists resources of a single type inside one compartment
 // in one region. Implementations return the already-constructed MQL resources.
 type ociCompartmentLister func(ctx context.Context, region string, compartmentID string) ([]any, error)

--- a/providers/oci/resources/compartments.go
+++ b/providers/oci/resources/compartments.go
@@ -104,15 +104,22 @@ func ociCollectCompartmentJobs(jobs []*jobpool.Job) ([]any, error) {
 	for i := range poolOfJobs.Jobs {
 		job := poolOfJobs.Jobs[i]
 		if job.Err != nil {
-			if ociRegionServiceUnavailable(job.Err) {
-				log.Debug().Err(job.Err).Msg("skipping oci region where the service is unavailable")
-				continue
-			}
+			// Order matters. OCI answers an authorization failure with 404
+			// NotAuthorizedOrNotFound, and ociRegionServiceUnavailable treats
+			// any 404 as an absent regional endpoint - so asking it first
+			// consumed every denial before it could be counted, and the
+			// all-denied guard below could never fire. The denial test is
+			// narrower (it matches on the error code, not just the status), so
+			// it goes first and the region test keeps the rest.
 			if ociCompartmentInaccessible(job.Err) {
 				denied++
 				if deniedErr == nil {
 					deniedErr = job.Err
 				}
+				continue
+			}
+			if ociRegionServiceUnavailable(job.Err) {
+				log.Debug().Err(job.Err).Msg("skipping oci region where the service is unavailable")
 				continue
 			}
 			hardErr = errors.Join(hardErr, job.Err)
@@ -147,22 +154,33 @@ func ociCollectCompartmentJobs(jobs []*jobpool.Job) ([]any, error) {
 	return res, nil
 }
 
+// ociNotAuthorizedOrNotFound is the error code OCI returns when the caller is
+// not permitted to see a resource. The service deliberately reports it for a
+// resource that does not exist as well, so that a caller cannot probe for the
+// existence of things it has no access to.
+const ociNotAuthorizedOrNotFound = "NotAuthorizedOrNotFound"
+
 // ociCompartmentInaccessible reports whether an error means "you cannot see
 // into this particular compartment" rather than a tenancy-wide fault.
 //
-// OCI collapses "does not exist" and "you are not authorized" into the same
-// NotAuthorizedOrNotFound response precisely so that a caller cannot probe for
-// the existence of resources it has no access to, so 403 and 404 are both
-// treated as an inaccessible compartment here. This is safe only because the
-// caller checks that at least one compartment did succeed.
+// A 403 is unambiguous. A 404 is not: it is both OCI's authorization denial
+// (carrying NotAuthorizedOrNotFound) and what a region with no endpoint for
+// the service returns. Matching the code rather than the bare status keeps the
+// two apart, which is what lets the caller test this before
+// ociRegionServiceUnavailable and still skip genuinely undeployed regions.
+//
+// Treating a denial as skippable is safe only because the caller checks that
+// at least one compartment did succeed.
 func ociCompartmentInaccessible(err error) bool {
 	svcErr, ok := common.IsServiceError(err)
 	if !ok {
 		return false
 	}
 	switch svcErr.GetHTTPStatusCode() {
-	case 403, 404:
+	case 403:
 		return true
+	case 404:
+		return svcErr.GetCode() == ociNotAuthorizedOrNotFound
 	default:
 		return false
 	}

--- a/providers/oci/resources/compartments_test.go
+++ b/providers/oci/resources/compartments_test.go
@@ -22,7 +22,13 @@ func TestOciCompartmentInaccessible(t *testing.T) {
 		// response so callers cannot probe for resources they cannot see, so
 		// both mean the same thing at compartment granularity.
 		{"403 not authorized", fakeServiceError{status: 403, code: "NotAuthorizedOrNotFound"}, true},
-		{"404 not found", fakeServiceError{status: 404, code: "NotAuthorizedOrNotFound"}, true},
+		{"404 not authorized or not found", fakeServiceError{status: 404, code: "NotAuthorizedOrNotFound"}, true},
+
+		// A 404 that is not the authorization denial is an absent endpoint,
+		// not a compartment the caller cannot read. Matching on the code
+		// rather than the status is what lets this run before
+		// ociRegionServiceUnavailable without swallowing undeployed regions.
+		{"404 plain not found", fakeServiceError{status: 404, code: "NotFound"}, false},
 
 		// A bad credential is tenancy-wide, not per-compartment, and must not
 		// be mistaken for a compartment the caller merely lacks read on.
@@ -59,8 +65,18 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 			return nil, fakeServiceError{status: 403, code: "NotAuthorizedOrNotFound"}
 		})
 	}
-	// A region where the service is not deployed at all.
+	// A region where the service is not deployed at all. Deliberately NOT
+	// NotAuthorizedOrNotFound: that code is OCI's authorization denial, and
+	// using it here is what previously let an entirely-denied tenancy be
+	// mistaken for a set of undeployed regions.
 	unavailable := func() *jobpool.Job {
+		return jobpool.NewJob(func() (jobpool.JobResult, error) {
+			return nil, fakeServiceError{status: 404, code: "NotFound"}
+		})
+	}
+	// The shape OCI actually returns when a policy does not grant read on a
+	// compartment. Same status as an absent endpoint, different code.
+	denied404 := func() *jobpool.Job {
 		return jobpool.NewJob(func() (jobpool.JobResult, error) {
 			return nil, fakeServiceError{status: 404, code: "NotAuthorizedOrNotFound"}
 		})
@@ -92,6 +108,33 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, res)
 		assert.Contains(t, err.Error(), "NotAuthorizedOrNotFound")
+	})
+
+	t.Run("every compartment denied with a 404 is an error, not an empty tenancy", func(t *testing.T) {
+		// OCI answers an authorization failure with 404
+		// NotAuthorizedOrNotFound, not 403. Classifying that as an absent
+		// regional endpoint made an under-scoped token return a clean, empty
+		// scan of the whole tenancy - the exact outcome the denied counter
+		// exists to prevent.
+		res, err := ociCollectCompartmentJobs([]*jobpool.Job{denied404(), denied404()})
+		require.Error(t, err)
+		assert.Nil(t, res)
+		assert.Contains(t, err.Error(), "NotAuthorizedOrNotFound")
+	})
+
+	t.Run("a 404-denied compartment does not discard the readable ones", func(t *testing.T) {
+		res, err := ociCollectCompartmentJobs([]*jobpool.Job{ok("a"), denied404(), ok("b")})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []any{"a", "b"}, res)
+	})
+
+	t.Run("an undeployed region does not rescue an all-denied run", func(t *testing.T) {
+		// The two 404s differ only by code. The denial still has to win, or a
+		// single undeployed region would push a broken token back onto the
+		// success path.
+		res, err := ociCollectCompartmentJobs([]*jobpool.Job{unavailable(), denied404()})
+		require.Error(t, err)
+		assert.Nil(t, res)
 	})
 
 	t.Run("a readable but empty compartment counts as success", func(t *testing.T) {

--- a/providers/oci/resources/compartments_test.go
+++ b/providers/oci/resources/compartments_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 )
 
@@ -50,6 +51,37 @@ func TestOciCompartmentInaccessible(t *testing.T) {
 			assert.Equal(t, tt.want, ociCompartmentInaccessible(tt.err))
 		})
 	}
+}
+
+func TestOciRegionsByID(t *testing.T) {
+	iad := &mqlOciRegion{}
+	iad.Id.Data = "us-ashburn-1"
+	iad.Id.State = plugin.StateIsSet
+	phx := &mqlOciRegion{}
+	phx.Id.Data = "us-phoenix-1"
+	phx.Id.State = plugin.StateIsSet
+
+	t.Run("indexes every region by its id", func(t *testing.T) {
+		got, err := ociRegionsByID([]any{iad, phx})
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		assert.Same(t, iad, got["us-ashburn-1"])
+		assert.Same(t, phx, got["us-phoenix-1"])
+	})
+
+	t.Run("no regions", func(t *testing.T) {
+		got, err := ociRegionsByID(nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("a non-region element is an error, not a silent gap", func(t *testing.T) {
+		// A compartment lister only receives the region as a string and looks
+		// the resource up in this map, so a dropped entry would surface much
+		// later as a missing region field rather than here.
+		_, err := ociRegionsByID([]any{iad, "us-phoenix-1"})
+		require.Error(t, err)
+	})
 }
 
 func TestOciCollectCompartmentJobs(t *testing.T) {

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -51,7 +51,16 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci with region %s", region)
 
-			regionResource := regionsByID[region]
+			// Guarded rather than indexed blindly: a miss would put a typed nil
+			// into the region field, and a nil *mqlOciRegion inside an interface
+			// is not the untyped nil the runtime treats as absent, so it panics
+			// on read instead of reporting null. The pool iterates the same
+			// regions this index was built from, so a miss means the two have
+			// drifted and is worth saying out loud.
+			regionResource, ok := regionsByID[region]
+			if !ok {
+				return nil, errors.New("no oci.region resource for region " + region)
+			}
 
 			svc, err := conn.ComputeClient(region)
 			if err != nil {

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -37,55 +37,29 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 		return nil, list.Error
 	}
 
-	// fetch instances
-	return ociRunRegionPool(o.getComputeInstances(conn, list.Data))
-}
-
-func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Instance, error) {
-	instances := []core.Instance{}
-	var page *string
-	for {
-		request := core.ListInstancesRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := computeClient.ListInstances(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		instances = append(instances, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+	regionsByID, err := ociRegionsByID(list.Data)
+	if err != nil {
+		return nil, err
 	}
 
-	return instances, nil
-}
+	// Compute instances are the resource most often placed in a per-team or
+	// per-environment compartment, and ListInstances only ever answers for the
+	// one compartment it is handed. Restricting the scan to the tenancy root
+	// meant a fleet of hundreds of hosts reported as zero instances, taking
+	// every patch, agent, and IMDS check down with it.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
 
-func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
+			regionResource := regionsByID[region]
 
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
-
-			svc, err := conn.ComputeClient(regionResource.Id.Data)
+			svc, err := conn.ComputeClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			instances, err := o.getComputeInstancesForRegion(ctx, svc, conn.TenantID())
+			instances, err := o.getComputeInstancesForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -212,23 +186,48 @@ func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regi
 					return nil, err
 				}
 				mqlInst := mqlInstance.(*mqlOciComputeInstance)
-				mqlInst.cacheRegion = regionResource.Id.Data
+				mqlInst.cacheRegion = region
+				mqlInst.cacheCompartmentID = stringValue(instance.CompartmentId)
 				if src, ok := instance.SourceDetails.(core.InstanceSourceViaBootVolumeDetails); ok {
 					mqlInst.cacheBootVolumeID = stringValue(src.BootVolumeId)
 				}
 				res = append(res, mqlInst)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Instance, error) {
+	instances := []core.Instance{}
+	var page *string
+	for {
+		request := core.ListInstancesRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := computeClient.ListInstances(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		instances = append(instances, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return instances, nil
 }
 
 type mqlOciComputeInstanceInternal struct {
-	cacheRegion       string
-	cacheBootVolumeID string
+	cacheRegion        string
+	cacheBootVolumeID  string
+	cacheCompartmentID string
 }
 
 func (o *mqlOciComputeInstance) id() (string, error) {
@@ -258,12 +257,24 @@ func (o *mqlOciComputeInstance) vnics() ([]any, error) {
 		return nil, err
 	}
 
-	// List VNIC attachments for this instance
+	// List VNIC attachments for this instance.
+	//
+	// Scoped to the instance's own compartment, not the tenancy root:
+	// ListVnicAttachments filters on the compartment as well as the instance,
+	// so asking the root about an instance that lives in a child compartment
+	// returned no attachments at all. That left the instance with no IPs, no
+	// subnet and no security groups, which the exposure checks then read as
+	// "not reachable" for exactly the instances nobody had looked at.
+	compartmentID := o.cacheCompartmentID
+	if compartmentID == "" {
+		compartmentID = conn.TenantID()
+	}
+
 	var attachments []core.VnicAttachment
 	var page *string
 	for {
 		response, err := computeSvc.ListVnicAttachments(ctx, core.ListVnicAttachmentsRequest{
-			CompartmentId: common.String(conn.TenantID()),
+			CompartmentId: common.String(compartmentID),
 			InstanceId:    common.String(o.Id.Data),
 			Page:          page,
 		})

--- a/providers/oci/resources/dns.go
+++ b/providers/oci/resources/dns.go
@@ -29,6 +29,13 @@ var ociDnsZoneScopes = []dns.ListZonesScopeEnum{
 	dns.ListZonesScopePrivate,
 }
 
+// ociDnsSteeringPolicyScopes are the scopes a steering policy can live in.
+// The listing scopes the same way zones do, so both have to be asked for.
+var ociDnsSteeringPolicyScopes = []dns.ListSteeringPoliciesScopeEnum{
+	dns.ListSteeringPoliciesScopeGlobal,
+	dns.ListSteeringPoliciesScopePrivate,
+}
+
 func (o *mqlOciDns) zones() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
@@ -138,22 +145,29 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 			}
 
 			policies := []dns.SteeringPolicySummary{}
-			var page *string
-			for {
-				response, err := client.ListSteeringPolicies(ctx, dns.ListSteeringPoliciesRequest{
-					CompartmentId: common.String(compartmentID),
-					Page:          page,
-				})
-				if err != nil {
-					return nil, err
-				}
+			// Scoped the same way zones are, and for the same reason: the
+			// listing returns one scope at a time rather than the union, so
+			// asking only for the default reports a tenancy's private traffic
+			// management as absent.
+			for _, scope := range ociDnsSteeringPolicyScopes {
+				var page *string
+				for {
+					response, err := client.ListSteeringPolicies(ctx, dns.ListSteeringPoliciesRequest{
+						CompartmentId: common.String(compartmentID),
+						Scope:         scope,
+						Page:          page,
+					})
+					if err != nil {
+						return nil, err
+					}
 
-				policies = append(policies, response.Items...)
+					policies = append(policies, response.Items...)
 
-				if response.OpcNextPage == nil {
-					break
+					if response.OpcNextPage == nil {
+						break
+					}
+					page = response.OpcNextPage
 				}
-				page = response.OpcNextPage
 			}
 
 			res := make([]any, 0, len(policies))

--- a/providers/oci/resources/identitydomains.go
+++ b/providers/oci/resources/identitydomains.go
@@ -27,6 +27,26 @@ import (
 // maximum and keeps the request count low on domains with many users.
 const ociScimPageSize = 200
 
+// ociScimAttributeSets selects which groups of attributes a SCIM listing
+// returns.
+//
+// A plain SCIM list returns only the attributes a schema marks
+// returned=always or returned=default. Anything marked returned=request is
+// omitted unless the caller asks for it, and the fields that carry the
+// security signal are exactly the ones marked that way: a user's login
+// history and MFA enrollment date, a user's group memberships, and a group's
+// member list. Without this the provider reported every account as never
+// having signed in and every group as empty, which reads as fact rather than
+// as a missing request parameter.
+//
+// The default set has to be listed alongside request, because naming
+// attributes narrows the response to what was named; asking for both keeps
+// everything a plain listing already returned.
+var ociScimAttributeSets = []identitydomains.AttributeSetsEnum{
+	identitydomains.AttributeSetsDefault,
+	identitydomains.AttributeSetsRequest,
+}
+
 func (o *mqlOciIdentity) domains() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	ctx := context.Background()
@@ -173,8 +193,9 @@ func (o *mqlOciIdentityDomain) users() ([]any, error) {
 	startIndex := 1
 	for {
 		response, err := client.ListUsers(ctx, identitydomains.ListUsersRequest{
-			StartIndex: common.Int(startIndex),
-			Count:      common.Int(ociScimPageSize),
+			StartIndex:    common.Int(startIndex),
+			Count:         common.Int(ociScimPageSize),
+			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
 			return nil, err
@@ -288,8 +309,9 @@ func (o *mqlOciIdentityDomain) groups() ([]any, error) {
 	startIndex := 1
 	for {
 		response, err := client.ListGroups(ctx, identitydomains.ListGroupsRequest{
-			StartIndex: common.Int(startIndex),
-			Count:      common.Int(ociScimPageSize),
+			StartIndex:    common.Int(startIndex),
+			Count:         common.Int(ociScimPageSize),
+			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
 			return nil, err
@@ -343,8 +365,9 @@ func (o *mqlOciIdentityDomain) passwordPolicies() ([]any, error) {
 	startIndex := 1
 	for {
 		response, err := client.ListPasswordPolicies(ctx, identitydomains.ListPasswordPoliciesRequest{
-			StartIndex: common.Int(startIndex),
-			Count:      common.Int(ociScimPageSize),
+			StartIndex:    common.Int(startIndex),
+			Count:         common.Int(ociScimPageSize),
+			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
 			return nil, err
@@ -457,8 +480,9 @@ func (o *mqlOciIdentityDomain) apps() ([]any, error) {
 	startIndex := 1
 	for {
 		response, err := client.ListApps(ctx, identitydomains.ListAppsRequest{
-			StartIndex: common.Int(startIndex),
-			Count:      common.Int(ociScimPageSize),
+			StartIndex:    common.Int(startIndex),
+			Count:         common.Int(ociScimPageSize),
+			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
@@ -35,7 +34,52 @@ func (o *mqlOciKms) vaults() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getVaults(conn, list.Data))
+	// Vaults are almost always created in the compartment of the service they
+	// encrypt, and ListVaults answers for one compartment with no way to recurse.
+	// A root-only listing therefore came back empty, and every typed vault
+	// reference from a database, bucket, or stream pool then had nothing to
+	// resolve against.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci kms with region %s", region)
+
+			svc, err := conn.KmsVaultClient(region)
+			if err != nil {
+				return nil, err
+			}
+
+			var res []any
+			vaults, err := o.getVaultsForRegion(ctx, svc, compartmentID)
+			if err != nil {
+				return nil, err
+			}
+
+			for i := range vaults {
+				vault := vaults[i]
+
+				var created *time.Time
+				if vault.TimeCreated != nil {
+					created = &vault.TimeCreated.Time
+				}
+
+				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
+					"id":                 llx.StringDataPtr(vault.Id),
+					"name":               llx.StringDataPtr(vault.DisplayName),
+					"compartmentID":      llx.StringDataPtr(vault.CompartmentId),
+					"vaultType":          llx.StringData(string(vault.VaultType)),
+					"state":              llx.StringData(string(vault.LifecycleState)),
+					"managementEndpoint": llx.StringDataPtr(vault.ManagementEndpoint),
+					"created":            llx.TimeDataPtr(created),
+				})
+				if err != nil {
+					return nil, err
+				}
+				mqlInstance.(*mqlOciKmsVault).region = region
+				res = append(res, mqlInstance)
+			}
+
+			return res, nil
+		})
 }
 
 func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagement.KmsVaultClient, compartmentID string) ([]keymanagement.VaultSummary, error) {
@@ -61,59 +105,6 @@ func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagemen
 	}
 
 	return entries, nil
-}
-
-func (o *mqlOciKms) getVaults(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci kms with region %s", regionResource.Id.Data)
-
-			svc, err := conn.KmsVaultClient(regionResource.Id.Data)
-			if err != nil {
-				return nil, err
-			}
-
-			var res []any
-			vaults, err := o.getVaultsForRegion(ctx, svc, conn.TenantID())
-			if err != nil {
-				return nil, err
-			}
-
-			for i := range vaults {
-				vault := vaults[i]
-
-				var created *time.Time
-				if vault.TimeCreated != nil {
-					created = &vault.TimeCreated.Time
-				}
-
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
-					"id":                 llx.StringDataPtr(vault.Id),
-					"name":               llx.StringDataPtr(vault.DisplayName),
-					"compartmentID":      llx.StringDataPtr(vault.CompartmentId),
-					"vaultType":          llx.StringData(string(vault.VaultType)),
-					"state":              llx.StringData(string(vault.LifecycleState)),
-					"managementEndpoint": llx.StringDataPtr(vault.ManagementEndpoint),
-					"created":            llx.TimeDataPtr(created),
-				})
-				if err != nil {
-					return nil, err
-				}
-				mqlInstance.(*mqlOciKmsVault).region = regionResource.Id.Data
-				res = append(res, mqlInstance)
-			}
-
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
 }
 
 type mqlOciKmsVaultInternal struct {

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -99,13 +99,9 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 					// missing flag on a non-private load balancer means public,
 					// so falling back to false would clear a genuinely
 					// internet-facing balancer.
-					isPublic := boolValue(ip.IsPublic)
-					if ip.IsPublic == nil {
-						isPublic = !boolValue(lb.IsPrivate)
-					}
 					entry := map[string]any{
 						"ipAddress": stringValue(ip.IpAddress),
-						"isPublic":  isPublic,
+						"isPublic":  ociIpIsPublic(ip.IsPublic, boolValue(lb.IsPrivate)),
 					}
 					if ip.ReservedIp != nil {
 						entry["reservedIpId"] = stringValue(ip.ReservedIp.Id)

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -14,7 +14,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -36,21 +35,16 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getLoadBalancers(conn, list.Data))
-}
+	// Load balancers belong to the compartment of the application they front, and
+	// ListLoadBalancers has no subtree flag. Scanning only the tenancy root meant
+	// the exposure surface an internet-facing balancer represents, along with its
+	// listener TLS settings and backend sets, never appeared in the inventory at
+	// all.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci load balancer with region %s", region)
 
-func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci load balancer with region %s", regionResource.Id.Data)
-
-			svc, err := conn.LoadBalancerClient(regionResource.Id.Data)
+			svc, err := conn.LoadBalancerClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -59,7 +53,7 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 			var page *string
 			for {
 				response, err := svc.ListLoadBalancers(ctx, loadbalancer.ListLoadBalancersRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -130,16 +124,13 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 				mqlLb := mqlInstance.(*mqlOciLoadBalancerLoadBalancer)
 				mqlLb.cacheListeners = lb.Listeners
 				mqlLb.cacheBackendSets = lb.BackendSets
-				mqlLb.cacheRegion = regionResource.Id.Data
+				mqlLb.cacheRegion = region
 				mqlLb.cacheSubnetIDs = lb.SubnetIds
 				res = append(res, mqlLb)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciLoadBalancerLoadBalancerInternal struct {

--- a/providers/oci/resources/messaging.go
+++ b/providers/oci/resources/messaging.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 
@@ -184,6 +185,44 @@ type mqlOciStreamingStreamPoolInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *streaming.StreamPool
+}
+
+// initOciStreamingStreamPool resolves a stream pool by OCID.
+//
+// Without an init, NewResource falls straight through to Create with whatever
+// args it was handed - here just an id - so `oci.streaming.streams.streamPool`
+// produced a resource with every other field unset and an empty cacheRegion,
+// which then built a client against an empty region. Resolving through the
+// pool listing returns the fully populated instance instead.
+func initOciStreamingStreamPool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
+		return nil, nil, errors.New("id required to fetch oci.streaming.streamPool")
+	}
+
+	obj, err := CreateResource(runtime, "oci.streaming", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	s := obj.(*mqlOciStreaming)
+
+	rawPools := s.GetStreamPools()
+	if rawPools.Error != nil {
+		return nil, nil, rawPools.Error
+	}
+
+	for _, raw := range rawPools.Data {
+		pool := raw.(*mqlOciStreamingStreamPool)
+		if pool.Id.Data == idVal {
+			return args, pool, nil
+		}
+	}
+
+	return nil, nil, errors.New("oci.streaming.streamPool not found: " + idVal)
 }
 
 func (o *mqlOciStreamingStreamPool) id() (string, error) {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -28,53 +28,32 @@ func (o *mqlOciNetwork) id() (string, error) {
 func (o *mqlOciNetwork) vcns() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociRunRegionPool(o.getVcns(conn))
-}
-
-func (s *mqlOciNetwork) getVcnsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.Vcn, error) {
-	vcns := []core.Vcn{}
-	var page *string
-	for {
-		request := core.ListVcnsRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := networkClient.ListVcns(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		vcns = append(vcns, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
-	}
-
-	return vcns, nil
-}
-
-func (o *mqlOciNetwork) getVcns(conn *connection.OciConnection) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.GetRegions(ctx)
+	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
 	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
+		return nil, err
 	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", *region.RegionKey)
+	oci := ociResource.(*mqlOci)
+	list := oci.GetRegions()
+	if list.Error != nil {
+		return nil, list.Error
+	}
 
-			svc, err := conn.NetworkClient(*region.RegionKey)
+	// ListVcns takes one compartment and has no subtree flag, so asking only for
+	// the tenancy root returned an empty VCN list for anyone who keeps their
+	// networking in a child compartment. Walking the compartment tree is what
+	// makes the whole network graph, subnets and route tables and gateways
+	// included, hang off something that actually exists.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
+
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			vcns, err := o.getVcnsForRegion(ctx, svc, conn.TenantID())
+			vcns, err := o.getVcnsForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -119,11 +98,34 @@ func (o *mqlOciNetwork) getVcns(conn *connection.OciConnection) []*jobpool.Job {
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (s *mqlOciNetwork) getVcnsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.Vcn, error) {
+	vcns := []core.Vcn{}
+	var page *string
+	for {
+		request := core.ListVcnsRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := networkClient.ListVcns(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		vcns = append(vcns, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return vcns, nil
 }
 
 func initOciNetworkVcn(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -164,95 +166,32 @@ func (o *mqlOciNetworkVcn) id() (string, error) {
 func (o *mqlOciNetwork) securityLists() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociRunRegionPool(o.getSecurityLists(conn))
-}
-
-func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.SecurityList, error) {
-	securityLists := []core.SecurityList{}
-	var page *string
-	for {
-		request := core.ListSecurityListsRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := networkClient.ListSecurityLists(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		securityLists = append(securityLists, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
-	}
-
-	return securityLists, nil
-}
-
-// OCI VCN SecurityList egress rule for allowing outbound IP packets
-type egressSecurityRule struct {
-	// Description of egress rule
-	Description string `json:"description,omitempty"`
-	// Indicates if this is a stateless rule. No omitempty: a stateful rule
-	// must emit `stateless: false`, not drop the key entirely.
-	Stateless bool `json:"stateless"`
-	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-	Protocol string `json:"protocol,omitempty"`
-	// Range of allowed IP addresses
-	Destination string `json:"destination,omitempty"`
-	// Type of destination
-	DestinationType string `json:"destinationType,omitempty"`
-	// TCP options
-	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
-	// Udp options
-	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
-	// Icmp options
-	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
-}
-
-// OCI VCN SecurityList Ingress rule for allowing inbound IP packets
-type ingressSecurityRule struct {
-	// Description of ingress rule
-	Description string `json:"description,omitempty"`
-	// Indicates if this is a stateless rule. No omitempty: a stateful rule
-	// must emit `stateless: false`, not drop the key entirely.
-	Stateless bool `json:"stateless"`
-	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-	Protocol string `json:"protocol,omitempty"`
-	// Range of allowed IP addresses
-	Source string `json:"source,omitempty"`
-	// Type of source
-	SourceType string `json:"sourceType,omitempty"`
-	// TCP options
-	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
-	// Udp options
-	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
-	// Icmp options
-	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
-}
-
-func (o *mqlOciNetwork) getSecurityLists(conn *connection.OciConnection) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.GetRegions(ctx)
+	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
 	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
+		return nil, err
 	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", *region.RegionKey)
+	oci := ociResource.(*mqlOci)
+	list := oci.GetRegions()
+	if list.Error != nil {
+		return nil, list.Error
+	}
 
-			svc, err := conn.NetworkClient(*region.RegionKey)
+	// Security lists live in the same compartment as the VCN they protect, and
+	// ListSecurityLists cannot search below the compartment it is given. Scanning
+	// only the tenancy root therefore reported a tenancy with no ingress rules
+	// anywhere, which reads as "nothing is exposed" when the truth is that
+	// nothing was looked at.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
+
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			securityLists, err := o.getSecurityListsForRegion(ctx, svc, conn.TenantID())
+			securityLists, err := o.getSecurityListsForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -330,15 +269,80 @@ func (o *mqlOciNetwork) getSecurityLists(conn *connection.OciConnection) []*jobp
 				}
 				sl := mqlInstance.(*mqlOciNetworkSecurityList)
 				sl.cacheVcnId = stringValue(securityList.VcnId)
-				sl.cacheRegion = stringValue(region.RegionKey)
+				sl.cacheRegion = region
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.SecurityList, error) {
+	securityLists := []core.SecurityList{}
+	var page *string
+	for {
+		request := core.ListSecurityListsRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := networkClient.ListSecurityLists(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		securityLists = append(securityLists, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return securityLists, nil
+}
+
+// OCI VCN SecurityList egress rule for allowing outbound IP packets
+type egressSecurityRule struct {
+	// Description of egress rule
+	Description string `json:"description,omitempty"`
+	// Indicates if this is a stateless rule. No omitempty: a stateful rule
+	// must emit `stateless: false`, not drop the key entirely.
+	Stateless bool `json:"stateless"`
+	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+	Protocol string `json:"protocol,omitempty"`
+	// Range of allowed IP addresses
+	Destination string `json:"destination,omitempty"`
+	// Type of destination
+	DestinationType string `json:"destinationType,omitempty"`
+	// TCP options
+	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
+	// Udp options
+	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
+	// Icmp options
+	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
+}
+
+// OCI VCN SecurityList Ingress rule for allowing inbound IP packets
+type ingressSecurityRule struct {
+	// Description of ingress rule
+	Description string `json:"description,omitempty"`
+	// Indicates if this is a stateless rule. No omitempty: a stateful rule
+	// must emit `stateless: false`, not drop the key entirely.
+	Stateless bool `json:"stateless"`
+	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+	Protocol string `json:"protocol,omitempty"`
+	// Range of allowed IP addresses
+	Source string `json:"source,omitempty"`
+	// Type of source
+	SourceType string `json:"sourceType,omitempty"`
+	// TCP options
+	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
+	// Udp options
+	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
+	// Icmp options
+	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
 }
 
 type mqlOciNetworkSecurityListInternal struct {
@@ -463,21 +467,16 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getSubnets(conn, list.Data))
-}
+	// Fanned out over the compartment tree, not just the tenancy root. The core
+	// list APIs have no subtree flag, so listing the root alone reported no
+	// subnets at all for any tenancy that groups its networking into child
+	// compartments - and left every typed reference to a subnet (load balancer
+	// exposure, database placement, stream pool networking) unable to resolve.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci subnets with region %s", region)
 
-func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci subnets with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -486,7 +485,7 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 			var page *string
 			for {
 				response, err := svc.ListSubnets(ctx, core.ListSubnetsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -545,11 +544,8 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 				res = append(res, mqlSub)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkSubnetInternal struct {
@@ -620,53 +616,22 @@ func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getNetworkSecurityGroups(conn, list.Data))
-}
+	// Network security groups are attached to VNICs that almost never live in the
+	// tenancy root, and ListNetworkSecurityGroups takes a single compartment with
+	// no way to descend. Enumerating per compartment is what lets an instance's
+	// nsgs resolve at all, instead of coming back empty and making every host
+	// look unprotected.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci NSGs with region %s", region)
 
-func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.NetworkSecurityGroup, error) {
-	nsgs := []core.NetworkSecurityGroup{}
-	var page *string
-	for {
-		request := core.ListNetworkSecurityGroupsRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := networkClient.ListNetworkSecurityGroups(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		nsgs = append(nsgs, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
-	}
-
-	return nsgs, nil
-}
-
-func (o *mqlOciNetwork) getNetworkSecurityGroups(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci NSGs with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			nsgs, err := o.getNSGsForRegion(ctx, svc, conn.TenantID())
+			nsgs, err := o.getNSGsForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -702,16 +667,39 @@ func (o *mqlOciNetwork) getNetworkSecurityGroups(conn *connection.OciConnection,
 					return nil, err
 				}
 				mqlNsg := mqlInstance.(*mqlOciNetworkNetworkSecurityGroup)
-				mqlNsg.region = regionResource.Id.Data
+				mqlNsg.region = region
 				mqlNsg.cacheVcnId = stringValue(nsg.VcnId)
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.NetworkSecurityGroup, error) {
+	nsgs := []core.NetworkSecurityGroup{}
+	var page *string
+	for {
+		request := core.ListNetworkSecurityGroupsRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := networkClient.ListNetworkSecurityGroups(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		nsgs = append(nsgs, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return nsgs, nil
 }
 
 type mqlOciNetworkNetworkSecurityGroupInternal struct {
@@ -1316,21 +1304,16 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getRouteTables(conn, list.Data))
-}
+	// A route table is created alongside the VCN it belongs to, so a tenancy that
+	// puts its VCNs in child compartments has no route tables in the root at all.
+	// ListRouteTables offers no subtree search, so the fan-out below is the only
+	// way a subnet's routeTable reference finds its target and egress paths stay
+	// auditable.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci route tables with region %s", region)
 
-func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci route tables with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -1339,7 +1322,7 @@ func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions [
 			var page *string
 			for {
 				response, err := svc.ListRouteTables(ctx, core.ListRouteTablesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -1407,11 +1390,8 @@ func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions [
 				res = append(res, mqlRt)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkRouteTableInternal struct {

--- a/providers/oci/resources/networkloadbalancer.go
+++ b/providers/oci/resources/networkloadbalancer.go
@@ -69,9 +69,22 @@ func (o *mqlOciNetworkLoadBalancer) newNetworkLoadBalancers(nlbs []networkloadba
 	for i := range nlbs {
 		nlb := nlbs[i]
 
-		ipAddresses, err := convert.JsonToDictSlice(nlb.IpAddresses)
-		if err != nil {
-			return nil, err
+		// Built by hand rather than marshalled from the SDK slice: isPublic is
+		// optional on the model, and exposure() reads the key back to decide
+		// internet reachability. A marshalled nil arrives as JSON null, which
+		// reads as "not public" and clears a genuinely internet-facing
+		// balancer. This mirrors the classic load balancer.
+		ipAddresses := make([]any, 0, len(nlb.IpAddresses))
+		for j := range nlb.IpAddresses {
+			ip := nlb.IpAddresses[j]
+			entry := map[string]any{
+				"ipAddress": stringValue(ip.IpAddress),
+				"isPublic":  ociIpIsPublic(ip.IsPublic, boolValue(nlb.IsPrivate)),
+			}
+			if ip.ReservedIp != nil {
+				entry["reservedIpId"] = stringValue(ip.ReservedIp.Id)
+			}
+			ipAddresses = append(ipAddresses, entry)
 		}
 
 		listeners, err := o.newListeners(stringValue(nlb.Id), nlb.Listeners)

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -2946,8 +2946,8 @@ private oci.serviceConnectorHub.connector @defaults("name sourceKind targetKind 
   // Configuration of the source the connector reads from
   //
   // Shape varies by `sourceKind`. A `logging` source has `logSources`,
-  // each with `compartmentId` and optionally `logGroupId` and `logId`; the
-  // tenancy audit log appears as a log group named `_Audit`. A
+  // each with `compartmentId` and optionally `logGroupId` and `logId`,
+  // where the tenancy audit log is named by the reserved value `_Audit`. A
   // `monitoring` source has `namespaceDetails`, a `streaming` source has
   // `streamId` and `cursor`, and a `plugin` source has `pluginName` and
   // `configMap`.
@@ -2967,9 +2967,16 @@ private oci.serviceConnectorHub.connector @defaults("name sourceKind targetKind 
   // Log groups the connector reads from
   //
   // The log groups named by a `logging` source. Empty for every other
-  // source kind. The tenancy audit log appears here as the `_Audit` log
-  // group, so a connector exporting audit events resolves to it.
+  // source kind. The tenancy audit log is not a customer log group and so
+  // does not appear here; `exportsAuditLog` reports it instead.
   sourceLogGroups() []oci.logging.logGroup
+  // Whether the connector exports the tenancy audit log
+  //
+  // True when a `logging` source names the reserved `_Audit` log group,
+  // which is the audit stream itself rather than a log group in a
+  // compartment. This is the check for whether control-plane audit events
+  // leave OCI for archival or a SIEM.
+  exportsAuditLog() bool
   // Configuration of the target the connector writes to
   //
   // Shape varies by `targetKind`. An `objectStorage` target has
@@ -5461,9 +5468,9 @@ private oci.apigateway.gateway @defaults("name") {
   // Hostname assigned to the gateway
   hostname string
   // Whether a response cache is configured (true for EXTERNAL_RESP_CACHE; false for NONE or unset)
-  hasResponseCache bool
+  hasResponseCache() bool
   // IP addresses assigned to the gateway
-  ipAddresses []string
+  ipAddresses() []string
   // Subnet the gateway is deployed in
   subnet() oci.network.subnet
   // Network Security Groups attached to the gateway
@@ -5471,7 +5478,7 @@ private oci.apigateway.gateway @defaults("name") {
   // TLS certificate used by the gateway (from the apigateway certificates service)
   certificate() oci.apigateway.certificate
   // OCIDs of CA bundles (from the certificatesmanagement service or the apigateway certificates service) used by the gateway for TLS validation
-  caBundleIds []string
+  caBundleIds() []string
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED)
   state string
   // Creation time
@@ -6450,7 +6457,7 @@ private oci.vulnerabilityScanning.hostCisBenchmarkScanResult @defaults("name ins
   // Each entry has `benchmarkIdentifier` (e.g., "1.1.1"),
   // `description` (the control statement), and `score` (PASS or
   // FAIL).
-  scores []dict
+  scores() []dict
   // Time the scan started
   //
   // Distinguishes a scan that never ran from one that ran and found
@@ -6489,7 +6496,7 @@ private oci.vulnerabilityScanning.hostEndpointProtectionScanResult @defaults("na
   // Each entry has `service` (the endpoint protection product name),
   // `configurationFinding` (the misconfiguration, if any), and
   // `severity`.
-  endpointProtections []dict
+  endpointProtections() []dict
   // Time the scan started
   //
   // Distinguishes a scan that never ran from one that ran and found

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -648,7 +648,7 @@ func init() {
 			Create: createOciStreamingStream,
 		},
 		"oci.streaming.streamPool": {
-			// to override args, implement: initOciStreamingStreamPool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciStreamingStreamPool,
 			Create: createOciStreamingStreamPool,
 		},
 		"oci.queue": {

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -3907,6 +3907,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.serviceConnectorHub.connector.sourceLogGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciServiceConnectorHubConnector).GetSourceLogGroups()).ToDataRes(types.Array(types.Resource("oci.logging.logGroup")))
 	},
+	"oci.serviceConnectorHub.connector.exportsAuditLog": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciServiceConnectorHubConnector).GetExportsAuditLog()).ToDataRes(types.Bool)
+	},
 	"oci.serviceConnectorHub.connector.target": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciServiceConnectorHubConnector).GetTarget()).ToDataRes(types.Dict)
 	},
@@ -12345,6 +12348,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.serviceConnectorHub.connector.sourceLogGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciServiceConnectorHubConnector).SourceLogGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"oci.serviceConnectorHub.connector.exportsAuditLog": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciServiceConnectorHubConnector).ExportsAuditLog, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"oci.serviceConnectorHub.connector.target": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29028,6 +29035,7 @@ type mqlOciServiceConnectorHubConnector struct {
 	TargetBucket    plugin.TValue[*mqlOciObjectStorageBucket]
 	TargetTopic     plugin.TValue[*mqlOciOnsTopic]
 	SourceLogGroups plugin.TValue[[]any]
+	ExportsAuditLog plugin.TValue[bool]
 	Target          plugin.TValue[any]
 	Tasks           plugin.TValue[[]any]
 	Created         plugin.TValue[*time.Time]
@@ -29177,6 +29185,12 @@ func (c *mqlOciServiceConnectorHubConnector) GetSourceLogGroups() *plugin.TValue
 		}
 
 		return c.sourceLogGroups()
+	})
+}
+
+func (c *mqlOciServiceConnectorHubConnector) GetExportsAuditLog() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ExportsAuditLog, func() (bool, error) {
+		return c.exportsAuditLog()
 	})
 }
 
@@ -37323,11 +37337,15 @@ func (c *mqlOciApigatewayGateway) GetHostname() *plugin.TValue[string] {
 }
 
 func (c *mqlOciApigatewayGateway) GetHasResponseCache() *plugin.TValue[bool] {
-	return &c.HasResponseCache
+	return plugin.GetOrCompute[bool](&c.HasResponseCache, func() (bool, error) {
+		return c.hasResponseCache()
+	})
 }
 
 func (c *mqlOciApigatewayGateway) GetIpAddresses() *plugin.TValue[[]any] {
-	return &c.IpAddresses
+	return plugin.GetOrCompute[[]any](&c.IpAddresses, func() ([]any, error) {
+		return c.ipAddresses()
+	})
 }
 
 func (c *mqlOciApigatewayGateway) GetSubnet() *plugin.TValue[*mqlOciNetworkSubnet] {
@@ -37379,7 +37397,9 @@ func (c *mqlOciApigatewayGateway) GetCertificate() *plugin.TValue[*mqlOciApigate
 }
 
 func (c *mqlOciApigatewayGateway) GetCaBundleIds() *plugin.TValue[[]any] {
-	return &c.CaBundleIds
+	return plugin.GetOrCompute[[]any](&c.CaBundleIds, func() ([]any, error) {
+		return c.caBundleIds()
+	})
 }
 
 func (c *mqlOciApigatewayGateway) GetState() *plugin.TValue[string] {
@@ -40881,7 +40901,9 @@ func (c *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) GetState() *plug
 }
 
 func (c *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) GetScores() *plugin.TValue[[]any] {
-	return &c.Scores
+	return plugin.GetOrCompute[[]any](&c.Scores, func() ([]any, error) {
+		return c.scores()
+	})
 }
 
 func (c *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) GetScanStarted() *plugin.TValue[*time.Time] {
@@ -41009,7 +41031,9 @@ func (c *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) GetState()
 }
 
 func (c *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) GetEndpointProtections() *plugin.TValue[[]any] {
-	return &c.EndpointProtections
+	return plugin.GetOrCompute[[]any](&c.EndpointProtections, func() ([]any, error) {
+		return c.endpointProtections()
+	})
 }
 
 func (c *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) GetScanStarted() *plugin.TValue[*time.Time] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -2294,6 +2294,7 @@ oci.serviceConnectorHub.connector.compartment 13.17.2
 oci.serviceConnectorHub.connector.created 13.17.2
 oci.serviceConnectorHub.connector.definedTags 13.17.2
 oci.serviceConnectorHub.connector.description 13.17.2
+oci.serviceConnectorHub.connector.exportsAuditLog 13.17.2
 oci.serviceConnectorHub.connector.freeformTags 13.17.2
 oci.serviceConnectorHub.connector.id 13.17.2
 oci.serviceConnectorHub.connector.name 13.17.2

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -287,6 +287,51 @@ func ociAnySubnetReachable(gates []ociSubnetGate) bool {
 // matters for a multi-subnet load balancer: a hardened public subnet paired
 // with a private subnet carrying the wide-open default VCN security list must
 // not combine into a reachable verdict.
+// ociIpIsPublic decides whether one of a load balancer's IP addresses faces
+// the internet.
+//
+// isPublic is optional on both load balancer SDK models. Absent does not mean
+// private: a balancer that is not marked private is public, so defaulting the
+// missing flag to false would clear a genuinely internet-facing balancer and
+// report it as unreachable.
+func ociIpIsPublic(isPublic *bool, lbIsPrivate bool) bool {
+	if isPublic != nil {
+		return *isPublic
+	}
+	return !lbIsPrivate
+}
+
+// ociLoadBalancerHasPublicIp reports whether any of a load balancer's IP
+// address entries is internet-facing.
+//
+// The entries are the dicts built at creation time, so this reads the
+// `isPublic` key back out. A private balancer short-circuits: its addresses
+// are internal whatever the individual flags say. An entry missing the key
+// falls back to the balancer's own private flag for the same reason
+// ociIpIsPublic does, so a dict built before that fallback existed still
+// resolves correctly.
+func ociLoadBalancerHasPublicIp(ips []any, isPrivate bool) bool {
+	if isPrivate {
+		return false
+	}
+	for _, e := range ips {
+		d, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		pub, ok := d["isPublic"].(bool)
+		if !ok {
+			// The key is absent or null rather than a bool. Not private, so
+			// treat it as public rather than silently clearing the balancer.
+			return true
+		}
+		if pub {
+			return true
+		}
+	}
+	return false
+}
+
 func ociAnySubnetAdmitsInternet(gates []ociSubnetGate, nsgOpenRuleCount int) bool {
 	for _, g := range gates {
 		if g.prohibitsIngress || !g.routesToInternet {
@@ -477,17 +522,7 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 	if ips.Error != nil {
 		return nil, ips.Error
 	}
-	hasPublicIp := false
-	if !isPrivate.Data {
-		for _, e := range ips.Data {
-			if d, ok := e.(map[string]any); ok {
-				if pub, _ := d["isPublic"].(bool); pub {
-					hasPublicIp = true
-					break
-				}
-			}
-		}
-	}
+	hasPublicIp := ociLoadBalancerHasPublicIp(ips.Data, isPrivate.Data)
 
 	listeners := l.GetListeners()
 	if listeners.Error != nil {
@@ -598,17 +633,7 @@ func (n *mqlOciNetworkLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposu
 	if ips.Error != nil {
 		return nil, ips.Error
 	}
-	hasPublicIp := false
-	if !isPrivate.Data {
-		for _, e := range ips.Data {
-			if d, ok := e.(map[string]any); ok {
-				if pub, _ := d["isPublic"].(bool); pub {
-					hasPublicIp = true
-					break
-				}
-			}
-		}
-	}
+	hasPublicIp := ociLoadBalancerHasPublicIp(ips.Data, isPrivate.Data)
 
 	listeners := n.GetListeners()
 	if listeners.Error != nil {

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -287,6 +287,19 @@ func ociAnySubnetReachable(gates []ociSubnetGate) bool {
 // matters for a multi-subnet load balancer: a hardened public subnet paired
 // with a private subnet carrying the wide-open default VCN security list must
 // not combine into a reachable verdict.
+
+func ociAnySubnetAdmitsInternet(gates []ociSubnetGate, nsgOpenRuleCount int) bool {
+	for _, g := range gates {
+		if g.prohibitsIngress || !g.routesToInternet {
+			continue
+		}
+		if ociIngressOpen(nsgOpenRuleCount, g.securityListAllows) {
+			return true
+		}
+	}
+	return false
+}
+
 // ociIpIsPublic decides whether one of a load balancer's IP addresses faces
 // the internet.
 //
@@ -326,18 +339,6 @@ func ociLoadBalancerHasPublicIp(ips []any, isPrivate bool) bool {
 			return true
 		}
 		if pub {
-			return true
-		}
-	}
-	return false
-}
-
-func ociAnySubnetAdmitsInternet(gates []ociSubnetGate, nsgOpenRuleCount int) bool {
-	for _, g := range gates {
-		if g.prohibitsIngress || !g.routesToInternet {
-			continue
-		}
-		if ociIngressOpen(nsgOpenRuleCount, g.securityListAllows) {
 			return true
 		}
 	}

--- a/providers/oci/resources/oci_exposure_lb_test.go
+++ b/providers/oci/resources/oci_exposure_lb_test.go
@@ -1,0 +1,87 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOciIpIsPublic(t *testing.T) {
+	yes, no := true, false
+
+	tests := []struct {
+		name        string
+		isPublic    *bool
+		lbIsPrivate bool
+		want        bool
+	}{
+		// An explicit flag always wins.
+		{"explicitly public", &yes, false, true},
+		{"explicitly private", &no, false, false},
+		{"explicitly public on a private balancer", &yes, true, true},
+
+		// The case that matters: isPublic is optional on both load balancer
+		// SDK models. Absent on a balancer that is not private means public.
+		// Defaulting to false here reported a genuinely internet-facing
+		// balancer as unreachable, so an "no load balancer may be exposed"
+		// policy passed with nothing to fail on.
+		{"absent on a public balancer", nil, false, true},
+		{"absent on a private balancer", nil, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ociIpIsPublic(tt.isPublic, tt.lbIsPrivate))
+		})
+	}
+}
+
+func TestOciLoadBalancerHasPublicIp(t *testing.T) {
+	ip := func(addr string, isPublic any) map[string]any {
+		return map[string]any{"ipAddress": addr, "isPublic": isPublic}
+	}
+
+	tests := []struct {
+		name      string
+		ips       []any
+		isPrivate bool
+		want      bool
+	}{
+		{"no addresses at all", nil, false, false},
+		{"one public address", []any{ip("203.0.113.10", true)}, false, true},
+		{"only private addresses", []any{ip("10.0.0.5", false)}, false, false},
+		{"a public address among private ones", []any{
+			ip("10.0.0.5", false), ip("203.0.113.10", true),
+		}, false, true},
+
+		// A private balancer's addresses are internal whatever the individual
+		// flags say, so the balancer flag short-circuits.
+		{"private balancer with a public-looking address", []any{
+			ip("203.0.113.10", true),
+		}, true, false},
+
+		// The regression: the network load balancer marshalled the SDK slice
+		// straight to JSON, so an optional isPublic arrived as null. Reading
+		// that back as "not public" cleared the balancer entirely.
+		{"missing isPublic on a public balancer", []any{
+			map[string]any{"ipAddress": "203.0.113.10"},
+		}, false, true},
+		{"null isPublic on a public balancer", []any{ip("203.0.113.10", nil)}, false, true},
+		{"null isPublic on a private balancer", []any{ip("10.0.0.5", nil)}, true, false},
+
+		// Malformed entries must not panic or be mistaken for a verdict.
+		{"non-map entry is skipped", []any{"203.0.113.10"}, false, false},
+		{"non-map entry alongside a public one", []any{
+			"garbage", ip("203.0.113.10", true),
+		}, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ociLoadBalancerHasPublicIp(tt.ips, tt.isPrivate))
+		})
+	}
+}

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
@@ -34,7 +33,53 @@ func (o *mqlOciOns) topics() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getTopics(conn, list.Data))
+	// Notification topics are created next to the alarms and connectors that
+	// publish to them, which puts them in child compartments. ListTopics has no
+	// subtree option, so a root-only sweep reported no topics and broke the alarm
+	// and Connector Hub destination references that point at them.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
+
+			svc, err := conn.NotificationControlPlaneClient(region)
+			if err != nil {
+				return nil, err
+			}
+
+			var res []any
+			topics, err := o.getTopicsForRegion(ctx, svc, compartmentID)
+			if err != nil {
+				return nil, err
+			}
+
+			for i := range topics {
+				topic := topics[i]
+
+				var created *time.Time
+				if topic.TimeCreated != nil {
+					created = &topic.TimeCreated.Time
+				}
+
+				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.ons.topic", map[string]*llx.RawData{
+					"id":            llx.StringDataPtr(topic.TopicId),
+					"name":          llx.StringDataPtr(topic.Name),
+					"description":   llx.StringDataPtr(topic.Description),
+					"compartmentID": llx.StringDataPtr(topic.CompartmentId),
+					"state":         llx.StringData(string(topic.LifecycleState)),
+					"created":       llx.TimeDataPtr(created),
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				mqlTopic := mqlInstance.(*mqlOciOnsTopic)
+				mqlTopic.region = region
+
+				res = append(res, mqlInstance)
+			}
+
+			return res, nil
+		})
 }
 
 func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.NotificationControlPlaneClient, compartmentID string) ([]ons.NotificationTopicSummary, error) {
@@ -61,61 +106,6 @@ func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.Notifica
 	}
 
 	return topics, nil
-}
-
-func (o *mqlOciOns) getTopics(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NotificationControlPlaneClient(regionResource.Id.Data)
-			if err != nil {
-				return nil, err
-			}
-
-			var res []any
-			topics, err := o.getTopicsForRegion(ctx, svc, conn.TenantID())
-			if err != nil {
-				return nil, err
-			}
-
-			for i := range topics {
-				topic := topics[i]
-
-				var created *time.Time
-				if topic.TimeCreated != nil {
-					created = &topic.TimeCreated.Time
-				}
-
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.ons.topic", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(topic.TopicId),
-					"name":          llx.StringDataPtr(topic.Name),
-					"description":   llx.StringDataPtr(topic.Description),
-					"compartmentID": llx.StringDataPtr(topic.CompartmentId),
-					"state":         llx.StringData(string(topic.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-				})
-				if err != nil {
-					return nil, err
-				}
-
-				mqlTopic := mqlInstance.(*mqlOciOnsTopic)
-				mqlTopic.region = regionResource.Id.Data
-
-				res = append(res, mqlInstance)
-			}
-
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
 }
 
 type mqlOciOnsTopicInternal struct {

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -36,21 +35,16 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getSecrets(conn, list.Data))
-}
+	// Secrets sit in the compartment of the application that consumes them, and
+	// ListSecrets accepts one compartment with no recursion. Asking only about
+	// the tenancy root left rotation status, expiry, and auto-generation checks
+	// with nothing to evaluate, which looked like a tenancy with no secrets
+	// rather than a scan that never reached them.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci vault secrets with region %s", region)
 
-func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci vault secrets with region %s", regionResource.Id.Data)
-
-			svc, err := conn.VaultsClient(regionResource.Id.Data)
+			svc, err := conn.VaultsClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -59,7 +53,7 @@ func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) 
 			var page *string
 			for {
 				response, err := svc.ListSecrets(ctx, vault.ListSecretsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -121,7 +115,7 @@ func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) 
 				mqlS := mqlInstance.(*mqlOciVaultSecret)
 				mqlS.cacheKeyId = stringValue(s.KeyId)
 				mqlS.cacheVaultId = stringValue(s.VaultId)
-				mqlS.cacheRegion = regionResource.Id.Data
+				mqlS.cacheRegion = region
 				if s.RotationConfig != nil {
 					mqlS.cacheRotationInterval = stringValue(s.RotationConfig.RotationInterval)
 					mqlS.cacheIsScheduledRotationEnabled = s.RotationConfig.IsScheduledRotationEnabled
@@ -133,11 +127,8 @@ func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) 
 				res = append(res, mqlS)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciVaultSecretInternal struct {

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -234,6 +234,54 @@ func (o *mqlOciServiceConnectorHubConnector) targetTopic() (*mqlOciOnsTopic, err
 	return res.(*mqlOciOnsTopic), nil
 }
 
+// ociAuditLogGroup is the reserved name Connector Hub uses for the tenancy
+// audit log. A logging source names its log group either by OCID or with this
+// sentinel, which is not an OCID and cannot be resolved to an
+// oci.logging.logGroup - it is the audit stream itself, not a customer log
+// group.
+const ociAuditLogGroup = "_Audit"
+
+// ociSplitLogGroupRefs separates the log-group references on a Connector Hub
+// logging source into the OCIDs that name a real log group and a flag for the
+// tenancy audit log.
+//
+// Passing every reference through to a log-group lookup meant the audit
+// sentinel failed to resolve and was dropped, so a connector exporting the
+// audit log - the reason most tenancies run Connector Hub at all - reported no
+// sources. A reference that is neither an OCID nor the sentinel is dropped:
+// only a compartment-scoped source, which names no log group.
+func ociSplitLogGroupRefs(refs []string) (ocids []string, exportsAuditLog bool) {
+	ocids = make([]string, 0, len(refs))
+	for _, ref := range refs {
+		switch {
+		case ref == ociAuditLogGroup:
+			exportsAuditLog = true
+		case isOcid(ref):
+			ocids = append(ocids, ref)
+		}
+	}
+	return ocids, exportsAuditLog
+}
+
+func (o *mqlOciServiceConnectorHubConnector) exportsAuditLog() (bool, error) {
+	detail, err := o.getDetail()
+	if err != nil {
+		return false, err
+	}
+
+	source, ok := detail.Source.(sch.LoggingSourceDetailsResponse)
+	if !ok {
+		return false, nil
+	}
+
+	refs := make([]string, 0, len(source.LogSources))
+	for i := range source.LogSources {
+		refs = append(refs, stringValue(source.LogSources[i].LogGroupId))
+	}
+	_, exportsAuditLog := ociSplitLogGroupRefs(refs)
+	return exportsAuditLog, nil
+}
+
 func (o *mqlOciServiceConnectorHubConnector) sourceLogGroups() ([]any, error) {
 	detail, err := o.getDetail()
 	if err != nil {
@@ -245,14 +293,14 @@ func (o *mqlOciServiceConnectorHubConnector) sourceLogGroups() ([]any, error) {
 		return []any{}, nil
 	}
 
-	res := make([]any, 0, len(source.LogSources))
+	refs := make([]string, 0, len(source.LogSources))
 	for i := range source.LogSources {
-		logGroupId := stringValue(source.LogSources[i].LogGroupId)
-		// A log source scoped to a whole compartment names no log group.
-		if logGroupId == "" {
-			continue
-		}
+		refs = append(refs, stringValue(source.LogSources[i].LogGroupId))
+	}
+	logGroupIds, _ := ociSplitLogGroupRefs(refs)
 
+	res := make([]any, 0, len(logGroupIds))
+	for _, logGroupId := range logGroupIds {
 		group, err := NewResource(o.MqlRuntime, "oci.logging.logGroup", map[string]*llx.RawData{
 			"id": llx.StringData(logGroupId),
 		})

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -203,9 +203,23 @@ func (o *mqlOciServiceConnectorHubConnector) targetBucket() (*mqlOciObjectStorag
 		return nil, nil
 	}
 
+	// The bucket's own init needs a region: it fetches the bucket detail to
+	// populate everything ListBuckets omits, and GetBucket is a regional call.
+	// Passing only namespace and name left that region unset, so every
+	// objectStorage-target connector failed with "region is required to fetch
+	// bucket details". A Connector Hub target bucket is in the connector's own
+	// region, which is already cached here.
+	regionRes, err := NewResource(o.MqlRuntime, "oci.region", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheRegion),
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	res, err := NewResource(o.MqlRuntime, "oci.objectStorage.bucket", map[string]*llx.RawData{
 		"namespace": llx.StringData(stringValue(target.Namespace)),
 		"name":      llx.StringData(stringValue(target.BucketName)),
+		"region":    llx.ResourceData(regionRes, "oci.region"),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -277,41 +277,42 @@ func ociSplitLogGroupRefs(refs []string) (ocids []string, exportsAuditLog bool) 
 	return ocids, exportsAuditLog
 }
 
-func (o *mqlOciServiceConnectorHubConnector) exportsAuditLog() (bool, error) {
+// loggingSource reads the connector's logging source once for the two fields
+// derived from it, so they cannot disagree about what the source names. A
+// connector whose source is any other kind reports no log groups and no audit
+// export, which is the accurate answer rather than a missing one.
+func (o *mqlOciServiceConnectorHubConnector) loggingSource() (logGroupIds []string, exportsAuditLog bool, err error) {
 	detail, err := o.getDetail()
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
 	source, ok := detail.Source.(sch.LoggingSourceDetailsResponse)
 	if !ok {
-		return false, nil
+		return nil, false, nil
 	}
 
 	refs := make([]string, 0, len(source.LogSources))
 	for i := range source.LogSources {
 		refs = append(refs, stringValue(source.LogSources[i].LogGroupId))
 	}
-	_, exportsAuditLog := ociSplitLogGroupRefs(refs)
+	logGroupIds, exportsAuditLog = ociSplitLogGroupRefs(refs)
+	return logGroupIds, exportsAuditLog, nil
+}
+
+func (o *mqlOciServiceConnectorHubConnector) exportsAuditLog() (bool, error) {
+	_, exportsAuditLog, err := o.loggingSource()
+	if err != nil {
+		return false, err
+	}
 	return exportsAuditLog, nil
 }
 
 func (o *mqlOciServiceConnectorHubConnector) sourceLogGroups() ([]any, error) {
-	detail, err := o.getDetail()
+	logGroupIds, _, err := o.loggingSource()
 	if err != nil {
 		return nil, err
 	}
-
-	source, ok := detail.Source.(sch.LoggingSourceDetailsResponse)
-	if !ok {
-		return []any{}, nil
-	}
-
-	refs := make([]string, 0, len(source.LogSources))
-	for i := range source.LogSources {
-		refs = append(refs, stringValue(source.LogSources[i].LogGroupId))
-	}
-	logGroupIds, _ := ociSplitLogGroupRefs(refs)
 
 	res := make([]any, 0, len(logGroupIds))
 	for _, logGroupId := range logGroupIds {

--- a/providers/oci/resources/serviceconnectorhub_test.go
+++ b/providers/oci/resources/serviceconnectorhub_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOciSplitLogGroupRefs(t *testing.T) {
+	const (
+		groupA = "ocid1.loggroup.oc1.us-ashburn-1.aaaaaaaaexamplegroupa"
+		groupB = "ocid1.loggroup.oc1.us-ashburn-1.aaaaaaaaexamplegroupb"
+	)
+
+	tests := []struct {
+		name      string
+		refs      []string
+		wantOcids []string
+		wantAudit bool
+	}{
+		{"no sources", nil, []string{}, false},
+
+		{"a single log group", []string{groupA}, []string{groupA}, false},
+		{"several log groups", []string{groupA, groupB}, []string{groupA, groupB}, false},
+
+		// The regression. `_Audit` is a reserved name for the tenancy audit
+		// stream, not an OCID, so it can never resolve to a log group. Feeding
+		// it to the lookup made it fail and get dropped, and a connector that
+		// exports the audit log - the main reason to run Connector Hub -
+		// reported no sources at all.
+		{"the audit sentinel alone", []string{"_Audit"}, []string{}, true},
+		{"the audit sentinel beside a log group", []string{"_Audit", groupA}, []string{groupA}, true},
+
+		// A source scoped to a whole compartment names no log group.
+		{"empty reference", []string{""}, []string{}, false},
+		{"empty reference beside a log group", []string{"", groupA}, []string{groupA}, false},
+
+		// Anything else is not resolvable and must not reach the lookup.
+		{"non-ocid junk", []string{"not-an-ocid"}, []string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ocids, audit := ociSplitLogGroupRefs(tt.refs)
+			assert.Equal(t, tt.wantOcids, ocids)
+			assert.Equal(t, tt.wantAudit, audit)
+		})
+	}
+}


### PR DESCRIPTION
Five defects found by a static review of the OCI provider. They share a shape: each returns data that looks authoritative and is wrong, with no error anywhere. A policy written over any of them passes vacuously.

## Identity domain users and groups are reported empty

SCIM returns only attributes a schema marks `returned=always` or `returned=default`. Anything marked `returned=request` is omitted **unless the request names it** — the SDK is explicit about this on `ListUsersRequest.Attributes`. None of the four SCIM list calls set `Attributes` or `AttributeSets`, and the `returned=request` fields turn out to be exactly the ones that carry the security signal:

| Field | Shipped as | SDK |
|---|---|---|
| `user.loginAttempts` | `0`, always | `extension_user_state_user.go:74` |
| `user.lastSuccessfulLogin` / `previousSuccessfulLogin` / `lastFailedLogin` | `null`, always | `:34, :47, :60` |
| `user.mfaEnabledOn` | `null`, always | `extension_mfa_user.go:100` |
| `user.groups` | `[]`, always | `user.go:414` |
| `group.memberCount` | `0`, always | `group.go:200` |
| `group.isRequestable` | `false`, always | `extension_requestable_group.go:35` |

A dormant-account audit (`users.where(lastSuccessfulLogin == null)`) matched **every account in the tenancy**; its inverse matched none. Every group reported zero members, including a 500-member admin group.

The fix asks for the default and request sets together. Note it has to be `AttributeSets` and not `Attributes` — per the same SDK doc, naming attributes *narrows* the response, so the obvious-looking fix would have broken the ~10 fields that currently work.

## An under-scoped token rendered as a clean, empty tenancy

`ociCollectCompartmentJobs` promises in its own doc comment that if every compartment refuses access it returns an error, because "reporting it as an empty tenancy would turn a broken credential into a clean scan." It could not keep that promise.

OCI answers an authorization failure with **404 `NotAuthorizedOrNotFound`** — the SDK's own retry table pairs that code with 404. But the loop asked `ociRegionServiceUnavailable` first, and that treats *any* 404 as an absent regional endpoint. Every denial was consumed before reaching the `denied` counter, so `succeeded == 0 && denied > 0` could never be true.

Fifteen listers across audit, databases, DNS, messaging, network load balancer, Resource Manager and Connector Hub returned `[]` with `err == nil` and a `log.Debug` invisible at default verbosity.

The denial test now matches on the error *code* rather than the bare status. That makes it strictly narrower than the region test, which is what lets it run first without swallowing genuinely undeployed regions.

## Five fields were never populated at all

The `.lr` declared `hasResponseCache`, `ipAddresses` and `caBundleIds` on `oci.apigateway.gateway`, and `scores` and `endpointProtections` on the vulnerability-scanning results, as **plain data fields** rather than computed ones. A plain field gets a plain generated getter (`return &c.X`), so the Go accessors written to populate them were never called by anything — including `fetchDetails()` and the `GetGateway` request inside it. The creator never set them either, so all five read as unset forever.

`go vet`'s unusedfunc check flags all five as unused methods, which is the tell. Declaring them computed wires the existing accessors up; no Go logic changed.

## A connector exporting the audit log reported no sources

Connector Hub names the tenancy audit log with the reserved value `_Audit` rather than an OCID (`sch/log_source.go:27`: *"Either `_Audit` or the OCID of the log group"*). It was passed to `initOciLoggingLogGroup`, which matches on OCID, failed, and got dropped by the accessor's log-and-continue. The schema meanwhile promised the opposite: *"The tenancy audit log appears here as the `_Audit` log group, so a connector exporting audit events resolves to it."*

Audit export is the main reason most tenancies run Connector Hub. `_Audit` now reports through a new `exportsAuditLog` field and the schema text is corrected.

## A public network load balancer read as unreachable

`isPublic` is optional on `networkloadbalancer/ip_address.go`. The NLB marshalled the SDK slice straight to JSON, so an absent flag arrived as `null` and `d["isPublic"].(bool)` read it back as `false` → `hasPublicIp: false` → `internetReachable: false`.

The classic load balancer already handles this, with a comment naming the exact hazard:

```go
// A missing flag on a non-private load balancer means public, so falling
// back to false would clear a genuinely internet-facing balancer.
```

The NLB bypassed it. Both now share `ociIpIsPublic` (the write side) and `ociLoadBalancerHasPublicIp` (the read side) so they cannot drift apart again.

## Tests

New coverage for each piece of pure logic touched: the 404-vs-404 classifier split, the public-IP fallback in both directions and with malformed entries, and the `_Audit` sentinel split.

Worth flagging that **two existing compartment fixtures encoded the bug as correct behaviour** — they described OCI's denial shape (`404 NotAuthorizedOrNotFound`) as an undeployed region, and one asserted that an all-denied run should return empty with no error. Both are corrected here.

## Verification

`make providers/build/oci` clean, `go test ./resources/` green, `gofmt` clean, generated files refreshed. No `.lr.versions` churn beyond the one new `exportsAuditLog` entry — changing a field from plain to computed does not add an entry.

Not live-verified: no OCI tenancy was available. The whole #9573–#9578 stack this reviews still has live verification owed.
