### PR TITLE
🐛 azure: close failed-open gaps in the exposure verdicts

### DIFF
--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -52,8 +52,14 @@ func isInternetOpenSourcePrefix(prefix string) bool {
 // "128.0.0.0/1"] -- which is all of IPv4 written as two prefixes. It is a
 // common way to express "any" and it defeats a per-entry check: every entry
 // looks like an ordinary CIDR, so an NSG opened this way read as closed and the
-// resource behind it reported internetReachable: false. Any zero-length IPv6
-// prefix is treated the same way.
+// resource behind it reported internetReachable: false.
+//
+// The aggregation is IPv4 only. A prefix that is open on its own is caught for
+// either family, so "::/0" still reports true, but IPv6 prefixes are not summed
+// against each other: an all-of-IPv6 set written as ["::/1", "8000::/1"] is not
+// recognized. The split-halves spelling exists to get past tooling that rejects
+// 0.0.0.0/0, which is an IPv4 habit, so that gap has not been worth 128-bit
+// range math.
 func prefixesCoverInternet(prefixes []string) bool {
 	var ranges []ipRange
 	for _, p := range prefixes {

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"math"
+	"net/netip"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,21 +16,89 @@ import (
 
 // --- Pure helpers (table-tested in azure_exposure_test.go) ---
 
-// internetOpenSourcePrefixes is the set of NSG source address prefixes that
-// represent "any internet source". An inbound Allow rule whose source matches
+// isInternetOpenSourcePrefix reports whether a single NSG source address prefix
+// represents "any internet source". An inbound Allow rule whose source matches
 // one of these exposes the destination to the public internet.
-//   - "*"            wildcard, any source
-//   - "0.0.0.0/0"    all IPv4
-//   - "::/0"         all IPv6
-//   - "internet"     the Azure "Internet" service tag (everything outside the VNet)
+//
+// The named forms are Azure's own vocabulary:
+//   - "*" / "any"  wildcard, any source
+//   - "internet"   the Azure "Internet" service tag (everything outside the VNet)
+//
+// Everything else is parsed as a prefix rather than string-compared, so any
+// zero-length prefix counts -- "0.0.0.0/0" and "::/0", but equally "0.0.0.0/0 "
+// or an IPv6 form written out in full. A string compare recognized only the two
+// canonical spellings, and a rule written any other way read as closed.
+//
+// Note this deliberately answers only for ONE prefix. A source list can cover
+// the whole internet without any single entry doing so -- see
+// prefixesCoverInternet.
 func isInternetOpenSourcePrefix(prefix string) bool {
 	p := strings.ToLower(strings.TrimSpace(prefix))
 	switch p {
-	case "*", "0.0.0.0/0", "::/0", "internet":
+	case "*", "any", "internet":
 		return true
-	default:
+	}
+	parsed, err := netip.ParsePrefix(p)
+	if err != nil {
 		return false
 	}
+	return parsed.Bits() == 0
+}
+
+// prefixesCoverInternet reports whether a set of source prefixes together cover
+// the whole public address space, even though no single entry does.
+//
+// The case that matters is the split-halves form -- ["0.0.0.0/1",
+// "128.0.0.0/1"] -- which is all of IPv4 written as two prefixes. It is a
+// common way to express "any" and it defeats a per-entry check: every entry
+// looks like an ordinary CIDR, so an NSG opened this way read as closed and the
+// resource behind it reported internetReachable: false. Any zero-length IPv6
+// prefix is treated the same way.
+func prefixesCoverInternet(prefixes []string) bool {
+	var ranges []ipRange
+	for _, p := range prefixes {
+		if isInternetOpenSourcePrefix(p) {
+			return true
+		}
+		parsed, err := netip.ParsePrefix(strings.TrimSpace(p))
+		if err != nil || !parsed.Addr().Is4() {
+			continue
+		}
+		lo := ipv4ToUint(parsed.Masked().Addr())
+		size := uint64(1) << (32 - parsed.Bits())
+		ranges = append(ranges, ipRange{lo: uint64(lo), hi: uint64(lo) + size - 1})
+	}
+	return rangesCoverAllIPv4(ranges)
+}
+
+type ipRange struct{ lo, hi uint64 }
+
+func ipv4ToUint(addr netip.Addr) uint32 {
+	b := addr.As4()
+	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+}
+
+// rangesCoverAllIPv4 merges the ranges and reports whether they span the entire
+// IPv4 address space.
+func rangesCoverAllIPv4(ranges []ipRange) bool {
+	if len(ranges) == 0 {
+		return false
+	}
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].lo < ranges[j].lo })
+	if ranges[0].lo != 0 {
+		return false
+	}
+	reached := ranges[0].hi
+	for _, r := range ranges[1:] {
+		// a gap means the space is not fully covered
+		if r.lo > reached+1 {
+			return false
+		}
+		if r.hi > reached {
+			reached = r.hi
+		}
+	}
+	return reached >= math.MaxUint32
 }
 
 // securityRuleAllowsInternetIngress reports whether a single NSG security rule
@@ -46,12 +116,7 @@ func securityRuleAllowsInternetIngress(direction, access, sourcePrefix string, s
 	if isInternetOpenSourcePrefix(sourcePrefix) {
 		return true
 	}
-	for _, p := range sourcePrefixes {
-		if isInternetOpenSourcePrefix(p) {
-			return true
-		}
-	}
-	return false
+	return prefixesCoverInternet(sourcePrefixes)
 }
 
 // publicNetworkAccessEnabled interprets the Azure `publicNetworkAccess` string,
@@ -63,20 +128,37 @@ func publicNetworkAccessEnabled(value string) bool {
 }
 
 // firewallRuleAllowsAnyInternet reports whether a database firewall rule (start
-// IP / end IP range) opens the server to the public internet. A rule qualifies
-// when it starts at 0.0.0.0 and extends to any address beyond it — this catches
-// the full IPv4 span (0.0.0.0 -> 255.255.255.255) as well as wide partial
-// ranges such as 0.0.0.0 -> 128.255.255.255.
+// IP / end IP range) opens the server to the public internet.
 //
-// The special "allow all Azure services" rule (0.0.0.0 -> 0.0.0.0) is
-// deliberately NOT treated as internet-open. That rule permits traffic only
-// from Azure-internal service IPs, not from arbitrary public addresses, so
-// counting it as internet-reachable would be a false positive for servers that
-// have nothing but that rule enabled.
+// The rule is judged on how much of the address space it actually admits, not
+// on the text of its endpoints. Anchoring on the literal string "0.0.0.0" got
+// this wrong in both directions: 1.0.0.0 -> 255.255.255.255 and
+// 0.0.0.1 -> 255.255.255.255 are the whole routable internet and read as
+// closed, while 0.0.0.0 -> 0.0.0.1 is two addresses and read as open.
+//
+// A rule counts as internet-open when it spans at least half of IPv4. That
+// keeps the documented wide-partial case (0.0.0.0 -> 128.255.255.255) and the
+// off-by-one variants above, and excludes ordinary allowlists.
+//
+// The special "allow all Azure services" rule (0.0.0.0 -> 0.0.0.0) is NOT
+// internet-open: it permits traffic only from Azure-internal service IPs, not
+// from arbitrary public addresses. The span test excludes it on its own, since
+// it admits a single address.
 func firewallRuleAllowsAnyInternet(startIp, endIp string) bool {
-	start := strings.TrimSpace(startIp)
-	end := strings.TrimSpace(endIp)
-	return start == "0.0.0.0" && end != "" && end != "0.0.0.0"
+	start, err := netip.ParseAddr(strings.TrimSpace(startIp))
+	if err != nil || !start.Is4() {
+		return false
+	}
+	end, err := netip.ParseAddr(strings.TrimSpace(endIp))
+	if err != nil || !end.Is4() {
+		return false
+	}
+	lo, hi := ipv4ToUint(start), ipv4ToUint(end)
+	if hi < lo {
+		return false
+	}
+	const halfOfIPv4 = uint64(1) << 31
+	return uint64(hi)-uint64(lo)+1 >= halfOfIPv4
 }
 
 // databaseInternetReachable combines the publicNetworkAccess gate with the
@@ -96,9 +178,16 @@ func databaseInternetReachable(publicNetworkAccess string, firewallRanges [][2]s
 }
 
 // aksApiServerInternetReachable reports whether an AKS API server is reachable
-// from the public internet. It is reachable only when the cluster is not a
-// private cluster, public network access is not disabled, and no authorized-IP
-// allowlist restricts API access. Any of those gates closes the exposure.
+// from the public internet. It is reachable when the cluster is not private,
+// public network access is not disabled, and no authorized-IP allowlist
+// meaningfully restricts API access.
+//
+// An allowlist only counts as a restriction when it actually restricts
+// something. Treating any non-empty list as a restriction meant a cluster
+// allowlisted to 0.0.0.0/0 -- what several Terraform modules emit when the
+// field cannot be left empty -- reported its API server as unreachable while it
+// was open to the world. The same applies to a list written as the two IPv4
+// halves.
 func aksApiServerInternetReachable(enablePrivateCluster bool, publicNetworkAccess string, authorizedIPRanges []string) bool {
 	if enablePrivateCluster {
 		return false
@@ -106,10 +195,10 @@ func aksApiServerInternetReachable(enablePrivateCluster bool, publicNetworkAcces
 	if !publicNetworkAccessEnabled(publicNetworkAccess) {
 		return false
 	}
-	if len(authorizedIPRanges) > 0 {
-		return false
+	if len(authorizedIPRanges) == 0 {
+		return true
 	}
-	return true
+	return prefixesCoverInternet(authorizedIPRanges)
 }
 
 // --- Resolvers ---
@@ -123,12 +212,20 @@ func ruleSourceIsInternet(rule map[string]any) bool {
 		return true
 	}
 	for _, key := range []string{"sourceAddressPrefixes", "expandedSourceAddressPrefix"} {
-		if arr, ok := rule[key].([]any); ok {
-			for _, p := range arr {
-				if s, ok := p.(string); ok && isInternetOpenSourcePrefix(s) {
-					return true
-				}
+		arr, ok := rule[key].([]any)
+		if !ok {
+			continue
+		}
+		prefixes := make([]string, 0, len(arr))
+		for _, p := range arr {
+			if s, ok := p.(string); ok {
+				prefixes = append(prefixes, s)
 			}
+		}
+		// judged as a set, not entry by entry: a source list can cover the
+		// whole internet without any single entry doing so
+		if prefixesCoverInternet(prefixes) {
+			return true
 		}
 	}
 	return false

--- a/providers/azure/resources/azure_exposure_coverage_test.go
+++ b/providers/azure/resources/azure_exposure_coverage_test.go
@@ -1,0 +1,159 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// These tests cover the cases the exposure predicates used to get wrong. Every
+// one of them is a failed-open verdict: the resource is reachable and the
+// provider reported that it was not, so a policy asserting "not reachable from
+// the internet" passed over an exposed resource.
+
+func TestIsInternetOpenSourcePrefixParsesRatherThanCompares(t *testing.T) {
+	open := []string{
+		"*", "any", "Any", "internet", "Internet", " INTERNET ",
+		"0.0.0.0/0", " 0.0.0.0/0 ",
+		"::/0",
+		// the same zero-length IPv6 prefix written out in full -- a string
+		// compare recognized only the short spelling
+		"0000:0000:0000:0000:0000:0000:0000:0000/0",
+	}
+	for _, p := range open {
+		assert.True(t, isInternetOpenSourcePrefix(p), "%q should be internet-open", p)
+	}
+
+	closed := []string{
+		"", "10.0.0.0/8", "0.0.0.0/1", "128.0.0.0/1", "2001:db8::/32",
+		"VirtualNetwork", "AzureLoadBalancer", "not-a-prefix", "0.0.0.0",
+	}
+	for _, p := range closed {
+		assert.False(t, isInternetOpenSourcePrefix(p), "%q should not be internet-open on its own", p)
+	}
+}
+
+// TestPrefixesCoverInternetSplitHalves is the case a per-entry check cannot
+// see: neither 0.0.0.0/1 nor 128.0.0.0/1 is a zero-length prefix, but together
+// they are all of IPv4. It is a common way to write "any", and an NSG opened
+// this way used to read as closed.
+func TestPrefixesCoverInternet(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		prefixes []string
+		want     bool
+	}{
+		{"the two IPv4 halves", []string{"0.0.0.0/1", "128.0.0.0/1"}, true},
+		{"halves in either order", []string{"128.0.0.0/1", "0.0.0.0/1"}, true},
+		{"quarters", []string{"0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"}, true},
+		{"halves with unrelated entries mixed in", []string{"10.0.0.0/8", "0.0.0.0/1", "203.0.113.0/24", "128.0.0.0/1"}, true},
+		{"a single zero-length prefix still counts", []string{"0.0.0.0/0"}, true},
+		{"a named tag still counts", []string{"10.0.0.0/8", "Internet"}, true},
+
+		{"one half alone leaves the other half unreachable", []string{"0.0.0.0/1"}, false},
+		{"the upper half alone does not start at zero", []string{"128.0.0.0/1"}, false},
+		{"a gap in the middle is not full coverage", []string{"0.0.0.0/2", "192.0.0.0/2"}, false},
+		{"ordinary allowlist", []string{"10.0.0.0/8", "203.0.113.0/24"}, false},
+		{"empty list", nil, false},
+		{"unparseable entries are ignored, not assumed open", []string{"garbage", "also-garbage"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, prefixesCoverInternet(tc.prefixes))
+		})
+	}
+}
+
+// TestFirewallRuleAllowsAnyInternetSpans covers the database firewall rule
+// forms that a string compare on the start address got wrong in both
+// directions.
+func TestFirewallRuleAllowsAnyInternetSpans(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		start, end string
+		want       bool
+	}{
+		{"the whole address space", "0.0.0.0", "255.255.255.255", true},
+		{"starts at 1.0.0.0 -- the whole routable internet", "1.0.0.0", "255.255.255.255", true},
+		{"off by one at the bottom", "0.0.0.1", "255.255.255.255", true},
+		{"the documented wide-partial case", "0.0.0.0", "128.255.255.255", true},
+
+		{"the allow-all-Azure-services rule is not internet-open", "0.0.0.0", "0.0.0.0", false},
+		{"two addresses is not the internet", "0.0.0.0", "0.0.0.1", false},
+		{"an office allowlist", "203.0.113.0", "203.0.113.255", false},
+		{"a private range", "10.0.0.0", "10.255.255.255", false},
+		{"an inverted range admits nothing", "255.255.255.255", "0.0.0.0", false},
+		{"unparseable input is not assumed open", "", "255.255.255.255", false},
+		{"a missing end is not assumed open", "0.0.0.0", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, firewallRuleAllowsAnyInternet(tc.start, tc.end))
+		})
+	}
+}
+
+// TestAksApiServerAllowlistMustActuallyRestrict pins the AKS case. Treating any
+// non-empty authorized-IP list as a restriction meant a cluster allowlisted to
+// 0.0.0.0/0 -- which is what several Terraform modules emit when the field
+// cannot be left empty -- reported its API server as unreachable.
+func TestAksApiServerAllowlistMustActuallyRestrict(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		private bool
+		pna     string
+		ranges  []string
+		want    bool
+	}{
+		{"public cluster, no allowlist", false, "Enabled", nil, true},
+		{"allowlisted to the whole internet", false, "Enabled", []string{"0.0.0.0/0"}, true},
+		{"allowlisted to the two IPv4 halves", false, "Enabled", []string{"0.0.0.0/1", "128.0.0.0/1"}, true},
+
+		{"a real allowlist restricts", false, "Enabled", []string{"203.0.113.0/24"}, false},
+		{"a real allowlist with several entries restricts", false, "Enabled", []string{"203.0.113.0/24", "198.51.100.0/24"}, false},
+		{"private clusters are never reachable", true, "Enabled", nil, false},
+		{"private wins even over an open allowlist", true, "Enabled", []string{"0.0.0.0/0"}, false},
+		{"public network access disabled closes it", false, "Disabled", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, aksApiServerInternetReachable(tc.private, tc.pna, tc.ranges))
+		})
+	}
+}
+
+// TestSecurityRuleSplitHalvesSource checks the set-level reasoning reaches the
+// NSG rule predicates, not just the standalone helper.
+func TestSecurityRuleSplitHalvesSource(t *testing.T) {
+	assert.True(t, securityRuleAllowsInternetIngress("Inbound", "Allow", "",
+		[]string{"0.0.0.0/1", "128.0.0.0/1"}),
+		"a rule whose source list covers all of IPv4 is internet-open")
+
+	assert.False(t, securityRuleAllowsInternetIngress("Inbound", "Allow", "",
+		[]string{"0.0.0.0/1"}),
+		"half the address space is not the whole internet")
+
+	assert.True(t, ruleSourceIsInternet(map[string]any{
+		"sourceAddressPrefixes": []any{"0.0.0.0/1", "128.0.0.0/1"},
+	}))
+
+	assert.False(t, ruleSourceIsInternet(map[string]any{
+		"sourceAddressPrefixes": []any{"10.0.0.0/8", "203.0.113.0/24"},
+	}))
+}
+
+func TestRangesCoverAllIPv4(t *testing.T) {
+	full := []ipRange{{0, 4294967295}}
+	assert.True(t, rangesCoverAllIPv4(full))
+
+	halves := []ipRange{{0, 2147483647}, {2147483648, 4294967295}}
+	assert.True(t, rangesCoverAllIPv4(halves), "adjacent ranges must join")
+
+	gap := []ipRange{{0, 2147483646}, {2147483648, 4294967295}}
+	assert.False(t, rangesCoverAllIPv4(gap), "a one-address gap is still a gap")
+
+	notFromZero := []ipRange{{1, 4294967295}}
+	assert.False(t, rangesCoverAllIPv4(notFromZero))
+
+	assert.False(t, rangesCoverAllIPv4(nil))
+}

--- a/providers/azure/resources/azure_exposure_coverage_test.go
+++ b/providers/azure/resources/azure_exposure_coverage_test.go
@@ -59,6 +59,12 @@ func TestPrefixesCoverInternet(t *testing.T) {
 		{"ordinary allowlist", []string{"10.0.0.0/8", "203.0.113.0/24"}, false},
 		{"empty list", nil, false},
 		{"unparseable entries are ignored, not assumed open", []string{"garbage", "also-garbage"}, false},
+
+		// The aggregation is IPv4 only, and these two pin that boundary so a
+		// later change has to move both the behavior and the doc comment.
+		{"a zero-length IPv6 prefix counts on its own", []string{"::/0"}, true},
+		{"IPv6 halves are not summed against each other", []string{"::/1", "8000::/1"}, false},
+		{"IPv6 entries do not complete an IPv4 half", []string{"0.0.0.0/1", "8000::/1"}, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, prefixesCoverInternet(tc.prefixes))

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -568,8 +568,15 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forContainers() (*mqlAzureSub
 	}
 
 	args := commonPricingArgs(containersPricing.Properties, ResourceAzureSubscriptionCloudDefenderServiceDefenderForContainers, subId)
-	args["defenderDaemonSet"] = llx.BoolData(arcDefender && kubernetesDefender)
-	args["azurePolicyForKubernetes"] = llx.BoolData(arcPolicyExt && kubernetesPolicyExt)
+	// Either cluster flavour counts. There are two policy definitions per
+	// component -- one for Arc-enabled Kubernetes, one for AKS -- and a
+	// subscription that runs only AKS, which is the common case, will never have
+	// the Arc policy assigned. Both constants used to hold the Arc GUID, so this
+	// was `x && x`; correcting the AKS GUID silently turned it into a real
+	// conjunction and every AKS-only subscription began reporting false for a
+	// component it demonstrably had.
+	args["defenderDaemonSet"] = llx.BoolData(arcDefender || kubernetesDefender)
+	args["azurePolicyForKubernetes"] = llx.BoolData(arcPolicyExt || kubernetesPolicyExt)
 
 	resource, err := CreateResource(a.MqlRuntime,
 		ResourceAzureSubscriptionCloudDefenderServiceDefenderForContainers,

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -4857,9 +4857,11 @@ func azureSubnetToMql(runtime *plugin.Runtime, subnet network.Subnet) (*mqlAzure
 		return nil, err
 	}
 	mqlSubnet := mqlAzure.(*mqlAzureSubscriptionNetworkServiceSubnet)
-	mqlSubnet.cacheNetworkSecurityGroupID = nsgID
-	mqlSubnet.cacheRouteTableID = routeTableID
+	// see azureInterfaceToMql: a reference-shaped payload must not clear values
+	// a full read already stored on the cached instance
 	if subnet.Properties != nil {
+		mqlSubnet.cacheNetworkSecurityGroupID = nsgID
+		mqlSubnet.cacheRouteTableID = routeTableID
 		for _, pe := range subnet.Properties.PrivateEndpoints {
 			if pe != nil && pe.ID != nil {
 				mqlSubnet.cachePrivateEndpointIDs = append(mqlSubnet.cachePrivateEndpointIDs, *pe.ID)
@@ -5100,8 +5102,12 @@ func azureInterfaceToMql(runtime *plugin.Runtime, iface network.Interface) (*mql
 		return nil, err
 	}
 	mqlIface := res.(*mqlAzureSubscriptionNetworkServiceInterface)
-	mqlIface.cacheNetworkSecurityGroupID = networkSecurityGroupId
+	// Only seed the cache fields from a response that actually carried
+	// properties. CreateResource returns the already-cached instance on a known
+	// __id, so writing unconditionally let a reference-shaped payload clear the
+	// values a full read had already stored.
 	if iface.Properties != nil {
+		mqlIface.cacheNetworkSecurityGroupID = networkSecurityGroupId
 		mqlIface.cacheIPConfigurations = iface.Properties.IPConfigurations
 	}
 	return mqlIface, nil
@@ -5292,10 +5298,20 @@ func (a *mqlAzureSubscriptionNetworkServiceSecurityGroup) interfaces() ([]any, e
 	}
 	res := []any{}
 	for _, iface := range a.cacheProperties.NetworkInterfaces {
-		if iface == nil {
+		// Resolve by id rather than mapping the embedded value. The SDK marks
+		// SecurityGroupPropertiesFormat.NetworkInterfaces as "a collection of
+		// references": ARM returns {"id": ...} with no properties. Mapping that
+		// through azureInterfaceToMql invented enableIPForwarding: false and an
+		// empty ipConfigurations list, and -- because CreateResource returns the
+		// already-cached instance for a known __id while the mapper then wrote
+		// its cache fields onto it -- wiped the NSG reference of a NIC that had
+		// been read properly, so nic.networkSecurityGroup() answered null for
+		// the rest of the scan. subnets() below has always done it this way.
+		if iface == nil || iface.ID == nil {
 			continue
 		}
-		mqlIface, err := azureInterfaceToMql(a.MqlRuntime, *iface)
+		mqlIface, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.interface",
+			map[string]*llx.RawData{"id": llx.StringDataPtr(iface.ID)})
 		if err != nil {
 			return nil, err
 		}
@@ -5932,7 +5948,17 @@ func (a *mqlAzureSubscriptionNetworkServiceServiceEndpointPolicyDefinition) id()
 func (a *mqlAzureSubscriptionNetworkServiceServiceEndpointPolicy) subnets() ([]any, error) {
 	res := []any{}
 	for _, subnet := range a.cacheSubnets {
-		mqlSubnet, err := azureSubnetToMql(a.MqlRuntime, subnet)
+		// Same shape as securityGroup.interfaces(): the SDK marks
+		// ServiceEndpointPolicyPropertiesFormat.Subnets as "a collection of
+		// references", so these carry an id and nothing else. Mapping them
+		// invented an empty addressPrefix and cleared the cached subnet's NSG
+		// and route-table references, which made subnet.networkSecurityGroup()
+		// answer null -- "this subnet has no NSG" -- for the rest of the scan.
+		if subnet.ID == nil {
+			continue
+		}
+		mqlSubnet, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+			map[string]*llx.RawData{"id": llx.StringDataPtr(subnet.ID)})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Found by a static bug-review pass over the provider. These are all **failed-open** verdicts: the resource is reachable from the internet and the provider reported that it was not. That is worse than a plain wrong value — a policy asserting "not reachable from the internet" *passed* over an exposed resource, and nothing in the output suggested the answer was unreliable.

`azure_exposure.go` backs `internetReachable` on five database resources plus VM `exposure()`, so a gap there is provider-wide.

## Address matching was string comparison

`isInternetOpenSourcePrefix` compared against two canonical spellings (`"0.0.0.0/0"`, `"::/0"`). A zero-length prefix written any other way read as closed. It now parses the prefix and accepts any `/0`, alongside the `*` / `any` / `internet` tags.

## A source list can cover the internet without any single entry doing so

`["0.0.0.0/1", "128.0.0.0/1"]` is all of IPv4 written as two prefixes — a common way to express "any", and one that defeats a per-entry check because every entry looks like an ordinary CIDR. An NSG opened this way read as closed and the resource behind it reported `internetReachable: false`.

Source lists are now judged **as a set** (merge the ranges, test for full coverage), and that reasoning reaches `securityRuleAllowsInternetIngress` and `ruleSourceIsInternet`, not just the standalone helper.

## Database firewall rules were anchored on the literal `"0.0.0.0"`

Wrong in both directions:

| rule | reality | reported before |
|---|---|---|
| `1.0.0.0` → `255.255.255.255` | the whole routable internet | **not reachable** |
| `0.0.0.1` → `255.255.255.255` | the whole internet | **not reachable** |
| `0.0.0.0` → `0.0.0.1` | two addresses | **reachable** |

A rule is now judged on how much of the address space it actually admits (≥ half of IPv4). The documented wide-partial case (`0.0.0.0` → `128.255.255.255`) still counts, and the `AllowAllWindowsAzureIps` rule (`0.0.0.0` → `0.0.0.0`) is still excluded — now because it admits a single address rather than by special case.

## An AKS allowlist only restricts when it actually restricts

Any non-empty `authorizedIPRanges` used to close the verdict, so a cluster allowlisted to `0.0.0.0/0` — what several Terraform modules emit when the field cannot be left empty — reported its API server as unreachable while it was open to the world. Same for the split-halves form.

## Defender for Containers required *both* cluster flavours

```go
args["defenderDaemonSet"]        = llx.BoolData(arcDefender && kubernetesDefender)
args["azurePolicyForKubernetes"] = llx.BoolData(arcPolicyExt && kubernetesPolicyExt)
```

There are two policy definitions per component — one for Arc-enabled Kubernetes, one for AKS — and a subscription that runs only AKS (the common case) will never have the Arc policy assigned. Both reported `false` on subscriptions that demonstrably had the component.

This is a regression rather than an original bug, and the constant block says so: both GUIDs used to be the Arc one, so the expression was `x && x`. Correcting the AKS GUID silently turned it into a real conjunction. Now `||`.

## NSG interfaces / SEP subnets were corrupting the resource cache

The SDK marks `SecurityGroupPropertiesFormat.NetworkInterfaces` and `ServiceEndpointPolicyPropertiesFormat.Subnets` as *"a collection of references"* — ARM returns `{"id": ...}` with no `properties`. The code ran them through the full `azureInterfaceToMql` / `azureSubnetToMql` mappers, which did two damaging things:

1. took the `Properties == nil` branch and **invented** `enableIPForwarding: false`, `addressPrefix: ""`, `defaultOutboundAccess: false`; and
2. **unconditionally** wrote their cache fields onto whatever `CreateResource` returned — which on a cache hit is the instance a full read had already populated.

So evaluating `securityGroups { interfaces }` cleared `cacheNetworkSecurityGroupID` on NICs that had been read properly, and `nic.networkSecurityGroup()` answered **null** — "this NIC has no NSG" — for the rest of the scan. Same for a subnet's NSG and route-table references via `serviceEndpointPolicies { subnets }`.

Both now resolve by id through `NewResource` (which is what the sibling `securityGroup.subnets()` has always done), and the mappers only seed cache fields from a response that actually carried properties.

## Tests

`azure_exposure_coverage_test.go` covers every case above as a table: the split-halves and quarters forms, coverage gaps, the firewall-range spans in both directions, the AKS allowlist matrix, the range-merge helper, and that the set-level reasoning reaches the NSG rule predicates. The existing exposure suite still passes unchanged.

## Notes

- Verified: `go build ./...`, `go test ./...`, `go vet`, `gofmt -l` clean.
- **Not** live-verified. The predicates are pure and fully covered by tests; the NSG/SEP cache change alters which API path resolves a NIC or subnet and would benefit from a `provider-verification` run.
- One deliberate judgment call: "internet-open" for a database firewall rule is defined as *spanning at least half of IPv4*. Some threshold is unavoidable — the alternative (requiring the exact full span) reintroduces the `1.0.0.0 → 255.255.255.255` false negative. Happy to move it if you'd prefer a different line.
- Sibling PRs from the same review touch `network.go` and `cloud_defender.go` in different functions.
