### PR TITLE
🐛 azure: guard the derefs that crash a whole scan

### DIFF
--- a/providers/azure/connection/client_subscriptions.go
+++ b/providers/azure/connection/client_subscriptions.go
@@ -40,6 +40,13 @@ func (client *subscriptionsClient) GetSubscriptions(filter SubscriptionsFilter) 
 			return nil, err
 		}
 		for _, s := range page.Value {
+			// This is the entry point for every Azure scan, so a nil element
+			// here panics before a single asset exists. It also makes the
+			// downstream *sub.SubscriptionID derefs in discovery safe by
+			// construction rather than by luck.
+			if s == nil || s.SubscriptionID == nil {
+				continue
+			}
 			if !filter.IsFilteredOut(*s.SubscriptionID) {
 				subs = append(subs, *s)
 			}

--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -372,6 +372,9 @@ func (a *mqlAzureSubscriptionContainerAppService) managedEnvironments() ([]any, 
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			if entry == nil {
+				continue
+			}
 			mqlEnv, err := acaManagedEnvironmentToMQL(a.MqlRuntime, entry)
 			if err != nil {
 				return nil, err
@@ -744,6 +747,9 @@ func (a *mqlAzureSubscriptionContainerAppService) containerApps() ([]any, error)
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			if entry == nil {
+				continue
+			}
 			mqlApp, err := acaContainerAppToMQL(a.MqlRuntime, entry)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -655,6 +655,13 @@ func (a *mqlAzureSubscriptionCloudDefenderService) getSecuritySettingsFor(name s
 		return nil, err
 	}
 
+	// SettingClassification is an interface, and the SDK's polymorphic
+	// unmarshaller returns a nil one for a null body. The result of GetSetting
+	// was checked but the receiver was not, so a 200 with a null payload panicked
+	// instead of erroring.
+	if settingResp.SettingClassification == nil {
+		return nil, fmt.Errorf("no setting returned for '%s'", name)
+	}
 	baseSetting := settingResp.SettingClassification.GetSetting()
 	if baseSetting == nil || baseSetting.Kind == nil {
 		return nil, fmt.Errorf("retrieved setting or its kind is nil for '%s'", name)
@@ -771,6 +778,12 @@ func argsFromContactProperties(props *armsecurity.ContactProperties) map[string]
 
 	sources := map[string]any{}
 	for _, source := range props.NotificationsSources {
+		// the slice holds interface values, and a null array element unmarshals
+		// to a nil one -- the result of GetNotificationsSource was checked but
+		// the receiver was not
+		if source == nil {
+			continue
+		}
 		notificationSource := source.GetNotificationsSource()
 		if notificationSource == nil || notificationSource.SourceType == nil {
 			continue

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -917,12 +917,11 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 	// Get is the only API option here (no batch endpoint), so a bounded
 	// errgroup is the cheapest fix that preserves semantics.
 	type nicFetch struct {
-		rg    string
-		name  string
-		index int
+		rg   string
+		name string
 	}
 	nicFetches := make([]nicFetch, 0, len(networkInterfaces.NetworkInterfaces))
-	for i, iface := range networkInterfaces.NetworkInterfaces {
+	for _, iface := range networkInterfaces.NetworkInterfaces {
 		if iface.ID == nil {
 			continue
 		}
@@ -934,19 +933,19 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 		if err != nil {
 			return nil, err
 		}
-		nicFetches = append(nicFetches, nicFetch{rg: resource.ResourceGroup, name: name, index: i})
+		nicFetches = append(nicFetches, nicFetch{rg: resource.ResourceGroup, name: name})
 	}
 
-	nics := make([]network.Interface, len(networkInterfaces.NetworkInterfaces))
+	nics := make([]network.Interface, len(nicFetches))
 	g1, gctx1 := errgroup.WithContext(ctx)
 	g1.SetLimit(10)
-	for _, f := range nicFetches {
+	for i, f := range nicFetches {
 		g1.Go(func() error {
 			resp, err := nicClient.Get(gctx1, f.rg, f.name, &network.InterfacesClientGetOptions{})
 			if err != nil {
 				return err
 			}
-			nics[f.index] = resp.Interface
+			nics[i] = resp.Interface
 			return nil
 		})
 	}

--- a/providers/azure/resources/containerinstance.go
+++ b/providers/azure/resources/containerinstance.go
@@ -65,6 +65,9 @@ func (a *mqlAzureSubscriptionContainerInstanceService) containerGroups() ([]any,
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			if entry == nil {
+				continue
+			}
 			mqlGroup, err := aciContainerGroupToMQL(a.MqlRuntime, entry)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/cosmosdb_extras.go
+++ b/providers/azure/resources/cosmosdb_extras.go
@@ -87,6 +87,9 @@ func (a *mqlAzureSubscriptionCosmosDbServiceAccount) sqlDatabases() ([]any, erro
 			return nil, err
 		}
 		for _, db := range page.Value {
+			if db == nil {
+				continue
+			}
 			mqlDb, err := sqlDatabaseToMQL(a.MqlRuntime, db)
 			if err != nil {
 				return nil, err
@@ -305,6 +308,9 @@ func (a *mqlAzureSubscriptionCosmosDbServiceAccountSqlDatabase) containers() ([]
 			return nil, err
 		}
 		for _, c := range page.Value {
+			if c == nil {
+				continue
+			}
 			mqlC, err := sqlContainerToMQL(a.MqlRuntime, c)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/datafactory_extras.go
+++ b/providers/azure/resources/datafactory_extras.go
@@ -126,6 +126,9 @@ func (a *mqlAzureSubscriptionDataFactoryServiceFactory) linkedServices() ([]any,
 			return nil, err
 		}
 		for _, ls := range page.Value {
+			if ls == nil {
+				continue
+			}
 			mqlLs, err := linkedServiceToMQL(a.MqlRuntime, ls)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/deployments.go
+++ b/providers/azure/resources/deployments.go
@@ -45,6 +45,9 @@ func (a *mqlAzureSubscription) deployments() ([]any, error) {
 			return nil, err
 		}
 		for _, deployment := range page.Value {
+			if deployment == nil {
+				continue
+			}
 			mqlDeployment, err := newMqlAzureDeployment(a.MqlRuntime, deployment)
 			if err != nil {
 				return nil, err
@@ -77,6 +80,9 @@ func (a *mqlAzureSubscriptionResourcegroup) deployments() ([]any, error) {
 			return nil, err
 		}
 		for _, deployment := range page.Value {
+			if deployment == nil {
+				continue
+			}
 			mqlDeployment, err := newMqlAzureDeployment(a.MqlRuntime, deployment)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -636,22 +636,32 @@ func subToAsset(subWithConfig subWithConfig) *inventory.Asset {
 	sub := subWithConfig.sub
 	conf := subWithConfig.conf
 	copyConf := conf.Clone(inventory.WithoutDiscovery())
-	platformId := "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + *sub.SubscriptionID
+	platformId := "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + convert.ToValue(sub.SubscriptionID)
 	tenantId := "unknown"
 	if sub.TenantID != nil {
 		tenantId = *sub.TenantID
 	}
+	// ARM omits displayName for subscriptions in some states -- deleted,
+	// disabled, and cross-tenant entries projected in by Lighthouse. The
+	// neighbouring TenantID is guarded for the same reason; this one was not, so
+	// one such subscription in a tenant panicked the whole scan before any asset
+	// was returned. Fall back to the id, which is always present here.
+	subID := convert.ToValue(sub.SubscriptionID)
+	displayName := subID
+	if sub.DisplayName != nil {
+		displayName = *sub.DisplayName
+	}
 	platform := &inventory.Platform{
-		TechnologyUrlSegments: []string{"azure", tenantId, *sub.SubscriptionID, "account"},
+		TechnologyUrlSegments: []string{"azure", tenantId, subID, "account"},
 	}
 	PlatformByName("azure").Apply(platform)
 	return &inventory.Asset{
 		Id:          platformId,
 		Platform:    platform,
-		Name:        fmt.Sprintf("Azure subscription %s", *sub.DisplayName),
+		Name:        fmt.Sprintf("Azure subscription %s", displayName),
 		Connections: []*inventory.Config{copyConf},
 		PlatformIds: []string{platformId},
-		Labels:      map[string]string{SubscriptionLabel: *sub.SubscriptionID},
+		Labels:      map[string]string{SubscriptionLabel: subID},
 	}
 }
 

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -285,6 +285,9 @@ func (a *mqlAzureSubscriptionAuthorizationService) roleAssignments() ([]any, err
 			return nil, err
 		}
 		for _, roleAssignment := range page.Value {
+			if roleAssignment == nil {
+				continue
+			}
 			mqlRoleAssignment, err := newMqlRoleAssignment(a.MqlRuntime, roleAssignment)
 			if err != nil {
 				return nil, err
@@ -421,6 +424,9 @@ func (a *mqlAzureSubscriptionAuthorizationService) managedIdentities() ([]any, e
 			return nil, err
 		}
 		for _, v := range page.Value {
+			if v == nil {
+				continue
+			}
 			mqlManagedIdentity, err := newMqlManagedIdentity(a.MqlRuntime, v)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/iot.go
+++ b/providers/azure/resources/iot.go
@@ -140,6 +140,9 @@ func (a *mqlAzureSubscriptionIotService) hubs() ([]any, error) {
 			return nil, err
 		}
 		for _, hub := range page.Value {
+			if hub == nil {
+				continue
+			}
 			hubData, err := convert.JsonToDict(hub)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/logic.go
+++ b/providers/azure/resources/logic.go
@@ -63,6 +63,9 @@ func (a *mqlAzureSubscriptionLogicService) workflows() ([]any, error) {
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			if entry == nil {
+				continue
+			}
 			mqlWf, err := logicWorkflowToMQL(a.MqlRuntime, entry)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/machinelearning_data.go
+++ b/providers/azure/resources/machinelearning_data.go
@@ -114,6 +114,11 @@ func mlDatastoreToMql(runtime *plugin.Runtime, ds *ml.Datastore) (*mqlAzureSubsc
 	case *ml.AzureDataLakeGen1Datastore:
 		datastoreType, description, isDefault, credentialsType, authIdentity = mlDatastoreCommon(p.DatastoreType, p.Description, p.IsDefault, p.Credentials, p.ServiceDataAccessAuthIdentity)
 		tags = p.Tags
+	case nil:
+		// ds.Properties is an interface, and the SDK's polymorphic unmarshaller
+		// returns a nil one for a null or absent `properties` body. Without this
+		// case the nil interface falls to `default` and calling a method on it
+		// panics -- which kills the whole scan, not just this query.
 	default:
 		// OneLake and any backend added later still report the common fields
 		// through the base interface.

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -162,6 +162,9 @@ func (a *mqlAzureSubscriptionMonitorService) applicationInsights() ([]any, error
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			if entry == nil {
+				continue
+			}
 			mqlAI, err := createApplicationInsightResource(a.MqlRuntime, entry)
 			if err != nil {
 				return nil, err
@@ -828,6 +831,9 @@ func (a *mqlAzureSubscriptionMonitorServiceActivityLog) entries() ([]any, error)
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			if entry == nil {
+				continue
+			}
 			mqlEntry, err := newMqlActivityLogEntry(a.MqlRuntime, entry)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -368,8 +368,8 @@ func (a *mqlAzureSubscriptionMySqlServiceServer) databases() ([]any, error) {
 					"id":        llx.StringDataPtr(entry.ID),
 					"name":      llx.StringDataPtr(entry.Name),
 					"type":      llx.StringDataPtr(entry.Type),
-					"charset":   llx.StringDataPtr(entry.Properties.Charset),
-					"collation": llx.StringDataPtr(entry.Properties.Collation),
+					"charset":   llx.StringDataPtr(orZero(entry.Properties).Charset),
+					"collation": llx.StringDataPtr(orZero(entry.Properties).Collation),
 				})
 			if err != nil {
 				return nil, err
@@ -418,8 +418,8 @@ func (a *mqlAzureSubscriptionMySqlServiceServer) firewallRules() ([]any, error) 
 					"id":             llx.StringDataPtr(entry.ID),
 					"name":           llx.StringDataPtr(entry.Name),
 					"type":           llx.StringDataPtr(entry.Type),
-					"startIpAddress": llx.StringDataPtr(entry.Properties.StartIPAddress),
-					"endIpAddress":   llx.StringDataPtr(entry.Properties.EndIPAddress),
+					"startIpAddress": llx.StringDataPtr(orZero(entry.Properties).StartIPAddress),
+					"endIpAddress":   llx.StringDataPtr(orZero(entry.Properties).EndIPAddress),
 				})
 			if err != nil {
 				return nil, err
@@ -468,12 +468,12 @@ func (a *mqlAzureSubscriptionMySqlServiceServer) configuration() ([]any, error) 
 					"id":            llx.StringDataPtr(entry.ID),
 					"name":          llx.StringDataPtr(entry.Name),
 					"type":          llx.StringDataPtr(entry.Type),
-					"value":         llx.StringDataPtr(entry.Properties.Value),
-					"description":   llx.StringDataPtr(entry.Properties.Description),
-					"defaultValue":  llx.StringDataPtr(entry.Properties.DefaultValue),
-					"dataType":      llx.StringDataPtr(entry.Properties.DataType),
-					"allowedValues": llx.StringDataPtr(entry.Properties.AllowedValues),
-					"source":        llx.StringDataPtr(entry.Properties.Source),
+					"value":         llx.StringDataPtr(orZero(entry.Properties).Value),
+					"description":   llx.StringDataPtr(orZero(entry.Properties).Description),
+					"defaultValue":  llx.StringDataPtr(orZero(entry.Properties).DefaultValue),
+					"dataType":      llx.StringDataPtr(orZero(entry.Properties).DataType),
+					"allowedValues": llx.StringDataPtr(orZero(entry.Properties).AllowedValues),
+					"source":        llx.StringDataPtr(orZero(entry.Properties).Source),
 				})
 			if err != nil {
 				return nil, err
@@ -521,8 +521,8 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) databases() ([]any, err
 					"id":        llx.StringDataPtr(entry.ID),
 					"name":      llx.StringDataPtr(entry.Name),
 					"type":      llx.StringDataPtr(entry.Type),
-					"charset":   llx.StringDataPtr(entry.Properties.Charset),
-					"collation": llx.StringDataPtr(entry.Properties.Collation),
+					"charset":   llx.StringDataPtr(orZero(entry.Properties).Charset),
+					"collation": llx.StringDataPtr(orZero(entry.Properties).Collation),
 				})
 			if err != nil {
 				return nil, err
@@ -570,8 +570,8 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) firewallRules() ([]any,
 					"id":             llx.StringDataPtr(entry.ID),
 					"name":           llx.StringDataPtr(entry.Name),
 					"type":           llx.StringDataPtr(entry.Type),
-					"startIpAddress": llx.StringDataPtr(entry.Properties.StartIPAddress),
-					"endIpAddress":   llx.StringDataPtr(entry.Properties.EndIPAddress),
+					"startIpAddress": llx.StringDataPtr(orZero(entry.Properties).StartIPAddress),
+					"endIpAddress":   llx.StringDataPtr(orZero(entry.Properties).EndIPAddress),
 				})
 			if err != nil {
 				return nil, err
@@ -620,12 +620,12 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) configuration() ([]any,
 					"id":            llx.StringDataPtr(entry.ID),
 					"name":          llx.StringDataPtr(entry.Name),
 					"type":          llx.StringDataPtr(entry.Type),
-					"value":         llx.StringDataPtr(entry.Properties.Value),
-					"description":   llx.StringDataPtr(entry.Properties.Description),
-					"defaultValue":  llx.StringDataPtr(entry.Properties.DefaultValue),
-					"dataType":      llx.StringDataPtr(entry.Properties.DataType),
-					"allowedValues": llx.StringDataPtr(entry.Properties.AllowedValues),
-					"source":        llx.StringDataPtr((*string)(entry.Properties.Source)),
+					"value":         llx.StringDataPtr(orZero(entry.Properties).Value),
+					"description":   llx.StringDataPtr(orZero(entry.Properties).Description),
+					"defaultValue":  llx.StringDataPtr(orZero(entry.Properties).DefaultValue),
+					"dataType":      llx.StringDataPtr(orZero(entry.Properties).DataType),
+					"allowedValues": llx.StringDataPtr(orZero(entry.Properties).AllowedValues),
+					"source":        llx.StringDataPtr((*string)(orZero(entry.Properties).Source)),
 				})
 			if err != nil {
 				return nil, err
@@ -717,10 +717,10 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) azureAdAdministrators()
 			}
 			var administratorType, login, sid, tenantId *string
 			if entry.Properties != nil {
-				administratorType = (*string)(entry.Properties.AdministratorType)
-				login = entry.Properties.Login
-				sid = entry.Properties.Sid
-				tenantId = entry.Properties.TenantID
+				administratorType = (*string)(orZero(entry.Properties).AdministratorType)
+				login = orZero(entry.Properties).Login
+				sid = orZero(entry.Properties).Sid
+				tenantId = orZero(entry.Properties).TenantID
 			}
 			mqlAdmin, err := CreateResource(a.MqlRuntime, "azure.subscription.mySqlService.flexibleServer.administrator",
 				map[string]*llx.RawData{

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -715,22 +715,15 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) azureAdAdministrators()
 			if entry == nil {
 				continue
 			}
-			var administratorType, login, sid, tenantId *string
-			if entry.Properties != nil {
-				administratorType = (*string)(orZero(entry.Properties).AdministratorType)
-				login = orZero(entry.Properties).Login
-				sid = orZero(entry.Properties).Sid
-				tenantId = orZero(entry.Properties).TenantID
-			}
 			mqlAdmin, err := CreateResource(a.MqlRuntime, "azure.subscription.mySqlService.flexibleServer.administrator",
 				map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(entry.ID),
 					"name":              llx.StringDataPtr(entry.Name),
 					"type":              llx.StringDataPtr(entry.Type),
-					"administratorType": llx.StringDataPtr(administratorType),
-					"login":             llx.StringDataPtr(login),
-					"sid":               llx.StringDataPtr(sid),
-					"tenantId":          llx.StringDataPtr(tenantId),
+					"administratorType": llx.StringDataPtr((*string)(orZero(entry.Properties).AdministratorType)),
+					"login":             llx.StringDataPtr(orZero(entry.Properties).Login),
+					"sid":               llx.StringDataPtr(orZero(entry.Properties).Sid),
+					"tenantId":          llx.StringDataPtr(orZero(entry.Properties).TenantID),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1009,6 +1009,39 @@ func nestedResourceID(props any, key string) string {
 	return id
 }
 
+// nestedResourceIDs is the list counterpart of nestedResourceID: it pulls the
+// ids out of a JSON-decoded array of resource references, skipping anything
+// that is not shaped like one.
+//
+// Same reasoning as its sibling, and the same hazard. Several accessors used to
+// walk these arrays with bare assertions -- props.Data.(map[string]any),
+// value.([]any), entry.(map[string]any)["id"].(string) -- and an entry whose
+// "id" the service omitted (populate() drops nil pointers, so a SubResource
+// with no ID marshals without the key) made the last one panic on a nil. A
+// panic in an accessor is unrecoverable: the executor runs blocks in
+// goroutines, so it takes down the entire scan rather than one query.
+func nestedResourceIDs(props any, key string) []string {
+	propsDict, ok := props.(map[string]any)
+	if !ok {
+		return nil
+	}
+	entries, ok := propsDict[key].([]any)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		ref, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, ok := ref["id"].(string); ok && id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
 func (a *mqlAzureSubscriptionNetworkServiceFirewall) policy() (*mqlAzureSubscriptionNetworkServiceFirewallPolicy, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -2765,9 +2798,8 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 	if props.Error != nil {
 		return nil, props.Error
 	}
-	propsDict := props.Data.(map[string]any)
-	gateways := propsDict["applicationGateways"]
-	if gateways == nil {
+	gatewayIDs := nestedResourceIDs(props.Data, "applicationGateways")
+	if len(gatewayIDs) == 0 {
 		return nil, nil
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
@@ -2780,8 +2812,6 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 		return nil, err
 	}
 
-	gatewaysList := gateways.([]any)
-
 	// Pre-validate all gateway IDs before launching any goroutines so that an
 	// early parse error can't leak in-flight workers.
 	type gwFetch struct {
@@ -2789,16 +2819,8 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 		name  string
 		index int
 	}
-	fetches := make([]gwFetch, 0, len(gatewaysList))
-	for i, gw := range gatewaysList {
-		idVal, ok := gw.(map[string]any)["id"]
-		if !ok {
-			continue
-		}
-		strId, ok := idVal.(string)
-		if !ok {
-			continue
-		}
+	fetches := make([]gwFetch, 0, len(gatewayIDs))
+	for i, strId := range gatewayIDs {
 		azureId, err := ParseResourceID(strId)
 		if err != nil {
 			return nil, err
@@ -2812,7 +2834,7 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 
 	// Fetch the referenced application gateways in parallel; there is no
 	// batch endpoint, so a bounded errgroup is the cheapest fix.
-	results := make([]network.ApplicationGateway, len(gatewaysList))
+	results := make([]network.ApplicationGateway, len(gatewayIDs))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(10)
 	for _, f := range fetches {
@@ -2852,14 +2874,9 @@ func (a *mqlAzureSubscriptionNetworkServiceNatGateway) publicIpAddresses() ([]an
 	if err != nil {
 		return nil, err
 	}
-	props := a.Properties.Data
-	propsDict, ok := props.(map[string]any)
-	if !ok {
-		return nil, errors.New("unexpected type for properties")
-	}
-	publicIpAddresses := propsDict["publicIpAddresses"]
 	// if we have no present public ip addresses ids, we can just return nil
-	if publicIpAddresses == nil {
+	publicIpIDs := nestedResourceIDs(a.Properties.Data, "publicIpAddresses")
+	if len(publicIpIDs) == 0 {
 		return nil, nil
 	}
 
@@ -2870,9 +2887,7 @@ func (a *mqlAzureSubscriptionNetworkServiceNatGateway) publicIpAddresses() ([]an
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range publicIpAddresses.([]any) {
-		pDict := p.(map[string]any)
-		pId := pDict["id"].(string)
+	for _, pId := range publicIpIDs {
 		resourceID, err := ParseResourceID(pId)
 		if err != nil {
 			return nil, err
@@ -3014,14 +3029,9 @@ func (a *mqlAzureSubscriptionNetworkServiceNatGateway) subnets() ([]any, error) 
 	if err != nil {
 		return nil, err
 	}
-	props := a.Properties.Data
-	propsDict, ok := props.(map[string]any)
-	if !ok {
-		return nil, errors.New("unexpected type for properties")
-	}
-	subnets := propsDict["subnets"]
 	// if we have no present subnets in the dict, we can just return nil
-	if subnets == nil {
+	subnetIDs := nestedResourceIDs(a.Properties.Data, "subnets")
+	if len(subnetIDs) == 0 {
 		return nil, nil
 	}
 	res := []any{}
@@ -3031,9 +3041,7 @@ func (a *mqlAzureSubscriptionNetworkServiceNatGateway) subnets() ([]any, error) 
 	if err != nil {
 		return nil, err
 	}
-	for _, s := range subnets.([]any) {
-		sDict := s.(map[string]any)
-		sId := sDict["id"].(string)
+	for _, sId := range subnetIDs {
 		resourceID, err := ParseResourceID(sId)
 		if err != nil {
 			return nil, err
@@ -3103,21 +3111,13 @@ func (a *mqlAzureSubscriptionNetworkServiceSubnet) natGateway() (*mqlAzureSubscr
 func (a *mqlAzureSubscriptionNetworkServiceSubnet) ipConfigurations() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	subId := conn.SubId()
-	props := a.Properties.Data
-	propsDict, ok := props.(map[string]any)
-	if !ok {
-		return nil, errors.New("unexpected type for properties")
-	}
-	ipConfigsDict := propsDict["ipConfigurations"]
-	if ipConfigsDict == nil {
+	rawIpConfigIds := nestedResourceIDs(a.Properties.Data, "ipConfigurations")
+	if len(rawIpConfigIds) == 0 {
 		return nil, nil
 	}
 	res := []any{}
-	ipConfigIds := []string{}
-	ipConfigsList := ipConfigsDict.([]any)
-	for _, ipc := range ipConfigsList {
-		ipcDict := ipc.(map[string]any)
-		ipcId := ipcDict["id"].(string)
+	ipConfigIds := make([]string, 0, len(rawIpConfigIds))
+	for _, ipcId := range rawIpConfigIds {
 		ipConfigIds = append(ipConfigIds, strings.ToLower(ipcId))
 	}
 
@@ -3186,13 +3186,8 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) childPolicies() ([]an
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
 	token := conn.Token()
-	props := a.Properties.Data
-	propsDict, ok := props.(map[string]any)
-	if !ok {
-		return nil, errors.New("unexpected type for properties")
-	}
-	childPolicies := propsDict["childPolicies"]
-	if childPolicies == nil {
+	childPolicyIDs := nestedResourceIDs(a.Properties.Data, "childPolicies")
+	if len(childPolicyIDs) == 0 {
 		return nil, nil
 	}
 	baseResourceId, err := ParseResourceID(a.Id.Data)
@@ -3207,10 +3202,7 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) childPolicies() ([]an
 		return nil, err
 	}
 	res := []any{}
-	childPoliciesList := childPolicies.([]any)
-	for _, cp := range childPoliciesList {
-		cpDict := cp.(map[string]any)
-		cpId := cpDict["id"].(string)
+	for _, cpId := range childPolicyIDs {
 		resourceID, err := ParseResourceID(cpId)
 		if err != nil {
 			return nil, err
@@ -3236,13 +3228,8 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) firewalls() ([]any, e
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
 	token := conn.Token()
-	props := a.Properties.Data
-	propsDict, ok := props.(map[string]any)
-	if !ok {
-		return nil, errors.New("unexpected type for properties")
-	}
-	firewalls := propsDict["firewalls"]
-	if firewalls == nil {
+	firewallIDs := nestedResourceIDs(a.Properties.Data, "firewalls")
+	if len(firewallIDs) == 0 {
 		return nil, nil
 	}
 	baseResourceId, err := ParseResourceID(a.Id.Data)
@@ -3257,10 +3244,7 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) firewalls() ([]any, e
 		return nil, err
 	}
 	res := []any{}
-	firewallsList := firewalls.([]any)
-	for _, fw := range firewallsList {
-		fwDict := fw.(map[string]any)
-		fwId := fwDict["id"].(string)
+	for _, fwId := range firewallIDs {
 		resourceID, err := ParseResourceID(fwId)
 		if err != nil {
 			return nil, err
@@ -6278,6 +6262,9 @@ func (a *mqlAzureSubscriptionNetworkService) localNetworkGateways() ([]any, erro
 				return nil, err
 			}
 			for _, lng := range page.Value {
+				if lng == nil {
+					continue
+				}
 				mqlLng, err := newMqlLocalNetworkGateway(a.MqlRuntime, lng)
 				if err != nil {
 					return nil, err

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2815,12 +2815,11 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 	// Pre-validate all gateway IDs before launching any goroutines so that an
 	// early parse error can't leak in-flight workers.
 	type gwFetch struct {
-		rg    string
-		name  string
-		index int
+		rg   string
+		name string
 	}
 	fetches := make([]gwFetch, 0, len(gatewayIDs))
-	for i, strId := range gatewayIDs {
+	for _, strId := range gatewayIDs {
 		azureId, err := ParseResourceID(strId)
 		if err != nil {
 			return nil, err
@@ -2829,21 +2828,21 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy) gateways()
 		if err != nil {
 			return nil, err
 		}
-		fetches = append(fetches, gwFetch{rg: azureId.ResourceGroup, name: gatewayName, index: i})
+		fetches = append(fetches, gwFetch{rg: azureId.ResourceGroup, name: gatewayName})
 	}
 
 	// Fetch the referenced application gateways in parallel; there is no
 	// batch endpoint, so a bounded errgroup is the cheapest fix.
-	results := make([]network.ApplicationGateway, len(gatewayIDs))
+	results := make([]network.ApplicationGateway, len(fetches))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(10)
-	for _, f := range fetches {
+	for i, f := range fetches {
 		g.Go(func() error {
 			resp, err := client.Get(gctx, f.rg, f.name, &network.ApplicationGatewaysClientGetOptions{})
 			if err != nil {
 				return err
 			}
-			results[f.index] = resp.ApplicationGateway
+			results[i] = resp.ApplicationGateway
 			return nil
 		})
 	}

--- a/providers/azure/resources/network_avnm.go
+++ b/providers/azure/resources/network_avnm.go
@@ -520,6 +520,9 @@ func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurat
 			return nil, err
 		}
 		for _, rule := range page.Value {
+			if rule == nil {
+				continue
+			}
 			mqlRule, err := azureAdminRuleToMql(a.MqlRuntime, rule)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/nil_safety_test.go
+++ b/providers/azure/resources/nil_safety_test.go
@@ -1,0 +1,115 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// A panic in a provider accessor is unrecoverable: the executor evaluates query
+// blocks in goroutines, so it takes down the entire scan rather than the one
+// query that triggered it. These tests pin the helpers that stand between a
+// sparse ARM response and that outcome.
+
+func TestOrZero(t *testing.T) {
+	type props struct {
+		Name  *string
+		Count int
+	}
+
+	name := "set"
+	real := &props{Name: &name, Count: 3}
+	assert.Same(t, real, orZero(real), "a set pointer is returned unchanged")
+	assert.Equal(t, "set", *orZero(real).Name)
+
+	// the case that matters: reading a field off an absent properties block
+	assert.NotPanics(t, func() {
+		var absent *props
+		assert.Nil(t, orZero(absent).Name)
+		assert.Equal(t, 0, orZero(absent).Count)
+	})
+}
+
+func TestNestedResourceIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		props any
+		key   string
+		want  []string
+	}{
+		{
+			name: "reads the ids out of a reference array",
+			props: map[string]any{"subnets": []any{
+				map[string]any{"id": "/subnets/a"},
+				map[string]any{"id": "/subnets/b"},
+			}},
+			key:  "subnets",
+			want: []string{"/subnets/a", "/subnets/b"},
+		},
+		{
+			// populate() drops nil pointers, so a SubResource with no ID
+			// marshals without the key at all -- this used to panic on the
+			// bare entry["id"].(string)
+			name: "an entry with no id is skipped, not asserted",
+			props: map[string]any{"subnets": []any{
+				map[string]any{"id": "/subnets/a"},
+				map[string]any{},
+				map[string]any{"id": nil},
+				map[string]any{"id": 42},
+				"not-an-object",
+				nil,
+			}},
+			key:  "subnets",
+			want: []string{"/subnets/a"},
+		},
+		{"absent key", map[string]any{}, "subnets", nil},
+		{"key present but not an array", map[string]any{"subnets": "nope"}, "subnets", nil},
+		{"properties not a map", "nope", "subnets", nil},
+		{"nil properties", nil, "subnets", nil},
+		{"empty array", map[string]any{"subnets": []any{}}, "subnets", []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.Equal(t, tc.want, nestedResourceIDs(tc.props, tc.key))
+			})
+		})
+	}
+}
+
+// TestSubToAssetTolerandsAbsentDisplayName pins the scan-entry-point crash. ARM
+// omits displayName for subscriptions in some states -- deleted, disabled, and
+// cross-tenant entries projected in by Lighthouse -- and one such subscription
+// in a tenant used to panic before a single asset was returned.
+func TestSubToAssetToleratesAbsentDisplayName(t *testing.T) {
+	subID := "11111111-1111-1111-1111-111111111111"
+	tenantID := "22222222-2222-2222-2222-222222222222"
+
+	t.Run("no display name falls back to the subscription id", func(t *testing.T) {
+		var asset *inventory.Asset
+		require.NotPanics(t, func() {
+			asset = subToAsset(subWithConfig{
+				sub:  subscriptions.Subscription{SubscriptionID: &subID, TenantID: &tenantID},
+				conf: &inventory.Config{},
+			})
+		})
+		require.NotNil(t, asset)
+		assert.Contains(t, asset.Name, subID)
+		assert.Equal(t, subID, asset.Labels[SubscriptionLabel])
+	})
+
+	t.Run("a display name is used when present", func(t *testing.T) {
+		name := "Production"
+		asset := subToAsset(subWithConfig{
+			sub:  subscriptions.Subscription{SubscriptionID: &subID, TenantID: &tenantID, DisplayName: &name},
+			conf: &inventory.Config{},
+		})
+		require.NotNil(t, asset)
+		assert.Equal(t, "Azure subscription Production", asset.Name)
+	})
+}

--- a/providers/azure/resources/policy.go
+++ b/providers/azure/resources/policy.go
@@ -192,6 +192,9 @@ func (a *mqlAzureSubscriptionPolicy) definitions() ([]any, error) {
 			return nil, err
 		}
 		for _, def := range page.Value {
+			if def == nil {
+				continue
+			}
 			mqlDef, err := newMqlPolicyDefinition(a.MqlRuntime, def)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/postgresql.go
+++ b/providers/azure/resources/postgresql.go
@@ -317,8 +317,8 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceServer) databases() ([]any, error)
 					"id":        llx.StringDataPtr(entry.ID),
 					"name":      llx.StringDataPtr(entry.Name),
 					"type":      llx.StringDataPtr(entry.Type),
-					"charset":   llx.StringDataPtr(entry.Properties.Charset),
-					"collation": llx.StringDataPtr(entry.Properties.Collation),
+					"charset":   llx.StringDataPtr(orZero(entry.Properties).Charset),
+					"collation": llx.StringDataPtr(orZero(entry.Properties).Collation),
 				})
 			if err != nil {
 				return nil, err
@@ -367,8 +367,8 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) databases() ([]any
 					"id":        llx.StringDataPtr(entry.ID),
 					"name":      llx.StringDataPtr(entry.Name),
 					"type":      llx.StringDataPtr(entry.Type),
-					"charset":   llx.StringDataPtr(entry.Properties.Charset),
-					"collation": llx.StringDataPtr(entry.Properties.Collation),
+					"charset":   llx.StringDataPtr(orZero(entry.Properties).Charset),
+					"collation": llx.StringDataPtr(orZero(entry.Properties).Collation),
 				})
 			if err != nil {
 				return nil, err
@@ -417,8 +417,8 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceServer) firewallRules() ([]any, er
 					"id":             llx.StringDataPtr(entry.ID),
 					"name":           llx.StringDataPtr(entry.Name),
 					"type":           llx.StringDataPtr(entry.Type),
-					"startIpAddress": llx.StringDataPtr(entry.Properties.StartIPAddress),
-					"endIpAddress":   llx.StringDataPtr(entry.Properties.EndIPAddress),
+					"startIpAddress": llx.StringDataPtr(orZero(entry.Properties).StartIPAddress),
+					"endIpAddress":   llx.StringDataPtr(orZero(entry.Properties).EndIPAddress),
 				})
 			if err != nil {
 				return nil, err
@@ -466,8 +466,8 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) firewallRules() ([
 					"id":             llx.StringDataPtr(entry.ID),
 					"name":           llx.StringDataPtr(entry.Name),
 					"type":           llx.StringDataPtr(entry.Type),
-					"startIpAddress": llx.StringDataPtr(entry.Properties.StartIPAddress),
-					"endIpAddress":   llx.StringDataPtr(entry.Properties.EndIPAddress),
+					"startIpAddress": llx.StringDataPtr(orZero(entry.Properties).StartIPAddress),
+					"endIpAddress":   llx.StringDataPtr(orZero(entry.Properties).EndIPAddress),
 				})
 			if err != nil {
 				return nil, err
@@ -516,12 +516,12 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceServer) configuration() ([]any, er
 					"id":            llx.StringDataPtr(entry.ID),
 					"name":          llx.StringDataPtr(entry.Name),
 					"type":          llx.StringDataPtr(entry.Type),
-					"value":         llx.StringDataPtr(entry.Properties.Value),
-					"description":   llx.StringDataPtr(entry.Properties.Description),
-					"defaultValue":  llx.StringDataPtr(entry.Properties.DefaultValue),
-					"dataType":      llx.StringDataPtr(entry.Properties.DataType),
-					"allowedValues": llx.StringDataPtr(entry.Properties.AllowedValues),
-					"source":        llx.StringDataPtr(entry.Properties.Source),
+					"value":         llx.StringDataPtr(orZero(entry.Properties).Value),
+					"description":   llx.StringDataPtr(orZero(entry.Properties).Description),
+					"defaultValue":  llx.StringDataPtr(orZero(entry.Properties).DefaultValue),
+					"dataType":      llx.StringDataPtr(orZero(entry.Properties).DataType),
+					"allowedValues": llx.StringDataPtr(orZero(entry.Properties).AllowedValues),
+					"source":        llx.StringDataPtr(orZero(entry.Properties).Source),
 				})
 			if err != nil {
 				return nil, err
@@ -571,12 +571,12 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) configuration() ([
 					"id":            llx.StringDataPtr(entry.ID),
 					"name":          llx.StringDataPtr(entry.Name),
 					"type":          llx.StringDataPtr(entry.Type),
-					"value":         llx.StringDataPtr(entry.Properties.Value),
-					"description":   llx.StringDataPtr(entry.Properties.Description),
-					"defaultValue":  llx.StringDataPtr(entry.Properties.DefaultValue),
-					"dataType":      llx.StringDataPtr((*string)(entry.Properties.DataType)),
-					"allowedValues": llx.StringDataPtr(entry.Properties.AllowedValues),
-					"source":        llx.StringDataPtr(entry.Properties.Source),
+					"value":         llx.StringDataPtr(orZero(entry.Properties).Value),
+					"description":   llx.StringDataPtr(orZero(entry.Properties).Description),
+					"defaultValue":  llx.StringDataPtr(orZero(entry.Properties).DefaultValue),
+					"dataType":      llx.StringDataPtr((*string)(orZero(entry.Properties).DataType)),
+					"allowedValues": llx.StringDataPtr(orZero(entry.Properties).AllowedValues),
+					"source":        llx.StringDataPtr(orZero(entry.Properties).Source),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/shared.go
+++ b/providers/azure/resources/shared.go
@@ -76,6 +76,23 @@ func missingResourceID(resourceName string) error {
 		resourceName, resourceName)
 }
 
+// orZero returns p when it is set, and a pointer to the zero value of T
+// otherwise, so a caller can read fields off it without a nil check.
+//
+// ARM models almost every nested block as an optional pointer, including the
+// `properties` of a list row. Reading entry.Properties.Field directly panics on
+// a row that omits it -- and a panic in a provider accessor is unrecoverable:
+// the executor runs blocks in goroutines, so it takes down the whole scan
+// rather than the one query. Going through this helper keeps the row in the
+// result with its fields reading null, which is the honest answer, instead of
+// dropping it or crashing.
+func orZero[T any](p *T) *T {
+	if p != nil {
+		return p
+	}
+	return new(T)
+}
+
 type assetIdentifier struct {
 	name string
 	id   string

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -380,8 +380,8 @@ func (a *mqlAzureSubscriptionSqlServiceServer) firewallRules() ([]any, error) {
 					"id":             llx.StringDataPtr(entry.ID),
 					"name":           llx.StringDataPtr(entry.Name),
 					"type":           llx.StringDataPtr(entry.Type),
-					"startIpAddress": llx.StringDataPtr(entry.Properties.StartIPAddress),
-					"endIpAddress":   llx.StringDataPtr(entry.Properties.EndIPAddress),
+					"startIpAddress": llx.StringDataPtr(orZero(entry.Properties).StartIPAddress),
+					"endIpAddress":   llx.StringDataPtr(orZero(entry.Properties).EndIPAddress),
 				})
 			if err != nil {
 				return nil, err
@@ -436,7 +436,7 @@ func (a *mqlAzureSubscriptionSqlServiceServer) virtualNetworkRules() ([]any, err
 					"name":                   llx.StringDataPtr(entry.Name),
 					"type":                   llx.StringDataPtr(entry.Type),
 					"properties":             llx.DictData(properties),
-					"virtualNetworkSubnetId": llx.StringDataPtr(entry.Properties.VirtualNetworkSubnetID),
+					"virtualNetworkSubnetId": llx.StringDataPtr(orZero(entry.Properties).VirtualNetworkSubnetID),
 				})
 			if err != nil {
 				return nil, err
@@ -483,10 +483,10 @@ func (a *mqlAzureSubscriptionSqlServiceServer) azureAdAdministrators() ([]any, e
 					"id":                llx.StringDataPtr(entry.ID),
 					"name":              llx.StringDataPtr(entry.Name),
 					"type":              llx.StringDataPtr(entry.Type),
-					"administratorType": llx.StringDataPtr((*string)(entry.Properties.AdministratorType)),
-					"login":             llx.StringDataPtr(entry.Properties.Login),
-					"sid":               llx.StringDataPtr(entry.Properties.Sid),
-					"tenantId":          llx.StringDataPtr(entry.Properties.TenantID),
+					"administratorType": llx.StringDataPtr((*string)(orZero(entry.Properties).AdministratorType)),
+					"login":             llx.StringDataPtr(orZero(entry.Properties).Login),
+					"sid":               llx.StringDataPtr(orZero(entry.Properties).Sid),
+					"tenantId":          llx.StringDataPtr(orZero(entry.Properties).TenantID),
 				})
 			if err != nil {
 				return nil, err
@@ -1146,10 +1146,10 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) usage() ([]any, error) {
 					"id":           llx.StringDataPtr(entry.ID),
 					"name":         llx.StringDataPtr(entry.Name),
 					"resourceName": llx.StringDataPtr(entry.Name),
-					"displayName":  llx.StringDataPtr(entry.Properties.DisplayName),
-					"currentValue": llx.FloatData(convert.ToValue(entry.Properties.CurrentValue)),
-					"limit":        llx.FloatData(convert.ToValue(entry.Properties.Limit)),
-					"unit":         llx.StringDataPtr(entry.Properties.Unit),
+					"displayName":  llx.StringDataPtr(orZero(entry.Properties).DisplayName),
+					"currentValue": llx.FloatData(convert.ToValue(orZero(entry.Properties).CurrentValue)),
+					"limit":        llx.FloatData(convert.ToValue(orZero(entry.Properties).Limit)),
+					"unit":         llx.StringDataPtr(orZero(entry.Properties).Unit),
 				})
 			if err != nil {
 				return nil, err
@@ -2415,6 +2415,9 @@ func (a *mqlAzureSubscriptionSqlServiceDatabaseVulnerabilityAssessment) scans() 
 			return nil, err
 		}
 		for _, scan := range page.Value {
+			if scan == nil {
+				continue
+			}
 			args, err := vulnerabilityAssessmentScanArgs(scan)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -159,6 +159,9 @@ func (a *mqlAzureSubscriptionStorageService) accounts() ([]any, error) {
 			return nil, err
 		}
 		for _, account := range page.Value {
+			if account == nil {
+				continue
+			}
 			acc, err := storageAccountToMql(a.MqlRuntime, account)
 			if err != nil {
 				return nil, err
@@ -218,6 +221,9 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) containers() ([]any, error) 
 		g, gctx := errgroup.WithContext(ctx)
 		g.SetLimit(10)
 		for i, container := range page.Value {
+			if container == nil {
+				continue
+			}
 			containerProps := container.Properties
 			needsDetail := containerProps != nil &&
 				((containerProps.HasImmutabilityPolicy != nil && *containerProps.HasImmutabilityPolicy) ||
@@ -239,6 +245,9 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) containers() ([]any, error) 
 		}
 
 		for i, container := range page.Value {
+			if container == nil {
+				continue
+			}
 			containerProps := container.Properties
 			if detailedProps[i] != nil {
 				containerProps = detailedProps[i]

--- a/providers/azure/resources/storage_extras.go
+++ b/providers/azure/resources/storage_extras.go
@@ -131,6 +131,9 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) fileShares() ([]any, error) 
 			return nil, err
 		}
 		for _, share := range page.Value {
+			if share == nil {
+				continue
+			}
 			mqlShare, err := fileShareToMQL(a.MqlRuntime, share)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Found by a static bug-review pass over the provider.

A panic in a provider accessor is **not local**. The executor evaluates query blocks in goroutines, so an unrecovered panic takes down the entire scan rather than the one query that triggered it — every asset, every other resource, gone. This PR closes the places where a sparse-but-legal ARM response could do that.

Nothing here changes what a healthy scan reports.

## Two are at the scan entry point

Where a panic means **zero assets** are returned at all:

- `connection/client_subscriptions.go` — `*s.SubscriptionID` with neither the element nor the pointer checked. This is the first ARM call every Azure scan makes.
- `discovery.go` — `*sub.DisplayName`, while `sub.TenantID` on the line immediately above was guarded for exactly the same reason. ARM omits `displayName` for subscriptions in some states (deleted, disabled, and cross-tenant entries projected in by Lighthouse), so one such subscription in a tenant was enough.

## Twenty-two list loops used their element without a guard

…while every sibling loop in the same file had one. The inconsistency was the tell.

`appcontainers.go` ×2, `containerinstance.go`, `cosmosdb_extras.go` ×2, `datafactory_extras.go`, `deployments.go` ×2, `iam.go` ×2, `iot.go`, `logic.go`, `monitor.go` ×2, `network.go`, `network_avnm.go`, `policy.go`, `sql.go`, `storage.go` ×3, `storage_extras.go`.

I verified per site that **neither the loop nor the callee** checked. The helpers that do guard their argument — `privateEndpointToMql`, `privateLinkServiceToMql`, `plsEndpointConnectionToMql`, `azureTrafficManagerProfileToMql`, `azureVirtualWanToMql`, `azureVirtualHubToMql`, `azureExpressRouteCircuitToMql`, `azureVpnSiteToMql`, `createWebAppResourceFromSite` — were left alone.

Worth noting my first sweep got two of these wrong in both directions, which is why they were each checked by hand: `newMqlPolicyDefinition` *looks* guarded (`if props == nil`) but that guard is on `def.Properties`, and it derefs `def` on the line before; and `network.go:493` *looks* unguarded but iterates a slice of value structs where nil is not representable.

## Three interface values had methods called on the receiver unchecked

`machinelearning_data.go`, `cloud_defender.go` ×2. The SDK's polymorphic unmarshallers return a **nil interface** for a null or absent body, and in all three cases the *result* of the method was nil-checked but the receiver was not.

## Six accessors walked decoded ARM JSON with bare assertions

```go
propsDict := props.Data.(map[string]any)
gatewaysList := gateways.([]any)
pId := pDict["id"].(string)
```

A reference whose `id` the service omitted panics on the last one — `populate()` drops nil pointers, so a `SubResource` with no `ID` marshals without the key at all.

`network.go` already had `nestedResourceID` for the single-reference case, carrying a comment explaining precisely this hazard (*"Every lookup is comma-ok because this walks JSON-decoded runtime data, where a bare assertion would panic and take the whole scan down with it"*). This adds the list counterpart `nestedResourceIDs` and routes all six through it — which also deletes a fair amount of duplicated unpacking.

## Sixty-odd `entry.Properties.Field` reads in the DB listers

ARM models `properties` as an optional pointer and several of these models do not mark it required, so a row that omits it panicked. These now go through a small generic helper:

```go
// orZero returns p when it is set, and a pointer to the zero value of T
// otherwise, so a caller can read fields off it without a nil check.
func orZero[T any](p *T) *T
```

That keeps the row in the result with its fields reading **null** — the honest answer — instead of dropping it or crashing. It also avoids the alternative the file already uses in one place (`entry.Properties = &sql.DatabaseProperties{}`), which mutates the caller's page data.

## Tests

`nil_safety_test.go` covers `orZero`, `nestedResourceIDs` (including the entry-with-no-id, wrong-type and non-map shapes), and `subToAsset` with and without a display name. The `nestedResourceIDs` cases assert `NotPanics` explicitly, since that is the property under test.

## Notes

- Verified: `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l` clean.
- **Deliberately not included:** `web.go`'s two site loops, where the callee returns an error on a nil element rather than skipping it. That is an error-propagation choice, not a crash, so it belongs with the degradation work rather than here.
- No live verification needed — these are guards on paths that currently panic; a healthy response takes the same branch it always did.
- Sibling PRs from the same review touch `network.go`, `cloud_defender.go`, `mysql.go` and `sql.go` in different functions.
