### PR TITLE
🌟 alicloud: wire discovery filters, add OSS/RDS targets, add README

### DIFF
--- a/providers/alicloud/README.md
+++ b/providers/alicloud/README.md
@@ -1,0 +1,160 @@
+# Alibaba Cloud Provider
+
+Query an Alibaba Cloud account: compute, networking, storage, managed databases, identity, and the security services.
+
+```bash
+cnspec shell alicloud
+cnspec scan alicloud --regions cn-hangzhou,ap-southeast-1
+```
+
+## Authentication
+
+Credentials are resolved in this order, stopping at the first that works:
+
+1. **CLI flags** — `--access-key-id`, `--access-key-secret`, `--sts-token`
+2. **Environment variables** — `ALIBABA_CLOUD_ACCESS_KEY_ID`, `ALIBABA_CLOUD_ACCESS_KEY_SECRET`, `ALIBABA_CLOUD_SECURITY_TOKEN` (the legacy `ALICLOUD_ACCESS_KEY` / `ALICLOUD_SECRET_KEY` names are also accepted)
+3. **Shared credentials file** — `~/.alibabacloud/credentials`
+4. **ECS instance RAM role** — when running on an ECS instance with a role attached
+
+### Access key
+
+```bash
+cnspec shell alicloud --access-key-id <id> --access-key-secret <secret>
+```
+
+```bash
+export ALIBABA_CLOUD_ACCESS_KEY_ID=<id>
+export ALIBABA_CLOUD_ACCESS_KEY_SECRET=<secret>
+cnspec shell alicloud
+```
+
+### Assuming a RAM role
+
+Scanning a member account from a management account, or using a dedicated audit role:
+
+```bash
+cnspec scan alicloud \
+  --role-arn acs:ram::<uid>:role/<role-name> \
+  --access-key-id <id> --access-key-secret <secret>
+```
+
+`--role-session-name` sets the session name (default `mondoo`).
+
+### Temporary credentials
+
+```bash
+export ALIBABA_CLOUD_SECURITY_TOKEN=<token>
+cnspec shell alicloud --access-key-id <id> --access-key-secret <secret>
+```
+
+## Permissions
+
+The credential needs read-only access. The `ReadOnlyAccess` system policy covers everything the provider queries. To scope it more tightly, grant the `Describe*`, `List*`, and `Get*` actions for the services you intend to query.
+
+Some services answer only in the region or partition that owns them. WAF, Cloud Firewall, and Anti-DDoS are center services reached through `cn-hangzhou` (China) or `ap-southeast-1` (international); CloudSSO through `cn-shanghai` or `us-east-1`. The provider probes both and reports an error only when neither answers, so a partition that legitimately has no such service reads as empty rather than failing the scan.
+
+## Regions
+
+By default every region enabled on the account is scanned. Narrow it with either flag:
+
+```bash
+cnspec scan alicloud --regions cn-hangzhou,ap-southeast-1
+cnspec scan alicloud --filters regions=cn-hangzhou --filters exclude:regions=cn-beijing
+```
+
+`--region` sets only the region used for account resolution and global services; it does not restrict the scan.
+
+## Discovery
+
+Scanning an account discovers one asset per major service object, each scoped to that object:
+
+| Target | Assets |
+|---|---|
+| `accounts` | the account itself (always the root asset) |
+| `k8s-clusters` | ACK clusters |
+| `albs` | Application Load Balancers |
+| `nlbs` | Network Load Balancers |
+| `vpcs` | VPC networks |
+| `oss-buckets` | OSS buckets |
+| `rds-instances` | RDS instances |
+| `waf` | Web Application Firewall instances |
+| `cloud-firewall` | the account's Cloud Firewall, when provisioned |
+| `auto` / `all` | every target above |
+
+```bash
+cnspec scan alicloud --discover vpcs,albs
+cnspec scan alicloud --discover accounts   # the account only, no child assets
+```
+
+## Filters
+
+`--filters` narrows what discovery turns into assets. Filters are applied in the resource listers, so a scan and a plain MQL query see the same set.
+
+| Filter | Effect |
+|---|---|
+| `regions=<csv>` | scan only these regions |
+| `exclude:regions=<csv>` | skip these regions |
+| `tag:<key>=<value[,value]>` | keep only objects carrying one of these tag values |
+| `exclude:tag:<key>=<value[,value]>` | drop objects carrying one of these tag values |
+
+```bash
+cnspec scan alicloud --filters tag:Environment=production
+cnspec scan alicloud --filters tag:Team=platform,security --filters exclude:tag:Lifecycle=temporary
+```
+
+An exclude filter always wins over an include filter. Tag filters apply to the objects that carry tags — ACK clusters, load balancers, VPCs, ECS instances, OSS buckets, and RDS instances. WAF and Cloud Firewall are untagged account-level services, so tag filters do not narrow them.
+
+Tag lookups that cost a separate API call (OSS buckets, RDS instances) are only performed when a tag filter is actually set.
+
+## Examples
+
+```coffee
+# ECS instances reachable from the internet whose metadata service
+# hands out role credentials without requiring a token
+alicloud.ecs.instances.where(internetExposed && metadataHttpTokens != "required") {
+  instanceName ramRole { roleName }
+}
+
+# security groups open to the world
+alicloud.ecs.securityGroups {
+  securityGroupName
+  permissions.where(sourceCidrIp == "0.0.0.0/0") { ipProtocol portRange }
+}
+
+# OSS buckets without block-public-access
+alicloud.oss.buckets.where(blockPublicAccess == false) { name acl policy }
+
+# RDS instances allowing connections from anywhere
+alicloud.rds.instances.where(securityIPList.contains("0.0.0.0/0")) {
+  dbInstanceId engine sslEnabled tdeEnabled
+}
+
+# RAM users holding administrator permissions directly
+alicloud.ram.users.where(attachedPolicies.any(policyName == "AdministratorAccess")) {
+  userName lastLoginDate mfaDevice
+}
+
+# who holds which access configuration on which member account
+alicloud.cloudsso.directories {
+  accessAssignments { principalName accessConfigurationName targetName }
+}
+
+# ActionTrail trails that are not logging
+alicloud.actiontrail.trails.where(status != "Enable") { name ossBucket { name } }
+```
+
+## Development
+
+```bash
+make providers/build/alicloud && make providers/install/alicloud
+mql shell alicloud
+```
+
+Resources are defined in `resources/alicloud.lr`. After editing it, regenerate:
+
+```bash
+make providers/mqlr
+./mqlr generate providers/alicloud/resources/alicloud.lr --dist providers/alicloud/resources
+```
+
+Adding a `mql<Resource>Internal` struct requires running the generator a second time so it is detected and embedded.

--- a/providers/alicloud/config/config.go
+++ b/providers/alicloud/config/config.go
@@ -43,6 +43,8 @@ Examples:
 				resources.DiscoveryVpcs,
 				resources.DiscoveryWaf,
 				resources.DiscoveryCloudFirewall,
+				resources.DiscoveryOssBuckets,
+				resources.DiscoveryRdsInstances,
 			},
 			Flags: []plugin.Flag{
 				{
@@ -86,6 +88,12 @@ Examples:
 					Type:    plugin.FlagType_String,
 					Default: "",
 					Desc:    "Comma-separated list of regions to scan (default: all enabled regions)",
+				},
+				{
+					Long:    "filters",
+					Type:    plugin.FlagType_KeyValue,
+					Default: "",
+					Desc:    "Filter discovered assets, e.g., --filters regions=cn-hangzhou,ap-southeast-1 --filters exclude:regions=cn-beijing --filters tag:Environment=production --filters exclude:tag:Environment=dev",
 				},
 			},
 		},

--- a/providers/alicloud/connection/clients.go
+++ b/providers/alicloud/connection/clients.go
@@ -377,7 +377,7 @@ func (c *AlicloudConnection) ResourceManagerClient() (*rmclient.Client, error) {
 // account is enumerated via the ECS DescribeRegions API.
 func (c *AlicloudConnection) GetRegions() ([]string, error) {
 	if len(c.regionFilter) > 0 {
-		return c.regionFilter, nil
+		return c.Filters.General.applyRegionFilters(c.regionFilter), nil
 	}
 
 	client, err := c.EcsClient(c.region)
@@ -399,7 +399,7 @@ func (c *AlicloudConnection) GetRegions() ([]string, error) {
 			regions = append(regions, *r.RegionId)
 		}
 	}
-	return regions, nil
+	return c.Filters.General.applyRegionFilters(regions), nil
 }
 
 // Identify looks up the account (UID) the credential belongs to via the STS

--- a/providers/alicloud/connection/connection.go
+++ b/providers/alicloud/connection/connection.go
@@ -49,6 +49,10 @@ type AlicloudConnection struct {
 	region       string
 	regionFilter []string
 
+	// Filters narrows which objects the listers return, and therefore which
+	// objects discovery turns into assets.
+	Filters DiscoveryFilters
+
 	accountID string
 
 	clientLock sync.Mutex
@@ -79,6 +83,8 @@ func NewAlicloudConnection(id uint32, asset *inventory.Asset, conf *inventory.Co
 			}
 		}
 	}
+
+	conn.Filters = DiscoveryFiltersFromOpts(opts)
 
 	accessKeyID := firstNonEmpty(opts[OptionAccessKeyID], os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"), os.Getenv("ALICLOUD_ACCESS_KEY"))
 	accessKeySecret := os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET")

--- a/providers/alicloud/connection/filters.go
+++ b/providers/alicloud/connection/filters.go
@@ -1,0 +1,117 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"slices"
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/filteropts"
+)
+
+// DiscoveryFilters narrows which objects discovery turns into assets, and which
+// objects the corresponding MQL listings return. Filters are applied in the
+// listers rather than in discovery, so a scan and a plain query see the same
+// set.
+type DiscoveryFilters struct {
+	General GeneralDiscoveryFilters
+}
+
+// GeneralDiscoveryFilters holds the filters that apply to every service.
+type GeneralDiscoveryFilters struct {
+	Regions        []string
+	ExcludeRegions []string
+	// Tags values may be a comma-separated list, so `tag:env=prod,staging`
+	// matches either value.
+	Tags map[string]string
+	// ExcludeTags values may be a comma-separated list, like Tags.
+	ExcludeTags map[string]string
+}
+
+// DiscoveryFiltersFromOpts reads the filter set out of the connection options
+// that ParseCLI populated from --filters.
+func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
+	return DiscoveryFilters{
+		General: GeneralDiscoveryFilters{
+			Regions:        filteropts.ParseCsvSliceOpt(opts, "regions"),
+			ExcludeRegions: filteropts.ParseCsvSliceOpt(opts, "exclude:regions"),
+			Tags:           parseMapOpt(opts, "tag:"),
+			ExcludeTags:    parseMapOpt(opts, "exclude:tag:"),
+		},
+	}
+}
+
+// parseMapOpt collects the options sharing a prefix into a map keyed by the
+// remainder, so `tag:env=prod` becomes {"env": "prod"}.
+func parseMapOpt(opts map[string]string, prefix string) map[string]string {
+	res := map[string]string{}
+	for k, v := range opts {
+		if key, ok := strings.CutPrefix(k, prefix); ok && key != "" {
+			res[key] = v
+		}
+	}
+	return res
+}
+
+// HasTags reports whether any tag filter was set. Callers gate their tag lookup
+// on this so an unfiltered scan does not pay for tags nobody asked for.
+func (f GeneralDiscoveryFilters) HasTags() bool {
+	return len(f.Tags) > 0 || len(f.ExcludeTags) > 0
+}
+
+// IsFilteredOutByTags reports whether a resource carrying these tags should be
+// skipped.
+func (f GeneralDiscoveryFilters) IsFilteredOutByTags(resourceTags map[string]string) bool {
+	return !f.matchesIncludeTags(resourceTags) || f.matchesExcludeTags(resourceTags)
+}
+
+// matchesIncludeTags reports whether the resource matches at least one include
+// filter. With no include filters set, everything matches.
+func (f GeneralDiscoveryFilters) matchesIncludeTags(resourceTags map[string]string) bool {
+	if len(f.Tags) == 0 {
+		return true
+	}
+	for k, csv := range f.Tags {
+		for v := range strings.SplitSeq(csv, ",") {
+			if tagValue, ok := resourceTags[k]; ok && tagValue == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matchesExcludeTags reports whether the resource matches any exclude filter,
+// in which case it is dropped regardless of the include filters.
+func (f GeneralDiscoveryFilters) matchesExcludeTags(resourceTags map[string]string) bool {
+	for k, csv := range f.ExcludeTags {
+		for v := range strings.SplitSeq(csv, ",") {
+			if tagValue, ok := resourceTags[k]; ok && tagValue == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// applyRegionFilters narrows a region list to the included regions and drops the
+// excluded ones. An include list that matches nothing yields no regions, which
+// is the honest answer for a filter that selects nothing.
+func (f GeneralDiscoveryFilters) applyRegionFilters(regions []string) []string {
+	if len(f.Regions) == 0 && len(f.ExcludeRegions) == 0 {
+		return regions
+	}
+
+	res := make([]string, 0, len(regions))
+	for _, r := range regions {
+		if len(f.Regions) > 0 && !slices.Contains(f.Regions, r) {
+			continue
+		}
+		if slices.Contains(f.ExcludeRegions, r) {
+			continue
+		}
+		res = append(res, r)
+	}
+	return res
+}

--- a/providers/alicloud/connection/filters_test.go
+++ b/providers/alicloud/connection/filters_test.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscoveryFiltersFromOpts(t *testing.T) {
+	f := DiscoveryFiltersFromOpts(map[string]string{
+		"regions":               "cn-hangzhou,ap-southeast-1",
+		"exclude:regions":       "cn-beijing",
+		"tag:Environment":       "production",
+		"tag:Team":              "platform,security",
+		"exclude:tag:Lifecycle": "temporary",
+		// unrelated connection options must not leak into the filters
+		"region":        "cn-hangzhou",
+		"access-key-id": "example",
+	}).General
+
+	assert.Equal(t, []string{"cn-hangzhou", "ap-southeast-1"}, f.Regions)
+	assert.Equal(t, []string{"cn-beijing"}, f.ExcludeRegions)
+	assert.Equal(t, map[string]string{"Environment": "production", "Team": "platform,security"}, f.Tags)
+	assert.Equal(t, map[string]string{"Lifecycle": "temporary"}, f.ExcludeTags)
+}
+
+func TestGeneralDiscoveryFiltersHasTags(t *testing.T) {
+	assert.False(t, GeneralDiscoveryFilters{}.HasTags())
+	assert.False(t, GeneralDiscoveryFilters{Regions: []string{"cn-hangzhou"}}.HasTags())
+	assert.True(t, GeneralDiscoveryFilters{Tags: map[string]string{"a": "b"}}.HasTags())
+	assert.True(t, GeneralDiscoveryFilters{ExcludeTags: map[string]string{"a": "b"}}.HasTags())
+}
+
+func TestIsFilteredOutByTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		filters  GeneralDiscoveryFilters
+		tags     map[string]string
+		filtered bool
+	}{
+		{
+			name:     "no filters keeps everything",
+			filters:  GeneralDiscoveryFilters{},
+			tags:     map[string]string{"Environment": "dev"},
+			filtered: false,
+		},
+		{
+			name:     "matching include tag is kept",
+			filters:  GeneralDiscoveryFilters{Tags: map[string]string{"Environment": "production"}},
+			tags:     map[string]string{"Environment": "production"},
+			filtered: false,
+		},
+		{
+			name:     "non-matching include tag is dropped",
+			filters:  GeneralDiscoveryFilters{Tags: map[string]string{"Environment": "production"}},
+			tags:     map[string]string{"Environment": "dev"},
+			filtered: true,
+		},
+		{
+			name:     "untagged resource is dropped when an include tag is set",
+			filters:  GeneralDiscoveryFilters{Tags: map[string]string{"Environment": "production"}},
+			tags:     map[string]string{},
+			filtered: true,
+		},
+		{
+			name:     "any value in a csv include list matches",
+			filters:  GeneralDiscoveryFilters{Tags: map[string]string{"Environment": "production,staging"}},
+			tags:     map[string]string{"Environment": "staging"},
+			filtered: false,
+		},
+		{
+			name:     "matching exclude tag is dropped",
+			filters:  GeneralDiscoveryFilters{ExcludeTags: map[string]string{"Lifecycle": "temporary"}},
+			tags:     map[string]string{"Lifecycle": "temporary"},
+			filtered: true,
+		},
+		{
+			// exclude must win, otherwise an explicit opt-out is silently
+			// overridden by a broader include filter
+			name: "exclude beats include",
+			filters: GeneralDiscoveryFilters{
+				Tags:        map[string]string{"Environment": "production"},
+				ExcludeTags: map[string]string{"Lifecycle": "temporary"},
+			},
+			tags:     map[string]string{"Environment": "production", "Lifecycle": "temporary"},
+			filtered: true,
+		},
+		{
+			name:     "exclude on an unrelated key keeps the resource",
+			filters:  GeneralDiscoveryFilters{ExcludeTags: map[string]string{"Lifecycle": "temporary"}},
+			tags:     map[string]string{"Environment": "production"},
+			filtered: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.filtered, tt.filters.IsFilteredOutByTags(tt.tags))
+		})
+	}
+}
+
+func TestApplyRegionFilters(t *testing.T) {
+	all := []string{"cn-hangzhou", "cn-beijing", "ap-southeast-1"}
+
+	t.Run("no filters returns everything", func(t *testing.T) {
+		assert.Equal(t, all, GeneralDiscoveryFilters{}.applyRegionFilters(all))
+	})
+
+	t.Run("include narrows to the listed regions", func(t *testing.T) {
+		f := GeneralDiscoveryFilters{Regions: []string{"cn-hangzhou", "ap-southeast-1"}}
+		assert.Equal(t, []string{"cn-hangzhou", "ap-southeast-1"}, f.applyRegionFilters(all))
+	})
+
+	t.Run("exclude drops the listed regions", func(t *testing.T) {
+		f := GeneralDiscoveryFilters{ExcludeRegions: []string{"cn-beijing"}}
+		assert.Equal(t, []string{"cn-hangzhou", "ap-southeast-1"}, f.applyRegionFilters(all))
+	})
+
+	t.Run("exclude beats include", func(t *testing.T) {
+		f := GeneralDiscoveryFilters{
+			Regions:        []string{"cn-hangzhou", "cn-beijing"},
+			ExcludeRegions: []string{"cn-beijing"},
+		}
+		assert.Equal(t, []string{"cn-hangzhou"}, f.applyRegionFilters(all))
+	})
+
+	// A filter that selects nothing must yield nothing rather than falling back
+	// to every region, which would scan far more than the user asked for.
+	t.Run("an include list matching nothing yields no regions", func(t *testing.T) {
+		f := GeneralDiscoveryFilters{Regions: []string{"us-east-1"}}
+		assert.Empty(t, f.applyRegionFilters(all))
+	})
+}

--- a/providers/alicloud/connection/platform.go
+++ b/providers/alicloud/connection/platform.go
@@ -16,6 +16,8 @@ const (
 	OptionVpcID         = "vpc-id"
 	OptionWafInstanceID = "waf-instance-id"
 	OptionCloudFirewall = "cloud-firewall"
+	OptionOssBucket     = "oss-bucket"
+	OptionRdsInstanceID = "rds-instance-id"
 )
 
 const (
@@ -26,6 +28,8 @@ const (
 	platformIDVpc           = "//platformid.api.mondoo.app/runtime/alicloud/vpc/network/"
 	platformIDWafInstance   = "//platformid.api.mondoo.app/runtime/alicloud/waf/instance/"
 	platformIDCloudFirewall = "//platformid.api.mondoo.app/runtime/alicloud/cloudfirewall/"
+	platformIDOssBucket     = "//platformid.api.mondoo.app/runtime/alicloud/oss/bucket/"
+	platformIDRdsInstance   = "//platformid.api.mondoo.app/runtime/alicloud/rds/instance/"
 )
 
 // Platforms is the static catalog of platforms the alicloud provider emits: the
@@ -39,6 +43,8 @@ var Platforms = []*plugin.PlatformInfo{
 	{Name: "alicloud-vpc", Title: "Alibaba Cloud VPC", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-waf-instance", Title: "Alibaba Cloud Web Application Firewall", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-cloud-firewall", Title: "Alibaba Cloud Cloud Firewall", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-oss-bucket", Title: "Alibaba Cloud OSS Bucket", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-rds-instance", Title: "Alibaba Cloud RDS Instance", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)
@@ -100,6 +106,18 @@ func NewCloudFirewallPlatform(accountID string) *inventory.Platform {
 		[]string{"technology=alicloud", "kind=cloud-firewall", "account=" + accountID})
 }
 
+// NewOssBucketPlatform returns the platform for a discovered OSS bucket asset.
+func NewOssBucketPlatform(bucketName string) *inventory.Platform {
+	return newPlatform("alicloud-oss-bucket", "",
+		[]string{"technology=alicloud", "kind=oss-bucket", "bucket=" + bucketName})
+}
+
+// NewRdsInstancePlatform returns the platform for a discovered RDS instance asset.
+func NewRdsInstancePlatform(instanceID string) *inventory.Platform {
+	return newPlatform("alicloud-rds-instance", "",
+		[]string{"technology=alicloud", "kind=rds-instance", "instance=" + instanceID})
+}
+
 func NewAccountIdentifier(accountID string) string       { return platformIDAccount + accountID }
 func NewAckClusterIdentifier(clusterID string) string    { return platformIDAckCluster + clusterID }
 func NewAlbIdentifier(lbID string) string                { return platformIDAlb + lbID }
@@ -107,3 +125,5 @@ func NewNlbIdentifier(lbID string) string                { return platformIDNlb 
 func NewVpcIdentifier(vpcID string) string               { return platformIDVpc + vpcID }
 func NewWafInstanceIdentifier(instanceID string) string  { return platformIDWafInstance + instanceID }
 func NewCloudFirewallIdentifier(accountID string) string { return platformIDCloudFirewall + accountID }
+func NewOssBucketIdentifier(bucketName string) string    { return platformIDOssBucket + bucketName }
+func NewRdsInstanceIdentifier(instanceID string) string  { return platformIDRdsInstance + instanceID }

--- a/providers/alicloud/provider/provider.go
+++ b/providers/alicloud/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -33,6 +34,36 @@ func stringFlag(flags map[string]*llx.Primitive, name string, envs ...string) st
 		}
 	}
 	return ""
+}
+
+// filterOptPrefixes are the --filters keys the provider understands. Anything
+// else is dropped rather than silently stored, so a typo surfaces as a filter
+// that plainly did nothing instead of one that appears accepted.
+var filterOptPrefixes = []string{
+	"regions",
+	"exclude:regions",
+	"tag:",
+	"exclude:tag:",
+}
+
+// parseFlagsToFiltersOpts flattens the --filters key-value flag into connection
+// options the connection reads back through DiscoveryFiltersFromOpts.
+func parseFlagsToFiltersOpts(flags map[string]*llx.Primitive) map[string]string {
+	opts := map[string]string{}
+
+	x, ok := flags["filters"]
+	if !ok || len(x.Map) == 0 {
+		return opts
+	}
+	for k, v := range x.Map {
+		for _, prefix := range filterOptPrefixes {
+			if strings.HasPrefix(k, prefix) {
+				opts[k] = string(v.Value)
+				break
+			}
+		}
+	}
+	return opts
 }
 
 type Service struct {
@@ -78,6 +109,10 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	secret := stringFlag(flags, "access-key-secret", "ALIBABA_CLOUD_ACCESS_KEY_SECRET", "ALICLOUD_SECRET_KEY")
 	if secret != "" {
 		conf.Credentials = append(conf.Credentials, vault.NewPasswordCredential("", secret))
+	}
+
+	for k, v := range parseFlagsToFiltersOpts(flags) {
+		conf.Options[k] = v
 	}
 
 	discoverTargets := []string{resources.DiscoveryAuto}

--- a/providers/alicloud/resources/alb.go
+++ b/providers/alicloud/resources/alb.go
@@ -64,6 +64,9 @@ func (r *mqlAlicloudAlb) loadBalancers() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				if filteredOutByTags(conn, mqlLb.Tags.Data) {
+					continue
+				}
 				res = append(res, mqlLb)
 			}
 			if resp.Body.NextToken == nil || *resp.Body.NextToken == "" {

--- a/providers/alicloud/resources/cs.go
+++ b/providers/alicloud/resources/cs.go
@@ -90,6 +90,9 @@ func (r *mqlAlicloudCs) clusters() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				if filteredOutByTags(conn, mqlCluster.Tags.Data) {
+					continue
+				}
 				res = append(res, mqlCluster)
 			}
 

--- a/providers/alicloud/resources/discovery.go
+++ b/providers/alicloud/resources/discovery.go
@@ -25,6 +25,8 @@ const (
 	DiscoveryVpcs          = "vpcs"
 	DiscoveryWaf           = "waf"
 	DiscoveryCloudFirewall = "cloud-firewall"
+	DiscoveryOssBuckets    = "oss-buckets"
+	DiscoveryRdsInstances  = "rds-instances"
 )
 
 // Discover enumerates the major service objects in the account and returns one
@@ -55,6 +57,10 @@ func Discover(runtime *plugin.Runtime, conf *inventory.Config) (*inventory.Inven
 			assets, err = discoverWaf(runtime, conn, conf)
 		case DiscoveryCloudFirewall:
 			assets, err = discoverCloudFirewall(runtime, conn, conf)
+		case DiscoveryOssBuckets:
+			assets, err = discoverOssBuckets(runtime, conn, conf)
+		case DiscoveryRdsInstances:
+			assets, err = discoverRdsInstances(runtime, conn, conf)
 		case DiscoveryAccounts:
 			// the account is already returned as the connected root asset, so it
 			// contributes no discovered child assets
@@ -81,6 +87,8 @@ func handleTargets(targets []string) []string {
 			DiscoveryVpcs,
 			DiscoveryWaf,
 			DiscoveryCloudFirewall,
+			DiscoveryOssBuckets,
+			DiscoveryRdsInstances,
 		}
 	}
 	return targets
@@ -174,6 +182,52 @@ func discoverVpcs(runtime *plugin.Runtime, conn *connection.AlicloudConnection, 
 		assets = append(assets, newChildAsset(conf, conn.ID(), vpc.RegionId.Data,
 			connection.NewVpcIdentifier(id), connection.NewVpcPlatform(id),
 			nameOr(vpc.VpcName.Data, id), connection.OptionVpcID, id))
+	}
+	return assets, nil
+}
+
+func discoverOssBuckets(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.oss", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	buckets, err := res.(*mqlAlicloudOss).buckets()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(buckets))
+	for _, ib := range buckets {
+		bucket := ib.(*mqlAlicloudOssBucket)
+		name := bucket.Name.Data
+		if name == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), bucket.Region.Data,
+			connection.NewOssBucketIdentifier(name), connection.NewOssBucketPlatform(name),
+			name, connection.OptionOssBucket, name))
+	}
+	return assets, nil
+}
+
+func discoverRdsInstances(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.rds", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	instances, err := res.(*mqlAlicloudRds).instances()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(instances))
+	for _, ii := range instances {
+		inst := ii.(*mqlAlicloudRdsInstance)
+		id := inst.DbInstanceId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), inst.RegionId.Data,
+			connection.NewRdsInstanceIdentifier(id), connection.NewRdsInstancePlatform(id),
+			nameOr(inst.DbInstanceDescription.Data, id), connection.OptionRdsInstanceID, id))
 	}
 	return assets, nil
 }

--- a/providers/alicloud/resources/discovery_test.go
+++ b/providers/alicloud/resources/discovery_test.go
@@ -15,6 +15,7 @@ func TestHandleTargets(t *testing.T) {
 	fineGrained := []string{
 		DiscoveryK8sClusters, DiscoveryAlbs, DiscoveryNlbs,
 		DiscoveryVpcs, DiscoveryWaf, DiscoveryCloudFirewall,
+		DiscoveryOssBuckets, DiscoveryRdsInstances,
 	}
 
 	assert.ElementsMatch(t, fineGrained, handleTargets([]string{DiscoveryAuto}))

--- a/providers/alicloud/resources/ecs.go
+++ b/providers/alicloud/resources/ecs.go
@@ -183,6 +183,9 @@ func ecsInstancesInRegion(runtime *plugin.Runtime, conn *connection.AlicloudConn
 			if err != nil {
 				return nil, err
 			}
+			if filteredOutByTags(conn, mqlInst.Tags.Data) {
+				continue
+			}
 			res = append(res, mqlInst)
 		}
 

--- a/providers/alicloud/resources/helpers.go
+++ b/providers/alicloud/resources/helpers.go
@@ -3,7 +3,10 @@
 
 package resources
 
-import tea "github.com/alibabacloud-go/tea/tea"
+import (
+	tea "github.com/alibabacloud-go/tea/tea"
+	"go.mondoo.com/mql/v13/providers/alicloud/connection"
+)
 
 // strPtrsToStrings converts a []*string SDK slice into a []string, dropping nil
 // and empty entries so downstream resolvers are never handed a blank id.
@@ -46,3 +49,29 @@ func int64PtrsToInts(in []*int64) []any {
 // ap-southeast-1 for the international partition. An account belongs to one of
 // them, so a call against the other partition returns no data (or an error).
 var alicloudCenterRegions = []string{"cn-hangzhou", "ap-southeast-1"}
+
+// filteredOutByTags reports whether a resource carrying these tags should be
+// dropped for the connection's --filters tag settings.
+//
+// Filters are applied in the listers rather than in discovery, so a scan and a
+// plain MQL query see the same set. Callers whose tags cost a separate API call
+// gate the lookup on conn.Filters.General.HasTags() first, so an unfiltered
+// scan does not pay for tags nobody asked for.
+func filteredOutByTags(conn *connection.AlicloudConnection, tags map[string]any) bool {
+	if !conn.Filters.General.HasTags() {
+		return false
+	}
+	return conn.Filters.General.IsFilteredOutByTags(tagsToStringMap(tags))
+}
+
+// tagsToStringMap narrows an MQL tag map to the string-valued entries the tag
+// filters compare against.
+func tagsToStringMap(tags map[string]any) map[string]string {
+	res := make(map[string]string, len(tags))
+	for k, v := range tags {
+		if s, ok := v.(string); ok {
+			res[k] = s
+		}
+	}
+	return res
+}

--- a/providers/alicloud/resources/nlb.go
+++ b/providers/alicloud/resources/nlb.go
@@ -63,6 +63,9 @@ func (r *mqlAlicloudNlb) loadBalancers() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				if filteredOutByTags(conn, mqlLb.Tags.Data) {
+					continue
+				}
 				res = append(res, mqlLb)
 			}
 			if resp.Body.NextToken == nil || *resp.Body.NextToken == "" {

--- a/providers/alicloud/resources/oss.go
+++ b/providers/alicloud/resources/oss.go
@@ -51,6 +51,17 @@ func (r *mqlAlicloudOss) buckets() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			// bucket tags cost a GetBucketTags call each, so only read them when
+			// a tag filter is actually set
+			if conn.Filters.General.HasTags() {
+				tags := bucket.GetTags()
+				if tags.Error != nil {
+					return nil, tags.Error
+				}
+				if filteredOutByTags(conn, tags.Data) {
+					continue
+				}
+			}
 			res = append(res, bucket)
 		}
 
@@ -119,6 +130,8 @@ func initAlicloudOssBucket(runtime *plugin.Runtime, args map[string]*llx.RawData
 	if len(args) > 1 {
 		return args, nil, nil
 	}
+	// on a discovered bucket asset, resolve the bucket the asset is scoped to
+	args = scopedInitIDArgs(runtime, args, connection.OptionOssBucket, "name")
 
 	name, err := requiredStringArg(args, "name", "alicloud.oss.bucket")
 	if err != nil {

--- a/providers/alicloud/resources/rds.go
+++ b/providers/alicloud/resources/rds.go
@@ -94,6 +94,17 @@ func (r *mqlAlicloudRds) instances() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				// instance tags cost a DescribeTags call each, so only read them
+				// when a tag filter is actually set
+				if conn.Filters.General.HasTags() {
+					tags := mqlInst.GetTags()
+					if tags.Error != nil {
+						return nil, tags.Error
+					}
+					if filteredOutByTags(conn, tags.Data) {
+						continue
+					}
+				}
 				res = append(res, mqlInst)
 			}
 
@@ -175,6 +186,9 @@ func initAlicloudRdsInstance(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+	// on a discovered RDS instance asset, resolve the instance the asset is
+	// scoped to
+	args = scopedInitArgs(runtime, args, connection.OptionRdsInstanceID, "dbInstanceId")
 
 	dbInstanceID, err := requiredStringArg(args, "dbInstanceId", "alicloud.rds.instance")
 	if err != nil {

--- a/providers/alicloud/resources/typed_refs.go
+++ b/providers/alicloud/resources/typed_refs.go
@@ -300,6 +300,20 @@ func scopedInitArgs(runtime *plugin.Runtime, args map[string]*llx.RawData, scope
 	}
 }
 
+// scopedInitIDArgs is the single-identifier form of scopedInitArgs, for
+// resources whose init takes only an id and no region of its own.
+func scopedInitIDArgs(runtime *plugin.Runtime, args map[string]*llx.RawData, scopeOption, idField string) map[string]*llx.RawData {
+	if len(args) != 0 {
+		return args
+	}
+	conn := runtime.Connection.(*connection.AlicloudConnection)
+	id, _, ok := conn.ScopedObject(scopeOption)
+	if !ok {
+		return args
+	}
+	return map[string]*llx.RawData{idField: llx.StringData(id)}
+}
+
 // requiredStringArg reads a required non-empty string argument from an init
 // args map, returning a descriptive error when it is missing or blank.
 func requiredStringArg(args map[string]*llx.RawData, name, resource string) (string, error) {

--- a/providers/alicloud/resources/vpc.go
+++ b/providers/alicloud/resources/vpc.go
@@ -148,6 +148,10 @@ func (r *mqlAlicloudVpc) networks() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				if mqlNetwork, ok := network.(*mqlAlicloudVpcNetwork); ok &&
+					filteredOutByTags(conn, mqlNetwork.Tags.Data) {
+					continue
+				}
 				res = append(res, network)
 			}
 


### PR DESCRIPTION
> Stacked on #9644 → #9643 → #9641. Review after those merge, or read the fourth commit only.

The provider had six discovery targets and **no filter support at all** — `grep -rn "Filters" providers/alicloud/` returned nothing but incidental comments. A user passing `--filters tag:Environment=production` had it accepted and silently ignored, and got every asset back. This is the `CLAUDE.md` §3.5 gate, unwired since discovery landed in #9239.

### Filters

Introduces `connection.DiscoveryFilters` with the general region and tag filters, parsed out of `--filters` by `ParseCLI`:

```bash
cnspec scan alicloud --filters regions=cn-hangzhou,ap-southeast-1
cnspec scan alicloud --filters exclude:regions=cn-beijing
cnspec scan alicloud --filters tag:Environment=production
cnspec scan alicloud --filters tag:Team=platform,security --filters exclude:tag:Lifecycle=temporary
```

Semantics, all unit-tested:

- an **exclude always beats an include** — otherwise an explicit opt-out is silently overridden by a broader include
- an **include list that matches nothing yields nothing**, rather than falling back to every region (which would scan far more than asked)
- an **untagged resource is dropped** when an include tag filter is set
- unrelated connection options (`region`, `access-key-id`) never leak into the filter set, and unknown `--filters` keys are dropped at parse time rather than silently stored

### Where filters are applied

**In the listers, not in `discovery.go`** — discovery reaches assets through the same `networks()` / `loadBalancers()` accessor a plain MQL query uses, so one check keeps both paths consistent.

| Lister | Filtered |
|---|---|
| `alicloud.cs.clusters` | ✅ tags inline |
| `alicloud.alb.loadBalancers` | ✅ tags inline |
| `alicloud.nlb.loadBalancers` | ✅ tags inline |
| `alicloud.vpc.networks` | ✅ tags inline |
| `alicloud.ecs.instances` | ✅ tags inline |
| `alicloud.oss.buckets` | ✅ gated — tags cost a `GetBucketTags` call each |
| `alicloud.rds.instances` | ✅ gated — tags cost a `DescribeTags` call each |
| `alicloud.waf.instances`, `alicloud.cloudFirewall` | region filters only — untagged account-level services |

The two gated listers check `conn.Filters.General.HasTags()` before reading tags at all, so an unfiltered scan doesn't pay per-object for tags nobody asked for.

Region filters apply in `GetRegions()`, so they narrow every region-fanning lister at once, including the ones with no tags.

### New discovery targets

`oss-buckets` and `rds-instances`, with their platforms, identifiers, and scope options. Both singular inits now resolve themselves from the scoped asset, so a discovered bucket or instance asset answers `alicloud.oss.bucket.acl` without arguments — the same binding #9344 established for the existing targets.

**ECS instances are deliberately still not a discovery target**, matching the decision made when discovery landed in #9239 to keep per-instance API assets out of the inventory. The tag filtering on `alicloud.ecs.instances` is still wired, since it's useful to plain queries regardless.

### README

`providers/alicloud/README.md` — the four credential sources and their precedence, the region/partition behavior of the center services (why WAF/Cloud Firewall/CloudSSO probe two regions), the discovery target table, the filter table, and example queries. No per-field documentation.

### Verification

`go build ./...`, `go vet ./...`, `go test ./...` pass. New `filters_test.go` covers option parsing, include/exclude precedence, CSV values, untagged resources, and region narrowing; `discovery_test.go` updated for the two new targets. Live verification pending the batched `provider-verification` run.
