### PR TITLE
📄 oci: correct enum and dict-key docs, add the job-to-stack edge

### DIFF
--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -416,10 +416,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 		rule := rules[i]
 
 		// Every field that decides whether the rule actually fires lives in
-		// DetectorDetails. A nil block means the API returned the rule without
-		// its configuration, so report it as disabled-unknown rather than
-		// defaulting isEnabled to false, which would read as an authoritative
-		// "this detection is off".
+		// DetectorDetails, which is optional on the summary. When it is absent
+		// these fall back to their zero values and isEnabled is emitted as an
+		// explicit false rather than left null, so an assertion over the rule
+		// fails instead of passing on a rule nobody could read. MQL evaluates
+		// null && null as true, so a null here would be the more dangerous
+		// answer.
 		var (
 			isEnabled              bool
 			riskLevel              string

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -2889,9 +2889,8 @@ private oci.audit.event @defaults("eventName principalName eventTime responseSta
   responseTime time
   // State transition the operation caused
   //
-  // Has `previousState` and `currentState` maps for operations that
-  // changed a resource's lifecycle state, and is empty for read-only
-  // calls.
+  // Has `previous` and `current` maps for operations that changed a
+  // resource's lifecycle state, and is empty for read-only calls.
   stateChange dict
   // Service-specific details recorded alongside the event
   additionalDetails dict
@@ -2935,7 +2934,7 @@ private oci.serviceConnectorHub.connector @defaults("name sourceKind targetKind 
   description string
   // Compartment containing the connector
   compartment() oci.compartment
-  // Connector lifecycle state (CREATING, UPDATING, ACTIVE, INACTIVE, DELETING, DELETED, FAILED)
+  // Connector lifecycle state (CREATING, UPDATING, ACTIVE, INACTIVE, NEEDS_ATTENTION, DELETING, DELETED, FAILED)
   state string
   // Detail explaining the current lifecycle state, for FAILED connectors
   stateDetails string
@@ -3538,7 +3537,7 @@ oci.resourceManager {
 // far in the past means the same thing. `jobs` lists the plan, apply,
 // destroy and drift-detection runs against the stack, which is the
 // change history for everything the stack manages.
-private oci.resourceManager.stack @defaults("name driftStatus state") {
+private oci.resourceManager.stack @defaults("name state terraformVersion") {
   // Stack OCID
   id string
   // Stack display name
@@ -3609,6 +3608,12 @@ private oci.resourceManager.job @defaults("name operation state") {
   name string
   // Compartment containing the job
   compartment() oci.compartment
+  // Stack the job ran against
+  //
+  // Every job belongs to a stack, so this is the route from a failed or
+  // rolled-back run to the configuration that produced it and to the
+  // Terraform state it manages.
+  stack() oci.resourceManager.stack
   // Operation the job performed (PLAN, APPLY, DESTROY, IMPORT_TF_STATE, PLAN_ROLLBACK, APPLY_ROLLBACK)
   operation string
   // Job lifecycle state (ACCEPTED, IN_PROGRESS, FAILED, SUCCEEDED, CANCELING, CANCELED)
@@ -3758,7 +3763,7 @@ private oci.queue.queue @defaults("name state") {
   timeoutInSeconds() int
   // Delivery attempts before a message moves to the dead-letter queue
   deadLetterQueueDeliveryCount() int
-  // Capabilities enabled on the queue (PRODUCER, CONSUMER)
+  // Capabilities enabled on the queue (CONSUMER_GROUPS, LARGE_MESSAGES)
   capabilities []string
   // Lifecycle state (CREATING, UPDATING, ACTIVE, INACTIVE, DELETING, DELETED, FAILED)
   state string

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -632,7 +632,7 @@ func init() {
 			Create: createOciResourceManager,
 		},
 		"oci.resourceManager.stack": {
-			// to override args, implement: initOciResourceManagerStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciResourceManagerStack,
 			Create: createOciResourceManagerStack,
 		},
 		"oci.resourceManager.job": {
@@ -4419,6 +4419,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.resourceManager.job.compartment": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciResourceManagerJob).GetCompartment()).ToDataRes(types.Resource("oci.compartment"))
+	},
+	"oci.resourceManager.job.stack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciResourceManagerJob).GetStack()).ToDataRes(types.Resource("oci.resourceManager.stack"))
 	},
 	"oci.resourceManager.job.operation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciResourceManagerJob).GetOperation()).ToDataRes(types.String)
@@ -13108,6 +13111,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.resourceManager.job.compartment": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciResourceManagerJob).Compartment, ok = plugin.RawToTValue[*mqlOciCompartment](v.Value, v.Error)
+		return
+	},
+	"oci.resourceManager.job.stack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciResourceManagerJob).Stack, ok = plugin.RawToTValue[*mqlOciResourceManagerStack](v.Value, v.Error)
 		return
 	},
 	"oci.resourceManager.job.operation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31209,6 +31216,7 @@ type mqlOciResourceManagerJob struct {
 	Id          plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Compartment plugin.TValue[*mqlOciCompartment]
+	Stack       plugin.TValue[*mqlOciResourceManagerStack]
 	Operation   plugin.TValue[string]
 	State       plugin.TValue[string]
 	Created     plugin.TValue[*time.Time]
@@ -31273,6 +31281,22 @@ func (c *mqlOciResourceManagerJob) GetCompartment() *plugin.TValue[*mqlOciCompar
 		}
 
 		return c.compartment()
+	})
+}
+
+func (c *mqlOciResourceManagerJob) GetStack() *plugin.TValue[*mqlOciResourceManagerStack] {
+	return plugin.GetOrCompute[*mqlOciResourceManagerStack](&c.Stack, func() (*mqlOciResourceManagerStack, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.resourceManager.job", c.__id, "stack")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciResourceManagerStack), nil
+			}
+		}
+
+		return c.stack()
 	})
 }
 

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -2269,6 +2269,7 @@ oci.resourceManager.job.finished 13.17.2
 oci.resourceManager.job.id 13.17.2
 oci.resourceManager.job.name 13.17.2
 oci.resourceManager.job.operation 13.17.2
+oci.resourceManager.job.stack 13.17.2
 oci.resourceManager.job.state 13.17.2
 oci.resourceManager.stack 13.17.2
 oci.resourceManager.stack.compartment 13.17.2

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/resourcemanager"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -252,6 +254,7 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 		}
 		mqlJobTyped := mqlJob.(*mqlOciResourceManagerJob)
 		mqlJobTyped.cacheCompartmentId = stringValue(job.CompartmentId)
+		mqlJobTyped.cacheStackId = stringValue(job.StackId)
 		res = append(res, mqlJobTyped)
 	}
 
@@ -260,6 +263,7 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 
 type mqlOciResourceManagerJobInternal struct {
 	cacheCompartmentId string
+	cacheStackId       string
 }
 
 func (o *mqlOciResourceManagerJob) id() (string, error) {
@@ -268,4 +272,55 @@ func (o *mqlOciResourceManagerJob) id() (string, error) {
 
 func (o *mqlOciResourceManagerJob) compartment() (*mqlOciCompartment, error) {
 	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+}
+
+func (o *mqlOciResourceManagerJob) stack() (*mqlOciResourceManagerStack, error) {
+	if o.cacheStackId == "" {
+		o.Stack.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(o.MqlRuntime, "oci.resourceManager.stack", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheStackId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciResourceManagerStack), nil
+}
+
+// initOciResourceManagerStack resolves a stack by OCID.
+//
+// The job accessor above reaches a stack by id, and without an init
+// NewResource would build one from that id alone: correct cache key, every
+// other field unset, and a detail fetch pointed at no region. Resolving
+// through the stack listing hands back the populated resource instead.
+func initOciResourceManagerStack(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
+		return nil, nil, errors.New("id required to fetch oci.resourceManager.stack")
+	}
+
+	obj, err := CreateResource(runtime, "oci.resourceManager", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	rm := obj.(*mqlOciResourceManager)
+
+	rawStacks := rm.GetStacks()
+	if rawStacks.Error != nil {
+		return nil, nil, rawStacks.Error
+	}
+
+	for _, raw := range rawStacks.Data {
+		stack := raw.(*mqlOciResourceManagerStack)
+		if stack.Id.Data == idVal {
+			return args, stack, nil
+		}
+	}
+
+	return nil, nil, errors.New("oci.resourceManager.stack not found: " + idVal)
 }


### PR DESCRIPTION
> Top of a four-PR stack: #9603 → #9606 → #9609 → this. Review the others first; this PR's diff is against #9609.

Documentation and data-model papercuts from the OCI static review. Nothing here changes what an existing query returns.

## Three schema descriptions named values that do not exist

| Field | Documented | Actual (SDK) |
|---|---|---|
| `oci.audit.event.stateChange` | `previousState`, `currentState` | `previous`, `current` — `audit/state_change.go:26,31` |
| `oci.queue.queue.capabilities` | `PRODUCER`, `CONSUMER` | `CONSUMER_GROUPS`, `LARGE_MESSAGES` — `queue/queue_capability.go:21` |
| `oci.serviceConnectorHub.connector.state` | list omitted `NEEDS_ATTENTION` | `sch/lifecycle_state.go` includes it |

The `stateChange` one is the sharpest: a policy written from the docs — `stateChange["previousState"] != null` — indexes into nothing and quietly matches no rows. The Go side was always correct; only the documentation was wrong.

`NEEDS_ATTENTION` matters because it is the state a connector lands in when it has *stopped moving data* while still looking configured — the one an operator most wants to catch, and it was missing from the list a policy author would enumerate.

## A code comment described the opposite of its code

The detector-rule mapper claimed it avoided defaulting `isEnabled` to false:

```go
// ...so report it as disabled-unknown rather than defaulting isEnabled to
// false, which would read as an authoritative "this detection is off".
var ( isEnabled bool )   // <- zero value: false, emitted explicitly
```

**The code is right.** MQL evaluates `null && null` as `true`, so a null there would let an assertion pass on a rule nobody could read; an explicit `false` makes it fail. The comment now says what the code does and why, so the next reader doesn't "fix" it into a real bug.

## A bare stack listing made one API call per stack

`driftStatus` is detail-only (`StackSummary` genuinely lacks it — the detail call is unavoidable) and was in the stack's `@defaults`. So typing `oci.resourceManager.stacks` in the shell with no block issued a `GetStack` for every stack in the tenancy. Defaults are now three fields the listing already returns; drift is still there for anyone who asks for it.

## A job could not reach its stack

Every Resource Manager job carries `StackId` — the route from a failed or rolled-back run to the configuration that produced it. It was unexposed.

Adding the accessor required adding `initOciResourceManagerStack` too: without an init, `NewResource` builds the stack from the id alone, leaving every other field unset and its detail fetch pointed at no region. That is the husk bug fixed for stream pools in #9606, and it would have been reintroduced here.

New field versioned `13.17.2`; `config.go` `Version` untouched.

## Deliberately not included

Typed `oci.region` accessors for the identity domain's `homeRegion` and `replicaRegions`, which the review flagged as a typed-reference gap.

`oci.region` is keyed on the region **key** (`IAD`) while `DomainSummary.HomeRegion` reports a region whose format the SDK doc does not specify — and OCI's identity-domain docs suggest the region **name** (`us-phoenix-1`). Resolving a name against a key-keyed init would produce a reference that silently fails, which is exactly the bug class this stack exists to remove. It needs one live tenancy to settle; I'd rather leave the raw strings than ship a guess.

## Verification

`make providers/build/oci` clean, `go vet` clean, `gofmt` clean, `go test ./resources/` green. Generated files refreshed. Not live-verified.
