### PR TITLE
🐛 azure: stop reporting fabricated and aliased data

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -596,8 +596,8 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   bootDiagnosticsStorageUri string
   // Base64-encoded user data passed to the VM at provisioning time (cloud-init equivalent)
   //
-  // Empty when user data is not set. Treat as sensitive: secrets and bootstrap credentials are sometimes embedded here.
-  userData string
+  // Empty when no user data is set. Treat as sensitive: secrets and bootstrap credentials are sometimes embedded here.
+  userData() string
   // VM extension
   extensions() []dict
   // Whether the Microsoft Defender for Endpoint (MDE) extension is installed on the VM

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -1515,7 +1515,7 @@ func init() {
 			Create: createAzureSubscriptionKeyVaultServiceKeyAutorotation,
 		},
 		"azure.subscription.keyVaultService.key": {
-			// to override args, implement: initAzureSubscriptionKeyVaultServiceKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionKeyVaultServiceKey,
 			Create: createAzureSubscriptionKeyVaultServiceKey,
 		},
 		"azure.subscription.keyVaultService.key.rotationPolicyObject": {
@@ -1543,7 +1543,7 @@ func init() {
 			Create: createAzureSubscriptionKeyVaultServiceCertificatePolicyX509CertificateProperties,
 		},
 		"azure.subscription.keyVaultService.secret": {
-			// to override args, implement: initAzureSubscriptionKeyVaultServiceSecret(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionKeyVaultServiceSecret,
 			Create: createAzureSubscriptionKeyVaultServiceSecret,
 		},
 		"azure.subscription.monitorService": {
@@ -48319,7 +48319,9 @@ func (c *mqlAzureSubscriptionComputeServiceVm) GetBootDiagnosticsStorageUri() *p
 }
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetUserData() *plugin.TValue[string] {
-	return &c.UserData
+	return plugin.GetOrCompute[string](&c.UserData, func() (string, error) {
+		return c.userData()
+	})
 }
 
 func (c *mqlAzureSubscriptionComputeServiceVm) GetExtensions() *plugin.TValue[[]any] {

--- a/providers/azure/resources/cache_id_test.go
+++ b/providers/azure/resources/cache_id_test.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/types"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func TestSubResourceCacheID(t *testing.T) {
+	armID := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb/outboundRules/r1"
+	empty := ""
+
+	for _, tc := range []struct {
+		name       string
+		armID      *string
+		parentID   string
+		collection string
+		element    string
+		want       string
+	}{
+		{
+			name:  "prefers the ARM id, which is already parent-qualified",
+			armID: &armID, parentID: "/lb", collection: "outboundRules", element: "r1",
+			want: armID,
+		},
+		{
+			name:  "falls back to a parent-qualified key when the id is nil",
+			armID: nil, parentID: "/subscriptions/s/.../loadBalancers/lb", collection: "outboundRules", element: "r1",
+			want: "/subscriptions/s/.../loadBalancers/lb/outboundRules/r1",
+		},
+		{
+			name:  "an empty id string is treated as absent, not as a key",
+			armID: &empty, parentID: "/lb", collection: "outboundRules", element: "r1",
+			want: "/lb/outboundRules/r1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, subResourceCacheID(tc.armID, tc.parentID, tc.collection, tc.element))
+		})
+	}
+}
+
+// TestSubResourceCacheIDSeparatesParents is the property that matters: two
+// same-named elements under different parents must never share a key. That is
+// the whole failure this helper exists to prevent -- CreateResource returns the
+// cached occupant of a key it has already seen, so a shared key makes the second
+// element silently render as the first.
+func TestSubResourceCacheIDSeparatesParents(t *testing.T) {
+	a := subResourceCacheID(nil, "/subscriptions/s/.../loadBalancers/lb-a", "outboundRules", "default")
+	b := subResourceCacheID(nil, "/subscriptions/s/.../loadBalancers/lb-b", "outboundRules", "default")
+	assert.NotEqual(t, a, b)
+
+	// ...and so must two different collections under one parent, which is the
+	// private-endpoint case: privateLinkServiceConnections and
+	// manualPrivateLinkServiceConnections can hold the same connection name.
+	auto := subResourceCacheID(nil, "/pe", "privateLinkServiceConnections", "conn")
+	manual := subResourceCacheID(nil, "/pe", "manualPrivateLinkServiceConnections", "conn")
+	assert.NotEqual(t, auto, manual)
+}
+
+func cacheIDTestRuntime() *plugin.Runtime {
+	return &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+// TestKeyVaultSubResourcesDoNotAlias pins the two Key Vault resources that had
+// no cache key at all. Both used to pass only an `id` field, which is an
+// ordinary declared field and does not feed __id, and neither has an id()
+// method -- so every access policy and every network ACL in a scan resolved to
+// the first one created. A vault with no firewall inherited the answer of a
+// vault that had one.
+func TestKeyVaultSubResourcesDoNotAlias(t *testing.T) {
+	t.Run("access policies", func(t *testing.T) {
+		runtime := cacheIDTestRuntime()
+		mk := func(vaultID, tenantID, objectID string) *mqlAzureSubscriptionKeyVaultServiceVaultAccessPolicy {
+			r, err := CreateResource(runtime, "azure.subscription.keyVaultService.vault.accessPolicy",
+				map[string]*llx.RawData{
+					"__id":                   llx.StringData(vaultID + "/accessPolicies/" + tenantID + "/" + objectID + "/"),
+					"id":                     llx.StringData(vaultID + "/accessPolicies/" + objectID),
+					"objectId":               llx.StringData(objectID),
+					"tenantId":               llx.StringData(tenantID),
+					"applicationId":          llx.StringData(""),
+					"keyPermissions":         llx.ArrayData([]any{}, types.String),
+					"secretPermissions":      llx.ArrayData([]any{}, types.String),
+					"certificatePermissions": llx.ArrayData([]any{}, types.String),
+					"storagePermissions":     llx.ArrayData([]any{}, types.String),
+				})
+			require.NoError(t, err)
+			return r.(*mqlAzureSubscriptionKeyVaultServiceVaultAccessPolicy)
+		}
+
+		// two policies on the same vault
+		p1 := mk("/vaults/kv", "tenant", "principal-a")
+		p2 := mk("/vaults/kv", "tenant", "principal-b")
+		assert.NotEqual(t, p1.MqlID(), p2.MqlID())
+		assert.Equal(t, "principal-a", p1.ObjectId.Data)
+		assert.Equal(t, "principal-b", p2.ObjectId.Data)
+
+		// the same principal on two different vaults
+		p3 := mk("/vaults/kv-other", "tenant", "principal-a")
+		assert.NotEqual(t, p1.MqlID(), p3.MqlID())
+	})
+
+	t.Run("network acls", func(t *testing.T) {
+		runtime := cacheIDTestRuntime()
+		mk := func(vaultID, defaultAction string) *mqlAzureSubscriptionKeyVaultServiceVaultNetworkAcls {
+			r, err := CreateResource(runtime, "azure.subscription.keyVaultService.vault.networkAcls",
+				map[string]*llx.RawData{
+					"__id":                    llx.StringData(vaultID + "/networkAcls"),
+					"id":                      llx.StringData(vaultID + "/networkAcls"),
+					"bypass":                  llx.StringData("AzureServices"),
+					"defaultAction":           llx.StringData(defaultAction),
+					"ipRules":                 llx.ArrayData([]any{}, types.String),
+					"virtualNetworkSubnetIds": llx.ArrayData([]any{}, types.String),
+				})
+			require.NoError(t, err)
+			return r.(*mqlAzureSubscriptionKeyVaultServiceVaultNetworkAcls)
+		}
+
+		locked := mk("/vaults/kv-locked", "Deny")
+		open := mk("/vaults/kv-open", "Allow")
+		assert.NotEqual(t, locked.MqlID(), open.MqlID())
+		// the failure this guards: the unfirewalled vault reporting Deny
+		assert.Equal(t, "Allow", open.DefaultAction.Data)
+	})
+}
+
+// TestRouteTablesDoNotAlias covers the network side of the same defect.
+func TestRouteTablesDoNotAlias(t *testing.T) {
+	runtime := cacheIDTestRuntime()
+	mk := func(name string) *mqlAzureSubscriptionNetworkServiceRouteTable {
+		id := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/routeTables/" + name
+		r, err := CreateResource(runtime, "azure.subscription.networkService.routeTable",
+			map[string]*llx.RawData{
+				"__id":                       llx.StringData(subResourceCacheID(&id, "/subscriptions/s", "routeTables", name)),
+				"id":                         llx.StringData(id),
+				"name":                       llx.StringData(name),
+				"location":                   llx.StringData("eastus"),
+				"tags":                       llx.MapData(map[string]any{}, types.String),
+				"type":                       llx.StringData("Microsoft.Network/routeTables"),
+				"etag":                       llx.StringData("etag"),
+				"disableBgpRoutePropagation": llx.BoolData(false),
+				"provisioningState":          llx.StringData("Succeeded"),
+				"routes":                     llx.ArrayData([]any{}, types.ResourceLike),
+			})
+		require.NoError(t, err)
+		return r.(*mqlAzureSubscriptionNetworkServiceRouteTable)
+	}
+
+	a := mk("rt-a")
+	b := mk("rt-b")
+	assert.NotEqual(t, a.MqlID(), b.MqlID())
+	assert.Equal(t, "rt-a", a.Name.Data)
+	assert.Equal(t, "rt-b", b.Name.Data)
+}
+
+// TestSubscriptionReferencesDoNotAlias pins the Lighthouse case. A reference
+// built from a subscription id alone carried no cache key, because
+// azure.subscription.id() reads the `id` field that those args never set -- so
+// a delegated role in a managed customer subscription resolved against whatever
+// subscription reached the shared empty key first.
+func TestSubscriptionReferencesDoNotAlias(t *testing.T) {
+	runtime := cacheIDTestRuntime()
+	mk := func(subID string) *mqlAzureSubscription {
+		r, err := CreateResource(runtime, "azure.subscription", map[string]*llx.RawData{
+			"__id":           llx.StringData("/subscriptions/" + subID),
+			"subscriptionId": llx.StringData(subID),
+		})
+		require.NoError(t, err)
+		return r.(*mqlAzureSubscription)
+	}
+
+	a := mk("11111111-1111-1111-1111-111111111111")
+	b := mk("22222222-2222-2222-2222-222222222222")
+	assert.NotEqual(t, a.MqlID(), b.MqlID())
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", a.SubscriptionId.Data)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", b.SubscriptionId.Data)
+}

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -816,18 +816,34 @@ func argsFromContactProperties(props *armsecurity.ContactProperties) map[string]
 	}
 	args["notificationsByRole"] = llx.DictData(notificationsByRole)
 
-	// emails
-	mails := ""
-	if props.Emails != nil {
-		mails = *props.Emails
-	}
-	mailsArr := strings.Split(mails, ";")
-	args["emails"] = llx.ArrayData(convert.SliceAnyToInterface(mailsArr), types.String)
+	args["emails"] = llx.ArrayData(splitSecurityContactEmails(props.Emails), types.String)
 
 	args["isEnabled"] = llx.BoolDataPtr(props.IsEnabled)
 	args["phone"] = llx.StringDataPtr(props.Phone)
 
 	return args
+}
+
+// splitSecurityContactEmails turns Defender's semicolon-separated contact list
+// into the addresses it actually holds.
+//
+// strings.Split("", ";") returns []string{""}, so a contact configured with a
+// phone number and no email used to report emails: [""] -- one element, not
+// zero. A check phrased `securityContacts.any(emails.length > 0)` passed on a
+// subscription with no email contact at all, which is the opposite of the
+// finding it was written to raise. Empty entries are dropped and each address
+// is trimmed, since the portal permits spaces around the separator.
+func splitSecurityContactEmails(emails *string) []any {
+	out := []any{}
+	if emails == nil {
+		return out
+	}
+	for _, e := range strings.Split(*emails, ";") {
+		if e = strings.TrimSpace(e); e != "" {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // buildExtensionResources creates typed extension sub-resources from a list of Azure SDK extensions.

--- a/providers/azure/resources/cloud_defender_test.go
+++ b/providers/azure/resources/cloud_defender_test.go
@@ -174,6 +174,33 @@ func TestArgsFromContactProperties(t *testing.T) {
 	})
 }
 
+// TestSplitSecurityContactEmails pins the empty case.
+//
+// strings.Split("", ";") returns []string{""}, so a contact with a phone number
+// and no email used to report emails: [""] -- one element, not zero. A check
+// phrased `securityContacts.any(emails.length > 0)` passed on a subscription
+// with no email contact configured at all, which is the inverse of the finding
+// it exists to raise.
+func TestSplitSecurityContactEmails(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input *string
+		want  []any
+	}{
+		{"nil is no addresses", nil, []any{}},
+		{"empty string is no addresses, not one empty address", ptr(""), []any{}},
+		{"a separator with nothing around it yields nothing", ptr(";"), []any{}},
+		{"single address", ptr("soc@example.com"), []any{"soc@example.com"}},
+		{"multiple addresses", ptr("a@example.com;b@example.com"), []any{"a@example.com", "b@example.com"}},
+		{"surrounding spaces are trimmed", ptr(" a@example.com ; b@example.com "), []any{"a@example.com", "b@example.com"}},
+		{"empty entries are dropped", ptr("a@example.com;;b@example.com"), []any{"a@example.com", "b@example.com"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitSecurityContactEmails(tc.input))
+		})
+	}
+}
+
 func TestSimpleDefenderDict(t *testing.T) {
 	t.Run("Enabled", func(t *testing.T) {
 		tv := &plugin.TValue[bool]{Data: true}

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -228,7 +228,7 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 	}
 
 	var bootDiagnosticsEnabled bool
-	var bootDiagnosticsStorageUri, userData string
+	var bootDiagnosticsStorageUri string
 	osType := vmOsType(vm.Properties)
 	if vm.Properties != nil {
 		if dp := vm.Properties.DiagnosticsProfile; dp != nil && dp.BootDiagnostics != nil {
@@ -238,9 +238,6 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 			if dp.BootDiagnostics.StorageURI != nil {
 				bootDiagnosticsStorageUri = *dp.BootDiagnostics.StorageURI
 			}
-		}
-		if vm.Properties.UserData != nil {
-			userData = *vm.Properties.UserData
 		}
 	}
 
@@ -303,7 +300,6 @@ func vmToMql(runtime *plugin.Runtime, vm compute.VirtualMachine) (*mqlAzureSubsc
 			"imageReference":                llx.ResourceData(mqlImageRef, mqlImageRef.MqlName()),
 			"bootDiagnosticsEnabled":        llx.BoolData(bootDiagnosticsEnabled),
 			"bootDiagnosticsStorageUri":     llx.StringData(bootDiagnosticsStorageUri),
-			"userData":                      llx.StringData(userData),
 			"identity":                      llx.DictData(identityDict),
 			"principalId":                   llx.StringDataPtr(principalId),
 		})
@@ -1056,6 +1052,50 @@ func initAzureSubscriptionComputeServiceVm(runtime *plugin.Runtime, args map[str
 		return nil, nil, err
 	}
 	return args, mqlVm, nil
+}
+
+// userData returns the VM's base64-encoded user data.
+//
+// ARM only returns userData when the read asks for it with $expand=userData,
+// and the list API cannot return it at all -- ExpandTypesForListVMs offers only
+// instanceView. Reading vm.Properties.UserData off a plain Get or List therefore
+// always produced "", so a hunt for credentials embedded in bootstrap data
+// (vms.where(userData != "")) came back empty on every subscription. Asking for
+// the expansion costs one read per VM, which is why this is a computed field
+// rather than part of the listing.
+func (a *mqlAzureSubscriptionComputeServiceVm) userData() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return "", err
+	}
+	vmName, err := resourceID.Component("virtualMachines")
+	if err != nil {
+		return "", err
+	}
+
+	client, err := compute.NewVirtualMachinesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	expand := compute.InstanceViewTypesUserData
+	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, vmName, &compute.VirtualMachinesClientGetOptions{
+		Expand: &expand,
+	})
+	if err != nil {
+		if isAzureNotConfigured(err) {
+			log.Warn().Err(err).Str("vm", a.Id.Data).Msg("could not read vm user data")
+			return "", nil
+		}
+		return "", err
+	}
+	if resp.Properties == nil {
+		return "", nil
+	}
+	return convert.ToValue(resp.Properties.UserData), nil
 }
 
 func (a *mqlAzureSubscriptionComputeServiceDiskEncryptionSet) id() (string, error) {

--- a/providers/azure/resources/cosmosdb.go
+++ b/providers/azure/resources/cosmosdb.go
@@ -228,9 +228,13 @@ func cosmosAccountToMql(runtime *plugin.Runtime, account *cosmosdb.DatabaseAccou
 			if rule.IgnoreMissingVNetServiceEndpoint != nil {
 				ignoreMissing = *rule.IgnoreMissingVNetServiceEndpoint
 			}
-			ruleId := *account.ID + "/virtualNetworkRules/" + subnetId
+			// convert.ToValue rather than a bare deref: the list path guards
+			// account.ID, but the init path reaches this function straight from
+			// a Get response.
+			ruleId := convert.ToValue(account.ID) + "/virtualNetworkRules/" + subnetId
 			mqlRule, err := CreateResource(runtime, "azure.subscription.cosmosDbService.account.virtualNetworkRule",
 				map[string]*llx.RawData{
+					"__id":                             llx.StringData(ruleId),
 					"id":                               llx.StringData(ruleId),
 					"subnetId":                         llx.StringData(subnetId),
 					"ignoreMissingVNetServiceEndpoint": llx.BoolData(ignoreMissing),

--- a/providers/azure/resources/dns_takeover.go
+++ b/providers/azure/resources/dns_takeover.go
@@ -122,27 +122,54 @@ func azureServiceForHostname(hostname string) string {
 
 // cnameTargetFromProperties pulls the CNAME target out of a record set's
 // properties, normalized. Returns "" for every record type other than CNAME.
+//
+// The key is matched case-insensitively because the armdns marshaller does not
+// lower-camel-case it: RecordSetProperties.MarshalJSON writes "CNAMERecord"
+// (likewise "ARecords", "MXRecords", "TXTRecords"). Reading "cnameRecord"
+// matched nothing, so cnameTarget and targetAzureService were empty on every
+// record in every subscription and a dangling-CNAME audit passed vacuously.
+// Accepting either spelling keeps this working if the SDK ever normalizes.
 func cnameTargetFromProperties(properties map[string]any) string {
-	cname, ok := properties["cnameRecord"].(map[string]any)
+	cname, ok := dictValueFold(properties, "CNAMERecord").(map[string]any)
 	if !ok {
 		return ""
 	}
-	target, ok := cname["cname"].(string)
+	target, ok := dictValueFold(cname, "cname").(string)
 	if !ok {
 		return ""
 	}
 	return normalizeDnsTarget(target)
 }
 
+// dictValueFold looks up key in m, ignoring case. Azure's generated marshallers
+// are inconsistent about the casing of JSON keys, and a lookup that assumes one
+// spelling fails silently -- it is indistinguishable from an absent value.
+//
+// An exact hit returns without scanning. Only a miss falls back to walking the
+// map, which is O(n) in its size and deliberate: these are ARM property bags
+// holding a handful of keys, so a case-folded map built per call would cost
+// more than the scan it replaced.
+func dictValueFold(m map[string]any, key string) any {
+	if v, ok := m[key]; ok {
+		return v
+	}
+	for k, v := range m {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return nil
+}
+
 // targetResourceIDFromProperties pulls the ARM ID an alias record set tracks.
 // Alias records are removed by Azure when their target resource is deleted, so a
 // non-empty value here means the record cannot be left dangling.
 func targetResourceIDFromProperties(properties map[string]any) string {
-	target, ok := properties["targetResource"].(map[string]any)
+	target, ok := dictValueFold(properties, "targetResource").(map[string]any)
 	if !ok {
 		return ""
 	}
-	id, ok := target["id"].(string)
+	id, ok := dictValueFold(target, "id").(string)
 	if !ok {
 		return ""
 	}

--- a/providers/azure/resources/dns_takeover_test.go
+++ b/providers/azure/resources/dns_takeover_test.go
@@ -6,7 +6,10 @@ package resources
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 )
 
 func TestNormalizeDnsTarget(t *testing.T) {
@@ -73,6 +76,63 @@ func TestAzureServiceForHostname(t *testing.T) {
 	t.Run("case and trailing dot are normalized", func(t *testing.T) {
 		assert.Equal(t, "App Service", azureServiceForHostname("Contoso.AzureWebsites.Net."))
 	})
+}
+
+// TestCnameTargetFromSdkRecordSet drives the parser with a real
+// armdns.RecordSetProperties put through the same convert.JsonToDict the
+// production path uses, rather than a hand-built map.
+//
+// This is the test that was missing. The parser read "cnameRecord" while the
+// SDK's marshaller emits "CNAMERecord", so cnameTarget and targetAzureService
+// were empty on every DNS record in every subscription and a dangling-CNAME
+// audit passed vacuously. A hand-built fixture agreed with the code and stayed
+// green; only a round-trip through the SDK type can catch this, and only a
+// round-trip will catch it again if Azure changes the casing.
+func TestCnameTargetFromSdkRecordSet(t *testing.T) {
+	t.Run("cname record", func(t *testing.T) {
+		cname := "Contoso.AzureWebsites.NET."
+		ttl := int64(300)
+		props, err := convert.JsonToDict(&armdns.RecordSetProperties{
+			TTL:         &ttl,
+			CnameRecord: &armdns.CnameRecord{Cname: &cname},
+		})
+		require.NoError(t, err)
+
+		// guard the premise: if the SDK ever lower-camel-cases this key, the
+		// assertion below would pass for the wrong reason
+		_, upper := props["CNAMERecord"]
+		require.True(t, upper, "expected the SDK to marshal the key as CNAMERecord, got %v", props)
+
+		assert.Equal(t, "contoso.azurewebsites.net", cnameTargetFromProperties(props))
+		assert.Equal(t, "App Service", azureServiceForHostname(cnameTargetFromProperties(props)))
+	})
+
+	t.Run("alias record target resource", func(t *testing.T) {
+		id := "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/trafficManagerProfiles/tm"
+		props, err := convert.JsonToDict(&armdns.RecordSetProperties{
+			TargetResource: &armdns.SubResource{ID: &id},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, id, targetResourceIDFromProperties(props))
+	})
+
+	t.Run("an A record has no cname target", func(t *testing.T) {
+		ip := "10.0.0.1"
+		props, err := convert.JsonToDict(&armdns.RecordSetProperties{
+			ARecords: []*armdns.ARecord{{IPv4Address: &ip}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", cnameTargetFromProperties(props))
+	})
+}
+
+func TestDictValueFold(t *testing.T) {
+	m := map[string]any{"CNAMERecord": "upper", "other": "lower"}
+	assert.Equal(t, "upper", dictValueFold(m, "CNAMERecord"), "exact match")
+	assert.Equal(t, "upper", dictValueFold(m, "cnameRecord"), "case-insensitive match")
+	assert.Equal(t, "lower", dictValueFold(m, "OTHER"))
+	assert.Nil(t, dictValueFold(m, "absent"))
+	assert.Nil(t, dictValueFold(nil, "anything"))
 }
 
 func TestCnameTargetFromProperties(t *testing.T) {

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -607,6 +607,77 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) certificates() ([]any, error)
 	return res, nil
 }
 
+// initAzureSubscriptionKeyVaultServiceSecret is the secret counterpart of
+// initAzureSubscriptionKeyVaultServiceKey: it resolves a secret known only by
+// its URI so contentType, managed, tags and the attributes are real values
+// rather than unset fields. See that function for the full reasoning.
+func initAzureSubscriptionKeyVaultServiceSecret(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	idRaw := args["id"]
+	if idRaw == nil {
+		return args, nil, nil
+	}
+	id, ok := idRaw.Value.(string)
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+
+	kvid, err := parseKeyVaultId(id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn := runtime.Connection.(*connection.AzureConnection)
+	client, err := azsecrets.NewClient(kvid.BaseUrl, conn.Token(), &azsecrets.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := client.GetSecret(context.Background(), kvid.Name, kvid.Version, nil)
+	if err != nil {
+		if isAzureNotConfigured(err) {
+			log.Warn().Err(err).Str("id", id).Msg("could not read key vault secret, reporting its attributes as null")
+			return keyVaultSecretArgs(id, nil), nil, nil
+		}
+		return nil, nil, err
+	}
+	return keyVaultSecretArgs(id, &resp.Secret), nil, nil
+}
+
+// keyVaultSecretArgs maps a secret onto the resource's fields. The secret's
+// Value is deliberately never read: this resource reports metadata only.
+func keyVaultSecretArgs(id string, secret *azsecrets.Secret) map[string]*llx.RawData {
+	args := map[string]*llx.RawData{
+		"id":          llx.StringData(id),
+		"tags":        llx.NilData,
+		"contentType": llx.NilData,
+		"managed":     llx.NilData,
+		"enabled":     llx.NilData,
+		"created":     llx.NilData,
+		"updated":     llx.NilData,
+		"expires":     llx.NilData,
+		"notBefore":   llx.NilData,
+	}
+	if secret == nil {
+		return args
+	}
+	args["tags"] = llx.MapData(convert.PtrMapStrToInterface(secret.Tags), types.String)
+	args["contentType"] = llx.StringDataPtr(secret.ContentType)
+	args["managed"] = llx.BoolDataPtr(secret.Managed)
+	if attrs := secret.Attributes; attrs != nil {
+		args["enabled"] = llx.BoolDataPtr(attrs.Enabled)
+		args["created"] = llx.TimeDataPtr(attrs.Created)
+		args["updated"] = llx.TimeDataPtr(attrs.Updated)
+		args["expires"] = llx.TimeDataPtr(attrs.Expires)
+		args["notBefore"] = llx.TimeDataPtr(attrs.NotBefore)
+	}
+	return args
+}
+
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) diagnosticSettings() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	return getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
@@ -750,8 +821,13 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) accessPolicies() ([]any, erro
 			}
 		}
 
+		// Azure keys an access policy on (tenantId, objectId, applicationId), so
+		// the object id alone is not unique within a vault, let alone across
+		// them. Without an explicit __id the resource has no cache key at all
+		// and every policy in the scan aliases to the first one created.
 		mqlRes, err := CreateResource(a.MqlRuntime, "azure.subscription.keyVaultService.vault.accessPolicy",
 			map[string]*llx.RawData{
+				"__id":                   llx.StringData(id + "/accessPolicies/" + tenantId + "/" + objectId + "/" + applicationId),
 				"id":                     llx.StringData(id + "/accessPolicies/" + objectId),
 				"objectId":               llx.StringData(objectId),
 				"tenantId":               llx.StringData(tenantId),
@@ -802,6 +878,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) networkAcls() (*mqlAzureSubsc
 
 	res, err := CreateResource(a.MqlRuntime, "azure.subscription.keyVaultService.vault.networkAcls",
 		map[string]*llx.RawData{
+			"__id":                    llx.StringData(id + "/networkAcls"),
 			"id":                      llx.StringData(id + "/networkAcls"),
 			"bypass":                  llx.StringData(bypass),
 			"defaultAction":           llx.StringData(defaultAction),
@@ -839,6 +916,92 @@ type mqlAzureSubscriptionKeyVaultServiceKeyInternal struct {
 	fetchOnce sync.Once
 	fetchResp *azkeys.GetKeyResponse
 	fetchErr  error
+}
+
+// initAzureSubscriptionKeyVaultServiceKey resolves a key that is known only by
+// its URI -- the shape every typed encryption-key accessor in this provider
+// hands back -- into a key with its real attributes.
+//
+// Without an init, NewResource went straight to Create with whatever the caller
+// passed, which was just the kid. enabled, expires, notBefore, created, updated
+// and recoveryLevel were therefore left *unset* rather than null on ~20
+// accessors: an unset field crosses the plugin boundary as an empty DataRes and
+// surfaces client-side as "primitive with no type information", and under MQL's
+// three-valued logic `{ enabled && expires > time.now }` then passes over a key
+// that is disabled or already expired. managed and tags were worse -- they were
+// passed as invented literals, so a certificate-backed key reported managed:
+// false as fact.
+func initAzureSubscriptionKeyVaultServiceKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// the collection path supplies every field already
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	kidRaw := args["kid"]
+	if kidRaw == nil {
+		return args, nil, nil
+	}
+	kid, ok := kidRaw.Value.(string)
+	if !ok || kid == "" {
+		return args, nil, nil
+	}
+
+	kvid, err := parseKeyVaultId(kid)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn := runtime.Connection.(*connection.AzureConnection)
+	client, err := azkeys.NewClient(kvid.BaseUrl, conn.Token(), &azkeys.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := client.GetKey(context.Background(), kvid.Name, kvid.Version, nil)
+	if err != nil {
+		// Reading a vault's metadata and reading a key inside it are separate
+		// permissions, so a caller can legitimately hold a reference it cannot
+		// resolve. Report the attributes as null -- unknown -- rather than
+		// failing the surrounding query or inventing values for them.
+		if isAzureNotConfigured(err) {
+			log.Warn().Err(err).Str("kid", kid).Msg("could not read key vault key, reporting its attributes as null")
+			return keyVaultKeyArgs(kid, nil), nil, nil
+		}
+		return nil, nil, err
+	}
+	return keyVaultKeyArgs(kid, &resp.KeyBundle), nil, nil
+}
+
+// keyVaultKeyArgs maps a key bundle onto the resource's fields. A nil bundle
+// sets every attribute to null, which is what the provider knows when the key
+// could not be read -- as distinct from leaving the fields unset.
+func keyVaultKeyArgs(kid string, bundle *azkeys.KeyBundle) map[string]*llx.RawData {
+	args := map[string]*llx.RawData{
+		"kid":           llx.StringData(kid),
+		"managed":       llx.NilData,
+		"tags":          llx.NilData,
+		"enabled":       llx.NilData,
+		"created":       llx.NilData,
+		"updated":       llx.NilData,
+		"expires":       llx.NilData,
+		"notBefore":     llx.NilData,
+		"recoveryLevel": llx.NilData,
+	}
+	if bundle == nil {
+		return args
+	}
+	args["managed"] = llx.BoolDataPtr(bundle.Managed)
+	args["tags"] = llx.MapData(convert.PtrMapStrToInterface(bundle.Tags), types.String)
+	if attrs := bundle.Attributes; attrs != nil {
+		args["enabled"] = llx.BoolDataPtr(attrs.Enabled)
+		args["created"] = llx.TimeDataPtr(attrs.Created)
+		args["updated"] = llx.TimeDataPtr(attrs.Updated)
+		args["expires"] = llx.TimeDataPtr(attrs.Expires)
+		args["notBefore"] = llx.TimeDataPtr(attrs.NotBefore)
+		args["recoveryLevel"] = llx.StringDataPtr((*string)(attrs.RecoveryLevel))
+	}
+	return args
 }
 
 // fetchKeyDetails fetches the full key from Azure Key Vault. The result is

--- a/providers/azure/resources/keyvault_args_test.go
+++ b/providers/azure/resources/keyvault_args_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// The key and secret resources reached through a typed encryption-key accessor
+// used to be built from the URI alone: enabled, expires, notBefore, created,
+// updated and recoveryLevel were left unset (not null), and managed and tags
+// were passed as invented literals. An unset field surfaces client-side as
+// "primitive with no type information", and under MQL's three-valued logic
+// `{ enabled && expires > time.now }` then passes over a key that is disabled or
+// already expired. These tests pin both halves: real values when the key reads,
+// explicit nulls when it does not.
+
+func TestKeyVaultKeyArgs(t *testing.T) {
+	kid := "https://v.vault.azure.net/keys/cmk/abc123"
+
+	t.Run("unreadable key reports null attributes, never unset and never invented", func(t *testing.T) {
+		args := keyVaultKeyArgs(kid, nil)
+
+		assert.Equal(t, kid, args["kid"].Value)
+		for _, field := range []string{"managed", "tags", "enabled", "created", "updated", "expires", "notBefore", "recoveryLevel"} {
+			if assert.Contains(t, args, field, "every declared field must be present so it reads as null rather than unset") {
+				assert.Equal(t, llx.NilData, args[field], "%s must be null, not a fabricated value", field)
+			}
+		}
+	})
+
+	t.Run("a managed, expiring key reports its real attributes", func(t *testing.T) {
+		expires := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+		enabled := true
+		managed := true
+		recovery := "Recoverable+Purgeable"
+		tagValue := "prod"
+
+		args := keyVaultKeyArgs(kid, &azkeys.KeyBundle{
+			Managed: &managed,
+			Tags:    map[string]*string{"env": &tagValue},
+			Attributes: &azkeys.KeyAttributes{
+				Enabled:       &enabled,
+				Expires:       &expires,
+				RecoveryLevel: &recovery,
+			},
+		})
+
+		assert.Equal(t, true, args["managed"].Value, "a certificate-backed key used to report managed: false as fact")
+		assert.Equal(t, true, args["enabled"].Value)
+		assert.Equal(t, "Recoverable+Purgeable", args["recoveryLevel"].Value)
+		assert.Equal(t, map[string]any{"env": "prod"}, args["tags"].Value)
+		assert.NotEqual(t, llx.NilData, args["expires"])
+	})
+
+	t.Run("a key with no attributes block still reports its identity", func(t *testing.T) {
+		managed := false
+		args := keyVaultKeyArgs(kid, &azkeys.KeyBundle{Managed: &managed})
+		assert.Equal(t, false, args["managed"].Value)
+		assert.Equal(t, llx.NilData, args["enabled"], "absent attributes are unknown, not false")
+	})
+}
+
+func TestKeyVaultSecretArgs(t *testing.T) {
+	id := "https://v.vault.azure.net/secrets/conn/abc123"
+
+	t.Run("unreadable secret reports null attributes", func(t *testing.T) {
+		args := keyVaultSecretArgs(id, nil)
+
+		assert.Equal(t, id, args["id"].Value)
+		for _, field := range []string{"tags", "contentType", "managed", "enabled", "created", "updated", "expires", "notBefore"} {
+			if assert.Contains(t, args, field) {
+				assert.Equal(t, llx.NilData, args[field], "%s must be null, not a fabricated value", field)
+			}
+		}
+	})
+
+	t.Run("a readable secret reports its metadata and never its value", func(t *testing.T) {
+		enabled := false
+		contentType := "text/plain"
+		args := keyVaultSecretArgs(id, &azsecrets.Secret{
+			ContentType: &contentType,
+			Attributes:  &azsecrets.SecretAttributes{Enabled: &enabled},
+		})
+
+		assert.Equal(t, "text/plain", args["contentType"].Value)
+		assert.Equal(t, false, args["enabled"].Value)
+		assert.NotContains(t, args, "value", "the secret's value must never reach a field")
+	})
+}

--- a/providers/azure/resources/lighthouse.go
+++ b/providers/azure/resources/lighthouse.go
@@ -221,7 +221,13 @@ func (a *mqlAzureSubscriptionLighthouseServiceRegistrationDefinitionAuthorizatio
 	}
 	wantGuid := lastPathSegment(a.RoleDefinitionId.Data)
 
+	// __id has to be explicit here. A Lighthouse assignment can name a managed
+	// customer subscription other than the connected one, and azure.subscription
+	// derives its cache key from the `id` field these args do not carry -- so
+	// without it the delegated role resolves against whichever subscription
+	// happened to populate the shared empty key first.
 	r, err := CreateResource(a.MqlRuntime, "azure.subscription", map[string]*llx.RawData{
+		"__id":           llx.StringData("/subscriptions/" + a.cacheSubId),
 		"subscriptionId": llx.StringData(a.cacheSubId),
 	})
 	if err != nil {
@@ -337,6 +343,7 @@ func (a *mqlAzureSubscriptionLighthouseServiceRegistrationAssignment) registrati
 	}
 
 	r, err := CreateResource(a.MqlRuntime, "azure.subscription", map[string]*llx.RawData{
+		"__id":           llx.StringData("/subscriptions/" + subId),
 		"subscriptionId": llx.StringData(subId),
 	})
 	if err != nil {

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -790,45 +790,15 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) privateEndpointConnecti
 			return nil, err
 		}
 	}
-	for _, pec := range connections {
-		if pec == nil {
-			continue
-		}
-		args := map[string]*llx.RawData{
-			"__id": llx.StringDataPtr(pec.ID),
-			"id":   llx.StringDataPtr(pec.ID),
-			"name": llx.StringDataPtr(pec.Name),
-			"type": llx.StringDataPtr(pec.Type),
-		}
-		if pec.Properties != nil {
-			propsMap, err := convert.JsonToDict(pec.Properties)
-			if err != nil {
-				return nil, err
-			}
-			args["properties"] = llx.DictData(propsMap)
-			if pec.Properties.PrivateEndpoint != nil {
-				args["privateEndpointId"] = llx.StringDataPtr(pec.Properties.PrivateEndpoint.ID)
-			}
-			if pec.Properties.ProvisioningState != nil {
-				args["provisioningState"] = llx.StringData(string(*pec.Properties.ProvisioningState))
-			}
-			if pec.Properties.PrivateLinkServiceConnectionState != nil {
-				stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(pec.ID),
-					stringEnumPtr(pec.Properties.PrivateLinkServiceConnectionState.ActionsRequired),
-					pec.Properties.PrivateLinkServiceConnectionState.Description,
-					stringEnumPtr(pec.Properties.PrivateLinkServiceConnectionState.Status))
-				if err != nil {
-					return nil, err
-				}
-				args["privateLinkServiceConnectionState"] = llx.ResourceData(stateRes, ResourceAzureSubscriptionPrivateEndpointConnectionConnectionState)
-			}
-		}
-		mqlConn, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, args)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, mqlConn)
+	// The shared helper seeds every declared field, including ipAddresses.
+	// Hand-rolling the args map here left ipAddresses out entirely, so it was
+	// unset rather than empty on every connection. It is handed the accumulated
+	// slice rather than resp.Value, so it sees every page and not just the first.
+	conns, err := azurePrivateEndpointConnectionsToMql(a.MqlRuntime, connections)
+	if err != nil {
+		return nil, err
 	}
+	res = append(res, conns...)
 	return res, nil
 }
 

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -876,6 +876,7 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) outboundRules() ([]any,
 		}
 		mqlOutbound, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.outboundRule",
 			map[string]*llx.RawData{
+				"__id":       llx.StringData(subResourceCacheID(outboundRule.ID, a.Id.Data, "outboundRules", convert.ToValue(outboundRule.Name))),
 				"id":         llx.StringDataPtr(outboundRule.ID),
 				"type":       llx.StringDataPtr(outboundRule.Type),
 				"name":       llx.StringDataPtr(outboundRule.Name),
@@ -905,6 +906,7 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) loadBalancerRules() ([]
 		}
 		mqlLbRule, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.loadBalancerRule",
 			map[string]*llx.RawData{
+				"__id":       llx.StringData(subResourceCacheID(lbRule.ID, a.Id.Data, "loadBalancingRules", convert.ToValue(lbRule.Name))),
 				"id":         llx.StringDataPtr(lbRule.ID),
 				"type":       llx.StringDataPtr(lbRule.Type),
 				"name":       llx.StringDataPtr(lbRule.Name),
@@ -1631,7 +1633,11 @@ func (a *mqlAzureSubscriptionNetworkService) virtualNetworkGateways() ([]any, er
 	}
 
 	// the virtual network gateways API works on resource-group level. therefore, we need to fetch all RGs first
+	// __id has to be explicit: azure.subscription.id() reads the `id` field,
+	// which these args do not carry, so without it every such reference shares
+	// the empty cache key and resolves to whichever subscription got there first.
 	sub, err := CreateResource(a.MqlRuntime, "azure.subscription", map[string]*llx.RawData{
+		"__id":           llx.StringData("/subscriptions/" + subId),
 		"subscriptionId": llx.StringData(subId),
 	})
 	if err != nil {
@@ -2058,15 +2064,18 @@ func privateEndpointToMql(runtime *plugin.Runtime, pe *network.PrivateEndpoint) 
 			}
 		}
 
+		peID := convert.ToValue(pe.ID)
+		// the two collections can hold connections of the same name, so the
+		// collection segment has to be part of the fallback cache key
 		for _, c := range pe.Properties.PrivateLinkServiceConnections {
-			mqlConn, err := privateLinkServiceConnectionToMql(runtime, c)
+			mqlConn, err := privateLinkServiceConnectionToMql(runtime, c, peID, "privateLinkServiceConnections")
 			if err != nil {
 				return nil, err
 			}
 			plsConns = append(plsConns, mqlConn)
 		}
 		for _, c := range pe.Properties.ManualPrivateLinkServiceConnections {
-			mqlConn, err := privateLinkServiceConnectionToMql(runtime, c)
+			mqlConn, err := privateLinkServiceConnectionToMql(runtime, c, peID, "manualPrivateLinkServiceConnections")
 			if err != nil {
 				return nil, err
 			}
@@ -2287,7 +2296,7 @@ func (a *mqlAzureSubscriptionNetworkServicePrivateEndpoint) privateDnsZoneGroups
 	return res, nil
 }
 
-func privateLinkServiceConnectionToMql(runtime *plugin.Runtime, c *network.PrivateLinkServiceConnection) (*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection, error) {
+func privateLinkServiceConnectionToMql(runtime *plugin.Runtime, c *network.PrivateLinkServiceConnection, parentID, collection string) (*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection, error) {
 	if c == nil {
 		return nil, errors.New("private link service connection is nil")
 	}
@@ -2310,6 +2319,7 @@ func privateLinkServiceConnectionToMql(runtime *plugin.Runtime, c *network.Priva
 
 	res, err := CreateResource(runtime, "azure.subscription.networkService.privateEndpoint.serviceconnection",
 		map[string]*llx.RawData{
+			"__id":                 llx.StringData(subResourceCacheID(c.ID, parentID, collection, convert.ToValue(c.Name))),
 			"id":                   llx.StringDataPtr(c.ID),
 			"name":                 llx.StringDataPtr(c.Name),
 			"privateLinkServiceId": llx.StringData(plsId),
@@ -2691,7 +2701,7 @@ func (a *mqlAzureSubscriptionNetworkService) routeTables() ([]any, error) {
 					if route == nil {
 						continue
 					}
-					mqlRoute, err := azureRouteToMql(a.MqlRuntime, route)
+					mqlRoute, err := azureRouteToMql(a.MqlRuntime, route, convert.ToValue(rt.ID))
 					if err != nil {
 						return nil, err
 					}
@@ -2701,6 +2711,7 @@ func (a *mqlAzureSubscriptionNetworkService) routeTables() ([]any, error) {
 
 			mqlRt, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.routeTable",
 				map[string]*llx.RawData{
+					"__id":                       llx.StringData(subResourceCacheID(rt.ID, "/subscriptions/"+subId, "routeTables", convert.ToValue(rt.Name))),
 					"id":                         llx.StringDataPtr(rt.ID),
 					"name":                       llx.StringDataPtr(rt.Name),
 					"location":                   llx.StringDataPtr(rt.Location),
@@ -2720,7 +2731,7 @@ func (a *mqlAzureSubscriptionNetworkService) routeTables() ([]any, error) {
 	return res, nil
 }
 
-func azureRouteToMql(runtime *plugin.Runtime, route *network.Route) (*mqlAzureSubscriptionNetworkServiceRoute, error) {
+func azureRouteToMql(runtime *plugin.Runtime, route *network.Route, routeTableID string) (*mqlAzureSubscriptionNetworkServiceRoute, error) {
 	var addressPrefix, nextHopType, nextHopIpAddress, provisioningState string
 	var hasBgpOverride bool
 	ecmpNextHopIpAddresses := []any{}
@@ -2742,6 +2753,7 @@ func azureRouteToMql(runtime *plugin.Runtime, route *network.Route) (*mqlAzureSu
 
 	res, err := CreateResource(runtime, "azure.subscription.networkService.route",
 		map[string]*llx.RawData{
+			"__id":                   llx.StringData(subResourceCacheID(route.ID, routeTableID, "routes", convert.ToValue(route.Name))),
 			"id":                     llx.StringDataPtr(route.ID),
 			"name":                   llx.StringDataPtr(route.Name),
 			"addressPrefix":          llx.StringData(addressPrefix),
@@ -6261,7 +6273,11 @@ func (a *mqlAzureSubscriptionNetworkService) localNetworkGateways() ([]any, erro
 	}
 
 	// the local network gateways API works on resource-group level, so we fetch all RGs first
+	// __id has to be explicit: azure.subscription.id() reads the `id` field,
+	// which these args do not carry, so without it every such reference shares
+	// the empty cache key and resolves to whichever subscription got there first.
 	sub, err := CreateResource(a.MqlRuntime, "azure.subscription", map[string]*llx.RawData{
+		"__id":           llx.StringData("/subscriptions/" + subId),
 		"subscriptionId": llx.StringData(subId),
 	})
 	if err != nil {

--- a/providers/azure/resources/postgresql.go
+++ b/providers/azure/resources/postgresql.go
@@ -716,45 +716,14 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) privateEndpointCon
 		if err != nil {
 			return nil, err
 		}
-		for _, pec := range page.Value {
-			if pec == nil {
-				continue
-			}
-			args := map[string]*llx.RawData{
-				"__id": llx.StringDataPtr(pec.ID),
-				"id":   llx.StringDataPtr(pec.ID),
-				"name": llx.StringDataPtr(pec.Name),
-				"type": llx.StringDataPtr(pec.Type),
-			}
-			if pec.Properties != nil {
-				propsMap, err := convert.JsonToDict(pec.Properties)
-				if err != nil {
-					return nil, err
-				}
-				args["properties"] = llx.DictData(propsMap)
-				if pec.Properties.PrivateEndpoint != nil {
-					args["privateEndpointId"] = llx.StringDataPtr(pec.Properties.PrivateEndpoint.ID)
-				}
-				if pec.Properties.ProvisioningState != nil {
-					args["provisioningState"] = llx.StringData(string(*pec.Properties.ProvisioningState))
-				}
-				if pec.Properties.PrivateLinkServiceConnectionState != nil {
-					stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(pec.ID),
-						stringEnumPtr(pec.Properties.PrivateLinkServiceConnectionState.ActionsRequired),
-						pec.Properties.PrivateLinkServiceConnectionState.Description,
-						stringEnumPtr(pec.Properties.PrivateLinkServiceConnectionState.Status))
-					if err != nil {
-						return nil, err
-					}
-					args["privateLinkServiceConnectionState"] = llx.ResourceData(stateRes, ResourceAzureSubscriptionPrivateEndpointConnectionConnectionState)
-				}
-			}
-			mqlConn, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, args)
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlConn)
+		// The shared helper seeds every declared field, including ipAddresses.
+		// Hand-rolling the args map here left ipAddresses out entirely, so it
+		// was unset rather than empty on every connection.
+		conns, err := azurePrivateEndpointConnectionsToMql(a.MqlRuntime, page.Value)
+		if err != nil {
+			return nil, err
 		}
+		res = append(res, conns...)
 	}
 	return res, nil
 }

--- a/providers/azure/resources/security_helpers.go
+++ b/providers/azure/resources/security_helpers.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/types"
 )
 
 // newKeyVaultKeyResource creates a typed azure.subscription.keyVaultService.key
@@ -17,13 +16,16 @@ func newKeyVaultKeyResource(runtime *plugin.Runtime, keyURI string) (*mqlAzureSu
 		return nil, nil
 	}
 
-	// Use NewResource so that if the key is already cached it gets reused.
+	// Use NewResource so that if the key is already cached it gets reused, and
+	// so initAzureSubscriptionKeyVaultServiceKey resolves the rest of the key.
 	// The KID field is the canonical identifier for key vault keys.
+	//
+	// managed and tags used to be passed as literals here. Nothing had read
+	// them, so a certificate-backed key reported managed: false and every key
+	// reached this way reported no tags -- both as fact.
 	mqlKey, err := NewResource(runtime, "azure.subscription.keyVaultService.key",
 		map[string]*llx.RawData{
-			"kid":     llx.StringData(keyURI),
-			"managed": llx.BoolData(false),
-			"tags":    llx.MapData(map[string]interface{}{}, types.String),
+			"kid": llx.StringData(keyURI),
 		})
 	if err != nil {
 		return nil, err
@@ -39,13 +41,12 @@ func newKeyVaultSecretResource(runtime *plugin.Runtime, secretURI string) (*mqlA
 		return nil, nil
 	}
 
-	// Use NewResource so that if the secret is already cached it gets reused.
+	// Use NewResource so that if the secret is already cached it gets reused, and
+	// so initAzureSubscriptionKeyVaultServiceSecret resolves the rest of it.
 	// The id field (the secret URI) is the canonical identifier for key vault secrets.
 	mqlSecret, err := NewResource(runtime, "azure.subscription.keyVaultService.secret",
 		map[string]*llx.RawData{
-			"id":      llx.StringData(secretURI),
-			"managed": llx.BoolData(false),
-			"tags":    llx.MapData(map[string]interface{}{}, types.String),
+			"id": llx.StringData(secretURI),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/shared.go
+++ b/providers/azure/resources/shared.go
@@ -93,6 +93,27 @@ func orZero[T any](p *T) *T {
 	return new(T)
 }
 
+// subResourceCacheID builds the cache key for a sub-resource that ARM normally
+// identifies by its own resource id.
+//
+// A resource created with neither an explicit "__id" argument nor an id()
+// method gets the empty cache key. CreateResource returns the cached occupant
+// of a key it has already seen, so every such instance in the scan aliases to
+// the first one created and the collection reports one row's data N times. The
+// failure is silent: the list has the right length, every entry has the wrong
+// contents.
+//
+// armID is preferred because it is already parent-qualified. When the service
+// omits it, parentID+collection+name reproduces the same shape from values the
+// caller always has, so an absent id degrades to a longer key rather than to a
+// shared one.
+func subResourceCacheID(armID *string, parentID, collection, name string) string {
+	if armID != nil && *armID != "" {
+		return *armID
+	}
+	return parentID + "/" + collection + "/" + name
+}
+
 type assetIdentifier struct {
 	name string
 	id   string

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -432,6 +432,7 @@ func (a *mqlAzureSubscriptionSqlServiceServer) virtualNetworkRules() ([]any, err
 
 			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.virtualNetworkRule",
 				map[string]*llx.RawData{
+					"__id":                   llx.StringData(subResourceCacheID(entry.ID, a.Id.Data, "virtualNetworkRules", convert.ToValue(entry.Name))),
 					"id":                     llx.StringDataPtr(entry.ID),
 					"name":                   llx.StringDataPtr(entry.Name),
 					"type":                   llx.StringDataPtr(entry.Type),
@@ -970,6 +971,7 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) advancedThreatProtection() (*mq
 
 	res, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.database.advancedthreatprotection",
 		map[string]*llx.RawData{
+			"__id":         llx.StringData(subResourceCacheID(policy.ID, a.Id.Data, "advancedThreatProtectionSettings", "default")),
 			"id":           llx.StringDataPtr(policy.ID),
 			"state":        llx.StringData(state),
 			"creationTime": llx.TimeDataPtr(creationTime),
@@ -1033,6 +1035,7 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) backupShortTermRetentionPolicy(
 
 	res, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.database.backupshorttermretentionpolicy",
 		map[string]*llx.RawData{
+			"__id":                      llx.StringData(subResourceCacheID(policy.ID, a.Id.Data, "backupShortTermRetentionPolicies", "default")),
 			"id":                        llx.StringDataPtr(policy.ID),
 			"retentionDays":             llx.IntData(retentionDays),
 			"diffBackupIntervalInHours": llx.IntData(diffBackupInterval),
@@ -1092,6 +1095,7 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) longTermRetentionPolicy() (*mql
 
 	res, err := CreateResource(a.MqlRuntime, "azure.subscription.sqlService.database.longtermretentionpolicy",
 		map[string]*llx.RawData{
+			"__id":             llx.StringData(subResourceCacheID(policy.ID, a.Id.Data, "backupLongTermRetentionPolicies", "default")),
 			"id":               llx.StringDataPtr(policy.ID),
 			"weeklyRetention":  llx.StringDataPtr(weeklyRetention),
 			"monthlyRetention": llx.StringDataPtr(monthlyRetention),
@@ -1874,46 +1878,14 @@ func (a *mqlAzureSubscriptionSqlServiceServer) privateEndpointConnections() ([]a
 		if err != nil {
 			return nil, err
 		}
-		for _, pec := range page.Value {
-			if pec == nil {
-				continue
-			}
-			args := map[string]*llx.RawData{
-				"__id": llx.StringDataPtr(pec.ID),
-				"id":   llx.StringDataPtr(pec.ID),
-				"name": llx.StringDataPtr(pec.Name),
-				"type": llx.StringDataPtr(pec.Type),
-			}
-			if pec.Properties != nil {
-				propsMap, err := convert.JsonToDict(pec.Properties)
-				if err != nil {
-					return nil, err
-				}
-				args["properties"] = llx.DictData(propsMap)
-				if pec.Properties.PrivateEndpoint != nil {
-					args["privateEndpointId"] = llx.StringDataPtr(pec.Properties.PrivateEndpoint.ID)
-				}
-				if pec.Properties.ProvisioningState != nil {
-					args["provisioningState"] = llx.StringData(string(*pec.Properties.ProvisioningState))
-				}
-				if pec.Properties.PrivateLinkServiceConnectionState != nil {
-					stateRes, err := newPrivateLinkServiceConnectionState(a.MqlRuntime, convert.ToValue(pec.ID),
-						stringEnumPtr(pec.Properties.PrivateLinkServiceConnectionState.ActionsRequired),
-						pec.Properties.PrivateLinkServiceConnectionState.Description,
-						stringEnumPtr(pec.Properties.PrivateLinkServiceConnectionState.Status))
-					if err != nil {
-						return nil, err
-					}
-					args["privateLinkServiceConnectionState"] = llx.ResourceData(stateRes, ResourceAzureSubscriptionPrivateEndpointConnectionConnectionState)
-				}
-			}
-
-			mqlConn, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionPrivateEndpointConnection, args)
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlConn)
+		// The shared helper seeds every declared field, including ipAddresses.
+		// Hand-rolling the args map here left ipAddresses out entirely, so it
+		// was unset rather than empty on every connection.
+		conns, err := azurePrivateEndpointConnectionsToMql(a.MqlRuntime, page.Value)
+		if err != nil {
+			return nil, err
 		}
+		res = append(res, conns...)
 	}
 	return res, nil
 }


### PR DESCRIPTION
Found by a static bug-review pass over the provider. Sixteen resources reported data that was either invented or belonged to a different resource entirely. Every one of these fails **silently** — the query returns the right shape with the wrong contents — so an audit over them draws a confident wrong conclusion with no error to notice.

Each finding below was confirmed against the SDK models and the generated code; the `__id` and DNS ones were reproduced with a test first.

## Empty cache keys → resources alias to the first one created

The generated `createXxx` sets `__id` from an explicit `"__id"` arg, falling back to an `id()` method only if one exists. Twelve `CreateResource` sites passed neither — they passed an `id` **field**, which is an ordinary declared field and does not feed the cache key. Every instance therefore landed on the key `<resourceName>\x00`, and `CreateResource` returns the cached occupant of a key it has already seen.

| resource | what the user saw |
|---|---|
| `keyVaultService.vault.networkAcls` | every vault reported the **first** vault's firewall — a vault with no firewall inherited another's `Deny` + IP rules |
| `keyVaultService.vault.accessPolicy` | one policy's principal and permissions repeated for every policy in the scan |
| `networkService.routeTable` / `.route` | one route table's routes reported for all of them |
| `networkService.outboundRule` / `.loadBalancerRule` | one LB's rules reported for all LBs |
| `networkService.privateEndpoint.serviceconnection` | one connection's state repeated |
| `sqlService.virtualNetworkRule` | one server's VNet rules repeated |
| `sqlService.database.advancedthreatprotection` / `.backupshorttermretentionpolicy` / `.longtermretentionpolicy` | one database's policy reported for every database |
| `cosmosDbService.account.virtualNetworkRule` | one account's VNet rules repeated |

Four further sites built an `azure.subscription` reference from a subscription id alone. `azure.subscription.id()` reads the `id` field those args never set, so they shared one husk. **Lighthouse is where this bites**: `registrationAssignment.roleDefinition` resolves a delegated role in a *managed customer* subscription, and it resolved against whichever subscription reached the shared key first. A cross-tenant grant is exactly the thing that must not silently resolve to the wrong scope.

New `subResourceCacheID` helper prefers the ARM id (already parent-qualified) and falls back to `parent/collection/name`, so an absent id degrades to a longer key rather than a shared one.

## Subdomain-takeover detection never worked

`cnameTargetFromProperties` read `properties["cnameRecord"]`. `armdns`' marshaller emits **`CNAMERecord`**:

```
marshalled keys: map[string]interface{}{"CNAMERecord":map[...]{"cname":"orphaned-app.azurewebsites.net"}, "TTL":300}
cnameTargetFromProperties => ""
azureServiceForHostname   => ""
```

So `cnameTarget` and `targetAzureService` were `""` on **every DNS record in every subscription**, and a dangling-CNAME audit passed vacuously across the fleet.

The existing unit test hand-built the map with the wrong casing, so it agreed with the code and stayed green. It now round-trips a real `armdns.RecordSetProperties` through the same `convert.JsonToDict` the production path uses — the only fixture shape that could have caught this, and the one that will catch it again on the next SDK bump.

## Key Vault typed key/secret references were husks with invented values

`azure.subscription.keyVaultService.key` had no init, so a reference built from a key URI — the shape **~20 encryption-key accessors** hand back (`storage`, `sql`, `cosmosdb`, `aks`, `mysql`, `postgresql`, `network`, …) — went straight to `Create` with just the `kid`:

```
Managed        set=true  null=false data=false   ← fabricated
Enabled        set=false null=false              ← UNSET
Expires        set=false null=false              ← UNSET
RecoveryLevel  set=false null=false              ← UNSET
```

An unset field surfaces client-side as `primitive with no type information`, and under MQL's three-valued logic `{ enabled && expires > time.now }` **passes** over a key that is disabled or already expired. `managed: false` was asserted as fact for certificate-backed keys.

Both resources now resolve their real attributes via an init, and report **null** — not a guess — when the caller can see the reference but not the key itself (reading a vault and reading a key inside it are separate permissions). The secret's `Value` is still never read.

## `vm.userData` was always empty

ARM only returns `userData` for `$expand=userData`, and the list API cannot return it at all (`ExpandTypesForListVMs` offers only `instanceView`). Reading `vm.Properties.UserData` off a plain Get or List always produced `""`, so `vms.where(userData != "")` — a hunt for credentials embedded in bootstrap data, which the field's own doc warns about — returned zero rows on every subscription. Now a computed field backed by the expanded read, so only queries that select it pay the per-VM call.

## Two smaller ones

- **`securityContact.emails` returned `[""]`** for a contact with no email, because `strings.Split("", ";")` yields one empty element — so `securityContacts.any(emails.length > 0)` passed with no email contact configured.
- **SQL / MySQL / PostgreSQL private-endpoint connections** hand-rolled their args map and omitted `ipAddresses` entirely, leaving a declared field permanently unset. They now use the shared helper that seeds every declared field (which carries a comment explaining exactly why).

## Tests

New pure-logic coverage for everything touched: `subResourceCacheID` (including the property that matters — two same-named elements under different parents never share a key), non-aliasing for the Key Vault, route-table and subscription resources, the SDK-round-trip DNS tests, `dictValueFold`, `splitSecurityContactEmails`, and the Key Vault arg mappers (real values when the key reads, explicit nulls when it does not, and never the secret's value).

## Notes

- `azure.lr` change is `userData string` → `userData() string`. Field-to-computed-method is not a type change and MQL query syntax is identical, so no `.lr.versions` churn; `azure.permissions.json` is unchanged (all three new calls use clients the provider already builds).
- Verified: `go build ./...`, `go test ./...`, `go vet`, `gofmt -l` clean, `go mod tidy` no-op, `make providers/build/azure`.
- **Not** live-verified against a real subscription. The `__id`, DNS and email fixes are provable statically and are covered by tests; the Key Vault init and `vm.userData` expansion touch live API behaviour and would benefit from a `provider-verification` run.
- Sibling PRs from the same review touch `network.go`, `cloud_defender.go`, `mysql.go` and `sql.go` in different functions — expect a clean auto-merge, possibly a small rebase for whichever lands last.
