### PR TITLE
🐛 azure: stop truncating the hand-rolled ARM collections

### DIFF
--- a/providers/azure/resources/advisor.go
+++ b/providers/azure/resources/advisor.go
@@ -244,8 +244,12 @@ func getAdvisorScoresByCategory(ctx context.Context, subscriptionId, host, token
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Advisor/advisorScore"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = runtime.JoinPaths(host, urlPath)
-	client := http.Client{}
-	req, err := http.NewRequest("GET", urlPath, nil)
+	// The Advisor score endpoint is genuinely single-page: AdvisorScoreResponse
+	// carries only `value`, with no nextLink, and armadvisor ships no client for
+	// it -- which is why this is hand-rolled at all. It still needs the shared
+	// client's timeout, since nothing else bounds a request made outside the
+	// azcore pipeline.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -255,13 +259,13 @@ func getAdvisorScoresByCategory(ctx context.Context, subscriptionId, host, token
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	resp, err := client.Do(req)
+	resp, err := armHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("failed to fetch advisor scores " + urlPath + ": " + resp.Status)
 	}
 

--- a/providers/azure/resources/arm_paging.go
+++ b/providers/azure/resources/arm_paging.go
@@ -1,0 +1,118 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// A handful of endpoints in this provider are fetched with a hand-rolled
+// request rather than through an SDK client, because the vendored SDK models
+// them as a single call or does not ship a client at all. Those requests get
+// none of what the azcore pipeline normally provides, so the pieces they still
+// need -- a bounded page walk, a request timeout, an honest error on a non-2xx
+// -- live here rather than being written out once per call site.
+
+const (
+	// maxArmPages bounds a nextLink walk. ARM is not supposed to return a
+	// cursor that cycles or never terminates, but nothing in the protocol
+	// prevents it, and an unbounded loop would hang the scan while growing the
+	// result without limit. A thousand pages is far beyond any real collection.
+	maxArmPages = 1000
+
+	// armHTTPTimeout bounds a single request. Without it a hung connection
+	// stalls the field forever: these requests do not go through the azcore
+	// pipeline, so nothing else imposes a deadline.
+	armHTTPTimeout = 60 * time.Second
+)
+
+// armHTTPClient is shared by the hand-rolled requests so they all get the
+// timeout. http.Client is safe for concurrent use.
+var armHTTPClient = &http.Client{Timeout: armHTTPTimeout}
+
+// armTokenFunc adapts a connection's credential to the getter fetchArmPages
+// wants, for callers that are not going through armSecurityConn.
+func armTokenFunc(ctx context.Context, conn *connection.AzureConnection) func() (azcore.AccessToken, error) {
+	return func() (azcore.AccessToken, error) {
+		return conn.Token().GetToken(ctx, policy.TokenRequestOptions{
+			Scopes: []string{"https://management.core.windows.net//.default"},
+		})
+	}
+}
+
+// fetchArmPages walks an ARM collection starting at firstURL, calling decode
+// with each page body. decode returns the nextLink to continue with, or "" to
+// stop.
+//
+// The token is fetched per page rather than once up front: a walk over a large
+// collection can outlive a bearer token, and the credential caches, so asking
+// again is cheap and only refreshes near expiry.
+func fetchArmPages(
+	ctx context.Context,
+	getToken func() (azcore.AccessToken, error),
+	firstURL string,
+	what string,
+	decode func(body []byte) (nextLink string, err error),
+) error {
+	seen := make(map[string]struct{}, 8)
+	next := firstURL
+
+	for page := 0; next != ""; page++ {
+		if page >= maxArmPages {
+			return fmt.Errorf("%s: stopped after %d pages, the service kept returning a nextLink", what, maxArmPages)
+		}
+		// A cursor that points at a page already fetched would loop forever and
+		// duplicate every row it returned.
+		if _, dup := seen[next]; dup {
+			return fmt.Errorf("%s: pagination cycled back to %s", what, next)
+		}
+		seen[next] = struct{}{}
+
+		token, err := getToken()
+		if err != nil {
+			return err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token.Token)
+
+		resp, err := armHTTPClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		// Read the status before the body: an error body must surface as an
+		// error, never be decoded as a zero-length page. That would report an
+		// empty collection as fact.
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return errors.New("failed to fetch " + what + " from " + next + ": " + resp.Status)
+		}
+
+		raw, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return err
+		}
+
+		next, err = decode(raw)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/providers/azure/resources/arm_paging.go
+++ b/providers/azure/resources/arm_paging.go
@@ -42,8 +42,8 @@ var armHTTPClient = &http.Client{Timeout: armHTTPTimeout}
 
 // armTokenFunc adapts a connection's credential to the getter fetchArmPages
 // wants, for callers that are not going through armSecurityConn.
-func armTokenFunc(ctx context.Context, conn *connection.AzureConnection) func() (azcore.AccessToken, error) {
-	return func() (azcore.AccessToken, error) {
+func armTokenFunc(conn *connection.AzureConnection) func(context.Context) (azcore.AccessToken, error) {
+	return func(ctx context.Context) (azcore.AccessToken, error) {
 		return conn.Token().GetToken(ctx, policy.TokenRequestOptions{
 			Scopes: []string{"https://management.core.windows.net//.default"},
 		})
@@ -56,10 +56,11 @@ func armTokenFunc(ctx context.Context, conn *connection.AzureConnection) func() 
 //
 // The token is fetched per page rather than once up front: a walk over a large
 // collection can outlive a bearer token, and the credential caches, so asking
-// again is cheap and only refreshes near expiry.
+// again is cheap and only refreshes near expiry. getToken takes the walk's
+// context so a refresh cannot outlive a cancelled walk.
 func fetchArmPages(
 	ctx context.Context,
-	getToken func() (azcore.AccessToken, error),
+	getToken func(context.Context) (azcore.AccessToken, error),
 	firstURL string,
 	what string,
 	decode func(body []byte) (nextLink string, err error),
@@ -78,7 +79,7 @@ func fetchArmPages(
 		}
 		seen[next] = struct{}{}
 
-		token, err := getToken()
+		token, err := getToken(ctx)
 		if err != nil {
 			return err
 		}

--- a/providers/azure/resources/arm_paging_test.go
+++ b/providers/azure/resources/arm_paging_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testToken() (azcore.AccessToken, error) {
+func testToken(context.Context) (azcore.AccessToken, error) {
 	return azcore.AccessToken{Token: "test-token"}, nil
 }
 
@@ -159,7 +159,7 @@ func TestFetchArmPagesPropagatesTokenErrors(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	badToken := func() (azcore.AccessToken, error) {
+	badToken := func(context.Context) (azcore.AccessToken, error) {
 		return azcore.AccessToken{}, assert.AnError
 	}
 	var got []string
@@ -177,4 +177,33 @@ func TestFetchArmPagesHonoursContextCancellation(t *testing.T) {
 
 	var got []string
 	require.Error(t, fetchArmPages(ctx, testToken, srv.URL, "things", collectPages(&got)))
+}
+
+// The per-page token refresh has to run under the walk's context, not one the
+// token getter closed over. A getter that reaches for context.Background()
+// keeps refreshing after the walk is cancelled.
+func TestFetchArmPagesPassesItsContextToTheTokenGetter(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/page1" {
+			fmt.Fprintf(w, `{"value":["a"],"nextLink":%q}`, srv.URL+"/page2")
+			return
+		}
+		fmt.Fprint(w, `{"value":["b"]}`)
+	}))
+	defer srv.Close()
+
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+
+	var seen []any
+	recordingToken := func(got context.Context) (azcore.AccessToken, error) {
+		seen = append(seen, got.Value(ctxKey{}))
+		return azcore.AccessToken{Token: "test-token"}, nil
+	}
+
+	var got []string
+	require.NoError(t, fetchArmPages(ctx, recordingToken, srv.URL+"/page1", "things", collectPages(&got)))
+	assert.Equal(t, []string{"a", "b"}, got)
+	assert.Equal(t, []any{"marker", "marker"}, seen, "every page's token refresh must see the walk's context")
 }

--- a/providers/azure/resources/arm_paging_test.go
+++ b/providers/azure/resources/arm_paging_test.go
@@ -1,0 +1,180 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testToken() (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "test-token"}, nil
+}
+
+// collectPages is the decode callback the real call sites use: accumulate the
+// page's values and hand back the cursor.
+func collectPages(into *[]string) func([]byte) (string, error) {
+	return func(raw []byte) (string, error) {
+		var page struct {
+			Value    []string `json:"value"`
+			NextLink string   `json:"nextLink"`
+		}
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return "", err
+		}
+		*into = append(*into, page.Value...)
+		return page.NextLink, nil
+	}
+}
+
+func TestFetchArmPagesFollowsTheCursor(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/page1":
+			fmt.Fprintf(w, `{"value":["a","b"],"nextLink":%q}`, srv.URL+"/page2")
+		case "/page2":
+			fmt.Fprintf(w, `{"value":["c"],"nextLink":%q}`, srv.URL+"/page3")
+		case "/page3":
+			fmt.Fprint(w, `{"value":["d"]}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	var got []string
+	require.NoError(t, fetchArmPages(context.Background(), testToken, srv.URL+"/page1", "things", collectPages(&got)))
+	assert.Equal(t, []string{"a", "b", "c", "d"}, got, "every page must reach the caller")
+}
+
+func TestFetchArmPagesStopsWithoutACursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"value":["only"]}`)
+	}))
+	defer srv.Close()
+
+	var got []string
+	require.NoError(t, fetchArmPages(context.Background(), testToken, srv.URL, "things", collectPages(&got)))
+	assert.Equal(t, []string{"only"}, got)
+}
+
+// A cursor that points back at a page already fetched would loop forever and
+// duplicate every row it returned. The walk has to notice rather than hang the
+// scan.
+func TestFetchArmPagesRejectsACycle(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// always points back at itself
+		fmt.Fprintf(w, `{"value":["x"],"nextLink":%q}`, srv.URL+"/loop")
+	}))
+	defer srv.Close()
+
+	var got []string
+	err := fetchArmPages(context.Background(), testToken, srv.URL+"/loop", "things", collectPages(&got))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycled")
+	assert.Len(t, got, 1, "the cycle must be caught on the second visit, not walked")
+}
+
+// A service that keeps handing back a fresh cursor forever must not grow the
+// result without bound.
+func TestFetchArmPagesIsBounded(t *testing.T) {
+	var srv *httptest.Server
+	page := 0
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		fmt.Fprintf(w, `{"value":["x"],"nextLink":"%s/p%d"}`, srv.URL, page)
+	}))
+	defer srv.Close()
+
+	var got []string
+	err := fetchArmPages(context.Background(), testToken, srv.URL+"/p0", "things", collectPages(&got))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped after")
+	assert.Len(t, got, maxArmPages)
+}
+
+// An error body must surface as an error, never be decoded as a zero-length
+// page -- that would report an empty collection as fact.
+func TestFetchArmPagesSurfacesNon2xx(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				fmt.Fprint(w, `{"value":[]}`)
+			}))
+			defer srv.Close()
+
+			var got []string
+			err := fetchArmPages(context.Background(), testToken, srv.URL, "things", collectPages(&got))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to fetch things")
+			assert.Empty(t, got)
+		})
+	}
+}
+
+// A non-2xx on a later page must fail the whole call rather than quietly
+// returning the pages already collected, which would look like a short list.
+func TestFetchArmPagesFailsOnALaterPage(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/page1" {
+			fmt.Fprintf(w, `{"value":["a"],"nextLink":%q}`, srv.URL+"/page2")
+			return
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	var got []string
+	err := fetchArmPages(context.Background(), testToken, srv.URL+"/page1", "things", collectPages(&got))
+	require.Error(t, err)
+}
+
+func TestFetchArmPagesPropagatesDecodeErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `not json`)
+	}))
+	defer srv.Close()
+
+	var got []string
+	require.Error(t, fetchArmPages(context.Background(), testToken, srv.URL, "things", collectPages(&got)))
+}
+
+func TestFetchArmPagesPropagatesTokenErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"value":[]}`)
+	}))
+	defer srv.Close()
+
+	badToken := func() (azcore.AccessToken, error) {
+		return azcore.AccessToken{}, assert.AnError
+	}
+	var got []string
+	require.Error(t, fetchArmPages(context.Background(), badToken, srv.URL, "things", collectPages(&got)))
+}
+
+func TestFetchArmPagesHonoursContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"value":[]}`)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var got []string
+	require.Error(t, fetchArmPages(ctx, testToken, srv.URL, "things", collectPages(&got)))
+}

--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -23,8 +23,8 @@ type armSecurityConn struct {
 	token          azcore.TokenCredential
 }
 
-func (a armSecurityConn) GetToken() (azcore.AccessToken, error) {
-	return a.token.GetToken(context.Background(), policy.TokenRequestOptions{
+func (a armSecurityConn) GetToken(ctx context.Context) (azcore.AccessToken, error) {
+	return a.token.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: []string{"https://management.core.windows.net//.default"},
 	})
 }

--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -6,10 +6,6 @@ package resources
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -56,90 +52,53 @@ func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssi
 	q.Set("api-version", "2022-06-01")
 	firstURL.RawQuery = q.Encode()
 
-	client := http.Client{}
 	result := PolicyAssignments{}
-	nextURL := firstURL.String()
-	for nextURL != "" {
-		// Fetch the token per page so a long pagination run over many policy
-		// assignments doesn't fail on an expired bearer token; the credential
-		// caches and only refreshes when the token is near expiry.
-		token, err := conn.GetToken()
-		if err != nil {
-			return PolicyAssignments{}, err
-		}
-		req, err := http.NewRequestWithContext(ctx, "GET", nextURL, nil)
-		if err != nil {
-			return PolicyAssignments{}, err
-		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return PolicyAssignments{}, err
-		}
-
-		if resp.StatusCode != 200 {
-			resp.Body.Close()
-			return PolicyAssignments{}, errors.New("failed to fetch policy assignments from " + nextURL + ": " + resp.Status)
-		}
-
-		raw, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return PolicyAssignments{}, err
-		}
-
+	err = fetchArmPages(ctx, conn.GetToken, firstURL.String(), "policy assignments", func(raw []byte) (string, error) {
 		page := PolicyAssignments{}
 		if err := json.Unmarshal(raw, &page); err != nil {
-			return PolicyAssignments{}, err
+			return "", err
 		}
 		result.PolicyAssignments = append(result.PolicyAssignments, page.PolicyAssignments...)
-
-		if page.NextLink == nil || *page.NextLink == "" {
-			break
+		if page.NextLink == nil {
+			return "", nil
 		}
-		nextURL = *page.NextLink
+		return *page.NextLink, nil
+	})
+	if err != nil {
+		return PolicyAssignments{}, err
 	}
 	return result, nil
 }
 
 func getServerVulnAssessmentSettings(ctx context.Context, conn armSecurityConn) (ServerVulnerabilityAssessmentsSettingsList, error) {
-	token, err := conn.GetToken()
-	if err != nil {
-		return ServerVulnerabilityAssessmentsSettingsList{}, err
-	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Security/serverVulnerabilityAssessmentsSettings"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(conn.subscriptionId))
 	urlPath = runtime.JoinPaths(conn.host, urlPath)
-	client := http.Client{}
-	req, err := http.NewRequest("GET", urlPath, nil)
+
+	firstURL, err := url.Parse(urlPath)
 	if err != nil {
 		return ServerVulnerabilityAssessmentsSettingsList{}, err
 	}
-	q := req.URL.Query()
+	q := firstURL.Query()
 	q.Set("api-version", "2022-01-01-preview")
-	req.URL.RawQuery = q.Encode()
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
+	firstURL.RawQuery = q.Encode()
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return ServerVulnerabilityAssessmentsSettingsList{}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return ServerVulnerabilityAssessmentsSettingsList{}, errors.New("failed to fetch server vulnerability assessment settings from " + urlPath + ": " + resp.Status)
-	}
-
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return ServerVulnerabilityAssessmentsSettingsList{}, err
-	}
 	result := ServerVulnerabilityAssessmentsSettingsList{}
-	err = json.Unmarshal(raw, &result)
-	return result, err
+	err = fetchArmPages(ctx, conn.GetToken, firstURL.String(), "server vulnerability assessment settings", func(raw []byte) (string, error) {
+		page := ServerVulnerabilityAssessmentsSettingsList{}
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return "", err
+		}
+		result.Settings = append(result.Settings, page.Settings...)
+		if page.NextLink == nil {
+			return "", nil
+		}
+		return *page.NextLink, nil
+	})
+	if err != nil {
+		return ServerVulnerabilityAssessmentsSettingsList{}, err
+	}
+	return result, nil
 }
 
 // https://learn.microsoft.com/en-us/azure/templates/microsoft.authorization/policyassignments?pivots=deployment-language-bicep#property-values
@@ -199,4 +158,8 @@ type ServerVulnerabilityAssessmentsSettings struct {
 
 type ServerVulnerabilityAssessmentsSettingsList struct {
 	Settings []ServerVulnerabilityAssessmentsSettings `json:"value"`
+	// The endpoint is paginated. Without this field the cursor was discarded at
+	// unmarshal, so the settings past the first page were not merely unfetched
+	// but invisible -- there was nothing to notice.
+	NextLink *string `json:"nextLink"`
 }

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -782,7 +782,7 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) privateEndpointConnecti
 		next = *resp.NextLink
 	}
 	if next != "" {
-		err = fetchArmPages(ctx, armTokenFunc(ctx, conn), next, "mysql private endpoint connections", func(raw []byte) (string, error) {
+		err = fetchArmPages(ctx, armTokenFunc(conn), next, "mysql private endpoint connections", func(raw []byte) (string, error) {
 			page := flexible.PrivateEndpointConnectionListResult{}
 			if err := json.Unmarshal(raw, &page); err != nil {
 				return "", err

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -5,13 +5,13 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -769,14 +769,35 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) privateEndpointConnecti
 	if err != nil {
 		return nil, err
 	}
-	// armmysqlflexibleservers/v2 models this as a single call even though the
-	// response carries a NextLink, so there is no pager to loop. Truncation is
-	// unlikely in practice (a server rarely has enough private endpoints to
-	// fill a page) but must not be silent if it ever happens.
-	if resp.NextLink != nil && *resp.NextLink != "" {
-		log.Warn().Str("server", server).Msg("mysql private endpoint connection list is paginated; only the first page is reported")
+	connections := resp.Value
+
+	// armmysqlflexibleservers/v2 exposes ListByServer as a plain method with no
+	// pager, even though the response carries a NextLink -- its postgresql
+	// counterpart does ship NewListByServerPager, so this is an SDK asymmetry
+	// rather than a non-paginated endpoint. The cursor used to be logged and
+	// dropped, which put the truncation in provider stderr where no query result
+	// or policy verdict could see it. Follow it instead.
+	next := ""
+	if resp.NextLink != nil {
+		next = *resp.NextLink
 	}
-	for _, pec := range resp.Value {
+	if next != "" {
+		err = fetchArmPages(ctx, armTokenFunc(ctx, conn), next, "mysql private endpoint connections", func(raw []byte) (string, error) {
+			page := flexible.PrivateEndpointConnectionListResult{}
+			if err := json.Unmarshal(raw, &page); err != nil {
+				return "", err
+			}
+			connections = append(connections, page.Value...)
+			if page.NextLink == nil {
+				return "", nil
+			}
+			return *page.NextLink, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, pec := range connections {
 		if pec == nil {
 			continue
 		}

--- a/providers/azure/resources/policy.go
+++ b/providers/azure/resources/policy.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -364,48 +362,26 @@ func (a *mqlAzureSubscriptionPolicy) exemptions() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	token, err := armConn.GetToken()
-	if err != nil {
-		return nil, err
-	}
-
-	url := fmt.Sprintf("%s/subscriptions/%s/providers/Microsoft.Authorization/policyExemptions?api-version=2022-07-01-preview",
+	firstURL := fmt.Sprintf("%s/subscriptions/%s/providers/Microsoft.Authorization/policyExemptions?api-version=2022-07-01-preview",
 		armConn.host, subId)
-	client := http.Client{}
+
 	res := []any{}
-	for url != "" {
-		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("Authorization", "Bearer "+token.Token)
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		raw, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, errors.New("failed to fetch policy exemptions: " + resp.Status)
-		}
-
+	err = fetchArmPages(ctx, armConn.GetToken, firstURL, "policy exemptions", func(raw []byte) (string, error) {
 		list := azurePolicyExemptionList{}
 		if err := json.Unmarshal(raw, &list); err != nil {
-			return nil, err
+			return "", err
 		}
 		for i := range list.Value {
 			mqlExemption, err := newMqlPolicyExemption(a.MqlRuntime, &list.Value[i])
 			if err != nil {
-				return nil, err
+				return "", err
 			}
 			res = append(res, mqlExemption)
 		}
-		url = list.NextLink
+		return list.NextLink, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return res, nil
 }


### PR DESCRIPTION
Found by a static bug-review pass over the provider.

**Pagination is otherwise in good shape here.** `NextPage(` and `.More()` counts match across all 92 resource files, and every one of ~250 SDK pagers loops correctly — the classic "read one page, forget the loop" truncation does not exist in the SDK-backed listers. Both real truncations are in the handful of requests that bypass the SDK, which is also the only place the loop has to be written by hand.

## Two silent truncations

**`getServerVulnAssessmentSettings`** issued a single `GET`, and its local model declared **no `NextLink` field at all** — so the cursor was not merely unfollowed, it was discarded at unmarshal and there was nothing left to notice. The result feeds `forServers.enabled`, so a setting landing past the first page made Defender for Servers read as not enabled.

**MySQL flexible-server private endpoint connections** did see the cursor and logged a warning:

```go
if resp.NextLink != nil && *resp.NextLink != "" {
    log.Warn().Str("server", server).Msg("... only the first page is reported")
}
```

A warning in provider stderr reaches no query result and no policy verdict. The list came back short and looked complete.

I checked whether an SDK bump fixes it: `armmysqlflexibleservers/v2` exposes `ListByServer` as a plain method with **no pager**, while its `armpostgresqlflexibleservers/v5` counterpart *does* ship `NewListByServerPager` — so this is an SDK asymmetry rather than a non-paginated endpoint, and `v2.0.0` is the latest published major. Following the cursor by hand is the only fix available.

## Two unbounded walks

Policy assignments and policy exemptions already followed `nextLink` correctly, but neither was bounded. ARM is not supposed to return a cursor that cycles or never terminates, but nothing in the protocol prevents it, and either would hang the scan while growing the result without limit.

## One shared walker

All four now go through `fetchArmPages`, which:

- **bounds the page count** (`maxArmPages`) and **rejects a cursor pointing at a page already fetched** — a self-referential `nextLink` would otherwise loop forever *and* duplicate every row it returned;
- **reads the status before the body**, so an error response can never be decoded as a zero-length page — in a security context an empty collection reads as "nothing configured", which is the worst possible way to fail;
- **applies a request timeout**. This was missing at every hand-rolled site: these requests do not go through the azcore pipeline, so nothing else imposed a deadline and a hung connection stalled the field indefinitely.

It also fetches the token per page, which the policy-assignments loop already did deliberately (a walk over a large collection can outlive a bearer token) and the exemptions loop did not.

The Advisor score fetch is **genuinely single-page** — `AdvisorScoreResponse` carries only `value` with no `nextLink`, and `armadvisor` ships no client for it, which is why it is hand-rolled at all — so it keeps its single request but picks up the shared client for the timeout.

Net effect on the two already-correct loops is a simplification: ~110 lines of duplicated request/decode/error handling replaced by the callback.

## Tests

`arm_paging_test.go` drives the walker against an `httptest` server: multi-page follow, termination without a cursor, cycle rejection, the page bound, non-2xx on the first page and on a later page (across 403 / 429 / 500), decode errors, token errors, and context cancellation. The non-2xx cases assert the result is **empty rather than partial**, since "short list that looks complete" is the failure mode being fixed.

## One deliberate omission

`getServerVulnAssessmentSettings` still uses the hand-rolled request on `api-version=2022-01-01-preview` rather than moving to `armsecurity`'s `ServerVulnerabilityAssessmentsSettingsClient`.

That swap would also fix the api-version drift and give it pipeline retries, and I'd have preferred it — but the SDK client is on `2023-05-01` and its setting-kind enum is `"azureServersSetting"` while this code matches on the resource **name** `"AzureServersSetting"`. Changing the wire contract underneath a security verdict needs confirmation against a live subscription first, so it's a separate change rather than a drive-by here.

## Notes

- Verified: `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l` clean.
- The MySQL cursor-following path only runs when a server actually has more connections than fit one page, so it is untested against live data — worth a `provider-verification` pass if you have such a server. Everything else is covered by the unit tests above.
- Sibling PRs from the same review touch `mysql.go` and `cloud_defender.go` in different functions.
