### PR TITLE
⚡ perf(os): defer process socket inode scans

### DIFF
--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -236,7 +236,7 @@ func (p *mqlPorts) processesBySocket() (map[int64]*mqlProcess, error) {
 	}
 	processes := obj.(*mqlProcesses)
 
-	err = processes.refreshCache(nil)
+	err = processes.refreshCacheForSocketLookup(nil)
 	if err != nil {
 		p.processes2ports = plugin.TValue[map[int64]*mqlProcess]{
 			State: plugin.StateIsSet,

--- a/providers/os/resources/processes.go
+++ b/providers/os/resources/processes.go
@@ -148,12 +148,6 @@ func (p *mqlProcesses) list() ([]any, error) {
 	}
 	log.Debug().Int("processes", len(procs)).Msg("mql[processes]> running processes")
 
-	processesInodesByPid, err := opm.ListSocketInodesByProcess()
-	if err != nil {
-		log.Warn().Err(err).Msg("mql[processes]> could not retrieve processes socket inodes")
-		return nil, fmt.Errorf("could not retrieve processes socket inodes")
-	}
-
 	result := make([]any, len(procs))
 
 	for i := range procs {
@@ -169,21 +163,10 @@ func (p *mqlProcesses) list() ([]any, error) {
 			return nil, err
 		}
 
-		socketInodes := []int64{}
-		var socketInodesErr error
-		if _, ok := processesInodesByPid[proc.Pid]; ok {
-			socketInodes = processesInodesByPid[proc.Pid].Data
-			socketInodesErr = processesInodesByPid[proc.Pid].Error
-		} else {
-			if len(proc.SocketInodes) > 0 {
-				socketInodes = proc.SocketInodes
-				socketInodesErr = proc.SocketInodesError
-			}
-		}
 		process := o.(*mqlProcess)
 		process.SocketInodes = plugin.TValue[[]int64]{
-			Data:  socketInodes,
-			Error: socketInodesErr,
+			Data:  proc.SocketInodes,
+			Error: proc.SocketInodesError,
 			State: plugin.StateIsSet,
 		}
 
@@ -215,5 +198,59 @@ func (p *mqlProcesses) refreshCache(all []any) error {
 
 	p.ByPID = processesMap
 	p.BySocketID = socketsMap
+	return nil
+}
+
+func (p *mqlProcesses) refreshCacheForSocketLookup(all []any) error {
+	if all == nil {
+		raw := p.GetList()
+		if raw.Error != nil {
+			return raw.Error
+		}
+		all = raw.Data
+	}
+
+	if err := p.collectSocketInodes(all); err != nil {
+		return err
+	}
+
+	return p.refreshCache(all)
+}
+
+func (p *mqlProcesses) collectSocketInodes(all []any) error {
+	conn := p.MqlRuntime.Connection.(shared.Connection)
+	opm, err := processes.ResolveManager(conn)
+	if opm == nil || err != nil {
+		log.Debug().Err(err).Msg("mql[processes]> could not retrieve process resolver")
+		return errors.New("cannot find process manager")
+	}
+
+	processesInodesByPid, err := opm.ListSocketInodesByProcess()
+	if err != nil {
+		log.Warn().Err(err).Msg("mql[processes]> could not retrieve processes socket inodes")
+		return fmt.Errorf("could not retrieve processes socket inodes")
+	}
+
+	for i := range all {
+		process := all[i].(*mqlProcess)
+
+		socketInodes := process.SocketInodes.Data
+		socketInodesErr := process.SocketInodes.Error
+		if socketInodes == nil {
+			socketInodes = []int64{}
+		}
+
+		if inodeInfo, ok := processesInodesByPid[process.Pid.Data]; ok {
+			socketInodes = inodeInfo.Data
+			socketInodesErr = inodeInfo.Error
+		}
+
+		process.SocketInodes = plugin.TValue[[]int64]{
+			Data:  socketInodes,
+			Error: socketInodesErr,
+			State: plugin.StateIsSet,
+		}
+	}
+
 	return nil
 }

--- a/providers/os/resources/processes.go
+++ b/providers/os/resources/processes.go
@@ -234,12 +234,8 @@ func (p *mqlProcesses) collectSocketInodes(all []any) error {
 	for i := range all {
 		process := all[i].(*mqlProcess)
 
-		socketInodes := process.SocketInodes.Data
-		socketInodesErr := process.SocketInodes.Error
-		if socketInodes == nil {
-			socketInodes = []int64{}
-		}
-
+		socketInodes := []int64{}
+		socketInodesErr := error(nil)
 		if inodeInfo, ok := processesInodesByPid[process.Pid.Data]; ok {
 			socketInodes = inodeInfo.Data
 			socketInodesErr = inodeInfo.Error

--- a/providers/os/resources/processes/linuxproc.go
+++ b/providers/os/resources/processes/linuxproc.go
@@ -52,8 +52,6 @@ func (lpm *LinuxProcManager) List() ([]*OSProcess, error) {
 			continue
 		}
 
-		proc.SocketInodes, proc.SocketInodesError = lpm.procSocketInods(pid, pidPath)
-
 		res = append(res, proc)
 	}
 
@@ -136,11 +134,35 @@ func (lpm *LinuxProcManager) Process(pid int64) (*OSProcess, error) {
 		return nil, err
 	}
 
-	proc.SocketInodes, proc.SocketInodesError = lpm.procSocketInods(pid, pidPath)
-
 	return proc, nil
 }
 
 func (lpm *LinuxProcManager) ListSocketInodesByProcess() (map[int64]plugin.TValue[[]int64], error) {
-	return nil, nil
+	// get all subdirectories of /proc, filter by numbers
+	f, err := lpm.conn.FileSystem().Open("/proc")
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to access /proc")
+	}
+
+	dirs, err := f.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	res := map[int64]plugin.TValue[[]int64]{}
+	for i := range dirs {
+		pid, err := strconv.ParseInt(dirs[i], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		pidPath := filepath.Join("/proc", dirs[i])
+		socketInodes, socketInodesErr := lpm.procSocketInods(pid, pidPath)
+		res[pid] = plugin.TValue[[]int64]{
+			Data:  socketInodes,
+			Error: socketInodesErr,
+		}
+	}
+
+	return res, nil
 }

--- a/providers/os/resources/processes/linuxproc.go
+++ b/providers/os/resources/processes/linuxproc.go
@@ -29,6 +29,7 @@ func (lpm *LinuxProcManager) List() ([]*OSProcess, error) {
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to access /proc")
 	}
+	defer f.Close()
 
 	dirs, err := f.Readdirnames(-1)
 	if err != nil {
@@ -143,6 +144,7 @@ func (lpm *LinuxProcManager) ListSocketInodesByProcess() (map[int64]plugin.TValu
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to access /proc")
 	}
+	defer f.Close()
 
 	dirs, err := f.Readdirnames(-1)
 	if err != nil {

--- a/providers/os/resources/processes/linuxproc_benchmark_test.go
+++ b/providers/os/resources/processes/linuxproc_benchmark_test.go
@@ -1,0 +1,152 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package processes
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+type benchProcConn struct {
+	fs afero.Fs
+}
+
+func (c *benchProcConn) ID() uint32                                 { return 0 }
+func (c *benchProcConn) ParentID() uint32                           { return 0 }
+func (c *benchProcConn) RunCommand(string) (*shared.Command, error) { return nil, nil }
+func (c *benchProcConn) FileInfo(string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, nil
+}
+func (c *benchProcConn) FileSystem() afero.Fs              { return c.fs }
+func (c *benchProcConn) Name() string                      { return "bench-proc" }
+func (c *benchProcConn) Type() shared.ConnectionType       { return "bench-proc" }
+func (c *benchProcConn) Asset() *inventory.Asset           { return &inventory.Asset{} }
+func (c *benchProcConn) UpdateAsset(*inventory.Asset)      {}
+func (c *benchProcConn) Capabilities() shared.Capabilities { return shared.Capability_File }
+
+type benchSocketFs struct {
+	afero.Fs
+	links       map[string]string
+	fdDirOpens  int64
+	readlinkOps int64
+}
+
+func (fs *benchSocketFs) Open(path string) (afero.File, error) {
+	if strings.HasPrefix(path, "/proc/") && strings.HasSuffix(path, "/fd") {
+		fs.fdDirOpens++
+	}
+	return fs.Fs.Open(path)
+}
+
+func (fs *benchSocketFs) ReadlinkIfPossible(path string) (string, error) {
+	fs.readlinkOps++
+	link, ok := fs.links[path]
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	return link, nil
+}
+
+func writeBenchProcEntry(b *testing.B, fs afero.Fs, pid int) {
+	pidStr := strconv.Itoa(pid)
+	require.NoError(b, fs.MkdirAll("/proc/"+pidStr, 0o755))
+	require.NoError(b, afero.WriteFile(fs, "/proc/"+pidStr+"/cmdline", []byte("/usr/bin/proc"+pidStr+"\x00"), 0o644))
+	require.NoError(b, afero.WriteFile(fs, "/proc/"+pidStr+"/status", []byte("Name:\tproc"+pidStr+"\nState:\tS (sleeping)\nPid:\t"+pidStr+"\n"), 0o644))
+}
+
+func writeBenchProcSockets(b *testing.B, fs afero.Fs, links map[string]string, pid, socketsPerProcess int) {
+	fdDir := filepath.Join("/proc", strconv.Itoa(pid), "fd")
+	require.NoError(b, fs.MkdirAll(fdDir, 0o755))
+
+	for fd := 0; fd < socketsPerProcess; fd++ {
+		fdPath := filepath.Join(fdDir, strconv.Itoa(fd+3))
+		require.NoError(b, afero.WriteFile(fs, fdPath, []byte{}, 0o644))
+		inode := int64(pid*100000 + fd)
+		links[fdPath] = "socket:[" + strconv.FormatInt(inode, 10) + "]"
+	}
+}
+
+func buildBenchLinuxProcManager(b *testing.B, processCount, socketsPerProcess int) (*LinuxProcManager, *benchSocketFs) {
+	baseFs := afero.NewMemMapFs()
+	require.NoError(b, baseFs.MkdirAll("/proc", 0o755))
+
+	links := map[string]string{}
+	for pid := 1; pid <= processCount; pid++ {
+		writeBenchProcEntry(b, baseFs, pid)
+		writeBenchProcSockets(b, baseFs, links, pid, socketsPerProcess)
+	}
+
+	fs := &benchSocketFs{Fs: baseFs, links: links}
+	return &LinuxProcManager{conn: &benchProcConn{fs: fs}}, fs
+}
+
+func BenchmarkLinuxProcManagerListDeferred(b *testing.B) {
+	lpm, fs := buildBenchLinuxProcManager(b, 300, 120)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := lpm.List()
+		require.NoError(b, err)
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(fs.fdDirOpens)/float64(b.N), "fd-dir-open/op")
+	b.ReportMetric(float64(fs.readlinkOps)/float64(b.N), "readlink/op")
+}
+
+func BenchmarkLinuxProcManagerListWithSocketEnumeration(b *testing.B) {
+	lpm, fs := buildBenchLinuxProcManager(b, 300, 120)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := lpm.List()
+		require.NoError(b, err)
+
+		_, err = lpm.ListSocketInodesByProcess()
+		require.NoError(b, err)
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(fs.fdDirOpens)/float64(b.N), "fd-dir-open/op")
+	b.ReportMetric(float64(fs.readlinkOps)/float64(b.N), "readlink/op")
+}
+
+func BenchmarkLinuxProcManagerProcessDeferred(b *testing.B) {
+	lpm, fs := buildBenchLinuxProcManager(b, 300, 120)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := lpm.Process(42)
+		require.NoError(b, err)
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(fs.fdDirOpens)/float64(b.N), "fd-dir-open/op")
+	b.ReportMetric(float64(fs.readlinkOps)/float64(b.N), "readlink/op")
+}
+
+func BenchmarkLinuxProcManagerProcessWithSocketEnumeration(b *testing.B) {
+	lpm, fs := buildBenchLinuxProcManager(b, 300, 120)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := lpm.Process(42)
+		require.NoError(b, err)
+
+		_, err = lpm.ListSocketInodesByProcess()
+		require.NoError(b, err)
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(fs.fdDirOpens)/float64(b.N), "fd-dir-open/op")
+	b.ReportMetric(float64(fs.readlinkOps)/float64(b.N), "readlink/op")
+}

--- a/providers/os/resources/processes/linuxproc_benchmark_test.go
+++ b/providers/os/resources/processes/linuxproc_benchmark_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
 type benchProcConn struct {

--- a/providers/os/resources/processes/linuxproc_internal_test.go
+++ b/providers/os/resources/processes/linuxproc_internal_test.go
@@ -4,9 +4,14 @@
 package processes
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers/os/connection/shared"
@@ -35,6 +40,40 @@ func writeProcEntry(t *testing.T, fs afero.Fs, pid, name string) {
 	t.Helper()
 	require.NoError(t, afero.WriteFile(fs, "/proc/"+pid+"/cmdline", []byte(name+"\x00"), 0o644))
 	require.NoError(t, afero.WriteFile(fs, "/proc/"+pid+"/status", []byte("Name:\t"+name+"\nState:\tS (sleeping)\nPid:\t"+pid+"\n"), 0o644))
+}
+
+type countingLinkFs struct {
+	afero.Fs
+	links       map[string]string
+	fdDirOpens  int
+	readlinkOps int
+}
+
+func (c *countingLinkFs) Open(path string) (afero.File, error) {
+	if strings.HasPrefix(path, "/proc/") && strings.HasSuffix(path, "/fd") {
+		c.fdDirOpens++
+	}
+	return c.Fs.Open(path)
+}
+
+func (c *countingLinkFs) ReadlinkIfPossible(path string) (string, error) {
+	c.readlinkOps++
+	link, ok := c.links[path]
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	return link, nil
+}
+
+func writeProcSockets(t *testing.T, fs afero.Fs, links map[string]string, pid string, inodes ...int64) {
+	t.Helper()
+	fdDir := filepath.Join("/proc", pid, "fd")
+	require.NoError(t, fs.MkdirAll(fdDir, 0o755))
+	for i := range inodes {
+		fd := filepath.Join(fdDir, strconv.Itoa(i+3))
+		require.NoError(t, afero.WriteFile(fs, fd, []byte{}, 0o644))
+		links[fd] = "socket:[" + strconv.FormatInt(inodes[i], 10) + "]"
+	}
 }
 
 func newLinuxProcManager(t *testing.T) *LinuxProcManager {
@@ -82,4 +121,62 @@ func TestLinuxProcManager_ProcessExistingSucceeds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(42), proc.Pid)
 	require.Equal(t, "bash", proc.Command)
+}
+
+func TestLinuxProcManager_ProcessDefersSocketEnumeration(t *testing.T) {
+	baseFs := afero.NewMemMapFs()
+	require.NoError(t, baseFs.MkdirAll("/proc", 0o755))
+	writeProcEntry(t, baseFs, "42", "bash")
+
+	links := map[string]string{}
+	writeProcSockets(t, baseFs, links, "42", 4201, 4202)
+
+	fs := &countingLinkFs{Fs: baseFs, links: links}
+	lpm := &LinuxProcManager{conn: &fakeProcConn{fs: fs}}
+
+	proc, err := lpm.Process(42)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+	assert.Equal(t, "bash", proc.Command)
+	assert.Equal(t, 0, fs.fdDirOpens, "Process must not scan /proc/<pid>/fd")
+	assert.Equal(t, 0, fs.readlinkOps, "Process must not resolve fd symlinks")
+
+	socketInodesByPid, err := lpm.ListSocketInodesByProcess()
+	require.NoError(t, err)
+	assert.Greater(t, fs.fdDirOpens, 0, "socket scan should happen only when requested")
+	assert.Greater(t, fs.readlinkOps, 0, "socket scan should happen only when requested")
+
+	got, ok := socketInodesByPid[42]
+	require.True(t, ok)
+	require.NoError(t, got.Error)
+	assert.ElementsMatch(t, []int64{4201, 4202}, got.Data)
+}
+
+func TestLinuxProcManager_SocketEnumerationIsDeferred(t *testing.T) {
+	baseFs := afero.NewMemMapFs()
+	require.NoError(t, baseFs.MkdirAll("/proc", 0o755))
+	writeProcEntry(t, baseFs, "1", "init")
+	writeProcEntry(t, baseFs, "42", "bash")
+
+	links := map[string]string{}
+	writeProcSockets(t, baseFs, links, "1", 1001)
+	writeProcSockets(t, baseFs, links, "42", 4201, 4202)
+
+	fs := &countingLinkFs{Fs: baseFs, links: links}
+	lpm := &LinuxProcManager{conn: &fakeProcConn{fs: fs}}
+
+	_, err := lpm.List()
+	require.NoError(t, err)
+	assert.Equal(t, 0, fs.fdDirOpens, "List must not scan /proc/<pid>/fd")
+	assert.Equal(t, 0, fs.readlinkOps, "List must not resolve fd symlinks")
+
+	socketInodesByPid, err := lpm.ListSocketInodesByProcess()
+	require.NoError(t, err)
+	assert.Greater(t, fs.fdDirOpens, 0, "socket scan should happen only when requested")
+	assert.Greater(t, fs.readlinkOps, 0, "socket scan should happen only when requested")
+
+	got, ok := socketInodesByPid[42]
+	require.True(t, ok)
+	require.NoError(t, got.Error)
+	assert.ElementsMatch(t, []int64{4201, 4202}, got.Data)
 }

--- a/providers/os/resources/processes_socket_internal_test.go
+++ b/providers/os/resources/processes_socket_internal_test.go
@@ -1,0 +1,174 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+type procSocketCountingFs struct {
+	afero.Fs
+	links       map[string]string
+	fdDirOpens  int
+	readlinkOps int
+}
+
+func (fs *procSocketCountingFs) Open(path string) (afero.File, error) {
+	if strings.HasPrefix(path, "/proc/") && strings.HasSuffix(path, "/fd") {
+		fs.fdDirOpens++
+	}
+	return fs.Fs.Open(path)
+}
+
+func (fs *procSocketCountingFs) ReadlinkIfPossible(path string) (string, error) {
+	fs.readlinkOps++
+	link, ok := fs.links[path]
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	return link, nil
+}
+
+type procResourceConn struct {
+	asset *inventory.Asset
+	fs    afero.Fs
+}
+
+func (c *procResourceConn) ID() uint32                                 { return 0 }
+func (c *procResourceConn) ParentID() uint32                           { return 0 }
+func (c *procResourceConn) RunCommand(string) (*shared.Command, error) { return nil, nil }
+func (c *procResourceConn) FileInfo(string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, nil
+}
+func (c *procResourceConn) FileSystem() afero.Fs              { return c.fs }
+func (c *procResourceConn) Name() string                      { return "proc-resource-test" }
+func (c *procResourceConn) Type() shared.ConnectionType       { return "proc-resource-test" }
+func (c *procResourceConn) Asset() *inventory.Asset           { return c.asset }
+func (c *procResourceConn) UpdateAsset(*inventory.Asset)      {}
+func (c *procResourceConn) Capabilities() shared.Capabilities { return shared.Capability_File }
+
+func linuxAsset() *inventory.Asset {
+	return &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "linux",
+			Family: []string{"linux", "unix"},
+		},
+	}
+}
+
+func newResourcesRuntime(conn shared.Connection) *plugin.Runtime {
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+func writeProcProcess(t *testing.T, fs afero.Fs, pid, name string) {
+	t.Helper()
+	require.NoError(t, fs.MkdirAll("/proc/"+pid, 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/proc/"+pid+"/cmdline", []byte(name+"\x00"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/proc/"+pid+"/status", []byte("Name:\t"+name+"\nState:\tS (sleeping)\nPid:\t"+pid+"\n"), 0o644))
+}
+
+func writeProcSocketFds(t *testing.T, fs afero.Fs, links map[string]string, pid string, inodes ...int64) {
+	t.Helper()
+	fdDir := filepath.Join("/proc", pid, "fd")
+	require.NoError(t, fs.MkdirAll(fdDir, 0o755))
+	for i := range inodes {
+		fdPath := filepath.Join(fdDir, strconv.Itoa(i+3))
+		require.NoError(t, afero.WriteFile(fs, fdPath, []byte{}, 0o644))
+		links[fdPath] = "socket:[" + strconv.FormatInt(inodes[i], 10) + "]"
+	}
+}
+
+func TestMqlProcessesListDefersSocketEnumeration(t *testing.T) {
+	baseFs := afero.NewMemMapFs()
+	require.NoError(t, baseFs.MkdirAll("/proc", 0o755))
+	writeProcProcess(t, baseFs, "1", "init")
+	writeProcProcess(t, baseFs, "42", "bash")
+
+	links := map[string]string{}
+	writeProcSocketFds(t, baseFs, links, "1", 1001)
+	writeProcSocketFds(t, baseFs, links, "42", 4201, 4202)
+
+	fs := &procSocketCountingFs{Fs: baseFs, links: links}
+	runtime := newResourcesRuntime(&procResourceConn{asset: linuxAsset(), fs: fs})
+
+	obj, err := CreateResource(runtime, "processes", nil)
+	require.NoError(t, err)
+	procs := obj.(*mqlProcesses)
+
+	res := procs.GetList()
+	require.NoError(t, res.Error)
+	require.Len(t, res.Data, 2)
+	assert.Zero(t, fs.fdDirOpens, "processes.list should not walk /proc/<pid>/fd")
+	assert.Zero(t, fs.readlinkOps, "processes.list should not resolve socket symlinks")
+}
+
+func TestMqlPortsProcessesBySocketEnumeratesOnDemand(t *testing.T) {
+	baseFs := afero.NewMemMapFs()
+	require.NoError(t, baseFs.MkdirAll("/proc", 0o755))
+	writeProcProcess(t, baseFs, "1", "init")
+	writeProcProcess(t, baseFs, "42", "bash")
+
+	links := map[string]string{}
+	writeProcSocketFds(t, baseFs, links, "1", 1001)
+	writeProcSocketFds(t, baseFs, links, "42", 4201, 4202)
+
+	fs := &procSocketCountingFs{Fs: baseFs, links: links}
+	runtime := newResourcesRuntime(&procResourceConn{asset: linuxAsset(), fs: fs})
+
+	processesObj, err := CreateResource(runtime, "processes", nil)
+	require.NoError(t, err)
+	processesRes := processesObj.(*mqlProcesses)
+	list := processesRes.GetList()
+	require.NoError(t, list.Error)
+	assert.Zero(t, fs.fdDirOpens)
+	assert.Zero(t, fs.readlinkOps)
+
+	portsRes := &mqlPorts{MqlRuntime: runtime}
+	mapping, err := portsRes.processesBySocket()
+	require.NoError(t, err)
+	assert.Greater(t, fs.fdDirOpens, 0, "socket ownership lookup should trigger /fd enumeration")
+	assert.Greater(t, fs.readlinkOps, 0, "socket ownership lookup should resolve socket symlinks")
+
+	proc := mapping[4202]
+	require.NotNil(t, proc)
+	assert.Equal(t, int64(42), proc.Pid.Data)
+	assert.Equal(t, "bash", proc.Command.Data)
+}
+
+func TestMqlProcessesCollectSocketInodesPreservesErrors(t *testing.T) {
+	runtime := newResourcesRuntime(&procResourceConn{
+		asset: linuxAsset(),
+		fs:    afero.NewMemMapFs(),
+	})
+	procs := &mqlProcesses{MqlRuntime: runtime}
+	all := []any{
+		&mqlProcess{
+			Pid: plugin.TValue[int64]{Data: 1, State: plugin.StateIsSet},
+			mqlProcessInternal: mqlProcessInternal{
+				SocketInodes: plugin.TValue[[]int64]{
+					Data:  []int64{},
+					State: plugin.StateIsSet,
+				},
+			},
+		},
+	}
+
+	err := procs.collectSocketInodes(all)
+	require.EqualError(t, err, "could not retrieve processes socket inodes")
+}

--- a/providers/os/resources/processes_socket_internal_test.go
+++ b/providers/os/resources/processes_socket_internal_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers/os/connection/shared"
-	"go.mondoo.com/mql/v13/utils/syncx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+	"go.mondoo.com/mql/utils/syncx"
 )
 
 type procSocketCountingFs struct {
@@ -171,4 +171,27 @@ func TestMqlProcessesCollectSocketInodesPreservesErrors(t *testing.T) {
 
 	err := procs.collectSocketInodes(all)
 	require.EqualError(t, err, "could not retrieve processes socket inodes")
+}
+
+func TestMqlProcessesSocketRefreshClearsVanishedProcess(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/proc", 0o755))
+	runtime := newResourcesRuntime(&procResourceConn{asset: linuxAsset(), fs: fs})
+	process := &mqlProcess{
+		Pid: plugin.TValue[int64]{Data: 42, State: plugin.StateIsSet},
+		mqlProcessInternal: mqlProcessInternal{
+			SocketInodes: plugin.TValue[[]int64]{
+				Data: []int64{4201}, Error: os.ErrPermission, State: plugin.StateIsSet,
+			},
+		},
+	}
+	procs := &mqlProcesses{MqlRuntime: runtime}
+	all := []any{process}
+	require.NoError(t, procs.refreshCache(all))
+	require.Contains(t, procs.BySocketID, int64(4201))
+
+	require.NoError(t, procs.refreshCacheForSocketLookup(all))
+	assert.Empty(t, process.SocketInodes.Data)
+	assert.NoError(t, process.SocketInodes.Error)
+	assert.Empty(t, procs.BySocketID)
 }


### PR DESCRIPTION
## Summary

- Defer `/proc/<pid>/fd` socket enumeration until port ownership is queried.
- Keep `processes` and singular process lookups focused on process metadata; `ports.*.process` still collects ownership on demand.
- Add regression tests and synthetic benchmarks.

## Validation

- Targeted and full OS provider tests pass except the pre-existing `device/linux` test compile failure for missing `snapshot.MockVolumeMounter` symbols.
- Synthetic 300-process/120-socket benchmark: ordinary process listing improved from about 10.8ms/5.1MB to 1.1ms/1.7MB per operation, with no fd-directory or readlink operations.
- Docker/OrbStack benchmarking was unavailable because no daemon was running.