### PR TITLE
🐛 gcp: fix cache-key collisions, discarded partial results, and hard-failing listers

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -203,7 +203,7 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 				}
 			}
 			mqlA, err := CreateResource(g.MqlRuntime, "gcp.project.bigqueryService.dataset.accessEntry", map[string]*llx.RawData{
-				"id":         llx.StringData(fmt.Sprintf("gcp.project.bigqueryService.dataset/%s/%s/accessEntry/%s/%s/%s", projectId, dataset.DatasetID, a.Role, entityTypeToString(a.EntityType), a.Entity)),
+				"id":         llx.StringData(fmt.Sprintf("gcp.project.bigqueryService.dataset/%s/%s/accessEntry/%s/%s/%s", projectId, dataset.DatasetID, a.Role, entityTypeToString(a.EntityType), accessEntryKey(a))),
 				"datasetId":  llx.StringData(dataset.DatasetID),
 				"role":       llx.StringData(string(a.Role)),
 				"entityType": llx.StringData(entityTypeToString(a.EntityType)),
@@ -815,6 +815,29 @@ func (g *mqlGcpProjectBigqueryServiceRoutine) id() (string, error) {
 	// Routine IDs are unique only within a dataset, so qualify with
 	// project + dataset (matches the model/table ids).
 	return fmt.Sprintf("gcp.project.bigqueryService.routine/%s/%s/%s", g.ProjectId.Data, g.DatasetId.Data, g.Id.Data), nil
+}
+
+// accessEntryKey returns the value that identifies a dataset access entry
+// within its (role, entityType) pair.
+//
+// For most entity kinds that is AccessEntry.Entity, but the BigQuery SDK
+// decoder leaves Entity EMPTY for view, routine and dataset entries and records
+// the reference in the typed View/Routine/Dataset field instead. Keying the
+// resource on Entity alone therefore produced the identical id for every
+// authorized view on a dataset, and CreateResource returned the first one for
+// all of them -- so a dataset sharing three views reported the same view three
+// times.
+func accessEntryKey(a *bigquery.AccessEntry) string {
+	switch {
+	case a.View != nil:
+		return fmt.Sprintf("%s:%s:%s", a.View.ProjectID, a.View.DatasetID, a.View.TableID)
+	case a.Routine != nil:
+		return fmt.Sprintf("%s:%s:%s", a.Routine.ProjectID, a.Routine.DatasetID, a.Routine.RoutineID)
+	case a.Dataset != nil:
+		return fmt.Sprintf("%s:%s", a.Dataset.Dataset.ProjectID, a.Dataset.Dataset.DatasetID)
+	default:
+		return a.Entity
+	}
 }
 
 func entityTypeToString(entityType bigquery.EntityType) string {

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -20,6 +20,26 @@ import (
 	"google.golang.org/api/option"
 )
 
+// bigtablePartialResult reports whether err is the Bigtable SDK's
+// ErrPartiallyUnavailable, which the admin client returns ALONGSIDE a populated
+// result slice when some locations are unreachable ("Return partial results and
+// an error in case of some locations are unavailable").
+//
+// It is a plain struct with no GRPCStatus(), so status.FromError does not
+// recognise it and isGRPCSkippable returns false -- the callers therefore took
+// the hard-error path and threw away the instances, clusters or backups the SDK
+// had just handed them. A transient blip in one region emptied the whole
+// Bigtable inventory.
+func bigtablePartialResult(err error, what string) bool {
+	var partial bigtable.ErrPartiallyUnavailable
+	if !errors.As(err, &partial) {
+		return false
+	}
+	log.Warn().Strs("locations", partial.Locations).Str("kind", what).
+		Msg("some Bigtable locations were unreachable; returning partial results")
+	return true
+}
+
 // bigtableAdminScopes are the OAuth scopes needed for Bigtable admin operations.
 var bigtableAdminScopes = []string{
 	bigtable.AdminScope,
@@ -136,11 +156,14 @@ func (g *mqlGcpProjectBigtableService) instances() ([]any, error) {
 
 	instances, err := iac.Instances(ctx)
 	if err != nil {
-		if isGRPCSkippable(err) {
-			log.Warn().Err(err).Msg("could not list Bigtable instances")
-			return nil, nil
+		if !bigtablePartialResult(err, "instances") {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list Bigtable instances")
+				return nil, nil
+			}
+			return nil, err
 		}
-		return nil, err
+		// fall through: instances holds the reachable locations' results
 	}
 
 	res := make([]any, 0, len(instances))
@@ -223,7 +246,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) clusters() ([]any, error) {
 	defer iac.Close()
 
 	clusters, err := iac.Clusters(ctx, instanceName)
-	if err != nil {
+	if err != nil && !bigtablePartialResult(err, "clusters") {
 		if isGRPCSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Bigtable clusters")
 			return nil, nil
@@ -610,7 +633,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 	defer iac.Close()
 
 	clusters, err := iac.Clusters(ctx, instanceName)
-	if err != nil {
+	if err != nil && !bigtablePartialResult(err, "clusters") {
 		if isGRPCSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Bigtable clusters for backup lookup")
 			return nil, nil

--- a/providers/gcp/resources/cache_keys_test.go
+++ b/providers/gcp/resources/cache_keys_test.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAccessEntryKeyDistinguishesReferenceEntries pins the identity of a
+// BigQuery dataset access entry.
+//
+// The SDK decoder leaves AccessEntry.Entity EMPTY for view, routine and dataset
+// entries and records the reference in the typed field instead. Keying the
+// resource on Entity alone therefore produced the identical cache key for every
+// authorized view on a dataset, and CreateResource returns the FIRST resource
+// stored under a key -- so a dataset sharing three views reported the same view
+// three times.
+func TestAccessEntryKeyDistinguishesReferenceEntries(t *testing.T) {
+	viewA := &bigquery.AccessEntry{
+		EntityType: bigquery.ViewEntity,
+		View:       &bigquery.Table{ProjectID: "p", DatasetID: "d", TableID: "view_a"},
+	}
+	viewB := &bigquery.AccessEntry{
+		EntityType: bigquery.ViewEntity,
+		View:       &bigquery.Table{ProjectID: "p", DatasetID: "d", TableID: "view_b"},
+	}
+
+	assert.NotEqual(t, accessEntryKey(viewA), accessEntryKey(viewB),
+		"two authorized views on the same dataset must not share a cache key")
+	assert.Equal(t, "p:d:view_a", accessEntryKey(viewA))
+
+	t.Run("routine", func(t *testing.T) {
+		r := &bigquery.AccessEntry{
+			EntityType: bigquery.RoutineEntity,
+			Routine:    &bigquery.Routine{ProjectID: "p", DatasetID: "d", RoutineID: "fn"},
+		}
+		assert.Equal(t, "p:d:fn", accessEntryKey(r))
+	})
+
+	t.Run("dataset", func(t *testing.T) {
+		d := &bigquery.AccessEntry{
+			EntityType: bigquery.DatasetEntity,
+			Dataset: &bigquery.DatasetAccessEntry{
+				Dataset: &bigquery.Dataset{ProjectID: "p", DatasetID: "shared"},
+			},
+		}
+		assert.Equal(t, "p:shared", accessEntryKey(d))
+	})
+
+	t.Run("plain entity kinds keep using Entity", func(t *testing.T) {
+		u := &bigquery.AccessEntry{EntityType: bigquery.UserEmailEntity, Entity: "a@b.com"}
+		assert.Equal(t, "a@b.com", accessEntryKey(u))
+
+		g := &bigquery.AccessEntry{EntityType: bigquery.SpecialGroupEntity, Entity: "allAuthenticatedUsers"}
+		assert.Equal(t, "allAuthenticatedUsers", accessEntryKey(g))
+	})
+}
+
+// TestMachineTypeIDIsZoneQualified pins the machine-type cache key.
+//
+// A machine type is a per-zone catalogue entry whose numeric id is a catalogue
+// CONSTANT: e2-medium carries the same Id in every zone. A key of
+// (project, id) therefore collapsed every zone's copy onto one cache entry, so
+// machineTypes() returned N duplicates all reporting the first zone, and
+// machineTypeByZoneAndName -- which indexes on zone+name -- only ever saw that
+// one zone, silently falling back to a per-instance MachineTypes.Get for every
+// VM elsewhere.
+func TestMachineTypeIDIsZoneQualified(t *testing.T) {
+	a := machineTypeID("my-project", "us-central1-a", "e2-medium")
+	b := machineTypeID("my-project", "us-central1-b", "e2-medium")
+	assert.NotEqual(t, a, b, "the same machine type in two zones must not share a cache key")
+
+	// Different projects must stay distinct too.
+	assert.NotEqual(t,
+		machineTypeID("project-a", "us-central1-a", "e2-medium"),
+		machineTypeID("project-b", "us-central1-a", "e2-medium"))
+
+	// And different types within one zone.
+	assert.NotEqual(t,
+		machineTypeID("p", "us-central1-a", "e2-medium"),
+		machineTypeID("p", "us-central1-a", "e2-standard-2"))
+
+	assert.Equal(t,
+		"gcp.project.computeService.machineType/p/us-central1-a/e2-medium",
+		machineTypeID("p", "us-central1-a", "e2-medium"))
+}

--- a/providers/gcp/resources/composer.go
+++ b/providers/gcp/resources/composer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -138,9 +139,15 @@ func (g *mqlGcpProjectComposerService) environments() ([]any, error) {
 			return nil
 		}); err != nil {
 			if composerServiceDisabled(err) {
-				// The Cloud Composer API is not enabled for the project; it
-				// is disabled project-wide, so no other region would succeed.
-				return []any{}, nil
+				// Cloud Composer is not offered in every Compute region, and
+				// this classifier treats any 404 as "not available here". It is
+				// therefore a PER-REGION signal, not a project-wide one:
+				// returning an empty slice here discarded every environment
+				// already collected from the regions that did answer, so a
+				// project with a dozen environments reported none.
+				log.Debug().Str("project", projectId).Str("region", region.Name).
+					Msg("cloud composer not available in region, skipping")
+				continue
 			}
 			// Surface transient or server-side errors instead of silently
 			// dropping this region's environments from the result set.

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -320,6 +320,17 @@ func (g *mqlGcpProjectComputeService) zones() ([]any, error) {
 	return res, nil
 }
 
+// machineTypeID builds the cache key for a machine type. The zone is part of
+// the key because a machine type is a per-zone catalogue entry and its numeric
+// id is shared across zones.
+func machineTypeID(projectId, zoneName, name string) string {
+	return "gcp.project.computeService.machineType/" + projectId + "/" + zoneName + "/" + name
+}
+
+// id is the fallback for a machine type built without an explicit "__id".
+// It cannot see the zone (the field holds a resource, not a name, and may not
+// be set yet at construction time), so newMqlMachineType passes "__id"
+// directly, which wins over this method.
 func (g *mqlGcpProjectComputeServiceMachineType) id() (string, error) {
 	if g.Id.Error != nil {
 		return "", g.Id.Error
@@ -341,6 +352,15 @@ func (g *mqlGcpProjectComputeServiceMachineType) zone() (any, error) {
 
 func newMqlMachineType(runtime *plugin.Runtime, entry *compute.MachineType, projectId string, zone *mqlGcpProjectComputeServiceZone) (*mqlGcpProjectComputeServiceMachineType, error) {
 	res, err := CreateResource(runtime, "gcp.project.computeService.machineType", map[string]*llx.RawData{
+		// Machine types are a per-zone catalogue and the numeric id is a
+		// catalogue constant: e2-medium carries the same Id in every zone. An
+		// id() keyed on (project, id) therefore collapsed every zone's copy
+		// onto one cache entry, so machineTypes() returned N duplicates all
+		// reporting the FIRST zone -- and machineTypeByZoneAndName, which
+		// indexes on zone+name, only ever saw that one zone, silently falling
+		// back to a per-instance MachineTypes.Get for every VM elsewhere.
+		// An explicit __id wins over id(); see the note on id() below.
+		"__id":                         llx.StringData(machineTypeID(projectId, zone.GetName().Data, entry.Name)),
 		"id":                           llx.StringData(strconv.FormatInt(int64(entry.Id), 10)),
 		"projectId":                    llx.StringData(projectId),
 		"name":                         llx.StringData(entry.Name),
@@ -4034,7 +4054,12 @@ func (g *mqlGcpProjectComputeServiceImage) iamPolicy() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return computeIamBindingsToResources(g.MqlRuntime, name, policy.Bindings)
+	// Qualify the binding ids by resource type and project. Keying on the bare
+	// name aliased an image and a snapshot that share a name (and the same
+	// image name across two scanned projects) onto one set of bindings, so a
+	// public image could read as private from whichever resolved first.
+	return computeIamBindingsToResources(g.MqlRuntime,
+		"gcp.project.computeService.image/"+projectId+"/"+name, policy.Bindings)
 }
 
 func (g *mqlGcpProjectComputeServiceInstance) hasPublicIp() (bool, error) {
@@ -4116,7 +4141,8 @@ func (g *mqlGcpProjectComputeServiceSnapshot) iamPolicy() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return computeIamBindingsToResources(g.MqlRuntime, name, policy.Bindings)
+	return computeIamBindingsToResources(g.MqlRuntime,
+		"gcp.project.computeService.snapshot/"+projectId+"/"+name, policy.Bindings)
 }
 
 func (g *mqlGcpProjectComputeServiceSnapshot) public() (bool, error) {

--- a/providers/gcp/resources/essential_contacts.go
+++ b/providers/gcp/resources/essential_contacts.go
@@ -61,6 +61,15 @@ func essentialContactsForParent(runtime *plugin.Runtime, conn *connection.GcpCon
 		err = contactSvc.Projects.Contacts.List(parent).Pages(ctx, process)
 	}
 	if err != nil {
+		// Only the project path is gated on isServiceEnabled; the organization
+		// and folder paths reach the API directly, and org-level
+		// essentialcontacts.contacts.list is a separate grant a project-scoped
+		// principal rarely holds. Degrade so one missing grant at the org node
+		// does not fail the whole query.
+		if isHTTPSkippable(err) {
+			log.Warn().Err(err).Str("parent", parent).Msg("could not list essential contacts")
+			return nil, nil
+		}
 		return nil, err
 	}
 	return mqlContacts, nil

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1359,7 +1359,7 @@ private gcp.resourcemanager.binding {
   //
   // True when the role is one of roles/iam.serviceAccountTokenCreator,
   // roles/iam.serviceAccountUser, roles/iam.workloadIdentityUser, or
-  // roles/iam.serviceAccountKeyAdmin — the roles that surface
+  // roles/iam.serviceAccountKeyAdmin. These are the roles that surface
   // impersonation and privilege-escalation paths.
   grantsImpersonation() bool
 }
@@ -3309,15 +3309,20 @@ private gcp.project.sqlService.instance @defaults("name") {
   replicas() []gcp.project.sqlService.instance
   // Detailed Cloud SQL instance configuration (tier, flags, backups, network, IAM)
   settings gcp.project.sqlService.instance.settings
-  // Whether the instance is reachable on a public IP — flat hoist of settings.ipConfiguration.ipv4Enabled
+  // Whether the instance is reachable on a public IP (flat hoist of settings.ipConfiguration.ipv4Enabled)
   publicIpEnabled() bool
   // Whether the instance is reachable from the internet (a public IP and an authorized network open to 0.0.0.0/0)
   internetReachable() bool
-  // Whether IAM database authentication is enabled — true when the cloudsql.iam_authentication database flag is on
+  // Whether IAM database authentication is enabled
+  //
+  // True when the Cloud SQL IAM authentication database flag is on. Cloud SQL
+  // spells that flag differently per engine (cloudsql.iam_authentication on
+  // PostgreSQL, cloudsql_iam_authentication on MySQL, and
+  // "cloudsql iam authentication" on SQL Server); all three are recognized.
   iamAuthenticationEnabled() bool
-  // Whether automated backups are enabled — flat hoist of settings.backupConfiguration.enabled
+  // Whether automated backups are enabled (flat hoist of settings.backupConfiguration.enabled)
   backupConfigurationEnabled() bool
-  // Whether point-in-time recovery is enabled — flat hoist of settings.backupConfiguration.pointInTimeRecoveryEnabled
+  // Whether point-in-time recovery is enabled (flat hoist of settings.backupConfiguration.pointInTimeRecoveryEnabled)
   pointInTimeRecoveryEnabled() bool
   // Whether the instance has any built-in (non-IAM) database users
   hasBuiltInUsers() bool
@@ -4039,7 +4044,7 @@ private gcp.project.bigqueryService.table @defaults("id") {
   // and other BigQuery types), `Description`, `Required`, `Repeated`, and a
   // nested `Schema` list for RECORD fields.
   schema []dict
-  // Cloud DLP table data profile for this table — sensitivity score, risk level, and predicted infoTypes. Null when discovery has not profiled this table
+  // Cloud DLP table data profile for this table: sensitivity score, risk level, and predicted infoTypes. Null when discovery has not profiled this table
   dlpDataProfile() gcp.project.dlpService.tableDataProfile
   // IAM policy bindings that grant access to this table or view
   iamPolicy() []gcp.resourcemanager.binding
@@ -4446,7 +4451,7 @@ private gcp.project.dnsService.responsePolicy @defaults("responsePolicyName") {
 // Google Kubernetes Engine (GKE)
 //
 // Use this resource as the entry point for GKE in the project. It hosts
-// the project's `clusters` — each exposing its node pools, network and
+// the project's `clusters`, each exposing its node pools, network and
 // control-plane configuration, workload identity, binary authorization,
 // release channel, and security posture for Kubernetes audits.
 private gcp.project.gkeService {
@@ -5868,7 +5873,7 @@ private gcp.project.kmsService.ekmConnection @defaults("name keyManagementMode l
   cryptoSpacePath string
   // Service Directory resolvers identifying the reachable EKM replicas
   //
-  // Each entry exposes `serviceDirectoryService` (the Service Directory service pointing to an EKM replica), `endpointFilter` (optional endpoint filter), `hostname` (the EKM replica hostname used at the TLS and HTTP layers), and `serverCertificates` (the leaf certificates the EKM presents — each carries its issuer, subject, validity window, fingerprints, and the raw PEM).
+  // Each entry exposes `serviceDirectoryService` (the Service Directory service pointing to an EKM replica), `endpointFilter` (optional endpoint filter), `hostname` (the EKM replica hostname used at the TLS and HTTP layers), and `serverCertificates` (the leaf certificates the EKM presents, each carrying its issuer, subject, validity window, fingerprints, and the raw PEM).
   serviceResolvers []dict
 }
 
@@ -6591,7 +6596,7 @@ private gcp.project.iamService.workloadIdentityPool.provider @defaults("displayN
   attributeCondition string
   // Whether an attribute condition is set on the provider
   //
-  // When false, every external token that satisfies the mapping is accepted —
+  // When false, every external token that satisfies the mapping is accepted,
   // the classic over-broad workload-identity-federation misconfiguration.
   hasAttributeCondition() bool
   // Discriminator for which credential family this provider trusts: `aws`, `oidc`, `saml`, or `x509`.
@@ -9197,7 +9202,7 @@ private gcp.project.spannerService.instance.instancePartition @defaults("name") 
 // Google Cloud (GCP) Bigtable
 //
 // Use this resource as the entry point for Bigtable in the project. It
-// hosts the project's `instances` — each exposing its clusters, app
+// hosts the project's `instances`, each exposing its clusters, app
 // profiles, storage type, and encryption configuration for wide-column
 // database audits.
 private gcp.project.bigtableService {
@@ -10565,7 +10570,7 @@ private gcp.project.certificateManagerService.certificateMapEntry @defaults("nam
 // DNS authorization used to prove domain ownership when issuing
 // Google-managed certificates. Each authorization covers a single `domain`
 // and its wildcard. `dnsResourceRecord` is the CNAME the operator must
-// publish under the domain's DNS zone — once that record resolves, Google
+// publish under the domain's DNS zone. Once that record resolves, Google
 // can mint managed certs for the domain. `type` distinguishes
 // `FIXED_RECORD` (a stable per-authorization CNAME target) from
 // `PER_PROJECT_RECORD` (a shared per-project CNAME target, available only
@@ -16387,7 +16392,7 @@ private gcp.project.containerAnalysisService {
   projectId string
   // Vulnerability occurrences
   occurrences() []gcp.project.containerAnalysisService.occurrence
-  // Notes — the metadata definitions (vulnerability, attestation authority, build provenance, ...) that occurrences reference
+  // Notes: the metadata definitions (vulnerability, attestation authority, build provenance, ...) that occurrences reference
   notes() []gcp.project.containerAnalysisService.note
 }
 
@@ -17800,7 +17805,7 @@ private gcp.project.datastreamService.route @defaults("name destinationAddress")
 //
 // Use this resource as the entry point for the unified Memorystore service
 // (Valkey and Redis) in the project. It hosts the project's `instances`
-// and the `backupCollections` that retain their backups — exposing node
+// and the `backupCollections` that retain their backups, exposing node
 // configuration, persistence, and encryption settings for cache-tier
 // audits.
 private gcp.project.memorystoreService {

--- a/providers/gcp/resources/sourcerepo.go
+++ b/providers/gcp/resources/sourcerepo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -82,6 +83,15 @@ func (g *mqlGcpProjectSourceRepositoriesService) repos() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
+		// Cloud Source Repositories is off by default and is unavailable
+		// altogether to projects that had not used it before June 2024, so a
+		// 403 SERVICE_DISABLED is the COMMON case here, not an exceptional one.
+		// service_sourcerepo is declared in services.go but was never wired to
+		// a gate, so this accessor hard-failed on most projects.
+		if isHTTPSkippable(err) {
+			log.Warn().Err(err).Str("project", projectId).Msg("could not list Cloud Source Repositories")
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -865,6 +865,13 @@ func (g *mqlGcpProjectSqlServiceInstance) databases() ([]any, error) {
 
 	dbs, err := sqladminSvc.Databases.List(projectId, instanceName).Do()
 	if err != nil {
+		// A principal often holds cloudsql.instances.list without the
+		// per-instance sub-collection permissions. Degrade to null so the
+		// instance still reports, rather than failing the whole query.
+		if isHTTPSkippable(err) {
+			log.Warn().Err(err).Str("instance", instanceName).Msg("could not list Cloud SQL databases")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -1119,6 +1126,13 @@ func (g *mqlGcpProjectSqlServiceInstance) users() ([]any, error) {
 
 	resp, err := sqladminSvc.Users.List(projectId, instanceName).Do()
 	if err != nil {
+		// hasBuiltInUsers() and localRootEnabled() both read this collection,
+		// so propagating a 403 here failed the two headline Cloud SQL
+		// hardening checks with an opaque error.
+		if isHTTPSkippable(err) {
+			log.Warn().Err(err).Str("instance", instanceName).Msg("could not list Cloud SQL users")
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -1201,6 +1215,10 @@ func (g *mqlGcpProjectSqlServiceInstance) sslCerts() ([]any, error) {
 
 	resp, err := sqladminSvc.SslCerts.List(projectId, instanceName).Do()
 	if err != nil {
+		if isHTTPSkippable(err) {
+			log.Warn().Err(err).Str("instance", instanceName).Msg("could not list Cloud SQL SSL certificates")
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -13,6 +13,7 @@ import (
 	aiplatform "cloud.google.com/go/aiplatform/apiv1"
 	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -199,15 +200,36 @@ func (g *mqlGcpProjectVertexaiService) listAcrossRegions(
 	}
 	wg.Wait()
 
-	var res []any
+	// A single region failing must not discard the ~33 that succeeded. Vertex
+	// AI fans out over one regional endpoint per region, so any one of them can
+	// return Unavailable, DeadlineExceeded or ResourceExhausted independently --
+	// none of which isVertexAIRegionSkippable covers -- and the whole inventory
+	// used to disappear behind it. Only report an error when EVERY region
+	// failed, which is the case that actually means "this did not work".
+	var (
+		res       []any
+		firstErr  error
+		failed    int
+		attempted int
+	)
 	for _, r := range results {
+		attempted++
 		if r.err != nil {
-			return nil, r.err
+			failed++
+			if firstErr == nil {
+				firstErr = r.err
+			}
+			log.Warn().Err(r.err).Str("kind", kind).Str("region", r.region).
+				Msg("vertexai region listing failed, continuing with the remaining regions")
+			continue
 		}
 		if r.skipped {
 			g.markRegionSkipped(kind, r.region)
 		}
 		res = append(res, r.items...)
+	}
+	if attempted > 0 && failed == attempted {
+		return nil, firstErr
 	}
 	return res, nil
 }
@@ -246,7 +268,10 @@ func (g *mqlGcpProjectVertexaiService) models() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -357,7 +382,10 @@ func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -663,7 +691,10 @@ func (g *mqlGcpProjectVertexaiService) pipelineJobs() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -826,7 +857,10 @@ func (g *mqlGcpProjectVertexaiService) datasets() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -902,7 +936,10 @@ func (g *mqlGcpProjectVertexaiService) featureOnlineStores() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -994,7 +1031,10 @@ func (g *mqlGcpProjectVertexaiService) tensorboards() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -1403,7 +1443,10 @@ func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -1460,7 +1503,10 @@ func (g *mqlGcpProjectVertexaiService) indexes() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -1553,7 +1599,10 @@ func (g *mqlGcpProjectVertexaiService) indexEndpoints() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -1637,7 +1686,10 @@ func (g *mqlGcpProjectVertexaiService) metadataStores() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -1708,7 +1760,10 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimes() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -1823,7 +1878,10 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimeTemplates() ([]any, error)
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -1945,7 +2003,10 @@ func (g *mqlGcpProjectVertexaiService) notebookExecutionJobs() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2025,7 +2086,10 @@ func (g *mqlGcpProjectVertexaiService) reasoningEngines() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2122,7 +2186,10 @@ func (g *mqlGcpProjectVertexaiService) ragCorpora() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2193,7 +2260,10 @@ func (g *mqlGcpProjectVertexaiService) featureGroups() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2259,7 +2329,10 @@ func (g *mqlGcpProjectVertexaiService) persistentResources() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2344,7 +2417,10 @@ func (g *mqlGcpProjectVertexaiService) schedules() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2477,7 +2553,10 @@ func (g *mqlGcpProjectVertexaiService) deploymentResourcePools() ([]any, error) 
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2549,7 +2628,10 @@ func (g *mqlGcpProjectVertexaiService) cachedContents() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2621,7 +2703,10 @@ func (g *mqlGcpProjectVertexaiService) batchPredictionJobs() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2707,7 +2792,10 @@ func (g *mqlGcpProjectVertexaiService) tuningJobs() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2793,7 +2881,10 @@ func (g *mqlGcpProjectVertexaiService) trainingPipelines() ([]any, error) {
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2873,7 +2964,10 @@ func (g *mqlGcpProjectVertexaiService) hyperparameterTuningJobs() ([]any, error)
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}
@@ -2961,7 +3055,10 @@ func (g *mqlGcpProjectVertexaiService) modelDeploymentMonitoringJobs() ([]any, e
 			}
 			if err != nil {
 				if isVertexAIRegionSkippable(err) {
-					return nil, true, nil
+					// Keep what this region already yielded: the iterator
+					// paginates lazily, so a skippable error on a later page
+					// must not discard the pages that succeeded.
+					return items, true, nil
 				}
 				return nil, false, err
 			}


### PR DESCRIPTION
> **Stacked on #9607** (Tier 2), which is stacked on #9604 (Tier 1). Review those first; the diff shown here is only Tier 3's commit.

Third and last tier of the static review pass. These are defects where the data returned is **incomplete or aliased** rather than individually wrong.

## Cache-key collisions — silent aliasing

### 1. BigQuery dataset access entries collapsed onto one key

The SDK decoder leaves `AccessEntry.Entity` **empty** for view, routine and dataset entries and records the reference in the typed `View`/`Routine`/`Dataset` field instead. The id was built from `Entity`, so every authorized view on a dataset produced the identical key, and `CreateResource` returns the first resource stored under a key — a dataset sharing three views reported **the same view three times**. `accessEntryKey()` now folds in the referenced object.

### 2. Machine types collapsed across zones

A machine type is a per-zone catalogue entry whose numeric id is a catalogue **constant** — `e2-medium` carries the same `Id` in every zone — so a key of `(project, id)` aliased all of them. Two effects:

- `machineTypes()` returned N duplicates all reporting the *first* zone.
- `machineTypeByZoneAndName` indexes on zone+name, so it only ever saw that one zone. `instance.machineType()` missed for every VM elsewhere and fell back to a per-instance `MachineTypes.Get` — **the AggregatedList optimization was dead for most VMs.**

Now passes an explicit zone-qualified `__id`.

### 3. Compute image and snapshot IAM bindings shared a key prefix

Both called `computeIamBindingsToResources` with the bare resource name, so an image and a snapshot sharing a name — or the same image name across two scanned projects — aliased onto one set of bindings. A public image could read as private from whichever resolved first.

## Discarded partial results

### 4. Composer threw away every region on the first unavailable one

`composerServiceDisabled` treats any 404 as "not available", but Cloud Composer isn't offered in every Compute region — so that's a **per-region** signal. Returning an empty slice discarded everything already collected from the ~48 regions walked so far: a project with a dozen environments could report none.

### 5. Vertex AI discarded a region's results on a mid-iteration skippable error

The GAPIC iterator paginates lazily, so pages 1..N-1 may have mapped fine before a resource-level `PermissionDenied` (or a `NotFound` from a resource deleted mid-scan) on a later page. All 25 listers returned `nil` there, dropping the pages that succeeded **and** marking the region skipped for the rest of the session.

### 6. Vertex AI failed all 33 regions when one failed

Each region is a separate regional endpoint, so any one can return `Unavailable`, `DeadlineExceeded` or `ResourceExhausted` independently — none of which `isVertexAIRegionSkippable` covers — and the whole inventory disappeared behind it. Now logs per-region failures and only errors when *every* region failed.

### 7. Bigtable discarded the results returned alongside `ErrPartiallyUnavailable`

The admin client returns partial results **and** an error when some locations are unreachable ("Return partial results and an error in case of some locations are unavailable"). That error is a plain struct with no `GRPCStatus()`, so `status.FromError` doesn't recognise it and `isGRPCSkippable` returns false — the callers took the hard-error path and threw away the instances, clusters and backups the SDK had just handed them.

## Hard-failing listers

### 8. Cloud SQL sub-collections never degraded

`sql.go` used `isHTTPSkippable` **zero times**, though 13 other files do. A principal with `cloudsql.instances.list` but not the per-instance permissions failed the whole query — and because `hasBuiltInUsers()` and `localRootEnabled()` both read `users()`, that took out the two headline Cloud SQL hardening checks with an opaque 403.

### 9. Cloud Source Repositories hard-failed on most projects

`service_sourcerepo` is declared in `services.go` and referenced nowhere — the intended gate was never wired. The API is off by default and unavailable entirely to projects that hadn't used it before June 2024, so `403 SERVICE_DISABLED` is the *common* case.

### 10. Essential Contacts org and folder paths never degraded

Only the project path is gated on `isServiceEnabled`; org-level `essentialcontacts.contacts.list` is a separate grant a project-scoped principal rarely holds.

## Also

Removes the 13 em dashes from `gcp.lr` (forbidden by CLAUDE.md) and rewrites `iamAuthenticationEnabled`'s doc into the two-part form now that it documents the per-engine flag spellings from #9607.

## Tests

`cache_keys_test.go` proves all three collision fixes produce distinct keys for the inputs that used to alias (two views on one dataset, one machine type in two zones, two projects), and that plain entity kinds still key on `Entity`.

## Deliberately deferred

Two groups from the review are **not** in this PR:

- **Typed-reference gaps** (`backendBucket.edgeSecurityPolicy`, `gkeBackup.backupPlan.cluster`, `sink.writerIdentity`, `dlp.jobTrigger` and ~10 more) are schema additions rather than bug fixes — they need `.lr` fields, `.lr.versions` entries and in some cases new inits, and want their own PR.
- **The remaining degrade-vs-propagate sites** (`securitycenter`, `kms`, `secretmanager`, `clouddeploy`, `datastream`, `iap`) are a product call about whether an under-scoped token should fail loudly or read as empty. The review flagged the *inconsistency*; picking the convention isn't mine to make. The three fixed here were chosen because a sibling in the same file already degrades, so they were unambiguously drift.

## Verification

`go build ./...`, `go test ./...` in `providers/gcp` (all 4 packages pass), `gofmt` clean, permissions manifest unchanged, `.lr` regenerates cleanly. Not yet verified against live GCP infrastructure — items 2, 4 and 7 are the ones most worth a live check.
