### PR TITLE
🐛 gcp: fix fabricated-absence bugs that make posture checks pass vacuously

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1365,6 +1365,10 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// "notebookRuntimeTemplate" by default; the real IAM permission is the
 		// plural form (matching aiplatform.notebookRuntimeTemplates.list).
 		"GetNotebookRuntimeTemplate": "aiplatform.notebookRuntimeTemplates.get",
+		// ScheduleClient.GetSchedule → singular "schedule" by default; the real
+		// IAM permission is the plural form (matching
+		// aiplatform.schedules.list).
+		"GetSchedule": "aiplatform.schedules.get",
 		// GetIamPolicy is the shared google.iam.v1 mixin method on both
 		// ModelClient and NotebookClient; map each to its resource-scoped
 		// permission (clientType derived from NewModelClient/NewNotebookClient).

--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -58,9 +58,20 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 
 	mqlKeys := make([]any, 0, len(apiKeyItems))
 	for _, k := range apiKeyItems {
-		var mqlRestrictions plugin.Resource
+		// The API omits the entire restrictions block for a key that has no
+		// restrictions, so the resource must be built either way: that absence
+		// IS the fully-unrestricted case the `unrestricted` predicate exists to
+		// report. Building it only when k.Restrictions != nil left
+		// `restrictions` null for precisely the keys a posture check is looking
+		// for, so `unrestricted` could never evaluate to true.
+		var (
+			mqlAndroidRestr   any
+			mqlBrowserRest    any
+			mqlIosRestr       any
+			mqlServerKeyRestr any
+			mqlApiTargets     = []any{}
+		)
 		if k.Restrictions != nil {
-			var mqlAndroidRestr any
 			if k.Restrictions.AndroidKeyRestrictions != nil {
 
 				type mqlAllowedApp struct {
@@ -85,7 +96,7 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 				}
 			}
 
-			mqlApiTargets := make([]any, 0, len(k.Restrictions.ApiTargets))
+			mqlApiTargets = make([]any, 0, len(k.Restrictions.ApiTargets))
 			if k.Restrictions.ApiTargets != nil {
 				type mqlApiTarget struct {
 					Service string   `json:"service"`
@@ -104,7 +115,6 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 				}
 			}
 
-			var mqlBrowserRest any
 			if k.Restrictions.BrowserKeyRestrictions != nil {
 				type mqlBrowserKeyRestrictions struct {
 					AllowedReferrers []string `json:"allowedReferrers"`
@@ -118,7 +128,6 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 				}
 			}
 
-			var mqlIosRestr any
 			if k.Restrictions.IosKeyRestrictions != nil {
 				type mqlIosKeyRestrictions struct {
 					AllowedBundleIds []string `json:"allowedBundleIds"`
@@ -132,7 +141,6 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 				}
 			}
 
-			var mqlServerKeyRestr any
 			if k.Restrictions.ServerKeyRestrictions != nil {
 				type mqlServerKeyRestrictions struct {
 					AllowedIps []string `json:"allowedIps"`
@@ -146,17 +154,18 @@ func (g *mqlGcpProject) apiKeys() ([]any, error) {
 				}
 			}
 
-			mqlRestrictions, err = CreateResource(g.MqlRuntime, "gcp.project.apiKey.restrictions", map[string]*llx.RawData{
-				"parentResourcePath":     llx.StringData(k.Name),
-				"androidKeyRestrictions": llx.DictData(mqlAndroidRestr),
-				"browserKeyRestrictions": llx.DictData(mqlBrowserRest),
-				"iosKeyRestrictions":     llx.DictData(mqlIosRestr),
-				"serverKeyRestrictions":  llx.DictData(mqlServerKeyRestr),
-				"apiTargets":             llx.ArrayData(mqlApiTargets, types.Dict),
-			})
-			if err != nil {
-				return nil, err
-			}
+		}
+
+		mqlRestrictions, err := CreateResource(g.MqlRuntime, "gcp.project.apiKey.restrictions", map[string]*llx.RawData{
+			"parentResourcePath":     llx.StringData(k.Name),
+			"androidKeyRestrictions": llx.DictData(mqlAndroidRestr),
+			"browserKeyRestrictions": llx.DictData(mqlBrowserRest),
+			"iosKeyRestrictions":     llx.DictData(mqlIosRestr),
+			"serverKeyRestrictions":  llx.DictData(mqlServerKeyRestr),
+			"apiTargets":             llx.ArrayData(mqlApiTargets, types.Dict),
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		mqlKey, err := CreateResource(g.MqlRuntime, "gcp.project.apiKey", map[string]*llx.RawData{

--- a/providers/gcp/resources/apikeys_test.go
+++ b/providers/gcp/resources/apikeys_test.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// setRestrictions builds the restrictions resource in the shape apiKeys()
+// produces it: every field explicitly set, with the "no restrictions of this
+// kind" case represented by a nil dict / empty list rather than an unset field.
+func setRestrictions(android, browser, ios, server any, apiTargets []any) *mqlGcpProjectApiKeyRestrictions {
+	return &mqlGcpProjectApiKeyRestrictions{
+		AndroidKeyRestrictions: plugin.TValue[any]{Data: android, State: plugin.StateIsSet},
+		BrowserKeyRestrictions: plugin.TValue[any]{Data: browser, State: plugin.StateIsSet},
+		IosKeyRestrictions:     plugin.TValue[any]{Data: ios, State: plugin.StateIsSet},
+		ServerKeyRestrictions:  plugin.TValue[any]{Data: server, State: plugin.StateIsSet},
+		ApiTargets:             plugin.TValue[[]any]{Data: apiTargets, State: plugin.StateIsSet},
+	}
+}
+
+// TestApiKeyUnrestricted pins the predicate that made this bug findable.
+//
+// The Keys.List response omits the whole `restrictions` block for a key with no
+// restrictions, so apiKeys() previously built the restrictions resource only
+// when k.Restrictions != nil. That left `restrictions` NULL for exactly the
+// fully-unrestricted keys, making `unrestricted` unreachable for them: the
+// all-empty case below could never occur in practice.
+func TestApiKeyUnrestricted(t *testing.T) {
+	dict := map[string]any{"allowedIps": []any{"10.0.0.0/8"}}
+	target := []any{map[string]any{"service": "storage.googleapis.com"}}
+
+	tests := []struct {
+		name string
+		res  *mqlGcpProjectApiKeyRestrictions
+		want bool
+	}{
+		{
+			// The case the API represents by omitting the block entirely.
+			name: "no restrictions at all",
+			res:  setRestrictions(nil, nil, nil, nil, []any{}),
+			want: true,
+		},
+		{
+			name: "server ip restriction only",
+			res:  setRestrictions(nil, nil, nil, dict, []any{}),
+			want: false,
+		},
+		{
+			name: "android restriction only",
+			res:  setRestrictions(dict, nil, nil, nil, []any{}),
+			want: false,
+		},
+		{
+			name: "browser restriction only",
+			res:  setRestrictions(nil, dict, nil, nil, []any{}),
+			want: false,
+		},
+		{
+			name: "ios restriction only",
+			res:  setRestrictions(nil, nil, dict, nil, []any{}),
+			want: false,
+		},
+		{
+			// An API-target restriction alone still narrows the key.
+			name: "api targets only",
+			res:  setRestrictions(nil, nil, nil, nil, target),
+			want: false,
+		},
+		{
+			name: "nil api target slice counts as none",
+			res:  setRestrictions(nil, nil, nil, nil, nil),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.res.unrestricted()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestApiKeyAppliedRestrictionTypes checks the companion accessor reports the
+// empty list (not null) for an unrestricted key, so a caller can tell "no
+// restrictions" from "could not read the restrictions".
+func TestApiKeyAppliedRestrictionTypes(t *testing.T) {
+	dict := map[string]any{"allowedIps": []any{"10.0.0.0/8"}}
+
+	t.Run("unrestricted key reports an empty list", func(t *testing.T) {
+		got, err := setRestrictions(nil, nil, nil, nil, []any{}).appliedRestrictionTypes()
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.NotNil(t, got, "must be an empty list, not null")
+	})
+
+	t.Run("restricted key names the applied types", func(t *testing.T) {
+		got, err := setRestrictions(nil, nil, nil, dict, []any{}).appliedRestrictionTypes()
+		require.NoError(t, err)
+		assert.Contains(t, got, "serverKeyRestrictions")
+	})
+}

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -32,8 +32,13 @@ func initGcpProjectBigqueryService(runtime *plugin.Runtime, args map[string]*llx
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	projectId := conn.ResourceID()
-	args["projectId"] = llx.StringData(projectId)
+	// Only default the project from the connection when the caller did not
+	// supply one; NewResource runs this init before the resource-cache lookup,
+	// so an unconditional overwrite would redirect a caller-scoped reference at
+	// the connection's own project.
+	if pid, ok := args["projectId"]; !ok || pid == nil {
+		args["projectId"] = llx.StringData(conn.ResourceID())
+	}
 
 	return args, nil, nil
 }

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -760,7 +760,11 @@ func getBigtableBackupByName(runtime *plugin.Runtime, backupResourceName string)
 	}
 	projectId := parts[1]
 	instanceName := parts[3]
-	clusterFullName := fmt.Sprintf("projects/%s/instances/%s/clusters/%s", parts[1], parts[3], parts[5])
+	// backups() stores ClusterInfo.Name, which the Bigtable SDK sets to the
+	// short cluster id (the last path segment), not the full resource path.
+	// Comparing against a full path here never matched, so sourceBackup was
+	// always null and backup lineage was invisible.
+	clusterShort := parts[5]
 	backupShort := parts[7]
 
 	obj, err := CreateResource(runtime, "gcp.project.bigtableService.instance", map[string]*llx.RawData{
@@ -783,7 +787,7 @@ func getBigtableBackupByName(runtime *plugin.Runtime, backupResourceName string)
 		if backup.ClusterName.Error != nil {
 			return nil, backup.ClusterName.Error
 		}
-		if backup.Name.Data == backupShort && backup.ClusterName.Data == clusterFullName {
+		if backup.Name.Data == backupShort && backup.ClusterName.Data == clusterShort {
 			return backup, nil
 		}
 	}

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -41,8 +41,15 @@ func initGcpProjectComputeService(runtime *plugin.Runtime, args map[string]*llx.
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	projectId := conn.ResourceID()
-	args["projectId"] = llx.StringData(projectId)
+	// Only default the project from the connection when the caller did not
+	// supply one. NewResource runs this init before the resource-cache lookup,
+	// so an unconditional overwrite redirects every caller-scoped reference
+	// (gcp.projects.list { compute.instances }, instance.exposure) at the
+	// connection's own project, and on an organization- or folder-scoped
+	// connection ResourceID() is not a project id at all.
+	if pid, ok := args["projectId"]; !ok || pid == nil {
+		args["projectId"] = llx.StringData(conn.ResourceID())
+	}
 
 	return args, nil, nil
 }
@@ -75,6 +82,25 @@ func (g *mqlGcpProjectComputeService) enabled() (bool, error) {
 		return false, err
 	}
 	return serviceEnabled, nil
+}
+
+// serviceEnabled resolves the compute service-enabled gate and propagates the
+// error from that resolution.
+//
+// Reading `GetEnabled().Data` on its own is not safe: enabled() resolves
+// gcp.project and calls isServiceEnabled, and on any failure of that chain (a
+// serviceusage permission gap, the Service Usage API itself disabled, a
+// transient error) GetOrCompute returns Data=false alongside a non-nil Error.
+// A caller that only reads Data then reports "this project has no instances /
+// firewalls / disks" for a project it was never able to check -- an empty list
+// is the most dangerous wrong answer for a posture check, because it passes
+// vacuously instead of failing or erroring.
+func (g *mqlGcpProjectComputeService) serviceEnabled() (bool, error) {
+	enabled := g.GetEnabled()
+	if enabled.Error != nil {
+		return false, enabled.Error
+	}
+	return enabled.Data, nil
 }
 
 func (g *mqlGcpProjectComputeService) id() (string, error) {
@@ -194,8 +220,11 @@ func newMqlZone(runtime *plugin.Runtime, z *compute.Zone) (any, error) {
 }
 
 func (g *mqlGcpProjectComputeService) regions() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -245,8 +274,11 @@ func (g *mqlGcpProjectComputeServiceZone) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) zones() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -328,8 +360,11 @@ func newMqlMachineType(runtime *plugin.Runtime, entry *compute.MachineType, proj
 }
 
 func (g *mqlGcpProjectComputeService) machineTypes() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -987,8 +1022,11 @@ func (g *mqlGcpProjectComputeServiceInstance) serviceAccountRefs() ([]any, error
 }
 
 func (g *mqlGcpProjectComputeService) instances() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1202,9 +1240,27 @@ func customerEncryptionKeyToDict(key *compute.CustomerEncryptionKey) map[string]
 	}
 }
 
+// computeAggregatedScope splits a Compute AggregatedList scope key into its
+// kind and name. Compute keys aggregated results by "zones/<zone>" for zonal
+// resources and "regions/<region>" for regional ones; the "global" bucket and
+// any future scope kind report ok=false so callers skip them explicitly rather
+// than silently mapping them into the wrong location.
+func computeAggregatedScope(scope string) (kind, name string, ok bool) {
+	if n, found := strings.CutPrefix(scope, "zones/"); found && n != "" {
+		return "zone", n, true
+	}
+	if n, found := strings.CutPrefix(scope, "regions/"); found && n != "" {
+		return "region", n, true
+	}
+	return "", "", false
+}
+
 func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1246,14 +1302,25 @@ func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 	req := computeSvc.Disks.AggregatedList(projectId)
 	if err := req.Pages(ctx, func(page *compute.DiskAggregatedList) error {
 		for scope, scopedList := range page.Items {
-			zoneName, ok := strings.CutPrefix(scope, "zones/")
+			// Disks are aggregated under both "zones/<zone>" (zonal) and
+			// "regions/<region>" (regional, synchronously replicated). Skipping
+			// the regional scope hid every regional PD -- the HA disk type --
+			// from encryption and source-image audits with no error.
+			kind, locationName, ok := computeAggregatedScope(scope)
 			if !ok {
-				// regional disks are not modeled today; preserve prior behavior
 				continue
 			}
-			zone, ok := zonesByName[zoneName]
-			if !ok {
-				continue
+			// A regional disk has no zone, so the field resolves to null. It
+			// must be llx.NilData and not a typed-nil resource pointer: a typed
+			// nil is a non-nil interface, which RawToTValue records as set and
+			// NOT null, and the runtime then dereferences it.
+			zoneData := llx.NilData
+			if kind == "zone" {
+				zone, found := zonesByName[locationName]
+				if !found {
+					continue
+				}
+				zoneData = llx.ResourceData(zone, "gcp.project.computeService.zone")
 			}
 			for _, disk := range scopedList.Disks {
 				guestOsFeatures := []string{}
@@ -1313,7 +1380,7 @@ func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 					"satisfiesPzs":                llx.BoolData(disk.SatisfiesPzs),
 					"sizeGb":                      llx.IntData(disk.SizeGb),
 					"status":                      llx.StringData(disk.Status),
-					"zone":                        llx.ResourceData(zone, "gcp.project.computeService.zone"),
+					"zone":                        zoneData,
 					"created":                     llx.TimeDataPtr(parseTime(disk.CreationTimestamp)),
 					"diskEncryptionKey":           llx.DictData(mqlDiskEnc),
 					"sourceImageEncryptionKey":    llx.DictData(mqlSourceImageEnc),
@@ -1458,8 +1525,11 @@ func initGcpProjectComputeServiceFirewall(runtime *plugin.Runtime, args map[stri
 }
 
 func (g *mqlGcpProjectComputeService) firewalls() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1566,8 +1636,11 @@ func (g *mqlGcpProjectComputeServiceSnapshot) managedBy() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) snapshots() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1833,8 +1906,11 @@ func (g *mqlGcpProjectComputeServiceImage) sourceSnapshot() (*mqlGcpProjectCompu
 }
 
 func (g *mqlGcpProjectComputeService) images() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -2152,8 +2228,11 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 }
 
 func (g *mqlGcpProjectComputeService) networks() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -2490,8 +2569,11 @@ func newMqlSubnetwork(projectId string, runtime *plugin.Runtime, subnetwork *com
 }
 
 func (g *mqlGcpProjectComputeService) subnetworks() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -2634,8 +2716,11 @@ func newMqlRouter(projectId string, region *mqlGcpProjectComputeServiceRegion, r
 }
 
 func (g *mqlGcpProjectComputeService) routers() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -2701,8 +2786,11 @@ func (g *mqlGcpProjectComputeService) routers() ([]any, error) {
 }
 
 func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3003,8 +3091,11 @@ func networkMode(n *compute.Network) string {
 }
 
 func (g *mqlGcpProjectComputeService) addresses() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3100,8 +3191,11 @@ func (g *mqlGcpProjectComputeServiceAddress) id() (string, error) {
 func (g *mqlGcpProjectComputeService) forwardingRules() ([]any, error) {
 	// when the service is not enabled, we return nil (mirrors the other 19
 	// compute list accessors so an API-disabled project degrades to empty
-	// rather than hard-failing this one query).
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3280,7 +3374,11 @@ func (g *mqlGcpProjectComputeServiceSecurityPolicyRule) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) securityPolicies() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3485,7 +3583,11 @@ func (g *mqlGcpProjectComputeServiceSslPolicy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) sslPolicies() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3568,7 +3670,11 @@ func (g *mqlGcpProjectComputeServiceSslCertificate) expired() (bool, error) {
 }
 
 func (g *mqlGcpProjectComputeService) sslCertificates() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3648,7 +3754,11 @@ func (g *mqlGcpProjectComputeServiceVpnGateway) network() (*mqlGcpProjectCompute
 }
 
 func (g *mqlGcpProjectComputeService) vpnGateways() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3720,7 +3830,11 @@ func (g *mqlGcpProjectComputeServiceVpnTunnel) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) vpnTunnels() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -3810,7 +3924,11 @@ func storagePoolSharedProjectIds(shareSettings *compute.StoragePoolShareSettings
 }
 
 func (g *mqlGcpProjectComputeService) storagePools() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/compute_enrichments.go
+++ b/providers/gcp/resources/compute_enrichments.go
@@ -21,7 +21,11 @@ import (
 // Health checks
 
 func (g *mqlGcpProjectComputeService) healthChecks() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -95,7 +99,11 @@ func (g *mqlGcpProjectComputeServiceHealthCheck) id() (string, error) {
 // URL maps
 
 func (g *mqlGcpProjectComputeService) urlMaps() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -157,7 +165,11 @@ func (g *mqlGcpProjectComputeServiceUrlMap) id() (string, error) {
 // Target HTTP proxies
 
 func (g *mqlGcpProjectComputeService) targetHttpProxies() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -232,7 +244,11 @@ func (g *mqlGcpProjectComputeServiceTargetHttpProxy) urlMap() (*mqlGcpProjectCom
 // Target HTTPS proxies
 
 func (g *mqlGcpProjectComputeService) targetHttpsProxies() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -23,7 +23,11 @@ import (
 // Instance groups
 
 func (g *mqlGcpProjectComputeService) instanceGroups() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -116,7 +120,11 @@ func (g *mqlGcpProjectComputeServiceInstanceGroup) subnetwork() (*mqlGcpProjectC
 // Instance group managers
 
 func (g *mqlGcpProjectComputeService) instanceGroupManagers() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -238,7 +246,11 @@ func (g *mqlGcpProjectComputeServiceInstanceGroupManager) instanceTemplate() (*m
 // Network firewall policies
 
 func (g *mqlGcpProjectComputeService) firewallPolicies() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {

--- a/providers/gcp/resources/compute_instance_templates.go
+++ b/providers/gcp/resources/compute_instance_templates.go
@@ -20,8 +20,11 @@ import (
 )
 
 func (g *mqlGcpProjectComputeService) instanceTemplates() ([]any, error) {
-	// when the service is not enabled, we return nil
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/compute_networking.go
+++ b/providers/gcp/resources/compute_networking.go
@@ -379,7 +379,11 @@ func (g *mqlGcpProjectComputeServiceRoute) network() (*mqlGcpProjectComputeServi
 }
 
 func (g *mqlGcpProjectComputeService) routes() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -466,7 +470,11 @@ func (g *mqlGcpProjectComputeServiceServiceAttachment) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) serviceAttachments() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -589,7 +597,11 @@ func (g *mqlGcpProjectComputeServiceNetworkEndpointGroup) subnetwork() (*mqlGcpP
 }
 
 func (g *mqlGcpProjectComputeService) networkEndpointGroups() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -680,7 +692,11 @@ func (g *mqlGcpProjectComputeServiceInterconnect) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) interconnects() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -772,7 +788,11 @@ func (g *mqlGcpProjectComputeServiceInterconnectAttachment) id() (string, error)
 }
 
 func (g *mqlGcpProjectComputeService) interconnectAttachments() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -855,7 +875,11 @@ func (g *mqlGcpProjectComputeServiceExternalVpnGateway) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) externalVpnGateways() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -926,7 +950,11 @@ func (g *mqlGcpProjectComputeServiceTargetTcpProxy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) targetTcpProxies() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1005,7 +1033,11 @@ func (g *mqlGcpProjectComputeServiceTargetSslProxy) sslPolicy() (*mqlGcpProjectC
 }
 
 func (g *mqlGcpProjectComputeService) targetSslProxies() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1064,7 +1096,11 @@ func (g *mqlGcpProjectComputeServicePacketMirroring) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) packetMirrorings() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1144,7 +1180,11 @@ func (g *mqlGcpProjectComputeServiceBackendBucket) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) backendBuckets() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1209,7 +1249,11 @@ func (g *mqlGcpProjectComputeServiceTargetPool) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) targetPools() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1272,7 +1316,11 @@ func (g *mqlGcpProjectComputeServicePublicAdvertisedPrefix) id() (string, error)
 }
 
 func (g *mqlGcpProjectComputeService) publicAdvertisedPrefixes() ([]any, error) {
-	if !g.GetEnabled().Data {
+	enabled, err := g.serviceEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/compute_scope_test.go
+++ b/providers/gcp/resources/compute_scope_test.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestComputeAggregatedScope pins the scope classification that decides which
+// buckets of a Compute AggregatedList response get mapped.
+//
+// disks() previously matched only the "zones/" prefix and skipped everything
+// else, so every regional (synchronously replicated) persistent disk was
+// dropped from gcp.project.compute.disks with no error -- and regional PDs are
+// the HA disk type, so encryption and source-image audits silently ran over an
+// incomplete inventory. The "region" case below is the one that regressed.
+func TestComputeAggregatedScope(t *testing.T) {
+	tests := []struct {
+		scope    string
+		wantKind string
+		wantName string
+		wantOK   bool
+	}{
+		{"zones/us-central1-a", "zone", "us-central1-a", true},
+		{"regions/us-central1", "region", "us-central1", true},
+		{"zones/europe-west4-b", "zone", "europe-west4-b", true},
+		{"regions/asia-southeast1", "region", "asia-southeast1", true},
+		// The aggregated response also carries a "global" bucket, which holds
+		// no zonal or regional location and must be skipped explicitly.
+		{"global", "", "", false},
+		// Defensive: a prefix with no name behind it must not yield an empty
+		// location that silently matches nothing in zonesByName.
+		{"zones/", "", "", false},
+		{"regions/", "", "", false},
+		{"", "", "", false},
+		{"somethingelse/us-central1", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scope, func(t *testing.T) {
+			kind, name, ok := computeAggregatedScope(tt.scope)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantKind, kind)
+			assert.Equal(t, tt.wantName, name)
+		})
+	}
+}
+
+// TestVertexaiRegionFromName covers the parser the new schedule init depends on
+// to pick a regional aiplatform endpoint. An empty result means the init cannot
+// build an endpoint at all, so the miss cases matter as much as the hits.
+func TestVertexaiRegionFromName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "schedule resource name",
+			in:   "projects/my-project/locations/us-central1/schedules/1234",
+			want: "us-central1",
+		},
+		{
+			name: "project number instead of id",
+			in:   "projects/415104041262/locations/europe-west4/pipelineJobs/abc",
+			want: "europe-west4",
+		},
+		{name: "no locations segment", in: "projects/my-project/schedules/1234", want: ""},
+		{name: "locations is the final segment", in: "projects/p/locations", want: ""},
+		{name: "empty", in: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, vertexaiRegionFromName(tt.in))
+		})
+	}
+}

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -139,8 +139,13 @@ func initGcpProjectDnsService(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	projectId := conn.ResourceID()
-	args["projectId"] = llx.StringData(projectId)
+	// Only default the project from the connection when the caller did not
+	// supply one; NewResource runs this init before the resource-cache lookup,
+	// so an unconditional overwrite would redirect a caller-scoped reference at
+	// the connection's own project.
+	if pid, ok := args["projectId"]; !ok || pid == nil {
+		args["projectId"] = llx.StringData(conn.ResourceID())
+	}
 
 	return args, nil, nil
 }

--- a/providers/gcp/resources/enabled_gate_test.go
+++ b/providers/gcp/resources/enabled_gate_test.go
@@ -1,0 +1,114 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoBareGetEnabledDataGate pins the service-enabled ERROR contract, the
+// companion to TestNoBareServiceEnabledGate in service_gate_test.go.
+//
+// The compute service resolves its gate through a real `enabled()` accessor
+// that builds gcp.project and calls isServiceEnabled. Both steps can fail: a
+// missing serviceusage.services.list permission, the Service Usage API itself
+// disabled, a transient error, or the phantom empty-project-id discovery asset.
+// On failure plugin.GetOrCompute returns
+//
+//	TValue[bool]{Data: false, Error: err}
+//
+// so a guard written as
+//
+//	if !g.GetEnabled().Data { return nil, nil }
+//
+// discards the error and reports an authoritative EMPTY COLLECTION for a
+// project that was never successfully checked. That is the most dangerous wrong
+// answer for a posture check: `instances.all(...)`, `firewalls.all(...)` and
+// every other assertion pass vacuously instead of failing or erroring.
+//
+// 40 accessors across compute.go, compute_networking.go, compute_enrichments.go,
+// compute_instance_groups_firewall_policies.go and compute_instance_templates.go
+// had this shape. Every gate must go through serviceEnabled(), which propagates
+// the error.
+func TestNoBareGetEnabledDataGate(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Data" {
+				return true
+			}
+			// match `<recv>.GetEnabled().Data`
+			call, ok := sel.X.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fn, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || fn.Sel.Name != "GetEnabled" {
+				return true
+			}
+			t.Errorf("%s: reads GetEnabled().Data directly, discarding the "+
+				"resolution error; a failed service-enabled check then reports an "+
+				"empty collection for a project it never checked. Use the "+
+				"serviceEnabled() helper (compute.go), which propagates the error",
+				fset.Position(sel.Pos()))
+			return true
+		})
+	}
+}
+
+// TestServiceEnabledHelperPropagatesError guards the helper itself: if it ever
+// stops returning the TValue's Error, every one of the 40 call sites silently
+// reverts to the bug above.
+func TestServiceEnabledHelperPropagatesError(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "compute.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse compute.go: %v", err)
+	}
+
+	var found bool
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "serviceEnabled" || fn.Recv == nil {
+			continue
+		}
+		found = true
+
+		var readsError bool
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "Error" {
+				readsError = true
+			}
+			return true
+		})
+		if !readsError {
+			t.Error("compute.go: serviceEnabled() never inspects the TValue's " +
+				"Error; a failed service-enabled resolution would silently read " +
+				"as 'service disabled' and return an empty collection")
+		}
+	}
+	if !found {
+		t.Error("compute.go: serviceEnabled() helper is gone; the 40 gate call " +
+			"sites depend on it to propagate the resolution error")
+	}
+}

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -1943,7 +1943,7 @@ func init() {
 			Create: createGcpProjectVertexaiServicePersistentResource,
 		},
 		"gcp.project.vertexaiService.schedule": {
-			// to override args, implement: initGcpProjectVertexaiServiceSchedule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectVertexaiServiceSchedule,
 			Create: createGcpProjectVertexaiServiceSchedule,
 		},
 		"gcp.project.vertexaiService.deploymentResourcePool": {

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.34.1",
-  "generated_at": "2026-08-06T17:19:21+02:00",
+  "generated_at": "2026-08-06T22:51:42-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -32,6 +32,7 @@
     "aiplatform.pipelineJobs.list",
     "aiplatform.ragCorpora.list",
     "aiplatform.reasoningEngines.list",
+    "aiplatform.schedules.get",
     "aiplatform.schedules.list",
     "aiplatform.tensorboards.list",
     "aiplatform.trainingPipelines.list",
@@ -463,6 +464,12 @@
       "permission": "aiplatform.reasoningEngines.list",
       "service": "aiplatform",
       "action": "ListReasoningEngines",
+      "source_file": "vertexai.go"
+    },
+    {
+      "permission": "aiplatform.schedules.get",
+      "service": "aiplatform",
+      "action": "GetSchedule",
       "source_file": "vertexai.go"
     },
     {

--- a/providers/gcp/resources/init_guard_test.go
+++ b/providers/gcp/resources/init_guard_test.go
@@ -258,6 +258,124 @@ func TestInitGuardsEveryDereferencedArg(t *testing.T) {
 	}
 }
 
+// TestInitDoesNotRedirectACallerSuppliedProject pins the invariant that makes
+// the unconditional `args["projectId"] = llx.StringData(conn.ResourceID())`
+// assignments safe.
+//
+// NewResource runs an init before the resource-cache lookup, so an init that
+// overwrites projectId redirects every caller-scoped reference
+// (gcp.projects.list { compute.instances }) at the connection's own project.
+// On an organization- or folder-scoped connection ResourceID() is not a
+// project id at all, so the reference resolves to nothing.
+//
+// Two shapes prevent that, and an init must use one of them:
+//
+//   - wrap the assignment in a check on args["projectId"], or
+//   - return early on `len(args) > 0`, which a caller-supplied projectId
+//     always trips.
+//
+// The second is what most service inits rely on, and it is invisible at the
+// assignment. Raising that threshold to `> 1` or `> 2` while adding a second
+// argument is an easy and silent way to reintroduce the redirection, so the
+// pairing is asserted here rather than left to review.
+func TestInitDoesNotRedirectACallerSuppliedProject(t *testing.T) {
+	fset := token.NewFileSet()
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "init") {
+				continue
+			}
+			// Only the top-level statements matter: an assignment nested in an
+			// if is guarded by that if, which the walk below treats separately.
+			for _, stmt := range fn.Body.List {
+				assign, ok := stmt.(*ast.AssignStmt)
+				if !ok || !assignsProjectIdFromResourceID(assign) {
+					continue
+				}
+				if !returnsEarlyOnAnyArg(fn.Body, assign.Pos()) {
+					t.Errorf("%s: %s overwrites args[\"projectId\"] with the connection's own "+
+						"resource id without an earlier `if len(args) > 0` return, so a "+
+						"caller-supplied project is silently redirected. Guard the assignment "+
+						"with `if pid, ok := args[\"projectId\"]; !ok || pid == nil`.",
+						fset.Position(assign.Pos()), fn.Name.Name)
+				}
+			}
+		}
+	}
+}
+
+// assignsProjectIdFromResourceID reports whether stmt is
+// args["projectId"] = <...conn.ResourceID()...>.
+func assignsProjectIdFromResourceID(stmt *ast.AssignStmt) bool {
+	if len(stmt.Lhs) != 1 || !isArgsIndex(stmt.Lhs[0], "projectId") {
+		return false
+	}
+	found := false
+	for _, rhs := range stmt.Rhs {
+		ast.Inspect(rhs, func(n ast.Node) bool {
+			if call, ok := n.(*ast.CallExpr); ok && calleeName(call.Fun) == "ResourceID" {
+				found = true
+				return false
+			}
+			return true
+		})
+	}
+	return found
+}
+
+// returnsEarlyOnAnyArg reports whether body contains, before pos, an
+// `if len(args) > 0 { ... return ... }`. A threshold above zero does not
+// count: it lets a caller pass projectId and still fall through.
+func returnsEarlyOnAnyArg(body *ast.BlockStmt, pos token.Pos) bool {
+	guarded := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok || ifStmt.Pos() >= pos {
+			return true
+		}
+		cond, ok := ifStmt.Cond.(*ast.BinaryExpr)
+		if !ok || cond.Op != token.GTR || !isLenOfArgs(cond.X) {
+			return true
+		}
+		lit, ok := cond.Y.(*ast.BasicLit)
+		if !ok || lit.Kind != token.INT || lit.Value != "0" {
+			return true
+		}
+		for _, stmt := range ifStmt.Body.List {
+			if _, isReturn := stmt.(*ast.ReturnStmt); isReturn {
+				guarded = true
+				return false
+			}
+		}
+		return true
+	})
+	return guarded
+}
+
+// isLenOfArgs reports whether e is the expression len(args).
+func isLenOfArgs(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || calleeName(call.Fun) != "len" || len(call.Args) != 1 {
+		return false
+	}
+	ident, ok := call.Args[0].(*ast.Ident)
+	return ok && ident.Name == "args"
+}
+
 // argsKeys returns the args key referenced by e, if e is args["<key>"].
 func argsKeys(e ast.Expr) []string {
 	idx, ok := e.(*ast.IndexExpr)

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -67,6 +67,7 @@ var validatedGCPPermissions = []string{
 	"aiplatform.pipelineJobs.list",
 	"aiplatform.ragCorpora.list",
 	"aiplatform.reasoningEngines.list",
+	"aiplatform.schedules.get",
 	"aiplatform.schedules.list",
 	"aiplatform.tensorboards.list",
 	"aiplatform.trainingPipelines.list",

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -75,8 +75,24 @@ func initGcpProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return nil, nil, err
 	}
 
-	projectId := fmt.Sprintf("projects/%s", conn.ResourceID())
-	project, err := svc.Projects.Get(projectId).Do()
+	// Resolve the project the caller asked for, not the one the connection
+	// happens to point at. NewResource runs this init before consulting the
+	// resource cache, so ignoring args["id"] would silently redirect every
+	// typed project reference (projectRefById, sharedVpcHost, folder
+	// managementProjectRef, ...) to the connection's own project -- and on an
+	// organization- or folder-scoped connection ResourceID() is not a project
+	// id at all. initGcpFolder resolves its id the same way.
+	projectRef := conn.ResourceID()
+	if raw := args["id"]; raw != nil {
+		if v, ok := raw.Value.(string); ok && v != "" {
+			projectRef = v
+		}
+	}
+	if projectRef == "" {
+		return nil, nil, errors.New("gcp.project requires a project id")
+	}
+
+	project, err := svc.Projects.Get(fmt.Sprintf("projects/%s", projectRef)).Do()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -49,8 +49,13 @@ func initGcpProjectStorageService(runtime *plugin.Runtime, args map[string]*llx.
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
-	projectId := conn.ResourceID()
-	args["projectId"] = llx.StringData(projectId)
+	// Only default the project from the connection when the caller did not
+	// supply one; NewResource runs this init before the resource-cache lookup,
+	// so an unconditional overwrite would redirect a caller-scoped reference at
+	// the connection's own project.
+	if pid, ok := args["projectId"]; !ok || pid == nil {
+		args["projectId"] = llx.StringData(conn.ResourceID())
+	}
 
 	return args, nil, nil
 }

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -2349,22 +2349,7 @@ func (g *mqlGcpProjectVertexaiService) schedules() ([]any, error) {
 				return nil, false, err
 			}
 
-			mqlSched, err := CreateResource(g.MqlRuntime, "gcp.project.vertexaiService.schedule", map[string]*llx.RawData{
-				"name":                  llx.StringData(sched.Name),
-				"displayName":           llx.StringData(sched.DisplayName),
-				"state":                 llx.StringData(sched.State.String()),
-				"cron":                  llx.StringData(sched.GetCron()),
-				"maxRunCount":           llx.IntData(sched.MaxRunCount),
-				"startedRunCount":       llx.IntData(sched.StartedRunCount),
-				"maxConcurrentRunCount": llx.IntData(sched.MaxConcurrentRunCount),
-				"allowQueueing":         llx.BoolData(sched.AllowQueueing),
-				"catchUp":               llx.BoolData(sched.CatchUp),
-				"startedAt":             llx.TimeDataPtr(timestampAsTimePtr(sched.StartTime)),
-				"endedAt":               llx.TimeDataPtr(timestampAsTimePtr(sched.EndTime)),
-				"createdAt":             llx.TimeDataPtr(timestampAsTimePtr(sched.CreateTime)),
-				"updatedAt":             llx.TimeDataPtr(timestampAsTimePtr(sched.UpdateTime)),
-				"nextRunTime":           llx.TimeDataPtr(timestampAsTimePtr(sched.NextRunTime)),
-			})
+			mqlSched, err := newMqlVertexaiSchedule(g.MqlRuntime, sched)
 			if err != nil {
 				return nil, false, err
 			}
@@ -2376,6 +2361,86 @@ func (g *mqlGcpProjectVertexaiService) schedules() ([]any, error) {
 
 func (g *mqlGcpProjectVertexaiServiceSchedule) id() (string, error) {
 	return g.Name.Data, g.Name.Error
+}
+
+// newMqlVertexaiSchedule maps a Vertex AI Schedule onto the MQL resource. It is
+// shared by the schedules() collection and the single-schedule init so both
+// paths populate the identical field set.
+func newMqlVertexaiSchedule(runtime *plugin.Runtime, sched *aiplatformpb.Schedule) (plugin.Resource, error) {
+	return CreateResource(runtime, "gcp.project.vertexaiService.schedule", map[string]*llx.RawData{
+		"name":                  llx.StringData(sched.Name),
+		"displayName":           llx.StringData(sched.DisplayName),
+		"state":                 llx.StringData(sched.State.String()),
+		"cron":                  llx.StringData(sched.GetCron()),
+		"maxRunCount":           llx.IntData(sched.MaxRunCount),
+		"startedRunCount":       llx.IntData(sched.StartedRunCount),
+		"maxConcurrentRunCount": llx.IntData(sched.MaxConcurrentRunCount),
+		"allowQueueing":         llx.BoolData(sched.AllowQueueing),
+		"catchUp":               llx.BoolData(sched.CatchUp),
+		"startedAt":             llx.TimeDataPtr(timestampAsTimePtr(sched.StartTime)),
+		"endedAt":               llx.TimeDataPtr(timestampAsTimePtr(sched.EndTime)),
+		"createdAt":             llx.TimeDataPtr(timestampAsTimePtr(sched.CreateTime)),
+		"updatedAt":             llx.TimeDataPtr(timestampAsTimePtr(sched.UpdateTime)),
+		"nextRunTime":           llx.TimeDataPtr(timestampAsTimePtr(sched.NextRunTime)),
+	})
+}
+
+// initGcpProjectVertexaiServiceSchedule resolves a single Vertex AI schedule by
+// its full resource name.
+//
+// Without an init, NewResource falls straight through to Create, so a typed
+// scheduleRef() reference produced a resource carrying only `name` -- every
+// other field unset, surfacing client-side as "primitive with no type
+// information" with no attribution. Whether that was visible depended on
+// whether schedules() had already run in the same session, so the same query
+// passed or returned nulls depending on evaluation order.
+func initGcpProjectVertexaiServiceSchedule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
+
+	region := vertexaiRegionFromName(name)
+	if region == "" {
+		return nil, nil, errors.New("vertexai schedule init: could not determine region from name " + name)
+	}
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx := context.Background()
+	client, err := aiplatform.NewScheduleClient(ctx,
+		option.WithCredentials(creds), connection.GRPCClientTraceOption(),
+		option.WithEndpoint(vertexaiEndpoint(region)),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	sched, err := client.GetSchedule(ctx, &aiplatformpb.GetScheduleRequest{Name: name})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := newMqlVertexaiSchedule(runtime, sched)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
 }
 
 func (g *mqlGcpProjectVertexaiService) deploymentResourcePools() ([]any, error) {


### PR DESCRIPTION
Six defects that hand users an authoritative **"there is nothing here"** for resources that do exist. An empty list is the most dangerous wrong answer in a security-inventory tool: a policy over it passes vacuously instead of failing or erroring.

Found by a static review pass over all 101 hand-written GCP resource files. Every finding was verified against the SDK source and the generated resource code before being fixed.

## 1. 40 compute accessors discarded the service-enabled *error*

```go
if !g.GetEnabled().Data {   // .Error is never read
    return nil, nil
}
```

`enabled()` resolves `gcp.project` and calls `isServiceEnabled`. On any failure of that chain — a missing `serviceusage.services.list` permission, the Service Usage API itself disabled, a transient error — `plugin.GetOrCompute` returns `Data=false` **alongside a non-nil `Error`**.

A service account without `serviceusage.services.list` therefore saw `instances`, `firewalls`, `disks`, `networks`, `subnetworks`, `routes`, `securityPolicies` and 33 more collections return `[]` with **no error**. All 40 sites (across `compute.go`, `compute_networking.go`, `compute_enrichments.go`, `compute_instance_groups_firewall_policies.go`, `compute_instance_templates.go`) now go through a `serviceEnabled()` helper that propagates it. `dataproc.go`, `dataplex.go`, `cloud_domains.go` and `workflows.go` already used the correct shape.

## 2. `initGcpProject` ignored `args["id"]`

It always fetched `projects/<conn.ResourceID()>`, then overwrote `args["id"]` with the result. `NewResource` runs `Init` **before** the resource-cache lookup (`gcp.lr.go:2437`), so every typed project reference — `projectRefById`, `sharedVpcHost`, folder `managementProjectRef` — resolved to the *connection's* project. On an organization- or folder-scoped connection `ResourceID()` is not a project id at all. The sibling `initGcpFolder` already read the arg correctly; this matches it.

## 3. Four service inits clobbered a caller-supplied `projectId`

`computeService`, `bigqueryService`, `dnsService` and `storageService` assigned `args["projectId"] = conn.ResourceID()` unconditionally behind a `len(args) > 2` guard that a single-arg call never trips. Both `mqlGcpProject.compute()` and `instance.exposure` pass exactly one arg via `NewResource`. They now default only when the caller supplied nothing, matching the existing guard in `initGcpProjectComputeServiceRegion`.

## 4. Regional persistent disks were never listed

`disks()` skipped every `regions/` scope of the `Disks.AggregatedList` response, so regional (synchronously replicated) PDs — the HA disk type — were invisible to encryption and source-image audits. Two "regional disk (no zone)" fallback branches in `common.go` and `attachedDisk.source()` were consequently unreachable; they now work.

A regional disk's `zone` resolves to `llx.NilData` rather than a typed-nil resource pointer: a typed nil is a non-nil interface, which `RawToTValue` records as **set and not null**, and the runtime then dereferences it.

## 5. Bigtable `sourceBackup()` could never resolve

`backups()` stores `ClusterInfo.Name`, which the SDK sets to the **short** cluster id (`admin.go:1977`), but the lookup compared it against a full `projects/…/clusters/…` path. The equality was never true, so backup lineage was always null.

## 6. vertexai `scheduleRef()` returned a field-less husk

`gcp.project.vertexaiService.schedule` was registered `Create`-only, so `NewResource` fell straight through to `Create` with only `name` set and all 13 other fields unset — surfacing as `llx: encountered a primitive with no type information`. Whether it was visible depended on whether `schedules()` had already run in the same session, making the same query order-dependent. Adds `initGcpProjectVertexaiServiceSchedule` and shares the mapping with `schedules()` via `newMqlVertexaiSchedule`.

## 7. `apiKey.restrictions` was null for exactly the unrestricted keys

The API omits the whole `restrictions` block for a key with no restrictions, and `apiKeys()` built the resource only when it was present. That absence **is** the fully-unrestricted case, so `unrestricted` could never report `true` for the keys a posture check is looking for.

## Permissions

The new `aiplatform.schedules.get` needed a `gcpPermissionOverrides` entry — the extractor derives a singular `aiplatform.schedule.get`, the same trap already handled for five sibling `Get*` calls.

## Tests

- **`enabled_gate_test.go`** — an AST guard that fails the build on any bare `GetEnabled().Data` gate, plus one that pins `serviceEnabled()` to keep reading `.Error`. Companion to the existing `service_gate_test.go`.
- **`compute_scope_test.go`** — table tests for the new `computeAggregatedScope` classifier (including the regional case that regressed) and for `vertexaiRegionFromName`, which the new schedule init depends on.
- **`apikeys_test.go`** — covers `unrestricted` / `appliedRestrictionTypes` including the all-empty case that could not previously occur.

The scope test caught a contract flaw in its own fix during development (the helper returned a `kind` alongside `ok=false`).

## Verification

`go build ./...`, `go test ./...` in `providers/gcp` (all 4 packages pass), `gofmt` clean, `gcp.lr.versions` unchanged (no new schema fields). Not yet verified against live GCP infrastructure.
