### PR TITLE
✨ Add Qdrant provider schema (design / RFC)

### DIFF
--- a/providers/qdrant/README.md
+++ b/providers/qdrant/README.md
@@ -1,0 +1,47 @@
+# Qdrant provider (PROTOTYPE - schema design)
+
+Wave 4 of the AI-service coverage concept. This directory currently contains
+**only the resource schema** (`resources/qdrant.lr`) as a design prototype for a
+net-new Qdrant provider (the vector-database archetype).
+
+It is intentionally **not registered** in `providers.yaml`, so it is not built by
+`make providers` and cannot break the build.
+
+## Why Qdrant
+
+Qdrant is a leading open-source vector database used as a RAG backend. Together
+with the existing Weaviate provider it establishes the vector-DB coverage
+pattern that Pinecone, Milvus/Zilliz, and Chroma follow. Vector stores hold
+embeddings of proprietary content, so anonymous access, TLS, and RBAC are the
+security-critical controls.
+
+## Resource surface (see `resources/qdrant.lr`)
+
+| Resource | Purpose | Security-relevant fields |
+|---|---|---|
+| `qdrant` | instance root | `apiKeyRequired`, `tlsEnabled`, `jwtRbacEnabled`, `readOnlyApiKeySupported` |
+| `qdrant.collection` | vector collection | `replicationFactor`, `onDiskPayload`, status |
+
+## Remaining steps to make this a working provider
+
+1. `config/config.go` — provider metadata + `Version`
+2. `connection/` — HTTP(S) connection with optional API key / JWT
+3. `provider/` — `ParseCLI` / `Connect` / `GetData` / `StoreData` / `Disconnect`
+4. `gen/main.go`, `main.go`, and registration in the four provider-registry sites
+5. `mqlr generate providers/qdrant/resources/qdrant.lr --dist providers/qdrant/resources`
+6. Implement the generated interfaces (Pattern A for the collections list; the
+   root posture fields come from the instance `/` and `/telemetry` endpoints)
+7. Generate `qdrant.permissions.json`, add `.lr.versions` entries
+8. **Verify against a live Qdrant instance** before GA
+
+## Planned cnspec security policy (`mondoo-qdrant-security`, Wave 4)
+
+Maps to the AI security control framework (Tier-2 self-hosted / vector DB):
+
+- **Authentication** — API key required (`qdrant.apiKeyRequired == true`)
+- **Transport** — TLS enabled (`qdrant.tlsEnabled == true`)
+- **Authorization** — JWT RBAC enabled (`qdrant.jwtRbacEnabled == true`)
+- **Resilience** — collections replicated (`qdrant.collections.all(replicationFactor > 1)`)
+
+Mirrors the shape of `mondoo-weaviate-security` (Wave 1). The policy ships once
+the provider builds and the fields are verified live.

--- a/providers/qdrant/resources/qdrant.lr
+++ b/providers/qdrant/resources/qdrant.lr
@@ -1,0 +1,72 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// PROTOTYPE - AI service coverage concept (Wave 4)
+// Schema design for a net-new Qdrant provider (vector-database archetype).
+// This .lr defines the resource surface only. Remaining steps before it builds:
+// config.go, connection/, provider/, gen/main.go, main.go, provider
+// registration, `mqlr generate`, resource implementation, and verification
+// against a live Qdrant instance. See providers/qdrant/README.md.
+
+option provider = "go.mondoo.com/mql/providers/qdrant"
+option go_package = "go.mondoo.com/mql/v13/providers/qdrant/resources"
+
+// Qdrant instance
+//
+// Vector database instance covering its version, transport security,
+// access-control posture, and the collections it hosts. Vector databases
+// store the embeddings that power retrieval-augmented generation and
+// often hold sensitive proprietary content, so the authentication, TLS,
+// and collection isolation surfaced here are security-critical.
+qdrant @defaults("version apiKeyRequired tlsEnabled") {
+  // Server version
+  version() string
+  // Whether an API key is required for requests
+  //
+  // When false the instance accepts unauthenticated requests, exposing
+  // all collections to anyone who can reach the endpoint.
+  apiKeyRequired() bool
+  // Whether read-only API keys are supported and in use
+  readOnlyApiKeySupported() bool
+  // Whether TLS is enabled for the API
+  tlsEnabled() bool
+  // Whether JWT-based role authorization is enabled
+  //
+  // When true, fine-grained access is enforced through signed tokens
+  // rather than a single shared API key with full access.
+  jwtRbacEnabled() bool
+  // Collections hosted on the instance
+  collections() []qdrant.collection
+}
+
+// Qdrant collection
+//
+// Named collection of vectors on a Qdrant instance, holding the
+// embeddings and payloads for one dataset. The `name` field selects the
+// collection, for example qdrant.collections.where(name == "documents").
+// Replication and sharding fields describe how the collection tolerates
+// node loss, and the payload-storage flag reports whether raw payloads
+// are kept on disk.
+qdrant.collection @defaults("name status vectorsCount") {
+  // Collection name
+  name string
+  // Collection status
+  //
+  // One of green, yellow, grey, or red.
+  status string
+  // Number of vectors stored in the collection
+  vectorsCount int
+  // Replication factor
+  //
+  // Number of replicas kept for each shard. A value of 1 means the
+  // collection cannot tolerate the loss of a node holding its shard.
+  replicationFactor int
+  // Number of shards the collection is split into
+  shardNumber int
+  // Distance metric used for similarity search
+  //
+  // One of Cosine, Euclid, Dot, or Manhattan.
+  distance string
+  // Whether payloads are stored on disk rather than in memory
+  onDiskPayload bool
+}


### PR DESCRIPTION
## Summary

Introduces the resource **schema** for a net-new **Qdrant** provider (the vector-database archetype), as part of the AI-service coverage effort. This PR is **schema design only** — a starting point for review of the resource surface before the Go implementation is written.

Adds `providers/qdrant/resources/qdrant.lr` and a README.

## Resource surface

| Resource | Purpose | Security-relevant fields |
|---|---|---|
| `qdrant` | instance root | `apiKeyRequired`, `tlsEnabled`, `jwtRbacEnabled`, `readOnlyApiKeySupported` |
| `qdrant.collection` | vector collection | `replicationFactor`, `onDiskPayload`, status |

Together with the existing **Weaviate** provider, this establishes the vector-DB coverage pattern that Pinecone, Milvus/Zilliz, and Chroma can follow. Vector stores hold embeddings of proprietary content, so anonymous access, TLS, and RBAC are the security-critical controls.

## Status / scope

- ✅ Schema validated with `mqlr generate` — parses clean.
- ⚠️ **Intentionally not registered** in `providers.yaml`, so `make providers` does not build it and this PR cannot break the build.
- Remaining work before it's a functioning provider (tracked in `providers/qdrant/README.md`): `config/`, `connection/`, `provider/`, `gen/main.go`, `main.go`, registration, resource implementation, `.lr.versions` / `permissions.json`, and verification against a live Qdrant instance.

A companion `mondoo-qdrant-security` cnspec policy (API-key auth, TLS, JWT RBAC, collection replication) follows once the provider builds, mirroring the shape of `mondoo-weaviate-security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0133uVKDrGXDwx17CeviDQNh)_