### PR TITLE
🐛 oci: list the whole compartment tree and fix wrong-scope queries

### DIFF
--- a/providers/oci/resources/audit.go
+++ b/providers/oci/resources/audit.go
@@ -76,7 +76,11 @@ func (o *mqlOciAudit) events() ([]any, error) {
 
 	// Audit events are recorded per region and per compartment, and the API
 	// offers no subtree flag, so both dimensions have to be walked.
-	endTime := time.Now().UTC()
+	// Truncated to the minute because the Audit API requires it: both bounds
+	// are documented as accepting minute granularity only, with seconds and
+	// milliseconds set to zero. The SDK serializes an SDKTime with RFC3339Nano,
+	// so an untruncated time.Now() puts seconds and nanoseconds on the wire.
+	endTime := time.Now().UTC().Truncate(time.Minute)
 	startTime := endTime.Add(-ociAuditEventWindow)
 
 	return ociRunCompartmentRegionPool(conn, regions.Data,

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -37,21 +37,15 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getCertificates(conn, list.Data))
-}
+	// Certificates are issued into the compartment of the load balancer or
+	// gateway that terminates TLS, and ListCertificates cannot look below the
+	// compartment it is given. A root-only listing reported no certificates at
+	// all, so expiry and renewal checks silently had nothing to inspect.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci certificates with region %s", region)
 
-func (o *mqlOciCertificates) getCertificates(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci certificates with region %s", regionResource.Id.Data)
-
-			svc, err := conn.CertificatesManagementClient(regionResource.Id.Data)
+			svc, err := conn.CertificatesManagementClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -60,7 +54,7 @@ func (o *mqlOciCertificates) getCertificates(conn *connection.OciConnection, reg
 			var page *string
 			for {
 				response, err := svc.ListCertificates(ctx, certificatesmanagement.ListCertificatesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -145,11 +139,8 @@ func (o *mqlOciCertificates) getCertificates(conn *connection.OciConnection, reg
 				mqlCert.cacheIssuerCaId = stringValue(c.IssuerCertificateAuthorityId)
 				res = append(res, mqlCert)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciCertificatesCertificateInternal struct {

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -34,6 +34,24 @@ type mqlOciCloudGuardInternal struct {
 	homeRegion     string
 }
 
+// ociCloudGuardProblemWindow is how far back the problem listing reaches.
+//
+// The service defaults this to 30 days when the caller leaves it unset, which
+// is short enough to hide the remediation history the resource exists to
+// expose: a finding resolved six weeks ago simply vanishes, and "was this ever
+// raised?" answers no. 90 days matches the shortest Audit retention period, so
+// the two detection-side resources cover a comparable span.
+const ociCloudGuardProblemWindow = 90 * 24 * time.Hour
+
+// ociCloudGuardProblemStates are the lifecycle states a problem listing has to
+// ask for. The filter takes one value at a time and defaults to ACTIVE, so
+// every state has to be requested explicitly or the resolved ones never
+// appear.
+var ociCloudGuardProblemStates = []cloudguard.ListProblemsLifecycleStateEnum{
+	cloudguard.ListProblemsLifecycleStateActive,
+	cloudguard.ListProblemsLifecycleStateInactive,
+}
+
 func (o *mqlOciCloudGuard) id() (string, error) {
 	return "oci.cloudGuard", nil
 }
@@ -72,6 +90,10 @@ func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 
 	// Resolve the home region before taking configLock: getHomeRegion takes its
 	// own lock, and nesting it inside this critical section would deadlock.
+	//
+	// This is the one caller that must not use getServiceRegion. The reporting
+	// region is read *from* this configuration, so asking for it here would
+	// recurse back into getConfig and never terminate.
 	homeRegion, err := o.getHomeRegion()
 	if err != nil {
 		return nil, err
@@ -102,6 +124,23 @@ func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 	return o.config, nil
 }
 
+// getServiceRegion returns the region Cloud Guard actually serves data from.
+//
+// Cloud Guard aggregates findings from every monitored region into a single
+// reporting region, chosen when the service is enabled. That is usually the
+// tenancy's home region but is not required to be, and querying the wrong one
+// returns nothing - a Cloud Guard posture check that reports no problems at
+// all while the console shows hundreds. The home region is the fallback,
+// because it is also what getConfig has to use to discover the reporting
+// region in the first place.
+func (o *mqlOciCloudGuard) getServiceRegion() (string, error) {
+	cfg, err := o.getConfig()
+	if err == nil && cfg != nil && stringValue(cfg.ReportingRegion) != "" {
+		return *cfg.ReportingRegion, nil
+	}
+	return o.getHomeRegion()
+}
+
 func (o *mqlOciCloudGuard) status() (bool, error) {
 	cfg, err := o.getConfig()
 	if err != nil {
@@ -129,12 +168,12 @@ func (o *mqlOciCloudGuard) selfManageResources() (bool, error) {
 func (o *mqlOciCloudGuard) targets() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -191,48 +230,63 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 	return res, nil
 }
 
-// problems lists every finding Cloud Guard has raised. The listing is
-// deliberately unfiltered: `lifecycleDetail` is exposed as a field so callers
-// decide whether they care about OPEN findings only or also want the
-// RESOLVED and DISMISSED history. Filtering to OPEN here would make a
-// dismissed-but-unfixed finding indistinguishable from one that never existed.
+// problems lists the findings Cloud Guard has raised.
+//
+// Leaving the request's filters unset does not mean "everything": the service
+// applies its own defaults, narrowing the result to problems whose lifecycle
+// state is ACTIVE and that were last detected within the past 30 days. Both
+// bounds are set explicitly here instead, so the scope is what this code says
+// it is rather than whatever the service currently defaults to.
+//
+// The window is deliberately wider than the default. `lifecycleDetail` is
+// exposed as a field so callers decide whether they care about OPEN findings
+// only or also want the RESOLVED and DISMISSED history, and that history is
+// the point - a dismissed-but-unfixed finding should be distinguishable from
+// one that never existed, which a 30-day cutoff quietly prevents.
 func (o *mqlOciCloudGuard) problems() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
 
 	ctx := context.Background()
+	since := common.SDKTime{Time: time.Now().UTC().Add(-ociCloudGuardProblemWindow)}
 	problems := []cloudguard.ProblemSummary{}
-	var page *string
-	for {
-		response, err := client.ListProblems(ctx, cloudguard.ListProblemsRequest{
-			CompartmentId: common.String(conn.TenantID()),
-			// Problems are raised against resources in sub-compartments, so
-			// without the subtree flag the tenancy root reports almost none.
-			CompartmentIdInSubtree: common.Bool(true),
-			// ACCESSIBLE degrades to the compartments the caller can read
-			// instead of failing the whole listing on the first one it cannot.
-			AccessLevel: cloudguard.ListProblemsAccessLevelAccessible,
-			Page:        page,
-		})
-		if err != nil {
-			return nil, err
-		}
+	// One pass per lifecycle state: the filter accepts a single value, and
+	// leaving it unset is not the union - the service falls back to ACTIVE.
+	for _, state := range ociCloudGuardProblemStates {
+		var page *string
+		for {
+			response, err := client.ListProblems(ctx, cloudguard.ListProblemsRequest{
+				CompartmentId: common.String(conn.TenantID()),
+				// Problems are raised against resources in sub-compartments, so
+				// without the subtree flag the tenancy root reports almost none.
+				CompartmentIdInSubtree: common.Bool(true),
+				// ACCESSIBLE degrades to the compartments the caller can read
+				// instead of failing the whole listing on the first one it cannot.
+				AccessLevel:                          cloudguard.ListProblemsAccessLevelAccessible,
+				LifecycleState:                       state,
+				TimeLastDetectedGreaterThanOrEqualTo: &since,
+				Page:                                 page,
+			})
+			if err != nil {
+				return nil, err
+			}
 
-		problems = append(problems, response.Items...)
+			problems = append(problems, response.Items...)
 
-		if response.OpcNextPage == nil {
-			break
+			if response.OpcNextPage == nil {
+				break
+			}
+			page = response.OpcNextPage
 		}
-		page = response.OpcNextPage
 	}
 
 	res := make([]any, 0, len(problems))
@@ -322,12 +376,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	homeRegion, err := obj.(*mqlOciCloudGuard).getHomeRegion()
+	serviceRegion, err := obj.(*mqlOciCloudGuard).getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -423,12 +477,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -486,12 +540,12 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -553,12 +607,12 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -616,12 +670,12 @@ func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	homeRegion, err := o.getHomeRegion()
+	serviceRegion, err := o.getServiceRegion()
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := conn.CloudGuardClient(homeRegion)
+	client, err := conn.CloudGuardClient(serviceRegion)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/compartments.go
+++ b/providers/oci/resources/compartments.go
@@ -20,6 +20,21 @@ import (
 // limits.
 const ociCompartmentPoolConcurrency = 10
 
+// ociRegionsByID indexes an oci.regions collection by region key so a
+// compartment lister, which only receives the region as a string, can still set
+// a typed oci.region field on the resources it builds.
+func ociRegionsByID(regions []any) (map[string]*mqlOciRegion, error) {
+	res := make(map[string]*mqlOciRegion, len(regions))
+	for _, region := range regions {
+		regionResource, ok := region.(*mqlOciRegion)
+		if !ok {
+			return nil, errors.New("invalid region type")
+		}
+		res[regionResource.Id.Data] = regionResource
+	}
+	return res, nil
+}
+
 // ociCompartmentLister lists resources of a single type inside one compartment
 // in one region. Implementations return the already-constructed MQL resources.
 type ociCompartmentLister func(ctx context.Context, region string, compartmentID string) ([]any, error)

--- a/providers/oci/resources/compartments_test.go
+++ b/providers/oci/resources/compartments_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 )
 
@@ -50,6 +51,37 @@ func TestOciCompartmentInaccessible(t *testing.T) {
 			assert.Equal(t, tt.want, ociCompartmentInaccessible(tt.err))
 		})
 	}
+}
+
+func TestOciRegionsByID(t *testing.T) {
+	iad := &mqlOciRegion{}
+	iad.Id.Data = "us-ashburn-1"
+	iad.Id.State = plugin.StateIsSet
+	phx := &mqlOciRegion{}
+	phx.Id.Data = "us-phoenix-1"
+	phx.Id.State = plugin.StateIsSet
+
+	t.Run("indexes every region by its id", func(t *testing.T) {
+		got, err := ociRegionsByID([]any{iad, phx})
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		assert.Same(t, iad, got["us-ashburn-1"])
+		assert.Same(t, phx, got["us-phoenix-1"])
+	})
+
+	t.Run("no regions", func(t *testing.T) {
+		got, err := ociRegionsByID(nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("a non-region element is an error, not a silent gap", func(t *testing.T) {
+		// A compartment lister only receives the region as a string and looks
+		// the resource up in this map, so a dropped entry would surface much
+		// later as a missing region field rather than here.
+		_, err := ociRegionsByID([]any{iad, "us-phoenix-1"})
+		require.Error(t, err)
+	})
 }
 
 func TestOciCollectCompartmentJobs(t *testing.T) {

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -37,55 +37,29 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 		return nil, list.Error
 	}
 
-	// fetch instances
-	return ociRunRegionPool(o.getComputeInstances(conn, list.Data))
-}
-
-func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Instance, error) {
-	instances := []core.Instance{}
-	var page *string
-	for {
-		request := core.ListInstancesRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := computeClient.ListInstances(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		instances = append(instances, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+	regionsByID, err := ociRegionsByID(list.Data)
+	if err != nil {
+		return nil, err
 	}
 
-	return instances, nil
-}
+	// Compute instances are the resource most often placed in a per-team or
+	// per-environment compartment, and ListInstances only ever answers for the
+	// one compartment it is handed. Restricting the scan to the tenancy root
+	// meant a fleet of hundreds of hosts reported as zero instances, taking
+	// every patch, agent, and IMDS check down with it.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
 
-func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
+			regionResource := regionsByID[region]
 
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
-
-			svc, err := conn.ComputeClient(regionResource.Id.Data)
+			svc, err := conn.ComputeClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			instances, err := o.getComputeInstancesForRegion(ctx, svc, conn.TenantID())
+			instances, err := o.getComputeInstancesForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -212,23 +186,48 @@ func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regi
 					return nil, err
 				}
 				mqlInst := mqlInstance.(*mqlOciComputeInstance)
-				mqlInst.cacheRegion = regionResource.Id.Data
+				mqlInst.cacheRegion = region
+				mqlInst.cacheCompartmentID = stringValue(instance.CompartmentId)
 				if src, ok := instance.SourceDetails.(core.InstanceSourceViaBootVolumeDetails); ok {
 					mqlInst.cacheBootVolumeID = stringValue(src.BootVolumeId)
 				}
 				res = append(res, mqlInst)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Instance, error) {
+	instances := []core.Instance{}
+	var page *string
+	for {
+		request := core.ListInstancesRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := computeClient.ListInstances(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		instances = append(instances, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return instances, nil
 }
 
 type mqlOciComputeInstanceInternal struct {
-	cacheRegion       string
-	cacheBootVolumeID string
+	cacheRegion        string
+	cacheBootVolumeID  string
+	cacheCompartmentID string
 }
 
 func (o *mqlOciComputeInstance) id() (string, error) {
@@ -258,12 +257,24 @@ func (o *mqlOciComputeInstance) vnics() ([]any, error) {
 		return nil, err
 	}
 
-	// List VNIC attachments for this instance
+	// List VNIC attachments for this instance.
+	//
+	// Scoped to the instance's own compartment, not the tenancy root:
+	// ListVnicAttachments filters on the compartment as well as the instance,
+	// so asking the root about an instance that lives in a child compartment
+	// returned no attachments at all. That left the instance with no IPs, no
+	// subnet and no security groups, which the exposure checks then read as
+	// "not reachable" for exactly the instances nobody had looked at.
+	compartmentID := o.cacheCompartmentID
+	if compartmentID == "" {
+		compartmentID = conn.TenantID()
+	}
+
 	var attachments []core.VnicAttachment
 	var page *string
 	for {
 		response, err := computeSvc.ListVnicAttachments(ctx, core.ListVnicAttachmentsRequest{
-			CompartmentId: common.String(conn.TenantID()),
+			CompartmentId: common.String(compartmentID),
 			InstanceId:    common.String(o.Id.Data),
 			Page:          page,
 		})

--- a/providers/oci/resources/dns.go
+++ b/providers/oci/resources/dns.go
@@ -29,6 +29,13 @@ var ociDnsZoneScopes = []dns.ListZonesScopeEnum{
 	dns.ListZonesScopePrivate,
 }
 
+// ociDnsSteeringPolicyScopes are the scopes a steering policy can live in.
+// The listing scopes the same way zones do, so both have to be asked for.
+var ociDnsSteeringPolicyScopes = []dns.ListSteeringPoliciesScopeEnum{
+	dns.ListSteeringPoliciesScopeGlobal,
+	dns.ListSteeringPoliciesScopePrivate,
+}
+
 func (o *mqlOciDns) zones() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
@@ -138,22 +145,29 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 			}
 
 			policies := []dns.SteeringPolicySummary{}
-			var page *string
-			for {
-				response, err := client.ListSteeringPolicies(ctx, dns.ListSteeringPoliciesRequest{
-					CompartmentId: common.String(compartmentID),
-					Page:          page,
-				})
-				if err != nil {
-					return nil, err
-				}
+			// Scoped the same way zones are, and for the same reason: the
+			// listing returns one scope at a time rather than the union, so
+			// asking only for the default reports a tenancy's private traffic
+			// management as absent.
+			for _, scope := range ociDnsSteeringPolicyScopes {
+				var page *string
+				for {
+					response, err := client.ListSteeringPolicies(ctx, dns.ListSteeringPoliciesRequest{
+						CompartmentId: common.String(compartmentID),
+						Scope:         scope,
+						Page:          page,
+					})
+					if err != nil {
+						return nil, err
+					}
 
-				policies = append(policies, response.Items...)
+					policies = append(policies, response.Items...)
 
-				if response.OpcNextPage == nil {
-					break
+					if response.OpcNextPage == nil {
+						break
+					}
+					page = response.OpcNextPage
 				}
-				page = response.OpcNextPage
 			}
 
 			res := make([]any, 0, len(policies))

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
@@ -35,7 +34,52 @@ func (o *mqlOciKms) vaults() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getVaults(conn, list.Data))
+	// Vaults are almost always created in the compartment of the service they
+	// encrypt, and ListVaults answers for one compartment with no way to recurse.
+	// A root-only listing therefore came back empty, and every typed vault
+	// reference from a database, bucket, or stream pool then had nothing to
+	// resolve against.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci kms with region %s", region)
+
+			svc, err := conn.KmsVaultClient(region)
+			if err != nil {
+				return nil, err
+			}
+
+			var res []any
+			vaults, err := o.getVaultsForRegion(ctx, svc, compartmentID)
+			if err != nil {
+				return nil, err
+			}
+
+			for i := range vaults {
+				vault := vaults[i]
+
+				var created *time.Time
+				if vault.TimeCreated != nil {
+					created = &vault.TimeCreated.Time
+				}
+
+				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
+					"id":                 llx.StringDataPtr(vault.Id),
+					"name":               llx.StringDataPtr(vault.DisplayName),
+					"compartmentID":      llx.StringDataPtr(vault.CompartmentId),
+					"vaultType":          llx.StringData(string(vault.VaultType)),
+					"state":              llx.StringData(string(vault.LifecycleState)),
+					"managementEndpoint": llx.StringDataPtr(vault.ManagementEndpoint),
+					"created":            llx.TimeDataPtr(created),
+				})
+				if err != nil {
+					return nil, err
+				}
+				mqlInstance.(*mqlOciKmsVault).region = region
+				res = append(res, mqlInstance)
+			}
+
+			return res, nil
+		})
 }
 
 func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagement.KmsVaultClient, compartmentID string) ([]keymanagement.VaultSummary, error) {
@@ -61,59 +105,6 @@ func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagemen
 	}
 
 	return entries, nil
-}
-
-func (o *mqlOciKms) getVaults(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci kms with region %s", regionResource.Id.Data)
-
-			svc, err := conn.KmsVaultClient(regionResource.Id.Data)
-			if err != nil {
-				return nil, err
-			}
-
-			var res []any
-			vaults, err := o.getVaultsForRegion(ctx, svc, conn.TenantID())
-			if err != nil {
-				return nil, err
-			}
-
-			for i := range vaults {
-				vault := vaults[i]
-
-				var created *time.Time
-				if vault.TimeCreated != nil {
-					created = &vault.TimeCreated.Time
-				}
-
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
-					"id":                 llx.StringDataPtr(vault.Id),
-					"name":               llx.StringDataPtr(vault.DisplayName),
-					"compartmentID":      llx.StringDataPtr(vault.CompartmentId),
-					"vaultType":          llx.StringData(string(vault.VaultType)),
-					"state":              llx.StringData(string(vault.LifecycleState)),
-					"managementEndpoint": llx.StringDataPtr(vault.ManagementEndpoint),
-					"created":            llx.TimeDataPtr(created),
-				})
-				if err != nil {
-					return nil, err
-				}
-				mqlInstance.(*mqlOciKmsVault).region = regionResource.Id.Data
-				res = append(res, mqlInstance)
-			}
-
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
 }
 
 type mqlOciKmsVaultInternal struct {

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -14,7 +14,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -36,21 +35,16 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getLoadBalancers(conn, list.Data))
-}
+	// Load balancers belong to the compartment of the application they front, and
+	// ListLoadBalancers has no subtree flag. Scanning only the tenancy root meant
+	// the exposure surface an internet-facing balancer represents, along with its
+	// listener TLS settings and backend sets, never appeared in the inventory at
+	// all.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci load balancer with region %s", region)
 
-func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci load balancer with region %s", regionResource.Id.Data)
-
-			svc, err := conn.LoadBalancerClient(regionResource.Id.Data)
+			svc, err := conn.LoadBalancerClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -59,7 +53,7 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 			var page *string
 			for {
 				response, err := svc.ListLoadBalancers(ctx, loadbalancer.ListLoadBalancersRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -130,16 +124,13 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 				mqlLb := mqlInstance.(*mqlOciLoadBalancerLoadBalancer)
 				mqlLb.cacheListeners = lb.Listeners
 				mqlLb.cacheBackendSets = lb.BackendSets
-				mqlLb.cacheRegion = regionResource.Id.Data
+				mqlLb.cacheRegion = region
 				mqlLb.cacheSubnetIDs = lb.SubnetIds
 				res = append(res, mqlLb)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciLoadBalancerLoadBalancerInternal struct {

--- a/providers/oci/resources/messaging.go
+++ b/providers/oci/resources/messaging.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 
@@ -184,6 +185,44 @@ type mqlOciStreamingStreamPoolInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *streaming.StreamPool
+}
+
+// initOciStreamingStreamPool resolves a stream pool by OCID.
+//
+// Without an init, NewResource falls straight through to Create with whatever
+// args it was handed - here just an id - so `oci.streaming.streams.streamPool`
+// produced a resource with every other field unset and an empty cacheRegion,
+// which then built a client against an empty region. Resolving through the
+// pool listing returns the fully populated instance instead.
+func initOciStreamingStreamPool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
+		return nil, nil, errors.New("id required to fetch oci.streaming.streamPool")
+	}
+
+	obj, err := CreateResource(runtime, "oci.streaming", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	s := obj.(*mqlOciStreaming)
+
+	rawPools := s.GetStreamPools()
+	if rawPools.Error != nil {
+		return nil, nil, rawPools.Error
+	}
+
+	for _, raw := range rawPools.Data {
+		pool := raw.(*mqlOciStreamingStreamPool)
+		if pool.Id.Data == idVal {
+			return args, pool, nil
+		}
+	}
+
+	return nil, nil, errors.New("oci.streaming.streamPool not found: " + idVal)
 }
 
 func (o *mqlOciStreamingStreamPool) id() (string, error) {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -28,53 +28,32 @@ func (o *mqlOciNetwork) id() (string, error) {
 func (o *mqlOciNetwork) vcns() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociRunRegionPool(o.getVcns(conn))
-}
-
-func (s *mqlOciNetwork) getVcnsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.Vcn, error) {
-	vcns := []core.Vcn{}
-	var page *string
-	for {
-		request := core.ListVcnsRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := networkClient.ListVcns(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		vcns = append(vcns, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
-	}
-
-	return vcns, nil
-}
-
-func (o *mqlOciNetwork) getVcns(conn *connection.OciConnection) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.GetRegions(ctx)
+	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
 	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
+		return nil, err
 	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", *region.RegionKey)
+	oci := ociResource.(*mqlOci)
+	list := oci.GetRegions()
+	if list.Error != nil {
+		return nil, list.Error
+	}
 
-			svc, err := conn.NetworkClient(*region.RegionKey)
+	// ListVcns takes one compartment and has no subtree flag, so asking only for
+	// the tenancy root returned an empty VCN list for anyone who keeps their
+	// networking in a child compartment. Walking the compartment tree is what
+	// makes the whole network graph, subnets and route tables and gateways
+	// included, hang off something that actually exists.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
+
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			vcns, err := o.getVcnsForRegion(ctx, svc, conn.TenantID())
+			vcns, err := o.getVcnsForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -119,11 +98,34 @@ func (o *mqlOciNetwork) getVcns(conn *connection.OciConnection) []*jobpool.Job {
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (s *mqlOciNetwork) getVcnsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.Vcn, error) {
+	vcns := []core.Vcn{}
+	var page *string
+	for {
+		request := core.ListVcnsRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := networkClient.ListVcns(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		vcns = append(vcns, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return vcns, nil
 }
 
 func initOciNetworkVcn(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -164,95 +166,32 @@ func (o *mqlOciNetworkVcn) id() (string, error) {
 func (o *mqlOciNetwork) securityLists() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociRunRegionPool(o.getSecurityLists(conn))
-}
-
-func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.SecurityList, error) {
-	securityLists := []core.SecurityList{}
-	var page *string
-	for {
-		request := core.ListSecurityListsRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := networkClient.ListSecurityLists(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		securityLists = append(securityLists, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
-	}
-
-	return securityLists, nil
-}
-
-// OCI VCN SecurityList egress rule for allowing outbound IP packets
-type egressSecurityRule struct {
-	// Description of egress rule
-	Description string `json:"description,omitempty"`
-	// Indicates if this is a stateless rule. No omitempty: a stateful rule
-	// must emit `stateless: false`, not drop the key entirely.
-	Stateless bool `json:"stateless"`
-	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-	Protocol string `json:"protocol,omitempty"`
-	// Range of allowed IP addresses
-	Destination string `json:"destination,omitempty"`
-	// Type of destination
-	DestinationType string `json:"destinationType,omitempty"`
-	// TCP options
-	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
-	// Udp options
-	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
-	// Icmp options
-	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
-}
-
-// OCI VCN SecurityList Ingress rule for allowing inbound IP packets
-type ingressSecurityRule struct {
-	// Description of ingress rule
-	Description string `json:"description,omitempty"`
-	// Indicates if this is a stateless rule. No omitempty: a stateful rule
-	// must emit `stateless: false`, not drop the key entirely.
-	Stateless bool `json:"stateless"`
-	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
-	Protocol string `json:"protocol,omitempty"`
-	// Range of allowed IP addresses
-	Source string `json:"source,omitempty"`
-	// Type of source
-	SourceType string `json:"sourceType,omitempty"`
-	// TCP options
-	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
-	// Udp options
-	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
-	// Icmp options
-	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
-}
-
-func (o *mqlOciNetwork) getSecurityLists(conn *connection.OciConnection) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.GetRegions(ctx)
+	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
 	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
+		return nil, err
 	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", *region.RegionKey)
+	oci := ociResource.(*mqlOci)
+	list := oci.GetRegions()
+	if list.Error != nil {
+		return nil, list.Error
+	}
 
-			svc, err := conn.NetworkClient(*region.RegionKey)
+	// Security lists live in the same compartment as the VCN they protect, and
+	// ListSecurityLists cannot search below the compartment it is given. Scanning
+	// only the tenancy root therefore reported a tenancy with no ingress rules
+	// anywhere, which reads as "nothing is exposed" when the truth is that
+	// nothing was looked at.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
+
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			securityLists, err := o.getSecurityListsForRegion(ctx, svc, conn.TenantID())
+			securityLists, err := o.getSecurityListsForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -330,15 +269,80 @@ func (o *mqlOciNetwork) getSecurityLists(conn *connection.OciConnection) []*jobp
 				}
 				sl := mqlInstance.(*mqlOciNetworkSecurityList)
 				sl.cacheVcnId = stringValue(securityList.VcnId)
-				sl.cacheRegion = stringValue(region.RegionKey)
+				sl.cacheRegion = region
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.SecurityList, error) {
+	securityLists := []core.SecurityList{}
+	var page *string
+	for {
+		request := core.ListSecurityListsRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := networkClient.ListSecurityLists(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		securityLists = append(securityLists, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return securityLists, nil
+}
+
+// OCI VCN SecurityList egress rule for allowing outbound IP packets
+type egressSecurityRule struct {
+	// Description of egress rule
+	Description string `json:"description,omitempty"`
+	// Indicates if this is a stateless rule. No omitempty: a stateful rule
+	// must emit `stateless: false`, not drop the key entirely.
+	Stateless bool `json:"stateless"`
+	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+	Protocol string `json:"protocol,omitempty"`
+	// Range of allowed IP addresses
+	Destination string `json:"destination,omitempty"`
+	// Type of destination
+	DestinationType string `json:"destinationType,omitempty"`
+	// TCP options
+	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
+	// Udp options
+	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
+	// Icmp options
+	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
+}
+
+// OCI VCN SecurityList Ingress rule for allowing inbound IP packets
+type ingressSecurityRule struct {
+	// Description of ingress rule
+	Description string `json:"description,omitempty"`
+	// Indicates if this is a stateless rule. No omitempty: a stateful rule
+	// must emit `stateless: false`, not drop the key entirely.
+	Stateless bool `json:"stateless"`
+	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+	Protocol string `json:"protocol,omitempty"`
+	// Range of allowed IP addresses
+	Source string `json:"source,omitempty"`
+	// Type of source
+	SourceType string `json:"sourceType,omitempty"`
+	// TCP options
+	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
+	// Udp options
+	UdpOptions *core.UdpOptions `json:"udpOptions,omitempty"`
+	// Icmp options
+	IcmpOptions *core.IcmpOptions `json:"icmpOptions,omitempty"`
 }
 
 type mqlOciNetworkSecurityListInternal struct {
@@ -463,21 +467,16 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getSubnets(conn, list.Data))
-}
+	// Fanned out over the compartment tree, not just the tenancy root. The core
+	// list APIs have no subtree flag, so listing the root alone reported no
+	// subnets at all for any tenancy that groups its networking into child
+	// compartments - and left every typed reference to a subnet (load balancer
+	// exposure, database placement, stream pool networking) unable to resolve.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci subnets with region %s", region)
 
-func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci subnets with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -486,7 +485,7 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 			var page *string
 			for {
 				response, err := svc.ListSubnets(ctx, core.ListSubnetsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -545,11 +544,8 @@ func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any
 				res = append(res, mqlSub)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkSubnetInternal struct {
@@ -620,53 +616,22 @@ func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getNetworkSecurityGroups(conn, list.Data))
-}
+	// Network security groups are attached to VNICs that almost never live in the
+	// tenancy root, and ListNetworkSecurityGroups takes a single compartment with
+	// no way to descend. Enumerating per compartment is what lets an instance's
+	// nsgs resolve at all, instead of coming back empty and making every host
+	// look unprotected.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci NSGs with region %s", region)
 
-func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.NetworkSecurityGroup, error) {
-	nsgs := []core.NetworkSecurityGroup{}
-	var page *string
-	for {
-		request := core.ListNetworkSecurityGroupsRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := networkClient.ListNetworkSecurityGroups(ctx, request)
-		if err != nil {
-			return nil, err
-		}
-
-		nsgs = append(nsgs, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
-	}
-
-	return nsgs, nil
-}
-
-func (o *mqlOciNetwork) getNetworkSecurityGroups(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci NSGs with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			var res []any
-			nsgs, err := o.getNSGsForRegion(ctx, svc, conn.TenantID())
+			nsgs, err := o.getNSGsForRegion(ctx, svc, compartmentID)
 			if err != nil {
 				return nil, err
 			}
@@ -702,16 +667,39 @@ func (o *mqlOciNetwork) getNetworkSecurityGroups(conn *connection.OciConnection,
 					return nil, err
 				}
 				mqlNsg := mqlInstance.(*mqlOciNetworkNetworkSecurityGroup)
-				mqlNsg.region = regionResource.Id.Data
+				mqlNsg.region = region
 				mqlNsg.cacheVcnId = stringValue(nsg.VcnId)
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.NetworkSecurityGroup, error) {
+	nsgs := []core.NetworkSecurityGroup{}
+	var page *string
+	for {
+		request := core.ListNetworkSecurityGroupsRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := networkClient.ListNetworkSecurityGroups(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		nsgs = append(nsgs, response.Items...)
+
+		if response.OpcNextPage == nil {
+			break
+		}
+
+		page = response.OpcNextPage
 	}
-	return tasks
+
+	return nsgs, nil
 }
 
 type mqlOciNetworkNetworkSecurityGroupInternal struct {
@@ -1316,21 +1304,16 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getRouteTables(conn, list.Data))
-}
+	// A route table is created alongside the VCN it belongs to, so a tenancy that
+	// puts its VCNs in child compartments has no route tables in the root at all.
+	// ListRouteTables offers no subtree search, so the fan-out below is the only
+	// way a subnet's routeTable reference finds its target and egress paths stay
+	// auditable.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci route tables with region %s", region)
 
-func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci route tables with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -1339,7 +1322,7 @@ func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions [
 			var page *string
 			for {
 				response, err := svc.ListRouteTables(ctx, core.ListRouteTablesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -1407,11 +1390,8 @@ func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions [
 				res = append(res, mqlRt)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkRouteTableInternal struct {

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -648,7 +648,7 @@ func init() {
 			Create: createOciStreamingStream,
 		},
 		"oci.streaming.streamPool": {
-			// to override args, implement: initOciStreamingStreamPool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciStreamingStreamPool,
 			Create: createOciStreamingStreamPool,
 		},
 		"oci.queue": {

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
@@ -34,7 +33,53 @@ func (o *mqlOciOns) topics() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getTopics(conn, list.Data))
+	// Notification topics are created next to the alarms and connectors that
+	// publish to them, which puts them in child compartments. ListTopics has no
+	// subtree option, so a root-only sweep reported no topics and broke the alarm
+	// and Connector Hub destination references that point at them.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
+
+			svc, err := conn.NotificationControlPlaneClient(region)
+			if err != nil {
+				return nil, err
+			}
+
+			var res []any
+			topics, err := o.getTopicsForRegion(ctx, svc, compartmentID)
+			if err != nil {
+				return nil, err
+			}
+
+			for i := range topics {
+				topic := topics[i]
+
+				var created *time.Time
+				if topic.TimeCreated != nil {
+					created = &topic.TimeCreated.Time
+				}
+
+				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.ons.topic", map[string]*llx.RawData{
+					"id":            llx.StringDataPtr(topic.TopicId),
+					"name":          llx.StringDataPtr(topic.Name),
+					"description":   llx.StringDataPtr(topic.Description),
+					"compartmentID": llx.StringDataPtr(topic.CompartmentId),
+					"state":         llx.StringData(string(topic.LifecycleState)),
+					"created":       llx.TimeDataPtr(created),
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				mqlTopic := mqlInstance.(*mqlOciOnsTopic)
+				mqlTopic.region = region
+
+				res = append(res, mqlInstance)
+			}
+
+			return res, nil
+		})
 }
 
 func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.NotificationControlPlaneClient, compartmentID string) ([]ons.NotificationTopicSummary, error) {
@@ -61,61 +106,6 @@ func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.Notifica
 	}
 
 	return topics, nil
-}
-
-func (o *mqlOciOns) getTopics(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NotificationControlPlaneClient(regionResource.Id.Data)
-			if err != nil {
-				return nil, err
-			}
-
-			var res []any
-			topics, err := o.getTopicsForRegion(ctx, svc, conn.TenantID())
-			if err != nil {
-				return nil, err
-			}
-
-			for i := range topics {
-				topic := topics[i]
-
-				var created *time.Time
-				if topic.TimeCreated != nil {
-					created = &topic.TimeCreated.Time
-				}
-
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.ons.topic", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(topic.TopicId),
-					"name":          llx.StringDataPtr(topic.Name),
-					"description":   llx.StringDataPtr(topic.Description),
-					"compartmentID": llx.StringDataPtr(topic.CompartmentId),
-					"state":         llx.StringData(string(topic.LifecycleState)),
-					"created":       llx.TimeDataPtr(created),
-				})
-				if err != nil {
-					return nil, err
-				}
-
-				mqlTopic := mqlInstance.(*mqlOciOnsTopic)
-				mqlTopic.region = regionResource.Id.Data
-
-				res = append(res, mqlInstance)
-			}
-
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
 }
 
 type mqlOciOnsTopicInternal struct {

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -36,21 +35,16 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 		return nil, list.Error
 	}
 
-	return ociRunRegionPool(o.getSecrets(conn, list.Data))
-}
+	// Secrets sit in the compartment of the application that consumes them, and
+	// ListSecrets accepts one compartment with no recursion. Asking only about
+	// the tenancy root left rotation status, expiry, and auto-generation checks
+	// with nothing to evaluate, which looked like a tenancy with no secrets
+	// rather than a scan that never reached them.
+	return ociRunCompartmentRegionPool(conn, list.Data,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci vault secrets with region %s", region)
 
-func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci vault secrets with region %s", regionResource.Id.Data)
-
-			svc, err := conn.VaultsClient(regionResource.Id.Data)
+			svc, err := conn.VaultsClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -59,7 +53,7 @@ func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) 
 			var page *string
 			for {
 				response, err := svc.ListSecrets(ctx, vault.ListSecretsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -121,7 +115,7 @@ func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) 
 				mqlS := mqlInstance.(*mqlOciVaultSecret)
 				mqlS.cacheKeyId = stringValue(s.KeyId)
 				mqlS.cacheVaultId = stringValue(s.VaultId)
-				mqlS.cacheRegion = regionResource.Id.Data
+				mqlS.cacheRegion = region
 				if s.RotationConfig != nil {
 					mqlS.cacheRotationInterval = stringValue(s.RotationConfig.RotationInterval)
 					mqlS.cacheIsScheduledRotationEnabled = s.RotationConfig.IsScheduledRotationEnabled
@@ -133,11 +127,8 @@ func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) 
 				res = append(res, mqlS)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciVaultSecretInternal struct {

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -203,9 +203,23 @@ func (o *mqlOciServiceConnectorHubConnector) targetBucket() (*mqlOciObjectStorag
 		return nil, nil
 	}
 
+	// The bucket's own init needs a region: it fetches the bucket detail to
+	// populate everything ListBuckets omits, and GetBucket is a regional call.
+	// Passing only namespace and name left that region unset, so every
+	// objectStorage-target connector failed with "region is required to fetch
+	// bucket details". A Connector Hub target bucket is in the connector's own
+	// region, which is already cached here.
+	regionRes, err := NewResource(o.MqlRuntime, "oci.region", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheRegion),
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	res, err := NewResource(o.MqlRuntime, "oci.objectStorage.bucket", map[string]*llx.RawData{
 		"namespace": llx.StringData(stringValue(target.Namespace)),
 		"name":      llx.StringData(stringValue(target.BucketName)),
+		"region":    llx.ResourceData(regionRes, "oci.region"),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
> Stacked on #9603. Review that one first; this PR's diff is against it.

Seven defects that narrow a query's scope without saying so. Each returns a short list or a failed lookup that reads as an answer.

## Collections saw only the tenancy root compartment

Most OCI list APIs take one compartment and have **no** `CompartmentIdInSubtree` flag — I checked each request struct in the SDK. Passing `conn.TenantID()` therefore lists the root compartment and nothing else, which is empty for any tenancy that groups resources into child compartments.

The newer services (added in #9573–#9578) already fan out over the compartment tree via `ociRunCompartmentRegionPool`. These did not, and the mismatch is what broke typed references pointing from a new resource into an old one:

| Accessor | Resolved through | Symptom |
|---|---|---|
| `subnet()`, `vcn()` | `oci.network.subnets` / `.vcns` | `oci.network.subnet not found: ocid1...` per row |
| `encryptionKey()` | `oci.kms.vaults` | error per row |
| `superuserSecret()`, `targetTopic()`, `tlsCertificate()`, `loadBalancer()` | secrets / topics / certificates / load balancers | error per row |
| `securityGroups()`, `kafka.subnets()` | NSGs / subnets | **silent `[]`** — and `ociNsgIngressVerdict` treats an empty NSG set as *open* |

Eleven listers converted: subnets, VCNs, security lists, network security groups, route tables, compute instances, KMS vaults, secrets, notification topics, certificates, load balancers.

A twelfth case is the same bug reached differently. `ListVnicAttachments` filters on compartment *as well as* instance id, and was passed the tenancy root — so an instance in a child compartment had no IPs, no subnet and no security groups, which the exposure checks read as "not reachable" for exactly the instances nobody had looked at. It now uses the instance's own compartment.

**This widens what several shipped collections return**, from the root compartment to the whole tenancy. That is the correction rather than a side effect, and it is what the newer services already do — but it is the one change here worth a second opinion, since it changes existing results. The previous review deferred it on effort grounds; the typed-ref breakage is what forces it now.

## Cloud Guard was queried in the wrong region

Cloud Guard aggregates findings from every monitored region into a single **reporting region**, chosen at enablement and not required to equal the home region. `cloudguard/configuration.go:24` makes `ReportingRegion` the config's only `mandatory:"true"` field — and the provider already exposed it as `reportingRegion()` without ever routing on it. All seven listers used the home region, so a tenancy that reports elsewhere saw no problems, no targets, no detector recipes, while the console showed hundreds.

`getConfig` necessarily still uses the home region — it is what discovers the reporting region, so asking for it there would recurse.

*Needs live confirmation on a tenancy where the two differ.*

## Cloud Guard problems were silently filtered

Leaving the request's filters unset is not "everything". The SDK documents two server-side defaults: `TimeLastDetectedGreaterThanOrEqualTo` → *"start time will be set to current time - 30 days"*, and `LifecycleState` → *"If no value is specified state is active."*

The code comment claimed the opposite — that the listing was deliberately unfiltered so callers could see the RESOLVED and DISMISSED history. The request could not deliver that. Both bounds are now explicit: a 90-day window (matching the shortest Audit retention) and one pass per lifecycle state, since the filter takes a single value.

## Private DNS steering policies were invisible

`ListSteeringPoliciesRequest` has the same `Scope` parameter as `ListZones`. The zones lister queries both scopes and carries a comment explaining why; the steering-policy lister 90 lines below omitted it and got only the default scope.

## Audit events sent a malformed time range

`ListEvents` documents both bounds as *"granularity to the minute. Seconds (and milliseconds, if included) must be set to `0`."* Both are `mandatory:"true"`, and `common/helpers.go` serializes `SDKTime` with `RFC3339Nano` — so an untruncated `time.Now()` put seconds *and* nanoseconds on the wire on every call. Now `.Truncate(time.Minute)`.

*Whether OCI rejects this outright or tolerates it needs one live call; the fix is correct either way.*

## A stream pool reached through a stream was an empty husk

There was no `initOciStreamingStreamPool`, so `NewResource` fell through to `Create` with nothing but an id — every other field unset, and an empty `cacheRegion` that then built a client against no region at all. Order-dependent, so it looked intermittent: it worked if `streamPools` happened to be materialized first in the same query.

## A connector's target bucket never resolved

`initOciObjectStorageBucket` calls `getBucketDetails()`, which errors *"region is required to fetch bucket details"* when region is nil. `targetBucket()` passed only namespace and name, so **every** objectStorage-target connector failed. The connector's own region was already cached on the resource.

## Verification

`make providers/build/oci` clean, `go vet` clean, `gofmt` clean, `go test ./resources/` green. Generated files refreshed — the only `oci.lr.go` change is the new stream-pool `Init` registration.

New tests for `ociRegionsByID` (the region index the converted listers use). The compartment fan-out itself is covered by the existing `ociCollectCompartmentJobs` suite.

Not live-verified — no OCI tenancy available. Three items above are flagged as wanting live confirmation.
