### PR TITLE
🧹 providers: lock schema JSON contract with tests, add status to list

### DIFF
--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -332,7 +332,43 @@ func loadSingleProviderSchema(existing providers.Providers, providerName string)
 type providerListEntry struct {
 	Name       string   `json:"name"`
 	Version    string   `json:"version"`
+	Status     string   `json:"status"`
 	Connectors []string `json:"connectors"`
+}
+
+// providerStatus reports whether a provider is compiled into the binary
+// ("builtin") or loaded from disk ("installed"). Builtin providers have no
+// on-disk path.
+func providerStatus(p *providers.Provider) string {
+	if p.Path == "" {
+		return "builtin"
+	}
+	return "installed"
+}
+
+// buildProviderListEntries projects providers into the JSON list shape, sorted
+// by name, with hidden connectors omitted. Kept separate from listCmd so the
+// output contract can be unit-tested without touching the provider registry.
+func buildProviderListEntries(all []*providers.Provider) []providerListEntry {
+	entries := make([]providerListEntry, 0, len(all))
+	for _, p := range all {
+		conns := make([]string, 0, len(p.Connectors))
+		for _, c := range p.Connectors {
+			if !c.IsHidden {
+				conns = append(conns, c.Name)
+			}
+		}
+		entries = append(entries, providerListEntry{
+			Name:       p.Name,
+			Version:    p.Version,
+			Status:     providerStatus(p),
+			Connectors: conns,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+	return entries
 }
 
 func listCmd(cmd *cobra.Command) {
@@ -342,24 +378,7 @@ func listCmd(cmd *cobra.Command) {
 	}
 
 	if isJsonOutput(cmd) {
-		entries := make([]providerListEntry, 0, len(all))
-		for _, p := range all {
-			conns := make([]string, 0, len(p.Connectors))
-			for _, c := range p.Connectors {
-				if !c.IsHidden {
-					conns = append(conns, c.Name)
-				}
-			}
-			entries = append(entries, providerListEntry{
-				Name:       p.Name,
-				Version:    p.Version,
-				Connectors: conns,
-			})
-		}
-		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].Name < entries[j].Name
-		})
-		if err := writeJSON(entries); err != nil {
+		if err := writeJSON(buildProviderListEntries(all)); err != nil {
 			log.Fatal().Err(err).Msg("failed to write JSON output")
 		}
 		return
@@ -394,6 +413,51 @@ type flagInfo struct {
 	Type    string `json:"type"`
 }
 
+// buildProviderInfoEntry projects a single provider into the info JSON shape,
+// omitting hidden connectors and hidden flags. Kept separate from infoProviders
+// so the output contract can be unit-tested with a fabricated provider.
+func buildProviderInfoEntry(p *providers.Provider) providerInfoEntry {
+	conns := make([]connectorInfo, 0, len(p.Connectors))
+	for _, c := range p.Connectors {
+		if c.IsHidden {
+			continue
+		}
+		flags := make([]flagInfo, 0, len(c.Flags))
+		for _, f := range c.Flags {
+			if f.Option&plugin.FlagOption_Hidden != 0 {
+				continue
+			}
+			flags = append(flags, flagInfo{
+				Long:    f.Long,
+				Short:   f.Short,
+				Default: f.Default,
+				Desc:    f.Desc,
+				Type:    flagTypeString(f.Type),
+			})
+		}
+		ci := connectorInfo{
+			Name:  c.Name,
+			Short: c.Short,
+			Flags: flags,
+		}
+		if len(c.Aliases) > 0 {
+			ci.Aliases = c.Aliases
+		}
+		if len(c.Discovery) > 0 {
+			ci.Discovery = c.Discovery
+		}
+		conns = append(conns, ci)
+	}
+
+	return providerInfoEntry{
+		Name:       p.Name,
+		ID:         p.ID,
+		Version:    p.Version,
+		Path:       p.Path,
+		Connectors: conns,
+	}
+}
+
 func infoProviders(cmd *cobra.Command, names []string) error {
 	existing, err := providers.ListActive()
 	if err != nil {
@@ -406,46 +470,7 @@ func infoProviders(cmd *cobra.Command, names []string) error {
 		if p == nil {
 			return fmt.Errorf("provider %q not found", name)
 		}
-
-		conns := make([]connectorInfo, 0, len(p.Connectors))
-		for _, c := range p.Connectors {
-			if c.IsHidden {
-				continue
-			}
-			flags := make([]flagInfo, 0, len(c.Flags))
-			for _, f := range c.Flags {
-				if f.Option&plugin.FlagOption_Hidden != 0 {
-					continue
-				}
-				flags = append(flags, flagInfo{
-					Long:    f.Long,
-					Short:   f.Short,
-					Default: f.Default,
-					Desc:    f.Desc,
-					Type:    flagTypeString(f.Type),
-				})
-			}
-			ci := connectorInfo{
-				Name:  c.Name,
-				Short: c.Short,
-				Flags: flags,
-			}
-			if len(c.Aliases) > 0 {
-				ci.Aliases = c.Aliases
-			}
-			if len(c.Discovery) > 0 {
-				ci.Discovery = c.Discovery
-			}
-			conns = append(conns, ci)
-		}
-
-		entries = append(entries, providerInfoEntry{
-			Name:       p.Name,
-			ID:         p.ID,
-			Version:    p.Version,
-			Path:       p.Path,
-			Connectors: conns,
-		})
+		entries = append(entries, buildProviderInfoEntry(p))
 	}
 
 	if isJsonOutput(cmd) {
@@ -505,13 +530,11 @@ type resourceSummary struct {
 	FieldCount int      `json:"field_count"`
 }
 
-func listResources(cmd *cobra.Command, providerName string) error {
-	excludeCoreNetwork, _ := cmd.Flags().GetBool("exclude-core-network")
-	schema, err := loadProviderSchema(providerName, !excludeCoreNetwork)
-	if err != nil {
-		return err
-	}
-
+// buildResourceList projects a schema into the resource-list JSON shape:
+// private resources are omitted and the remainder are sorted by name. Kept
+// separate from listResources so the output contract can be unit-tested with a
+// fabricated schema.
+func buildResourceList(schema resources.ResourcesSchema, providerName string) resourceList {
 	allResources := schema.AllResources()
 	summaries := make([]resourceSummary, 0, len(allResources))
 	for name, ri := range allResources {
@@ -542,17 +565,28 @@ func listResources(cmd *cobra.Command, providerName string) error {
 	sort.Slice(summaries, func(i, j int) bool {
 		return summaries[i].Name < summaries[j].Name
 	})
+	return resourceList{
+		Provider:       providerName,
+		TotalResources: len(summaries),
+		Resources:      summaries,
+	}
+}
 
-	if isJsonOutput(cmd) {
-		return writeJSON(resourceList{
-			Provider:       providerName,
-			TotalResources: len(summaries),
-			Resources:      summaries,
-		})
+func listResources(cmd *cobra.Command, providerName string) error {
+	excludeCoreNetwork, _ := cmd.Flags().GetBool("exclude-core-network")
+	schema, err := loadProviderSchema(providerName, !excludeCoreNetwork)
+	if err != nil {
+		return err
 	}
 
-	fmt.Printf("%s (%d resources)\n\n", theme.DefaultTheme.Primary(providerName), len(summaries))
-	for _, r := range summaries {
+	list := buildResourceList(schema, providerName)
+
+	if isJsonOutput(cmd) {
+		return writeJSON(list)
+	}
+
+	fmt.Printf("%s (%d resources)\n\n", theme.DefaultTheme.Primary(providerName), list.TotalResources)
+	for _, r := range list.Resources {
 		title := ""
 		if r.Title != "" {
 			title = " - " + r.Title
@@ -586,17 +620,11 @@ type fieldDetail struct {
 	IsMandatory bool   `json:"is_mandatory,omitempty"`
 }
 
-func showResource(cmd *cobra.Command, providerName string, resourceName string) error {
-	schema, err := loadProviderSchema(providerName, true)
-	if err != nil {
-		return err
-	}
-
-	ri := schema.Lookup(resourceName)
-	if ri == nil {
-		return fmt.Errorf("resource %q not found in provider %q", resourceName, providerName)
-	}
-
+// buildResourceDetail projects a resource into the detail JSON shape: private
+// fields are omitted and the remainder are sorted by name. Kept separate from
+// showResource so the output contract can be unit-tested with a fabricated
+// resource.
+func buildResourceDetail(ri *resources.ResourceInfo) resourceDetail {
 	fields := make([]fieldDetail, 0, len(ri.Fields))
 	for _, f := range ri.Fields {
 		if f.IsPrivate {
@@ -620,7 +648,7 @@ func showResource(cmd *cobra.Command, providerName string, resourceName string) 
 		defaults = strings.Split(ri.Defaults, " ")
 	}
 
-	detail := resourceDetail{
+	return resourceDetail{
 		Name:       ri.Name,
 		Title:      ri.Title,
 		Desc:       ri.Desc,
@@ -631,21 +659,35 @@ func showResource(cmd *cobra.Command, providerName string, resourceName string) 
 		FieldCount: len(fields),
 		Fields:     fields,
 	}
+}
+
+func showResource(cmd *cobra.Command, providerName string, resourceName string) error {
+	schema, err := loadProviderSchema(providerName, true)
+	if err != nil {
+		return err
+	}
+
+	ri := schema.Lookup(resourceName)
+	if ri == nil {
+		return fmt.Errorf("resource %q not found in provider %q", resourceName, providerName)
+	}
+
+	detail := buildResourceDetail(ri)
 
 	if isJsonOutput(cmd) {
 		return writeJSON(detail)
 	}
 
-	fmt.Printf("%s%s\n", theme.DefaultTheme.Primary(ri.Name), maturityTag(ri.Maturity))
-	if ri.Title != "" {
-		fmt.Printf("  %s\n", ri.Title)
+	fmt.Printf("%s%s\n", theme.DefaultTheme.Primary(detail.Name), maturityTag(detail.Maturity))
+	if detail.Title != "" {
+		fmt.Printf("  %s\n", detail.Title)
 	}
-	if ri.Desc != "" {
-		fmt.Printf("  %s\n", ri.Desc)
+	if detail.Desc != "" {
+		fmt.Printf("  %s\n", detail.Desc)
 	}
 	fmt.Println()
-	fmt.Printf("  Fields (%d):\n", len(fields))
-	for _, f := range fields {
+	fmt.Printf("  Fields (%d):\n", len(detail.Fields))
+	for _, f := range detail.Fields {
 		mandatory := ""
 		if f.IsMandatory {
 			mandatory = " (required)"

--- a/apps/mql/cmd/providers_test.go
+++ b/apps/mql/cmd/providers_test.go
@@ -4,11 +4,15 @@
 package cmd
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
+	"go.mondoo.com/mql/types"
 )
 
 // updateTestProvider builds a minimal Provider for selectProvidersToUpdate
@@ -73,4 +77,179 @@ func TestSelectProvidersToUpdate_BuiltinNameIsNotUpdatable(t *testing.T) {
 
 	assert.Empty(t, toUpdate)
 	assert.Equal(t, []string{"core"}, notInstalled)
+}
+
+// --- schema/JSON output contract ---
+//
+// These tests lock the JSON shape emitted by the schema-browsing commands
+// (providers list/info/resources). They exercise the pure builder functions
+// with fabricated inputs so the contract is verified without a provider
+// registry or installed providers on disk.
+
+func TestShortProviderName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"go.mondoo.com/mql/providers/aws", "aws"},
+		{"go.mondoo.com/mql/providers/core", "core"},
+		{"go.mondoo.com/mql/providers/aws/resources", "aws"},
+		{"aws", "aws"},
+		{"some/other/path", "path"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, shortProviderName(c.in), "input %q", c.in)
+	}
+}
+
+func TestBuildProviderListEntries(t *testing.T) {
+	all := []*providers.Provider{
+		{Provider: &plugin.Provider{
+			Name:    "os",
+			Version: "13.2.0",
+			Connectors: []plugin.Connector{
+				{Name: "local"},
+				{Name: "internal", IsHidden: true}, // must be omitted
+			},
+		}, Path: "/p/os"},
+		{Provider: &plugin.Provider{Name: "core", Version: "13.2.0"}}, // builtin (no path)
+	}
+
+	entries := buildProviderListEntries(all)
+
+	// sorted by name
+	require.Len(t, entries, 2)
+	assert.Equal(t, "core", entries[0].Name)
+	assert.Equal(t, "os", entries[1].Name)
+
+	// status derives from on-disk path
+	assert.Equal(t, "builtin", entries[0].Status)
+	assert.Equal(t, "installed", entries[1].Status)
+
+	// hidden connectors are dropped
+	assert.Equal(t, []string{"local"}, entries[1].Connectors)
+
+	// JSON contract: status is always present (not omitempty)
+	blob, err := json.Marshal(entries[0])
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(blob, &m))
+	assert.Contains(t, m, "status")
+	assert.Equal(t, "builtin", m["status"])
+}
+
+func TestBuildProviderInfoEntry(t *testing.T) {
+	p := &providers.Provider{Provider: &plugin.Provider{
+		Name:    "aws",
+		ID:      "go.mondoo.com/mql/providers/aws",
+		Version: "13.2.0",
+		Connectors: []plugin.Connector{
+			{
+				Name:      "aws",
+				Short:     "Amazon Web Services",
+				Aliases:   []string{"amazon"},
+				Discovery: []string{"accounts"},
+				Flags: []plugin.Flag{
+					{Long: "profile", Type: plugin.FlagType_String, Desc: "AWS profile"},
+					{Long: "secret", Type: plugin.FlagType_String, Option: plugin.FlagOption_Hidden}, // omitted
+				},
+			},
+			{Name: "hidden-conn", IsHidden: true}, // omitted
+		},
+	}, Path: "/p/aws"}
+
+	entry := buildProviderInfoEntry(p)
+
+	assert.Equal(t, "aws", entry.Name)
+	assert.Equal(t, "go.mondoo.com/mql/providers/aws", entry.ID)
+	assert.Equal(t, "/p/aws", entry.Path)
+
+	require.Len(t, entry.Connectors, 1, "hidden connector omitted")
+	conn := entry.Connectors[0]
+	assert.Equal(t, "aws", conn.Name)
+	assert.Equal(t, []string{"amazon"}, conn.Aliases)
+	assert.Equal(t, []string{"accounts"}, conn.Discovery)
+
+	require.Len(t, conn.Flags, 1, "hidden flag omitted")
+	assert.Equal(t, "profile", conn.Flags[0].Long)
+	assert.Equal(t, "string", conn.Flags[0].Type)
+}
+
+func TestBuildResourceList(t *testing.T) {
+	schema := &resources.Schema{Resources: map[string]*resources.ResourceInfo{
+		"aws.s3.bucket": {
+			Name:     "aws.s3.bucket",
+			Title:    "Amazon S3 Bucket",
+			Provider: "go.mondoo.com/mql/providers/aws",
+			Fields: map[string]*resources.Field{
+				"arn":  {Name: "arn", Type: string(types.String)},
+				"name": {Name: "name", Type: string(types.String)},
+			},
+		},
+		"aws.deprecated.thing": {
+			Name:     "aws.deprecated.thing",
+			Provider: "go.mondoo.com/mql/providers/aws",
+			Maturity: resources.MaturityDeprecated,
+		},
+		"aws.internal.secret": {
+			Name:    "aws.internal.secret",
+			Private: true, // must be omitted
+		},
+	}}
+
+	list := buildResourceList(schema, "aws")
+
+	assert.Equal(t, "aws", list.Provider)
+	require.Equal(t, 2, list.TotalResources, "private resource omitted")
+	require.Len(t, list.Resources, 2)
+
+	// sorted by name
+	assert.Equal(t, "aws.deprecated.thing", list.Resources[0].Name)
+	assert.Equal(t, "aws.s3.bucket", list.Resources[1].Name)
+
+	// origin shortened, maturity surfaced, field count
+	assert.Equal(t, "aws", list.Resources[1].Provider)
+	assert.Equal(t, "deprecated", list.Resources[0].Maturity)
+	assert.Equal(t, 2, list.Resources[1].FieldCount)
+}
+
+func TestBuildResourceDetail(t *testing.T) {
+	ri := &resources.ResourceInfo{
+		Name:     "aws.s3.bucket",
+		Title:    "Amazon S3 Bucket",
+		Provider: "go.mondoo.com/mql/providers/aws",
+		Fields: map[string]*resources.Field{
+			"name":   {Name: "name", Type: string(types.String), IsMandatory: true},
+			"arn":    {Name: "arn", Type: string(types.String), Maturity: resources.MaturityDeprecated},
+			"hidden": {Name: "hidden", Type: string(types.String), IsPrivate: true}, // omitted
+		},
+	}
+
+	detail := buildResourceDetail(ri)
+
+	assert.Equal(t, "aws.s3.bucket", detail.Name)
+	assert.Equal(t, "aws", detail.Provider)
+	require.Equal(t, 2, detail.FieldCount, "private field omitted")
+	require.Len(t, detail.Fields, 2)
+
+	// sorted by name: arn, name
+	assert.Equal(t, "arn", detail.Fields[0].Name)
+	assert.Equal(t, "name", detail.Fields[1].Name)
+
+	// type label, maturity, mandatory
+	assert.Equal(t, "string", detail.Fields[0].Type)
+	assert.Equal(t, "deprecated", detail.Fields[0].Maturity)
+	assert.True(t, detail.Fields[1].IsMandatory)
+
+	// JSON contract: is_mandatory omitted when false, present when true
+	blob, err := json.Marshal(detail.Fields[1])
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(blob, &m))
+	assert.Contains(t, m, "is_mandatory")
+	blob, err = json.Marshal(detail.Fields[0])
+	require.NoError(t, err)
+	m = map[string]any{}
+	require.NoError(t, json.Unmarshal(blob, &m))
+	assert.NotContains(t, m, "is_mandatory")
 }


### PR DESCRIPTION
## What

Two things:

1. **`status` on `providers list --json`** — adds a `status` field (`"builtin"` for providers compiled into the binary, `"installed"` for those loaded from disk), derived from the provider's on-disk path.
2. **JSON-contract tests** — extracts the JSON projection logic from the command handlers into pure builder functions and adds unit tests that pin the output shape.

## Why

The schema-browsing JSON (`providers list` / `info` / `resources`) is the contract agents parse, but nothing guarded its shape, and the commands read from the provider registry / disk so they weren't unit-testable as written.

## How

- Extracted `buildProviderListEntries`, `buildProviderInfoEntry`, `buildResourceList`, and `buildResourceDetail` as pure functions. The handlers now just load data and call these — no behavior change.
- New tests fabricate providers / schemas in memory (same style as the existing `updateTestProvider` helpers) and assert: `status` values and that the key is always present; hidden connectors/flags omitted; private resources/fields omitted; sort order; provider-origin shortening; maturity surfacing; type labels; and `omitempty` on `is_mandatory`.

`gofmt`, `go build`, `go vet`, and `go test ./apps/mql/cmd/` all pass (5 new tests).

## Stack

PR 3 of 3, based on #9657 (provider origin), which is based on #9656 (maturity). Merge #9656 → #9657 → this in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)