### PR TITLE
✨ postgresdb: detect pgvector per database

### DIFF
--- a/providers/postgresdb/README.md
+++ b/providers/postgresdb/README.md
@@ -124,6 +124,20 @@ postgresdb.instance.databases.where.first.schemas.where.first.tables: [
 ]
 ```
 
+**Databases with pgvector (embedding stores)**
+
+Find databases that have the pgvector extension installed, and read its version to check against pgvector advisories. An empty `pgvectorVersion` means it is not installed.
+
+```shell
+mql> postgresdb.instance.databases.where(pgvectorVersion != "") { name pgvectorVersion }
+postgresdb.instance.databases.where: [
+  0: {
+    name: "postgres"
+    pgvectorVersion: "0.8.6"
+  }
+]
+```
+
 ## Verification
 
 Confirm the connection with a single query:

--- a/providers/postgresdb/resources/databases.go
+++ b/providers/postgresdb/resources/databases.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -232,6 +233,28 @@ func (r *mqlPostgresdbDatabase) extensions() ([]any, error) {
 		return nil, err
 	}
 	return listExtensions(r.MqlRuntime, pool, r.__id)
+}
+
+// pgvectorVersion returns the installed pgvector (the `vector` extension)
+// version, or an empty string when it is not installed in this database.
+func (r *mqlPostgresdbDatabase) pgvectorVersion() (string, error) {
+	if !r.AllowConnections.Data {
+		return "", nil
+	}
+	pool, err := pgPool(r.MqlRuntime, r.Name.Data)
+	if err != nil {
+		return "", err
+	}
+	var version string
+	err = pool.QueryRow(pgContext(),
+		`SELECT COALESCE(extversion, '') FROM pg_extension WHERE extname = 'vector'`).Scan(&version)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return version, nil
 }
 
 // --- schema -----------------------------------------------------------------

--- a/providers/postgresdb/resources/integration_test.go
+++ b/providers/postgresdb/resources/integration_test.go
@@ -122,6 +122,9 @@ func TestIntegrationResolveAll(t *testing.T) {
 		}
 		resolveList(t, name+".privileges", db.GetPrivileges())
 		resolveList(t, name+".extensions", db.GetExtensions())
+		if v := db.GetPgvectorVersion(); v.Error != nil {
+			t.Errorf("%s.pgvectorVersion errored: %v", name, v.Error)
+		}
 		resolveList(t, name+".publications", db.GetPublications())
 		for _, f := range resolveList(t, name+".foreignServers", db.GetForeignServers()) {
 			fs := f.(*mqlPostgresdbForeignServer)

--- a/providers/postgresdb/resources/postgresdb.lr
+++ b/providers/postgresdb/resources/postgresdb.lr
@@ -132,6 +132,14 @@ postgresdb.database @defaults("name") {
   functions() []postgresdb.function
   // Extensions installed in the database
   extensions() []postgresdb.extension
+  // Installed pgvector version, empty when pgvector is not installed
+  //
+  // pgvector adds vector similarity search through the `vector` extension; a
+  // database with it installed typically stores embeddings. An empty value
+  // means it is not installed. Use it to find such databases, for example
+  // databases.where(pgvectorVersion != ""), and to check the version against
+  // known pgvector advisories.
+  pgvectorVersion() string
   // Foreign servers defined in the database (for foreign-data wrappers)
   foreignServers() []postgresdb.foreignServer
   // Logical-replication publications defined in the database

--- a/providers/postgresdb/resources/postgresdb.lr.go
+++ b/providers/postgresdb/resources/postgresdb.lr.go
@@ -309,6 +309,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"postgresdb.database.extensions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPostgresdbDatabase).GetExtensions()).ToDataRes(types.Array(types.Resource("postgresdb.extension")))
 	},
+	"postgresdb.database.pgvectorVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPostgresdbDatabase).GetPgvectorVersion()).ToDataRes(types.String)
+	},
 	"postgresdb.database.foreignServers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPostgresdbDatabase).GetForeignServers()).ToDataRes(types.Array(types.Resource("postgresdb.foreignServer")))
 	},
@@ -758,6 +761,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"postgresdb.database.extensions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPostgresdbDatabase).Extensions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"postgresdb.database.pgvectorVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPostgresdbDatabase).PgvectorVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"postgresdb.database.foreignServers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1573,6 +1580,7 @@ type mqlPostgresdbDatabase struct {
 	Schemas          plugin.TValue[[]any]
 	Functions        plugin.TValue[[]any]
 	Extensions       plugin.TValue[[]any]
+	PgvectorVersion  plugin.TValue[string]
 	ForeignServers   plugin.TValue[[]any]
 	Publications     plugin.TValue[[]any]
 }
@@ -1718,6 +1726,12 @@ func (c *mqlPostgresdbDatabase) GetExtensions() *plugin.TValue[[]any] {
 		}
 
 		return c.extensions()
+	})
+}
+
+func (c *mqlPostgresdbDatabase) GetPgvectorVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.PgvectorVersion, func() (string, error) {
+		return c.pgvectorVersion()
 	})
 }
 

--- a/providers/postgresdb/resources/postgresdb.lr.versions
+++ b/providers/postgresdb/resources/postgresdb.lr.versions
@@ -15,6 +15,7 @@ postgresdb.database.isTemplate 13.0.0
 postgresdb.database.name 13.0.0
 postgresdb.database.oid 13.0.0
 postgresdb.database.owner 13.0.0
+postgresdb.database.pgvectorVersion 13.0.1
 postgresdb.database.privileges 13.0.0
 postgresdb.database.publications 13.0.0
 postgresdb.database.schemas 13.0.0


### PR DESCRIPTION
## What

Adds a **`pgvectorVersion`** field to `postgresdb.database`: the installed version of the pgvector `vector` extension, or empty when it is not installed.

This is the roadmap's "cheap vector signal on existing providers" — a small convenience field rather than a new provider. A database with pgvector installed typically stores embeddings, so this surfaces the AI data layer for security review, and the version supports checking against pgvector advisories.

## Why a field (not just `extensions.where(name == "vector")`)

pgvector was already *detectable* by scanning the per-database `extensions` list, but a first-class field makes the common audit query direct and gives the version without digging:

```
mql> postgresdb.instance.databases.where(pgvectorVersion != "") { name pgvectorVersion }
postgresdb.instance.databases.where: [
  0: { name: "postgres"  pgvectorVersion: "0.8.6" }
]
```

## Implementation notes

- Read per database from `pg_extension` (extensions are per-database in PostgreSQL), reusing the existing per-database connection pool.
- Returns empty (not an error) when the extension is absent or the database disallows connections, consistent with the other per-database accessors.
- No new dependency: `pgx/v5` was already in the module graph via `pgxpool`.

## Versioning

New field pinned to **`13.0.1`** — the next patch after the shipped `13.0.0`. All existing entries stay at `13.0.0`; only this field bumps.

## Verification

Verified live against `pgvector/pgvector:pg16`: the `postgres` database (with `CREATE EXTENSION vector`) reports `0.8.6`, a `plain` database without it reports `""`, and the `.where(pgvectorVersion != "")` audit query returns only the former. The env-gated integration suite exercises the accessor across every discovered database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
