### PR TITLE
🌟 gcp: key firewall ports by protocol and give the network its rules

### DIFF
--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -525,13 +525,10 @@ func getNetworkByUrl(networkUrl string, runtime *plugin.Runtime) (*mqlGcpProject
 		return nil, nil
 	}
 
-	params := strings.TrimPrefix(networkUrl, "https://www.googleapis.com/compute/v1/")
-	params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
-	parts := strings.Split(params, "/")
-	if len(parts) < 5 || parts[0] != "projects" || parts[3] != "networks" {
+	project, name, ok := parseNetworkURL(networkUrl)
+	if !ok {
 		return nil, fmt.Errorf("unrecognized network reference: %q", networkUrl)
 	}
-	project, name := parts[1], parts[4]
 
 	// Use NewResource so initGcpProjectComputeServiceNetwork runs and
 	// populates every field (scalars like autoCreateSubnetworks would

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1623,6 +1623,8 @@ func (g *mqlGcpProjectComputeService) firewalls() ([]any, error) {
 				"created":               llx.TimeDataPtr(parseTime(firewall.CreationTimestamp)),
 				"allowed":               llx.ArrayData(allowedDict, types.Dict),
 				"denied":                llx.ArrayData(deniedDict, types.Dict),
+				"allowedProtocols":      llx.MapData(firewallAllowedProtocolPorts(firewall.Allowed), types.Array(types.String)),
+				"deniedProtocols":       llx.MapData(firewallDeniedProtocolPorts(firewall.Denied), types.Array(types.String)),
 				"targetTags":            llx.ArrayData(convert.SliceAnyToInterface(firewall.TargetTags), types.String),
 				"loggingEnabled":        llx.BoolData(firewall.LogConfig != nil && firewall.LogConfig.Enable),
 				"logConfig":             llx.DictData(firewallLogConfigDict),

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -373,8 +373,10 @@ func mqlFirewallPolicyRules(runtime *plugin.Runtime, policyId string, rules []*c
 
 		var srcIpRanges, destIpRanges, srcAddressGroups, destAddressGroups []any
 		var layer4Configs []any
+		layer4Protocols := map[string]any{}
 		srcSecureTags := map[string]any{}
 		if r.Match != nil {
+			layer4Protocols = layer4ProtocolPorts(r.Match.Layer4Configs)
 			srcIpRanges = convert.SliceAnyToInterface(r.Match.SrcIpRanges)
 			destIpRanges = convert.SliceAnyToInterface(r.Match.DestIpRanges)
 			srcAddressGroups = convert.SliceAnyToInterface(r.Match.SrcAddressGroups)
@@ -419,6 +421,7 @@ func mqlFirewallPolicyRules(runtime *plugin.Runtime, policyId string, rules []*c
 			"srcIpRanges":           llx.ArrayData(srcIpRanges, types.String),
 			"destIpRanges":          llx.ArrayData(destIpRanges, types.String),
 			"layer4Configs":         llx.ArrayData(layer4Configs, types.Dict),
+			"layer4Protocols":       llx.MapData(layer4Protocols, types.Array(types.String)),
 			"srcSecureTags":         llx.MapData(srcSecureTags, types.String),
 			"srcAddressGroups":      llx.ArrayData(srcAddressGroups, types.String),
 			"destAddressGroups":     llx.ArrayData(destAddressGroups, types.String),

--- a/providers/gcp/resources/compute_network_children.go
+++ b/providers/gcp/resources/compute_network_children.go
@@ -1,0 +1,171 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"google.golang.org/api/compute/v1"
+)
+
+// protocolPort is the shape Compute uses for a layer 4 match, shared by VPC
+// firewall rules (as FirewallAllowed / FirewallDenied) and firewall policy
+// rules (as FirewallPolicyRuleMatcherLayer4Config). The three are distinct SDK
+// types carrying the same two fields, so each is adapted to this one.
+type protocolPort struct {
+	protocol string
+	ports    []string
+}
+
+// protocolPorts collapses layer 4 entries into a map keyed by protocol.
+//
+// Compute returns them as a list of {ipProtocol, ports} objects, which leaves
+// the ports a dict level below the rule and out of reach of a query. A protocol
+// is not documented to repeat within one rule, but ports are appended rather
+// than assigned so a repeat merges instead of silently dropping an entry. An
+// empty port list is meaningful: it means every port of that protocol, and is
+// the only form protocols carrying no ports (icmp, esp, ah) take.
+func protocolPorts(entries []protocolPort) map[string]any {
+	res := map[string]any{}
+	for _, e := range entries {
+		if e.protocol == "" {
+			continue
+		}
+		existing, ok := res[e.protocol].([]any)
+		if !ok {
+			existing = []any{}
+		}
+		for _, p := range e.ports {
+			existing = append(existing, p)
+		}
+		res[e.protocol] = existing
+	}
+	return res
+}
+
+// firewallAllowedProtocolPorts adapts a VPC firewall rule's allow list.
+func firewallAllowedProtocolPorts(entries []*compute.FirewallAllowed) map[string]any {
+	flat := make([]protocolPort, 0, len(entries))
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		flat = append(flat, protocolPort{protocol: e.IPProtocol, ports: e.Ports})
+	}
+	return protocolPorts(flat)
+}
+
+// firewallDeniedProtocolPorts adapts a VPC firewall rule's deny list.
+func firewallDeniedProtocolPorts(entries []*compute.FirewallDenied) map[string]any {
+	flat := make([]protocolPort, 0, len(entries))
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		flat = append(flat, protocolPort{protocol: e.IPProtocol, ports: e.Ports})
+	}
+	return protocolPorts(flat)
+}
+
+// layer4ProtocolPorts adapts a firewall policy rule's layer 4 match.
+func layer4ProtocolPorts(entries []*compute.FirewallPolicyRuleMatcherLayer4Config) map[string]any {
+	flat := make([]protocolPort, 0, len(entries))
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		flat = append(flat, protocolPort{protocol: e.IpProtocol, ports: e.Ports})
+	}
+	return protocolPorts(flat)
+}
+
+// parseNetworkURL extracts the project and name from a compute network
+// self-link. It accepts both the www.googleapis.com and compute.googleapis.com
+// forms, matching parseSubnetworkURL.
+func parseNetworkURL(networkUrl string) (project, name string, ok bool) {
+	if networkUrl == "" {
+		return "", "", false
+	}
+	// Format is https://www.googleapis.com/compute/v1/projects/project1/global/networks/network-1
+	params := strings.TrimPrefix(networkUrl, "https://www.googleapis.com/compute/v1/")
+	params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
+	parts := strings.Split(params, "/")
+	if len(parts) < 5 || parts[0] != "projects" || parts[3] != "networks" {
+		return "", "", false
+	}
+	return parts[1], parts[4], true
+}
+
+// networkChildren filters one of the project-wide compute listings down to the
+// members of this network.
+//
+// Compute's firewall and route listings are project-scoped, not network-scoped,
+// so there is no call that returns "the firewall rules of this network". Both
+// resources reference their network by self-link URL, which is why selecting
+// them meant matching that URL by hand. The parent gcp.project.computeService
+// is runtime-cached, so a query walking several networks lists once rather than
+// once per network.
+func networkChildren[T any](
+	g *mqlGcpProjectComputeServiceNetwork,
+	list func(*mqlGcpProjectComputeService) *plugin.TValue[[]any],
+	networkUrlOf func(T) string,
+) ([]any, error) {
+	if g.ProjectId.Error != nil {
+		return nil, g.ProjectId.Error
+	}
+	if g.Name.Error != nil {
+		return nil, g.Name.Error
+	}
+	projectID, name := g.ProjectId.Data, g.Name.Data
+
+	svc, err := CreateResource(g.MqlRuntime, "gcp.project.computeService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := list(svc.(*mqlGcpProjectComputeService))
+	if all.Error != nil {
+		return nil, all.Error
+	}
+
+	res := []any{}
+	for _, entry := range all.Data {
+		child, ok := entry.(T)
+		if !ok {
+			continue
+		}
+		// A reference that does not parse is skipped rather than treated as a
+		// match: attributing an unrecognized network URL to this network would
+		// report a rule as applying where it does not.
+		childProject, childName, ok := parseNetworkURL(networkUrlOf(child))
+		if !ok {
+			continue
+		}
+		if childProject == projectID && childName == name {
+			res = append(res, entry)
+		}
+	}
+	return res, nil
+}
+
+func (g *mqlGcpProjectComputeServiceNetwork) firewalls() ([]any, error) {
+	return networkChildren(g,
+		func(s *mqlGcpProjectComputeService) *plugin.TValue[[]any] { return s.GetFirewalls() },
+		func(f *mqlGcpProjectComputeServiceFirewall) string { return f.cacheNetworkUrl })
+}
+
+func (g *mqlGcpProjectComputeServiceNetwork) routes() ([]any, error) {
+	return networkChildren(g,
+		func(s *mqlGcpProjectComputeService) *plugin.TValue[[]any] { return s.GetRoutes() },
+		func(r *mqlGcpProjectComputeServiceRoute) string {
+			if r.NetworkUrl.Error != nil {
+				return ""
+			}
+			return r.NetworkUrl.Data
+		})
+}

--- a/providers/gcp/resources/compute_network_children_test.go
+++ b/providers/gcp/resources/compute_network_children_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+)
+
+func TestParseNetworkURL(t *testing.T) {
+	tests := []struct {
+		name             string
+		url              string
+		project, network string
+		ok               bool
+	}{
+		{
+			name: "www.googleapis.com form",
+			url:  "https://www.googleapis.com/compute/v1/projects/proj-1/global/networks/net-1",
+			// Both host forms appear in the same API responses depending on the
+			// field, so a matcher that handles only one silently drops rules.
+			project: "proj-1", network: "net-1", ok: true,
+		},
+		{
+			name:    "compute.googleapis.com form",
+			url:     "https://compute.googleapis.com/compute/v1/projects/proj-2/global/networks/net-2",
+			project: "proj-2", network: "net-2", ok: true,
+		},
+		{
+			name: "empty url",
+			url:  "",
+		},
+		{
+			// A subnetwork self-link must not be mistaken for a network one.
+			name: "subnetwork url is rejected",
+			url:  "https://www.googleapis.com/compute/v1/projects/proj-1/regions/us-central1/subnetworks/sub-1",
+		},
+		{
+			name: "truncated url",
+			url:  "https://www.googleapis.com/compute/v1/projects/proj-1/global",
+		},
+		{
+			name: "unrelated url",
+			url:  "not-a-url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			project, network, ok := parseNetworkURL(tt.url)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.project, project)
+			assert.Equal(t, tt.network, network)
+		})
+	}
+}
+
+func TestFirewallAllowedProtocolPorts(t *testing.T) {
+	got := firewallAllowedProtocolPorts([]*compute.FirewallAllowed{
+		{IPProtocol: "tcp", Ports: []string{"22", "8000-8080"}},
+		{IPProtocol: "icmp"},
+	})
+
+	assert.Equal(t, map[string]any{
+		"tcp": []any{"22", "8000-8080"},
+		// icmp carries no ports; the empty list must still be present so the
+		// protocol itself is queryable, rather than the key vanishing.
+		"icmp": []any{},
+	}, got)
+}
+
+func TestFirewallDeniedProtocolPorts(t *testing.T) {
+	got := firewallDeniedProtocolPorts([]*compute.FirewallDenied{
+		{IPProtocol: "udp", Ports: []string{"53"}},
+	})
+	assert.Equal(t, map[string]any{"udp": []any{"53"}}, got)
+}
+
+func TestLayer4ProtocolPorts(t *testing.T) {
+	got := layer4ProtocolPorts([]*compute.FirewallPolicyRuleMatcherLayer4Config{
+		{IpProtocol: "tcp", Ports: []string{"443"}},
+	})
+	assert.Equal(t, map[string]any{"tcp": []any{"443"}}, got)
+}
+
+func TestProtocolPortsMergesRepeatedProtocol(t *testing.T) {
+	// A protocol is not documented to repeat within one rule, but if it does the
+	// ports must merge rather than the second entry overwriting the first.
+	got := protocolPorts([]protocolPort{
+		{protocol: "tcp", ports: []string{"22"}},
+		{protocol: "tcp", ports: []string{"443"}},
+	})
+	assert.Equal(t, map[string]any{"tcp": []any{"22", "443"}}, got)
+}
+
+func TestProtocolPortsSkipsNilAndEmpty(t *testing.T) {
+	// A nil SDK entry must not panic, and an entry with no protocol has nothing
+	// to key on so it is dropped rather than creating an "" bucket.
+	assert.Equal(t, map[string]any{}, firewallAllowedProtocolPorts([]*compute.FirewallAllowed{nil}))
+	assert.Equal(t, map[string]any{}, protocolPorts([]protocolPort{{protocol: "", ports: []string{"22"}}}))
+	assert.Equal(t, map[string]any{}, protocolPorts(nil))
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2524,10 +2524,27 @@ private gcp.project.computeService.firewall @defaults("name") {
   targetServiceAccountRefs() []gcp.project.iamService.serviceAccount
   // Creation timestamp
   created time
-  // List of ALLOW rules specified by this firewall
-  allowed []dict
-  // List of DENY rules specified by this firewall
-  denied []dict
+  // ALLOW rule dicts
+  //
+  // Deprecated in favor of allowedProtocols. Each entry: {ipProtocol, ports}.
+  allowed @maturity("deprecated") []dict
+  // DENY rule dicts
+  //
+  // Deprecated in favor of deniedProtocols. Each entry: {ipProtocol, ports}.
+  denied @maturity("deprecated") []dict
+  // Ports this rule allows, keyed by protocol
+  //
+  // Maps each protocol the rule permits (tcp, udp, icmp, esp, ah, sctp, ipip,
+  // or an IANA protocol number) to the ports it permits for that protocol.
+  // A port entry is either a single port ("22") or an inclusive range
+  // ("8000-8080"). An empty list means every port of that protocol, which is
+  // also the only form protocols that carry no ports (such as icmp) take.
+  allowedProtocols map[string][]string
+  // Ports this rule denies, keyed by protocol
+  //
+  // Same shape as allowedProtocols. A firewall rule carries either allow
+  // entries or deny entries, never both, so one of the two is always empty.
+  deniedProtocols map[string][]string
   // Instance tags that the firewall rule applies to
   targetTags []string
   // Whether firewall logging is enabled for this rule
@@ -2585,6 +2602,18 @@ gcp.project.computeService.network @defaults("name") {
   subnetworkUrls []string
   // Subnetworks in the network
   subnetworks() []gcp.project.computeService.subnetwork
+  // VPC firewall rules attached to the network
+  //
+  // The rules whose network is this one, in the project's firewall list.
+  // Selecting them here avoids matching each rule's network self-link URL by
+  // hand. Firewall policy rules are separate and reachable through
+  // firewallPolicyRef.
+  firewalls() []gcp.project.computeService.firewall
+  // Routes defined on the network
+  //
+  // Both the routes created with the network and any custom routes added to
+  // it, including the default route whose next hop is the internet gateway.
+  routes() []gcp.project.computeService.route
   // The range of internal IPv6 addresses owned by this network
   internalIpv6Range string
   // URL of the firewall policy applied to this network
@@ -11029,8 +11058,17 @@ private gcp.project.computeService.firewallPolicy.rule @defaults("priority actio
   srcIpRanges []string
   // Destination IPv4/IPv6 CIDR ranges the rule matches
   destIpRanges []string
-  // Protocol/port combinations the rule matches (each entry: {ipProtocol, ports[]})
-  layer4Configs []dict
+  // Layer 4 configuration dicts
+  //
+  // Deprecated in favor of layer4Protocols. Each entry: {ipProtocol, ports}.
+  layer4Configs @maturity("deprecated") []dict
+  // Ports the rule matches, keyed by protocol
+  //
+  // Maps each protocol the rule matches (tcp, udp, icmp, esp, ah, sctp, or an
+  // IANA protocol number) to the ports it matches for that protocol. A port
+  // entry is either a single port ("22") or an inclusive range ("8000-8080").
+  // An empty list means every port of that protocol.
+  layer4Protocols map[string][]string
   // Source secure tag values the rule matches (tag name -> state, e.g. EFFECTIVE / INEFFECTIVE)
   srcSecureTags map[string]string
   // Source address groups the rule matches

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4911,6 +4911,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.firewall.denied": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetDenied()).ToDataRes(types.Array(types.Dict))
 	},
+	"gcp.project.computeService.firewall.allowedProtocols": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetAllowedProtocols()).ToDataRes(types.Map(types.String, types.Array(types.String)))
+	},
+	"gcp.project.computeService.firewall.deniedProtocols": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetDeniedProtocols()).ToDataRes(types.Map(types.String, types.Array(types.String)))
+	},
 	"gcp.project.computeService.firewall.targetTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetTargetTags()).ToDataRes(types.Array(types.String))
 	},
@@ -4976,6 +4982,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.network.subnetworks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetSubnetworks()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.subnetwork")))
+	},
+	"gcp.project.computeService.network.firewalls": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetwork).GetFirewalls()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.firewall")))
+	},
+	"gcp.project.computeService.network.routes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetwork).GetRoutes()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.route")))
 	},
 	"gcp.project.computeService.network.internalIpv6Range": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetInternalIpv6Range()).ToDataRes(types.String)
@@ -12410,6 +12422,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.firewallPolicy.rule.layer4Configs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewallPolicyRule).GetLayer4Configs()).ToDataRes(types.Array(types.Dict))
+	},
+	"gcp.project.computeService.firewallPolicy.rule.layer4Protocols": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewallPolicyRule).GetLayer4Protocols()).ToDataRes(types.Map(types.String, types.Array(types.String)))
 	},
 	"gcp.project.computeService.firewallPolicy.rule.srcSecureTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewallPolicyRule).GetSrcSecureTags()).ToDataRes(types.Map(types.String, types.String))
@@ -22132,6 +22147,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceFirewall).Denied, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.firewall.allowedProtocols": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).AllowedProtocols, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.firewall.deniedProtocols": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).DeniedProtocols, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.firewall.targetTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewall).TargetTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -22222,6 +22245,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.network.subnetworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetwork).Subnetworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.firewalls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetwork).Firewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.routes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetwork).Routes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.network.internalIpv6Range": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -32998,6 +33029,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.firewallPolicy.rule.layer4Configs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceFirewallPolicyRule).Layer4Configs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.firewallPolicy.rule.layer4Protocols": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewallPolicyRule).Layer4Protocols, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.firewallPolicy.rule.srcSecureTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51062,6 +51097,8 @@ type mqlGcpProjectComputeServiceFirewall struct {
 	Created                  plugin.TValue[*time.Time]
 	Allowed                  plugin.TValue[[]any]
 	Denied                   plugin.TValue[[]any]
+	AllowedProtocols         plugin.TValue[map[string]any]
+	DeniedProtocols          plugin.TValue[map[string]any]
 	TargetTags               plugin.TValue[[]any]
 	LoggingEnabled           plugin.TValue[bool]
 	LogConfig                plugin.TValue[any]
@@ -51216,6 +51253,14 @@ func (c *mqlGcpProjectComputeServiceFirewall) GetDenied() *plugin.TValue[[]any] 
 	return &c.Denied
 }
 
+func (c *mqlGcpProjectComputeServiceFirewall) GetAllowedProtocols() *plugin.TValue[map[string]any] {
+	return &c.AllowedProtocols
+}
+
+func (c *mqlGcpProjectComputeServiceFirewall) GetDeniedProtocols() *plugin.TValue[map[string]any] {
+	return &c.DeniedProtocols
+}
+
 func (c *mqlGcpProjectComputeServiceFirewall) GetTargetTags() *plugin.TValue[[]any] {
 	return &c.TargetTags
 }
@@ -51270,6 +51315,8 @@ type mqlGcpProjectComputeServiceNetwork struct {
 	Mode                                  plugin.TValue[string]
 	SubnetworkUrls                        plugin.TValue[[]any]
 	Subnetworks                           plugin.TValue[[]any]
+	Firewalls                             plugin.TValue[[]any]
+	Routes                                plugin.TValue[[]any]
 	InternalIpv6Range                     plugin.TValue[string]
 	FirewallPolicy                        plugin.TValue[string]
 	FirewallPolicyRef                     plugin.TValue[*mqlGcpProjectComputeServiceFirewallPolicy]
@@ -51405,6 +51452,38 @@ func (c *mqlGcpProjectComputeServiceNetwork) GetSubnetworks() *plugin.TValue[[]a
 		}
 
 		return c.subnetworks()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceNetwork) GetFirewalls() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Firewalls, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.network", c.__id, "firewalls")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.firewalls()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceNetwork) GetRoutes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Routes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.network", c.__id, "routes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.routes()
 	})
 }
 
@@ -76172,6 +76251,7 @@ type mqlGcpProjectComputeServiceFirewallPolicyRule struct {
 	SrcIpRanges           plugin.TValue[[]any]
 	DestIpRanges          plugin.TValue[[]any]
 	Layer4Configs         plugin.TValue[[]any]
+	Layer4Protocols       plugin.TValue[map[string]any]
 	SrcSecureTags         plugin.TValue[map[string]any]
 	SrcAddressGroups      plugin.TValue[[]any]
 	DestAddressGroups     plugin.TValue[[]any]
@@ -76273,6 +76353,10 @@ func (c *mqlGcpProjectComputeServiceFirewallPolicyRule) GetDestIpRanges() *plugi
 
 func (c *mqlGcpProjectComputeServiceFirewallPolicyRule) GetLayer4Configs() *plugin.TValue[[]any] {
 	return &c.Layer4Configs
+}
+
+func (c *mqlGcpProjectComputeServiceFirewallPolicyRule) GetLayer4Protocols() *plugin.TValue[map[string]any] {
+	return &c.Layer4Protocols
 }
 
 func (c *mqlGcpProjectComputeServiceFirewallPolicyRule) GetSrcSecureTags() *plugin.TValue[map[string]any] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1769,10 +1769,12 @@ gcp.project.computeService.externalVpnGateway.selfLink 13.6.1
 gcp.project.computeService.externalVpnGateways 13.6.1
 gcp.project.computeService.firewall 9.0.0
 gcp.project.computeService.firewall.allowed 9.0.0
+gcp.project.computeService.firewall.allowedProtocols 13.34.2
 gcp.project.computeService.firewall.allowsRdpFromInternet 13.12.2
 gcp.project.computeService.firewall.allowsSshFromInternet 13.12.2
 gcp.project.computeService.firewall.created 9.0.0
 gcp.project.computeService.firewall.denied 9.0.0
+gcp.project.computeService.firewall.deniedProtocols 13.34.2
 gcp.project.computeService.firewall.description 9.0.0
 gcp.project.computeService.firewall.destinationRanges 9.0.0
 gcp.project.computeService.firewall.direction 9.0.0
@@ -1814,6 +1816,7 @@ gcp.project.computeService.firewallPolicy.rule.disabled 11.6.6
 gcp.project.computeService.firewallPolicy.rule.enableLogging 11.6.6
 gcp.project.computeService.firewallPolicy.rule.id 11.6.6
 gcp.project.computeService.firewallPolicy.rule.layer4Configs 13.14.2
+gcp.project.computeService.firewallPolicy.rule.layer4Protocols 13.34.2
 gcp.project.computeService.firewallPolicy.rule.match 11.6.6
 gcp.project.computeService.firewallPolicy.rule.priority 11.6.6
 gcp.project.computeService.firewallPolicy.rule.ruleName 11.6.6
@@ -2174,6 +2177,7 @@ gcp.project.computeService.network.description 9.0.0
 gcp.project.computeService.network.enableUlaInternalIpv6 9.0.0
 gcp.project.computeService.network.firewallPolicy 11.6.6
 gcp.project.computeService.network.firewallPolicyRef 13.27.2
+gcp.project.computeService.network.firewalls 13.34.2
 gcp.project.computeService.network.gatewayIPv4 9.0.0
 gcp.project.computeService.network.id 9.0.0
 gcp.project.computeService.network.internalIpv6Range 11.6.6
@@ -2200,6 +2204,7 @@ gcp.project.computeService.network.peering.state 11.6.6
 gcp.project.computeService.network.peering.stateDetails 11.6.6
 gcp.project.computeService.network.peerings 9.0.0
 gcp.project.computeService.network.projectId 9.0.0
+gcp.project.computeService.network.routes 13.34.2
 gcp.project.computeService.network.routingMode 9.0.0
 gcp.project.computeService.network.subnetworkUrls 9.0.0
 gcp.project.computeService.network.subnetworks 9.0.0


### PR DESCRIPTION
## Why

Compute returns a firewall rule's layer 4 match as a list of `{ipProtocol, ports}` objects, and the provider passed it straight through as `[]dict`. Nothing is missing from the fetch — the structure is discarded on the way out, and it leaves **the ports a `dict` level below the rule**, so selecting a rule by the port it opens was not expressible.

Separately, firewall rules and routes reference their network only by self-link URL. Answering "which firewall rules apply to this VPC" meant listing every rule in the project and matching `https://www.googleapis.com/compute/v1/projects/.../networks/...` by hand.

## What

**Protocol-keyed ports.** `allowedProtocols` / `deniedProtocols` on the VPC firewall rule, and `layer4Protocols` on the firewall policy rule (the rules that override VPC rules), each `map[string][]string` keyed by protocol.

```
gcp.project.computeService.firewalls.where(allowedProtocols["tcp"] != empty)

gcp.project.computeService.firewalls.where(
  direction == "INGRESS" && !disabled && sourceRanges.contains("0.0.0.0/0")
) { name allowedProtocols }
```

CLAUDE.md steers `{type, value}` pairs toward a map rather than a two-field sub-resource, and `map[string][]string` is already used elsewhere in the schema, so no new resource type was needed.

Two details that matter for correctness:
- **An empty port list is kept, not dropped.** It means *every* port of that protocol, and is the only form protocols carrying no ports (`icmp`, `esp`, `ah`) take. Dropping the key would make an ICMP-any rule invisible.
- **Ports append rather than assign.** A protocol is not documented to repeat within one rule, but if it ever does, a naive map assignment silently discards an entry.

**Network back-links.** `network.firewalls()` and `network.routes()`, filtered over the runtime-cached `gcp.project.computeService`, so a query walking several networks lists once rather than once per network. The self-link parsing `getNetworkByUrl` did inline is extracted to `parseNetworkURL` and shared. An unparseable reference is **skipped rather than counted as a match** — attributing an unrecognized URL to this network would report a rule as applying where it does not.

## Compatibility

Additive. `allowed`, `denied`, and `layer4Configs` are kept and marked `@maturity("deprecated")`. No new API calls — the build reports `gcp: 287 permissions (unchanged)`. Schema entries at `13.34.2`.

## Testing

`parseNetworkURL` and the three protocol adapters are table-tested, covering both self-link host forms, the subnetwork-URL-must-not-match case, the empty-port-list case, the repeated-protocol merge, and nil SDK entries. `go test ./resources/...` passes.

**Not live-verified** — batched per the usual practice.

## Deliberately deferred

`instance.networkInterface.accessConfigs` is still `[]dict`, and it holds `natIP` — the instance's actual public IP. GCP permits only one external access config per NIC, so CLAUDE.md's "flatten scalars into the parent" likely applies rather than a sub-resource, but that is a separate design call from the mechanical transform in this PR. Worth its own change.
