### PR TITLE
🌟 alicloud: type the RAM identity graph

### DIFF
--- a/providers/alicloud/resources/alicloud.lr
+++ b/providers/alicloud/resources/alicloud.lr
@@ -75,12 +75,20 @@ alicloud.ram.user {
   accessKeys() []alicloud.ram.accessKey
   // Groups the user belongs to
   groups() []alicloud.ram.group
-  // Policies attached directly to the user
+  // Policy attachment records for policies attached directly to the user
   //
   // Each entry lists the policyName, policyType (System or Custom),
   // defaultVersion, description, and attachDate of a policy attached to the
-  // user.
+  // user. Use attachedPolicies to reach the policy itself, including its
+  // permission statements.
   policies() []dict
+  // Policies attached directly to the user
+  //
+  // The permission policies granted to the user by direct attachment, not
+  // counting policies the user inherits through group membership. Traverse to
+  // policyDocument to inspect the permission statements a user holds, for
+  // example to find users granted the AdministratorAccess system policy.
+  attachedPolicies() []alicloud.ram.policy
   // Multi-factor authentication device bound to the user
   //
   // The serialNumber and type of the bound MFA device, or null when the user
@@ -130,12 +138,19 @@ alicloud.ram.group {
   updateDate time
   // Users that belong to the group
   users() []alicloud.ram.user
-  // Policies attached to the group
+  // Policy attachment records for policies attached to the group
   //
   // Each entry lists the policyName, policyType (System or Custom),
   // defaultVersion, description, and attachDate of a policy attached to the
-  // group.
+  // group. Use attachedPolicies to reach the policy itself, including its
+  // permission statements.
   policies() []dict
+  // Policies attached to the group
+  //
+  // The permission policies every member of the group inherits. Traverse to
+  // policyDocument to inspect the permission statements granted through group
+  // membership.
+  attachedPolicies() []alicloud.ram.policy
 }
 
 // Resource Access Management role
@@ -166,20 +181,29 @@ alicloud.ram.role {
   // The assume-role policy as a JSON string, naming the principals permitted to
   // assume this role and the conditions on that trust.
   assumeRolePolicyDocument() string
-  // Policies attached to the role
+  // Policy attachment records for policies attached to the role
   //
   // Each entry lists the policyName, policyType (System or Custom),
   // defaultVersion, description, and attachDate of a policy attached to the
-  // role.
+  // role. Use attachedPolicies to reach the policy itself, including its
+  // permission statements.
   policies() []dict
+  // Policies attached to the role
+  //
+  // The permission policies a session that assumes this role receives.
+  // Traverse to policyDocument alongside assumeRolePolicyDocument to see both
+  // who may assume the role and what the assumed session is allowed to do.
+  attachedPolicies() []alicloud.ram.policy
 }
 
 // Resource Access Management permission policy
 //
-// A permission policy, keyed by policyName. Exposes the policy metadata,
-// attachment count, and default version, along with the policy document of the
-// default version. System policies are managed by Alibaba Cloud; custom
-// policies are defined in the account.
+// A permission policy. Exposes the policy metadata, attachment count, and
+// default version, along with the policy document of the default version.
+// System policies are managed by Alibaba Cloud; custom policies are defined in
+// the account. The policyName and policyType fields together select a single
+// policy, for example
+// `alicloud.ram.policy(policyName: "AdministratorAccess", policyType: "System")`.
 alicloud.ram.policy {
   // Policy name, used as the lookup key
   policyName string

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -126,7 +126,7 @@ func init() {
 			Create: createAlicloudRamRole,
 		},
 		"alicloud.ram.policy": {
-			// to override args, implement: initAlicloudRamPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAlicloudRamPolicy,
 			Create: createAlicloudRamPolicy,
 		},
 		"alicloud.ram.passwordPolicy": {
@@ -548,6 +548,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.ram.user.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamUser).GetPolicies()).ToDataRes(types.Array(types.Dict))
 	},
+	"alicloud.ram.user.attachedPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRamUser).GetAttachedPolicies()).ToDataRes(types.Array(types.Resource("alicloud.ram.policy")))
+	},
 	"alicloud.ram.user.mfaDevice": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamUser).GetMfaDevice()).ToDataRes(types.Dict)
 	},
@@ -587,6 +590,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.ram.group.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamGroup).GetPolicies()).ToDataRes(types.Array(types.Dict))
 	},
+	"alicloud.ram.group.attachedPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRamGroup).GetAttachedPolicies()).ToDataRes(types.Array(types.Resource("alicloud.ram.policy")))
+	},
 	"alicloud.ram.role.roleId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamRole).GetRoleId()).ToDataRes(types.String)
 	},
@@ -616,6 +622,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.ram.role.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamRole).GetPolicies()).ToDataRes(types.Array(types.Dict))
+	},
+	"alicloud.ram.role.attachedPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRamRole).GetAttachedPolicies()).ToDataRes(types.Array(types.Resource("alicloud.ram.policy")))
 	},
 	"alicloud.ram.policy.policyName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamPolicy).GetPolicyName()).ToDataRes(types.String)
@@ -3964,6 +3973,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudRamUser).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"alicloud.ram.user.attachedPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRamUser).AttachedPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"alicloud.ram.user.mfaDevice": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudRamUser).MfaDevice, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -4024,6 +4037,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudRamGroup).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"alicloud.ram.group.attachedPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRamGroup).AttachedPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"alicloud.ram.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudRamRole).__id, ok = v.Value.(string)
 		return
@@ -4066,6 +4083,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.ram.role.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudRamRole).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"alicloud.ram.role.attachedPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRamRole).AttachedPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"alicloud.ram.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8907,20 +8928,21 @@ type mqlAlicloudRamUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAlicloudRamUserInternal it will be used here
-	UserId        plugin.TValue[string]
-	UserName      plugin.TValue[string]
-	DisplayName   plugin.TValue[string]
-	Email         plugin.TValue[string]
-	MobilePhone   plugin.TValue[string]
-	Comments      plugin.TValue[string]
-	CreateDate    plugin.TValue[*time.Time]
-	UpdateDate    plugin.TValue[*time.Time]
-	LastLoginDate plugin.TValue[*time.Time]
-	AccessKeys    plugin.TValue[[]any]
-	Groups        plugin.TValue[[]any]
-	Policies      plugin.TValue[[]any]
-	MfaDevice     plugin.TValue[any]
-	LoginProfile  plugin.TValue[any]
+	UserId           plugin.TValue[string]
+	UserName         plugin.TValue[string]
+	DisplayName      plugin.TValue[string]
+	Email            plugin.TValue[string]
+	MobilePhone      plugin.TValue[string]
+	Comments         plugin.TValue[string]
+	CreateDate       plugin.TValue[*time.Time]
+	UpdateDate       plugin.TValue[*time.Time]
+	LastLoginDate    plugin.TValue[*time.Time]
+	AccessKeys       plugin.TValue[[]any]
+	Groups           plugin.TValue[[]any]
+	Policies         plugin.TValue[[]any]
+	AttachedPolicies plugin.TValue[[]any]
+	MfaDevice        plugin.TValue[any]
+	LoginProfile     plugin.TValue[any]
 }
 
 // createAlicloudRamUser creates a new instance of this resource
@@ -9036,6 +9058,22 @@ func (c *mqlAlicloudRamUser) GetPolicies() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAlicloudRamUser) GetAttachedPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AttachedPolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ram.user", c.__id, "attachedPolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.attachedPolicies()
+	})
+}
+
 func (c *mqlAlicloudRamUser) GetMfaDevice() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.MfaDevice, func() (any, error) {
 		return c.mfaDevice()
@@ -9117,13 +9155,14 @@ type mqlAlicloudRamGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAlicloudRamGroupInternal it will be used here
-	GroupId    plugin.TValue[string]
-	GroupName  plugin.TValue[string]
-	Comments   plugin.TValue[string]
-	CreateDate plugin.TValue[*time.Time]
-	UpdateDate plugin.TValue[*time.Time]
-	Users      plugin.TValue[[]any]
-	Policies   plugin.TValue[[]any]
+	GroupId          plugin.TValue[string]
+	GroupName        plugin.TValue[string]
+	Comments         plugin.TValue[string]
+	CreateDate       plugin.TValue[*time.Time]
+	UpdateDate       plugin.TValue[*time.Time]
+	Users            plugin.TValue[[]any]
+	Policies         plugin.TValue[[]any]
+	AttachedPolicies plugin.TValue[[]any]
 }
 
 // createAlicloudRamGroup creates a new instance of this resource
@@ -9205,6 +9244,22 @@ func (c *mqlAlicloudRamGroup) GetPolicies() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAlicloudRamGroup) GetAttachedPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AttachedPolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ram.group", c.__id, "attachedPolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.attachedPolicies()
+	})
+}
+
 // mqlAlicloudRamRole for the alicloud.ram.role resource
 type mqlAlicloudRamRole struct {
 	MqlRuntime *plugin.Runtime
@@ -9220,6 +9275,7 @@ type mqlAlicloudRamRole struct {
 	Tags                     plugin.TValue[map[string]any]
 	AssumeRolePolicyDocument plugin.TValue[string]
 	Policies                 plugin.TValue[[]any]
+	AttachedPolicies         plugin.TValue[[]any]
 }
 
 // createAlicloudRamRole creates a new instance of this resource
@@ -9300,6 +9356,22 @@ func (c *mqlAlicloudRamRole) GetAssumeRolePolicyDocument() *plugin.TValue[string
 func (c *mqlAlicloudRamRole) GetPolicies() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
 		return c.policies()
+	})
+}
+
+func (c *mqlAlicloudRamRole) GetAttachedPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AttachedPolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ram.role", c.__id, "attachedPolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.attachedPolicies()
 	})
 }
 

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -8927,7 +8927,7 @@ func (c *mqlAlicloudRam) GetSecurityPreference() *plugin.TValue[any] {
 type mqlAlicloudRamUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAlicloudRamUserInternal it will be used here
+	mqlAlicloudRamUserInternal
 	UserId           plugin.TValue[string]
 	UserName         plugin.TValue[string]
 	DisplayName      plugin.TValue[string]
@@ -9154,7 +9154,7 @@ func (c *mqlAlicloudRamAccessKey) GetCreateDate() *plugin.TValue[*time.Time] {
 type mqlAlicloudRamGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAlicloudRamGroupInternal it will be used here
+	mqlAlicloudRamGroupInternal
 	GroupId          plugin.TValue[string]
 	GroupName        plugin.TValue[string]
 	Comments         plugin.TValue[string]
@@ -9264,7 +9264,7 @@ func (c *mqlAlicloudRamGroup) GetAttachedPolicies() *plugin.TValue[[]any] {
 type mqlAlicloudRamRole struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAlicloudRamRoleInternal it will be used here
+	mqlAlicloudRamRoleInternal
 	RoleId                   plugin.TValue[string]
 	RoleName                 plugin.TValue[string]
 	Arn                      plugin.TValue[string]

--- a/providers/alicloud/resources/alicloud.lr.versions
+++ b/providers/alicloud/resources/alicloud.lr.versions
@@ -776,6 +776,7 @@ alicloud.ram.accessKey.createDate 13.0.0
 alicloud.ram.accessKey.status 13.0.0
 alicloud.ram.accessKey.userName 13.0.0
 alicloud.ram.group 13.0.0
+alicloud.ram.group.attachedPolicies 13.2.5
 alicloud.ram.group.comments 13.0.0
 alicloud.ram.group.createDate 13.0.0
 alicloud.ram.group.groupId 13.0.0
@@ -808,6 +809,7 @@ alicloud.ram.policy.updateDate 13.0.0
 alicloud.ram.role 13.0.0
 alicloud.ram.role.arn 13.0.0
 alicloud.ram.role.assumeRolePolicyDocument 13.0.0
+alicloud.ram.role.attachedPolicies 13.2.5
 alicloud.ram.role.createDate 13.0.0
 alicloud.ram.role.description 13.0.0
 alicloud.ram.role.maxSessionDuration 13.0.0
@@ -820,6 +822,7 @@ alicloud.ram.roles 13.0.0
 alicloud.ram.securityPreference 13.0.0
 alicloud.ram.user 13.0.0
 alicloud.ram.user.accessKeys 13.0.0
+alicloud.ram.user.attachedPolicies 13.2.5
 alicloud.ram.user.comments 13.0.0
 alicloud.ram.user.createDate 13.0.0
 alicloud.ram.user.displayName 13.0.0

--- a/providers/alicloud/resources/ram.go
+++ b/providers/alicloud/resources/ram.go
@@ -542,6 +542,39 @@ func (r *mqlAlicloudRamUser) policies() ([]any, error) {
 	return res, nil
 }
 
+func (r *mqlAlicloudRamUser) attachedPolicies() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RamClient()
+	if err != nil {
+		return nil, err
+	}
+
+	userName := r.UserName.Data
+	resp, err := client.ListPoliciesForUser(&ramclient.ListPoliciesForUserRequest{UserName: &userName})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
+		return res, nil
+	}
+	for _, p := range resp.Body.Policies.Policy {
+		if p == nil {
+			continue
+		}
+		policy, err := resolveRamPolicy(r.MqlRuntime, p.PolicyName, p.PolicyType)
+		if err != nil {
+			return nil, err
+		}
+		if policy == nil {
+			continue
+		}
+		res = append(res, policy)
+	}
+	return res, nil
+}
+
 func (r *mqlAlicloudRamUser) mfaDevice() (any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
 	client, err := conn.RamClient()
@@ -723,6 +756,39 @@ func (r *mqlAlicloudRamGroup) policies() ([]any, error) {
 	return res, nil
 }
 
+func (r *mqlAlicloudRamGroup) attachedPolicies() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RamClient()
+	if err != nil {
+		return nil, err
+	}
+
+	groupName := r.GroupName.Data
+	resp, err := client.ListPoliciesForGroup(&ramclient.ListPoliciesForGroupRequest{GroupName: &groupName})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
+		return res, nil
+	}
+	for _, p := range resp.Body.Policies.Policy {
+		if p == nil {
+			continue
+		}
+		policy, err := resolveRamPolicy(r.MqlRuntime, p.PolicyName, p.PolicyType)
+		if err != nil {
+			return nil, err
+		}
+		if policy == nil {
+			continue
+		}
+		res = append(res, policy)
+	}
+	return res, nil
+}
+
 func (r *mqlAlicloudRamRole) id() (string, error) {
 	return r.RoleName.Data, nil
 }
@@ -748,11 +814,18 @@ func resolveRamRole(runtime *plugin.Runtime, roleName string) (*mqlAlicloudRamRo
 // which is required because GetRole (unlike ListRoles) does not return them.
 // Returns an empty map on any error so a resolved role is never a husk.
 func ramRoleTags(client *ramclient.Client, roleName string) map[string]any {
+	return ramTags(client, "role", roleName)
+}
+
+// ramTags reads the tags of a single RAM resource. GetRole and GetPolicy omit
+// tags that their List counterparts return, so the ref-resolved form of those
+// resources fills the gap from here.
+func ramTags(client *ramclient.Client, resourceType, resourceName string) map[string]any {
 	tags := map[string]any{}
-	resourceType := "role"
-	name := roleName
+	rt := resourceType
+	name := resourceName
 	resp, err := client.ListTagResources(&ramclient.ListTagResourcesRequest{
-		ResourceType:  &resourceType,
+		ResourceType:  &rt,
 		ResourceNames: []*string{&name},
 	})
 	if err != nil || resp == nil || resp.Body == nil {
@@ -862,8 +935,116 @@ func (r *mqlAlicloudRamRole) policies() ([]any, error) {
 	return res, nil
 }
 
+func (r *mqlAlicloudRamRole) attachedPolicies() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RamClient()
+	if err != nil {
+		return nil, err
+	}
+
+	roleName := r.RoleName.Data
+	resp, err := client.ListPoliciesForRole(&ramclient.ListPoliciesForRoleRequest{RoleName: &roleName})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
+		return res, nil
+	}
+	for _, p := range resp.Body.Policies.Policy {
+		if p == nil {
+			continue
+		}
+		policy, err := resolveRamPolicy(r.MqlRuntime, p.PolicyName, p.PolicyType)
+		if err != nil {
+			return nil, err
+		}
+		if policy == nil {
+			continue
+		}
+		res = append(res, policy)
+	}
+	return res, nil
+}
+
 func (r *mqlAlicloudRamPolicy) id() (string, error) {
 	return r.PolicyType.Data + "/" + r.PolicyName.Data, nil
+}
+
+// initAlicloudRamPolicy resolves a single policy from its name and type.
+//
+// NewResource runs this before it consults the resource cache, so the cache
+// probe here is what keeps a policy that is attached to many users from costing
+// one GetPolicy call per attachment.
+func initAlicloudRamPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	policyName, err := requiredStringArg(args, "policyName", "alicloud.ram.policy")
+	if err != nil {
+		return nil, nil, err
+	}
+	policyType, err := requiredStringArg(args, "policyType", "alicloud.ram.policy")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if x, ok := runtime.Resources.Get("alicloud.ram.policy\x00" + policyType + "/" + policyName); ok {
+		return nil, x, nil
+	}
+
+	conn := runtime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RamClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.GetPolicy(&ramclient.GetPolicyRequest{
+		PolicyName: &policyName,
+		PolicyType: &policyType,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp == nil || resp.Body == nil || resp.Body.Policy == nil {
+		return nil, nil, fmt.Errorf("alicloud.ram.policy %q of type %q not found", policyName, policyType)
+	}
+
+	p := resp.Body.Policy
+	res, err := CreateResource(runtime, "alicloud.ram.policy", map[string]*llx.RawData{
+		"__id":            llx.StringData(policyType + "/" + policyName),
+		"policyName":      llx.StringDataPtr(p.PolicyName),
+		"policyType":      llx.StringDataPtr(p.PolicyType),
+		"description":     llx.StringDataPtr(p.Description),
+		"defaultVersion":  llx.StringDataPtr(p.DefaultVersion),
+		"attachmentCount": llx.IntDataPtr(p.AttachmentCount),
+		"createDate":      llx.TimeDataPtr(ramParseTime(p.CreateDate)),
+		"updateDate":      llx.TimeDataPtr(ramParseTime(p.UpdateDate)),
+		"tags":            llx.MapData(ramTags(client, "policy", policyName), types.String),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+// resolveRamPolicy turns a policy name and type into a typed policy resource,
+// returning nil when either is blank.
+func resolveRamPolicy(runtime *plugin.Runtime, policyName, policyType *string) (*mqlAlicloudRamPolicy, error) {
+	name := ramStrVal(policyName)
+	policyKind := ramStrVal(policyType)
+	if name == "" || policyKind == "" {
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "alicloud.ram.policy", map[string]*llx.RawData{
+		"policyName": llx.StringData(name),
+		"policyType": llx.StringData(policyKind),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAlicloudRamPolicy), nil
 }
 
 func (r *mqlAlicloudRamPolicy) policyDocument() (string, error) {

--- a/providers/alicloud/resources/ram.go
+++ b/providers/alicloud/resources/ram.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	ramclient "github.com/alibabacloud-go/ram-20150501/v2/client"
@@ -516,24 +517,48 @@ func (r *mqlAlicloudRamUser) groups() ([]any, error) {
 	return res, nil
 }
 
-func (r *mqlAlicloudRamUser) policies() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
-	client, err := conn.RamClient()
-	if err != nil {
-		return nil, err
-	}
+// mqlAlicloudRamUserInternal memoizes the user's policy attachment list, which
+// both the policies and attachedPolicies fields read.
+type mqlAlicloudRamUserInternal struct {
+	attachmentsOnce sync.Once
+	attachments     []*ramclient.ListPoliciesForUserResponseBodyPoliciesPolicy
+	attachmentsErr  error
+}
 
-	userName := r.UserName.Data
-	resp, err := client.ListPoliciesForUser(&ramclient.ListPoliciesForUserRequest{UserName: &userName})
+// policyAttachments lists the policies attached to the user, once. Both
+// policies and attachedPolicies read the same response, so querying them
+// together costs one ListPoliciesForUser call rather than two.
+func (r *mqlAlicloudRamUser) policyAttachments() ([]*ramclient.ListPoliciesForUserResponseBodyPoliciesPolicy, error) {
+	r.attachmentsOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+		client, err := conn.RamClient()
+		if err != nil {
+			r.attachmentsErr = err
+			return
+		}
+
+		userName := r.UserName.Data
+		resp, err := client.ListPoliciesForUser(&ramclient.ListPoliciesForUserRequest{UserName: &userName})
+		if err != nil {
+			r.attachmentsErr = err
+			return
+		}
+		if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
+			return
+		}
+		r.attachments = resp.Body.Policies.Policy
+	})
+	return r.attachments, r.attachmentsErr
+}
+
+func (r *mqlAlicloudRamUser) policies() ([]any, error) {
+	attachments, err := r.policyAttachments()
 	if err != nil {
 		return nil, err
 	}
 
 	res := []any{}
-	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
-		return res, nil
-	}
-	for _, p := range resp.Body.Policies.Policy {
+	for _, p := range attachments {
 		if p == nil {
 			continue
 		}
@@ -543,23 +568,13 @@ func (r *mqlAlicloudRamUser) policies() ([]any, error) {
 }
 
 func (r *mqlAlicloudRamUser) attachedPolicies() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
-	client, err := conn.RamClient()
-	if err != nil {
-		return nil, err
-	}
-
-	userName := r.UserName.Data
-	resp, err := client.ListPoliciesForUser(&ramclient.ListPoliciesForUserRequest{UserName: &userName})
+	attachments, err := r.policyAttachments()
 	if err != nil {
 		return nil, err
 	}
 
 	res := []any{}
-	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
-		return res, nil
-	}
-	for _, p := range resp.Body.Policies.Policy {
+	for _, p := range attachments {
 		if p == nil {
 			continue
 		}
@@ -730,24 +745,46 @@ func (r *mqlAlicloudRamGroup) users() ([]any, error) {
 	return res, nil
 }
 
-func (r *mqlAlicloudRamGroup) policies() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
-	client, err := conn.RamClient()
-	if err != nil {
-		return nil, err
-	}
+// mqlAlicloudRamGroupInternal memoizes the group's policy attachment list,
+// which both the policies and attachedPolicies fields read.
+type mqlAlicloudRamGroupInternal struct {
+	attachmentsOnce sync.Once
+	attachments     []*ramclient.ListPoliciesForGroupResponseBodyPoliciesPolicy
+	attachmentsErr  error
+}
 
-	groupName := r.GroupName.Data
-	resp, err := client.ListPoliciesForGroup(&ramclient.ListPoliciesForGroupRequest{GroupName: &groupName})
+// policyAttachments lists the policies attached to the group, once.
+func (r *mqlAlicloudRamGroup) policyAttachments() ([]*ramclient.ListPoliciesForGroupResponseBodyPoliciesPolicy, error) {
+	r.attachmentsOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+		client, err := conn.RamClient()
+		if err != nil {
+			r.attachmentsErr = err
+			return
+		}
+
+		groupName := r.GroupName.Data
+		resp, err := client.ListPoliciesForGroup(&ramclient.ListPoliciesForGroupRequest{GroupName: &groupName})
+		if err != nil {
+			r.attachmentsErr = err
+			return
+		}
+		if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
+			return
+		}
+		r.attachments = resp.Body.Policies.Policy
+	})
+	return r.attachments, r.attachmentsErr
+}
+
+func (r *mqlAlicloudRamGroup) policies() ([]any, error) {
+	attachments, err := r.policyAttachments()
 	if err != nil {
 		return nil, err
 	}
 
 	res := []any{}
-	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
-		return res, nil
-	}
-	for _, p := range resp.Body.Policies.Policy {
+	for _, p := range attachments {
 		if p == nil {
 			continue
 		}
@@ -757,23 +794,13 @@ func (r *mqlAlicloudRamGroup) policies() ([]any, error) {
 }
 
 func (r *mqlAlicloudRamGroup) attachedPolicies() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
-	client, err := conn.RamClient()
-	if err != nil {
-		return nil, err
-	}
-
-	groupName := r.GroupName.Data
-	resp, err := client.ListPoliciesForGroup(&ramclient.ListPoliciesForGroupRequest{GroupName: &groupName})
+	attachments, err := r.policyAttachments()
 	if err != nil {
 		return nil, err
 	}
 
 	res := []any{}
-	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
-		return res, nil
-	}
-	for _, p := range resp.Body.Policies.Policy {
+	for _, p := range attachments {
 		if p == nil {
 			continue
 		}
@@ -909,24 +936,46 @@ func (r *mqlAlicloudRamRole) assumeRolePolicyDocument() (string, error) {
 	return ramStrVal(resp.Body.Role.AssumeRolePolicyDocument), nil
 }
 
-func (r *mqlAlicloudRamRole) policies() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
-	client, err := conn.RamClient()
-	if err != nil {
-		return nil, err
-	}
+// mqlAlicloudRamRoleInternal memoizes the role's policy attachment list, which
+// both the policies and attachedPolicies fields read.
+type mqlAlicloudRamRoleInternal struct {
+	attachmentsOnce sync.Once
+	attachments     []*ramclient.ListPoliciesForRoleResponseBodyPoliciesPolicy
+	attachmentsErr  error
+}
 
-	roleName := r.RoleName.Data
-	resp, err := client.ListPoliciesForRole(&ramclient.ListPoliciesForRoleRequest{RoleName: &roleName})
+// policyAttachments lists the policies attached to the role, once.
+func (r *mqlAlicloudRamRole) policyAttachments() ([]*ramclient.ListPoliciesForRoleResponseBodyPoliciesPolicy, error) {
+	r.attachmentsOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+		client, err := conn.RamClient()
+		if err != nil {
+			r.attachmentsErr = err
+			return
+		}
+
+		roleName := r.RoleName.Data
+		resp, err := client.ListPoliciesForRole(&ramclient.ListPoliciesForRoleRequest{RoleName: &roleName})
+		if err != nil {
+			r.attachmentsErr = err
+			return
+		}
+		if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
+			return
+		}
+		r.attachments = resp.Body.Policies.Policy
+	})
+	return r.attachments, r.attachmentsErr
+}
+
+func (r *mqlAlicloudRamRole) policies() ([]any, error) {
+	attachments, err := r.policyAttachments()
 	if err != nil {
 		return nil, err
 	}
 
 	res := []any{}
-	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
-		return res, nil
-	}
-	for _, p := range resp.Body.Policies.Policy {
+	for _, p := range attachments {
 		if p == nil {
 			continue
 		}
@@ -936,23 +985,13 @@ func (r *mqlAlicloudRamRole) policies() ([]any, error) {
 }
 
 func (r *mqlAlicloudRamRole) attachedPolicies() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
-	client, err := conn.RamClient()
-	if err != nil {
-		return nil, err
-	}
-
-	roleName := r.RoleName.Data
-	resp, err := client.ListPoliciesForRole(&ramclient.ListPoliciesForRoleRequest{RoleName: &roleName})
+	attachments, err := r.policyAttachments()
 	if err != nil {
 		return nil, err
 	}
 
 	res := []any{}
-	if resp == nil || resp.Body == nil || resp.Body.Policies == nil {
-		return res, nil
-	}
-	for _, p := range resp.Body.Policies.Policy {
+	for _, p := range attachments {
 		if p == nil {
 			continue
 		}


### PR DESCRIPTION
Adds `attachedPolicies()` to `alicloud.ram.user`, `.group`, and `.role`, returning typed `alicloud.ram.policy` resources rather than only the untyped attachment dicts. This makes the permission side of the RAM identity graph traversable.

### Why

`alicloud.ram.policy` has existed since the provider landed, but nothing pointed at it. The three `policies()` fields return dicts that *name* a policy without being able to reach it, so no query could get from an identity to the permission statements it actually holds. That is the core question a permissions audit asks.

### What is now queryable

```coffee
# users holding the AdministratorAccess system policy directly
alicloud.ram.users.where(attachedPolicies.any(policyName == "AdministratorAccess"))

# the full picture for a role: who may assume it, and what it can then do
alicloud.ram.roles {
  roleName
  assumeRolePolicyDocument
  attachedPolicies { policyName policyType policyDocument }
}

# permissions inherited through group membership
alicloud.ram.groups { groupName attachedPolicies { policyName } }

# a single policy by name and type
alicloud.ram.policy(policyName: "AdministratorAccess", policyType: "System").policyDocument
```

### Changes

- `attachedPolicies() []alicloud.ram.policy` on `ram.user`, `ram.group`, `ram.role`
- `initAlicloudRamPolicy` resolving a policy from `policyName` + `policyType` (the pair that identifies a policy — `AdministratorAccess` can exist as both a System and a Custom policy)
- `ramRoleTags` generalized to `ramTags(client, resourceType, name)`; `GetPolicy` omits tags that `ListPolicies` returns, the same gap `GetRole` has

### Note on N+1

`NewResource` runs a resource's `Init` **before** it consults the resource cache — it has to, since the `__id` isn't known until the init resolves it. A policy attached to 40 users would therefore cost 40 identical `GetPolicy` calls. The init probes `runtime.Resources` itself first, which collapses that to one call per distinct policy. This mirrors the existing `initAlicloudRamRole`.

### Note on the existing `policies()` dicts

They are **not** deprecated here. They carry the per-attachment `attachDate`, which is a property of the attachment edge and has nowhere to live on the policy resource itself, so deprecating them would lose data. Their doc comments now direct readers to `attachedPolicies` for the policy body. If the attach date turns out to matter, the follow-up is an attachment sub-resource (`policy()` ref + `attachDate`), not a widening of this field.

### Verification

Codegen clean, `go build ./...` and `go test ./resources/...` pass. Live verification against a real Alibaba Cloud account is pending the batched `provider-verification` run covering this stack.
