### PR TITLE
🌟 aws: type the security group references on a rule

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -19866,18 +19866,67 @@ private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProto
   prefixListIds []dict
   // Managed prefix lists this rule targets
   prefixLists() []aws.ec2.managedPrefixList
-  // Security group references the rule allows
+  // Security group reference dicts
   //
-  // Each entry carries GroupId and GroupName of the referenced security
-  // group, UserId of the account that owns it, VpcId and
-  // VpcPeeringConnectionId when the reference crosses a VPC peering
+  // Deprecated in favor of peers. Each entry carries GroupId and GroupName of
+  // the referenced security group, UserId of the account that owns it, VpcId
+  // and VpcPeeringConnectionId when the reference crosses a VPC peering
   // connection, PeeringStatus, and an optional Description.
-  userIdGroupPairs []dict
+  userIdGroupPairs @maturity("deprecated") []dict
+  // Security groups the rule allows traffic from or to
+  //
+  // A rule can name another security group instead of an address range, so
+  // that every instance in that group is permitted. These references are what
+  // carries reachability between workloads inside a VPC, and following them
+  // shows which groups can reach a group without any address appearing in the
+  // rule.
+  peers []aws.ec2.securitygroup.ippermission.peer
   // Whether the rule allows traffic from the entire internet
   //
   // True when the IPv4 ranges include `0.0.0.0/0` or the IPv6 ranges include
   // `::/0`.
   includesPublicSource() bool
+}
+
+// Security group named by a security group rule
+//
+// A reference from one security group rule to another security group, which
+// permits every instance in the referenced group rather than an address range.
+// The reference is either within one VPC or across a VPC peering connection,
+// and `peeringConnection` with `peeringStatus` says which and whether the
+// peering is still active: a reference whose peering has been deleted stays on
+// the rule but no longer carries traffic.
+private aws.ec2.securitygroup.ippermission.peer @defaults("groupId accountId peeringStatus") {
+  // ID of the referenced security group
+  groupId string
+  // Name of the referenced security group, returned only for EC2-Classic references
+  groupName string
+  // Account that owns the referenced security group
+  //
+  // Differs from the scanned account when the rule permits a group in another
+  // account across a VPC peering connection.
+  accountId string
+  // Description recorded on the reference
+  description string
+  // State of the VPC peering connection the reference crosses
+  //
+  // Empty when the reference stays inside one VPC. Otherwise one of the
+  // peering connection states, of which only `active` carries traffic.
+  peeringStatus string
+  // Referenced security group
+  //
+  // Null when the group belongs to another account or is reached across a VPC
+  // peering connection, because neither is readable with the credentials
+  // scanning this account. Read groupId and accountId in that case; a null
+  // here means the group was not resolvable, never that the rule does not
+  // reference one.
+  securityGroup() aws.ec2.securitygroup
+  // VPC of the referenced security group, when the reference crosses a peering connection
+  vpc() aws.vpc
+  // VPC peering connection the reference crosses
+  //
+  // Null when the reference stays inside one VPC.
+  peeringConnection() aws.vpc.peeringConnection
 }
 
 // AWS Config

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -19921,7 +19921,11 @@ private aws.ec2.securitygroup.ippermission.peer @defaults("groupId accountId pee
   // here means the group was not resolvable, never that the rule does not
   // reference one.
   securityGroup() aws.ec2.securitygroup
-  // VPC of the referenced security group, when the reference crosses a peering connection
+  // VPC of the referenced security group
+  //
+  // Returned by AWS only when the reference crosses a VPC peering connection,
+  // since within one VPC the VPC is the rule's own. Null when the referenced
+  // group belongs to another account, whose VPC is not readable here.
   vpc() aws.vpc
   // VPC peering connection the reference crosses
   //

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -643,6 +643,7 @@ const (
 	ResourceAwsEc2InstancePlacement                                             string = "aws.ec2.instance.placement"
 	ResourceAwsEc2Securitygroup                                                 string = "aws.ec2.securitygroup"
 	ResourceAwsEc2SecuritygroupIppermission                                     string = "aws.ec2.securitygroup.ippermission"
+	ResourceAwsEc2SecuritygroupIppermissionPeer                                 string = "aws.ec2.securitygroup.ippermission.peer"
 	ResourceAwsConfig                                                           string = "aws.config"
 	ResourceAwsConfigRule                                                       string = "aws.config.rule"
 	ResourceAwsConfigRuleComplianceDetail                                       string = "aws.config.rule.complianceDetail"
@@ -3504,6 +3505,10 @@ func init() {
 		"aws.ec2.securitygroup.ippermission": {
 			// to override args, implement: initAwsEc2SecuritygroupIppermission(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsEc2SecuritygroupIppermission,
+		},
+		"aws.ec2.securitygroup.ippermission.peer": {
+			// to override args, implement: initAwsEc2SecuritygroupIppermissionPeer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsEc2SecuritygroupIppermissionPeer,
 		},
 		"aws.config": {
 			// to override args, implement: initAwsConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -25206,8 +25211,35 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.securitygroup.ippermission.userIdGroupPairs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetUserIdGroupPairs()).ToDataRes(types.Array(types.Dict))
 	},
+	"aws.ec2.securitygroup.ippermission.peers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetPeers()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup.ippermission.peer")))
+	},
 	"aws.ec2.securitygroup.ippermission.includesPublicSource": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2SecuritygroupIppermission).GetIncludesPublicSource()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.securitygroup.ippermission.peer.groupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetGroupId()).ToDataRes(types.String)
+	},
+	"aws.ec2.securitygroup.ippermission.peer.groupName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetGroupName()).ToDataRes(types.String)
+	},
+	"aws.ec2.securitygroup.ippermission.peer.accountId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetAccountId()).ToDataRes(types.String)
+	},
+	"aws.ec2.securitygroup.ippermission.peer.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.ec2.securitygroup.ippermission.peer.peeringStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetPeeringStatus()).ToDataRes(types.String)
+	},
+	"aws.ec2.securitygroup.ippermission.peer.securityGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetSecurityGroup()).ToDataRes(types.Resource("aws.ec2.securitygroup"))
+	},
+	"aws.ec2.securitygroup.ippermission.peer.vpc": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetVpc()).ToDataRes(types.Resource("aws.vpc"))
+	},
+	"aws.ec2.securitygroup.ippermission.peer.peeringConnection": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GetPeeringConnection()).ToDataRes(types.Resource("aws.vpc.peeringConnection"))
 	},
 	"aws.config.recorders": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfig).GetRecorders()).ToDataRes(types.Array(types.Resource("aws.config.recorder")))
@@ -66350,8 +66382,48 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2SecuritygroupIppermission).UserIdGroupPairs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.securitygroup.ippermission.peers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermission).Peers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.securitygroup.ippermission.includesPublicSource": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2SecuritygroupIppermission).IncludesPublicSource, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.groupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.groupName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).GroupName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.accountId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).AccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.peeringStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).PeeringStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.securityGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).SecurityGroup, ok = plugin.RawToTValue[*mqlAwsEc2Securitygroup](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).Vpc, ok = plugin.RawToTValue[*mqlAwsVpc](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.ippermission.peer.peeringConnection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2SecuritygroupIppermissionPeer).PeeringConnection, ok = plugin.RawToTValue[*mqlAwsVpcPeeringConnection](v.Value, v.Error)
 		return
 	},
 	"aws.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -159580,6 +159652,7 @@ type mqlAwsEc2SecuritygroupIppermission struct {
 	PrefixListIds        plugin.TValue[[]any]
 	PrefixLists          plugin.TValue[[]any]
 	UserIdGroupPairs     plugin.TValue[[]any]
+	Peers                plugin.TValue[[]any]
 	IncludesPublicSource plugin.TValue[bool]
 }
 
@@ -159676,9 +159749,128 @@ func (c *mqlAwsEc2SecuritygroupIppermission) GetUserIdGroupPairs() *plugin.TValu
 	return &c.UserIdGroupPairs
 }
 
+func (c *mqlAwsEc2SecuritygroupIppermission) GetPeers() *plugin.TValue[[]any] {
+	return &c.Peers
+}
+
 func (c *mqlAwsEc2SecuritygroupIppermission) GetIncludesPublicSource() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IncludesPublicSource, func() (bool, error) {
 		return c.includesPublicSource()
+	})
+}
+
+// mqlAwsEc2SecuritygroupIppermissionPeer for the aws.ec2.securitygroup.ippermission.peer resource
+type mqlAwsEc2SecuritygroupIppermissionPeer struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAwsEc2SecuritygroupIppermissionPeerInternal
+	GroupId           plugin.TValue[string]
+	GroupName         plugin.TValue[string]
+	AccountId         plugin.TValue[string]
+	Description       plugin.TValue[string]
+	PeeringStatus     plugin.TValue[string]
+	SecurityGroup     plugin.TValue[*mqlAwsEc2Securitygroup]
+	Vpc               plugin.TValue[*mqlAwsVpc]
+	PeeringConnection plugin.TValue[*mqlAwsVpcPeeringConnection]
+}
+
+// createAwsEc2SecuritygroupIppermissionPeer creates a new instance of this resource
+func createAwsEc2SecuritygroupIppermissionPeer(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsEc2SecuritygroupIppermissionPeer{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.ec2.securitygroup.ippermission.peer", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) MqlName() string {
+	return "aws.ec2.securitygroup.ippermission.peer"
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetGroupId() *plugin.TValue[string] {
+	return &c.GroupId
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetGroupName() *plugin.TValue[string] {
+	return &c.GroupName
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetAccountId() *plugin.TValue[string] {
+	return &c.AccountId
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetPeeringStatus() *plugin.TValue[string] {
+	return &c.PeeringStatus
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetSecurityGroup() *plugin.TValue[*mqlAwsEc2Securitygroup] {
+	return plugin.GetOrCompute[*mqlAwsEc2Securitygroup](&c.SecurityGroup, func() (*mqlAwsEc2Securitygroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.securitygroup.ippermission.peer", c.__id, "securityGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsEc2Securitygroup), nil
+			}
+		}
+
+		return c.securityGroup()
+	})
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetVpc() *plugin.TValue[*mqlAwsVpc] {
+	return plugin.GetOrCompute[*mqlAwsVpc](&c.Vpc, func() (*mqlAwsVpc, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.securitygroup.ippermission.peer", c.__id, "vpc")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpc), nil
+			}
+		}
+
+		return c.vpc()
+	})
+}
+
+func (c *mqlAwsEc2SecuritygroupIppermissionPeer) GetPeeringConnection() *plugin.TValue[*mqlAwsVpcPeeringConnection] {
+	return plugin.GetOrCompute[*mqlAwsVpcPeeringConnection](&c.PeeringConnection, func() (*mqlAwsVpcPeeringConnection, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.securitygroup.ippermission.peer", c.__id, "peeringConnection")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpcPeeringConnection), nil
+			}
+		}
+
+		return c.peeringConnection()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3863,6 +3863,16 @@ aws.ec2.securitygroup.ippermission.ipRangeDetails 13.23.2
 aws.ec2.securitygroup.ippermission.ipRanges 11.15.2
 aws.ec2.securitygroup.ippermission.ipv6RangeDetails 13.23.2
 aws.ec2.securitygroup.ippermission.ipv6Ranges 11.15.2
+aws.ec2.securitygroup.ippermission.peer 13.52.2
+aws.ec2.securitygroup.ippermission.peer.accountId 13.52.2
+aws.ec2.securitygroup.ippermission.peer.description 13.52.2
+aws.ec2.securitygroup.ippermission.peer.groupId 13.52.2
+aws.ec2.securitygroup.ippermission.peer.groupName 13.52.2
+aws.ec2.securitygroup.ippermission.peer.peeringConnection 13.52.2
+aws.ec2.securitygroup.ippermission.peer.peeringStatus 13.52.2
+aws.ec2.securitygroup.ippermission.peer.securityGroup 13.52.2
+aws.ec2.securitygroup.ippermission.peer.vpc 13.52.2
+aws.ec2.securitygroup.ippermission.peers 13.52.2
 aws.ec2.securitygroup.ippermission.prefixListIds 11.15.2
 aws.ec2.securitygroup.ippermission.prefixLists 13.23.2
 aws.ec2.securitygroup.ippermission.toPort 11.15.2

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -619,9 +619,14 @@ func (a *mqlAwsEc2Securitygroup) ipPermissions() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		permissionID := a.groupId + "-" + strconv.Itoa(p)
+		peers, err := buildSecurityGroupPeers(a.MqlRuntime, permissionID, a.region, accountId, permission.UserIdGroupPairs)
+		if err != nil {
+			return nil, err
+		}
 		mqlSecurityGroupIpPermission, err := CreateResource(a.MqlRuntime, ResourceAwsEc2SecuritygroupIppermission,
 			map[string]*llx.RawData{
-				"id":               llx.StringData(a.groupId + "-" + strconv.Itoa(p)),
+				"id":               llx.StringData(permissionID),
 				"fromPort":         llx.IntDataDefault(permission.FromPort, -1),
 				"toPort":           llx.IntDataDefault(permission.ToPort, -1),
 				"ipProtocol":       llx.StringDataPtr(permission.IpProtocol),
@@ -631,6 +636,7 @@ func (a *mqlAwsEc2Securitygroup) ipPermissions() ([]any, error) {
 				"ipv6RangeDetails": llx.ArrayData(ipv6RangeDetails, types.Any),
 				"prefixListIds":    llx.ArrayData(prefixListIds, types.Any),
 				"userIdGroupPairs": llx.ArrayData(userIdGroupPairs, types.Any),
+				"peers":            llx.ArrayData(peers, types.Resource("aws.ec2.securitygroup.ippermission.peer")),
 			})
 		if err != nil {
 			return nil, err
@@ -661,9 +667,14 @@ func (a *mqlAwsEc2Securitygroup) ipPermissionsEgress() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		permissionID := a.groupId + "-" + strconv.Itoa(p) + "-egress"
+		peers, err := buildSecurityGroupPeers(a.MqlRuntime, permissionID, a.region, accountId, permission.UserIdGroupPairs)
+		if err != nil {
+			return nil, err
+		}
 		mqlSecurityGroupIpPermission, err := CreateResource(a.MqlRuntime, ResourceAwsEc2SecuritygroupIppermission,
 			map[string]*llx.RawData{
-				"id":               llx.StringData(a.groupId + "-" + strconv.Itoa(p) + "-egress"),
+				"id":               llx.StringData(permissionID),
 				"fromPort":         llx.IntDataDefault(permission.FromPort, -1),
 				"toPort":           llx.IntDataDefault(permission.ToPort, -1),
 				"ipProtocol":       llx.StringDataPtr(permission.IpProtocol),
@@ -673,6 +684,7 @@ func (a *mqlAwsEc2Securitygroup) ipPermissionsEgress() ([]any, error) {
 				"ipv6RangeDetails": llx.ArrayData(ipv6RangeDetails, types.Any),
 				"prefixListIds":    llx.ArrayData(prefixListIds, types.Any),
 				"userIdGroupPairs": llx.ArrayData(userIdGroupPairs, types.Any),
+				"peers":            llx.ArrayData(peers, types.Resource("aws.ec2.securitygroup.ippermission.peer")),
 			})
 		if err != nil {
 			return nil, err

--- a/providers/aws/resources/aws_ec2_sg_peers.go
+++ b/providers/aws/resources/aws_ec2_sg_peers.go
@@ -1,0 +1,131 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"strconv"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+)
+
+type mqlAwsEc2SecuritygroupIppermissionPeerInternal struct {
+	cacheGroupId             string
+	cacheAccountId           string
+	cacheVpcId               string
+	cachePeeringConnectionId string
+	cacheRegion              string
+	cacheScanningAccountId   string
+}
+
+// buildSecurityGroupPeers turns a rule's security group references into typed
+// resources. permissionID scopes the cache key: the same group can be
+// referenced by several rules on one security group, and by both an ingress and
+// an egress rule, so keying on the referenced group alone would collapse them
+// into a single instance.
+func buildSecurityGroupPeers(
+	runtime *plugin.Runtime,
+	permissionID, region, scanningAccountID string,
+	pairs []ec2types.UserIdGroupPair,
+) ([]any, error) {
+	res := make([]any, 0, len(pairs))
+	for i := range pairs {
+		pair := pairs[i]
+		groupID := convert.ToValue(pair.GroupId)
+
+		mqlPeer, err := CreateResource(runtime, "aws.ec2.securitygroup.ippermission.peer",
+			map[string]*llx.RawData{
+				"__id":          llx.StringData(permissionID + "/peer/" + strconv.Itoa(i) + "/" + groupID),
+				"groupId":       llx.StringData(groupID),
+				"groupName":     llx.StringData(convert.ToValue(pair.GroupName)),
+				"accountId":     llx.StringData(convert.ToValue(pair.UserId)),
+				"description":   llx.StringData(convert.ToValue(pair.Description)),
+				"peeringStatus": llx.StringData(convert.ToValue(pair.PeeringStatus)),
+			})
+		if err != nil {
+			return nil, err
+		}
+
+		peer := mqlPeer.(*mqlAwsEc2SecuritygroupIppermissionPeer)
+		peer.cacheGroupId = groupID
+		peer.cacheAccountId = convert.ToValue(pair.UserId)
+		peer.cacheVpcId = convert.ToValue(pair.VpcId)
+		peer.cachePeeringConnectionId = convert.ToValue(pair.VpcPeeringConnectionId)
+		peer.cacheRegion = region
+		peer.cacheScanningAccountId = scanningAccountID
+
+		res = append(res, mqlPeer)
+	}
+	return res, nil
+}
+
+// peerIsResolvable reports whether the referenced group can be described with
+// the credentials scanning this account.
+//
+// A reference that names another account cannot be, and neither can one that
+// crosses a VPC peering connection, since peering may put the group in another
+// region and the rule carries no region of its own to build an ARN from.
+func peerIsResolvable(groupID, accountID, peeringConnectionID, scanningAccountID string) bool {
+	if groupID == "" || peeringConnectionID != "" {
+		return false
+	}
+	// An empty UserId means AWS did not name an owner, which happens for
+	// references within the scanned account.
+	return accountID == "" || accountID == scanningAccountID
+}
+
+// securityGroup resolves the referenced group when it is readable here.
+//
+// Building an ARN for a group in another account would produce a resource that
+// fails to resolve, and because a failed resolution is logged and skipped that
+// would surface as a silently absent group rather than as the cross-account
+// reference it is. Returning null while leaving groupId and accountId
+// populated states the limit instead of hiding it.
+func (a *mqlAwsEc2SecuritygroupIppermissionPeer) securityGroup() (*mqlAwsEc2Securitygroup, error) {
+	if !peerIsResolvable(a.cacheGroupId, a.cacheAccountId, a.cachePeeringConnectionId, a.cacheScanningAccountId) {
+		a.SecurityGroup.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	sgArn := fmt.Sprintf("arn:aws:ec2:%s:%s:security-group/%s", a.cacheRegion, a.cacheScanningAccountId, a.cacheGroupId)
+	res, err := NewResource(a.MqlRuntime, ResourceAwsEc2Securitygroup,
+		map[string]*llx.RawData{"arn": llx.StringData(sgArn)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsEc2Securitygroup), nil
+}
+
+// vpc resolves the VPC of the referenced group. AWS returns it only when the
+// reference crosses a peering connection; within one VPC the field is empty
+// because the VPC is the rule's own.
+func (a *mqlAwsEc2SecuritygroupIppermissionPeer) vpc() (*mqlAwsVpc, error) {
+	if a.cacheVpcId == "" {
+		a.Vpc.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.vpc",
+		map[string]*llx.RawData{"id": llx.StringData(a.cacheVpcId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpc), nil
+}
+
+// peeringConnection resolves the peering connection the reference crosses.
+func (a *mqlAwsEc2SecuritygroupIppermissionPeer) peeringConnection() (*mqlAwsVpcPeeringConnection, error) {
+	if a.cachePeeringConnectionId == "" {
+		a.PeeringConnection.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.vpc.peeringConnection",
+		map[string]*llx.RawData{"id": llx.StringData(a.cachePeeringConnectionId)})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsVpcPeeringConnection), nil
+}

--- a/providers/aws/resources/aws_ec2_sg_peers.go
+++ b/providers/aws/resources/aws_ec2_sg_peers.go
@@ -103,8 +103,15 @@ func (a *mqlAwsEc2SecuritygroupIppermissionPeer) securityGroup() (*mqlAwsEc2Secu
 // vpc resolves the VPC of the referenced group. AWS returns it only when the
 // reference crosses a peering connection; within one VPC the field is empty
 // because the VPC is the rule's own.
+//
+// Resolution is limited to the scanned account. initAwsVpc falls back to
+// scanning the cached VPC list and returns an error when it finds no match, so
+// a VPC on the far side of a cross-account peering would fail the query rather
+// than come back empty. Same-account peering, including across regions, still
+// resolves: the fallback searches every listed region.
 func (a *mqlAwsEc2SecuritygroupIppermissionPeer) vpc() (*mqlAwsVpc, error) {
-	if a.cacheVpcId == "" {
+	crossAccount := a.cacheAccountId != "" && a.cacheAccountId != a.cacheScanningAccountId
+	if a.cacheVpcId == "" || crossAccount {
 		a.Vpc.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -117,15 +124,32 @@ func (a *mqlAwsEc2SecuritygroupIppermissionPeer) vpc() (*mqlAwsVpc, error) {
 }
 
 // peeringConnection resolves the peering connection the reference crosses.
+//
+// The region is a required lookup hint, not a schema field:
+// initAwsVpcPeeringConnection returns without fetching when it is missing,
+// which would leave a blank resource whose fields are unset rather than null.
+// The rule's own region is the right hint because the peering connection is
+// visible from both sides, so it exists in this account's region even when the
+// referenced group belongs to another account.
 func (a *mqlAwsEc2SecuritygroupIppermissionPeer) peeringConnection() (*mqlAwsVpcPeeringConnection, error) {
 	if a.cachePeeringConnectionId == "" {
 		a.PeeringConnection.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(a.MqlRuntime, "aws.vpc.peeringConnection",
-		map[string]*llx.RawData{"id": llx.StringData(a.cachePeeringConnectionId)})
+		peeringConnectionLookupArgs(a.cachePeeringConnectionId, a.cacheRegion))
 	if err != nil {
 		return nil, err
 	}
 	return res.(*mqlAwsVpcPeeringConnection), nil
+}
+
+// peeringConnectionLookupArgs builds the argument set initAwsVpcPeeringConnection
+// needs. Both keys are required: without region the init returns early and the
+// runtime builds a blank resource instead of fetching.
+func peeringConnectionLookupArgs(peeringConnectionID, region string) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"id":     llx.StringData(peeringConnectionID),
+		"region": llx.StringData(region),
+	}
 }

--- a/providers/aws/resources/aws_ec2_sg_peers_test.go
+++ b/providers/aws/resources/aws_ec2_sg_peers_test.go
@@ -65,3 +65,23 @@ func TestPeerIsResolvable(t *testing.T) {
 		})
 	}
 }
+
+// initAwsVpcPeeringConnection treats region as a required lookup hint and
+// returns without fetching when it is absent, leaving a blank resource whose
+// fields are unset rather than null. That failure is invisible from the
+// accessor's side, so pin the argument set the accessor sends.
+//
+// The inits in this provider do not take a uniform argument set
+// (initAwsEc2Instance accepts only arn, initAwsVpc accepts arn or id), which is
+// what makes an omitted argument easy to ship.
+func TestPeeringConnectionLookupArgsIncludeRegion(t *testing.T) {
+	peer := &mqlAwsEc2SecuritygroupIppermissionPeer{}
+	peer.cachePeeringConnectionId = "pcx-abc"
+	peer.cacheRegion = "us-east-1"
+
+	args := peeringConnectionLookupArgs(peer.cachePeeringConnectionId, peer.cacheRegion)
+
+	assert.Equal(t, "pcx-abc", args["id"].Value)
+	assert.Equal(t, "us-east-1", args["region"].Value,
+		"region must be sent or the init falls through and builds a blank resource")
+}

--- a/providers/aws/resources/aws_ec2_sg_peers_test.go
+++ b/providers/aws/resources/aws_ec2_sg_peers_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeerIsResolvable(t *testing.T) {
+	const scanning = "111111111111"
+
+	tests := []struct {
+		name                string
+		groupID             string
+		accountID           string
+		peeringConnectionID string
+		want                bool
+	}{
+		{
+			name:    "same account, no peering",
+			groupID: "sg-123", accountID: scanning,
+			want: true,
+		},
+		{
+			// AWS omits UserId for references inside the scanned account.
+			name:    "no owner named means same account",
+			groupID: "sg-123", accountID: "",
+			want: true,
+		},
+		{
+			// The group lives in another account and cannot be described with
+			// these credentials. Resolving it anyway would yield a resource that
+			// fails to load, which reads as an absent group rather than a
+			// cross-account reference.
+			name:    "other account is not resolvable",
+			groupID: "sg-123", accountID: "999999999999",
+			want: false,
+		},
+		{
+			// Peering may place the group in another region, and the rule
+			// carries no region of its own to build an ARN from.
+			name:    "peering connection is not resolvable",
+			groupID: "sg-123", accountID: scanning, peeringConnectionID: "pcx-abc",
+			want: false,
+		},
+		{
+			name:    "cross account across peering is not resolvable",
+			groupID: "sg-123", accountID: "999999999999", peeringConnectionID: "pcx-abc",
+			want: false,
+		},
+		{
+			name:    "missing group id is not resolvable",
+			groupID: "", accountID: scanning,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := peerIsResolvable(tt.groupID, tt.accountID, tt.peeringConnectionID, scanning)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fourth and last of the network typing series (oci #9624, gcp #9636, azure #9638). Off `main`, independent of the others.

## Why

A security group rule can name **another security group** instead of an address range, permitting every instance in that group. Inside a VPC that reference — not any CIDR — is what actually carries reachability between workloads. It was a `[]dict`, so following the edge meant pulling `GroupId` out of a dict and looking the group up by hand.

AWS's own network graph is otherwise the strongest of the four providers; this was the notable remaining untyped edge in it.

## What

`peers`, typed off `UserIdGroupPair`, with the referenced group resolved:

```
aws.ec2.securitygroups.where(
  ipPermissions.any(peers.any(groupId == "sg-0123456789abcdef0")))

aws.ec2.securitygroups.ipPermissions.peers.where(peeringStatus == "active") {
  groupId accountId peeringConnection.id
}
```

Each peer carries `groupId`, `groupName`, `accountId`, `description`, `peeringStatus`, plus typed `securityGroup()`, `vpc()`, and `peeringConnection()`.

## Where it deliberately returns null

`securityGroup()` resolves **only** when the referenced group is readable with the credentials scanning this account:

- **Another account** — not describable here.
- **Across a VPC peering connection** — peering may place the group in another region, and the rule carries no region of its own to build an ARN from.

Both return null with `groupId` and `accountId` left populated, and the field doc says so. Building an ARN anyway would produce a resource that fails to load — and since a failed resolution is logged and skipped, that would surface as a **silently absent group** rather than as the cross-account reference it actually is. This is the failure mode CLAUDE.md warns about for typed accessors, so the limit is stated rather than hidden.

`peerIsResolvable` is table-tested across all six combinations, including the empty-`UserId` case (AWS omits the owner for references inside the scanned account, which must read as resolvable, not as cross-account).

## Cache key

The key is the permission id plus the position, not the referenced group. One group can be named by several rules on the same security group, and by both an ingress and an egress rule — keying on the group alone would collapse them into a single instance, and the extra rules would silently vanish.

## Compatibility

Additive. `userIdGroupPairs` is kept and marked `@maturity("deprecated")`; the `effectiveIngress` computation that reads those dicts is untouched. No new API calls — the build reports `aws: 1021 permissions (unchanged)`. Schema entries at `13.52.2`.

## Testing

`go test ./resources/...` passes. **Not live-verified** — batched per the usual practice. Highest-risk to exercise: a rule referencing a peered group, to confirm `securityGroup()` returns null while `peeringConnection()` resolves.

## Not included

`prefixLists()` already exists, so `prefixListIds` needed no work. Still `[]dict` and worth a follow-up: the `attachments` on `internetgateway` / `egressOnlyInternetGateway` / `vpnGateway` (which hide the gateway→VPC edge), and `transitgateway.peeringAttachment.{accepter,requester}TgwInfo`.
