### PR TITLE
🐛 multierr: Deduplicate preserves first-occurrence order

### DIFF
--- a/utils/multierr/errors.go
+++ b/utils/multierr/errors.go
@@ -71,22 +71,27 @@ func (m *Errors) Error() string {
 	return res.String()
 }
 
+// Deduplicate returns the errors with duplicates (by message) removed,
+// preserving first-occurrence order. Order preservation is load-bearing:
+// callers render the result into user-visible strings (score messages,
+// upload failures), and rebuilding the slice from a map made the rendered
+// order a per-run dice roll — the same errors produced differently-ordered
+// messages on every scan.
 func (m Errors) Deduplicate() error {
 	if len(m.Errors) == 0 {
 		return nil
 	}
 
-	track := map[string]error{}
+	seen := make(map[string]struct{}, len(m.Errors))
+	res := make([]error, 0, len(m.Errors))
 	for i := range m.Errors {
 		e := m.Errors[i]
-		track[e.Error()] = e
-	}
-
-	res := make([]error, len(track))
-	i := 0
-	for _, v := range track {
-		res[i] = v
-		i++
+		msg := e.Error()
+		if _, ok := seen[msg]; ok {
+			continue
+		}
+		seen[msg] = struct{}{}
+		res = append(res, e)
 	}
 	return &Errors{Errors: res}
 }

--- a/utils/multierr/errors_test.go
+++ b/utils/multierr/errors_test.go
@@ -32,4 +32,31 @@ func TestMultiErr(t *testing.T) {
 		err := e.Deduplicate()
 		assert.Nil(t, err)
 	})
+
+	// Deduplicate must preserve first-occurrence order: callers render the
+	// result into user-visible strings, and a map-ordered rebuild made the
+	// same errors produce differently-ordered messages on every run. With
+	// three distinct errors an order regression flips the rendered string
+	// with probability 5/6 per attempt, so 50 identical runs fail loudly.
+	t.Run("deduplicate preserves first-occurrence order", func(t *testing.T) {
+		build := func() multierr.Errors {
+			var e multierr.Errors
+			e.Add(
+				errors.New("fdesetup list failed"),
+				errors.New("fdesetup hasinstitutionalrecoverykey failed"),
+				errors.New("fdesetup list failed"),
+				errors.New("fdesetup haspersonalrecoverykey failed"),
+			)
+			return e
+		}
+
+		want := "3 errors occurred:\n" +
+			"\t* fdesetup list failed\n" +
+			"\t* fdesetup hasinstitutionalrecoverykey failed\n" +
+			"\t* fdesetup haspersonalrecoverykey failed\n"
+
+		for range 50 {
+			assert.Equal(t, want, build().Deduplicate().Error())
+		}
+	})
 }


### PR DESCRIPTION
## The bug

`Errors.Deduplicate()` rebuilt its result by ranging over the dedup map, so the returned errors came back in **Go's randomized map-iteration order** — deterministic input, differently-ordered output on every run.

Callers render the result into user-visible strings (cnspec's score messages, upload-failure reports), so the same set of errors produced a differently-ordered message on every scan — churning stored score rows and scan history on content that didn't change. Surfaced by the scan-content-digest work, whose per-row digests flagged byte-level churn on otherwise identical scans; mondoohq/cnspec#3179 is the executor-side companion (it no longer relies on `Deduplicate` for message rendering, so the two PRs are independent — this one fixes the shared utility for every other caller).

## The fix

Dedup keeps **first-occurrence order**: same contract (dedup by message, empty → nil), the order simply becomes stable. Regression test renders three distinct errors 50 times and asserts an identical string — unfixed, the order flips with probability 5/6 per attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HHX819u6q9PngxJfpCaST