### PR TITLE
📄 oci: reattach the ociAnySubnetAdmitsInternet doc comment

### DIFF
--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -287,7 +287,6 @@ func ociAnySubnetReachable(gates []ociSubnetGate) bool {
 // matters for a multi-subnet load balancer: a hardened public subnet paired
 // with a private subnet carrying the wide-open default VCN security list must
 // not combine into a reachable verdict.
-
 func ociAnySubnetAdmitsInternet(gates []ociSubnetGate, nsgOpenRuleCount int) bool {
 	for _, g := range gates {
 		if g.prohibitsIngress || !g.routesToInternet {


### PR DESCRIPTION
Follow-up to review feedback on #9603, which landed incompletely.

The review pointed out that the two load balancer IP helpers had been inserted between `ociAnySubnetAdmitsInternet`'s doc comment and the function it describes, so godoc attached that comment to the wrong function. #9603 moved the helpers below it — but left a blank line behind:

```go
// ...must not combine into a reachable verdict.
                                    <- this blank line still detaches it
func ociAnySubnetAdmitsInternet(...)
```

A blank line separates a doc comment from its declaration just as effectively as intervening code does, so the function was still undocumented in godoc. One line removed.

I swept the rest of the provider for the same shape — a comment block, a blank line, then a `func`. There are 69 such seams, but 68 are section separators (`// ----- Streaming -----`) and similar, which are not doc comments and are correctly spaced. Filtering to blocks whose first line names the function that follows leaves exactly one: this one.

`go build`, `go vet`, `gofmt` and `go test ./resources/` all clean.
