### PR TITLE
🧹 oci: make pagination a property of the call, not something each author remembers

### DIFF
--- a/providers/oci/resources/aiservices.go
+++ b/providers/oci/resources/aiservices.go
@@ -99,20 +99,17 @@ func (o *mqlOciAiLanguage) id() (string, error) { return "oci.ai.language", nil 
 func (o *mqlOciAiLanguage) projects() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AILanguageClient, func(svc *ailanguage.AIServiceLanguageClient) ([]any, error) {
-		var items []ailanguage.ProjectSummary
-		var page *string
-		for {
-			resp, err := svc.ListProjects(context.Background(), ailanguage.ListProjectsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]ailanguage.ProjectSummary, *string, error) {
+			resp, err := svc.ListProjects(ctx, ailanguage.ListProjectsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {
@@ -140,20 +137,17 @@ func (o *mqlOciAiLanguage) projects() ([]any, error) {
 func (o *mqlOciAiLanguage) models() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AILanguageClient, func(svc *ailanguage.AIServiceLanguageClient) ([]any, error) {
-		var items []ailanguage.ModelSummary
-		var page *string
-		for {
-			resp, err := svc.ListModels(context.Background(), ailanguage.ListModelsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]ailanguage.ModelSummary, *string, error) {
+			resp, err := svc.ListModels(ctx, ailanguage.ListModelsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {
@@ -189,20 +183,17 @@ func (o *mqlOciAiLanguage) models() ([]any, error) {
 func (o *mqlOciAiLanguage) endpoints() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AILanguageClient, func(svc *ailanguage.AIServiceLanguageClient) ([]any, error) {
-		var items []ailanguage.EndpointSummary
-		var page *string
-		for {
-			resp, err := svc.ListEndpoints(context.Background(), ailanguage.ListEndpointsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]ailanguage.EndpointSummary, *string, error) {
+			resp, err := svc.ListEndpoints(ctx, ailanguage.ListEndpointsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {
@@ -317,20 +308,17 @@ func (o *mqlOciAiVision) id() (string, error) { return "oci.ai.vision", nil }
 func (o *mqlOciAiVision) projects() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AIVisionClient, func(svc *aivision.AIServiceVisionClient) ([]any, error) {
-		var items []aivision.ProjectSummary
-		var page *string
-		for {
-			resp, err := svc.ListProjects(context.Background(), aivision.ListProjectsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]aivision.ProjectSummary, *string, error) {
+			resp, err := svc.ListProjects(ctx, aivision.ListProjectsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {
@@ -357,20 +345,17 @@ func (o *mqlOciAiVision) projects() ([]any, error) {
 func (o *mqlOciAiVision) models() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AIVisionClient, func(svc *aivision.AIServiceVisionClient) ([]any, error) {
-		var items []aivision.ModelSummary
-		var page *string
-		for {
-			resp, err := svc.ListModels(context.Background(), aivision.ListModelsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]aivision.ModelSummary, *string, error) {
+			resp, err := svc.ListModels(ctx, aivision.ListModelsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {
@@ -448,20 +433,17 @@ func (o *mqlOciAiSpeech) id() (string, error) { return "oci.ai.speech", nil }
 func (o *mqlOciAiSpeech) customizations() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AISpeechClient, func(svc *aispeech.AIServiceSpeechClient) ([]any, error) {
-		var items []aispeech.CustomizationSummary
-		var page *string
-		for {
-			resp, err := svc.ListCustomizations(context.Background(), aispeech.ListCustomizationsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]aispeech.CustomizationSummary, *string, error) {
+			resp, err := svc.ListCustomizations(ctx, aispeech.ListCustomizationsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {
@@ -507,20 +489,17 @@ func (o *mqlOciAiDocument) id() (string, error) { return "oci.ai.document", nil 
 func (o *mqlOciAiDocument) projects() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AIDocumentClient, func(svc *aidocument.AIServiceDocumentClient) ([]any, error) {
-		var items []aidocument.ProjectSummary
-		var page *string
-		for {
-			resp, err := svc.ListProjects(context.Background(), aidocument.ListProjectsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]aidocument.ProjectSummary, *string, error) {
+			resp, err := svc.ListProjects(ctx, aidocument.ListProjectsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {
@@ -548,20 +527,17 @@ func (o *mqlOciAiDocument) projects() ([]any, error) {
 func (o *mqlOciAiDocument) models() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	return ociListRegionalAIClient(o.MqlRuntime, conn.AIDocumentClient, func(svc *aidocument.AIServiceDocumentClient) ([]any, error) {
-		var items []aidocument.ModelSummary
-		var page *string
-		for {
-			resp, err := svc.ListModels(context.Background(), aidocument.ListModelsRequest{
+		items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]aidocument.ModelSummary, *string, error) {
+			resp, err := svc.ListModels(ctx, aidocument.ListModelsRequest{
 				CompartmentId: common.String(conn.TenantID()), Page: page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-			items = append(items, resp.Items...)
-			if resp.OpcNextPage == nil {
-				break
-			}
-			page = resp.OpcNextPage
+			return resp.Items, resp.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		res := make([]any, 0, len(items))
 		for i := range items {

--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -59,21 +59,18 @@ func (o *mqlOciApigateway) getGateways(conn *connection.OciConnection, regions [
 				return nil, err
 			}
 
-			var items []apigateway.GatewaySummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]apigateway.GatewaySummary, *string, error) {
 				response, err := svc.ListGateways(ctx, apigateway.ListGatewaysRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -303,21 +300,18 @@ func (o *mqlOciApigateway) getDeployments(conn *connection.OciConnection, region
 				return nil, err
 			}
 
-			var items []apigateway.DeploymentSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]apigateway.DeploymentSummary, *string, error) {
 				response, err := svc.ListDeployments(ctx, apigateway.ListDeploymentsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -714,21 +708,18 @@ func (o *mqlOciApigateway) getCertificates(conn *connection.OciConnection, regio
 				return nil, err
 			}
 
-			var items []apigateway.CertificateSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]apigateway.CertificateSummary, *string, error) {
 				response, err := svc.ListCertificates(ctx, apigateway.ListCertificatesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))

--- a/providers/oci/resources/audit.go
+++ b/providers/oci/resources/audit.go
@@ -90,9 +90,7 @@ func (o *mqlOciAudit) events() ([]any, error) {
 				return nil, err
 			}
 
-			events := []audit.AuditEvent{}
-			var page *string
-			for {
+			events, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]audit.AuditEvent, *string, error) {
 				response, err := client.ListEvents(ctx, audit.ListEventsRequest{
 					CompartmentId: common.String(compartmentID),
 					StartTime:     &common.SDKTime{Time: startTime},
@@ -100,15 +98,12 @@ func (o *mqlOciAudit) events() ([]any, error) {
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				events = append(events, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			return o.newAuditEvents(events)

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -56,23 +56,18 @@ func (o *mqlOciBastion) getBastions(conn *connection.OciConnection, regions []an
 				return nil, err
 			}
 
-			bastions := []bastion.BastionSummary{}
-			var page *string
-			for {
+			bastions, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]bastion.BastionSummary, *string, error) {
 				response, err := svc.ListBastions(ctx, bastion.ListBastionsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				bastions = append(bastions, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any

--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -78,9 +78,7 @@ func (o *mqlOciObjectStorage) buckets() ([]any, error) {
 }
 
 func (o *mqlOciObjectStorage) getBucketsForRegion(ctx context.Context, objectStorageClient *objectstorage.ObjectStorageClient, compartmentID string, namespace string) ([]objectstorage.BucketSummary, error) {
-	entries := []objectstorage.BucketSummary{}
-	var page *string
-	for {
+	entries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]objectstorage.BucketSummary, *string, error) {
 		request := objectstorage.ListBucketsRequest{
 			NamespaceName: common.String(namespace),
 			CompartmentId: common.String(compartmentID),
@@ -89,16 +87,12 @@ func (o *mqlOciObjectStorage) getBucketsForRegion(ctx context.Context, objectSto
 
 		response, err := objectStorageClient.ListBuckets(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		entries = append(entries, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return entries, nil
@@ -518,22 +512,19 @@ func (o *mqlOciObjectStorageBucket) retentionRules() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	var rules []objectstorage.RetentionRuleSummary
-	var page *string
-	for {
+	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]objectstorage.RetentionRuleSummary, *string, error) {
 		response, err := client.ListRetentionRules(ctx, objectstorage.ListRetentionRulesRequest{
 			NamespaceName: common.String(namespace.Data),
 			BucketName:    common.String(name.Data),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		rules = append(rules, response.Items...)
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(rules))
@@ -609,22 +600,19 @@ func (o *mqlOciObjectStorageBucket) preauthenticatedRequests() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	var pars []objectstorage.PreauthenticatedRequestSummary
-	var page *string
-	for {
+	pars, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]objectstorage.PreauthenticatedRequestSummary, *string, error) {
 		response, err := client.ListPreauthenticatedRequests(ctx, objectstorage.ListPreauthenticatedRequestsRequest{
 			NamespaceName: common.String(namespace.Data),
 			BucketName:    common.String(name.Data),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		pars = append(pars, response.Items...)
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(pars))

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -50,21 +50,18 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 				return nil, err
 			}
 
-			var items []certificatesmanagement.CertificateSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]certificatesmanagement.CertificateSummary, *string, error) {
 				response, err := svc.ListCertificates(ctx, certificatesmanagement.ListCertificatesRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -257,21 +254,18 @@ func (o *mqlOciCertificates) getCertificateAuthorities(conn *connection.OciConne
 				return nil, err
 			}
 
-			var items []certificatesmanagement.CertificateAuthoritySummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]certificatesmanagement.CertificateAuthoritySummary, *string, error) {
 				response, err := svc.ListCertificateAuthorities(ctx, certificatesmanagement.ListCertificateAuthoritiesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -445,21 +439,18 @@ func (o *mqlOciCertificates) getCaBundles(conn *connection.OciConnection, region
 				return nil, err
 			}
 
-			var items []certificatesmanagement.CaBundleSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]certificatesmanagement.CaBundleSummary, *string, error) {
 				response, err := svc.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -179,9 +179,7 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	targets := []cloudguard.TargetSummary{}
-	var page *string
-	for {
+	targets, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.TargetSummary, *string, error) {
 		response, err := client.ListTargets(ctx, cloudguard.ListTargetsRequest{
 			CompartmentId: common.String(conn.TenantID()),
 			// Cloud Guard targets are attached to sub-compartments far more
@@ -190,15 +188,12 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 			Page:                   page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		targets = append(targets, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(targets))
@@ -262,8 +257,7 @@ func (o *mqlOciCloudGuard) problems() ([]any, error) {
 	// One pass per lifecycle state: the filter accepts a single value, and
 	// leaving it unset is not the union - the service falls back to ACTIVE.
 	for _, state := range ociCloudGuardProblemStates {
-		var page *string
-		for {
+		perState, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.ProblemSummary, *string, error) {
 			response, err := client.ListProblems(ctx, cloudguard.ListProblemsRequest{
 				CompartmentId: common.String(conn.TenantID()),
 				// Problems are raised against resources in sub-compartments, so
@@ -277,16 +271,14 @@ func (o *mqlOciCloudGuard) problems() ([]any, error) {
 				Page:                                 page,
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
-
-			problems = append(problems, response.Items...)
-
-			if response.OpcNextPage == nil {
-				break
-			}
-			page = response.OpcNextPage
+			return response.Items, response.OpcNextPage, nil
+		})
+		if err != nil {
+			return nil, err
 		}
+		problems = append(problems, perState...)
 	}
 
 	res := make([]any, 0, len(problems))
@@ -387,9 +379,7 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	rules := []cloudguard.DetectorRecipeDetectorRuleSummary{}
-	var page *string
-	for {
+	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.DetectorRecipeDetectorRuleSummary, *string, error) {
 		response, err := client.ListDetectorRecipeDetectorRules(ctx, cloudguard.ListDetectorRecipeDetectorRulesRequest{
 			DetectorRecipeId: common.String(o.Id.Data),
 			// Read from the cached value rather than the public compartmentID
@@ -400,15 +390,12 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		rules = append(rules, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(rules))
@@ -494,24 +481,19 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	recipes := []cloudguard.DetectorRecipeSummary{}
-	var page *string
-	for {
+	recipes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.DetectorRecipeSummary, *string, error) {
 		response, err := client.ListDetectorRecipes(ctx, cloudguard.ListDetectorRecipesRequest{
 			CompartmentId:          common.String(conn.TenantID()),
 			CompartmentIdInSubtree: common.Bool(true),
 			Page:                   page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		recipes = append(recipes, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(recipes))
@@ -563,9 +545,7 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	zones := []cloudguard.SecurityZoneSummary{}
-	var page *string
-	for {
+	zones, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.SecurityZoneSummary, *string, error) {
 		// Security zones are attached to compartments and practically never to
 		// the tenancy root, so without the subtree flag a correctly zoned
 		// tenancy reported none at all.
@@ -575,15 +555,12 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 			Page:                             page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		zones = append(zones, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(zones))
@@ -630,23 +607,18 @@ func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	recipes := []cloudguard.SecurityRecipeSummary{}
-	var page *string
-	for {
+	recipes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.SecurityRecipeSummary, *string, error) {
 		response, err := client.ListSecurityRecipes(ctx, cloudguard.ListSecurityRecipesRequest{
 			CompartmentId: common.String(conn.TenantID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		recipes = append(recipes, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(recipes))
@@ -693,23 +665,18 @@ func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	policies := []cloudguard.SecurityPolicySummary{}
-	var page *string
-	for {
+	policies, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]cloudguard.SecurityPolicySummary, *string, error) {
 		response, err := client.ListSecurityPolicies(ctx, cloudguard.ListSecurityPoliciesRequest{
 			CompartmentId: common.String(conn.TenantID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		policies = append(policies, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(policies))

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -208,9 +208,7 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 }
 
 func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Instance, error) {
-	instances := []core.Instance{}
-	var page *string
-	for {
+	instances, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Instance, *string, error) {
 		request := core.ListInstancesRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -218,16 +216,12 @@ func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, comput
 
 		response, err := computeClient.ListInstances(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		instances = append(instances, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return instances, nil
@@ -279,22 +273,19 @@ func (o *mqlOciComputeInstance) vnics() ([]any, error) {
 		compartmentID = conn.TenantID()
 	}
 
-	var attachments []core.VnicAttachment
-	var page *string
-	for {
+	attachments, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.VnicAttachment, *string, error) {
 		response, err := computeSvc.ListVnicAttachments(ctx, core.ListVnicAttachmentsRequest{
 			CompartmentId: common.String(compartmentID),
 			InstanceId:    common.String(o.Id.Data),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		attachments = append(attachments, response.Items...)
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(attachments))
@@ -365,9 +356,7 @@ func (o *mqlOciCompute) images() ([]any, error) {
 }
 
 func (o *mqlOciCompute) getComputeImagesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Image, error) {
-	images := []core.Image{}
-	var page *string
-	for {
+	images, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Image, *string, error) {
 		request := core.ListImagesRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -375,16 +364,12 @@ func (o *mqlOciCompute) getComputeImagesForRegion(ctx context.Context, computeCl
 
 		response, err := computeClient.ListImages(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		images = append(images, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return images, nil
@@ -490,9 +475,7 @@ func (o *mqlOciCompute) blockVolumes() ([]any, error) {
 }
 
 func (o *mqlOciCompute) getBlockVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.Volume, error) {
-	volumes := []core.Volume{}
-	var page *string
-	for {
+	volumes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Volume, *string, error) {
 		request := core.ListVolumesRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -500,16 +483,12 @@ func (o *mqlOciCompute) getBlockVolumesForRegion(ctx context.Context, client *co
 
 		response, err := client.ListVolumes(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		volumes = append(volumes, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return volumes, nil
@@ -623,9 +602,7 @@ func (o *mqlOciCompute) bootVolumes() ([]any, error) {
 }
 
 func (o *mqlOciCompute) getBootVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.BootVolume, error) {
-	bootVolumes := []core.BootVolume{}
-	var page *string
-	for {
+	bootVolumes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.BootVolume, *string, error) {
 		request := core.ListBootVolumesRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -633,16 +610,12 @@ func (o *mqlOciCompute) getBootVolumesForRegion(ctx context.Context, client *cor
 
 		response, err := client.ListBootVolumes(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		bootVolumes = append(bootVolumes, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return bootVolumes, nil

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -97,23 +97,18 @@ func (o *mqlOciContainerInstances) getContainerInstances(conn *connection.OciCon
 				return nil, err
 			}
 
-			var items []containerinstances.ContainerInstanceSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerinstances.ContainerInstanceSummary, *string, error) {
 				response, err := svc.ListContainerInstances(ctx, containerinstances.ListContainerInstancesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				items = append(items, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -194,24 +189,19 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 		return nil, err
 	}
 
-	var items []containerinstances.ContainerSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerinstances.ContainerSummary, *string, error) {
 		response, err := svc.ListContainers(ctx, containerinstances.ListContainersRequest{
 			CompartmentId:       common.String(o.CompartmentID.Data),
 			ContainerInstanceId: common.String(o.Id.Data),
 			Page:                page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		items = append(items, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -57,23 +57,18 @@ func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []
 				return nil, err
 			}
 
-			var items []database.DbSystemSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.DbSystemSummary, *string, error) {
 				response, err := svc.ListDbSystems(ctx, database.ListDbSystemsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				items = append(items, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -208,23 +203,18 @@ func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, 
 				return nil, err
 			}
 
-			var items []database.AutonomousDatabaseSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.AutonomousDatabaseSummary, *string, error) {
 				response, err := svc.ListAutonomousDatabases(ctx, database.ListAutonomousDatabasesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				items = append(items, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -403,21 +393,18 @@ func (o *mqlOciDatabase) getDatabaseBackups(conn *connection.OciConnection, regi
 				return nil, err
 			}
 
-			var items []database.BackupSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.BackupSummary, *string, error) {
 				response, err := svc.ListBackups(ctx, database.ListBackupsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -572,21 +559,18 @@ func (o *mqlOciDatabase) getAutonomousDatabaseBackups(conn *connection.OciConnec
 				return nil, err
 			}
 
-			var items []database.AutonomousDatabaseBackupSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.AutonomousDatabaseBackupSummary, *string, error) {
 				response, err := svc.ListAutonomousDatabaseBackups(ctx, database.ListAutonomousDatabaseBackupsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))

--- a/providers/oci/resources/databases.go
+++ b/providers/oci/resources/databases.go
@@ -56,23 +56,18 @@ func (o *mqlOciMysql) dbSystems() ([]any, error) {
 				return nil, err
 			}
 
-			systems := []mysql.DbSystemSummary{}
-			var page *string
-			for {
+			systems, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]mysql.DbSystemSummary, *string, error) {
 				response, err := client.ListDbSystems(ctx, mysql.ListDbSystemsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				systems = append(systems, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(systems))
@@ -288,23 +283,18 @@ func (o *mqlOciPostgresql) dbSystems() ([]any, error) {
 				return nil, err
 			}
 
-			systems := []psql.DbSystemSummary{}
-			var page *string
-			for {
+			systems, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]psql.DbSystemSummary, *string, error) {
 				response, err := client.ListDbSystems(ctx, psql.ListDbSystemsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				systems = append(systems, response.DbSystemCollection.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.DbSystemCollection.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(systems))
@@ -508,23 +498,18 @@ func (o *mqlOciNosql) tables() ([]any, error) {
 				return nil, err
 			}
 
-			tables := []nosql.TableSummary{}
-			var page *string
-			for {
+			tables, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]nosql.TableSummary, *string, error) {
 				response, err := client.ListTables(ctx, nosql.ListTablesRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				tables = append(tables, response.TableCollection.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.TableCollection.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(tables))
@@ -599,23 +584,18 @@ func (o *mqlOciOpensearch) clusters() ([]any, error) {
 				return nil, err
 			}
 
-			clusters := []opensearch.OpensearchClusterSummary{}
-			var page *string
-			for {
+			clusters, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]opensearch.OpensearchClusterSummary, *string, error) {
 				response, err := client.ListOpensearchClusters(ctx, opensearch.ListOpensearchClustersRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				clusters = append(clusters, response.OpensearchClusterCollection.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.OpensearchClusterCollection.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(clusters))
@@ -808,23 +788,18 @@ func (o *mqlOciGoldenGate) deployments() ([]any, error) {
 				return nil, err
 			}
 
-			deployments := []goldengate.DeploymentSummary{}
-			var page *string
-			for {
+			deployments, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]goldengate.DeploymentSummary, *string, error) {
 				response, err := client.ListDeployments(ctx, goldengate.ListDeploymentsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				deployments = append(deployments, response.DeploymentCollection.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.DeploymentCollection.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(deployments))

--- a/providers/oci/resources/datasafe.go
+++ b/providers/oci/resources/datasafe.go
@@ -166,23 +166,20 @@ func (o *mqlOciDataSafe) targetDatabases() ([]any, error) {
 				return nil, err
 			}
 			compartmentId, subtree := dataSafeFromTenantSubtree(conn.TenantID())
-			items := []datasafe.TargetDatabaseSummary{}
-			var page *string
-			for {
-				resp, err := svc.ListTargetDatabases(context.Background(), datasafe.ListTargetDatabasesRequest{
+			items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]datasafe.TargetDatabaseSummary, *string, error) {
+				resp, err := svc.ListTargetDatabases(ctx, datasafe.ListTargetDatabasesRequest{
 					CompartmentId:          common.String(compartmentId),
 					CompartmentIdInSubtree: subtree,
 					Page:                   page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe target databases")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				items = append(items, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe target databases")
+				return jobpool.JobResult([]any{}), nil
 			}
 
 			res := make([]any, 0, len(items))
@@ -237,23 +234,20 @@ func (o *mqlOciDataSafe) securityAssessments() ([]any, error) {
 				return nil, err
 			}
 			compartmentId, subtree := dataSafeFromTenantSubtree(conn.TenantID())
-			items := []datasafe.SecurityAssessmentSummary{}
-			var page *string
-			for {
-				resp, err := svc.ListSecurityAssessments(context.Background(), datasafe.ListSecurityAssessmentsRequest{
+			items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]datasafe.SecurityAssessmentSummary, *string, error) {
+				resp, err := svc.ListSecurityAssessments(ctx, datasafe.ListSecurityAssessmentsRequest{
 					CompartmentId:          common.String(compartmentId),
 					CompartmentIdInSubtree: subtree,
 					Page:                   page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe security assessments")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				items = append(items, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe security assessments")
+				return jobpool.JobResult([]any{}), nil
 			}
 
 			res := make([]any, 0, len(items))
@@ -307,23 +301,20 @@ func (o *mqlOciDataSafe) userAssessments() ([]any, error) {
 				return nil, err
 			}
 			compartmentId, subtree := dataSafeFromTenantSubtree(conn.TenantID())
-			items := []datasafe.UserAssessmentSummary{}
-			var page *string
-			for {
-				resp, err := svc.ListUserAssessments(context.Background(), datasafe.ListUserAssessmentsRequest{
+			items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]datasafe.UserAssessmentSummary, *string, error) {
+				resp, err := svc.ListUserAssessments(ctx, datasafe.ListUserAssessmentsRequest{
 					CompartmentId:          common.String(compartmentId),
 					CompartmentIdInSubtree: subtree,
 					Page:                   page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe user assessments")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				items = append(items, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe user assessments")
+				return jobpool.JobResult([]any{}), nil
 			}
 
 			res := make([]any, 0, len(items))
@@ -377,23 +368,20 @@ func (o *mqlOciDataSafe) sensitiveDataModels() ([]any, error) {
 				return nil, err
 			}
 			compartmentId, subtree := dataSafeFromTenantSubtree(conn.TenantID())
-			items := []datasafe.SensitiveDataModelSummary{}
-			var page *string
-			for {
-				resp, err := svc.ListSensitiveDataModels(context.Background(), datasafe.ListSensitiveDataModelsRequest{
+			items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]datasafe.SensitiveDataModelSummary, *string, error) {
+				resp, err := svc.ListSensitiveDataModels(ctx, datasafe.ListSensitiveDataModelsRequest{
 					CompartmentId:          common.String(compartmentId),
 					CompartmentIdInSubtree: subtree,
 					Page:                   page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe sensitive data models")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				items = append(items, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe sensitive data models")
+				return jobpool.JobResult([]any{}), nil
 			}
 
 			res := make([]any, 0, len(items))
@@ -446,23 +434,20 @@ func (o *mqlOciDataSafe) sensitiveTypes() ([]any, error) {
 				return nil, err
 			}
 			compartmentId, subtree := dataSafeFromTenantSubtree(conn.TenantID())
-			items := []datasafe.SensitiveTypeSummary{}
-			var page *string
-			for {
-				resp, err := svc.ListSensitiveTypes(context.Background(), datasafe.ListSensitiveTypesRequest{
+			items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]datasafe.SensitiveTypeSummary, *string, error) {
+				resp, err := svc.ListSensitiveTypes(ctx, datasafe.ListSensitiveTypesRequest{
 					CompartmentId:          common.String(compartmentId),
 					CompartmentIdInSubtree: subtree,
 					Page:                   page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe sensitive types")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				items = append(items, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe sensitive types")
+				return jobpool.JobResult([]any{}), nil
 			}
 
 			res := make([]any, 0, len(items))
@@ -515,23 +500,20 @@ func (o *mqlOciDataSafe) maskingPolicies() ([]any, error) {
 				return nil, err
 			}
 			compartmentId, subtree := dataSafeFromTenantSubtree(conn.TenantID())
-			items := []datasafe.MaskingPolicySummary{}
-			var page *string
-			for {
-				resp, err := svc.ListMaskingPolicies(context.Background(), datasafe.ListMaskingPoliciesRequest{
+			items, err := ociPaginate(context.Background(), func(ctx context.Context, page *string) ([]datasafe.MaskingPolicySummary, *string, error) {
+				resp, err := svc.ListMaskingPolicies(ctx, datasafe.ListMaskingPoliciesRequest{
 					CompartmentId:          common.String(compartmentId),
 					CompartmentIdInSubtree: subtree,
 					Page:                   page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe masking policies")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				items = append(items, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list Data Safe masking policies")
+				return jobpool.JobResult([]any{}), nil
 			}
 
 			res := make([]any, 0, len(items))

--- a/providers/oci/resources/datascience.go
+++ b/providers/oci/resources/datascience.go
@@ -69,21 +69,18 @@ func (o *mqlOciAiDataScience) projects() ([]any, error) {
 
 func (o *mqlOciAiDataScience) fetchProjects(svc *datascience.DataScienceClient) ([]any, error) {
 	ctx := context.Background()
-	var items []datascience.ProjectSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]datascience.ProjectSummary, *string, error) {
 		resp, err := svc.ListProjects(ctx, datascience.ListProjectsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -128,21 +125,18 @@ func (o *mqlOciAiDataScience) notebookSessions() ([]any, error) {
 
 func (o *mqlOciAiDataScience) fetchNotebookSessions(svc *datascience.DataScienceClient) ([]any, error) {
 	ctx := context.Background()
-	var items []datascience.NotebookSessionSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]datascience.NotebookSessionSummary, *string, error) {
 		resp, err := svc.ListNotebookSessions(ctx, datascience.ListNotebookSessionsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -233,21 +227,18 @@ func (o *mqlOciAiDataScience) models() ([]any, error) {
 
 func (o *mqlOciAiDataScience) fetchModels(svc *datascience.DataScienceClient) ([]any, error) {
 	ctx := context.Background()
-	var items []datascience.ModelSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]datascience.ModelSummary, *string, error) {
 		resp, err := svc.ListModels(ctx, datascience.ListModelsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -325,21 +316,18 @@ func (o *mqlOciAiDataScience) modelVersionSets() ([]any, error) {
 
 func (o *mqlOciAiDataScience) fetchModelVersionSets(svc *datascience.DataScienceClient) ([]any, error) {
 	ctx := context.Background()
-	var items []datascience.ModelVersionSetSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]datascience.ModelVersionSetSummary, *string, error) {
 		resp, err := svc.ListModelVersionSets(ctx, datascience.ListModelVersionSetsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -396,21 +384,18 @@ func (o *mqlOciAiDataScience) modelDeployments() ([]any, error) {
 
 func (o *mqlOciAiDataScience) fetchModelDeployments(svc *datascience.DataScienceClient) ([]any, error) {
 	ctx := context.Background()
-	var items []datascience.ModelDeploymentSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]datascience.ModelDeploymentSummary, *string, error) {
 		resp, err := svc.ListModelDeployments(ctx, datascience.ListModelDeploymentsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -479,21 +464,18 @@ func (o *mqlOciAiDataScience) jobs() ([]any, error) {
 
 func (o *mqlOciAiDataScience) fetchJobs(svc *datascience.DataScienceClient) ([]any, error) {
 	ctx := context.Background()
-	var items []datascience.JobSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]datascience.JobSummary, *string, error) {
 		resp, err := svc.ListJobs(ctx, datascience.ListJobsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -548,21 +530,18 @@ func (o *mqlOciAiDataScience) pipelines() ([]any, error) {
 
 func (o *mqlOciAiDataScience) fetchPipelines(svc *datascience.DataScienceClient) ([]any, error) {
 	ctx := context.Background()
-	var items []datascience.PipelineSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]datascience.PipelineSummary, *string, error) {
 		resp, err := svc.ListPipelines(ctx, datascience.ListPipelinesRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))

--- a/providers/oci/resources/dns.go
+++ b/providers/oci/resources/dns.go
@@ -59,24 +59,21 @@ func (o *mqlOciDns) zones() ([]any, error) {
 
 			zones := []dns.ZoneSummary{}
 			for _, scope := range ociDnsZoneScopes {
-				var page *string
-				for {
+				perScope, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]dns.ZoneSummary, *string, error) {
 					response, err := client.ListZones(ctx, dns.ListZonesRequest{
 						CompartmentId: common.String(compartmentID),
 						Scope:         scope,
 						Page:          page,
 					})
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
-
-					zones = append(zones, response.Items...)
-
-					if response.OpcNextPage == nil {
-						break
-					}
-					page = response.OpcNextPage
+					return response.Items, response.OpcNextPage, nil
+				})
+				if err != nil {
+					return nil, err
 				}
+				zones = append(zones, perScope...)
 			}
 
 			return o.newZones(region, zones)
@@ -158,24 +155,21 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 			// asking only for the default reports a tenancy's private traffic
 			// management as absent.
 			for _, scope := range ociDnsSteeringPolicyScopes {
-				var page *string
-				for {
+				perScope, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]dns.SteeringPolicySummary, *string, error) {
 					response, err := client.ListSteeringPolicies(ctx, dns.ListSteeringPoliciesRequest{
 						CompartmentId: common.String(compartmentID),
 						Scope:         scope,
 						Page:          page,
 					})
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
-
-					policies = append(policies, response.Items...)
-
-					if response.OpcNextPage == nil {
-						break
-					}
-					page = response.OpcNextPage
+					return response.Items, response.OpcNextPage, nil
+				})
+				if err != nil {
+					return nil, err
 				}
+				policies = append(policies, perScope...)
 			}
 
 			res := make([]any, 0, len(policies))
@@ -237,9 +231,7 @@ func (o *mqlOciDnsZone) records() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	records := []dns.Record{}
-	var page *string
-	for {
+	records, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]dns.Record, *string, error) {
 		response, err := client.GetZoneRecords(ctx, dns.GetZoneRecordsRequest{
 			ZoneNameOrId: common.String(o.Id.Data),
 			// A private zone is only addressable within its scope, and the
@@ -248,15 +240,12 @@ func (o *mqlOciDnsZone) records() ([]any, error) {
 			Page:  page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		records = append(records, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(records))

--- a/providers/oci/resources/events.go
+++ b/providers/oci/resources/events.go
@@ -39,9 +39,7 @@ func (o *mqlOciEvents) rules() ([]any, error) {
 }
 
 func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *events.EventsClient, compartmentID string) ([]events.RuleSummary, error) {
-	rules := []events.RuleSummary{}
-	var page *string
-	for {
+	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]events.RuleSummary, *string, error) {
 		request := events.ListRulesRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -49,16 +47,12 @@ func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *event
 
 		response, err := client.ListRules(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		rules = append(rules, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return rules, nil

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -40,9 +40,7 @@ func (o *mqlOciFileStorage) fileSystems() ([]any, error) {
 }
 
 func (o *mqlOciFileStorage) getFileSystemsForAD(ctx context.Context, fsClient *filestorage.FileStorageClient, compartmentID string, availabilityDomain string) ([]filestorage.FileSystemSummary, error) {
-	fileSystems := []filestorage.FileSystemSummary{}
-	var page *string
-	for {
+	fileSystems, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]filestorage.FileSystemSummary, *string, error) {
 		request := filestorage.ListFileSystemsRequest{
 			CompartmentId:      common.String(compartmentID),
 			AvailabilityDomain: common.String(availabilityDomain),
@@ -51,16 +49,12 @@ func (o *mqlOciFileStorage) getFileSystemsForAD(ctx context.Context, fsClient *f
 
 		response, err := fsClient.ListFileSystems(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		fileSystems = append(fileSystems, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return fileSystems, nil

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -56,23 +56,18 @@ func (o *mqlOciFunctions) getApplications(conn *connection.OciConnection, region
 				return nil, err
 			}
 
-			var items []functions.ApplicationSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]functions.ApplicationSummary, *string, error) {
 				response, err := svc.ListApplications(ctx, functions.ListApplicationsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				items = append(items, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -243,23 +238,18 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 		return nil, err
 	}
 
-	var items []functions.FunctionSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]functions.FunctionSummary, *string, error) {
 		response, err := svc.ListFunctions(ctx, functions.ListFunctionsRequest{
 			ApplicationId: common.String(o.Id.Data),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		items = append(items, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))

--- a/providers/oci/resources/generativeai.go
+++ b/providers/oci/resources/generativeai.go
@@ -69,21 +69,18 @@ func (o *mqlOciAiGenerativeAi) dedicatedAiClusters() ([]any, error) {
 
 func (o *mqlOciAiGenerativeAi) fetchDedicatedAiClusters(svc *generativeai.GenerativeAiClient, _ string) ([]any, error) {
 	ctx := context.Background()
-	var items []generativeai.DedicatedAiClusterSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeai.DedicatedAiClusterSummary, *string, error) {
 		resp, err := svc.ListDedicatedAiClusters(ctx, generativeai.ListDedicatedAiClustersRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -137,21 +134,18 @@ func (o *mqlOciAiGenerativeAi) models() ([]any, error) {
 
 func (o *mqlOciAiGenerativeAi) fetchModels(svc *generativeai.GenerativeAiClient, _ string) ([]any, error) {
 	ctx := context.Background()
-	var items []generativeai.ModelSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeai.ModelSummary, *string, error) {
 		resp, err := svc.ListModels(ctx, generativeai.ListModelsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))
@@ -223,21 +217,18 @@ func (o *mqlOciAiGenerativeAi) endpoints() ([]any, error) {
 
 func (o *mqlOciAiGenerativeAi) fetchEndpoints(svc *generativeai.GenerativeAiClient, region string) ([]any, error) {
 	ctx := context.Background()
-	var items []generativeai.EndpointSummary
-	var page *string
-	for {
+	items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeai.EndpointSummary, *string, error) {
 		resp, err := svc.ListEndpoints(ctx, generativeai.ListEndpointsRequest{
 			CompartmentId: common.String(o.compartmentID()),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		items = append(items, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(items))

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -66,25 +66,22 @@ func (o *mqlOciAiAgents) getAgents(conn *connection.OciConnection, regions []any
 				return nil, err
 			}
 
-			items := []generativeaiagent.AgentSummary{}
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.AgentSummary, *string, error) {
 				response, err := svc.ListAgents(ctx, generativeaiagent.ListAgentsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					if ociRegionServiceUnavailable(err) {
-						log.Debug().Str("region", regionResource.Id.Data).Msg("generative ai agents not available in region, skipping")
-						return jobpool.JobResult([]any{}), nil
-					}
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				if ociRegionServiceUnavailable(err) {
+					log.Debug().Str("region", regionResource.Id.Data).Msg("generative ai agents not available in region, skipping")
+					return jobpool.JobResult([]any{}), nil
 				}
-				page = response.OpcNextPage
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -181,24 +178,21 @@ func (o *mqlOciAiAgents) getAgentEndpoints(conn *connection.OciConnection, regio
 				return nil, err
 			}
 
-			items := []generativeaiagent.AgentEndpointSummary{}
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.AgentEndpointSummary, *string, error) {
 				response, err := svc.ListAgentEndpoints(ctx, generativeaiagent.ListAgentEndpointsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					if ociRegionServiceUnavailable(err) {
-						return jobpool.JobResult([]any{}), nil
-					}
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				if ociRegionServiceUnavailable(err) {
+					return jobpool.JobResult([]any{}), nil
 				}
-				page = response.OpcNextPage
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -322,24 +316,21 @@ func (o *mqlOciAiAgents) getKnowledgeBases(conn *connection.OciConnection, regio
 				return nil, err
 			}
 
-			items := []generativeaiagent.KnowledgeBaseSummary{}
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.KnowledgeBaseSummary, *string, error) {
 				response, err := svc.ListKnowledgeBases(ctx, generativeaiagent.ListKnowledgeBasesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					if ociRegionServiceUnavailable(err) {
-						return jobpool.JobResult([]any{}), nil
-					}
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				if ociRegionServiceUnavailable(err) {
+					return jobpool.JobResult([]any{}), nil
 				}
-				page = response.OpcNextPage
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -429,24 +420,21 @@ func (o *mqlOciAiAgents) getDataSources(conn *connection.OciConnection, regions 
 				return nil, err
 			}
 
-			items := []generativeaiagent.DataSourceSummary{}
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.DataSourceSummary, *string, error) {
 				response, err := svc.ListDataSources(ctx, generativeaiagent.ListDataSourcesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					if ociRegionServiceUnavailable(err) {
-						return jobpool.JobResult([]any{}), nil
-					}
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				if ociRegionServiceUnavailable(err) {
+					return jobpool.JobResult([]any{}), nil
 				}
-				page = response.OpcNextPage
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))
@@ -557,24 +545,21 @@ func (o *mqlOciAiAgents) getTools(conn *connection.OciConnection, regions []any)
 				return nil, err
 			}
 
-			items := []generativeaiagent.ToolSummary{}
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.ToolSummary, *string, error) {
 				response, err := svc.ListTools(ctx, generativeaiagent.ListToolsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					if ociRegionServiceUnavailable(err) {
-						return jobpool.JobResult([]any{}), nil
-					}
-					return nil, err
+					return nil, nil, err
 				}
-				items = append(items, response.Items...)
-				if response.OpcNextPage == nil {
-					break
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				if ociRegionServiceUnavailable(err) {
+					return jobpool.JobResult([]any{}), nil
 				}
-				page = response.OpcNextPage
+				return nil, err
 			}
 
 			res := make([]any, 0, len(items))

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -30,9 +30,7 @@ func (o *mqlOciIdentity) users() ([]any, error) {
 }
 
 func (s *mqlOciIdentity) listUsers(ctx context.Context, identityClient identity.IdentityClient, compartmentID string) ([]identity.User, error) {
-	users := []identity.User{}
-	var page *string
-	for {
+	users, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.User, *string, error) {
 		request := identity.ListUsersRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -40,16 +38,12 @@ func (s *mqlOciIdentity) listUsers(ctx context.Context, identityClient identity.
 
 		response, err := identityClient.ListUsers(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		users = append(users, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return users, nil
@@ -373,26 +367,25 @@ func (o *mqlOciIdentityUser) groups() ([]any, error) {
 
 	ctx := context.Background()
 	grpMember := map[string]bool{}
-	var page *string
-	for {
-		memberships, err := client.ListUserGroupMemberships(ctx, identity.ListUserGroupMembershipsRequest{
+	memberships, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.UserGroupMembership, *string, error) {
+		response, err := client.ListUserGroupMemberships(ctx, identity.ListUserGroupMembershipsRequest{
 			CompartmentId: common.String(compartmentID),
 			UserId:        common.String(userId),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		for i := range memberships.Items {
-			m := memberships.Items[i]
-			if m.GroupId != nil {
-				grpMember[*m.GroupId] = true
-			}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range memberships {
+		m := memberships[i]
+		if m.GroupId != nil {
+			grpMember[*m.GroupId] = true
 		}
-		if memberships.OpcNextPage == nil {
-			break
-		}
-		page = memberships.OpcNextPage
 	}
 
 	// fetch all groups and filter the groups
@@ -426,9 +419,7 @@ func (o *mqlOciIdentity) groups() ([]any, error) {
 }
 
 func (s *mqlOciIdentity) listGroups(ctx context.Context, identityClient identity.IdentityClient, compartmentID string) ([]identity.Group, error) {
-	groups := []identity.Group{}
-	var page *string
-	for {
+	groups, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.Group, *string, error) {
 		request := identity.ListGroupsRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -436,16 +427,12 @@ func (s *mqlOciIdentity) listGroups(ctx context.Context, identityClient identity
 
 		response, err := identityClient.ListGroups(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		groups = append(groups, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return groups, nil
@@ -520,9 +507,7 @@ func (o *mqlOciIdentity) policies() ([]any, error) {
 }
 
 func (s *mqlOciIdentity) listPolicies(ctx context.Context, identityClient identity.IdentityClient, compartmentID string) ([]identity.Policy, error) {
-	policies := []identity.Policy{}
-	var page *string
-	for {
+	policies, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.Policy, *string, error) {
 		request := identity.ListPoliciesRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -530,16 +515,12 @@ func (s *mqlOciIdentity) listPolicies(ctx context.Context, identityClient identi
 
 		response, err := identityClient.ListPolicies(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		policies = append(policies, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return policies, nil
@@ -663,23 +644,18 @@ func (o *mqlOciIdentityUser) mfaDevices() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	var page *string
-	var devices []identity.MfaTotpDeviceSummary
-	for {
+	devices, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.MfaTotpDeviceSummary, *string, error) {
 		response, err := client.ListMfaTotpDevices(ctx, identity.ListMfaTotpDevicesRequest{
 			UserId: common.String(o.Id.Data),
 			Page:   page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		devices = append(devices, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(devices))
@@ -726,26 +702,25 @@ func (o *mqlOciIdentityGroup) members() ([]any, error) {
 
 	ctx := context.Background()
 	userMember := map[string]bool{}
-	var page *string
-	for {
-		memberships, err := client.ListUserGroupMemberships(ctx, identity.ListUserGroupMembershipsRequest{
+	memberships, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.UserGroupMembership, *string, error) {
+		response, err := client.ListUserGroupMemberships(ctx, identity.ListUserGroupMembershipsRequest{
 			CompartmentId: common.String(o.CompartmentID.Data),
 			GroupId:       common.String(o.Id.Data),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		for i := range memberships.Items {
-			m := memberships.Items[i]
-			if m.UserId != nil {
-				userMember[*m.UserId] = true
-			}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range memberships {
+		m := memberships[i]
+		if m.UserId != nil {
+			userMember[*m.UserId] = true
 		}
-		if memberships.OpcNextPage == nil {
-			break
-		}
-		page = memberships.OpcNextPage
 	}
 
 	obj, err := NewResource(o.MqlRuntime, "oci.identity", nil)
@@ -778,35 +753,35 @@ func (o *mqlOciIdentityUser) dbCredentials() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	res := []any{}
-	var page *string
-	for {
+	creds, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.DbCredentialSummary, *string, error) {
 		resp, err := client.ListDbCredentials(ctx, identity.ListDbCredentialsRequest{
 			UserId: common.String(o.Id.Data),
 			Page:   page,
 		})
 		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range creds {
+		cred := creds[i]
+
+		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.dbCredential", map[string]*llx.RawData{
+			"id":          llx.StringDataPtr(cred.Id),
+			"description": llx.StringDataPtr(cred.Description),
+			"created":     sdkTimeData(cred.TimeCreated),
+			"expires":     sdkTimeData(cred.TimeExpires),
+			"state":       llx.StringData(string(cred.LifecycleState)),
+		})
+		if err != nil {
 			return nil, err
 		}
-		for i := range resp.Items {
-			cred := resp.Items[i]
-
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.dbCredential", map[string]*llx.RawData{
-				"id":          llx.StringDataPtr(cred.Id),
-				"description": llx.StringDataPtr(cred.Description),
-				"created":     sdkTimeData(cred.TimeCreated),
-				"expires":     sdkTimeData(cred.TimeExpires),
-				"state":       llx.StringData(string(cred.LifecycleState)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlInstance)
-		}
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		res = append(res, mqlInstance)
 	}
 
 	return res, nil
@@ -872,51 +847,51 @@ func (o *mqlOciIdentityUser) oauth2ClientCredentials() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	res := []any{}
-	var page *string
-	for {
+	creds, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.OAuth2ClientCredentialSummary, *string, error) {
 		resp, err := client.ListOAuthClientCredentials(ctx, identity.ListOAuthClientCredentialsRequest{
 			UserId: common.String(o.Id.Data),
 			Page:   page,
 		})
 		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range creds {
+		cred := creds[i]
+
+		scopes := make([]ociOauthScope, 0, len(cred.Scopes))
+		for j := range cred.Scopes {
+			s := cred.Scopes[j]
+			scopes = append(scopes, ociOauthScope{
+				Audience: stringValue(s.Audience),
+				Scope:    stringValue(s.Scope),
+			})
+		}
+		scopesDict, err := convert.JsonToDictSlice(scopes)
+		if err != nil {
 			return nil, err
 		}
-		for i := range resp.Items {
-			cred := resp.Items[i]
 
-			scopes := make([]ociOauthScope, 0, len(cred.Scopes))
-			for j := range cred.Scopes {
-				s := cred.Scopes[j]
-				scopes = append(scopes, ociOauthScope{
-					Audience: stringValue(s.Audience),
-					Scope:    stringValue(s.Scope),
-				})
-			}
-			scopesDict, err := convert.JsonToDictSlice(scopes)
-			if err != nil {
-				return nil, err
-			}
-
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.oauth2ClientCredential", map[string]*llx.RawData{
-				"id":            llx.StringDataPtr(cred.Id),
-				"name":          llx.StringDataPtr(cred.Name),
-				"description":   llx.StringDataPtr(cred.Description),
-				"compartmentID": llx.StringDataPtr(cred.CompartmentId),
-				"scopes":        llx.ArrayData(scopesDict, types.Dict),
-				"created":       sdkTimeData(cred.TimeCreated),
-				"expires":       sdkTimeData(cred.ExpiresOn),
-				"state":         llx.StringData(string(cred.LifecycleState)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlInstance)
+		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.oauth2ClientCredential", map[string]*llx.RawData{
+			"id":            llx.StringDataPtr(cred.Id),
+			"name":          llx.StringDataPtr(cred.Name),
+			"description":   llx.StringDataPtr(cred.Description),
+			"compartmentID": llx.StringDataPtr(cred.CompartmentId),
+			"scopes":        llx.ArrayData(scopesDict, types.Dict),
+			"created":       sdkTimeData(cred.TimeCreated),
+			"expires":       sdkTimeData(cred.ExpiresOn),
+			"state":         llx.StringData(string(cred.LifecycleState)),
+		})
+		if err != nil {
+			return nil, err
 		}
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		res = append(res, mqlInstance)
 	}
 
 	return res, nil
@@ -935,39 +910,39 @@ func (o *mqlOciIdentity) dynamicGroups() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	res := []any{}
-	var page *string
-	for {
+	groups, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.DynamicGroup, *string, error) {
 		resp, err := client.ListDynamicGroups(ctx, identity.ListDynamicGroupsRequest{
 			CompartmentId: common.String(conn.TenantID()),
 			Page:          page,
 		})
 		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range groups {
+		dg := groups[i]
+
+		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.dynamicGroup", map[string]*llx.RawData{
+			"id":            llx.StringDataPtr(dg.Id),
+			"compartmentID": llx.StringDataPtr(dg.CompartmentId),
+			"name":          llx.StringDataPtr(dg.Name),
+			"description":   llx.StringDataPtr(dg.Description),
+			"matchingRule":  llx.StringDataPtr(dg.MatchingRule),
+			"created":       sdkTimeData(dg.TimeCreated),
+			"state":         llx.StringData(string(dg.LifecycleState)),
+			"freeformTags":  llx.MapData(strMapToAny(dg.FreeformTags), types.String),
+			"definedTags":   llx.MapData(definedTagsToAny(dg.DefinedTags), types.Any),
+		})
+		if err != nil {
 			return nil, err
 		}
-		for i := range resp.Items {
-			dg := resp.Items[i]
-
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.dynamicGroup", map[string]*llx.RawData{
-				"id":            llx.StringDataPtr(dg.Id),
-				"compartmentID": llx.StringDataPtr(dg.CompartmentId),
-				"name":          llx.StringDataPtr(dg.Name),
-				"description":   llx.StringDataPtr(dg.Description),
-				"matchingRule":  llx.StringDataPtr(dg.MatchingRule),
-				"created":       sdkTimeData(dg.TimeCreated),
-				"state":         llx.StringData(string(dg.LifecycleState)),
-				"freeformTags":  llx.MapData(strMapToAny(dg.FreeformTags), types.String),
-				"definedTags":   llx.MapData(definedTagsToAny(dg.DefinedTags), types.Any),
-			})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlInstance)
-		}
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		res = append(res, mqlInstance)
 	}
 
 	return res, nil
@@ -986,9 +961,7 @@ func (o *mqlOciIdentity) identityProviders() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	res := []any{}
-	var page *string
-	for {
+	providers, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.IdentityProvider, *string, error) {
 		// SAML2 is the only federation protocol the ListIdentityProviders API accepts.
 		resp, err := client.ListIdentityProviders(ctx, identity.ListIdentityProvidersRequest{
 			Protocol:      identity.ListIdentityProvidersProtocolSaml2,
@@ -996,48 +969,50 @@ func (o *mqlOciIdentity) identityProviders() ([]any, error) {
 			Page:          page,
 		})
 		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range providers {
+		idp := providers[i]
+
+		args := map[string]*llx.RawData{
+			"id":                 llx.StringDataPtr(idp.GetId()),
+			"compartmentID":      llx.StringDataPtr(idp.GetCompartmentId()),
+			"name":               llx.StringDataPtr(idp.GetName()),
+			"description":        llx.StringDataPtr(idp.GetDescription()),
+			"productType":        llx.StringDataPtr(idp.GetProductType()),
+			"created":            sdkTimeData(idp.GetTimeCreated()),
+			"state":              llx.StringData(string(idp.GetLifecycleState())),
+			"freeformTags":       llx.MapData(strMapToAny(idp.GetFreeformTags()), types.String),
+			"definedTags":        llx.MapData(definedTagsToAny(idp.GetDefinedTags()), types.Any),
+			"protocol":           llx.StringData(""),
+			"metadataUrl":        llx.StringData(""),
+			"signingCertificate": llx.StringData(""),
+			"redirectUrl":        llx.StringData(""),
+		}
+		if saml, ok := idp.(identity.Saml2IdentityProvider); ok {
+			args["protocol"] = llx.StringData("SAML2")
+			args["metadataUrl"] = llx.StringDataPtr(saml.MetadataUrl)
+			args["signingCertificate"] = llx.StringDataPtr(saml.SigningCertificate)
+			args["redirectUrl"] = llx.StringDataPtr(saml.RedirectUrl)
+		} else {
+			// SAML2 is the only protocol ListIdentityProviders accepts today;
+			// warn if OCI ever returns another so the gap is noticed.
+			log.Warn().Str("id", stringValue(idp.GetId())).
+				Msgf("oci.identity.identityProvider: unexpected provider type %T, SAML2-specific fields left empty", idp)
+		}
+
+		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.identityProvider", args)
+		if err != nil {
 			return nil, err
 		}
-		for i := range resp.Items {
-			idp := resp.Items[i]
-
-			args := map[string]*llx.RawData{
-				"id":                 llx.StringDataPtr(idp.GetId()),
-				"compartmentID":      llx.StringDataPtr(idp.GetCompartmentId()),
-				"name":               llx.StringDataPtr(idp.GetName()),
-				"description":        llx.StringDataPtr(idp.GetDescription()),
-				"productType":        llx.StringDataPtr(idp.GetProductType()),
-				"created":            sdkTimeData(idp.GetTimeCreated()),
-				"state":              llx.StringData(string(idp.GetLifecycleState())),
-				"freeformTags":       llx.MapData(strMapToAny(idp.GetFreeformTags()), types.String),
-				"definedTags":        llx.MapData(definedTagsToAny(idp.GetDefinedTags()), types.Any),
-				"protocol":           llx.StringData(""),
-				"metadataUrl":        llx.StringData(""),
-				"signingCertificate": llx.StringData(""),
-				"redirectUrl":        llx.StringData(""),
-			}
-			if saml, ok := idp.(identity.Saml2IdentityProvider); ok {
-				args["protocol"] = llx.StringData("SAML2")
-				args["metadataUrl"] = llx.StringDataPtr(saml.MetadataUrl)
-				args["signingCertificate"] = llx.StringDataPtr(saml.SigningCertificate)
-				args["redirectUrl"] = llx.StringDataPtr(saml.RedirectUrl)
-			} else {
-				// SAML2 is the only protocol ListIdentityProviders accepts today;
-				// warn if OCI ever returns another so the gap is noticed.
-				log.Warn().Str("id", stringValue(idp.GetId())).
-					Msgf("oci.identity.identityProvider: unexpected provider type %T, SAML2-specific fields left empty", idp)
-			}
-
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.identityProvider", args)
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlInstance)
-		}
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		res = append(res, mqlInstance)
 	}
 
 	return res, nil
@@ -1064,53 +1039,53 @@ func (o *mqlOciIdentity) networkSources() ([]any, error) {
 
 	ctx := context.Background()
 	res := []any{}
-	var page *string
-	for {
+	sources, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.NetworkSourcesSummary, *string, error) {
 		resp, err := client.ListNetworkSources(ctx, identity.ListNetworkSourcesRequest{
 			CompartmentId: common.String(conn.TenantID()),
 			Page:          page,
 		})
 		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range sources {
+		ns := sources[i]
+
+		virtual := make([]ociNetworkVirtualSource, 0, len(ns.VirtualSourceList))
+		for j := range ns.VirtualSourceList {
+			v := ns.VirtualSourceList[j]
+			virtual = append(virtual, ociNetworkVirtualSource{
+				VcnId:    stringValue(v.VcnId),
+				IpRanges: v.IpRanges,
+			})
+		}
+		virtualDict, err := convert.JsonToDictSlice(virtual)
+		if err != nil {
 			return nil, err
 		}
-		for i := range resp.Items {
-			ns := resp.Items[i]
 
-			virtual := make([]ociNetworkVirtualSource, 0, len(ns.VirtualSourceList))
-			for j := range ns.VirtualSourceList {
-				v := ns.VirtualSourceList[j]
-				virtual = append(virtual, ociNetworkVirtualSource{
-					VcnId:    stringValue(v.VcnId),
-					IpRanges: v.IpRanges,
-				})
-			}
-			virtualDict, err := convert.JsonToDictSlice(virtual)
-			if err != nil {
-				return nil, err
-			}
-
-			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.networkSource", map[string]*llx.RawData{
-				"id":                llx.StringDataPtr(ns.Id),
-				"compartmentID":     llx.StringDataPtr(ns.CompartmentId),
-				"name":              llx.StringDataPtr(ns.Name),
-				"description":       llx.StringDataPtr(ns.Description),
-				"publicSourceList":  llx.ArrayData(stringsToAny(ns.PublicSourceList), types.String),
-				"virtualSourceList": llx.ArrayData(virtualDict, types.Dict),
-				"services":          llx.ArrayData(stringsToAny(ns.Services), types.String),
-				"created":           sdkTimeData(ns.TimeCreated),
-				"state":             llx.StringData(string(ns.LifecycleState)),
-				"freeformTags":      llx.MapData(strMapToAny(ns.FreeformTags), types.String),
-				"definedTags":       llx.MapData(definedTagsToAny(ns.DefinedTags), types.Any),
-			})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlInstance)
+		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.networkSource", map[string]*llx.RawData{
+			"id":                llx.StringDataPtr(ns.Id),
+			"compartmentID":     llx.StringDataPtr(ns.CompartmentId),
+			"name":              llx.StringDataPtr(ns.Name),
+			"description":       llx.StringDataPtr(ns.Description),
+			"publicSourceList":  llx.ArrayData(stringsToAny(ns.PublicSourceList), types.String),
+			"virtualSourceList": llx.ArrayData(virtualDict, types.Dict),
+			"services":          llx.ArrayData(stringsToAny(ns.Services), types.String),
+			"created":           sdkTimeData(ns.TimeCreated),
+			"state":             llx.StringData(string(ns.LifecycleState)),
+			"freeformTags":      llx.MapData(strMapToAny(ns.FreeformTags), types.String),
+			"definedTags":       llx.MapData(definedTagsToAny(ns.DefinedTags), types.Any),
+		})
+		if err != nil {
+			return nil, err
 		}
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		res = append(res, mqlInstance)
 	}
 
 	return res, nil

--- a/providers/oci/resources/identitydomains.go
+++ b/providers/oci/resources/identitydomains.go
@@ -107,27 +107,25 @@ func (o *mqlOciIdentity) domains() ([]any, error) {
 		}
 
 		jobs = append(jobs, jobpool.NewJob(func() (jobpool.JobResult, error) {
-			// []any rather than []identity.DomainSummary: the collector joins
-			// results by asserting []any and silently drops anything else.
-			domains := []any{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]identity.DomainSummary, *string, error) {
 				response, err := client.ListDomains(ctx, identity.ListDomainsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
+			}
 
-				for i := range response.Items {
-					domains = append(domains, response.Items[i])
-				}
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+			// []any rather than []identity.DomainSummary: the collector joins
+			// results by asserting []any and silently drops anything else.
+			domains := make([]any, 0, len(summaries))
+			for i := range summaries {
+				domains = append(domains, summaries[i])
 			}
 
 			return jobpool.JobResult(domains), nil
@@ -238,25 +236,19 @@ func (o *mqlOciIdentityDomain) users() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	users := []identitydomains.User{}
-	startIndex := 1
-	for {
+	users, err := ociScimPaginate(ctx, func(ctx context.Context, startIndex int) ([]identitydomains.User, *int, error) {
 		response, err := client.ListUsers(ctx, identitydomains.ListUsersRequest{
 			StartIndex:    common.Int(startIndex),
 			Count:         common.Int(ociScimPageSize),
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, ociScimError(err, o.Name.Data, "users")
+			return nil, nil, ociScimError(err, o.Name.Data, "users")
 		}
-
-		users = append(users, response.Users.Resources...)
-
-		next, more := ociScimNextIndex(startIndex, len(response.Users.Resources), response.Users.TotalResults, ociScimPageSize)
-		if !more {
-			break
-		}
-		startIndex = next
+		return response.Users.Resources, response.Users.TotalResults, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(users))
@@ -354,25 +346,19 @@ func (o *mqlOciIdentityDomain) groups() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	groups := []identitydomains.Group{}
-	startIndex := 1
-	for {
+	groups, err := ociScimPaginate(ctx, func(ctx context.Context, startIndex int) ([]identitydomains.Group, *int, error) {
 		response, err := client.ListGroups(ctx, identitydomains.ListGroupsRequest{
 			StartIndex:    common.Int(startIndex),
 			Count:         common.Int(ociScimPageSize),
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, ociScimError(err, o.Name.Data, "groups")
+			return nil, nil, ociScimError(err, o.Name.Data, "groups")
 		}
-
-		groups = append(groups, response.Groups.Resources...)
-
-		next, more := ociScimNextIndex(startIndex, len(response.Groups.Resources), response.Groups.TotalResults, ociScimPageSize)
-		if !more {
-			break
-		}
-		startIndex = next
+		return response.Groups.Resources, response.Groups.TotalResults, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(groups))
@@ -410,25 +396,19 @@ func (o *mqlOciIdentityDomain) passwordPolicies() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	policies := []identitydomains.PasswordPolicy{}
-	startIndex := 1
-	for {
+	policies, err := ociScimPaginate(ctx, func(ctx context.Context, startIndex int) ([]identitydomains.PasswordPolicy, *int, error) {
 		response, err := client.ListPasswordPolicies(ctx, identitydomains.ListPasswordPoliciesRequest{
 			StartIndex:    common.Int(startIndex),
 			Count:         common.Int(ociScimPageSize),
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, ociScimError(err, o.Name.Data, "password policies")
+			return nil, nil, ociScimError(err, o.Name.Data, "password policies")
 		}
-
-		policies = append(policies, response.PasswordPolicies.Resources...)
-
-		next, more := ociScimNextIndex(startIndex, len(response.PasswordPolicies.Resources), response.PasswordPolicies.TotalResults, ociScimPageSize)
-		if !more {
-			break
-		}
-		startIndex = next
+		return response.PasswordPolicies.Resources, response.PasswordPolicies.TotalResults, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(policies))
@@ -525,25 +505,19 @@ func (o *mqlOciIdentityDomain) apps() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	apps := []identitydomains.App{}
-	startIndex := 1
-	for {
+	apps, err := ociScimPaginate(ctx, func(ctx context.Context, startIndex int) ([]identitydomains.App, *int, error) {
 		response, err := client.ListApps(ctx, identitydomains.ListAppsRequest{
 			StartIndex:    common.Int(startIndex),
 			Count:         common.Int(ociScimPageSize),
 			AttributeSets: ociScimAttributeSets,
 		})
 		if err != nil {
-			return nil, ociScimError(err, o.Name.Data, "apps")
+			return nil, nil, ociScimError(err, o.Name.Data, "apps")
 		}
-
-		apps = append(apps, response.Apps.Resources...)
-
-		next, more := ociScimNextIndex(startIndex, len(response.Apps.Resources), response.Apps.TotalResults, ociScimPageSize)
-		if !more {
-			break
-		}
-		startIndex = next
+		return response.Apps.Resources, response.Apps.TotalResults, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(apps))

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -83,9 +83,7 @@ func (o *mqlOciKms) vaults() ([]any, error) {
 }
 
 func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagement.KmsVaultClient, compartmentID string) ([]keymanagement.VaultSummary, error) {
-	entries := []keymanagement.VaultSummary{}
-	var page *string
-	for {
+	entries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]keymanagement.VaultSummary, *string, error) {
 		request := keymanagement.ListVaultsRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -93,15 +91,12 @@ func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagemen
 
 		response, err := client.ListVaults(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		entries = append(entries, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return entries, nil
@@ -199,9 +194,7 @@ func (o *mqlOciKmsVault) keys() ([]any, error) {
 }
 
 func (o *mqlOciKmsVault) getKeysForVault(ctx context.Context, client *keymanagement.KmsManagementClient, compartmentID string) ([]keymanagement.KeySummary, error) {
-	entries := []keymanagement.KeySummary{}
-	var page *string
-	for {
+	entries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]keymanagement.KeySummary, *string, error) {
 		request := keymanagement.ListKeysRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -209,15 +202,12 @@ func (o *mqlOciKmsVault) getKeysForVault(ctx context.Context, client *keymanagem
 
 		response, err := client.ListKeys(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		entries = append(entries, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return entries, nil
@@ -335,23 +325,18 @@ func (o *mqlOciKmsKey) keyVersions() ([]any, error) {
 		return nil, err
 	}
 
-	versions := []keymanagement.KeyVersionSummary{}
-	var page *string
-	for {
+	versions, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]keymanagement.KeyVersionSummary, *string, error) {
 		response, err := svc.ListKeyVersions(ctx, keymanagement.ListKeyVersionsRequest{
 			KeyId: common.String(o.Id.Data),
 			Page:  page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		versions = append(versions, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(versions))

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -49,23 +49,18 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 				return nil, err
 			}
 
-			lbs := []loadbalancer.LoadBalancer{}
-			var page *string
-			for {
+			lbs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]loadbalancer.LoadBalancer, *string, error) {
 				response, err := svc.ListLoadBalancers(ctx, loadbalancer.ListLoadBalancersRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				lbs = append(lbs, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -40,9 +40,7 @@ func (o *mqlOciLogging) logGroups() ([]any, error) {
 }
 
 func (o *mqlOciLogging) getLogGroupsForRegion(ctx context.Context, client *logging.LoggingManagementClient, compartmentID string) ([]logging.LogGroupSummary, error) {
-	entries := []logging.LogGroupSummary{}
-	var page *string
-	for {
+	entries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]logging.LogGroupSummary, *string, error) {
 		request := logging.ListLogGroupsRequest{
 			CompartmentId:            common.String(compartmentID),
 			IsCompartmentIdInSubtree: common.Bool(true),
@@ -51,15 +49,12 @@ func (o *mqlOciLogging) getLogGroupsForRegion(ctx context.Context, client *loggi
 
 		response, err := client.ListLogGroups(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		entries = append(entries, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return entries, nil
@@ -219,9 +214,7 @@ func (o *mqlOciLoggingLogGroup) logs() ([]any, error) {
 }
 
 func (o *mqlOciLoggingLogGroup) getLogsForGroup(ctx context.Context, client *logging.LoggingManagementClient, logGroupId string) ([]logging.LogSummary, error) {
-	entries := []logging.LogSummary{}
-	var page *string
-	for {
+	entries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]logging.LogSummary, *string, error) {
 		request := logging.ListLogsRequest{
 			LogGroupId: common.String(logGroupId),
 			Page:       page,
@@ -229,15 +222,12 @@ func (o *mqlOciLoggingLogGroup) getLogsForGroup(ctx context.Context, client *log
 
 		response, err := client.ListLogs(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		entries = append(entries, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return entries, nil

--- a/providers/oci/resources/messaging.go
+++ b/providers/oci/resources/messaging.go
@@ -41,23 +41,18 @@ func (o *mqlOciStreaming) streams() ([]any, error) {
 				return nil, err
 			}
 
-			streams := []streaming.StreamSummary{}
-			var page *string
-			for {
+			streams, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]streaming.StreamSummary, *string, error) {
 				response, err := client.ListStreams(ctx, streaming.ListStreamsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				streams = append(streams, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(streams))
@@ -102,23 +97,18 @@ func (o *mqlOciStreaming) streamPools() ([]any, error) {
 				return nil, err
 			}
 
-			pools := []streaming.StreamPoolSummary{}
-			var page *string
-			for {
+			pools, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]streaming.StreamPoolSummary, *string, error) {
 				response, err := client.ListStreamPools(ctx, streaming.ListStreamPoolsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				pools = append(pools, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(pools))
@@ -372,23 +362,18 @@ func (o *mqlOciQueue) queues() ([]any, error) {
 				return nil, err
 			}
 
-			queues := []queue.QueueSummary{}
-			var page *string
-			for {
+			queues, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]queue.QueueSummary, *string, error) {
 				response, err := client.ListQueues(ctx, queue.ListQueuesRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				queues = append(queues, response.QueueCollection.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.QueueCollection.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(queues))
@@ -540,23 +525,18 @@ func (o *mqlOciKafka) clusters() ([]any, error) {
 				return nil, err
 			}
 
-			clusters := []managedkafka.KafkaClusterSummary{}
-			var page *string
-			for {
+			clusters, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]managedkafka.KafkaClusterSummary, *string, error) {
 				response, err := client.ListKafkaClusters(ctx, managedkafka.ListKafkaClustersRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				clusters = append(clusters, response.KafkaClusterCollection.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.KafkaClusterCollection.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(clusters))

--- a/providers/oci/resources/monitoring.go
+++ b/providers/oci/resources/monitoring.go
@@ -52,9 +52,7 @@ func (o *mqlOciMonitoring) getAlarms(conn *connection.OciConnection, regions []a
 				return nil, err
 			}
 
-			alarms := []monitoring.AlarmSummary{}
-			var page *string
-			for {
+			alarms, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]monitoring.AlarmSummary, *string, error) {
 				response, err := svc.ListAlarms(ctx, monitoring.ListAlarmsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					// Alarms are normally created in a workload compartment,
@@ -63,15 +61,12 @@ func (o *mqlOciMonitoring) getAlarms(conn *connection.OciConnection, regions []a
 					Page:                   page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				alarms = append(alarms, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -103,9 +103,7 @@ func (o *mqlOciNetwork) vcns() ([]any, error) {
 }
 
 func (s *mqlOciNetwork) getVcnsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.Vcn, error) {
-	vcns := []core.Vcn{}
-	var page *string
-	for {
+	vcns, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Vcn, *string, error) {
 		request := core.ListVcnsRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -113,16 +111,12 @@ func (s *mqlOciNetwork) getVcnsForRegion(ctx context.Context, networkClient *cor
 
 		response, err := networkClient.ListVcns(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		vcns = append(vcns, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return vcns, nil
@@ -298,9 +292,7 @@ func (o *mqlOciNetwork) securityLists() ([]any, error) {
 }
 
 func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.SecurityList, error) {
-	securityLists := []core.SecurityList{}
-	var page *string
-	for {
+	securityLists, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.SecurityList, *string, error) {
 		request := core.ListSecurityListsRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -308,16 +300,12 @@ func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkCl
 
 		response, err := networkClient.ListSecurityLists(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		securityLists = append(securityLists, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return securityLists, nil
@@ -501,23 +489,18 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 				return nil, err
 			}
 
-			subnets := []core.Subnet{}
-			var page *string
-			for {
+			subnets, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Subnet, *string, error) {
 				response, err := svc.ListSubnets(ctx, core.ListSubnetsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				subnets = append(subnets, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -697,9 +680,7 @@ func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 }
 
 func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.NetworkSecurityGroup, error) {
-	nsgs := []core.NetworkSecurityGroup{}
-	var page *string
-	for {
+	nsgs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.NetworkSecurityGroup, *string, error) {
 		request := core.ListNetworkSecurityGroupsRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -707,16 +688,12 @@ func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *cor
 
 		response, err := networkClient.ListNetworkSecurityGroups(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		nsgs = append(nsgs, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nsgs, nil
@@ -841,9 +818,7 @@ type nsgSecurityRule struct {
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) getRulesForNSG(ctx context.Context, networkClient *core.VirtualNetworkClient, nsgId string) ([]core.SecurityRule, error) {
-	rules := []core.SecurityRule{}
-	var page *string
-	for {
+	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.SecurityRule, *string, error) {
 		request := core.ListNetworkSecurityGroupSecurityRulesRequest{
 			NetworkSecurityGroupId: common.String(nsgId),
 			Page:                   page,
@@ -851,16 +826,12 @@ func (o *mqlOciNetworkNetworkSecurityGroup) getRulesForNSG(ctx context.Context, 
 
 		response, err := networkClient.ListNetworkSecurityGroupSecurityRules(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		rules = append(rules, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return rules, nil
@@ -1008,21 +979,18 @@ func (o *mqlOciNetworkNetworkSecurityGroup) attachedVnics() ([]any, error) {
 		return nil, err
 	}
 
-	var attachments []core.NetworkSecurityGroupVnic
-	var page *string
-	for {
+	attachments, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.NetworkSecurityGroupVnic, *string, error) {
 		response, err := networkClient.ListNetworkSecurityGroupVnics(ctx, core.ListNetworkSecurityGroupVnicsRequest{
 			NetworkSecurityGroupId: common.String(o.Id.Data),
 			Page:                   page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		attachments = append(attachments, response.Items...)
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(attachments))
@@ -1120,23 +1088,18 @@ func (o *mqlOciNetwork) getInternetGateways(conn *connection.OciConnection, regi
 				return nil, err
 			}
 
-			igws := []core.InternetGateway{}
-			var page *string
-			for {
+			igws, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.InternetGateway, *string, error) {
 				response, err := svc.ListInternetGateways(ctx, core.ListInternetGatewaysRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				igws = append(igws, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -1239,23 +1202,18 @@ func (o *mqlOciNetwork) getNatGateways(conn *connection.OciConnection, regions [
 				return nil, err
 			}
 
-			natGws := []core.NatGateway{}
-			var page *string
-			for {
+			natGws, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.NatGateway, *string, error) {
 				response, err := svc.ListNatGateways(ctx, core.ListNatGatewaysRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				natGws = append(natGws, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -1368,23 +1326,18 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 				return nil, err
 			}
 
-			rts := []core.RouteTable{}
-			var page *string
-			for {
+			rts, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.RouteTable, *string, error) {
 				response, err := svc.ListRouteTables(ctx, core.ListRouteTablesRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				rts = append(rts, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -1554,8 +1507,7 @@ func (o *mqlOciNetwork) getPublicIps(conn *connection.OciConnection, regions []a
 				core.ListPublicIpsLifetimeReserved,
 				core.ListPublicIpsLifetimeEphemeral,
 			} {
-				var page *string
-				for {
+				perLifetime, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.PublicIp, *string, error) {
 					response, err := svc.ListPublicIps(ctx, core.ListPublicIpsRequest{
 						Scope:         core.ListPublicIpsScopeRegion,
 						CompartmentId: common.String(conn.TenantID()),
@@ -1563,16 +1515,14 @@ func (o *mqlOciNetwork) getPublicIps(conn *connection.OciConnection, regions []a
 						Page:          page,
 					})
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
-
-					publicIps = append(publicIps, response.Items...)
-
-					if response.OpcNextPage == nil {
-						break
-					}
-					page = response.OpcNextPage
+					return response.Items, response.OpcNextPage, nil
+				})
+				if err != nil {
+					return nil, err
 				}
+				publicIps = append(publicIps, perLifetime...)
 			}
 
 			var res []any

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -56,23 +56,18 @@ func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, reg
 				return nil, err
 			}
 
-			firewalls := []networkfirewall.NetworkFirewallSummary{}
-			var page *string
-			for {
+			firewalls, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkfirewall.NetworkFirewallSummary, *string, error) {
 				response, err := svc.ListNetworkFirewalls(ctx, networkfirewall.ListNetworkFirewallsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				firewalls = append(firewalls, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -203,23 +198,18 @@ func (o *mqlOciNetworkFirewall) getPolicies(conn *connection.OciConnection, regi
 				return nil, err
 			}
 
-			policies := []networkfirewall.NetworkFirewallPolicySummary{}
-			var page *string
-			for {
+			policies, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkfirewall.NetworkFirewallPolicySummary, *string, error) {
 				response, err := svc.ListNetworkFirewallPolicies(ctx, networkfirewall.ListNetworkFirewallPoliciesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				policies = append(policies, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -349,21 +339,18 @@ func (o *mqlOciNetworkFirewallPolicy) decryptionProfiles() ([]any, error) {
 
 	// The list returns summaries only (name/type); the blocking booleans
 	// require a per-profile Get.
-	summaries := []networkfirewall.DecryptionProfileSummary{}
-	var page *string
-	for {
+	summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkfirewall.DecryptionProfileSummary, *string, error) {
 		resp, err := svc.ListDecryptionProfiles(ctx, networkfirewall.ListDecryptionProfilesRequest{
 			NetworkFirewallPolicyId: common.String(o.Id.Data),
 			Page:                    page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		summaries = append(summaries, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(summaries))
@@ -401,36 +388,36 @@ func (o *mqlOciNetworkFirewallPolicy) securityRules() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	res := []any{}
-	var page *string
-	for {
+	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkfirewall.SecurityRuleSummary, *string, error) {
 		resp, err := svc.ListSecurityRules(ctx, networkfirewall.ListSecurityRulesRequest{
 			NetworkFirewallPolicyId: common.String(o.Id.Data),
 			Page:                    page,
 		})
 		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range rules {
+		r := rules[i]
+		name := stringValue(r.Name)
+		mqlRule, err := CreateResource(o.MqlRuntime, "oci.networkFirewall.policy.securityRule", map[string]*llx.RawData{
+			"__id":          llx.StringData(o.Id.Data + "/securityRule/" + name),
+			"name":          llx.StringData(name),
+			"action":        llx.StringData(string(r.Action)),
+			"inspection":    llx.StringData(string(r.Inspection)),
+			"priorityOrder": llx.IntDataPtr(r.PriorityOrder),
+			"description":   llx.StringDataPtr(r.Description),
+		})
+		if err != nil {
 			return nil, err
 		}
-		for i := range resp.Items {
-			r := resp.Items[i]
-			name := stringValue(r.Name)
-			mqlRule, err := CreateResource(o.MqlRuntime, "oci.networkFirewall.policy.securityRule", map[string]*llx.RawData{
-				"__id":          llx.StringData(o.Id.Data + "/securityRule/" + name),
-				"name":          llx.StringData(name),
-				"action":        llx.StringData(string(r.Action)),
-				"inspection":    llx.StringData(string(r.Inspection)),
-				"priorityOrder": llx.IntDataPtr(r.PriorityOrder),
-				"description":   llx.StringDataPtr(r.Description),
-			})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlRule)
-		}
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		res = append(res, mqlRule)
 	}
 	return res, nil
 }
@@ -445,37 +432,37 @@ func (o *mqlOciNetworkFirewallPolicy) decryptionRules() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	res := []any{}
-	var page *string
-	for {
+	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkfirewall.DecryptionRuleSummary, *string, error) {
 		resp, err := svc.ListDecryptionRules(ctx, networkfirewall.ListDecryptionRulesRequest{
 			NetworkFirewallPolicyId: common.String(o.Id.Data),
 			Page:                    page,
 		})
 		if err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range rules {
+		r := rules[i]
+		name := stringValue(r.Name)
+		mqlRule, err := CreateResource(o.MqlRuntime, "oci.networkFirewall.policy.decryptionRule", map[string]*llx.RawData{
+			"__id":              llx.StringData(o.Id.Data + "/decryptionRule/" + name),
+			"name":              llx.StringData(name),
+			"action":            llx.StringData(string(r.Action)),
+			"decryptionProfile": llx.StringDataPtr(r.DecryptionProfile),
+			"secret":            llx.StringDataPtr(r.Secret),
+			"priorityOrder":     llx.IntDataPtr(r.PriorityOrder),
+			"description":       llx.StringDataPtr(r.Description),
+		})
+		if err != nil {
 			return nil, err
 		}
-		for i := range resp.Items {
-			r := resp.Items[i]
-			name := stringValue(r.Name)
-			mqlRule, err := CreateResource(o.MqlRuntime, "oci.networkFirewall.policy.decryptionRule", map[string]*llx.RawData{
-				"__id":              llx.StringData(o.Id.Data + "/decryptionRule/" + name),
-				"name":              llx.StringData(name),
-				"action":            llx.StringData(string(r.Action)),
-				"decryptionProfile": llx.StringDataPtr(r.DecryptionProfile),
-				"secret":            llx.StringDataPtr(r.Secret),
-				"priorityOrder":     llx.IntDataPtr(r.PriorityOrder),
-				"description":       llx.StringDataPtr(r.Description),
-			})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlRule)
-		}
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		res = append(res, mqlRule)
 	}
 	return res, nil
 }

--- a/providers/oci/resources/networkloadbalancer.go
+++ b/providers/oci/resources/networkloadbalancer.go
@@ -41,23 +41,18 @@ func (o *mqlOciNetworkLoadBalancer) loadBalancers() ([]any, error) {
 				return nil, err
 			}
 
-			nlbs := []networkloadbalancer.NetworkLoadBalancerSummary{}
-			var page *string
-			for {
+			nlbs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkloadbalancer.NetworkLoadBalancerSummary, *string, error) {
 				response, err := client.ListNetworkLoadBalancers(ctx, networkloadbalancer.ListNetworkLoadBalancersRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				nlbs = append(nlbs, response.NetworkLoadBalancerCollection.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.NetworkLoadBalancerCollection.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			return o.newNetworkLoadBalancers(nlbs)

--- a/providers/oci/resources/ocipage.go
+++ b/providers/oci/resources/ocipage.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "context"
+
+// OCI paginates almost every list API the same way: the request carries an
+// opaque `Page` token and the response returns the next one as `OpcNextPage`,
+// nil when the collection is exhausted. That uniformity is why one helper can
+// cover the whole provider.
+//
+// It replaces a loop that was hand-written at every list call in this package.
+// Each copy was correct, but the shape has a silent failure mode: leave the
+// loop out and the lister returns the first page and looks like a complete
+// answer. An inventory tool reporting a confident subset is worse than one
+// reporting an error, and nothing about a missing loop looks wrong on review.
+// Going through a helper makes the paging a property of the call rather than
+// something each author has to remember.
+
+// ociPaginate collects every page of an OCI list call.
+//
+// The callback issues one request for the given page token - nil on the first
+// call - and returns that page's items along with the next token. Returning a
+// nil token ends the walk.
+//
+// An error ends the walk and discards what was collected. That is deliberate:
+// a partial list that is indistinguishable from a complete one is exactly the
+// outcome the callers' error handling is built to avoid, and the pool wrappers
+// upstream decide which failures are expected (an absent regional endpoint, an
+// unreadable compartment) and which under-report resources.
+func ociPaginate[T any](ctx context.Context, page func(ctx context.Context, page *string) ([]T, *string, error)) ([]T, error) {
+	var items []T
+	var token *string
+	for {
+		batch, next, err := page(ctx, token)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, batch...)
+		if next == nil {
+			return items, nil
+		}
+		token = next
+	}
+}
+
+// ociScimPaginate collects every page of a SCIM list call against an identity
+// domain.
+//
+// The identity-domains API does not use OCI's page tokens. It is SCIM, so
+// paging is a 1-based `startIndex` with a `count`, and the response reports
+// `totalResults` rather than a next-page token. ociScimNextIndex owns the
+// termination rule, including the case where a domain omits totalResults
+// entirely and a short page is the only signal that the collection is done.
+//
+// The callback returns the page's resources and the response's totalResults so
+// that the caller keeps control of which field of the SCIM envelope to read -
+// each list wraps its resources under a differently named member - and of how
+// to wrap the error, which carries the domain name for attribution.
+func ociScimPaginate[T any](ctx context.Context, page func(ctx context.Context, startIndex int) ([]T, *int, error)) ([]T, error) {
+	var items []T
+	startIndex := 1
+	for {
+		batch, total, err := page(ctx, startIndex)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, batch...)
+		next, more := ociScimNextIndex(startIndex, len(batch), total, ociScimPageSize)
+		if !more {
+			return items, nil
+		}
+		startIndex = next
+	}
+}

--- a/providers/oci/resources/ocipage_test.go
+++ b/providers/oci/resources/ocipage_test.go
@@ -1,0 +1,246 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+var errPageFailed = errors.New("page request failed")
+
+// token is a helper for the *string page tokens OCI uses.
+func token(s string) *string { return &s }
+
+// TestOciPaginateWalksEveryPage covers the shape all 143 converted call sites
+// share: pages are concatenated in order, and the walk stops when the response
+// reports no next page.
+func TestOciPaginateWalksEveryPage(t *testing.T) {
+	pages := [][]int{{1, 2}, {3, 4}, {5}}
+	nextTokens := []*string{token("p2"), token("p3"), nil}
+
+	var sawTokens []*string
+	call := 0
+	items, err := ociPaginate(context.Background(), func(_ context.Context, page *string) ([]int, *string, error) {
+		sawTokens = append(sawTokens, page)
+		batch, next := pages[call], nextTokens[call]
+		call++
+		return batch, next, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []int{1, 2, 3, 4, 5}
+	if len(items) != len(want) {
+		t.Fatalf("got %d items, want %d: %v", len(items), len(want), items)
+	}
+	for i := range want {
+		if items[i] != want[i] {
+			t.Errorf("item %d = %d, want %d (pages concatenated out of order)", i, items[i], want[i])
+		}
+	}
+
+	// The first request must carry no token, and each later one must carry the
+	// token the previous response returned. Getting this wrong re-requests page
+	// one forever.
+	if len(sawTokens) != 3 {
+		t.Fatalf("made %d requests, want 3", len(sawTokens))
+	}
+	if sawTokens[0] != nil {
+		t.Errorf("first request carried token %q, want nil", *sawTokens[0])
+	}
+	if sawTokens[1] == nil || *sawTokens[1] != "p2" {
+		t.Errorf("second request did not carry the first response's token")
+	}
+	if sawTokens[2] == nil || *sawTokens[2] != "p3" {
+		t.Errorf("third request did not carry the second response's token")
+	}
+}
+
+// TestOciPaginateSinglePage is the common case: one request, no next token.
+func TestOciPaginateSinglePage(t *testing.T) {
+	calls := 0
+	items, err := ociPaginate(context.Background(), func(_ context.Context, _ *string) ([]string, *string, error) {
+		calls++
+		return []string{"only"}, nil, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("made %d requests for a single page, want 1", calls)
+	}
+	if len(items) != 1 || items[0] != "only" {
+		t.Errorf("got %v, want [only]", items)
+	}
+}
+
+// TestOciPaginateEmptyCollection pins that an empty collection is not an error
+// and does not loop. Listers hand the result straight to a range loop, so nil
+// and empty behave alike downstream.
+func TestOciPaginateEmptyCollection(t *testing.T) {
+	calls := 0
+	items, err := ociPaginate(context.Background(), func(_ context.Context, _ *string) ([]int, *string, error) {
+		calls++
+		return nil, nil, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("made %d requests, want 1", calls)
+	}
+	if len(items) != 0 {
+		t.Errorf("got %v, want no items", items)
+	}
+}
+
+// TestOciPaginateDiscardsPartialResultOnError is the property the callers'
+// error handling depends on. A half-collected list returned alongside an error
+// invites a caller to use it, and a confident subset is the failure mode the
+// pool wrappers exist to prevent.
+func TestOciPaginateDiscardsPartialResultOnError(t *testing.T) {
+	call := 0
+	items, err := ociPaginate(context.Background(), func(_ context.Context, _ *string) ([]int, *string, error) {
+		call++
+		if call < 3 {
+			return []int{call}, token("more"), nil
+		}
+		return nil, nil, errPageFailed
+	})
+	if !errors.Is(err, errPageFailed) {
+		t.Fatalf("got error %v, want errPageFailed", err)
+	}
+	if items != nil {
+		t.Errorf("got %v alongside the error, want nil", items)
+	}
+}
+
+// TestOciPaginateSurfacesAFirstPageError makes sure a failure before anything
+// was collected is reported rather than read as an empty collection.
+func TestOciPaginateSurfacesAFirstPageError(t *testing.T) {
+	_, err := ociPaginate(context.Background(), func(_ context.Context, _ *string) ([]int, *string, error) {
+		return nil, nil, errPageFailed
+	})
+	if !errors.Is(err, errPageFailed) {
+		t.Fatalf("got error %v, want errPageFailed", err)
+	}
+}
+
+// TestOciPaginatePassesTheContextThrough keeps the context reaching the request
+// rather than being swallowed by the helper, so a cancelled scan stops paging.
+func TestOciPaginatePassesTheContextThrough(t *testing.T) {
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "carried")
+
+	_, err := ociPaginate(ctx, func(inner context.Context, _ *string) ([]int, *string, error) {
+		if inner.Value(ctxKey{}) != "carried" {
+			t.Error("the callback received a different context than the caller passed")
+		}
+		return nil, nil, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- SCIM ------------------------------------------------------------------
+
+// TestOciScimPaginateWalksByStartIndex covers the identity-domains scheme:
+// 1-based startIndex advanced by the number of resources returned, terminating
+// once the reported total is passed.
+func TestOciScimPaginateWalksByStartIndex(t *testing.T) {
+	total := ociScimPageSize + 3
+
+	var sawIndexes []int
+	items, err := ociScimPaginate(context.Background(), func(_ context.Context, startIndex int) ([]int, *int, error) {
+		sawIndexes = append(sawIndexes, startIndex)
+		if startIndex == 1 {
+			return make([]int, ociScimPageSize), &total, nil
+		}
+		return make([]int, 3), &total, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != total {
+		t.Errorf("collected %d resources, want %d", len(items), total)
+	}
+
+	// SCIM is 1-based, and the second page starts one past the first page's
+	// last resource. An off-by-one here silently skips or repeats a user.
+	want := []int{1, 1 + ociScimPageSize}
+	if len(sawIndexes) != len(want) {
+		t.Fatalf("made %d requests at %v, want %d", len(sawIndexes), sawIndexes, len(want))
+	}
+	for i := range want {
+		if sawIndexes[i] != want[i] {
+			t.Errorf("request %d used startIndex %d, want %d", i, sawIndexes[i], want[i])
+		}
+	}
+}
+
+// TestOciScimPaginateStopsOnAShortPageWithoutATotal covers a domain that omits
+// totalResults, where a page shorter than the requested count is the only
+// signal that the collection is exhausted.
+func TestOciScimPaginateStopsOnAShortPageWithoutATotal(t *testing.T) {
+	calls := 0
+	items, err := ociScimPaginate(context.Background(), func(_ context.Context, _ int) ([]int, *int, error) {
+		calls++
+		if calls == 1 {
+			return make([]int, ociScimPageSize), nil, nil
+		}
+		return make([]int, 5), nil, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("made %d requests, want 2 (a short page ends the walk)", calls)
+	}
+	if want := ociScimPageSize + 5; len(items) != want {
+		t.Errorf("collected %d resources, want %d", len(items), want)
+	}
+}
+
+// TestOciScimPaginateStopsOnAnEmptyPage guards the termination case that would
+// otherwise loop forever: a page with no resources cannot advance startIndex.
+func TestOciScimPaginateStopsOnAnEmptyPage(t *testing.T) {
+	calls := 0
+	items, err := ociScimPaginate(context.Background(), func(_ context.Context, _ int) ([]int, *int, error) {
+		calls++
+		return nil, nil, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("made %d requests for an empty collection, want 1", calls)
+	}
+	if len(items) != 0 {
+		t.Errorf("got %v, want no resources", items)
+	}
+}
+
+// TestOciScimPaginateDiscardsPartialResultOnError mirrors the token-based
+// helper: the caller must not receive a partial page set with an error.
+func TestOciScimPaginateDiscardsPartialResultOnError(t *testing.T) {
+	total := ociScimPageSize * 3
+	calls := 0
+	items, err := ociScimPaginate(context.Background(), func(_ context.Context, _ int) ([]int, *int, error) {
+		calls++
+		if calls == 1 {
+			return make([]int, ociScimPageSize), &total, nil
+		}
+		return nil, nil, errPageFailed
+	})
+	if !errors.Is(err, errPageFailed) {
+		t.Fatalf("got error %v, want errPageFailed", err)
+	}
+	if items != nil {
+		t.Errorf("got %d resources alongside the error, want nil", len(items))
+	}
+}

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -57,23 +57,18 @@ func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) [
 				return nil, err
 			}
 
-			clusters := []containerengine.ClusterSummary{}
-			var page *string
-			for {
+			clusters, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerengine.ClusterSummary, *string, error) {
 				response, err := svc.ListClusters(ctx, containerengine.ListClustersRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				clusters = append(clusters, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -298,24 +293,19 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 	}
 
 	clusterId := o.Id.Data
-	pools := []containerengine.NodePoolSummary{}
-	var page *string
-	for {
+	pools, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerengine.NodePoolSummary, *string, error) {
 		response, err := svc.ListNodePools(ctx, containerengine.ListNodePoolsRequest{
 			CompartmentId: common.String(o.CompartmentID.Data),
 			ClusterId:     common.String(clusterId),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		pools = append(pools, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(pools))

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -83,9 +83,7 @@ func (o *mqlOciOns) topics() ([]any, error) {
 }
 
 func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.NotificationControlPlaneClient, compartmentID string) ([]ons.NotificationTopicSummary, error) {
-	topics := []ons.NotificationTopicSummary{}
-	var page *string
-	for {
+	topics, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]ons.NotificationTopicSummary, *string, error) {
 		request := ons.ListTopicsRequest{
 			CompartmentId: common.String(compartmentID),
 			Page:          page,
@@ -93,16 +91,12 @@ func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.Notifica
 
 		response, err := client.ListTopics(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		topics = append(topics, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return topics, nil
@@ -158,9 +152,7 @@ func (o *mqlOciOnsTopic) subscriptions() ([]any, error) {
 	topicId := o.Id.Data
 	ctx := context.Background()
 
-	subs := []ons.SubscriptionSummary{}
-	var page *string
-	for {
+	subs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]ons.SubscriptionSummary, *string, error) {
 		request := ons.ListSubscriptionsRequest{
 			CompartmentId: common.String(conn.TenantID()),
 			TopicId:       common.String(topicId),
@@ -169,16 +161,12 @@ func (o *mqlOciOnsTopic) subscriptions() ([]any, error) {
 
 		response, err := client.ListSubscriptions(ctx, request)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		subs = append(subs, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(subs))

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -54,23 +54,18 @@ func (o *mqlOciRedis) getClusters(conn *connection.OciConnection, regions []any)
 				return nil, err
 			}
 
-			clusters := []redis.RedisClusterSummary{}
-			var page *string
-			for {
+			clusters, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]redis.RedisClusterSummary, *string, error) {
 				response, err := svc.ListRedisClusters(ctx, redis.ListRedisClustersRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				clusters = append(clusters, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(clusters))

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -39,23 +39,18 @@ func (o *mqlOciResourceManager) stacks() ([]any, error) {
 				return nil, err
 			}
 
-			stacks := []resourcemanager.StackSummary{}
-			var page *string
-			for {
+			stacks, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]resourcemanager.StackSummary, *string, error) {
 				response, err := client.ListStacks(ctx, resourcemanager.ListStacksRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				stacks = append(stacks, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(stacks))
@@ -218,23 +213,18 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 	}
 
 	ctx := context.Background()
-	jobs := []resourcemanager.JobSummary{}
-	var page *string
-	for {
+	jobs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]resourcemanager.JobSummary, *string, error) {
 		response, err := client.ListJobs(ctx, resourcemanager.ListJobsRequest{
 			StackId: common.String(o.Id.Data),
 			Page:    page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		jobs = append(jobs, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(jobs))

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -49,23 +49,18 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 				return nil, err
 			}
 
-			secrets := []vault.SecretSummary{}
-			var page *string
-			for {
+			secrets, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vault.SecretSummary, *string, error) {
 				response, err := svc.ListSecrets(ctx, vault.ListSecretsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				secrets = append(secrets, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -241,23 +236,18 @@ func (o *mqlOciVaultSecret) secretVersions() ([]any, error) {
 		return nil, err
 	}
 
-	versions := []vault.SecretVersionSummary{}
-	var page *string
-	for {
+	versions, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vault.SecretVersionSummary, *string, error) {
 		response, err := svc.ListSecretVersions(ctx, vault.ListSecretVersionsRequest{
 			SecretId: common.String(o.Id.Data),
 			Page:     page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-
-		versions = append(versions, response.Items...)
-
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(versions))

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -41,23 +41,18 @@ func (o *mqlOciServiceConnectorHub) connectors() ([]any, error) {
 				return nil, err
 			}
 
-			connectors := []sch.ServiceConnectorSummary{}
-			var page *string
-			for {
+			connectors, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]sch.ServiceConnectorSummary, *string, error) {
 				response, err := client.ListServiceConnectors(ctx, sch.ListServiceConnectorsRequest{
 					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				connectors = append(connectors, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(connectors))

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -65,21 +65,18 @@ func (o *mqlOciNetwork) getDrgs(conn *connection.OciConnection, regions []any) [
 				return nil, err
 			}
 
-			drgs := []core.Drg{}
-			var page *string
-			for {
+			drgs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Drg, *string, error) {
 				response, err := svc.ListDrgs(ctx, core.ListDrgsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				drgs = append(drgs, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -166,9 +163,7 @@ func (o *mqlOciNetworkDrg) attachments() ([]any, error) {
 	}
 	ctx := context.Background()
 
-	atts := []core.DrgAttachment{}
-	var page *string
-	for {
+	atts, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.DrgAttachment, *string, error) {
 		// AttachmentType defaults to VCN server-side, so leaving it unset hid
 		// every IPSec tunnel, FastConnect virtual circuit and remote peering
 		// attachment - exactly the hybrid-connectivity edges this resource
@@ -181,13 +176,12 @@ func (o *mqlOciNetworkDrg) attachments() ([]any, error) {
 			Page:           page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		atts = append(atts, response.Items...)
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(atts))
@@ -266,22 +260,19 @@ func (o *mqlOciNetworkDrg) remotePeeringConnections() ([]any, error) {
 	}
 	ctx := context.Background()
 
-	rpcs := []core.RemotePeeringConnection{}
-	var page *string
-	for {
+	rpcs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.RemotePeeringConnection, *string, error) {
 		response, err := svc.ListRemotePeeringConnections(ctx, core.ListRemotePeeringConnectionsRequest{
 			CompartmentId: common.String(conn.TenantID()),
 			DrgId:         common.String(o.Id.Data),
 			Page:          page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		rpcs = append(rpcs, response.Items...)
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(rpcs))
@@ -451,21 +442,18 @@ func (o *mqlOciNetwork) getLocalPeeringGateways(conn *connection.OciConnection, 
 				return nil, err
 			}
 
-			lpgs := []core.LocalPeeringGateway{}
-			var page *string
-			for {
+			lpgs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.LocalPeeringGateway, *string, error) {
 				response, err := svc.ListLocalPeeringGateways(ctx, core.ListLocalPeeringGatewaysRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				lpgs = append(lpgs, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -620,21 +608,18 @@ func (o *mqlOciNetwork) getServiceGateways(conn *connection.OciConnection, regio
 				return nil, err
 			}
 
-			sgws := []core.ServiceGateway{}
-			var page *string
-			for {
+			sgws, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.ServiceGateway, *string, error) {
 				response, err := svc.ListServiceGateways(ctx, core.ListServiceGatewaysRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				sgws = append(sgws, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -48,21 +48,18 @@ func (o *mqlOciNetwork) getCpes(conn *connection.OciConnection, regions []any) [
 				return nil, err
 			}
 
-			cpes := []core.Cpe{}
-			var page *string
-			for {
+			cpes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Cpe, *string, error) {
 				response, err := svc.ListCpes(ctx, core.ListCpesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				cpes = append(cpes, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -168,21 +165,18 @@ func (o *mqlOciNetwork) getIpsecConnections(conn *connection.OciConnection, regi
 				return nil, err
 			}
 
-			conns := []core.IpSecConnection{}
-			var page *string
-			for {
+			conns, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.IpSecConnection, *string, error) {
 				response, err := svc.ListIPSecConnections(ctx, core.ListIPSecConnectionsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				conns = append(conns, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -300,21 +294,18 @@ func (o *mqlOciNetworkIpsecConnection) tunnels() ([]any, error) {
 	}
 	ctx := context.Background()
 
-	tunnels := []core.IpSecConnectionTunnel{}
-	var page *string
-	for {
+	tunnels, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.IpSecConnectionTunnel, *string, error) {
 		response, err := svc.ListIPSecConnectionTunnels(ctx, core.ListIPSecConnectionTunnelsRequest{
 			IpscId: common.String(o.Id.Data),
 			Page:   page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		tunnels = append(tunnels, response.Items...)
-		if response.OpcNextPage == nil {
-			break
-		}
-		page = response.OpcNextPage
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	res := make([]any, 0, len(tunnels))
@@ -696,21 +687,18 @@ func (o *mqlOciNetwork) getVirtualCircuits(conn *connection.OciConnection, regio
 				return nil, err
 			}
 
-			vcs := []core.VirtualCircuit{}
-			var page *string
-			for {
+			vcs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.VirtualCircuit, *string, error) {
 				response, err := svc.ListVirtualCircuits(ctx, core.ListVirtualCircuitsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				vcs = append(vcs, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -853,21 +841,18 @@ func (o *mqlOciNetwork) getCrossConnects(conn *connection.OciConnection, regions
 				return nil, err
 			}
 
-			xcs := []core.CrossConnect{}
-			var page *string
-			for {
+			xcs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.CrossConnect, *string, error) {
 				response, err := svc.ListCrossConnects(ctx, core.ListCrossConnectsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				xcs = append(xcs, response.Items...)
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any

--- a/providers/oci/resources/vulnerabilityscanning.go
+++ b/providers/oci/resources/vulnerabilityscanning.go
@@ -67,22 +67,19 @@ func (o *mqlOciVulnerabilityScanning) fetchHostScanRecipes(conn *connection.OciC
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.HostScanRecipeSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.HostScanRecipeSummary, *string, error) {
 				resp, err := svc.ListHostScanRecipes(ctx, vulnerabilityscanning.ListHostScanRecipesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host scan recipes")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host scan recipes")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -258,22 +255,19 @@ func (o *mqlOciVulnerabilityScanning) fetchHostScanTargets(conn *connection.OciC
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.HostScanTargetSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.HostScanTargetSummary, *string, error) {
 				resp, err := svc.ListHostScanTargets(ctx, vulnerabilityscanning.ListHostScanTargetsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host scan targets")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host scan targets")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -381,22 +375,19 @@ func (o *mqlOciVulnerabilityScanning) fetchContainerScanRecipes(conn *connection
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.ContainerScanRecipeSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.ContainerScanRecipeSummary, *string, error) {
 				resp, err := svc.ListContainerScanRecipes(ctx, vulnerabilityscanning.ListContainerScanRecipesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS container scan recipes")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS container scan recipes")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -492,22 +483,19 @@ func (o *mqlOciVulnerabilityScanning) fetchContainerScanTargets(conn *connection
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.ContainerScanTargetSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.ContainerScanTargetSummary, *string, error) {
 				resp, err := svc.ListContainerScanTargets(ctx, vulnerabilityscanning.ListContainerScanTargetsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS container scan targets")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS container scan targets")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -628,22 +616,19 @@ func (o *mqlOciVulnerabilityScanning) fetchHostAgentScanResults(conn *connection
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.HostAgentScanResultSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.HostAgentScanResultSummary, *string, error) {
 				resp, err := svc.ListHostAgentScanResults(ctx, vulnerabilityscanning.ListHostAgentScanResultsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host agent scan results")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host agent scan results")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -835,22 +820,19 @@ func (o *mqlOciVulnerabilityScanning) fetchHostPortScanResults(conn *connection.
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.HostPortScanResultSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.HostPortScanResultSummary, *string, error) {
 				resp, err := svc.ListHostPortScanResults(ctx, vulnerabilityscanning.ListHostPortScanResultsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host port scan results")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host port scan results")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -1004,22 +986,19 @@ func (o *mqlOciVulnerabilityScanning) fetchHostCisBenchmarkScanResults(conn *con
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.HostCisBenchmarkScanResultSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.HostCisBenchmarkScanResultSummary, *string, error) {
 				resp, err := svc.ListHostCisBenchmarkScanResults(ctx, vulnerabilityscanning.ListHostCisBenchmarkScanResultsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host CIS benchmark scan results")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host CIS benchmark scan results")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -1144,22 +1123,19 @@ func (o *mqlOciVulnerabilityScanning) fetchHostEndpointProtectionScanResults(con
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.HostEndpointProtectionScanResultSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.HostEndpointProtectionScanResultSummary, *string, error) {
 				resp, err := svc.ListHostEndpointProtectionScanResults(ctx, vulnerabilityscanning.ListHostEndpointProtectionScanResultsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host endpoint protection scan results")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS host endpoint protection scan results")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -1295,22 +1271,19 @@ func (o *mqlOciVulnerabilityScanning) fetchContainerScanResults(conn *connection
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.ContainerScanResultSummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.ContainerScanResultSummary, *string, error) {
 				resp, err := svc.ListContainerScanResults(ctx, vulnerabilityscanning.ListContainerScanResultsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS container scan results")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS container scan results")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -1486,22 +1459,19 @@ func (o *mqlOciVulnerabilityScanning) fetchVulnerabilities(conn *connection.OciC
 			if err != nil {
 				return nil, err
 			}
-			summaries := []vulnerabilityscanning.VulnerabilitySummary{}
-			var page *string
-			for {
+			summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.VulnerabilitySummary, *string, error) {
 				resp, err := svc.ListVulnerabilities(ctx, vulnerabilityscanning.ListVulnerabilitiesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS vulnerabilities")
-					return jobpool.JobResult([]any{}), nil
+					return nil, nil, err
 				}
-				summaries = append(summaries, resp.Items...)
-				if resp.OpcNextPage == nil {
-					break
-				}
-				page = resp.OpcNextPage
+				return resp.Items, resp.OpcNextPage, nil
+			})
+			if err != nil {
+				log.Debug().Err(err).Str("region", regionId).Msg("could not list VSS vulnerabilities")
+				return jobpool.JobResult([]any{}), nil
 			}
 			res := make([]any, 0, len(summaries))
 			for i := range summaries {
@@ -1640,21 +1610,18 @@ func (o *mqlOciVulnerabilityScanningVulnerability) impactedHosts() ([]any, error
 		return nil, err
 	}
 	ctx := context.Background()
-	summaries := []vulnerabilityscanning.VulnerabilityImpactedHostSummary{}
-	var page *string
-	for {
+	summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.VulnerabilityImpactedHostSummary, *string, error) {
 		resp, err := svc.ListVulnerabilityImpactedHosts(ctx, vulnerabilityscanning.ListVulnerabilityImpactedHostsRequest{
 			VulnerabilityId: common.String(o.Id.Data),
 			Page:            page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		summaries = append(summaries, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	res := make([]any, 0, len(summaries))
 	for _, s := range summaries {
@@ -1679,21 +1646,18 @@ func (o *mqlOciVulnerabilityScanningVulnerability) impactedContainerImages() ([]
 		return nil, err
 	}
 	ctx := context.Background()
-	summaries := []vulnerabilityscanning.VulnerabilityImpactedContainerSummary{}
-	var page *string
-	for {
+	summaries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]vulnerabilityscanning.VulnerabilityImpactedContainerSummary, *string, error) {
 		resp, err := svc.ListVulnerabilityImpactedContainers(ctx, vulnerabilityscanning.ListVulnerabilityImpactedContainersRequest{
 			VulnerabilityId: common.String(o.Id.Data),
 			Page:            page,
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		summaries = append(summaries, resp.Items...)
-		if resp.OpcNextPage == nil {
-			break
-		}
-		page = resp.OpcNextPage
+		return resp.Items, resp.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	res := make([]any, 0, len(summaries))
 	for _, s := range summaries {

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -54,23 +54,18 @@ func (o *mqlOciWaf) getFirewalls(conn *connection.OciConnection, regions []any) 
 				return nil, err
 			}
 
-			var items []waf.WebAppFirewallSummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]waf.WebAppFirewallSummary, *string, error) {
 				response, err := svc.ListWebAppFirewalls(ctx, waf.ListWebAppFirewallsRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				items = append(items, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any
@@ -195,23 +190,18 @@ func (o *mqlOciWaf) getPolicies(conn *connection.OciConnection, regions []any) [
 				return nil, err
 			}
 
-			var items []waf.WebAppFirewallPolicySummary
-			var page *string
-			for {
+			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]waf.WebAppFirewallPolicySummary, *string, error) {
 				response, err := svc.ListWebAppFirewallPolicies(ctx, waf.ListWebAppFirewallPoliciesRequest{
 					CompartmentId: common.String(conn.TenantID()),
 					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-
-				items = append(items, response.Items...)
-
-				if response.OpcNextPage == nil {
-					break
-				}
-				page = response.OpcNextPage
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			var res []any


### PR DESCRIPTION
## What

Replace 148 hand-rolled pagination loops with two helpers. **143** token-paged loops (`Page` in, `OpcNextPage` out) and **5** SCIM loops in identity domains.

```go
items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]T, *string, error) {
    resp, err := client.ListThings(ctx, sdk.ListThingsRequest{..., Page: page})
    if err != nil {
        return nil, nil, err
    }
    return resp.Items, resp.OpcNextPage, nil
})
```

## Why

Every copy of the loop was correct. The problem is the shape's failure mode: **leave the loop out and the lister returns the first page and looks like a complete answer.** Nothing about a missing loop looks wrong on review, and an inventory tool reporting a confident subset is worse than one reporting an error. Going through a helper makes paging a property of the call rather than something each author has to remember.

`ociScimPaginate` covers identity domains, which is not token-paged — SCIM uses a 1-based `startIndex` with a `count` and reports `totalResults`. `ociScimNextIndex` keeps owning the termination rule, including the case where a domain omits `totalResults` and a short page is the only signal the collection is done.

## Behavior is unchanged

Before converting anything I verified all 143 loops share one shape: **no early exits, no page or item caps, and no response field other than `OpcNextPage` deciding termination.** (The only two `break`s in the package not tied to a page check are in `policy_statement.go` pure logic.)

**The error handling is the part that is not mechanical, and the reason this is not a regex.** Sixteen sites do not return the list error — they log it and return an empty *successful* result for the whole job:

```go
if err != nil {
    log.Debug().Err(err).Str("region", regionId).Msg("could not list ...")
    return jobpool.JobResult([]any{}), nil
}
```

Mapping those to `return nil, err` would have turned a swallowed failure into a hard one. Instead **the entire `if err != nil` block moves out of the loop verbatim** and the closure returns the error — one rule that preserves both the returning and the swallowing sites.

**15 loops were converted by hand** because they did more than collect: some process items inline into a map instead of appending, some build MQL resources inside the page loop, and some sit inside an outer loop over lifecycle states / DNS scopes / public-IP lifetimes and accumulate across iterations. Collecting first and mapping second preserves order exactly, since pages concatenate in arrival order.

## Verification

Beyond `go build`, `go vet`, and `go test -race ./...`:

**Unit tests on the primitives** — page concatenation and order, token threading (first request carries no token, each later one carries the previous response's), single page, empty collection, first-page error, mid-pagination error discarding the partial result, context pass-through. For SCIM: `startIndex` advancement, termination on the reported total, termination on a short page with no total, and termination on an empty page — which would otherwise loop forever, since an empty page cannot advance `startIndex`.

**A per-file audit against the base commit** confirms three properties are identical for all 40 files: the error-handling shape (swallow vs. return), the set of SDK `List*` calls, and the set of resource names passed to `CreateResource`/`NewResource`. Nothing added, nothing dropped.

I also confirmed no empty result changed from `[]` to `null`: every paginated SDK slice is remapped into a locally-built `[]any` before reaching MQL, and the one place that returns a converted slice directly (`identitydomains` domains) is explicitly `make([]any, 0, len(...))` to match the original non-nil `[]any{}`.

## One consequence worth naming

A lister now holds a whole collection of SDK structs before mapping it, where it previously mapped page by page. For the collection sizes this provider deals with that is not a concern, but it is a real change in allocation profile rather than a pure no-op.

## Context

PR 2 of six behavior-preserving PRs restructuring this provider's internals; PR 1 was #9650. The user-facing surface — the `.lr` schema, all 211 resources, field names and types, discovery targets, CLI flags — does not move in any of them.

Still to come: one scope-typed fan-out replacing the two competing idioms, mapping helpers, a generic typed-ref resolver, and a table-driven discovery registry.

Two behavior-*changing* follow-ups stay quarantined out of that sequence: migrating the 73 root-compartment-only listers to walk the compartment tree, and converging the two pools' error policies. **This PR surfaces a third candidate for that list** — the 16 sites above that swallow a list error and report an empty collection are the same class of defect (a confident empty result), and worth revisiting deliberately rather than as a side effect of a refactor.

## Verification owed

Live validation against a real tenancy is still outstanding for this provider (carried over from #9573–#9578). The highest-value thing to exercise here is SCIM pagination against a domain with more than 200 users, since that is the only path where the termination rule is non-trivial.
