### PR TITLE
📄 providers: standardize developer READMEs + scaffold template

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -278,6 +278,8 @@ After scaffolding, register the provider in these files:
 - **`DEVELOPMENT.md`** — add the provider path to the `go.work` provider list (alphabetically)
 - **`Makefile`** — add the provider name to the `PROVIDERS` list (alphabetically)
 
+The scaffold also emits a `providers/<provider-id>/README.md` from a shared template with the canonical structure (Prerequisites, Authentication, Usage, Discovery, Examples, Resources, Verification, Troubleshooting). Fill in its `TODO` sections — at minimum **Authentication** and **Examples** — with real flags and runnable `mql shell <provider-id>` queries and their output. Keep it developer-focused; do not hand-list every resource and field (the resource reference is generated from the `.lr` schema comments). Use the `snowflake` and `shodan` provider READMEs as models.
+
 ### Asset URL tree
 
 Set `AssetUrlTrees` in `providers/<your-provider>/config/config.go` so assets discovered by the provider land under a stable technology bucket. This is what Mondoo Platform uses to group and filter assets across providers.

--- a/apps/provider-scaffold/template/README.md.template
+++ b/apps/provider-scaffold/template/README.md.template
@@ -1,0 +1,68 @@
+# {{ .ProviderName }} Provider
+
+<!-- TODO: one to three sentences describing what this provider inventories and why
+     someone would query it (the security posture or assets it exposes). -->
+The `{{ .ProviderID }}` provider connects to {{ .ProviderName }} and inventories it through
+read-only queries.
+
+## Prerequisites
+
+<!-- TODO (optional): required tooling, versions, network access, or account permissions.
+     Delete this section if there are none. -->
+
+## Authentication
+
+<!-- TODO: how to authenticate. List the connection flags/arguments, and give one runnable
+     example per auth method. Use blockquote tips for how to obtain credentials. Keep it to a
+     few lines for a simple token/env-var provider. -->
+
+Arguments:
+
+- `--user` - the user to authenticate as.
+- `--ask-pass` - prompt for the password (or `--password`).
+
+```shell
+mql shell {{ .ProviderID }} --user USER --ask-pass
+```
+
+## Usage
+
+Open an interactive shell:
+
+```shell
+mql shell {{ .ProviderID }}
+```
+
+## Discovery
+
+<!-- TODO (optional): only for providers that emit child assets. Describe the asset model and
+     the `--discover` targets, with a scan example. Delete this section if the provider emits a
+     single asset. -->
+
+## Examples
+
+<!-- TODO: several labeled example queries. Each should have a short prose lead-in, a runnable
+     `mql>` query, and its real output. These are what new developers rely on most, so make them
+     copy-pasteable and representative of the provider's key resources. -->
+
+**Example query**
+
+Describe what this query returns.
+
+```shell
+mql> {{ .ProviderID }}.<resource>
+```
+
+## Resources
+
+<!-- TODO (optional): a short pointer to the resources this provider exposes. Do NOT hand-list
+     every field; the resource reference is generated from the `.lr` schema comments. -->
+
+## Verification
+
+<!-- TODO (optional): one or two quick queries that confirm the connection and permissions work,
+     plus what an empty result implies (e.g. missing read permission). -->
+
+## Troubleshooting
+
+<!-- TODO (optional): common errors and their fixes. Delete if not needed. -->

--- a/providers/ansible/README.md
+++ b/providers/ansible/README.md
@@ -9,7 +9,7 @@ metadata, and dependencies), static inventory and host/group variables, Galaxy
 requirements, `ansible.cfg`, and vault-encrypted files. Nothing is executed
 against an inventory; the analysis is entirely static.
 
-## Get started
+## Usage
 
 ```shell
 ±> mql shell ansible providers/ansible/play/testdata/play_cert_validation.yaml
@@ -27,7 +27,7 @@ ansible.plays: [
 ]
 ```
 
-## Common Queries
+## Examples
 
 Query all plays in a playbook:
 
@@ -40,51 +40,6 @@ Access specific play details:
 ```javascript
 ansible.plays.first.name
 ```
-
-## Project analysis
-
-Connect to a project directory to analyze the whole codebase through the
-`ansible.project` resource:
-
-```shell
-mql shell ansible ./my-ansible-project
-```
-
-```javascript
-// Roles defined in the project, with the roles they depend on
-ansible.project.roles { name dependencies { name } }
-
-// External roles and collections pulled in from Galaxy, and what is vendored
-ansible.project.requirements { roles collections }
-ansible.project.collections { name version }
-
-// Custom modules and plugins shipped in the project (supply chain)
-ansible.project.plugins { name type }
-
-// Security-relevant ansible.cfg settings
-ansible.project.config { hostKeyChecking become }
-
-// Vault-encrypted files and inline encrypted variables
-ansible.project.vault { files { cipher } variables { key file } }
-
-// Test/quality signals
-ansible.project { lintConfig moleculeScenarios }
-```
-
-Tasks expose the module they invoke directly, so audits can select by module
-without knowing the exact key in `action`:
-
-```javascript
-// Flag any task that shells out
-ansible.project.playbooks.all(
-  plays.all(tasks.all(module != /command|shell/))
-)
-```
-
-The single-playbook queries above continue to work unchanged when the provider
-is pointed at a file rather than a directory.
-
-## Example
 
 Assume the following ansible tasks where we install httpd
 with [yum](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/dnf_module.html#ansible-collections-ansible-builtin-dnf-module):
@@ -201,3 +156,46 @@ Execute the policy scan:
 ```shell
 cnspec scan ansible providers/ansible/play/testdata/play_cert_validation.yaml -f providers/ansible/examples/policy.mql.yaml
 ```
+
+## Project analysis
+
+Connect to a project directory to analyze the whole codebase through the
+`ansible.project` resource:
+
+```shell
+mql shell ansible ./my-ansible-project
+```
+
+```javascript
+// Roles defined in the project, with the roles they depend on
+ansible.project.roles { name dependencies { name } }
+
+// External roles and collections pulled in from Galaxy, and what is vendored
+ansible.project.requirements { roles collections }
+ansible.project.collections { name version }
+
+// Custom modules and plugins shipped in the project (supply chain)
+ansible.project.plugins { name type }
+
+// Security-relevant ansible.cfg settings
+ansible.project.config { hostKeyChecking become }
+
+// Vault-encrypted files and inline encrypted variables
+ansible.project.vault { files { cipher } variables { key file } }
+
+// Test/quality signals
+ansible.project { lintConfig moleculeScenarios }
+```
+
+Tasks expose the module they invoke directly, so audits can select by module
+without knowing the exact key in `action`:
+
+```javascript
+// Flag any task that shells out
+ansible.project.playbooks.all(
+  plays.all(tasks.all(module != /command|shell/))
+)
+```
+
+The single-playbook queries above continue to work unchanged when the provider
+is pointed at a file rather than a directory.

--- a/providers/claude/README.md
+++ b/providers/claude/README.md
@@ -155,30 +155,6 @@ mql shell claude
 Admin keys work alongside both API key and WIF authentication for the standard
 API.
 
-## Resource Scoping
-
-| Key type | Resources |
-|----------|-----------|
-| Standard API key / WIF | `claude.models`, `claude.agents`, `claude.environments`, `claude.sessions`, `claude.files`, `claude.skills`, `claude.vaults`, `claude.memoryStores`, `claude.messageBatches`, `claude.userProfiles` |
-| Admin API key | `claude.organization` (workspaces, members, invites, apiKeys, rateLimits, usageReport, costReport, activities) |
-
-Standard API keys are workspace-scoped — each key accesses resources in one
-workspace. To scan multiple workspaces, either run separate scans per workspace
-or use the admin key for organization-level visibility (the admin key cannot
-access workspace-level standard API resources like models or agents).
-
-## Discovery
-
-When an admin token is provided, the provider discovers the organization and its
-workspaces as separate assets with distinct platform IDs:
-
-```bash
-# Discover org + workspaces
-mql shell claude --admin-token sk-ant-admin01-... --discover all
-```
-
-Discovery targets: `all`, `auto`, `organization`, `workspaces`.
-
 ## Usage
 
 ```bash
@@ -210,6 +186,30 @@ mql shell claude --admin-token sk-ant-admin01-...
 # Combined: both standard and admin resources
 mql shell claude --token sk-ant-api03-... --admin-token sk-ant-admin01-...
 ```
+
+## Discovery
+
+When an admin token is provided, the provider discovers the organization and its
+workspaces as separate assets with distinct platform IDs:
+
+```bash
+# Discover org + workspaces
+mql shell claude --admin-token sk-ant-admin01-... --discover all
+```
+
+Discovery targets: `all`, `auto`, `organization`, `workspaces`.
+
+## Resource Scoping
+
+| Key type | Resources |
+|----------|-----------|
+| Standard API key / WIF | `claude.models`, `claude.agents`, `claude.environments`, `claude.sessions`, `claude.files`, `claude.skills`, `claude.vaults`, `claude.memoryStores`, `claude.messageBatches`, `claude.userProfiles` |
+| Admin API key | `claude.organization` (workspaces, members, invites, apiKeys, rateLimits, usageReport, costReport, activities) |
+
+Standard API keys are workspace-scoped — each key accesses resources in one
+workspace. To scan multiple workspaces, either run separate scans per workspace
+or use the admin key for organization-level visibility (the admin key cannot
+access workspace-level standard API resources like models or agents).
 
 ## Credential Chain
 

--- a/providers/databricks/README.md
+++ b/providers/databricks/README.md
@@ -27,7 +27,7 @@ access you want to audit (account admin for full account coverage, plus
 workspace entitlement for each workspace you want to reach).
 
 ```shell
-cnspec shell databricks \
+mql shell databricks \
   --account-id <account-id> \
   --client-id <client-id> \
   --client-secret <client-secret>
@@ -36,7 +36,7 @@ cnspec shell databricks \
 ### Personal access token (single workspace)
 
 ```shell
-cnspec shell databricks --host <workspace-url> --token <pat>
+mql shell databricks --host <workspace-url> --token <pat>
 ```
 
 ### Environment variables
@@ -58,13 +58,13 @@ Discovery is controlled with `--discover`:
 - `auto` / `all` (default) discovers every workspace.
 - `workspaces` is the explicit workspace target.
 
-## Example queries
+## Examples
 
 Account plane:
 
 ```shell
 # Service principals that are still active
-cnspec shell databricks --account-id <id> --client-id <id> --client-secret <secret> \
+mql shell databricks --account-id <id> --client-id <id> --client-secret <secret> \
   -c "databricks.servicePrincipals.where(active)"
 
 # Workspaces not protected by a customer-managed key

--- a/providers/datadog/README.md
+++ b/providers/datadog/README.md
@@ -31,54 +31,6 @@ mql shell datadog --api-key <key> --app-key <key>
 mql shell datadog --api-key <key> --app-key <key> --site datadoghq.eu
 ```
 
-## Required Permissions
-
-By default, an unscoped Application Key inherits all permissions of the user who created it. For production use, Datadog supports [scoped Application Keys](https://docs.datadoghq.com/account_management/api-app-keys/) that restrict access to specific RBAC permissions.
-
-The table below lists the Datadog RBAC permission each resource requires. These are the same permission names shown in **Datadog > Organization Settings > Roles**.
-
-| Resource | Required RBAC Permission |
-|---|---|
-| `datadog.users` | `user_access_invite` |
-| `datadog.roles` | `user_access_invite` |
-| `datadog.serviceAccounts` | `user_access_invite` |
-| `datadog.monitors` | `monitors_read` |
-| `datadog.dashboards` | `dashboards_read` |
-| `datadog.slos` | `slos_read` |
-| `datadog.downtimes` | `monitors_downtime` |
-| `datadog.syntheticsTests` | `synthetics_read` |
-| `datadog.syntheticsGlobalVariables` | `synthetics_read` |
-| `datadog.syntheticsPrivateLocations` | `synthetics_read` |
-| `datadog.logIndexes` | `logs_read_index_data` |
-| `datadog.logsArchives` | `logs_read_archives` |
-| `datadog.securityRules` | `security_monitoring_rules_read` |
-| `datadog.securityFilters` | `security_monitoring_filters_read` |
-| `datadog.securitySuppressions` | `security_monitoring_suppressions_read` |
-| `datadog.sensitiveDataScannerGroups` | `data_scanner_read` |
-| `datadog.apiKeys` | `api_keys_read` |
-| `datadog.applicationKeys` | `user_app_keys` |
-| `datadog.ipAllowlistEntries` / `ipAllowlistEnabled` | `org_management` |
-| `datadog.integrationAwsAccounts` | `aws_configuration_read` |
-| `datadog.teams` | `teams_read` |
-| `datadog.rumApplications` | `rum_apps_read` |
-
-> **Tip**: For full access to all resources, use an unscoped Application Key (it inherits all permissions from its creator). Scoped keys are recommended for production use to follow least-privilege principles.
-
-> **Note**: Some resources require your Datadog plan to include the corresponding product. If the feature is not enabled, the API returns 403 Forbidden regardless of your key's permissions. The provider handles this gracefully by returning an empty list and logging a warning.
-
-### Plan-Gated Resources
-
-The following resources require specific Datadog products to be enabled in your organization:
-
-| Resource | Required Product |
-|---|---|
-| `datadog.securityRules` | Cloud SIEM |
-| `datadog.securityFilters` | Cloud SIEM |
-| `datadog.securitySuppressions` | Cloud SIEM |
-| `datadog.sensitiveDataScannerGroups` | Sensitive Data Scanner |
-
-To check which products are enabled, go to **Datadog > Organization Settings > Subscription** or contact your Datadog account representative.
-
 ## Examples
 
 **List all users**
@@ -144,3 +96,51 @@ mql> datadog.teams { name handle userCount }
 ```shell
 mql> datadog.logsArchives { name query state destinationType }
 ```
+
+## Required Permissions
+
+By default, an unscoped Application Key inherits all permissions of the user who created it. For production use, Datadog supports [scoped Application Keys](https://docs.datadoghq.com/account_management/api-app-keys/) that restrict access to specific RBAC permissions.
+
+The table below lists the Datadog RBAC permission each resource requires. These are the same permission names shown in **Datadog > Organization Settings > Roles**.
+
+| Resource | Required RBAC Permission |
+|---|---|
+| `datadog.users` | `user_access_invite` |
+| `datadog.roles` | `user_access_invite` |
+| `datadog.serviceAccounts` | `user_access_invite` |
+| `datadog.monitors` | `monitors_read` |
+| `datadog.dashboards` | `dashboards_read` |
+| `datadog.slos` | `slos_read` |
+| `datadog.downtimes` | `monitors_downtime` |
+| `datadog.syntheticsTests` | `synthetics_read` |
+| `datadog.syntheticsGlobalVariables` | `synthetics_read` |
+| `datadog.syntheticsPrivateLocations` | `synthetics_read` |
+| `datadog.logIndexes` | `logs_read_index_data` |
+| `datadog.logsArchives` | `logs_read_archives` |
+| `datadog.securityRules` | `security_monitoring_rules_read` |
+| `datadog.securityFilters` | `security_monitoring_filters_read` |
+| `datadog.securitySuppressions` | `security_monitoring_suppressions_read` |
+| `datadog.sensitiveDataScannerGroups` | `data_scanner_read` |
+| `datadog.apiKeys` | `api_keys_read` |
+| `datadog.applicationKeys` | `user_app_keys` |
+| `datadog.ipAllowlistEntries` / `ipAllowlistEnabled` | `org_management` |
+| `datadog.integrationAwsAccounts` | `aws_configuration_read` |
+| `datadog.teams` | `teams_read` |
+| `datadog.rumApplications` | `rum_apps_read` |
+
+> **Tip**: For full access to all resources, use an unscoped Application Key (it inherits all permissions from its creator). Scoped keys are recommended for production use to follow least-privilege principles.
+
+> **Note**: Some resources require your Datadog plan to include the corresponding product. If the feature is not enabled, the API returns 403 Forbidden regardless of your key's permissions. The provider handles this gracefully by returning an empty list and logging a warning.
+
+### Plan-Gated Resources
+
+The following resources require specific Datadog products to be enabled in your organization:
+
+| Resource | Required Product |
+|---|---|
+| `datadog.securityRules` | Cloud SIEM |
+| `datadog.securityFilters` | Cloud SIEM |
+| `datadog.securitySuppressions` | Cloud SIEM |
+| `datadog.sensitiveDataScannerGroups` | Sensitive Data Scanner |
+
+To check which products are enabled, go to **Datadog > Organization Settings > Subscription** or contact your Datadog account representative.

--- a/providers/digitalocean/README.md
+++ b/providers/digitalocean/README.md
@@ -29,13 +29,13 @@ export DIGITALOCEAN_SPACES_REGION="nyc3"
 ### CLI flag
 
 ```bash
-cnspec shell digitalocean --token <api-token>
+mql shell digitalocean --token <api-token>
 ```
 
 If `DIGITALOCEAN_TOKEN` is set, you can omit the flag:
 
 ```bash
-cnspec shell digitalocean
+mql shell digitalocean
 ```
 
 ## Discovery
@@ -53,21 +53,15 @@ The provider connects to the account as a single asset and can expand it into ch
 | `spaces-buckets` | Spaces buckets (requires Spaces credentials) |
 
 ```bash
-cnspec shell digitalocean --discover all
+mql shell digitalocean --discover all
 ```
-
-## Notes
-
-- **Spaces** resources return an empty list unless `DIGITALOCEAN_SPACES_KEY` and `DIGITALOCEAN_SPACES_SECRET` are set.
-- **Functions** are backed by Apache OpenWhisk. Listing the functions (actions) deployed in a namespace reaches the namespace's Functions API host using credentials retrieved from the DigitalOcean API.
-- Resources the token cannot read (for example, a scoped token) are handled gracefully where possible.
 
 ## Examples
 
 Launch an interactive shell and run queries:
 
 ```bash
-cnspec shell digitalocean
+mql shell digitalocean
 ```
 
 List Droplets and flag any without a firewall:
@@ -111,3 +105,9 @@ You can also run a policy scan:
 ```bash
 cnspec scan digitalocean
 ```
+
+## Notes
+
+- **Spaces** resources return an empty list unless `DIGITALOCEAN_SPACES_KEY` and `DIGITALOCEAN_SPACES_SECRET` are set.
+- **Functions** are backed by Apache OpenWhisk. Listing the functions (actions) deployed in a namespace reaches the namespace's Functions API host using credentials retrieved from the DigitalOcean API.
+- Resources the token cannot read (for example, a scoped token) are handled gracefully where possible.

--- a/providers/ipinfo/README.md
+++ b/providers/ipinfo/README.md
@@ -1,13 +1,17 @@
 # IPinfo Provider
 
-```shell
-mql shell ipinfo
-```
+## Authentication
 
 For authentication, you can use the `IPINFO_TOKEN` environment variable.
 
 ```shell
 export IPINFO_TOKEN="<token>"
+```
+
+## Usage
+
+```shell
+mql shell ipinfo
 ```
 
 ## Examples

--- a/providers/mistral/README.md
+++ b/providers/mistral/README.md
@@ -37,7 +37,7 @@ export MISTRAL_API_KEY=<api-key>
 mql shell mistral
 ```
 
-## Example Queries
+## Examples
 
 ### List all models with capabilities
 

--- a/providers/mongodbatlas/README.md
+++ b/providers/mongodbatlas/README.md
@@ -26,7 +26,7 @@ A public/private API key pair (HTTP Digest). Grant the key organization
 read-only access to audit the whole organization.
 
 ```shell
-cnspec shell mongodbatlas \
+mql shell mongodbatlas \
   --org-id <org-id> \
   --public-key <public-key> \
   --private-key <private-key>
@@ -35,7 +35,7 @@ cnspec shell mongodbatlas \
 ### Service account (OAuth2)
 
 ```shell
-cnspec shell mongodbatlas \
+mql shell mongodbatlas \
   --org-id <org-id> \
   --client-id <client-id> \
   --client-secret <client-secret>
@@ -58,13 +58,13 @@ Discovery is controlled with `--discover`:
 - `auto` / `all` (default) discovers every project.
 - `projects` is the explicit project target.
 
-## Example queries
+## Examples
 
 Organization plane:
 
 ```shell
 # Organizations that do not require multi-factor authentication
-cnspec shell mongodbatlas --org-id <id> --public-key <pub> --private-key <priv> \
+mql shell mongodbatlas --org-id <id> --public-key <pub> --private-key <priv> \
   -c "mongodbatlas.multiFactorAuthRequired"
 
 # API keys and their roles

--- a/providers/ms365/README.md
+++ b/providers/ms365/README.md
@@ -20,7 +20,7 @@ brew install --cask powershell
 ### Linux
 Please refer to the [documentation](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-linux) based on your distribution.
 
-## Authenticating
+## Authentication
 You will need to provide your app's client and tenant id as well certificate.
 ```
 export MS365_CLIENT_ID='your-client-id'

--- a/providers/mssql/README.md
+++ b/providers/mssql/README.md
@@ -1,0 +1,141 @@
+# Microsoft SQL Server Provider
+
+The `mssql` provider connects to a Microsoft SQL Server instance over TDS and inventories it through read-only catalog queries (`sys.*` and `msdb.*`). It exposes server principals (logins and roles), permissions, databases and their users/roles, credentials, linked servers, SQL Agent proxies, audits, encryption keys, and surface-area configuration options, so you can audit the instance's security posture (the CIS SQL Server benchmark) without touching the data.
+
+## Authentication
+
+The provider authenticates with a SQL login, Windows (NTLM) integrated auth, or a Microsoft Entra ID access token, and connects with a configurable TDS encryption mode.
+
+Arguments:
+
+- `--host` - the instance hostname or IP address (also accepted as the positional argument).
+- `--port` - the instance port (default `1433`).
+- `--instance` - a named instance (resolved via SQL Browser when the port is unknown).
+- `--user` (`-u`) - the login name (`sa`, `DOMAIN\user`, or a user principal name).
+- `--password` (`-p`) - the password, or `--ask-pass` to be prompted.
+- `--auth` - `sql` (default), `windows`, or `azure`.
+- `--token` - a Microsoft Entra ID access token (for `--auth azure`).
+- `--database` - scope the connection to a single database.
+- `--encrypt` - `strict`, `mandatory` (default), `optional`, or `disable`.
+- `--trust-server-certificate` - skip TLS certificate validation.
+
+```shell
+mql shell mssql sql.contoso.com --user sa --ask-pass
+```
+
+> Prefer a least-privileged login for auditing. `VIEW ANY DEFINITION` (or the `##MS_DefinitionReader##` role on 2022+) lets the provider see all server principals and permissions; without it some principals are invisible rather than causing a failure.
+
+## Usage
+
+Open an interactive shell against an instance:
+
+```shell
+mql shell mssql sql.contoso.com --user sa --ask-pass
+```
+
+Named instance, or Windows/Entra authentication:
+
+```shell
+mql shell mssql sql.contoso.com --instance SQL2022 --auth windows --user 'CONTOSO\auditor' --ask-pass
+mql shell mssql sql.contoso.com --auth azure --user auditor@contoso.com --token <access-token>
+```
+
+## Discovery
+
+By default the provider discovers each online database as its own `mssql-database` asset, alongside the instance asset. The `--discover` targets control which child assets are emitted:
+
+- `auto` (default) - also emit one asset per online database. Same as `all`.
+- `all` - also emit one asset per online database.
+- `databases` - also emit one asset per online database.
+- `instance` / `none` - the instance only, without per-database assets.
+
+```shell
+# Scan the instance and every database
+cnspec scan mssql sql.contoso.com --user auditor --ask-pass
+
+# Scan the instance only
+cnspec scan mssql sql.contoso.com --user auditor --ask-pass --discover none
+```
+
+## Examples
+
+**Server version and authentication mode**
+
+Read the instance metadata, including whether mixed-mode (SQL + Windows) authentication is enabled.
+
+```shell
+mql> mssql.server { version edition isMixedModeAuthEnabled }
+mssql.server: {
+  isMixedModeAuthEnabled: true
+  version: "Microsoft SQL Server 2022 (RTM-CU26) ... Developer Edition (64-bit) on Linux ..."
+  edition: "Developer Edition (64-bit)"
+}
+```
+
+**State of the `sa` login (CIS 2.13)**
+
+Check whether the built-in `sa` login is disabled.
+
+```shell
+mql> mssql.server.logins.where(name == "sa") { name isDisabled }
+mssql.server.logins.where: [
+  0: {
+    name: "sa"
+    isDisabled: false
+  }
+]
+```
+
+**Surface-area configuration (CIS 2.x)**
+
+Read a `sp_configure` option's running value, for example `clr enabled`.
+
+```shell
+mql> mssql.server.configurations.where(name == "clr enabled") { name valueInUse }
+mssql.server.configurations.where: [
+  0: {
+    valueInUse: 0
+    name: "clr enabled"
+  }
+]
+```
+
+**Trustworthy databases (CIS 2.9)**
+
+Report the Trustworthy and TDE state of a database.
+
+```shell
+mql> mssql.server.databases.where(name == "TESTDB") { name isTrustworthy isEncrypted }
+mssql.server.databases.where: [
+  0: {
+    isTrustworthy: false
+    name: "TESTDB"
+    isEncrypted: false
+  }
+]
+```
+
+**Backup encryption (CIS 7.3)**
+
+List a database's backup history and whether each backup set is encrypted.
+
+```shell
+mql> mssql.server.databases.where(name == "TESTDB").first.backups { type isEncrypted keyAlgorithm }
+mssql.server.databases.where.first.backups: [
+  0: {
+    type: "DATABASE"
+    isEncrypted: true
+    keyAlgorithm: "aes_256"
+  }
+]
+```
+
+## Verification
+
+Confirm the connection with a single query:
+
+```shell
+mql shell mssql sql.contoso.com --user sa --ask-pass -c "mssql.server { version edition }"
+```
+
+If `mssql.server.logins` is missing principals you expect, the login lacks `VIEW ANY DEFINITION`; grant it (or the `##MS_DefinitionReader##` role) and retry.

--- a/providers/mysqldb/README.md
+++ b/providers/mysqldb/README.md
@@ -1,0 +1,141 @@
+# MySQL Provider
+
+The `mysqldb` provider connects to a MySQL, MariaDB, or Percona server and inventories it through read-only queries against `information_schema`, `performance_schema`, and the system catalogs. It exposes accounts, privileges, roles, schemas, routines, plugins, components, and configuration variables, so you can audit the server's security posture (the CIS MySQL benchmark) without touching the data.
+
+The server flavor is detected automatically and reported as `mysqldb.instance.flavor` (`mysql`, `mariadb`, or `percona`), so one provider covers all three engines.
+
+## Authentication
+
+The provider authenticates with a MySQL user and password, and connects over TLS according to `--tls-mode`.
+
+Arguments:
+
+- `--host` - the server hostname or IP address (also accepted as the positional argument).
+- `--port` - the server port (default `3306`).
+- `--user` (`-u`) - the user to authenticate as.
+- `--password` (`-p`) - the password, or `--ask-pass` to be prompted.
+- `--database` - an optional default schema for the connection.
+- `--tls-mode` - `false`, `skip-verify`, `preferred` (default), or `true`.
+- `--tls-ca`, `--tls-cert`, `--tls-key` - paths to CA and client-certificate material for verified or mutual TLS.
+
+```shell
+mql shell mysqldb db.contoso.com --user root --ask-pass
+```
+
+> Prefer a least-privileged account for auditing. Read access to `mysql.user`, `information_schema`, and `performance_schema` is enough for the resources below; without it those collections return empty rather than failing the scan.
+
+## Usage
+
+Open an interactive shell against a server:
+
+```shell
+mql shell mysqldb --host db.contoso.com --user root --ask-pass
+```
+
+The host may also be given as the positional argument, and a verified-TLS connection adds the certificate flags:
+
+```shell
+mql shell mysqldb db.contoso.com --user auditor --ask-pass --tls-mode true --tls-ca ca.pem
+```
+
+## Discovery
+
+By default the provider discovers each schema (database) on the server as its own `mysqldb-database` asset, alongside the server asset. The `--discover` targets control which child assets are emitted:
+
+- `auto` (default) - also emit one asset per schema. Same as `all`.
+- `all` - also emit one asset per schema.
+- `databases` - also emit one asset per schema.
+- `none` - the server only, without per-schema assets.
+
+```shell
+# Scan the server and every schema
+cnspec scan mysqldb db.contoso.com --user auditor --ask-pass
+
+# Scan the server only
+cnspec scan mysqldb db.contoso.com --user auditor --ask-pass --discover none
+```
+
+## Examples
+
+**Server version and hardening settings**
+
+Read the instance metadata and a few security-relevant variables at once.
+
+```shell
+mql> mysqldb.instance { version flavor requireSecureTransport localInfile }
+mysqldb.instance: {
+  version: "11.8.8-MariaDB-ubu2404"
+  localInfile: true
+  requireSecureTransport: false
+  flavor: "mariadb"
+}
+```
+
+**Anonymous or wildcard-host accounts (CIS 7.6 / 7.7)**
+
+Find accounts that are anonymous or reachable from any host.
+
+```shell
+mql> mysqldb.instance.users.where(isAnonymous || isWildcardHost) { user host }
+mysqldb.instance.users.where: [
+  0: {
+    host: "%"
+    user: "root"
+  }
+]
+```
+
+**Accounts without a password (CIS 7.3)**
+
+Find accounts that have no password set.
+
+```shell
+mql> mysqldb.instance.users.where(hasPassword == false) { user host authPlugin }
+mysqldb.instance.users.where: [
+  0: {
+    host: "localhost"
+    authPlugin: "mysql_native_password"
+    user: "mariadb.sys"
+  }
+]
+```
+
+**Global privileges held by an account (CIS 5.x least-privilege)**
+
+List the global (server-wide) privileges granted to an account, for reviewing over-broad grants such as `SUPER`, `FILE`, or `PROCESS`.
+
+```shell
+mql> mysqldb.instance.users.where(user == "appuser").first.privileges.where(scope == "GLOBAL") { privilegeType scope }
+mysqldb.instance.users.where.first.privileges.where: [
+  0: {
+    scope: "GLOBAL"
+    privilegeType: "PROCESS"
+  }
+]
+```
+
+**SECURITY DEFINER routines (CIS 5.10)**
+
+List stored routines and whether each runs as its definer, a privilege-escalation surface when the definer is highly privileged.
+
+```shell
+mql> mysqldb.instance.schemas.where(name == "appdb").first.routines { name type securityType definer }
+mysqldb.instance.schemas.where.first.routines: [
+  0: {
+    definer: "appuser@%"
+    name: "secdef_proc"
+    securityType: "DEFINER"
+    type: "PROCEDURE"
+  }
+]
+```
+
+## Verification
+
+Confirm the connection and permissions with a single query:
+
+```shell
+mql shell mysqldb db.contoso.com --user root --ask-pass -c "mysqldb.instance { version flavor }"
+```
+
+If `mysqldb.instance.users` comes back empty, the connecting account cannot read `mysql.user`; grant it read access (or use a more privileged auditing account) and retry.

--- a/providers/nmap/README.md
+++ b/providers/nmap/README.md
@@ -4,17 +4,17 @@ Nmap, short for Network Mapper, is a powerful and versatile open-source tool use
 
 The nmap provider maps primary objects and attributes that nmap uses to store and manage information about scanned targets, discovered hosts, and their associated ports and services.
 
-## Pre-requisites
+## Prerequisites
 
 This provider requires the Nmap tool to be installed on your system. You can download and install Nmap from the official [website](https://nmap.org/download.html).
 
-## Get Started
+## Usage
 
 ```shell
 mql shell nmap
 ```
 
-## Example
+## Examples
 
 *Scan active IP address in network*
 
@@ -84,7 +84,7 @@ nmap.network.hosts: [
 ]
 ```
 
-# Advanced Usage
+## Advanced Usage
 
 Discover all exposed hosts on a network.
 
@@ -98,7 +98,7 @@ Connect to a specific IP address and display all open ports.
 mql shell nmap host 8.8.8.8
 ```
 
-## Verifying the Installation of nmap
+## Verification
 
 To verify the installation of nmap, run the following command:
 

--- a/providers/openstack/README.md
+++ b/providers/openstack/README.md
@@ -2,17 +2,17 @@
 
 Query OpenStack projects with mql and cnspec. Built on `gophercloud/v2`.
 
-## Coverage
+## Prerequisites
 
-Seven OpenStack services across 34 resources:
+- A reachable Keystone v3 endpoint
+- Project-scoped credentials (username/password, application credential, or `clouds.yaml` entry)
+- Network access to the service catalog endpoints for each subsystem you want to query
 
-- **Identity (Keystone v3)** — projects, users, roles, domains
-- **Compute (Nova v2)** — servers, flavors, keypairs, server groups
-- **Image (Glance v2)** — images
-- **Networking (Neutron v2)** — networks, subnets, routers, ports, floating IPs, security groups (with rules), subnet pools, QoS policies, trunks, FWaaS v2 (groups, policies, rules)
-- **Block Storage (Cinder v3)** — volumes, snapshots
-- **Key Manager (Barbican v1)** — secrets, containers, orders
-- **Load Balancer (Octavia v2)** — load balancers, listeners, pools, members, health monitors, L7 policies, L7 rules
+Permissions:
+
+- Tenant tokens see their own project's data across all services.
+- Listing all `users`, `roles`, or admin-only Keystone endpoints requires admin scope.
+- Calls to services that aren't deployed (e.g. Octavia or Barbican on smaller clouds) return empty rather than failing the query, so policies can be portable across clouds with different service catalogs.
 
 ## Usage
 
@@ -46,6 +46,18 @@ mql shell openstack \
 
 Auth precedence (highest first): CLI flags → `--cloud` (resolves a `clouds.yaml` entry) → `OS_*` environment variables.
 
+## Coverage
+
+Seven OpenStack services across 34 resources:
+
+- **Identity (Keystone v3)** — projects, users, roles, domains
+- **Compute (Nova v2)** — servers, flavors, keypairs, server groups
+- **Image (Glance v2)** — images
+- **Networking (Neutron v2)** — networks, subnets, routers, ports, floating IPs, security groups (with rules), subnet pools, QoS policies, trunks, FWaaS v2 (groups, policies, rules)
+- **Block Storage (Cinder v3)** — volumes, snapshots
+- **Key Manager (Barbican v1)** — secrets, containers, orders
+- **Load Balancer (Octavia v2)** — load balancers, listeners, pools, members, health monitors, L7 policies, L7 rules
+
 ## Asset URL
 
 Assets are placed under `technology=openstack` with the project ID as the discriminant:
@@ -55,15 +67,3 @@ technology=openstack/project=<project-uuid>
 ```
 
 Each connection produces exactly one asset (the Keystone-scoped project). The asset's platform is `openstack-project`; family is `["openstack"]`.
-
-## Requirements
-
-- A reachable Keystone v3 endpoint
-- Project-scoped credentials (username/password, application credential, or `clouds.yaml` entry)
-- Network access to the service catalog endpoints for each subsystem you want to query
-
-Permissions:
-
-- Tenant tokens see their own project's data across all services.
-- Listing all `users`, `roles`, or admin-only Keystone endpoints requires admin scope.
-- Calls to services that aren't deployed (e.g. Octavia or Barbican on smaller clouds) return empty rather than failing the query, so policies can be portable across clouds with different service catalogs.

--- a/providers/os/README.md
+++ b/providers/os/README.md
@@ -1,5 +1,15 @@
-## os provider for cnquery/cnspec
+# OS Provider
 
-This provides makes the operating system accessible, including Linux, macOS, Windows and many more.
+This provider makes the operating system accessible, including Linux, macOS, Windows, and many more.
 
 It provides connectors for Local OS, SSH, WinRM, and Docker.
+
+## Usage
+
+```shell
+mql shell os
+```
+
+## Examples
+
+<!-- TODO: add example queries -->

--- a/providers/postgresdb/README.md
+++ b/providers/postgresdb/README.md
@@ -1,0 +1,135 @@
+# PostgreSQL Provider
+
+The `postgresdb` provider connects to a PostgreSQL server and inventories it through read-only queries against `pg_catalog` and `information_schema`. It exposes roles, databases, schemas, tables, functions, privileges, host-based authentication rules, extensions, foreign servers, and configuration settings, so you can audit the server's security posture (the CIS PostgreSQL benchmark) without touching the data.
+
+## Authentication
+
+The provider authenticates with a PostgreSQL role and password, and connects over TLS according to `--sslmode`.
+
+Arguments:
+
+- `--host` - the server hostname or IP address (also accepted as the positional argument).
+- `--port` - the server port (default `5432`).
+- `--user` (`-u`) - the role to authenticate as.
+- `--password` (`-p`) - the password, or `--ask-pass` to be prompted.
+- `--database` - the database used for the initial (server) connection (default `postgres`).
+- `--sslmode` - `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, or `verify-full`.
+- `--sslrootcert`, `--sslcert`, `--sslkey` - paths to CA and client-certificate material for verified or mutual TLS.
+
+```shell
+mql shell postgresdb db.contoso.com --user postgres --ask-pass
+```
+
+> Prefer a least-privileged role for auditing. Some fields (a role's `passwordType`, and the `hbaRules`) require superuser or a `pg_read_all_settings`/`pg_read_all_stats` membership; without it those degrade to null or empty rather than failing the scan.
+
+## Usage
+
+Open an interactive shell against a server:
+
+```shell
+mql shell postgresdb --host db.contoso.com --user postgres --ask-pass
+```
+
+For a verified-TLS connection, add the certificate flags:
+
+```shell
+mql shell postgresdb db.contoso.com --user auditor --ask-pass --sslmode verify-full --sslrootcert ca.pem
+```
+
+## Discovery
+
+Because PostgreSQL cannot query across databases, the provider connects per database. By default it discovers each connectable database as its own `postgres-database` asset, alongside the server asset. The `--discover` targets control which child assets are emitted:
+
+- `auto` (default) - also emit one asset per database. Same as `all`.
+- `all` - also emit one asset per database.
+- `databases` - also emit one asset per database.
+- `none` - the server only, without per-database assets.
+
+```shell
+# Scan the server and every database
+cnspec scan postgresdb db.contoso.com --user auditor --ask-pass
+
+# Scan the server only
+cnspec scan postgresdb db.contoso.com --user auditor --ask-pass --discover none
+```
+
+## Examples
+
+**Server settings**
+
+Read the version and a couple of security-relevant settings at once.
+
+```shell
+mql> postgresdb.instance { version ssl passwordEncryption }
+postgresdb.instance: {
+  version: "PostgreSQL 17.10 (Debian 17.10-1.pgdg13+1) on aarch64-unknown-linux-gnu, ..."
+  ssl: false
+  passwordEncryption: "scram-sha-256"
+}
+```
+
+**Superuser roles (CIS 4.3)**
+
+List the roles that hold superuser, to review over-broad administrative access.
+
+```shell
+mql> postgresdb.instance.roles.where(isSuperuser) { name canLogin }
+postgresdb.instance.roles.where: [
+  0: {
+    canLogin: true
+    name: "postgres"
+  }
+]
+```
+
+**Privileges on the `public` schema**
+
+List the privileges granted on a database's `public` schema, to confirm `CREATE` is not granted to `PUBLIC`.
+
+```shell
+mql> postgresdb.instance.databases.where(name == "appdb").first.schemas.where(name == "public").first.privileges { grantee privilegeType }
+postgresdb.instance.databases.where.first.schemas.where.first.privileges: [
+  0: { privilegeType: "USAGE"  grantee: "pg_database_owner" }
+  1: { privilegeType: "CREATE" grantee: "pg_database_owner" }
+  2: { privilegeType: "USAGE"  grantee: "PUBLIC" }
+]
+```
+
+**SECURITY DEFINER functions (CIS 4.5)**
+
+Find functions that run with their owner's privileges, a privilege-escalation surface.
+
+```shell
+mql> postgresdb.instance.databases.where(name == "appdb").first.functions.where(isSecurityDefiner) { name schema isSecurityDefiner }
+postgresdb.instance.databases.where.first.functions.where: [
+  0: {
+    name: "secdef_fn"
+    isSecurityDefiner: true
+    schema: "appschema"
+  }
+]
+```
+
+**Tables with row-level security (CIS 4.7)**
+
+Report which tables have row-level security enabled.
+
+```shell
+mql> postgresdb.instance.databases.where(name == "appdb").first.schemas.where(name == "appschema").first.tables { name rowSecurityEnabled }
+postgresdb.instance.databases.where.first.schemas.where.first.tables: [
+  0: {
+    rowSecurityEnabled: true
+    name: "t1"
+  }
+]
+```
+
+## Verification
+
+Confirm the connection with a single query:
+
+```shell
+mql shell postgresdb db.contoso.com --user postgres --ask-pass -c "postgresdb.instance { version }"
+```
+
+If a role's `passwordType` or the `hbaRules` come back null/empty, the connecting role lacks the privilege to read `pg_authid` / `pg_hba_file_rules`; use a more privileged auditing role and retry.

--- a/providers/proxmox/README.md
+++ b/providers/proxmox/README.md
@@ -2,16 +2,11 @@
 
 Query and scan Proxmox VE clusters with cnspec/cnquery.
 
-## Features
+## Prerequisites
 
-- **Cluster**: Cluster status, quorum, HA resources, options
-- **Nodes**: Hardware info, services, DNS, timezone, certificates, subscription, repositories, updates, firewall rules
-- **VMs**: Configuration, resource metrics, network interfaces, disks, snapshots, tags, firewall rules
-- **Updates**: Package update checks via QEMU Guest Agent (apt, dnf, Windows) and node APT
-- **Storage**: Storage pools with capacity monitoring
-- **Access Control**: Users, API tokens, roles and privileges
-- **Firewall**: Rules at cluster, node, and VM level
-- **Security Policy**: 20+ checks covering patch management, certificate hygiene, access control, and more
+- Proxmox VE 7.x or 8.x
+- API token with at least `PVEAuditor` role
+- QEMU Guest Agent installed in VMs (for update queries)
 
 ## Usage
 
@@ -29,34 +24,7 @@ mql shell proxmox --host https://192.168.1.10:8006 \
   --token 'PVEAPIToken=user@realm!tokenid=secret'
 ```
 
-## MQL Resources
-
-| Resource                    | Description                                         |
-|-----------------------------|-----------------------------------------------------|
-| `proxmox`                   | Root resource — cluster overview                    |
-| `proxmox.cluster`           | Cluster status, quorum, HA                          |
-| `proxmox.cluster.haResource`| High-availability managed resource                  |
-| `proxmox.node`              | Cluster node with full hardware/system details      |
-| `proxmox.node.update`       | Pending package update on a node                    |
-| `proxmox.vm`                | QEMU virtual machine with config and metrics        |
-| `proxmox.vm.network`        | Network interface attached to a VM                  |
-| `proxmox.vm.disk`           | Disk device attached to a VM                        |
-| `proxmox.vm.snapshot`       | VM snapshot                                         |
-| `proxmox.vm.update`         | Pending software update inside a VM (via QGA)       |
-| `proxmox.storage`           | Storage pool with capacity information              |
-| `proxmox.pool`              | Resource pool                                       |
-| `proxmox.network`           | Node network interface (bridge, bond, VLAN)         |
-| `proxmox.dns`               | DNS configuration on a node                         |
-| `proxmox.service`           | systemd service on a node                           |
-| `proxmox.certificate`       | TLS/SSL certificate on a node                       |
-| `proxmox.subscription`      | Proxmox subscription status                         |
-| `proxmox.repository`        | APT repository configured on a node                 |
-| `proxmox.firewall.rule`     | Firewall rule (cluster, node, or VM level)          |
-| `proxmox.user`              | User account                                        |
-| `proxmox.token`             | API token for a user                                |
-| `proxmox.role`              | Access control role                                 |
-
-### Example Queries
+## Examples
 
 ```mql
 # Cluster overview
@@ -87,8 +55,40 @@ proxmox.users { id tokens { id expire privsep } }
 proxmox.vms { name firewallRules { pos action proto dest dport } }
 ```
 
-## Requirements
+## Resources
 
-- Proxmox VE 7.x or 8.x
-- API token with at least `PVEAuditor` role
-- QEMU Guest Agent installed in VMs (for update queries)
+| Resource                    | Description                                         |
+|-----------------------------|-----------------------------------------------------|
+| `proxmox`                   | Root resource — cluster overview                    |
+| `proxmox.cluster`           | Cluster status, quorum, HA                          |
+| `proxmox.cluster.haResource`| High-availability managed resource                  |
+| `proxmox.node`              | Cluster node with full hardware/system details      |
+| `proxmox.node.update`       | Pending package update on a node                    |
+| `proxmox.vm`                | QEMU virtual machine with config and metrics        |
+| `proxmox.vm.network`        | Network interface attached to a VM                  |
+| `proxmox.vm.disk`           | Disk device attached to a VM                        |
+| `proxmox.vm.snapshot`       | VM snapshot                                         |
+| `proxmox.vm.update`         | Pending software update inside a VM (via QGA)       |
+| `proxmox.storage`           | Storage pool with capacity information              |
+| `proxmox.pool`              | Resource pool                                       |
+| `proxmox.network`           | Node network interface (bridge, bond, VLAN)         |
+| `proxmox.dns`               | DNS configuration on a node                         |
+| `proxmox.service`           | systemd service on a node                           |
+| `proxmox.certificate`       | TLS/SSL certificate on a node                       |
+| `proxmox.subscription`      | Proxmox subscription status                         |
+| `proxmox.repository`        | APT repository configured on a node                 |
+| `proxmox.firewall.rule`     | Firewall rule (cluster, node, or VM level)          |
+| `proxmox.user`              | User account                                        |
+| `proxmox.token`             | API token for a user                                |
+| `proxmox.role`              | Access control role                                 |
+
+## Features
+
+- **Cluster**: Cluster status, quorum, HA resources, options
+- **Nodes**: Hardware info, services, DNS, timezone, certificates, subscription, repositories, updates, firewall rules
+- **VMs**: Configuration, resource metrics, network interfaces, disks, snapshots, tags, firewall rules
+- **Updates**: Package update checks via QEMU Guest Agent (apt, dnf, Windows) and node APT
+- **Storage**: Storage pools with capacity monitoring
+- **Access Control**: Users, API tokens, roles and privileges
+- **Firewall**: Rules at cluster, node, and VM level
+- **Security Policy**: 20+ checks covering patch management, certificate hygiene, access control, and more

--- a/providers/shodan/README.md
+++ b/providers/shodan/README.md
@@ -1,13 +1,17 @@
 # Shodan Provider
 
-```shell
-mql shell shodan
-```
+## Authentication
 
 For authentication, you can use the `SHODAN_TOKEN` environment variable.
 
 ```shell
 export SHODAN_TOKEN="<token>"
+```
+
+## Usage
+
+```shell
+mql shell shodan
 ```
 
 ## Examples
@@ -126,7 +130,7 @@ shodan.domain.nsrecords.where.where: [
 ]
 ```
 
-# Advanced Usage
+## Advanced Usage
 
 Discover all exposed hosts on a network.
 

--- a/providers/snowflake/README.md
+++ b/providers/snowflake/README.md
@@ -4,6 +4,8 @@
 mql shell snowflake
 ```
 
+## Authentication
+
 Required arguments:
 
 - `--account` - The Snowflake account name.
@@ -22,7 +24,7 @@ Arguments:
 - `--token` - The programmatic access token.
 
 ```shell
-cnspec shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --token <your PAT>
+mql shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --token <your PAT>
 ```
 
 > To generate a PAT, use [Snowsight](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens) and assign it to your user. Prefer a token scoped to the least-privileged role that still allows the scan.
@@ -34,7 +36,7 @@ Arguments:
 - `--identity-file` (`-i`) - The path to the private key file.
 
 ```shell
-cnspec shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --identity-file ~/.ssh/id_rsa
+mql shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --identity-file ~/.ssh/id_rsa
 ```
 
 > You need to generate a RSA key pair and assign the public key to your user via [Snowsight](https://docs.snowflake.com/en/user-guide/key-pair-auth).
@@ -49,12 +51,12 @@ Arguments:
 - `--ask-pass` - Prompt for the Snowflake password.
 
 ```shell
-cnspec shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --ask-pass
+mql shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --ask-pass
 ```
 
 > To create a username and password, use [Snowsight](https://docs.snowflake.com/en/user-guide/admin-user-management#using-snowsight) or using [SQL](https://docs.snowflake.com/en/user-guide/admin-user-management#using-sql).
 
-## Asset Discovery
+## Discovery
 
 A scan surfaces the Snowflake account as its own asset and, in addition, one asset per database in the account:
 

--- a/providers/tailscale/README.md
+++ b/providers/tailscale/README.md
@@ -3,6 +3,8 @@
 Use the tailscale provider to query devices, users, DNS namespaces, and more information about a Tailscale network,
 known as a `tailnet`.
 
+## Authentication
+
 To authenticate using an API access token:
 
 ```
@@ -83,7 +85,7 @@ tailscale.user: {
 }
 ```
 
-# Advanced usage
+## Advanced Usage
 
 **Discover all devices (any computer or mobile device) that join the tailnet `example.com`**
 

--- a/providers/together/README.md
+++ b/providers/together/README.md
@@ -41,31 +41,6 @@ For self-hosted or proxy setups:
 mql shell together --token <api-key> --base-url https://my-proxy.example.com/v1
 ```
 
-## Resources
-
-| Resource | Description |
-|---|---|
-| `together.models` | Available models in the Together AI catalog |
-| `together.endpoints` | Dedicated and serverless endpoint deployments |
-| `together.fineTunes` | Fine-tuning jobs |
-| `together.deployments` | Container deployments (Jig) with GPU allocation |
-| `together.files` | Uploaded files for fine-tuning, eval, or batch |
-| `together.clusters` | GPU compute clusters |
-| `together.cluster.storageVolumes` | Persistent storage attached to clusters |
-| `together.secrets` | Managed secrets for deployments |
-| `together.batches` | Batch inference jobs |
-| `together.evals` | Evaluation jobs |
-| `together.volumes` | Persistent volumes for deployments |
-
-### Enterprise-Only Resources
-
-The following resources require an enterprise Together AI account. On non-enterprise accounts, they return empty lists:
-
-- `together.deployments`
-- `together.clusters` (and `cluster.storageVolumes`)
-- `together.secrets`
-- `together.volumes`
-
 ## Examples
 
 **List all available models**
@@ -195,3 +170,28 @@ mql> together.volumes { name type currentVersion mountedBy }
 ```bash
 mql> together { models.length endpoints.length fineTunes.length deployments.length batches.length files.length }
 ```
+
+## Resources
+
+| Resource | Description |
+|---|---|
+| `together.models` | Available models in the Together AI catalog |
+| `together.endpoints` | Dedicated and serverless endpoint deployments |
+| `together.fineTunes` | Fine-tuning jobs |
+| `together.deployments` | Container deployments (Jig) with GPU allocation |
+| `together.files` | Uploaded files for fine-tuning, eval, or batch |
+| `together.clusters` | GPU compute clusters |
+| `together.cluster.storageVolumes` | Persistent storage attached to clusters |
+| `together.secrets` | Managed secrets for deployments |
+| `together.batches` | Batch inference jobs |
+| `together.evals` | Evaluation jobs |
+| `together.volumes` | Persistent volumes for deployments |
+
+### Enterprise-Only Resources
+
+The following resources require an enterprise Together AI account. On non-enterprise accounts, they return empty lists:
+
+- `together.deployments`
+- `together.clusters` (and `cluster.storageVolumes`)
+- `together.secrets`
+- `together.volumes`

--- a/providers/vercel/README.md
+++ b/providers/vercel/README.md
@@ -12,11 +12,11 @@ Provide the token in one of two ways:
 
 ```bash
 # flag
-cnspec shell vercel --token <access_token>
+mql shell vercel --token <access_token>
 
 # environment variable (VERCEL_TOKEN or VERCEL_API_TOKEN)
 export VERCEL_TOKEN=<access_token>
-cnspec shell vercel
+mql shell vercel
 ```
 
 ## Discovery
@@ -39,7 +39,7 @@ Restrict to a single team with `--team` (slug or ID):
 cnspec scan vercel --token <access_token> --team acme
 ```
 
-## Example queries
+## Examples
 
 ```coffee
 # Teams that do not enforce SAML single sign-on

--- a/providers/vllm/README.md
+++ b/providers/vllm/README.md
@@ -5,6 +5,12 @@ inference server. It checks selected documentation, metadata, OpenAI-compatible,
 metrics, utility, and operational endpoints from the URL supplied to the
 connector.
 
+## Authentication
+
+Authenticated comparison probes use an API key from `--api-key`, inventory
+credentials, the `api-key` option, or `VLLM_API_KEY`. Explicit credentials in
+the connection configuration take precedence over environment variables.
+
 ## Usage
 
 ```bash
@@ -14,12 +20,6 @@ mql shell vllm https://vllm.example.com --api-key <token>
 
 Use `--insecure` only for lab or test endpoints where TLS certificate
 verification is intentionally disabled.
-
-## Authentication
-
-Authenticated comparison probes use an API key from `--api-key`, inventory
-credentials, the `api-key` option, or `VLLM_API_KEY`. Explicit credentials in
-the connection configuration take precedence over environment variables.
 
 ## Security Considerations
 


### PR DESCRIPTION
## Summary

Provider READMEs are developer-facing docs (how to invoke a provider via `mql shell`, how to authenticate, and runnable example queries), but only 22 of 65 providers had one and they were structurally inconsistent (5–286 lines, no shared section order). This standardizes them.

- **Canonical structure** — a single section order all providers follow: `# <Name> Provider` intro → `## Prerequisites` → `## Authentication` → `## Usage` → `## Discovery` → `## Examples` → `## Resources` → `## Verification` → `## Troubleshooting` (optional sections omitted when N/A). All headings H2; `mql shell` used for shell invocations. Modeled on the `snowflake` (discovery/DB) and `shodan` (concise API) READMEs.
- **Scaffold template** — `apps/provider-scaffold/template/README.md.template` so every new provider is generated with this structure and TODO placeholders; DEVELOPMENT.md notes the fill-in step.
- **New DB provider READMEs** — full READMEs for `mssql`, `postgresdb`, and `mysqldb`, with example queries verified against live containers (SQL Server 2022, PostgreSQL 17, MariaDB 11 / MySQL 8).
- **Normalized the existing 22** — reordered sections, fixed casing, promoted stray H1 "Advanced Usage" → H2 (nmap/shodan/tailscale), added missing `## Authentication` headings (ipinfo/snowflake/tailscale), converted `cnspec shell` → `mql shell` (leaving `cnspec scan` examples), and turned the `os` stub into a real (minimal) README. Mechanical only — existing prose, queries, output, tables, and links preserved.

The ~43 providers without a README are intentionally out of scope for this pass (a genuine example query needs per-provider knowledge/infra); the scaffold template makes future ones consistent, and they can be backfilled later.

## Verification

- Scaffolded a throwaway provider and confirmed `README.md` renders with `mql shell <id>` and the TODO skeleton.
- Every example in the mssql/postgresdb/mysqldb READMEs was run against a live container and its real output pasted.
- Post-normalization checks: exactly one H1 (`# <Name> Provider`) per README; no `cnspec shell` remaining; no duplicate `## Usage`; `typos` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
