### PR TITLE
🧹 oci: cache failed detail fetches and stop over-counting global DNS

### DIFF
--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -392,8 +392,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 	for {
 		response, err := client.ListDetectorRecipeDetectorRules(ctx, cloudguard.ListDetectorRecipeDetectorRulesRequest{
 			DetectorRecipeId: common.String(o.Id.Data),
-			CompartmentId:    common.String(o.CompartmentID.Data),
-			Page:             page,
+			// Read from the cached value rather than the public compartmentID
+			// field, which is marked deprecated in favour of compartment().
+			// Removing that field in a later major version would otherwise
+			// quietly scope this listing to the empty string.
+			CompartmentId: common.String(o.cacheCompartmentId),
+			Page:          page,
 		})
 		if err != nil {
 			return nil, err
@@ -531,10 +535,16 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, mqlInstance)
+		mqlRecipe := mqlInstance.(*mqlOciCloudGuardDetectorRecipe)
+		mqlRecipe.cacheCompartmentId = stringValue(recipe.CompartmentId)
+		res = append(res, mqlRecipe)
 	}
 
 	return res, nil
+}
+
+type mqlOciCloudGuardDetectorRecipeInternal struct {
+	cacheCompartmentId string
 }
 
 func (o *mqlOciCloudGuard) securityZones() ([]any, error) {

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -416,10 +416,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 		rule := rules[i]
 
 		// Every field that decides whether the rule actually fires lives in
-		// DetectorDetails. A nil block means the API returned the rule without
-		// its configuration, so report it as disabled-unknown rather than
-		// defaulting isEnabled to false, which would read as an authoritative
-		// "this detection is off".
+		// DetectorDetails, which is optional on the summary. When it is absent
+		// these fall back to their zero values and isEnabled is emitted as an
+		// explicit false rather than left null, so an assertion over the rule
+		// fails instead of passing on a rule nobody could read. MQL evaluates
+		// null && null as true, so a null here would be the more dangerous
+		// answer.
 		var (
 			isEnabled              bool
 			riskLevel              string

--- a/providers/oci/resources/compartments.go
+++ b/providers/oci/resources/compartments.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
@@ -33,6 +34,34 @@ func ociRegionsByID(regions []any) (map[string]*mqlOciRegion, error) {
 		res[regionResource.Id.Data] = regionResource
 	}
 	return res, nil
+}
+
+// ociDedupeByID drops repeated resources from a fan-out result.
+//
+// The compartment pool queries every (region, compartment) pair, which is
+// right for a regional service but over-counts a global one: OCI's public DNS
+// is served from every regional endpoint, so each global zone comes back once
+// per subscribed region. Because CreateResource returns the cached instance
+// for an id it has already seen, those repeats are the same resource appearing
+// several times rather than distinct rows, and a length or a where() over the
+// collection silently multiplies by the region count.
+func ociDedupeByID(items []any) []any {
+	res := make([]any, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		resource, ok := item.(plugin.Resource)
+		if !ok {
+			res = append(res, item)
+			continue
+		}
+		id := resource.MqlID()
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		res = append(res, item)
+	}
+	return res
 }
 
 // ociCompartmentLister lists resources of a single type inside one compartment

--- a/providers/oci/resources/compartments_test.go
+++ b/providers/oci/resources/compartments_test.go
@@ -84,6 +84,43 @@ func TestOciRegionsByID(t *testing.T) {
 	})
 }
 
+func TestOciDedupeByID(t *testing.T) {
+	zone := func(id string) *mqlOciDnsZone {
+		z := &mqlOciDnsZone{}
+		z.__id = id
+		return z
+	}
+
+	t.Run("no items", func(t *testing.T) {
+		assert.Empty(t, ociDedupeByID(nil))
+	})
+
+	t.Run("distinct resources are all kept", func(t *testing.T) {
+		a, b := zone("oci.dns.zone/a"), zone("oci.dns.zone/b")
+		assert.Equal(t, []any{a, b}, ociDedupeByID([]any{a, b}))
+	})
+
+	t.Run("a global zone seen once per region collapses to one", func(t *testing.T) {
+		// CreateResource returns the cached instance for an id it has already
+		// built, so the region fan-out yields the same pointer N times rather
+		// than N distinct rows. Without this, zones.length multiplies by the
+		// number of subscribed regions.
+		a := zone("oci.dns.zone/a")
+		assert.Equal(t, []any{a}, ociDedupeByID([]any{a, a, a}))
+	})
+
+	t.Run("order of first appearance is preserved", func(t *testing.T) {
+		a, b, c := zone("oci.dns.zone/a"), zone("oci.dns.zone/b"), zone("oci.dns.zone/c")
+		assert.Equal(t, []any{a, b, c}, ociDedupeByID([]any{a, b, a, c, b}))
+	})
+
+	t.Run("a non-resource element passes through untouched", func(t *testing.T) {
+		// Nothing in the provider does this today, but dropping an element the
+		// helper does not recognise would be a silent data loss of its own.
+		assert.Equal(t, []any{"raw", "raw"}, ociDedupeByID([]any{"raw", "raw"}))
+	})
+}
+
 func TestOciCollectCompartmentJobs(t *testing.T) {
 	ok := func(items ...any) *jobpool.Job {
 		return jobpool.NewJob(func() (jobpool.JobResult, error) {

--- a/providers/oci/resources/databases.go
+++ b/providers/oci/resources/databases.go
@@ -145,6 +145,7 @@ type mqlOciMysqlDbSystemInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *mysql.DbSystem
+	detailErr     error
 }
 
 func (o *mqlOciMysqlDbSystem) id() (string, error) {
@@ -157,18 +158,22 @@ func (o *mqlOciMysqlDbSystem) compartment() (*mqlOciCompartment, error) {
 
 func (o *mqlOciMysqlDbSystem) getDetail() (*mysql.DbSystem, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.MysqlDbSystemClient(o.cacheRegion)
 	if err != nil {
+		// A failed detail call is remembered as well, so a DB system we are
+		// not allowed to read is asked for once instead of once per field.
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -176,6 +181,8 @@ func (o *mqlOciMysqlDbSystem) getDetail() (*mysql.DbSystem, error) {
 		DbSystemId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -345,6 +352,7 @@ type mqlOciPostgresqlDbSystemInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *psql.DbSystem
+	detailErr     error
 }
 
 func (o *mqlOciPostgresqlDbSystem) id() (string, error) {
@@ -357,18 +365,20 @@ func (o *mqlOciPostgresqlDbSystem) compartment() (*mqlOciCompartment, error) {
 
 func (o *mqlOciPostgresqlDbSystem) getDetail() (*psql.DbSystem, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.PostgresqlClient(o.cacheRegion)
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -376,6 +386,8 @@ func (o *mqlOciPostgresqlDbSystem) getDetail() (*psql.DbSystem, error) {
 		DbSystemId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -665,6 +677,7 @@ type mqlOciOpensearchClusterInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *opensearch.OpensearchCluster
+	detailErr     error
 }
 
 func (o *mqlOciOpensearchCluster) id() (string, error) {
@@ -677,18 +690,20 @@ func (o *mqlOciOpensearchCluster) compartment() (*mqlOciCompartment, error) {
 
 func (o *mqlOciOpensearchCluster) getDetail() (*opensearch.OpensearchCluster, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.OpensearchClusterClient(o.cacheRegion)
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -696,6 +711,8 @@ func (o *mqlOciOpensearchCluster) getDetail() (*opensearch.OpensearchCluster, er
 		OpensearchClusterId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -866,6 +883,7 @@ type mqlOciGoldenGateDeploymentInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *goldengate.Deployment
+	detailErr     error
 }
 
 func (o *mqlOciGoldenGateDeployment) id() (string, error) {
@@ -896,18 +914,20 @@ func (o *mqlOciGoldenGateDeployment) loadBalancer() (*mqlOciLoadBalancerLoadBala
 
 func (o *mqlOciGoldenGateDeployment) getDetail() (*goldengate.Deployment, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.GoldenGateClient(o.cacheRegion)
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -915,6 +935,8 @@ func (o *mqlOciGoldenGateDeployment) getDetail() (*goldengate.Deployment, error)
 		DeploymentId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 

--- a/providers/oci/resources/dns.go
+++ b/providers/oci/resources/dns.go
@@ -48,7 +48,9 @@ func (o *mqlOciDns) zones() ([]any, error) {
 		return nil, regions.Error
 	}
 
-	return ociRunCompartmentRegionPool(conn, regions.Data,
+	// Deduplicated: a global zone is returned by every regional DNS
+	// endpoint, so the region fan-out sees it once per subscribed region.
+	items, err := ociRunCompartmentRegionPool(conn, regions.Data,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.DnsClient(region)
 			if err != nil {
@@ -79,6 +81,10 @@ func (o *mqlOciDns) zones() ([]any, error) {
 
 			return o.newZones(region, zones)
 		})
+	if err != nil {
+		return nil, err
+	}
+	return ociDedupeByID(items), nil
 }
 
 func (o *mqlOciDns) newZones(region string, zones []dns.ZoneSummary) ([]any, error) {
@@ -137,7 +143,9 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 		return nil, regions.Error
 	}
 
-	return ociRunCompartmentRegionPool(conn, regions.Data,
+	// Deduplicated: a global steering policy is returned by every regional DNS
+	// endpoint, so the region fan-out sees it once per subscribed region.
+	items, err := ociRunCompartmentRegionPool(conn, regions.Data,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.DnsClient(region)
 			if err != nil {
@@ -195,6 +203,10 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 
 			return res, nil
 		})
+	if err != nil {
+		return nil, err
+	}
+	return ociDedupeByID(items), nil
 }
 
 type mqlOciDnsZoneInternal struct {

--- a/providers/oci/resources/identitydomains.go
+++ b/providers/oci/resources/identitydomains.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -47,6 +49,34 @@ var ociScimAttributeSets = []identitydomains.AttributeSetsEnum{
 	identitydomains.AttributeSetsRequest,
 }
 
+// ociScimError annotates a failed SCIM call with the domain it was made
+// against and, for an authorization failure, what is actually missing.
+//
+// Reading a domain's users or groups needs a role granted inside that domain,
+// which is separate from the tenancy-level policy that lets ListDomains
+// enumerate it. A principal set up to read the tenancy therefore lists every
+// domain and then fails on all of them, and the bare SCIM error says only that
+// something was not authorized, naming neither the domain nor the role.
+//
+// The error is deliberately not degraded to an empty collection. An empty user
+// list is indistinguishable from a domain with no users, and a scan that
+// reports no users where it simply could not look is the failure mode this
+// provider is most concerned with.
+func ociScimError(err error, domainName string, collection string) error {
+	if err == nil {
+		return nil
+	}
+	if svcErr, ok := common.IsServiceError(err); ok {
+		switch svcErr.GetHTTPStatusCode() {
+		case 401, 403, 404:
+			return fmt.Errorf(
+				"cannot read %s of identity domain %q: the scanning principal needs a role within the domain, such as Identity Domain Administrator or User Administrator, which tenancy-level policy does not grant: %w",
+				collection, domainName, err)
+		}
+	}
+	return fmt.Errorf("cannot read %s of identity domain %q: %w", collection, domainName, err)
+}
+
 func (o *mqlOciIdentity) domains() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	ctx := context.Background()
@@ -60,72 +90,91 @@ func (o *mqlOciIdentity) domains() ([]any, error) {
 	// this is a single listing rather than a region fan-out. They can be
 	// created in any compartment, though, so the compartment tree still has to
 	// be walked.
+	//
+	// Concurrently, because GetCompartments returns the entire subtree and a
+	// tenancy with a few hundred compartments turned one field access into a
+	// few hundred sequential round-trips.
 	compartments, err := conn.GetCompartments(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	res := []any{}
+	jobs := make([]*jobpool.Job, 0, len(compartments))
 	for i := range compartments {
 		compartmentID := stringValue(compartments[i].Id)
 		if compartmentID == "" {
 			continue
 		}
 
-		domains := []identity.DomainSummary{}
-		var page *string
-		for {
-			response, err := client.ListDomains(ctx, identity.ListDomainsRequest{
-				CompartmentId: common.String(compartmentID),
-				Page:          page,
-			})
-			if err != nil {
-				// A compartment the caller cannot read is expected; anything
-				// else is a real fault, matching the compartment fan-out.
-				if ociCompartmentInaccessible(err) {
+		jobs = append(jobs, jobpool.NewJob(func() (jobpool.JobResult, error) {
+			// []any rather than []identity.DomainSummary: the collector joins
+			// results by asserting []any and silently drops anything else.
+			domains := []any{}
+			var page *string
+			for {
+				response, err := client.ListDomains(ctx, identity.ListDomainsRequest{
+					CompartmentId: common.String(compartmentID),
+					Page:          page,
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				for i := range response.Items {
+					domains = append(domains, response.Items[i])
+				}
+
+				if response.OpcNextPage == nil {
 					break
 				}
-				return nil, err
+				page = response.OpcNextPage
 			}
 
-			domains = append(domains, response.Items...)
+			return jobpool.JobResult(domains), nil
+		}))
+	}
 
-			if response.OpcNextPage == nil {
-				break
-			}
-			page = response.OpcNextPage
+	// The same accounting the resource listers use: a compartment the caller
+	// cannot read is skipped, but every compartment refusing access is an
+	// under-scoped token rather than a tenancy without identity domains.
+	collected, err := ociCollectCompartmentJobs(jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for j := range collected {
+		d, ok := collected[j].(identity.DomainSummary)
+		if !ok {
+			continue
 		}
 
-		for j := range domains {
-			d := domains[j]
-
-			replicaRegions := make([]string, 0, len(d.ReplicaRegions))
-			for _, r := range d.ReplicaRegions {
-				replicaRegions = append(replicaRegions, stringValue(r.Region))
-			}
-
-			mqlDomain, err := CreateResource(o.MqlRuntime, "oci.identity.domain", map[string]*llx.RawData{
-				"id":              llx.StringDataPtr(d.Id),
-				"name":            llx.StringDataPtr(d.DisplayName),
-				"description":     llx.StringDataPtr(d.Description),
-				"type":            llx.StringData(string(d.Type)),
-				"licenseType":     llx.StringDataPtr(d.LicenseType),
-				"homeRegion":      llx.StringDataPtr(d.HomeRegion),
-				"replicaRegions":  llx.ArrayData(stringsToAny(replicaRegions), types.String),
-				"isHiddenOnLogin": llx.BoolData(boolValue(d.IsHiddenOnLogin)),
-				"state":           llx.StringData(string(d.LifecycleState)),
-				"created":         sdkTimeData(d.TimeCreated),
-				"freeformTags":    llx.MapData(strMapToAny(d.FreeformTags), types.String),
-				"definedTags":     llx.MapData(definedTagsToAny(d.DefinedTags), types.Any),
-			})
-			if err != nil {
-				return nil, err
-			}
-			mqlDomainTyped := mqlDomain.(*mqlOciIdentityDomain)
-			mqlDomainTyped.cacheCompartmentId = stringValue(d.CompartmentId)
-			mqlDomainTyped.cacheUrl = stringValue(d.Url)
-			res = append(res, mqlDomainTyped)
+		replicaRegions := make([]string, 0, len(d.ReplicaRegions))
+		for _, r := range d.ReplicaRegions {
+			replicaRegions = append(replicaRegions, stringValue(r.Region))
 		}
+
+		mqlDomain, err := CreateResource(o.MqlRuntime, "oci.identity.domain", map[string]*llx.RawData{
+			"id":              llx.StringDataPtr(d.Id),
+			"name":            llx.StringDataPtr(d.DisplayName),
+			"description":     llx.StringDataPtr(d.Description),
+			"type":            llx.StringData(string(d.Type)),
+			"licenseType":     llx.StringDataPtr(d.LicenseType),
+			"homeRegion":      llx.StringDataPtr(d.HomeRegion),
+			"replicaRegions":  llx.ArrayData(stringsToAny(replicaRegions), types.String),
+			"isHiddenOnLogin": llx.BoolData(boolValue(d.IsHiddenOnLogin)),
+			"state":           llx.StringData(string(d.LifecycleState)),
+			"created":         sdkTimeData(d.TimeCreated),
+			"freeformTags":    llx.MapData(strMapToAny(d.FreeformTags), types.String),
+			"definedTags":     llx.MapData(definedTagsToAny(d.DefinedTags), types.Any),
+		})
+		if err != nil {
+			return nil, err
+		}
+		mqlDomainTyped := mqlDomain.(*mqlOciIdentityDomain)
+		mqlDomainTyped.cacheCompartmentId = stringValue(d.CompartmentId)
+		mqlDomainTyped.cacheUrl = stringValue(d.Url)
+		res = append(res, mqlDomainTyped)
 	}
 
 	return res, nil
@@ -198,7 +247,7 @@ func (o *mqlOciIdentityDomain) users() ([]any, error) {
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, err
+			return nil, ociScimError(err, o.Name.Data, "users")
 		}
 
 		users = append(users, response.Users.Resources...)
@@ -314,7 +363,7 @@ func (o *mqlOciIdentityDomain) groups() ([]any, error) {
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, err
+			return nil, ociScimError(err, o.Name.Data, "groups")
 		}
 
 		groups = append(groups, response.Groups.Resources...)
@@ -370,7 +419,7 @@ func (o *mqlOciIdentityDomain) passwordPolicies() ([]any, error) {
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, err
+			return nil, ociScimError(err, o.Name.Data, "password policies")
 		}
 
 		policies = append(policies, response.PasswordPolicies.Resources...)
@@ -434,7 +483,7 @@ func (o *mqlOciIdentityDomain) authenticationFactorSettings() (*mqlOciIdentityDo
 	response, err := client.ListAuthenticationFactorSettings(context.Background(),
 		identitydomains.ListAuthenticationFactorSettingsRequest{})
 	if err != nil {
-		return nil, err
+		return nil, ociScimError(err, o.Name.Data, "authentication factor settings")
 	}
 
 	// The service models this as a collection, but a domain has exactly one
@@ -485,7 +534,7 @@ func (o *mqlOciIdentityDomain) apps() ([]any, error) {
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, err
+			return nil, ociScimError(err, o.Name.Data, "apps")
 		}
 
 		apps = append(apps, response.Apps.Resources...)

--- a/providers/oci/resources/messaging.go
+++ b/providers/oci/resources/messaging.go
@@ -185,6 +185,7 @@ type mqlOciStreamingStreamPoolInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *streaming.StreamPool
+	detailErr     error
 }
 
 // initOciStreamingStreamPool resolves a stream pool by OCID.
@@ -235,18 +236,22 @@ func (o *mqlOciStreamingStreamPool) compartment() (*mqlOciCompartment, error) {
 
 func (o *mqlOciStreamingStreamPool) getDetail() (*streaming.StreamPool, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.StreamAdminClient(o.cacheRegion)
 	if err != nil {
+		// Cache the failure next to the value. Otherwise every detail-backed
+		// field on this resource re-issues the same denied or missing lookup.
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -254,6 +259,8 @@ func (o *mqlOciStreamingStreamPool) getDetail() (*streaming.StreamPool, error) {
 		StreamPoolId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -428,6 +435,7 @@ type mqlOciQueueQueueInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *queue.Queue
+	detailErr     error
 }
 
 func (o *mqlOciQueueQueue) id() (string, error) {
@@ -440,18 +448,20 @@ func (o *mqlOciQueueQueue) compartment() (*mqlOciCompartment, error) {
 
 func (o *mqlOciQueueQueue) getDetail() (*queue.Queue, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.QueueAdminClient(o.cacheRegion)
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -459,6 +469,8 @@ func (o *mqlOciQueueQueue) getDetail() (*queue.Queue, error) {
 		QueueId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -610,6 +622,7 @@ type mqlOciKafkaClusterInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *managedkafka.KafkaCluster
+	detailErr     error
 }
 
 func (o *mqlOciKafkaCluster) id() (string, error) {
@@ -641,18 +654,20 @@ func (o *mqlOciKafkaCluster) subnets() ([]any, error) {
 
 func (o *mqlOciKafkaCluster) getDetail() (*managedkafka.KafkaCluster, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.KafkaClusterClient(o.cacheRegion)
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -660,6 +675,8 @@ func (o *mqlOciKafkaCluster) getDetail() (*managedkafka.KafkaCluster, error) {
 		KafkaClusterId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -2964,9 +2964,8 @@ private oci.audit.event @defaults("eventName principalName eventTime responseSta
   responseTime time
   // State transition the operation caused
   //
-  // Has `previousState` and `currentState` maps for operations that
-  // changed a resource's lifecycle state, and is empty for read-only
-  // calls.
+  // Has `previous` and `current` maps for operations that changed a
+  // resource's lifecycle state, and is empty for read-only calls.
   stateChange dict
   // Service-specific details recorded alongside the event
   additionalDetails dict
@@ -3010,7 +3009,7 @@ private oci.serviceConnectorHub.connector @defaults("name sourceKind targetKind 
   description string
   // Compartment containing the connector
   compartment() oci.compartment
-  // Connector lifecycle state (CREATING, UPDATING, ACTIVE, INACTIVE, DELETING, DELETED, FAILED)
+  // Connector lifecycle state (CREATING, UPDATING, ACTIVE, INACTIVE, NEEDS_ATTENTION, DELETING, DELETED, FAILED)
   state string
   // Detail explaining the current lifecycle state, for FAILED connectors
   stateDetails string
@@ -3613,7 +3612,7 @@ oci.resourceManager {
 // far in the past means the same thing. `jobs` lists the plan, apply,
 // destroy and drift-detection runs against the stack, which is the
 // change history for everything the stack manages.
-private oci.resourceManager.stack @defaults("name driftStatus state") {
+private oci.resourceManager.stack @defaults("name state terraformVersion") {
   // Stack OCID
   id string
   // Stack display name
@@ -3684,6 +3683,12 @@ private oci.resourceManager.job @defaults("name operation state") {
   name string
   // Compartment containing the job
   compartment() oci.compartment
+  // Stack the job ran against
+  //
+  // Every job belongs to a stack, so this is the route from a failed or
+  // rolled-back run to the configuration that produced it and to the
+  // Terraform state it manages.
+  stack() oci.resourceManager.stack
   // Operation the job performed (PLAN, APPLY, DESTROY, IMPORT_TF_STATE, PLAN_ROLLBACK, APPLY_ROLLBACK)
   operation string
   // Job lifecycle state (ACCEPTED, IN_PROGRESS, FAILED, SUCCEEDED, CANCELING, CANCELED)
@@ -3833,7 +3838,7 @@ private oci.queue.queue @defaults("name state") {
   timeoutInSeconds() int
   // Delivery attempts before a message moves to the dead-letter queue
   deadLetterQueueDeliveryCount() int
-  // Capabilities enabled on the queue (PRODUCER, CONSUMER)
+  // Capabilities enabled on the queue (CONSUMER_GROUPS, LARGE_MESSAGES)
   capabilities []string
   // Lifecycle state (CREATING, UPDATING, ACTIVE, INACTIVE, DELETING, DELETED, FAILED)
   state string

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -27902,7 +27902,7 @@ func (c *mqlOciCloudGuardTarget) GetSystemTags() *plugin.TValue[map[string]any] 
 type mqlOciCloudGuardDetectorRecipe struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlOciCloudGuardDetectorRecipeInternal it will be used here
+	mqlOciCloudGuardDetectorRecipeInternal
 	Id            plugin.TValue[string]
 	Name          plugin.TValue[string]
 	Description   plugin.TValue[string]

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -637,7 +637,7 @@ func init() {
 			Create: createOciResourceManager,
 		},
 		"oci.resourceManager.stack": {
-			// to override args, implement: initOciResourceManagerStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciResourceManagerStack,
 			Create: createOciResourceManagerStack,
 		},
 		"oci.resourceManager.job": {
@@ -4463,6 +4463,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.resourceManager.job.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciResourceManagerJob).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
+	"oci.resourceManager.job.stack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciResourceManagerJob).GetStack()).ToDataRes(types.Resource("oci.resourceManager.stack"))
 	},
 	"oci.resourceManager.job.operation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciResourceManagerJob).GetOperation()).ToDataRes(types.String)
@@ -13208,6 +13211,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.resourceManager.job.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciResourceManagerJob).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
+	"oci.resourceManager.job.stack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciResourceManagerJob).Stack, ok = plugin.RawToTValue[*mqlOciResourceManagerStack](v.Value, v.Error)
 		return
 	},
 	"oci.resourceManager.job.operation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31461,6 +31468,7 @@ type mqlOciResourceManagerJob struct {
 	Id          plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Compartment plugin.TValue[*mqlOciCompartment]
+	Stack       plugin.TValue[*mqlOciResourceManagerStack]
 	Operation   plugin.TValue[string]
 	State       plugin.TValue[string]
 	Created     plugin.TValue[*time.Time]
@@ -31525,6 +31533,22 @@ func (c *mqlOciResourceManagerJob) GetCompartment() *plugin.TValue[*mqlOciCompar
 		}
 
 		return c.compartment()
+	})
+}
+
+func (c *mqlOciResourceManagerJob) GetStack() *plugin.TValue[*mqlOciResourceManagerStack] {
+	return plugin.GetOrCompute[*mqlOciResourceManagerStack](&c.Stack, func() (*mqlOciResourceManagerStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.resourceManager.job", c.__id, "stack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciResourceManagerStack), nil
+			}
+		}
+
+		return c.stack()
 	})
 }
 

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -2283,6 +2283,7 @@ oci.resourceManager.job.finished 13.17.2
 oci.resourceManager.job.id 13.17.2
 oci.resourceManager.job.name 13.17.2
 oci.resourceManager.job.operation 13.17.2
+oci.resourceManager.job.stack 13.17.2
 oci.resourceManager.job.state 13.17.2
 oci.resourceManager.stack 13.17.2
 oci.resourceManager.stack.compartment 13.17.2

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -93,6 +93,7 @@ type mqlOciResourceManagerStackInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *resourcemanager.Stack
+	detailErr     error
 }
 
 func (o *mqlOciResourceManagerStack) id() (string, error) {
@@ -105,18 +106,22 @@ func (o *mqlOciResourceManagerStack) compartment() (*mqlOciCompartment, error) {
 
 func (o *mqlOciResourceManagerStack) getDetail() (*resourcemanager.Stack, error) {
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.ResourceManagerClient(o.cacheRegion)
 	if err != nil {
+		// Hold on to the error as well, so a stack that cannot be read is not
+		// requested again by every field that depends on this call.
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -124,6 +129,8 @@ func (o *mqlOciResourceManagerStack) getDetail() (*resourcemanager.Stack, error)
 		StackId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/resourcemanager"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -252,6 +254,7 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 		}
 		mqlJobTyped := mqlJob.(*mqlOciResourceManagerJob)
 		mqlJobTyped.cacheCompartmentId = stringValue(job.CompartmentId)
+		mqlJobTyped.cacheStackId = stringValue(job.StackId)
 		res = append(res, mqlJobTyped)
 	}
 
@@ -260,6 +263,7 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 
 type mqlOciResourceManagerJobInternal struct {
 	cacheCompartmentId string
+	cacheStackId       string
 }
 
 func (o *mqlOciResourceManagerJob) id() (string, error) {
@@ -268,4 +272,55 @@ func (o *mqlOciResourceManagerJob) id() (string, error) {
 
 func (o *mqlOciResourceManagerJob) compartment() (*mqlOciCompartment, error) {
 	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+}
+
+func (o *mqlOciResourceManagerJob) stack() (*mqlOciResourceManagerStack, error) {
+	if o.cacheStackId == "" {
+		o.Stack.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.resourceManager.stack", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheStackId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciResourceManagerStack), nil
+}
+
+// initOciResourceManagerStack resolves a stack by OCID.
+//
+// The job accessor above reaches a stack by id, and without an init
+// NewResource would build one from that id alone: correct cache key, every
+// other field unset, and a detail fetch pointed at no region. Resolving
+// through the stack listing hands back the populated resource instead.
+func initOciResourceManagerStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
+		return nil, nil, errors.New("id required to fetch oci.resourceManager.stack")
+	}
+
+	obj, err := CreateResource(runtime, "oci.resourceManager", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	rm := obj.(*mqlOciResourceManager)
+
+	rawStacks := rm.GetStacks()
+	if rawStacks.Error != nil {
+		return nil, nil, rawStacks.Error
+	}
+
+	for _, raw := range rawStacks.Data {
+		stack := raw.(*mqlOciResourceManagerStack)
+		if stack.Id.Data == idVal {
+			return args, stack, nil
+		}
+	}
+
+	return nil, nil, errors.New("oci.resourceManager.stack not found: " + idVal)
 }

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -106,6 +106,7 @@ type mqlOciServiceConnectorHubConnectorInternal struct {
 	detailLock    sync.Mutex
 	detailFetched atomic.Bool
 	detail        *sch.ServiceConnector
+	detailErr     error
 }
 
 func (o *mqlOciServiceConnectorHubConnector) id() (string, error) {
@@ -120,18 +121,22 @@ func (o *mqlOciServiceConnectorHubConnector) getDetail() (*sch.ServiceConnector,
 	// Fast path: five computed fields share this fetch, so after the first one
 	// the rest should not queue on the mutex just to read a cached pointer.
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	o.detailLock.Lock()
 	defer o.detailLock.Unlock()
 	if o.detailFetched.Load() {
-		return o.detail, nil
+		return o.detail, o.detailErr
 	}
 
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	client, err := conn.ServiceConnectorClient(o.cacheRegion)
 	if err != nil {
+		// The error is kept too. The fields sharing this fetch would each
+		// repeat the same failing request if only successes were remembered.
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 
@@ -139,6 +144,8 @@ func (o *mqlOciServiceConnectorHubConnector) getDetail() (*sch.ServiceConnector,
 		ServiceConnectorId: common.String(o.Id.Data),
 	})
 	if err != nil {
+		o.detailErr = err
+		o.detailFetched.Store(true)
 		return nil, err
 	}
 


### PR DESCRIPTION
> Stacked on #9606 (which is stacked on #9603). Review those first; this PR's diff is against #9606.

Four robustness defects from the OCI static review. None returns wrong data on its own, but each makes a scan noisier, slower, or harder to trust than it should be.

## A failed detail fetch was retried once per field

Nine lazy `getDetail` helpers guard themselves with `atomic.Bool` + mutex, but set the flag only on the success path:

```go
	response, err := client.GetDbSystem(...)
	if err != nil {
		return nil, err          // <- detailFetched stays false
	}
	o.detail = &response.DbSystem
	o.detailFetched.Store(true)
```

So a denied or deleted resource is re-requested by **every** computed field sharing the fetch. OCI's verb ladder splits `inspect` (grants `ListDbSystems`) from `read` (grants `GetDbSystem`), and a policy granting only `inspect database-family` is a documented least-privilege setup. Under it, one PostgreSQL DB system in an unreadable compartment issues **nine identical failing calls** — nine `.lr` fields go through `getDetail` — which is a good way to earn a 429 that then fails the compartments that *do* work.

Fixed in all nine: mysql, postgresql, opensearch, goldengate, stream pool, queue, kafka cluster, connector, resource-manager stack. The `atomic.Bool` + mutex double-check is unchanged.

## Global DNS zones were counted once per subscribed region

OCI serves public DNS from every regional endpoint, so the `ociRunCompartmentRegionPool` fan-out sees each global zone once per region. Since `CreateResource` returns the *cached instance* for an id it has already built, those repeats are the same pointer appearing N times rather than N distinct rows — `oci.dns.zones.length` multiplies by the region count, and `.where(...)` returns duplicates.

Zones and steering policies now pass through a shared `ociDedupeByID`. Private zones are genuinely regional and unaffected (they have distinct ids per region).

*The premise — that every regional endpoint returns the same global set — is the one thing here I could not settle from the SDK alone. The dedupe is harmless if it turns out not to.*

## Detector rules were scoped by a deprecated field

`rules()` passed `o.CompartmentID.Data` as the listing's compartment. That field is `@maturity("deprecated")` in favour of `compartment()`. A v14 deprecated-field sweep deleting it would have left the request scoped to the empty string with nothing to catch it — the load-bearing-deprecated-field pattern. It now reads a cached value on the Internal struct.

## Identity domain failures were unattributable, and the listing was serial

Reading a domain's users or groups needs a role granted **inside that domain** (Identity Domain Administrator, User Administrator), which is separate from the tenancy-level policy that lets `ListDomains` enumerate it. So a principal set up to read the tenancy lists every domain and then fails on all of them — with a raw SCIM error naming neither the domain nor the missing role. The error now says both.

It is deliberately **not** degraded to an empty collection. An empty user list cannot be told apart from a domain that has no users, and that is precisely the failure mode the rest of this review stack is about. A loud error is the right answer here.

Separately, `domains()` walked the compartment subtree one blocking request at a time. `GetCompartments` returns the whole tree, so on a tenancy with a few hundred compartments a single field access became a few hundred sequential round-trips. It now uses the same pool and the same denied-compartment accounting as every other lister.

One thing worth noting for reviewers: `ociCollectCompartmentJobs` joins results by asserting `job.Result.([]any)`, so a job returning a typed slice is silently dropped. The new job builds `[]any` directly for that reason.

## Tests

Both new pure helpers are covered. `ociDedupeByID` includes the case that motivated it (one resource returned N times), first-appearance ordering, and a non-resource passthrough — dropping an element the helper does not recognise would be a silent data loss of its own.

## Verification

`make providers/build/oci` clean, `go vet` clean, `gofmt` clean, `go test ./resources/` green. Not live-verified; no OCI tenancy available.
