### PR TITLE
🧹 oci: build each service client once per region instead of per job

### DIFF
--- a/providers/oci/connection/clients.go
+++ b/providers/oci/connection/clients.go
@@ -4,8 +4,8 @@
 package connection
 
 import (
-	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -57,152 +57,142 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/waf"
 )
 
-func (c *OciConnection) IdentityClient() (identity.IdentityClient, error) {
-	return identity.NewIdentityClientWithConfigurationProvider(c.config)
-}
-
-func (c *OciConnection) TenantID() string {
-	return c.tenancyOcid
-}
-
-func (c *OciConnection) Tenant(ctx context.Context) (*identity.Tenancy, error) {
-	oClient, err := c.IdentityClient()
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := oClient.GetTenancy(ctx, identity.GetTenancyRequest{
-		TenancyId: &c.tenancyOcid,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &resp.Tenancy, nil
-}
-
-// GetCompartments returns the tenancy root plus every active compartment
-// beneath it.
+// Every OCI service client this provider talks to is built here, once per
+// (service, region), and shared from then on.
 //
-// The result is memoized for the lifetime of the connection. A dozen listers
-// fan out over the compartment tree, and each one asking for it separately
-// meant walking the same paginated ListCompartments a dozen times per scan.
+// Sharing is the point. A lister fans out over every (region, compartment) pair
+// in the tenancy, and each job used to construct its own client. Because
+// common.NewClientWithConfig gives each client a fresh OciHTTPTransportWrapper,
+// and therefore its own connection pool, a fifty-compartment tenancy across
+// five regions built 250 clients that shared no TCP connections and repeated
+// the TLS handshake for every one. Reusing a client per region is what lets the
+// SDK's transport pool do its job.
 //
-// A failure is not cached: an Identity call that fails on a throttle should be
-// retried by the next lister rather than turning one bad moment into a scan
-// with no compartments at all.
-func (c *OciConnection) GetCompartments(ctx context.Context) ([]identity.Compartment, error) {
-	c.compartmentLock.Lock()
-	defer c.compartmentLock.Unlock()
-	if c.compartmentsDone {
-		return c.compartmentList, nil
-	}
+// The safety condition is narrow and worth stating: a shared client must never
+// be mutated after it is published. BaseClient.Call takes a value receiver and
+// prepareRequest writes nothing back to the client, so concurrent requests are
+// safe - but SetRegion, SetCustomClientConfiguration and the HTTPClient swap in
+// failFastOnUnreachableRegion all write to the client. Those happen inside the
+// build closure below, before the client is ever visible to another goroutine,
+// and nothing outside this file touches a client afterwards.
 
-	oClient, err := c.IdentityClient()
-	if err != nil {
-		return nil, err
-	}
-
-	compartments := make([]identity.Compartment, 0)
-
-	req := identity.GetCompartmentRequest{
-		CompartmentId: &c.tenancyOcid,
-	}
-
-	resp, err := oClient.GetCompartment(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	compartments = append(compartments, resp.Compartment)
-
-	var page *string
-	for {
-		request := identity.ListCompartmentsRequest{
-			CompartmentId:          common.String(c.tenancyOcid),
-			CompartmentIdInSubtree: common.Bool(true),
-			LifecycleState:         identity.CompartmentLifecycleStateActive,
-			Page:                   page,
+// cachedClient returns the client stored under key, building it on first use.
+//
+// A build failure is deliberately not cached: an auth or config error that
+// resolves (a refreshed instance-principal token, say) should be retried by the
+// next caller rather than poisoning the key for the rest of the scan.
+//
+// Two goroutines racing on a cold key may both build, but LoadOrStore publishes
+// only one and both callers receive it, so "one client per key" holds even
+// though "one build per key" does not.
+//
+// The type assertions are checked rather than bare. The compiler already
+// guarantees that an accessor's constructor matches its declared return type,
+// but nothing checks the key strings, and two accessors for differently-typed
+// clients sharing one key would otherwise panic here. A panic inside a lister
+// takes down the whole scan, so a shared key is reported as an error against
+// the offending key instead.
+func cachedClient[T any](c *OciConnection, key string, build func() (T, error)) (T, error) {
+	if cached, ok := c.clients.Load(key); ok {
+		client, ok := cached.(T)
+		if !ok {
+			var zero T
+			return zero, fmt.Errorf("oci client cache key %q already holds a %T: two accessors share a key", key, cached)
 		}
+		return client, nil
+	}
 
-		response, err := oClient.ListCompartments(ctx, request)
+	client, err := build()
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+
+	shared, _ := c.clients.LoadOrStore(key, client)
+	typed, ok := shared.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("oci client cache key %q already holds a %T: two accessors share a key", key, shared)
+	}
+	return typed, nil
+}
+
+// ociClient constrains PT to *T for a client type whose region is set through a
+// pointer receiver, which is every regional client in the OCI SDK.
+type ociClient[T any] interface {
+	*T
+	SetRegion(region string)
+}
+
+// regionalClient builds, points at a region, and caches a standard OCI service
+// client. The SDK constructors return the client by value, so the pointer is
+// taken here and the region applied to it before anything else can see it.
+func regionalClient[T any, PT ociClient[T]](
+	c *OciConnection,
+	service string,
+	region string,
+	build func(common.ConfigurationProvider) (T, error),
+) (PT, error) {
+	return cachedClient(c, service+"/"+region, func() (PT, error) {
+		client, err := build(c.config)
 		if err != nil {
-			return nil, errors.Join(errors.New("failed to list compartments in tenancy: "+c.tenancyOcid), err)
+			return nil, err
 		}
-
-		for i := range response.Items {
-			compartments = append(compartments, response.Items[i])
-		}
-
-		page = response.OpcNextPage
-		if response.OpcNextPage == nil {
-			break
-		}
-	}
-
-	c.compartmentList = compartments
-	c.compartmentsDone = true
-	return compartments, nil
+		regioned := PT(&client)
+		regioned.SetRegion(region)
+		return regioned, nil
+	})
 }
 
-func (c *OciConnection) GetRegions(ctx context.Context) ([]identity.RegionSubscription, error) {
-	oClient, err := c.IdentityClient()
-	if err != nil {
-		return nil, err
-	}
-
-	request := identity.ListRegionSubscriptionsRequest{
-		TenancyId: common.String(c.tenancyOcid),
-	}
-
-	response, err := oClient.ListRegionSubscriptions(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-
-	regions := make([]identity.RegionSubscription, 0)
-	for _, region := range response.Items {
-		if region.Status != identity.RegionSubscriptionStatusReady {
-			continue
+// aiClient builds a regional client for one of the AI services, which are
+// deployed in only a subset of regions and need the fail-fast treatment below.
+//
+// It exists so that adding an AI service cannot quietly skip that step: the
+// only way to reach these constructors is through a helper that applies it. The
+// base accessor is passed in because common.BaseClient is an embedded field
+// rather than an interface method, so there is no way to reach it generically.
+func aiClient[T any, PT ociClient[T]](
+	c *OciConnection,
+	service string,
+	region string,
+	build func(common.ConfigurationProvider) (T, error),
+	base func(PT) *common.BaseClient,
+) (PT, error) {
+	return cachedClient(c, service+"/"+region, func() (PT, error) {
+		client, err := build(c.config)
+		if err != nil {
+			return nil, err
 		}
-		regions = append(regions, region)
-	}
-
-	return regions, nil
+		regioned := PT(&client)
+		regioned.SetRegion(region)
+		failFastOnUnreachableRegion(base(regioned))
+		return regioned, nil
+	})
 }
 
-func (c *OciConnection) ComputeClient(region string) (*core.ComputeClient, error) {
-	client, err := core.NewComputeClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+// endpointClient caches a client addressed by an explicit endpoint rather than
+// a region. Identity domains and KMS management both publish per-resource
+// endpoints, so the endpoint is the cache key.
+func endpointClient[T any](c *OciConnection, service, endpoint string, build func() (T, error)) (T, error) {
+	return cachedClient(c, service+"/"+endpoint, build)
+}
+
+// --- Identity ---------------------------------------------------------------
+
+// IdentityClient talks to IAM in the region the configuration provider names.
+// OCI IAM is global within a realm, so unlike the accessors below this one is
+// not addressed by region.
+// The key is deliberately not "identity/" + something: IdentityClientWithRegion
+// builds "identity/<region>", and an empty region would land on the same key
+// with a different client type.
+func (c *OciConnection) IdentityClient() (identity.IdentityClient, error) {
+	return cachedClient(c, "identity-global", func() (identity.IdentityClient, error) {
+		return identity.NewIdentityClientWithConfigurationProvider(c.config)
+	})
 }
 
 func (c *OciConnection) IdentityClientWithRegion(region string) (*identity.IdentityClient, error) {
-	client, err := identity.NewIdentityClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) NetworkClient(region string) (*core.VirtualNetworkClient, error) {
-	client, err := core.NewVirtualNetworkClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) AuditClient(region string) (*audit.AuditClient, error) {
-	client, err := audit.NewAuditClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+	return regionalClient(c, "identity", region, identity.NewIdentityClientWithConfigurationProvider)
 }
 
 // IdentityDomainsClient builds a client for one identity domain.
@@ -215,381 +205,248 @@ func (c *OciConnection) IdentityDomainsClient(endpoint string) (*identitydomains
 	if endpoint == "" {
 		return nil, errors.New("an identity domain endpoint is required")
 	}
-	client, err := identitydomains.NewIdentityDomainsClientWithConfigurationProvider(c.config, endpoint)
-	if err != nil {
-		return nil, err
-	}
-	return &client, nil
+	return endpointClient(c, "identitydomains", endpoint, func() (*identitydomains.IdentityDomainsClient, error) {
+		client, err := identitydomains.NewIdentityDomainsClientWithConfigurationProvider(c.config, endpoint)
+		if err != nil {
+			return nil, err
+		}
+		return &client, nil
+	})
 }
 
-func (c *OciConnection) ResourceManagerClient(region string) (*resourcemanager.ResourceManagerClient, error) {
-	client, err := resourcemanager.NewResourceManagerClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+// --- Core (compute, networking, block storage) ------------------------------
+
+func (c *OciConnection) ComputeClient(region string) (*core.ComputeClient, error) {
+	return regionalClient(c, "compute", region, core.NewComputeClientWithConfigurationProvider)
 }
 
-func (c *OciConnection) StreamAdminClient(region string) (*streaming.StreamAdminClient, error) {
-	client, err := streaming.NewStreamAdminClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) QueueAdminClient(region string) (*queue.QueueAdminClient, error) {
-	client, err := queue.NewQueueAdminClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) KafkaClusterClient(region string) (*managedkafka.KafkaClusterClient, error) {
-	client, err := managedkafka.NewKafkaClusterClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) MysqlDbSystemClient(region string) (*mysql.DbSystemClient, error) {
-	client, err := mysql.NewDbSystemClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) PostgresqlClient(region string) (*psql.PostgresqlClient, error) {
-	client, err := psql.NewPostgresqlClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) NosqlClient(region string) (*nosql.NosqlClient, error) {
-	client, err := nosql.NewNosqlClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) OpensearchClusterClient(region string) (*opensearch.OpensearchClusterClient, error) {
-	client, err := opensearch.NewOpensearchClusterClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) GoldenGateClient(region string) (*goldengate.GoldenGateClient, error) {
-	client, err := goldengate.NewGoldenGateClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) DnsClient(region string) (*dns.DnsClient, error) {
-	client, err := dns.NewDnsClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) ServiceConnectorClient(region string) (*sch.ServiceConnectorClient, error) {
-	client, err := sch.NewServiceConnectorClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) ObjectStorageClient(region string) (*objectstorage.ObjectStorageClient, error) {
-	client, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+func (c *OciConnection) NetworkClient(region string) (*core.VirtualNetworkClient, error) {
+	return regionalClient(c, "vcn", region, core.NewVirtualNetworkClientWithConfigurationProvider)
 }
 
 func (c *OciConnection) BlockstorageClient(region string) (*core.BlockstorageClient, error) {
-	client, err := core.NewBlockstorageClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+	return regionalClient(c, "blockstorage", region, core.NewBlockstorageClientWithConfigurationProvider)
+}
+
+// --- Storage ----------------------------------------------------------------
+
+func (c *OciConnection) ObjectStorageClient(region string) (*objectstorage.ObjectStorageClient, error) {
+	return regionalClient(c, "objectstorage", region, objectstorage.NewObjectStorageClientWithConfigurationProvider)
 }
 
 func (c *OciConnection) FileStorageClient(region string) (*filestorage.FileStorageClient, error) {
-	client, err := filestorage.NewFileStorageClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+	return regionalClient(c, "filestorage", region, filestorage.NewFileStorageClientWithConfigurationProvider)
 }
 
-func (c *OciConnection) LoggingClient(region string) (*logging.LoggingManagementClient, error) {
-	client, err := logging.NewLoggingManagementClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) KmsVaultClient(region string) (*keymanagement.KmsVaultClient, error) {
-	client, err := keymanagement.NewKmsVaultClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) KmsManagementClient(endpoint string) (*keymanagement.KmsManagementClient, error) {
-	client, err := keymanagement.NewKmsManagementClientWithConfigurationProvider(c.config, endpoint)
-	if err != nil {
-		return nil, err
-	}
-	return &client, nil
-}
-
-func (c *OciConnection) EventsClient(region string) (*events.EventsClient, error) {
-	client, err := events.NewEventsClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) NotificationControlPlaneClient(region string) (*ons.NotificationControlPlaneClient, error) {
-	client, err := ons.NewNotificationControlPlaneClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) CloudGuardClient(region string) (*cloudguard.CloudGuardClient, error) {
-	client, err := cloudguard.NewCloudGuardClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) NotificationDataPlaneClient(region string) (*ons.NotificationDataPlaneClient, error) {
-	client, err := ons.NewNotificationDataPlaneClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) BastionClient(region string) (*bastion.BastionClient, error) {
-	client, err := bastion.NewBastionClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) MonitoringClient(region string) (*monitoring.MonitoringClient, error) {
-	client, err := monitoring.NewMonitoringClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) VaultsClient(region string) (*vault.VaultsClient, error) {
-	client, err := vault.NewVaultsClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) LoadBalancerClient(region string) (*loadbalancer.LoadBalancerClient, error) {
-	client, err := loadbalancer.NewLoadBalancerClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) NetworkFirewallClient(region string) (*networkfirewall.NetworkFirewallClient, error) {
-	client, err := networkfirewall.NewNetworkFirewallClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) NetworkLoadBalancerClient(region string) (*networkloadbalancer.NetworkLoadBalancerClient, error) {
-	client, err := networkloadbalancer.NewNetworkLoadBalancerClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) ContainerEngineClient(region string) (*containerengine.ContainerEngineClient, error) {
-	client, err := containerengine.NewContainerEngineClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) WafClient(region string) (*waf.WafClient, error) {
-	client, err := waf.NewWafClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
+// --- Databases --------------------------------------------------------------
 
 func (c *OciConnection) DatabaseClient(region string) (*database.DatabaseClient, error) {
-	client, err := database.NewDatabaseClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+	return regionalClient(c, "database", region, database.NewDatabaseClientWithConfigurationProvider)
 }
 
-func (c *OciConnection) DataSafeClient(region string) (*datasafe.DataSafeClient, error) {
-	client, err := datasafe.NewDataSafeClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+func (c *OciConnection) MysqlDbSystemClient(region string) (*mysql.DbSystemClient, error) {
+	return regionalClient(c, "mysql", region, mysql.NewDbSystemClientWithConfigurationProvider)
 }
 
-func (c *OciConnection) FunctionsManagementClient(region string) (*functions.FunctionsManagementClient, error) {
-	client, err := functions.NewFunctionsManagementClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+func (c *OciConnection) PostgresqlClient(region string) (*psql.PostgresqlClient, error) {
+	return regionalClient(c, "postgresql", region, psql.NewPostgresqlClientWithConfigurationProvider)
 }
 
-func (c *OciConnection) ContainerInstanceClient(region string) (*containerinstances.ContainerInstanceClient, error) {
-	client, err := containerinstances.NewContainerInstanceClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+func (c *OciConnection) NosqlClient(region string) (*nosql.NosqlClient, error) {
+	return regionalClient(c, "nosql", region, nosql.NewNosqlClientWithConfigurationProvider)
 }
 
-func (c *OciConnection) ApiGatewayClient(region string) (*apigateway.ApiGatewayClient, error) {
-	client, err := apigateway.NewApiGatewayClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) ApiGatewayGatewayClient(region string) (*apigateway.GatewayClient, error) {
-	client, err := apigateway.NewGatewayClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) ApiGatewayDeploymentClient(region string) (*apigateway.DeploymentClient, error) {
-	client, err := apigateway.NewDeploymentClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
-}
-
-func (c *OciConnection) CertificatesManagementClient(region string) (*certificatesmanagement.CertificatesManagementClient, error) {
-	client, err := certificatesmanagement.NewCertificatesManagementClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+func (c *OciConnection) OpensearchClusterClient(region string) (*opensearch.OpensearchClusterClient, error) {
+	return regionalClient(c, "opensearch", region, opensearch.NewOpensearchClusterClientWithConfigurationProvider)
 }
 
 func (c *OciConnection) RedisClusterClient(region string) (*redis.RedisClusterClient, error) {
-	client, err := redis.NewRedisClusterClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+	return regionalClient(c, "redis", region, redis.NewRedisClusterClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) GoldenGateClient(region string) (*goldengate.GoldenGateClient, error) {
+	return regionalClient(c, "goldengate", region, goldengate.NewGoldenGateClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) DataSafeClient(region string) (*datasafe.DataSafeClient, error) {
+	return regionalClient(c, "datasafe", region, datasafe.NewDataSafeClientWithConfigurationProvider)
+}
+
+// --- Messaging --------------------------------------------------------------
+
+func (c *OciConnection) StreamAdminClient(region string) (*streaming.StreamAdminClient, error) {
+	return regionalClient(c, "streaming", region, streaming.NewStreamAdminClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) QueueAdminClient(region string) (*queue.QueueAdminClient, error) {
+	return regionalClient(c, "queue", region, queue.NewQueueAdminClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) KafkaClusterClient(region string) (*managedkafka.KafkaClusterClient, error) {
+	return regionalClient(c, "kafka", region, managedkafka.NewKafkaClusterClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) EventsClient(region string) (*events.EventsClient, error) {
+	return regionalClient(c, "events", region, events.NewEventsClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) NotificationControlPlaneClient(region string) (*ons.NotificationControlPlaneClient, error) {
+	return regionalClient(c, "ons-controlplane", region, ons.NewNotificationControlPlaneClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) NotificationDataPlaneClient(region string) (*ons.NotificationDataPlaneClient, error) {
+	return regionalClient(c, "ons-dataplane", region, ons.NewNotificationDataPlaneClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) ServiceConnectorClient(region string) (*sch.ServiceConnectorClient, error) {
+	return regionalClient(c, "sch", region, sch.NewServiceConnectorClientWithConfigurationProvider)
+}
+
+// --- Networking edge --------------------------------------------------------
+
+func (c *OciConnection) LoadBalancerClient(region string) (*loadbalancer.LoadBalancerClient, error) {
+	return regionalClient(c, "loadbalancer", region, loadbalancer.NewLoadBalancerClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) NetworkLoadBalancerClient(region string) (*networkloadbalancer.NetworkLoadBalancerClient, error) {
+	return regionalClient(c, "networkloadbalancer", region, networkloadbalancer.NewNetworkLoadBalancerClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) NetworkFirewallClient(region string) (*networkfirewall.NetworkFirewallClient, error) {
+	return regionalClient(c, "networkfirewall", region, networkfirewall.NewNetworkFirewallClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) WafClient(region string) (*waf.WafClient, error) {
+	return regionalClient(c, "waf", region, waf.NewWafClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) DnsClient(region string) (*dns.DnsClient, error) {
+	return regionalClient(c, "dns", region, dns.NewDnsClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) BastionClient(region string) (*bastion.BastionClient, error) {
+	return regionalClient(c, "bastion", region, bastion.NewBastionClientWithConfigurationProvider)
+}
+
+// --- API gateway ------------------------------------------------------------
+
+func (c *OciConnection) ApiGatewayClient(region string) (*apigateway.ApiGatewayClient, error) {
+	return regionalClient(c, "apigateway", region, apigateway.NewApiGatewayClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) ApiGatewayGatewayClient(region string) (*apigateway.GatewayClient, error) {
+	return regionalClient(c, "apigateway-gateway", region, apigateway.NewGatewayClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) ApiGatewayDeploymentClient(region string) (*apigateway.DeploymentClient, error) {
+	return regionalClient(c, "apigateway-deployment", region, apigateway.NewDeploymentClientWithConfigurationProvider)
+}
+
+// --- Containers and functions ----------------------------------------------
+
+func (c *OciConnection) ContainerEngineClient(region string) (*containerengine.ContainerEngineClient, error) {
+	return regionalClient(c, "containerengine", region, containerengine.NewContainerEngineClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) ContainerInstanceClient(region string) (*containerinstances.ContainerInstanceClient, error) {
+	return regionalClient(c, "containerinstances", region, containerinstances.NewContainerInstanceClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) FunctionsManagementClient(region string) (*functions.FunctionsManagementClient, error) {
+	return regionalClient(c, "functions", region, functions.NewFunctionsManagementClientWithConfigurationProvider)
+}
+
+// --- Keys, secrets, certificates -------------------------------------------
+
+func (c *OciConnection) KmsVaultClient(region string) (*keymanagement.KmsVaultClient, error) {
+	return regionalClient(c, "kms-vault", region, keymanagement.NewKmsVaultClientWithConfigurationProvider)
+}
+
+// KmsManagementClient talks to one vault's management endpoint. A KMS vault
+// serves key operations only from the endpoint it publishes, so like the
+// identity-domains client this one is addressed by endpoint rather than region.
+func (c *OciConnection) KmsManagementClient(endpoint string) (*keymanagement.KmsManagementClient, error) {
+	return endpointClient(c, "kms-management", endpoint, func() (*keymanagement.KmsManagementClient, error) {
+		client, err := keymanagement.NewKmsManagementClientWithConfigurationProvider(c.config, endpoint)
+		if err != nil {
+			return nil, err
+		}
+		return &client, nil
+	})
+}
+
+func (c *OciConnection) VaultsClient(region string) (*vault.VaultsClient, error) {
+	return regionalClient(c, "vaults", region, vault.NewVaultsClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) CertificatesManagementClient(region string) (*certificatesmanagement.CertificatesManagementClient, error) {
+	return regionalClient(c, "certificatesmanagement", region, certificatesmanagement.NewCertificatesManagementClientWithConfigurationProvider)
+}
+
+// --- Governance and observability ------------------------------------------
+
+func (c *OciConnection) AuditClient(region string) (*audit.AuditClient, error) {
+	return regionalClient(c, "audit", region, audit.NewAuditClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) CloudGuardClient(region string) (*cloudguard.CloudGuardClient, error) {
+	return regionalClient(c, "cloudguard", region, cloudguard.NewCloudGuardClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) LoggingClient(region string) (*logging.LoggingManagementClient, error) {
+	return regionalClient(c, "logging", region, logging.NewLoggingManagementClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) MonitoringClient(region string) (*monitoring.MonitoringClient, error) {
+	return regionalClient(c, "monitoring", region, monitoring.NewMonitoringClientWithConfigurationProvider)
+}
+
+func (c *OciConnection) ResourceManagerClient(region string) (*resourcemanager.ResourceManagerClient, error) {
+	return regionalClient(c, "resourcemanager", region, resourcemanager.NewResourceManagerClientWithConfigurationProvider)
 }
 
 func (c *OciConnection) VulnerabilityScanningClient(region string) (*vulnerabilityscanning.VulnerabilityScanningClient, error) {
-	client, err := vulnerabilityscanning.NewVulnerabilityScanningClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	return &client, nil
+	return regionalClient(c, "vulnerabilityscanning", region, vulnerabilityscanning.NewVulnerabilityScanningClientWithConfigurationProvider)
+}
+
+// --- AI services ------------------------------------------------------------
+//
+// These go through aiClient so that failFastOnUnreachableRegion is applied to
+// every one of them. See the comment on that function for why.
+
+func (c *OciConnection) GenerativeAiClient(region string) (*generativeai.GenerativeAiClient, error) {
+	return aiClient(c, "generativeai", region, generativeai.NewGenerativeAiClientWithConfigurationProvider,
+		func(p *generativeai.GenerativeAiClient) *common.BaseClient { return &p.BaseClient })
 }
 
 func (c *OciConnection) GenerativeAiAgentClient(region string) (*generativeaiagent.GenerativeAiAgentClient, error) {
-	client, err := generativeaiagent.NewGenerativeAiAgentClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	failFastOnUnreachableRegion(&client.BaseClient)
-	return &client, nil
+	return aiClient(c, "generativeaiagent", region, generativeaiagent.NewGenerativeAiAgentClientWithConfigurationProvider,
+		func(p *generativeaiagent.GenerativeAiAgentClient) *common.BaseClient { return &p.BaseClient })
 }
 
 func (c *OciConnection) DataScienceClient(region string) (*datascience.DataScienceClient, error) {
-	client, err := datascience.NewDataScienceClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	failFastOnUnreachableRegion(&client.BaseClient)
-	return &client, nil
+	return aiClient(c, "datascience", region, datascience.NewDataScienceClientWithConfigurationProvider,
+		func(p *datascience.DataScienceClient) *common.BaseClient { return &p.BaseClient })
+}
+
+func (c *OciConnection) AILanguageClient(region string) (*ailanguage.AIServiceLanguageClient, error) {
+	return aiClient(c, "ailanguage", region, ailanguage.NewAIServiceLanguageClientWithConfigurationProvider,
+		func(p *ailanguage.AIServiceLanguageClient) *common.BaseClient { return &p.BaseClient })
+}
+
+func (c *OciConnection) AIVisionClient(region string) (*aivision.AIServiceVisionClient, error) {
+	return aiClient(c, "aivision", region, aivision.NewAIServiceVisionClientWithConfigurationProvider,
+		func(p *aivision.AIServiceVisionClient) *common.BaseClient { return &p.BaseClient })
+}
+
+func (c *OciConnection) AISpeechClient(region string) (*aispeech.AIServiceSpeechClient, error) {
+	return aiClient(c, "aispeech", region, aispeech.NewAIServiceSpeechClientWithConfigurationProvider,
+		func(p *aispeech.AIServiceSpeechClient) *common.BaseClient { return &p.BaseClient })
+}
+
+func (c *OciConnection) AIDocumentClient(region string) (*aidocument.AIServiceDocumentClient, error) {
+	return aiClient(c, "aidocument", region, aidocument.NewAIServiceDocumentClientWithConfigurationProvider,
+		func(p *aidocument.AIServiceDocumentClient) *common.BaseClient { return &p.BaseClient })
 }
 
 // failFastOnUnreachableRegion caps the per-request timeout and narrows the
@@ -629,53 +486,3 @@ func failFastOnUnreachableRegion(bc *common.BaseClient) {
 // while staying short enough that an undeployed wildcard-DNS region does not
 // stall the scan.
 const unreachableRegionTimeout = 45 * time.Second
-
-func (c *OciConnection) GenerativeAiClient(region string) (*generativeai.GenerativeAiClient, error) {
-	client, err := generativeai.NewGenerativeAiClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	failFastOnUnreachableRegion(&client.BaseClient)
-	return &client, nil
-}
-
-func (c *OciConnection) AILanguageClient(region string) (*ailanguage.AIServiceLanguageClient, error) {
-	client, err := ailanguage.NewAIServiceLanguageClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	failFastOnUnreachableRegion(&client.BaseClient)
-	return &client, nil
-}
-
-func (c *OciConnection) AIVisionClient(region string) (*aivision.AIServiceVisionClient, error) {
-	client, err := aivision.NewAIServiceVisionClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	failFastOnUnreachableRegion(&client.BaseClient)
-	return &client, nil
-}
-
-func (c *OciConnection) AISpeechClient(region string) (*aispeech.AIServiceSpeechClient, error) {
-	client, err := aispeech.NewAIServiceSpeechClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	failFastOnUnreachableRegion(&client.BaseClient)
-	return &client, nil
-}
-
-func (c *OciConnection) AIDocumentClient(region string) (*aidocument.AIServiceDocumentClient, error) {
-	client, err := aidocument.NewAIServiceDocumentClientWithConfigurationProvider(c.config)
-	if err != nil {
-		return nil, err
-	}
-	client.SetRegion(region)
-	failFastOnUnreachableRegion(&client.BaseClient)
-	return &client, nil
-}

--- a/providers/oci/connection/clients_test.go
+++ b/providers/oci/connection/clients_test.go
@@ -1,0 +1,475 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+// errFailedBuild stands in for whatever a client constructor can fail with.
+var errFailedBuild = errors.New("simulated build failure")
+
+// endpointer is the one thing every OCI service client has in common: an
+// Endpoint() promoted from the embedded common.BaseClient. It is what lets a
+// single table cover fifty differently-typed accessors.
+type endpointer interface {
+	Endpoint() string
+}
+
+const (
+	testTenancyOCID = "ocid1.tenancy.oc1..aaaaaaaatestonly"
+	testUserOCID    = "ocid1.user.oc1..aaaaaaaatestonly"
+
+	// Two real region names, deliberately in different realms' geographies, so
+	// a client that ignored the requested region produces a visible collision.
+	regionA = "us-ashburn-1"
+	regionB = "eu-frankfurt-1"
+)
+
+// testConnection builds a connection backed by a freshly generated key. No
+// request is ever sent - the SDK needs a parseable key to construct a signer,
+// and generating one keeps the test free of fixtures and of anything that looks
+// like a real credential.
+func testConnection(t *testing.T) *OciConnection {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating a test key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return &OciConnection{
+		config: common.NewRawConfigurationProvider(
+			testTenancyOCID, testUserOCID, regionA,
+			"aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+			string(keyPEM), nil,
+		),
+		// tenancyOcid is read by TenantID(); no client construction needs it.
+		tenancyOcid: testTenancyOCID,
+	}
+}
+
+// errorType and endpointerType support clientAccessorNames below.
+var (
+	errorType      = reflect.TypeFor[error]()
+	endpointerType = reflect.TypeFor[endpointer]()
+)
+
+// clientAccessorNames reflects over OciConnection to find every method that
+// hands back an OCI service client, identified structurally: it returns
+// (something with an Endpoint(), error).
+//
+// Reflection rather than a hand-kept list, because the whole value of the
+// coverage test below is that it notices an accessor a human forgot.
+func clientAccessorNames(t *testing.T) []string {
+	t.Helper()
+
+	typ := reflect.TypeFor[*OciConnection]()
+	names := make([]string, 0, typ.NumMethod())
+	for method := range typ.Methods() {
+		signature := method.Type
+		if signature.NumOut() != 2 || signature.Out(1) != errorType {
+			continue
+		}
+		returned := signature.Out(0)
+		if returned.Implements(endpointerType) || reflect.PointerTo(returned).Implements(endpointerType) {
+			names = append(names, method.Name)
+		}
+	}
+	return names
+}
+
+// regionalAccessors is every client accessor addressed by region.
+//
+// The point of enumerating all of them is that clients.go builds each one
+// through a shared generic helper. A mis-wired service string or constructor
+// would compile perfectly and only show up as requests aimed at the wrong
+// service or the wrong region, which no other test in this provider would
+// catch. Keep this list in sync with clients.go; a new regional accessor
+// belongs here.
+var regionalAccessors = map[string]func(*OciConnection, string) (endpointer, error){
+	// Identity
+	"IdentityClientWithRegion": func(c *OciConnection, r string) (endpointer, error) { return c.IdentityClientWithRegion(r) },
+
+	// Core
+	"ComputeClient":      func(c *OciConnection, r string) (endpointer, error) { return c.ComputeClient(r) },
+	"NetworkClient":      func(c *OciConnection, r string) (endpointer, error) { return c.NetworkClient(r) },
+	"BlockstorageClient": func(c *OciConnection, r string) (endpointer, error) { return c.BlockstorageClient(r) },
+
+	// Storage
+	"ObjectStorageClient": func(c *OciConnection, r string) (endpointer, error) { return c.ObjectStorageClient(r) },
+	"FileStorageClient":   func(c *OciConnection, r string) (endpointer, error) { return c.FileStorageClient(r) },
+
+	// Databases
+	"DatabaseClient":          func(c *OciConnection, r string) (endpointer, error) { return c.DatabaseClient(r) },
+	"MysqlDbSystemClient":     func(c *OciConnection, r string) (endpointer, error) { return c.MysqlDbSystemClient(r) },
+	"PostgresqlClient":        func(c *OciConnection, r string) (endpointer, error) { return c.PostgresqlClient(r) },
+	"NosqlClient":             func(c *OciConnection, r string) (endpointer, error) { return c.NosqlClient(r) },
+	"OpensearchClusterClient": func(c *OciConnection, r string) (endpointer, error) { return c.OpensearchClusterClient(r) },
+	"RedisClusterClient":      func(c *OciConnection, r string) (endpointer, error) { return c.RedisClusterClient(r) },
+	"GoldenGateClient":        func(c *OciConnection, r string) (endpointer, error) { return c.GoldenGateClient(r) },
+	"DataSafeClient":          func(c *OciConnection, r string) (endpointer, error) { return c.DataSafeClient(r) },
+
+	// Messaging
+	"StreamAdminClient":              func(c *OciConnection, r string) (endpointer, error) { return c.StreamAdminClient(r) },
+	"QueueAdminClient":               func(c *OciConnection, r string) (endpointer, error) { return c.QueueAdminClient(r) },
+	"KafkaClusterClient":             func(c *OciConnection, r string) (endpointer, error) { return c.KafkaClusterClient(r) },
+	"EventsClient":                   func(c *OciConnection, r string) (endpointer, error) { return c.EventsClient(r) },
+	"NotificationControlPlaneClient": func(c *OciConnection, r string) (endpointer, error) { return c.NotificationControlPlaneClient(r) },
+	"NotificationDataPlaneClient":    func(c *OciConnection, r string) (endpointer, error) { return c.NotificationDataPlaneClient(r) },
+	"ServiceConnectorClient":         func(c *OciConnection, r string) (endpointer, error) { return c.ServiceConnectorClient(r) },
+
+	// Networking edge
+	"LoadBalancerClient":        func(c *OciConnection, r string) (endpointer, error) { return c.LoadBalancerClient(r) },
+	"NetworkLoadBalancerClient": func(c *OciConnection, r string) (endpointer, error) { return c.NetworkLoadBalancerClient(r) },
+	"NetworkFirewallClient":     func(c *OciConnection, r string) (endpointer, error) { return c.NetworkFirewallClient(r) },
+	"WafClient":                 func(c *OciConnection, r string) (endpointer, error) { return c.WafClient(r) },
+	"DnsClient":                 func(c *OciConnection, r string) (endpointer, error) { return c.DnsClient(r) },
+	"BastionClient":             func(c *OciConnection, r string) (endpointer, error) { return c.BastionClient(r) },
+
+	// API gateway
+	"ApiGatewayClient":           func(c *OciConnection, r string) (endpointer, error) { return c.ApiGatewayClient(r) },
+	"ApiGatewayGatewayClient":    func(c *OciConnection, r string) (endpointer, error) { return c.ApiGatewayGatewayClient(r) },
+	"ApiGatewayDeploymentClient": func(c *OciConnection, r string) (endpointer, error) { return c.ApiGatewayDeploymentClient(r) },
+
+	// Containers and functions
+	"ContainerEngineClient":     func(c *OciConnection, r string) (endpointer, error) { return c.ContainerEngineClient(r) },
+	"ContainerInstanceClient":   func(c *OciConnection, r string) (endpointer, error) { return c.ContainerInstanceClient(r) },
+	"FunctionsManagementClient": func(c *OciConnection, r string) (endpointer, error) { return c.FunctionsManagementClient(r) },
+
+	// Keys, secrets, certificates
+	"KmsVaultClient":               func(c *OciConnection, r string) (endpointer, error) { return c.KmsVaultClient(r) },
+	"VaultsClient":                 func(c *OciConnection, r string) (endpointer, error) { return c.VaultsClient(r) },
+	"CertificatesManagementClient": func(c *OciConnection, r string) (endpointer, error) { return c.CertificatesManagementClient(r) },
+
+	// Governance and observability
+	"AuditClient":                 func(c *OciConnection, r string) (endpointer, error) { return c.AuditClient(r) },
+	"CloudGuardClient":            func(c *OciConnection, r string) (endpointer, error) { return c.CloudGuardClient(r) },
+	"LoggingClient":               func(c *OciConnection, r string) (endpointer, error) { return c.LoggingClient(r) },
+	"MonitoringClient":            func(c *OciConnection, r string) (endpointer, error) { return c.MonitoringClient(r) },
+	"ResourceManagerClient":       func(c *OciConnection, r string) (endpointer, error) { return c.ResourceManagerClient(r) },
+	"VulnerabilityScanningClient": func(c *OciConnection, r string) (endpointer, error) { return c.VulnerabilityScanningClient(r) },
+
+	// AI services
+	"GenerativeAiClient":      func(c *OciConnection, r string) (endpointer, error) { return c.GenerativeAiClient(r) },
+	"GenerativeAiAgentClient": func(c *OciConnection, r string) (endpointer, error) { return c.GenerativeAiAgentClient(r) },
+	"DataScienceClient":       func(c *OciConnection, r string) (endpointer, error) { return c.DataScienceClient(r) },
+	"AILanguageClient":        func(c *OciConnection, r string) (endpointer, error) { return c.AILanguageClient(r) },
+	"AIVisionClient":          func(c *OciConnection, r string) (endpointer, error) { return c.AIVisionClient(r) },
+	"AISpeechClient":          func(c *OciConnection, r string) (endpointer, error) { return c.AISpeechClient(r) },
+	"AIDocumentClient":        func(c *OciConnection, r string) (endpointer, error) { return c.AIDocumentClient(r) },
+}
+
+// TestRegionalClientsTargetTheRequestedRegion is the proof that collapsing ~50
+// hand-written accessors onto one generic helper did not mis-wire any of them.
+//
+// Each accessor has to satisfy three things at once: the endpoint names the
+// region it was asked for, two regions do not share a client, and the same
+// region hands back the same client. The first catches a dropped SetRegion, the
+// second a cache key missing its region, the third a cache key that is not
+// shared at all.
+func TestRegionalClientsTargetTheRequestedRegion(t *testing.T) {
+	for name, accessor := range regionalAccessors {
+		t.Run(name, func(t *testing.T) {
+			conn := testConnection(t)
+
+			a, err := accessor(conn, regionA)
+			if err != nil {
+				t.Fatalf("%s(%q): %v", name, regionA, err)
+			}
+			b, err := accessor(conn, regionB)
+			if err != nil {
+				t.Fatalf("%s(%q): %v", name, regionB, err)
+			}
+
+			endpointA, endpointB := a.Endpoint(), b.Endpoint()
+
+			if !strings.Contains(endpointA, regionA) {
+				t.Errorf("%s(%q) endpoint %q does not name the region", name, regionA, endpointA)
+			}
+			if !strings.Contains(endpointB, regionB) {
+				t.Errorf("%s(%q) endpoint %q does not name the region", name, regionB, endpointB)
+			}
+			if endpointA == endpointB {
+				t.Errorf("%s: both regions resolved to the same endpoint %q", name, endpointA)
+			}
+			if a == b {
+				t.Errorf("%s: both regions returned the same cached client; the cache key is missing the region", name)
+			}
+
+			// Same region, second call: must be the identical client, or the
+			// fan-out is still paying for a new connection pool per job.
+			again, err := accessor(conn, regionA)
+			if err != nil {
+				t.Fatalf("%s(%q) on the second call: %v", name, regionA, err)
+			}
+			if again != a {
+				t.Errorf("%s(%q) built a second client instead of reusing the cached one", name, regionA)
+			}
+		})
+	}
+}
+
+// TestEveryRegionalAccessorIsCovered fails when clients.go grows a regional
+// accessor that regionalAccessors above does not list, so the exhaustiveness
+// this file claims stays true instead of decaying silently.
+func TestEveryRegionalAccessorIsCovered(t *testing.T) {
+	// Accessors that are deliberately not region-addressed.
+	exempt := map[string]string{
+		"IdentityClient":        "global within a realm; uses the config provider's region",
+		"IdentityDomainsClient": "addressed by the domain's own endpoint",
+		"KmsManagementClient":   "addressed by the vault's management endpoint",
+	}
+
+	discovered := clientAccessorNames(t)
+
+	// Without this the test passes vacuously if the reflection above ever stops
+	// matching - a renamed Endpoint(), a changed return shape - and the
+	// exhaustiveness claim would quietly become worthless.
+	if want := len(regionalAccessors) + len(exempt); len(discovered) != want {
+		t.Errorf("reflection found %d client accessors, expected %d (%d regional + %d exempt); "+
+			"if an accessor was added or removed, update regionalAccessors or exempt",
+			len(discovered), want, len(regionalAccessors), len(exempt))
+	}
+
+	for _, name := range discovered {
+		if _, ok := regionalAccessors[name]; ok {
+			continue
+		}
+		if _, ok := exempt[name]; ok {
+			continue
+		}
+		t.Errorf("%s is declared on OciConnection but is neither in regionalAccessors nor exempt; "+
+			"add it to one of the two so the wiring stays covered", name)
+	}
+}
+
+// TestClientCacheKeysDoNotCollide is the check the compiler cannot make.
+//
+// An accessor's constructor is type-checked against its declared return type, so
+// a wrong constructor will not build. The cache key is just a string: two
+// accessors for differently-typed clients that happen to share one - the three
+// apigateway clients, the two ons planes, the two keymanagement clients - would
+// hand the second caller the first caller's client. Exercising every accessor
+// against one connection and counting the distinct keys catches that.
+func TestClientCacheKeysDoNotCollide(t *testing.T) {
+	conn := testConnection(t)
+
+	for name, accessor := range regionalAccessors {
+		if _, err := accessor(conn, regionA); err != nil {
+			t.Fatalf("%s(%q): %v", name, regionA, err)
+		}
+	}
+	if _, err := conn.IdentityClient(); err != nil {
+		t.Fatalf("IdentityClient(): %v", err)
+	}
+
+	keys := 0
+	conn.clients.Range(func(_, _ any) bool {
+		keys++
+		return true
+	})
+
+	// One key per accessor. A collision shows up as a shortfall, and because
+	// cachedClient reports a type mismatch as an error rather than panicking,
+	// the loop above would already have failed for a same-region collision.
+	if want := len(regionalAccessors) + 1; keys != want {
+		t.Errorf("cached %d clients for %d accessors; two accessors are sharing a cache key", keys, want)
+	}
+}
+
+// TestIdentityClientIsShared covers the one accessor that returns its client by
+// value. Callers get copies, but they must be copies of a single underlying
+// client rather than a fresh construction per call.
+func TestIdentityClientIsShared(t *testing.T) {
+	conn := testConnection(t)
+
+	first, err := conn.IdentityClient()
+	if err != nil {
+		t.Fatalf("IdentityClient(): %v", err)
+	}
+	second, err := conn.IdentityClient()
+	if err != nil {
+		t.Fatalf("IdentityClient() on the second call: %v", err)
+	}
+
+	// The copies share the BaseClient's HTTPClient pointer, which is the thing
+	// that owns the connection pool.
+	if first.HTTPClient != second.HTTPClient {
+		t.Error("IdentityClient() built a second client; the two copies do not share a transport")
+	}
+}
+
+// TestEndpointAddressedClientsKeyOnTheEndpoint checks the two clients that are
+// addressed by endpoint rather than region: distinct endpoints must not collide
+// in the shared cache.
+func TestEndpointAddressedClientsKeyOnTheEndpoint(t *testing.T) {
+	conn := testConnection(t)
+
+	const (
+		domainA = "https://idcs-aaaa.identity.oraclecloud.com"
+		domainB = "https://idcs-bbbb.identity.oraclecloud.com"
+	)
+
+	a, err := conn.IdentityDomainsClient(domainA)
+	if err != nil {
+		t.Fatalf("IdentityDomainsClient(%q): %v", domainA, err)
+	}
+	b, err := conn.IdentityDomainsClient(domainB)
+	if err != nil {
+		t.Fatalf("IdentityDomainsClient(%q): %v", domainB, err)
+	}
+	if a == b {
+		t.Error("two identity domains shared one client; the cache key is missing the endpoint")
+	}
+	again, err := conn.IdentityDomainsClient(domainA)
+	if err != nil {
+		t.Fatalf("IdentityDomainsClient(%q) on the second call: %v", domainA, err)
+	}
+	if again != a {
+		t.Error("IdentityDomainsClient did not reuse the cached client for a repeated endpoint")
+	}
+
+	vaultA, err := conn.KmsManagementClient("https://aaaa-management.kms.us-ashburn-1.oci.oraclecloud.com")
+	if err != nil {
+		t.Fatalf("KmsManagementClient: %v", err)
+	}
+	vaultB, err := conn.KmsManagementClient("https://bbbb-management.kms.us-ashburn-1.oci.oraclecloud.com")
+	if err != nil {
+		t.Fatalf("KmsManagementClient: %v", err)
+	}
+	if vaultA == vaultB {
+		t.Error("two KMS vaults shared one management client; the cache key is missing the endpoint")
+	}
+}
+
+// TestIdentityDomainsClientRejectsAnEmptyEndpoint pins the guard that keeps an
+// empty endpoint from reaching the SDK, and confirms the failure is not cached
+// under the empty key.
+func TestIdentityDomainsClientRejectsAnEmptyEndpoint(t *testing.T) {
+	conn := testConnection(t)
+
+	if _, err := conn.IdentityDomainsClient(""); err == nil {
+		t.Fatal("expected an error for an empty identity domain endpoint")
+	}
+	if _, cached := conn.clients.Load("identitydomains/"); cached {
+		t.Error("a rejected endpoint was cached; a later valid call would receive the failure")
+	}
+}
+
+// TestCachedClientDoesNotCacheFailures makes the retry-after-failure property
+// explicit: a build error must leave the key empty so a transient auth or
+// config failure does not poison it for the rest of the scan.
+func TestCachedClientDoesNotCacheFailures(t *testing.T) {
+	conn := testConnection(t)
+
+	calls := 0
+	failing := func() (*int, error) {
+		calls++
+		return nil, errFailedBuild
+	}
+
+	if _, err := cachedClient(conn, "test/failing", failing); err == nil {
+		t.Fatal("expected the build error to surface")
+	}
+	if _, err := cachedClient(conn, "test/failing", failing); err == nil {
+		t.Fatal("expected the build error to surface on the second call too")
+	}
+	if calls != 2 {
+		t.Errorf("build ran %d times; a failure must not be cached", calls)
+	}
+
+	// Once it succeeds, the result is cached and the build stops running.
+	value := 42
+	succeeding := func() (*int, error) {
+		calls++
+		return &value, nil
+	}
+	first, err := cachedClient(conn, "test/failing", succeeding)
+	if err != nil {
+		t.Fatalf("unexpected error after recovery: %v", err)
+	}
+	second, err := cachedClient(conn, "test/failing", succeeding)
+	if err != nil {
+		t.Fatalf("unexpected error on the cached read: %v", err)
+	}
+	if first != second {
+		t.Error("a successful build was not cached")
+	}
+	if calls != 3 {
+		t.Errorf("build ran %d times; the successful result should have been reused", calls)
+	}
+}
+
+// TestCachedClientIsSafeUnderConcurrency is the property the fan-out depends on.
+// Run under -race it also covers the sync.Map access itself; without the shared
+// cache every one of these callers would have built its own client.
+func TestCachedClientIsSafeUnderConcurrency(t *testing.T) {
+	conn := testConnection(t)
+
+	const goroutines = 32
+	results := make([]*int, goroutines)
+	value := 7
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Go(func() {
+			got, err := cachedClient(conn, "test/concurrent", func() (*int, error) {
+				// A fresh allocation per build, so a second published client is
+				// detectable as a different pointer.
+				v := value
+				return &v, nil
+			})
+			if err != nil {
+				t.Errorf("cachedClient: %v", err)
+				return
+			}
+			results[i] = got
+		})
+	}
+	wg.Wait()
+
+	for i, got := range results {
+		if got == nil {
+			t.Fatalf("goroutine %d got no client", i)
+		}
+		if got != results[0] {
+			t.Fatalf("goroutine %d received a different client; exactly one must be published", i)
+		}
+	}
+}
+
+// TestRegionalClientsAreIndependentAcrossConnections guards against the cache
+// accidentally becoming process-wide. Two tenancies scanned in one run must not
+// share clients, because they do not share credentials.
+func TestRegionalClientsAreIndependentAcrossConnections(t *testing.T) {
+	first := testConnection(t)
+	second := testConnection(t)
+
+	a, err := first.ComputeClient(regionA)
+	if err != nil {
+		t.Fatalf("ComputeClient on the first connection: %v", err)
+	}
+	b, err := second.ComputeClient(regionA)
+	if err != nil {
+		t.Fatalf("ComputeClient on the second connection: %v", err)
+	}
+	if a == b {
+		t.Error("two connections shared a client; the cache must be per-connection")
+	}
+}

--- a/providers/oci/connection/connection.go
+++ b/providers/oci/connection/connection.go
@@ -30,6 +30,10 @@ type OciConnection struct {
 	compartmentLock  sync.Mutex
 	compartmentList  []identity.Compartment
 	compartmentsDone bool
+
+	// Service clients, keyed by "<service>/<region-or-endpoint>". See
+	// cachedClient in clients.go for why they are shared rather than rebuilt.
+	clients sync.Map
 }
 
 func NewOciConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*OciConnection, error) {

--- a/providers/oci/connection/tenancy.go
+++ b/providers/oci/connection/tenancy.go
@@ -1,0 +1,124 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"context"
+	"errors"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identity"
+)
+
+// The tenancy-shaped reads every lister depends on before it can fan out: which
+// tenancy this is, which compartments it contains, and which regions it is
+// subscribed to.
+
+func (c *OciConnection) TenantID() string {
+	return c.tenancyOcid
+}
+
+func (c *OciConnection) Tenant(ctx context.Context) (*identity.Tenancy, error) {
+	oClient, err := c.IdentityClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := oClient.GetTenancy(ctx, identity.GetTenancyRequest{
+		TenancyId: &c.tenancyOcid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Tenancy, nil
+}
+
+// GetCompartments returns the tenancy root plus every active compartment
+// beneath it.
+//
+// The result is memoized for the lifetime of the connection. A dozen listers
+// fan out over the compartment tree, and each one asking for it separately
+// meant walking the same paginated ListCompartments a dozen times per scan.
+//
+// A failure is not cached: an Identity call that fails on a throttle should be
+// retried by the next lister rather than turning one bad moment into a scan
+// with no compartments at all.
+func (c *OciConnection) GetCompartments(ctx context.Context) ([]identity.Compartment, error) {
+	c.compartmentLock.Lock()
+	defer c.compartmentLock.Unlock()
+	if c.compartmentsDone {
+		return c.compartmentList, nil
+	}
+
+	oClient, err := c.IdentityClient()
+	if err != nil {
+		return nil, err
+	}
+
+	compartments := make([]identity.Compartment, 0)
+
+	req := identity.GetCompartmentRequest{
+		CompartmentId: &c.tenancyOcid,
+	}
+
+	resp, err := oClient.GetCompartment(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	compartments = append(compartments, resp.Compartment)
+
+	var page *string
+	for {
+		request := identity.ListCompartmentsRequest{
+			CompartmentId:          common.String(c.tenancyOcid),
+			CompartmentIdInSubtree: common.Bool(true),
+			LifecycleState:         identity.CompartmentLifecycleStateActive,
+			Page:                   page,
+		}
+
+		response, err := oClient.ListCompartments(ctx, request)
+		if err != nil {
+			return nil, errors.Join(errors.New("failed to list compartments in tenancy: "+c.tenancyOcid), err)
+		}
+
+		for i := range response.Items {
+			compartments = append(compartments, response.Items[i])
+		}
+
+		page = response.OpcNextPage
+		if response.OpcNextPage == nil {
+			break
+		}
+	}
+
+	c.compartmentList = compartments
+	c.compartmentsDone = true
+	return compartments, nil
+}
+
+func (c *OciConnection) GetRegions(ctx context.Context) ([]identity.RegionSubscription, error) {
+	oClient, err := c.IdentityClient()
+	if err != nil {
+		return nil, err
+	}
+
+	request := identity.ListRegionSubscriptionsRequest{
+		TenancyId: common.String(c.tenancyOcid),
+	}
+
+	response, err := oClient.ListRegionSubscriptions(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	regions := make([]identity.RegionSubscription, 0)
+	for _, region := range response.Items {
+		if region.Status != identity.RegionSubscriptionStatusReady {
+			continue
+		}
+		regions = append(regions, region)
+	}
+
+	return regions, nil
+}


### PR DESCRIPTION
## What

Build each OCI service client **once per `(service, region)`** and share it, instead of constructing a fresh one at every point of use.

A lister fans out over every `(region, compartment)` pair in the tenancy, so a fifty-compartment tenancy across five subscribed regions built **250 clients for one collection**.

That is not just allocation. `common.NewClientWithConfig` gives each client its own `OciHTTPTransportWrapper`, and therefore its own connection pool, so those 250 clients shared no TCP connections and repeated the TLS handshake for every one. **This provider had no connection reuse at all.**

## Why it is safe to share

Narrow, and worth stating precisely:

- `BaseClient.Call` takes a **value receiver** and `prepareRequest` writes nothing back to the client, so concurrent requests do not race.
- What *does* write to a client is `SetRegion`, `SetCustomClientConfiguration`, and the `HTTPClient` swap inside `failFastOnUnreachableRegion`. All three now happen **inside the build closure**, before the client is visible to another goroutine.
- Nothing outside `clients.go` touches a client after construction (verified: no `SetRegion` / `Host =` / `HTTPClient =` anywhere in `resources/`).

A build failure is deliberately **not** cached, so a transient auth or config failure is retried by the next caller rather than poisoning the key for the rest of the scan.

## Behavior

Unchanged. Same endpoints, same requests, same results. All **56 method signatures on `OciConnection` are byte-identical**, so no caller moved.

## Also in here

The ~60 copy-paste accessors collapse onto three helpers — `regionalClient`, `aiClient`, `endpointClient` — which has the side benefit of making the genuinely different clients *visible* instead of hiding them among identical siblings:

- the two **endpoint-addressed** clients (identity domains, KMS management)
- the seven **AI** clients that need the fail-fast timeout for regions where the service is not deployed

Adding an AI service can no longer skip the fail-fast step, because the only route to those constructors applies it.

The tenancy, compartment, and region reads move to `tenancy.go` unchanged, so `clients.go` is only the client registry.

## Tests

Two invariants, neither checked by the compiler:

- **Every regional accessor targets the region it was handed**, two regions do not share a client, and the same region reuses one. The accessor list is derived by **reflection**, so a new accessor nobody added to the table fails rather than going quietly uncovered. 49 regional + 3 exempt = 52, matching the 56 methods minus the 4 that are not clients. A non-vacuity guard fails if the reflection ever stops matching.
- **Cache keys do not collide.** An accessor's constructor is type-checked against its declared return type, but the key is just a string — and the three apigateway clients, two ons planes and two keymanagement clients are exactly the shape that collides. A shared key is now reported as an error *naming the key* rather than panicking on a failed type assertion, because a panic inside a lister takes down the whole scan.

Both tests were mutation-checked: renaming a table entry and deliberately colliding two apigateway keys each produce the intended failure.

`go build`, `go vet`, and `go test -race ./...` are clean across the provider.

## Context

First of six behavior-preserving PRs restructuring this provider's internals. The user-facing surface — the `.lr` schema, all 211 resources, field names and types, discovery targets, CLI flags — does not move in any of them. Still to come: a generic paginator (~90 hand-written loops), one scope-typed fan-out replacing the two competing idioms, mapping helpers, a generic typed-ref resolver, and a table-driven discovery registry.

Two behavior-*changing* follow-ups are deliberately quarantined out of that sequence: migrating the 73 root-compartment-only listers to walk the compartment tree, and converging the two pools' error policies.

## Verification owed

Live validation against a real tenancy is still outstanding for this provider (carried over from #9573–#9578). The two things here most deserving of that eventual pass are the shared-client behavior under real concurrent fan-out, and the AI clients' fail-fast path in regions where the service is not deployed.
