### PR TITLE
🧹 oci: one fan-out, with the compartment scope named at the call site

### DIFF
--- a/providers/oci/resources/aiservices.go
+++ b/providers/oci/resources/aiservices.go
@@ -24,7 +24,7 @@ import (
 // subscribed region concurrently and flattens the results. Regions where the
 // service is not available are skipped (see ociRegionServiceUnavailable).
 func ociListRegionalAI(runtime *plugin.Runtime, fetch func(region string) ([]any, error)) ([]any, error) {
-	regions, err := ociAgentRegions(runtime)
+	regions, err := ociRegionsFor(runtime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -16,7 +16,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -30,38 +29,18 @@ func (o *mqlOciApigateway) id() (string, error) {
 func (o *mqlOciApigateway) gateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci api gateways with region %s", region)
 
-	return ociRunRegionPool(o.getGateways(conn, list.Data))
-}
-
-func (o *mqlOciApigateway) getGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci api gateways with region %s", regionResource.Id.Data)
-
-			svc, err := conn.ApiGatewayGatewayClient(regionResource.Id.Data)
+			svc, err := conn.ApiGatewayGatewayClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]apigateway.GatewaySummary, *string, error) {
 				response, err := svc.ListGateways(ctx, apigateway.ListGatewaysRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -112,18 +91,15 @@ func (o *mqlOciApigateway) getGateways(conn *connection.OciConnection, regions [
 					return nil, err
 				}
 				mqlGw := mqlInstance.(*mqlOciApigatewayGateway)
-				mqlGw.region = regionResource.Id.Data
+				mqlGw.region = region
 				mqlGw.cacheSubnetId = stringValue(g.SubnetId)
 				mqlGw.cacheCertificateId = stringValue(g.CertificateId)
 				mqlGw.cacheNsgIds = append([]string(nil), g.NetworkSecurityGroupIds...)
 				res = append(res, mqlGw)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciApigatewayGatewayInternal struct {
@@ -271,38 +247,18 @@ func (o *mqlOciApigatewayGateway) hasResponseCache() (bool, error) {
 func (o *mqlOciApigateway) deployments() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci api gateway deployments with region %s", region)
 
-	return ociRunRegionPool(o.getDeployments(conn, list.Data))
-}
-
-func (o *mqlOciApigateway) getDeployments(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci api gateway deployments with region %s", regionResource.Id.Data)
-
-			svc, err := conn.ApiGatewayDeploymentClient(regionResource.Id.Data)
+			svc, err := conn.ApiGatewayDeploymentClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]apigateway.DeploymentSummary, *string, error) {
 				response, err := svc.ListDeployments(ctx, apigateway.ListDeploymentsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -352,16 +308,13 @@ func (o *mqlOciApigateway) getDeployments(conn *connection.OciConnection, region
 					return nil, err
 				}
 				mqlDep := mqlInstance.(*mqlOciApigatewayDeployment)
-				mqlDep.region = regionResource.Id.Data
+				mqlDep.region = region
 				mqlDep.cacheGatewayId = stringValue(d.GatewayId)
 				res = append(res, mqlDep)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciApigatewayDeploymentInternal struct {
@@ -679,38 +632,18 @@ func (o *mqlOciApigatewayDeployment) hasDynamicAuthentication() (bool, error) {
 func (o *mqlOciApigateway) certificates() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci api gateway certificates with region %s", region)
 
-	return ociRunRegionPool(o.getCertificates(conn, list.Data))
-}
-
-func (o *mqlOciApigateway) getCertificates(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci api gateway certificates with region %s", regionResource.Id.Data)
-
-			svc, err := conn.ApiGatewayClient(regionResource.Id.Data)
+			svc, err := conn.ApiGatewayClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]apigateway.CertificateSummary, *string, error) {
 				response, err := svc.ListCertificates(ctx, apigateway.ListCertificatesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -766,11 +699,8 @@ func (o *mqlOciApigateway) getCertificates(conn *connection.OciConnection, regio
 				}
 				res = append(res, mqlInstance)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciApigatewayCertificate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/oci/resources/audit.go
+++ b/providers/oci/resources/audit.go
@@ -65,15 +65,6 @@ func (o *mqlOciAudit) retentionPeriodDays() (int64, error) {
 func (o *mqlOciAudit) events() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	regions := ociResource.(*mqlOci).GetRegions()
-	if regions.Error != nil {
-		return nil, regions.Error
-	}
-
 	// Audit events are recorded per region and per compartment, and the API
 	// offers no subtree flag, so both dimensions have to be walked.
 	// Truncated to the minute because the Audit API requires it: both bounds
@@ -83,7 +74,7 @@ func (o *mqlOciAudit) events() ([]any, error) {
 	endTime := time.Now().UTC().Truncate(time.Minute)
 	startTime := endTime.Add(-ociAuditEventWindow)
 
-	return ociRunCompartmentRegionPool(conn, regions.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.AuditClient(region)
 			if err != nil {

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -27,38 +25,18 @@ func (o *mqlOciBastion) id() (string, error) {
 func (o *mqlOciBastion) bastions() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci bastion with region %s", region)
 
-	return ociRunRegionPool(o.getBastions(conn, list.Data))
-}
-
-func (o *mqlOciBastion) getBastions(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci bastion with region %s", regionResource.Id.Data)
-
-			svc, err := conn.BastionClient(regionResource.Id.Data)
+			svc, err := conn.BastionClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			bastions, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]bastion.BastionSummary, *string, error) {
 				response, err := svc.ListBastions(ctx, bastion.ListBastionsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -100,15 +78,12 @@ func (o *mqlOciBastion) getBastions(conn *connection.OciConnection, regions []an
 				mqlB := mqlInstance.(*mqlOciBastionInstance)
 				mqlB.cacheTargetVcnId = stringValue(b.TargetVcnId)
 				mqlB.cacheTargetSubnetId = stringValue(b.TargetSubnetId)
-				mqlB.region = regionResource.Id.Data
+				mqlB.region = region
 				res = append(res, mqlB)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciBastionInstanceInternal struct {

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -27,21 +26,11 @@ func (o *mqlOciCertificates) id() (string, error) {
 func (o *mqlOciCertificates) certificates() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Certificates are issued into the compartment of the load balancer or
 	// gateway that terminates TLS, and ListCertificates cannot look below the
 	// compartment it is given. A root-only listing reported no certificates at
 	// all, so expiry and renewal checks silently had nothing to inspect.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci certificates with region %s", region)
 
@@ -225,38 +214,18 @@ func initOciCertificatesCertificateAuthority(runtime *plugin.Runtime, args map[s
 func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci certificate authorities with region %s", region)
 
-	return ociRunRegionPool(o.getCertificateAuthorities(conn, list.Data))
-}
-
-func (o *mqlOciCertificates) getCertificateAuthorities(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci certificate authorities with region %s", regionResource.Id.Data)
-
-			svc, err := conn.CertificatesManagementClient(regionResource.Id.Data)
+			svc, err := conn.CertificatesManagementClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]certificatesmanagement.CertificateAuthoritySummary, *string, error) {
 				response, err := svc.ListCertificateAuthorities(ctx, certificatesmanagement.ListCertificateAuthoritiesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -327,11 +296,8 @@ func (o *mqlOciCertificates) getCertificateAuthorities(conn *connection.OciConne
 				mqlCa.cacheKmsKeyId = stringValue(ca.KmsKeyId)
 				res = append(res, mqlCa)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciCertificatesCertificateAuthorityInternal struct {
@@ -410,38 +376,18 @@ func initOciCertificatesCaBundle(runtime *plugin.Runtime, args map[string]*llx.R
 func (o *mqlOciCertificates) caBundles() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci CA bundles with region %s", region)
 
-	return ociRunRegionPool(o.getCaBundles(conn, list.Data))
-}
-
-func (o *mqlOciCertificates) getCaBundles(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci CA bundles with region %s", regionResource.Id.Data)
-
-			svc, err := conn.CertificatesManagementClient(regionResource.Id.Data)
+			svc, err := conn.CertificatesManagementClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]certificatesmanagement.CaBundleSummary, *string, error) {
 				response, err := svc.ListCaBundles(ctx, certificatesmanagement.ListCaBundlesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -486,11 +432,8 @@ func (o *mqlOciCertificates) getCaBundles(conn *connection.OciConnection, region
 				}
 				res = append(res, mqlInstance)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func (o *mqlOciCertificatesCaBundle) id() (string, error) {

--- a/providers/oci/resources/compartments.go
+++ b/providers/oci/resources/compartments.go
@@ -4,26 +4,18 @@
 package resources
 
 import (
-	"context"
 	"errors"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
-	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
-// ociCompartmentPoolConcurrency bounds how many (region, compartment) list
-// calls run at once. Compartment fan-out multiplies the request count by the
-// compartment tree size, so this is deliberately higher than the plain
-// per-region pool while still staying well inside OCI's per-tenancy rate
-// limits.
-const ociCompartmentPoolConcurrency = 10
+// Compartment-shaped helpers used by listers. The fan-out itself lives in
+// ociscope.go.
 
-// ociRegionsByID indexes an oci.regions collection by region key so a
-// compartment lister, which only receives the region as a string, can still set
-// a typed oci.region field on the resources it builds.
+// ociRegionsByID indexes an oci.regions collection by region key so a lister,
+// which receives the region as a string, can still set a typed oci.region field
+// on the resources it builds.
 func ociRegionsByID(regions []any) (map[string]*mqlOciRegion, error) {
 	res := make(map[string]*mqlOciRegion, len(regions))
 	for _, region := range regions {
@@ -38,13 +30,13 @@ func ociRegionsByID(regions []any) (map[string]*mqlOciRegion, error) {
 
 // ociDedupeByID drops repeated resources from a fan-out result.
 //
-// The compartment pool queries every (region, compartment) pair, which is
-// right for a regional service but over-counts a global one: OCI's public DNS
-// is served from every regional endpoint, so each global zone comes back once
-// per subscribed region. Because CreateResource returns the cached instance
-// for an id it has already seen, those repeats are the same resource appearing
-// several times rather than distinct rows, and a length or a where() over the
-// collection silently multiplies by the region count.
+// The compartment scope queries every (region, compartment) pair, which is right
+// for a regional service but over-counts a global one: OCI's public DNS is served
+// from every regional endpoint, so each global zone comes back once per
+// subscribed region. Because CreateResource returns the cached instance for an id
+// it has already seen, those repeats are the same resource appearing several
+// times rather than distinct rows, and a length or a where() over the collection
+// silently multiplies by the region count.
 func ociDedupeByID(items []any) []any {
 	res := make([]any, 0, len(items))
 	seen := make(map[string]struct{}, len(items))
@@ -62,140 +54,6 @@ func ociDedupeByID(items []any) []any {
 		res = append(res, item)
 	}
 	return res
-}
-
-// ociCompartmentLister lists resources of a single type inside one compartment
-// in one region. Implementations return the already-constructed MQL resources.
-type ociCompartmentLister func(ctx context.Context, region string, compartmentID string) ([]any, error)
-
-// ociRunCompartmentRegionPool fans a lister out over every (region, compartment)
-// pair in the tenancy and joins the results.
-//
-// Most OCI list APIs are scoped to a single compartment and, unlike Cloud Guard
-// or Logging, offer no `compartmentIdInSubtree` flag. Listing only the tenancy
-// root - which is what passing conn.TenantID() as the compartment does - then
-// reports nothing at all for any tenancy that organizes its resources into
-// child compartments, which is the normal way to run OCI. An empty result that
-// looks authoritative is the worst outcome for an inventory tool, so the
-// compartment tree is walked explicitly instead.
-func ociRunCompartmentRegionPool(conn *connection.OciConnection, regions []any, list ociCompartmentLister) ([]any, error) {
-	ctx := context.Background()
-
-	compartments, err := conn.GetCompartments(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	jobs := make([]*jobpool.Job, 0, len(regions)*len(compartments))
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return nil, errors.New("invalid region type")
-		}
-		regionID := regionResource.Id.Data
-
-		for i := range compartments {
-			compartmentID := stringValue(compartments[i].Id)
-			if compartmentID == "" {
-				continue
-			}
-
-			jobs = append(jobs, jobpool.NewJob(func() (jobpool.JobResult, error) {
-				items, err := list(ctx, regionID, compartmentID)
-				if err != nil {
-					return nil, err
-				}
-				return jobpool.JobResult(items), nil
-			}))
-		}
-	}
-
-	return ociCollectCompartmentJobs(jobs)
-}
-
-// ociCollectCompartmentJobs joins the results of a compartment fan-out.
-//
-// Error handling has to distinguish three cases that all surface as an error
-// from a single job:
-//
-//   - The service has no endpoint in this region. Expected; skipped, matching
-//     ociRunRegionPool.
-//   - The caller cannot read this one compartment. Also expected: OCI policies
-//     are routinely written per-compartment, so a scanning principal that can
-//     read ten of fifty compartments is correctly configured, not broken. The
-//     compartment is skipped and counted.
-//   - Anything else (throttling, 5xx, malformed request) is a real fault and is
-//     returned, because silently dropping it would under-report resources.
-//
-// The one case that must not be swallowed is *every* compartment refusing
-// access. That is an under-scoped token, and reporting it as an empty tenancy
-// would turn a broken credential into a clean scan.
-func ociCollectCompartmentJobs(jobs []*jobpool.Job) ([]any, error) {
-	if len(jobs) == 0 {
-		return []any{}, nil
-	}
-
-	poolOfJobs := jobpool.CreatePool(jobs, ociCompartmentPoolConcurrency)
-	poolOfJobs.Run()
-
-	res := []any{}
-	var (
-		hardErr   error
-		deniedErr error
-		denied    int
-		succeeded int
-	)
-	for i := range poolOfJobs.Jobs {
-		job := poolOfJobs.Jobs[i]
-		if job.Err != nil {
-			// Order matters. OCI answers an authorization failure with 404
-			// NotAuthorizedOrNotFound, and ociRegionServiceUnavailable treats
-			// any 404 as an absent regional endpoint - so asking it first
-			// consumed every denial before it could be counted, and the
-			// all-denied guard below could never fire. The denial test is
-			// narrower (it matches on the error code, not just the status), so
-			// it goes first and the region test keeps the rest.
-			if ociCompartmentInaccessible(job.Err) {
-				denied++
-				if deniedErr == nil {
-					deniedErr = job.Err
-				}
-				continue
-			}
-			if ociRegionServiceUnavailable(job.Err) {
-				log.Debug().Err(job.Err).Msg("skipping oci region where the service is unavailable")
-				continue
-			}
-			hardErr = errors.Join(hardErr, job.Err)
-			continue
-		}
-
-		succeeded++
-		items, ok := job.Result.([]any)
-		if !ok {
-			continue
-		}
-		res = append(res, items...)
-	}
-
-	if hardErr != nil {
-		return nil, hardErr
-	}
-
-	if succeeded == 0 && denied > 0 {
-		return nil, deniedErr
-	}
-
-	if denied > 0 {
-		// Visible rather than silent: the result is a partial view of the
-		// tenancy and the operator should know how partial.
-		log.Warn().
-			Int("compartments_denied", denied).
-			Int("compartments_read", succeeded).
-			Msg("oci: listed a partial view of the tenancy, some compartments were not readable")
-	}
-
-	return res, nil
 }
 
 // ociNotAuthorizedOrNotFound is the error code OCI returns when the caller is

--- a/providers/oci/resources/compartments_test.go
+++ b/providers/oci/resources/compartments_test.go
@@ -157,7 +157,7 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 	}
 
 	t.Run("all compartments succeed", func(t *testing.T) {
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{ok("a"), ok("b", "c")})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{ok("a"), ok("b", "c")}, ociScopeAllCompartments.concurrency())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []any{"a", "b", "c"}, res)
 	})
@@ -165,7 +165,7 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 	t.Run("a denied compartment does not discard the readable ones", func(t *testing.T) {
 		// The whole point of the fan-out: a scanning principal with read on
 		// some compartments is correctly configured, not broken.
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{ok("a"), denied(), ok("b")})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{ok("a"), denied(), ok("b")}, ociScopeAllCompartments.concurrency())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []any{"a", "b"}, res)
 	})
@@ -173,7 +173,7 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 	t.Run("every compartment denied is an error, not an empty tenancy", func(t *testing.T) {
 		// The failure this guard exists for: an under-scoped token must not
 		// render as a clean scan of a tenancy with nothing in it.
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{denied(), denied()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{denied(), denied()}, ociScopeAllCompartments.concurrency())
 		require.Error(t, err)
 		assert.Nil(t, res)
 		assert.Contains(t, err.Error(), "NotAuthorizedOrNotFound")
@@ -185,14 +185,14 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 		// regional endpoint made an under-scoped token return a clean, empty
 		// scan of the whole tenancy - the exact outcome the denied counter
 		// exists to prevent.
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{denied404(), denied404()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{denied404(), denied404()}, ociScopeAllCompartments.concurrency())
 		require.Error(t, err)
 		assert.Nil(t, res)
 		assert.Contains(t, err.Error(), "NotAuthorizedOrNotFound")
 	})
 
 	t.Run("a 404-denied compartment does not discard the readable ones", func(t *testing.T) {
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{ok("a"), denied404(), ok("b")})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{ok("a"), denied404(), ok("b")}, ociScopeAllCompartments.concurrency())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []any{"a", "b"}, res)
 	})
@@ -201,14 +201,14 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 		// The two 404s differ only by code. The denial still has to win, or a
 		// single undeployed region would push a broken token back onto the
 		// success path.
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{unavailable(), denied404()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{unavailable(), denied404()}, ociScopeAllCompartments.concurrency())
 		require.Error(t, err)
 		assert.Nil(t, res)
 	})
 
 	t.Run("a readable but empty compartment counts as success", func(t *testing.T) {
 		// Distinguishes "read everything, found nothing" from "could not read".
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{ok(), denied()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{ok(), denied()}, ociScopeAllCompartments.concurrency())
 		require.NoError(t, err)
 		assert.Empty(t, res)
 	})
@@ -216,32 +216,32 @@ func TestOciCollectCompartmentJobs(t *testing.T) {
 	t.Run("an unavailable region is skipped without counting as denied", func(t *testing.T) {
 		// A service with no endpoint in a region is an expected absence, so it
 		// must not push an otherwise all-denied run into the success path.
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{unavailable(), denied()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{unavailable(), denied()}, ociScopeAllCompartments.concurrency())
 		require.Error(t, err)
 		assert.Nil(t, res)
 	})
 
 	t.Run("every region unavailable is an empty result, not an error", func(t *testing.T) {
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{unavailable(), unavailable()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{unavailable(), unavailable()}, ociScopeAllCompartments.concurrency())
 		require.NoError(t, err)
 		assert.Empty(t, res)
 	})
 
 	t.Run("a throttled compartment is reported", func(t *testing.T) {
 		// Silently dropping a 429 would under-report resources that exist.
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{ok("a"), throttled()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{ok("a"), throttled()}, ociScopeAllCompartments.concurrency())
 		require.Error(t, err)
 		assert.Nil(t, res)
 	})
 
 	t.Run("a hard error wins over partial success", func(t *testing.T) {
-		res, err := ociCollectCompartmentJobs([]*jobpool.Job{ok("a"), denied(), throttled()})
+		res, err := ociJoinCompartmentJobs([]*jobpool.Job{ok("a"), denied(), throttled()}, ociScopeAllCompartments.concurrency())
 		require.Error(t, err)
 		assert.Nil(t, res)
 	})
 
 	t.Run("no jobs", func(t *testing.T) {
-		res, err := ociCollectCompartmentJobs(nil)
+		res, err := ociJoinCompartmentJobs(nil, ociScopeAllCompartments.concurrency())
 		require.NoError(t, err)
 		assert.Empty(t, res)
 	})

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -14,7 +14,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -26,18 +25,13 @@ func (e *mqlOciCompute) id() (string, error) {
 func (o *mqlOciCompute) instances() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	// fetch regions
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
+	// The lister receives the region as a key, so index the oci.regions
+	// collection to let it set a typed region field on each instance.
+	regions, err := ociRegionsFor(o.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
-	regionsByID, err := ociRegionsByID(list.Data)
+	regionsByID, err := ociRegionsByID(regions)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +41,7 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 	// one compartment it is handed. Restricting the scan to the tenancy root
 	// meant a fleet of hundreds of hosts reported as zero instances, taking
 	// every patch, agent, and IMDS check down with it.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci with region %s", region)
 
@@ -340,53 +334,27 @@ func (o *mqlOciComputeVnic) subnet() (*mqlOciNetworkSubnet, error) {
 func (o *mqlOciCompute) images() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	// fetch regions
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
+	// The lister receives the region as a key, so index the oci.regions
+	// collection to let it set a typed region field on each image.
+	regions, err := ociRegionsFor(o.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
-	// fetch images
-	return ociRunRegionPool(o.getComputeImage(conn, list.Data))
-}
-
-func (o *mqlOciCompute) getComputeImagesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Image, error) {
-	images, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Image, *string, error) {
-		request := core.ListImagesRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := computeClient.ListImages(ctx, request)
-		if err != nil {
-			return nil, nil, err
-		}
-		return response.Items, response.OpcNextPage, nil
-	})
+	regionsByID, err := ociRegionsByID(regions)
 	if err != nil {
 		return nil, err
 	}
 
-	return images, nil
-}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
 
-func (o *mqlOciCompute) getComputeImage(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
+			regionResource, ok := regionsByID[region]
+			if !ok {
+				return nil, errors.New("no oci.region resource for region " + region)
+			}
 
-			svc, err := conn.ComputeClient(regionResource.Id.Data)
+			svc, err := conn.ComputeClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -443,11 +411,28 @@ func (o *mqlOciCompute) getComputeImage(conn *connection.OciConnection, regions 
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciCompute) getComputeImagesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Image, error) {
+	images, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Image, *string, error) {
+		request := core.ListImagesRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := computeClient.ListImages(ctx, request)
+		if err != nil {
+			return nil, nil, err
+		}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return tasks
+
+	return images, nil
 }
 
 type mqlOciComputeImageInternal struct {
@@ -461,51 +446,11 @@ func (o *mqlOciComputeImage) id() (string, error) {
 func (o *mqlOciCompute) blockVolumes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
 
-	return ociRunRegionPool(o.getBlockVolumes(conn, list.Data))
-}
-
-func (o *mqlOciCompute) getBlockVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.Volume, error) {
-	volumes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Volume, *string, error) {
-		request := core.ListVolumesRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := client.ListVolumes(ctx, request)
-		if err != nil {
-			return nil, nil, err
-		}
-		return response.Items, response.OpcNextPage, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return volumes, nil
-}
-
-func (o *mqlOciCompute) getBlockVolumes(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
-
-			svc, err := conn.BlockstorageClient(regionResource.Id.Data)
+			svc, err := conn.BlockstorageClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -555,11 +500,28 @@ func (o *mqlOciCompute) getBlockVolumes(conn *connection.OciConnection, regions 
 				res = append(res, mqlBV)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciCompute) getBlockVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.Volume, error) {
+	volumes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Volume, *string, error) {
+		request := core.ListVolumesRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := client.ListVolumes(ctx, request)
+		if err != nil {
+			return nil, nil, err
+		}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return tasks
+
+	return volumes, nil
 }
 
 type mqlOciComputeBlockVolumeInternal struct {
@@ -588,51 +550,11 @@ func (o *mqlOciComputeBlockVolume) kmsKey() (*mqlOciKmsKey, error) {
 func (o *mqlOciCompute) bootVolumes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
 
-	return ociRunRegionPool(o.getBootVolumes(conn, list.Data))
-}
-
-func (o *mqlOciCompute) getBootVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.BootVolume, error) {
-	bootVolumes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.BootVolume, *string, error) {
-		request := core.ListBootVolumesRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := client.ListBootVolumes(ctx, request)
-		if err != nil {
-			return nil, nil, err
-		}
-		return response.Items, response.OpcNextPage, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return bootVolumes, nil
-}
-
-func (o *mqlOciCompute) getBootVolumes(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
-
-			svc, err := conn.BlockstorageClient(regionResource.Id.Data)
+			svc, err := conn.BlockstorageClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -680,11 +602,28 @@ func (o *mqlOciCompute) getBootVolumes(conn *connection.OciConnection, regions [
 				res = append(res, mqlBV)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciCompute) getBootVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.BootVolume, error) {
+	bootVolumes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.BootVolume, *string, error) {
+		request := core.ListBootVolumesRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := client.ListBootVolumes(ctx, request)
+		if err != nil {
+			return nil, nil, err
+		}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return tasks
+
+	return bootVolumes, nil
 }
 
 type mqlOciComputeBootVolumeInternal struct {

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -13,7 +12,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -68,38 +66,18 @@ func (o *mqlOciContainerInstances) id() (string, error) {
 func (o *mqlOciContainerInstances) instances() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci container instances with region %s", region)
 
-	return ociRunRegionPool(o.getContainerInstances(conn, list.Data))
-}
-
-func (o *mqlOciContainerInstances) getContainerInstances(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci container instances with region %s", regionResource.Id.Data)
-
-			svc, err := conn.ContainerInstanceClient(regionResource.Id.Data)
+			svc, err := conn.ContainerInstanceClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerinstances.ContainerInstanceSummary, *string, error) {
 				response, err := svc.ListContainerInstances(ctx, containerinstances.ListContainerInstancesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -161,15 +139,12 @@ func (o *mqlOciContainerInstances) getContainerInstances(conn *connection.OciCon
 					return nil, err
 				}
 				mqlCI := mqlInstance.(*mqlOciContainerInstancesInstance)
-				mqlCI.region = regionResource.Id.Data
+				mqlCI.region = region
 				res = append(res, mqlCI)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciContainerInstancesInstanceInternal struct {

--- a/providers/oci/resources/conversion.go
+++ b/providers/oci/resources/conversion.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 )
@@ -205,45 +204,24 @@ func ociRegionServiceUnavailable(err error) bool {
 	return false
 }
 
-// ociRunRegionPool runs a set of per-region jobs and returns the union of the
-// ones that succeeded, skipping only the regions where the service genuinely
-// has no endpoint.
+// ociRunRegionPool joins a set of jobs the caller built itself, under the same
+// error policy ociCollect applies to the tenancy-root scope.
 //
-// The distinction matters in both directions. Failing the whole collection
-// when any region errors turned one unsubscribed or undeployed region into a
-// tenancy-wide failure. But skipping *every* error is just as wrong the other
-// way: a 403 from an IAM gap, a 429 throttle or a 500 would silently
-// under-report resources, and an authoritative-looking short list is worse
-// than an error in an inventory tool.
+// It is the escape hatch for the handful of collections that are not a
+// (region, compartment) fan-out and so cannot go through ociCollect:
 //
-// So ociRegionServiceUnavailable decides. An absent endpoint is an expected
-// condition and is skipped; anything else is a real problem and is reported,
-// joined across regions so a broken token names every region it affected.
+//   - OCI IAM is global within a realm. Every regional identity endpoint serves
+//     the same tenancy-wide set, so users, groups and policies run as a single
+//     job. Fanning them out over regions returned each one once per subscribed
+//     region, and because CreateResource hands back the cached instance for a
+//     repeated __id, the result held N copies of one pointer and every count was
+//     inflated N-fold.
+//   - The AI services wrap their per-region fetch in their own helper so an
+//     undeployed region is skipped per-region rather than per-job.
+//
+// Anything that is a plain (region, compartment) fan-out should use ociCollect,
+// which names its scope. This exists so those two cases do not have to pretend
+// to be one.
 func ociRunRegionPool(jobs []*jobpool.Job) ([]any, error) {
-	poolOfJobs := jobpool.CreatePool(jobs, 5)
-	poolOfJobs.Run()
-
-	res := []any{}
-	var hardErr error
-	for i := range poolOfJobs.Jobs {
-		job := poolOfJobs.Jobs[i]
-		if job.Err != nil {
-			if ociRegionServiceUnavailable(job.Err) {
-				log.Debug().Err(job.Err).Msg("skipping oci region where the service is unavailable")
-				continue
-			}
-			hardErr = errors.Join(hardErr, job.Err)
-			continue
-		}
-		items, ok := job.Result.([]any)
-		if !ok {
-			continue
-		}
-		res = append(res, items...)
-	}
-
-	if hardErr != nil {
-		return nil, hardErr
-	}
-	return res, nil
+	return ociJoinRegionJobs(jobs, ociScopeTenancyRoot.concurrency())
 }

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -14,7 +13,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -28,38 +26,18 @@ func (o *mqlOciDatabase) id() (string, error) {
 func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci DB systems with region %s", region)
 
-	return ociRunRegionPool(o.getDbSystems(conn, list.Data))
-}
-
-func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci DB systems with region %s", regionResource.Id.Data)
-
-			svc, err := conn.DatabaseClient(regionResource.Id.Data)
+			svc, err := conn.DatabaseClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.DbSystemSummary, *string, error) {
 				response, err := svc.ListDbSystems(ctx, database.ListDbSystemsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -124,11 +102,8 @@ func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []
 				res = append(res, mqlDb)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciDatabaseDbSystemInternal struct {
@@ -174,38 +149,18 @@ func (o *mqlOciDatabaseDbSystem) subnet() (*mqlOciNetworkSubnet, error) {
 func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci autonomous databases with region %s", region)
 
-	return ociRunRegionPool(o.getAutonomousDatabases(conn, list.Data))
-}
-
-func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci autonomous databases with region %s", regionResource.Id.Data)
-
-			svc, err := conn.DatabaseClient(regionResource.Id.Data)
+			svc, err := conn.DatabaseClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.AutonomousDatabaseSummary, *string, error) {
 				response, err := svc.ListAutonomousDatabases(ctx, database.ListAutonomousDatabasesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -299,11 +254,8 @@ func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, 
 				res = append(res, mqlAdb)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciDatabaseAutonomousDatabaseInternal struct {
@@ -364,38 +316,18 @@ func (o *mqlOciDatabaseAutonomousDatabase) subnet() (*mqlOciNetworkSubnet, error
 func (o *mqlOciDatabase) backups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci database backups with region %s", region)
 
-	return ociRunRegionPool(o.getDatabaseBackups(conn, list.Data))
-}
-
-func (o *mqlOciDatabase) getDatabaseBackups(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci database backups with region %s", regionResource.Id.Data)
-
-			svc, err := conn.DatabaseClient(regionResource.Id.Data)
+			svc, err := conn.DatabaseClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.BackupSummary, *string, error) {
 				response, err := svc.ListBackups(ctx, database.ListBackupsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -456,11 +388,8 @@ func (o *mqlOciDatabase) getDatabaseBackups(conn *connection.OciConnection, regi
 				res = append(res, mqlBackup)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciDatabaseBackupInternal struct {
@@ -505,63 +434,18 @@ func (o *mqlOciDatabaseBackup) kmsVault() (*mqlOciKmsVault, error) {
 func (o *mqlOciDatabase) autonomousDatabaseBackups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci autonomous database backups with region %s", region)
 
-	return ociRunRegionPool(o.getAutonomousDatabaseBackups(conn, list.Data))
-}
-
-// backups on an individual autonomous database returns its backups by
-// filtering the service-wide listing. We rely on the tenancy-wide listing
-// being cached and filter client-side, which avoids fanning out region calls
-// per-database when the parent list is already fetched.
-func (o *mqlOciDatabaseAutonomousDatabase) backups() ([]any, error) {
-	dbObj, err := CreateResource(o.MqlRuntime, "oci.database", nil)
-	if err != nil {
-		return nil, err
-	}
-	db := dbObj.(*mqlOciDatabase)
-	raw := db.GetAutonomousDatabaseBackups()
-	if raw.Error != nil {
-		return nil, raw.Error
-	}
-	dbID := o.Id.Data
-	res := []any{}
-	for _, r := range raw.Data {
-		b := r.(*mqlOciDatabaseAutonomousDatabaseBackup)
-		if b.cacheAutonomousDatabaseId == dbID {
-			res = append(res, b)
-		}
-	}
-	return res, nil
-}
-
-func (o *mqlOciDatabase) getAutonomousDatabaseBackups(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci autonomous database backups with region %s", regionResource.Id.Data)
-
-			svc, err := conn.DatabaseClient(regionResource.Id.Data)
+			svc, err := conn.DatabaseClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]database.AutonomousDatabaseBackupSummary, *string, error) {
 				response, err := svc.ListAutonomousDatabaseBackups(ctx, database.ListAutonomousDatabaseBackupsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -623,11 +507,33 @@ func (o *mqlOciDatabase) getAutonomousDatabaseBackups(conn *connection.OciConnec
 				res = append(res, mqlBackup)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
+			return res, nil
+		})
+}
+
+// backups on an individual autonomous database returns its backups by
+// filtering the service-wide listing. We rely on the tenancy-wide listing
+// being cached and filter client-side, which avoids fanning out region calls
+// per-database when the parent list is already fetched.
+func (o *mqlOciDatabaseAutonomousDatabase) backups() ([]any, error) {
+	dbObj, err := CreateResource(o.MqlRuntime, "oci.database", nil)
+	if err != nil {
+		return nil, err
 	}
-	return tasks
+	db := dbObj.(*mqlOciDatabase)
+	raw := db.GetAutonomousDatabaseBackups()
+	if raw.Error != nil {
+		return nil, raw.Error
+	}
+	dbID := o.Id.Data
+	res := []any{}
+	for _, r := range raw.Data {
+		b := r.(*mqlOciDatabaseAutonomousDatabaseBackup)
+		if b.cacheAutonomousDatabaseId == dbID {
+			res = append(res, b)
+		}
+	}
+	return res, nil
 }
 
 type mqlOciDatabaseAutonomousDatabaseBackupInternal struct {

--- a/providers/oci/resources/databases.go
+++ b/providers/oci/resources/databases.go
@@ -44,12 +44,7 @@ func (o *mqlOciMysql) id() (string, error) {
 func (o *mqlOciMysql) dbSystems() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.MysqlDbSystemClient(region)
 			if err != nil {
@@ -271,12 +266,7 @@ func (o *mqlOciPostgresql) id() (string, error) {
 func (o *mqlOciPostgresql) dbSystems() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.PostgresqlClient(region)
 			if err != nil {
@@ -486,12 +476,7 @@ func (o *mqlOciNosql) id() (string, error) {
 func (o *mqlOciNosql) tables() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.NosqlClient(region)
 			if err != nil {
@@ -572,12 +557,7 @@ func (o *mqlOciOpensearch) id() (string, error) {
 func (o *mqlOciOpensearch) clusters() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.OpensearchClusterClient(region)
 			if err != nil {
@@ -776,12 +756,7 @@ func (o *mqlOciGoldenGate) id() (string, error) {
 func (o *mqlOciGoldenGate) deployments() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.GoldenGateClient(region)
 			if err != nil {

--- a/providers/oci/resources/datascience.go
+++ b/providers/oci/resources/datascience.go
@@ -26,7 +26,7 @@ func (o *mqlOciAiDataScience) id() (string, error) {
 // not available are skipped (see ociRegionServiceUnavailable).
 func (o *mqlOciAiDataScience) listRegional(fetch func(svc *datascience.DataScienceClient) ([]any, error)) ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := ociAgentRegions(o.MqlRuntime)
+	regions, err := ociRegionsFor(o.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/dns.go
+++ b/providers/oci/resources/dns.go
@@ -39,18 +39,9 @@ var ociDnsSteeringPolicyScopes = []dns.ListSteeringPoliciesScopeEnum{
 func (o *mqlOciDns) zones() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	regions := ociResource.(*mqlOci).GetRegions()
-	if regions.Error != nil {
-		return nil, regions.Error
-	}
-
 	// Deduplicated: a global zone is returned by every regional DNS
 	// endpoint, so the region fan-out sees it once per subscribed region.
-	items, err := ociRunCompartmentRegionPool(conn, regions.Data,
+	items, err := ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.DnsClient(region)
 			if err != nil {
@@ -131,18 +122,9 @@ func (o *mqlOciDns) newZones(region string, zones []dns.ZoneSummary) ([]any, err
 func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	regions := ociResource.(*mqlOci).GetRegions()
-	if regions.Error != nil {
-		return nil, regions.Error
-	}
-
 	// Deduplicated: a global steering policy is returned by every regional DNS
 	// endpoint, so the region fan-out sees it once per subscribed region.
-	items, err := ociRunCompartmentRegionPool(conn, regions.Data,
+	items, err := ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.DnsClient(region)
 			if err != nil {

--- a/providers/oci/resources/events.go
+++ b/providers/oci/resources/events.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/events"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
@@ -25,51 +23,11 @@ func (o *mqlOciEvents) id() (string, error) {
 func (o *mqlOciEvents) rules() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
 
-	return ociRunRegionPool(o.getEventRules(conn, list.Data))
-}
-
-func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *events.EventsClient, compartmentID string) ([]events.RuleSummary, error) {
-	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]events.RuleSummary, *string, error) {
-		request := events.ListRulesRequest{
-			CompartmentId: common.String(compartmentID),
-			Page:          page,
-		}
-
-		response, err := client.ListRules(ctx, request)
-		if err != nil {
-			return nil, nil, err
-		}
-		return response.Items, response.OpcNextPage, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return rules, nil
-}
-
-func (o *mqlOciEvents) getEventRules(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
-
-			svc, err := conn.EventsClient(regionResource.Id.Data)
+			svc, err := conn.EventsClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -103,16 +61,33 @@ func (o *mqlOciEvents) getEventRules(conn *connection.OciConnection, regions []a
 				}
 
 				mqlRule := mqlInstance.(*mqlOciEventsRule)
-				mqlRule.region = regionResource.Id.Data
+				mqlRule.region = region
 
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *events.EventsClient, compartmentID string) ([]events.RuleSummary, error) {
+	rules, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]events.RuleSummary, *string, error) {
+		request := events.ListRulesRequest{
+			CompartmentId: common.String(compartmentID),
+			Page:          page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := client.ListRules(ctx, request)
+		if err != nil {
+			return nil, nil, err
+		}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return tasks
+
+	return rules, nil
 }
 
 type mqlOciEventsRuleInternal struct {

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -14,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -26,65 +24,24 @@ func (o *mqlOciFileStorage) id() (string, error) {
 func (o *mqlOciFileStorage) fileSystems() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
-	return ociRunRegionPool(o.getFileSystems(conn, list.Data))
-}
-
-func (o *mqlOciFileStorage) getFileSystemsForAD(ctx context.Context, fsClient *filestorage.FileStorageClient, compartmentID string, availabilityDomain string) ([]filestorage.FileSystemSummary, error) {
-	fileSystems, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]filestorage.FileSystemSummary, *string, error) {
-		request := filestorage.ListFileSystemsRequest{
-			CompartmentId:      common.String(compartmentID),
-			AvailabilityDomain: common.String(availabilityDomain),
-			Page:               page,
-		}
-
-		response, err := fsClient.ListFileSystems(ctx, request)
-		if err != nil {
-			return nil, nil, err
-		}
-		return response.Items, response.OpcNextPage, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return fileSystems, nil
-}
-
-func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", regionResource.Id.Data)
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci with region %s", region)
 
 			// Get availability domains for this region
-			identityClient, err := conn.IdentityClientWithRegion(regionResource.Id.Data)
+			identityClient, err := conn.IdentityClientWithRegion(region)
 			if err != nil {
 				return nil, err
 			}
 
 			adResponse, err := identityClient.ListAvailabilityDomains(ctx, identity.ListAvailabilityDomainsRequest{
-				CompartmentId: common.String(conn.TenantID()),
+				CompartmentId: common.String(compartmentID),
 			})
 			if err != nil {
 				return nil, err
 			}
 
-			fsClient, err := conn.FileStorageClient(regionResource.Id.Data)
+			fsClient, err := conn.FileStorageClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -134,11 +91,29 @@ func (o *mqlOciFileStorage) getFileSystems(conn *connection.OciConnection, regio
 				}
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciFileStorage) getFileSystemsForAD(ctx context.Context, fsClient *filestorage.FileStorageClient, compartmentID string, availabilityDomain string) ([]filestorage.FileSystemSummary, error) {
+	fileSystems, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]filestorage.FileSystemSummary, *string, error) {
+		request := filestorage.ListFileSystemsRequest{
+			CompartmentId:      common.String(compartmentID),
+			AvailabilityDomain: common.String(availabilityDomain),
+			Page:               page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := fsClient.ListFileSystems(ctx, request)
+		if err != nil {
+			return nil, nil, err
+		}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return tasks
+
+	return fileSystems, nil
 }
 
 type mqlOciFileStorageFileSystemInternal struct {

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -27,38 +25,18 @@ func (o *mqlOciFunctions) id() (string, error) {
 func (o *mqlOciFunctions) applications() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci functions with region %s", region)
 
-	return ociRunRegionPool(o.getApplications(conn, list.Data))
-}
-
-func (o *mqlOciFunctions) getApplications(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci functions with region %s", regionResource.Id.Data)
-
-			svc, err := conn.FunctionsManagementClient(regionResource.Id.Data)
+			svc, err := conn.FunctionsManagementClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]functions.ApplicationSummary, *string, error) {
 				response, err := svc.ListApplications(ctx, functions.ListApplicationsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -119,17 +97,14 @@ func (o *mqlOciFunctions) getApplications(conn *connection.OciConnection, region
 					return nil, err
 				}
 				mqlApp := mqlInstance.(*mqlOciFunctionsApplication)
-				mqlApp.region = regionResource.Id.Data
+				mqlApp.region = region
 				mqlApp.cacheSubnetIds = app.SubnetIds
 				mqlApp.cacheNsgIds = app.NetworkSecurityGroupIds
 				res = append(res, mqlApp)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciFunctionsApplicationInternal struct {

--- a/providers/oci/resources/generativeai.go
+++ b/providers/oci/resources/generativeai.go
@@ -30,7 +30,7 @@ func (o *mqlOciAiGenerativeAi) compartmentID() string {
 // not available are skipped (see ociRegionServiceUnavailable).
 func (o *mqlOciAiGenerativeAi) listRegional(fetch func(svc *generativeai.GenerativeAiClient, region string) ([]any, error)) ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := ociAgentRegions(o.MqlRuntime)
+	regions, err := ociRegionsFor(o.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -26,49 +25,23 @@ func (o *mqlOciAiAgents) id() (string, error) {
 	return "oci.ai.agents", nil
 }
 
-func ociAgentRegions(runtime *plugin.Runtime) ([]any, error) {
-	ociResource, err := CreateResource(runtime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	regions := ociResource.(*mqlOci).GetRegions()
-	if regions.Error != nil {
-		return nil, regions.Error
-	}
-	return regions.Data, nil
-}
-
 // ----- agents -----
 
 func (o *mqlOciAiAgents) agents() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := ociAgentRegions(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
 
-	return ociRunRegionPool(o.getAgents(conn, regions))
-}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci generative ai agents with region %s", region)
 
-func (o *mqlOciAiAgents) getAgents(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci generative ai agents with region %s", regionResource.Id.Data)
-
-			svc, err := conn.GenerativeAiAgentClient(regionResource.Id.Data)
+			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.AgentSummary, *string, error) {
 				response, err := svc.ListAgents(ctx, generativeaiagent.ListAgentsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -78,8 +51,8 @@ func (o *mqlOciAiAgents) getAgents(conn *connection.OciConnection, regions []any
 			})
 			if err != nil {
 				if ociRegionServiceUnavailable(err) {
-					log.Debug().Str("region", regionResource.Id.Data).Msg("generative ai agents not available in region, skipping")
-					return jobpool.JobResult([]any{}), nil
+					log.Debug().Str("region", region).Msg("generative ai agents not available in region, skipping")
+					return []any{}, nil
 				}
 				return nil, err
 			}
@@ -112,11 +85,8 @@ func (o *mqlOciAiAgents) getAgents(conn *connection.OciConnection, regions []any
 				}
 				res = append(res, mqlAgent)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciAiAgentsAgent(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -156,31 +126,17 @@ func (o *mqlOciAiAgentsAgent) compartment() (*mqlOciCompartment, error) {
 
 func (o *mqlOciAiAgents) agentEndpoints() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := ociAgentRegions(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
 
-	return ociRunRegionPool(o.getAgentEndpoints(conn, regions))
-}
-
-func (o *mqlOciAiAgents) getAgentEndpoints(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			svc, err := conn.GenerativeAiAgentClient(regionResource.Id.Data)
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.AgentEndpointSummary, *string, error) {
 				response, err := svc.ListAgentEndpoints(ctx, generativeaiagent.ListAgentEndpointsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -190,7 +146,7 @@ func (o *mqlOciAiAgents) getAgentEndpoints(conn *connection.OciConnection, regio
 			})
 			if err != nil {
 				if ociRegionServiceUnavailable(err) {
-					return jobpool.JobResult([]any{}), nil
+					return []any{}, nil
 				}
 				return nil, err
 			}
@@ -242,11 +198,8 @@ func (o *mqlOciAiAgents) getAgentEndpoints(conn *connection.OciConnection, regio
 				mqlEndpointTyped.cacheAgentId = stringValue(e.AgentId)
 				res = append(res, mqlEndpointTyped)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciAiAgentsEndpointInternal struct {
@@ -294,31 +247,17 @@ func (o *mqlOciAiAgentsEndpoint) agent() (*mqlOciAiAgentsAgent, error) {
 
 func (o *mqlOciAiAgents) knowledgeBases() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := ociAgentRegions(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
 
-	return ociRunRegionPool(o.getKnowledgeBases(conn, regions))
-}
-
-func (o *mqlOciAiAgents) getKnowledgeBases(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			svc, err := conn.GenerativeAiAgentClient(regionResource.Id.Data)
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.KnowledgeBaseSummary, *string, error) {
 				response, err := svc.ListKnowledgeBases(ctx, generativeaiagent.ListKnowledgeBasesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -328,7 +267,7 @@ func (o *mqlOciAiAgents) getKnowledgeBases(conn *connection.OciConnection, regio
 			})
 			if err != nil {
 				if ociRegionServiceUnavailable(err) {
-					return jobpool.JobResult([]any{}), nil
+					return []any{}, nil
 				}
 				return nil, err
 			}
@@ -354,11 +293,8 @@ func (o *mqlOciAiAgents) getKnowledgeBases(conn *connection.OciConnection, regio
 				}
 				res = append(res, mqlKb)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciAiAgentsKnowledgeBase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -398,31 +334,17 @@ func (o *mqlOciAiAgentsKnowledgeBase) compartment() (*mqlOciCompartment, error) 
 
 func (o *mqlOciAiAgents) dataSources() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := ociAgentRegions(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
 
-	return ociRunRegionPool(o.getDataSources(conn, regions))
-}
-
-func (o *mqlOciAiAgents) getDataSources(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			svc, err := conn.GenerativeAiAgentClient(regionResource.Id.Data)
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.DataSourceSummary, *string, error) {
 				response, err := svc.ListDataSources(ctx, generativeaiagent.ListDataSourcesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -432,7 +354,7 @@ func (o *mqlOciAiAgents) getDataSources(conn *connection.OciConnection, regions 
 			})
 			if err != nil {
 				if ociRegionServiceUnavailable(err) {
-					return jobpool.JobResult([]any{}), nil
+					return []any{}, nil
 				}
 				return nil, err
 			}
@@ -461,11 +383,8 @@ func (o *mqlOciAiAgents) getDataSources(conn *connection.OciConnection, regions 
 				mqlDsTyped.cacheKnowledgeBaseId = stringValue(ds.KnowledgeBaseId)
 				res = append(res, mqlDsTyped)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciAiAgentsDataSourceInternal struct {
@@ -523,31 +442,17 @@ func (o *mqlOciAiAgentsDataSource) knowledgeBase() (*mqlOciAiAgentsKnowledgeBase
 
 func (o *mqlOciAiAgents) tools() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := ociAgentRegions(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
 
-	return ociRunRegionPool(o.getTools(conn, regions))
-}
-
-func (o *mqlOciAiAgents) getTools(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			svc, err := conn.GenerativeAiAgentClient(regionResource.Id.Data)
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]generativeaiagent.ToolSummary, *string, error) {
 				response, err := svc.ListTools(ctx, generativeaiagent.ListToolsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -557,7 +462,7 @@ func (o *mqlOciAiAgents) getTools(conn *connection.OciConnection, regions []any)
 			})
 			if err != nil {
 				if ociRegionServiceUnavailable(err) {
-					return jobpool.JobResult([]any{}), nil
+					return []any{}, nil
 				}
 				return nil, err
 			}
@@ -593,11 +498,8 @@ func (o *mqlOciAiAgents) getTools(conn *connection.OciConnection, regions []any)
 				mqlToolTyped.cacheAgentId = stringValue(t.AgentId)
 				res = append(res, mqlToolTyped)
 			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciAiAgentsToolInternal struct {

--- a/providers/oci/resources/identitydomains.go
+++ b/providers/oci/resources/identitydomains.go
@@ -132,10 +132,13 @@ func (o *mqlOciIdentity) domains() ([]any, error) {
 		}))
 	}
 
-	// The same accounting the resource listers use: a compartment the caller
-	// cannot read is skipped, but every compartment refusing access is an
-	// under-scoped token rather than a tenancy without identity domains.
-	collected, err := ociCollectCompartmentJobs(jobs)
+	// The same accounting the resource listers get from ociCollect, applied
+	// directly because identity domains are global: they are listed per
+	// compartment but not per region, so there is no region dimension to fan out
+	// over. A compartment the caller cannot read is skipped, but every
+	// compartment refusing access is an under-scoped token rather than a tenancy
+	// without identity domains.
+	collected, err := ociJoinCompartmentJobs(jobs, ociScopeAllCompartments.concurrency())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -24,22 +24,12 @@ func (o *mqlOciKms) id() (string, error) {
 func (o *mqlOciKms) vaults() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Vaults are almost always created in the compartment of the service they
 	// encrypt, and ListVaults answers for one compartment with no way to recurse.
 	// A root-only listing therefore came back empty, and every typed vault
 	// reference from a database, bucket, or stream pool then had nothing to
 	// resolve against.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci kms with region %s", region)
 

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -25,22 +25,12 @@ func (o *mqlOciLoadBalancer) id() (string, error) {
 func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Load balancers belong to the compartment of the application they front, and
 	// ListLoadBalancers has no subtree flag. Scanning only the tenancy root meant
 	// the exposure surface an internet-facing balancer represents, along with its
 	// listener TLS settings and backend sets, never appeared in the inventory at
 	// all.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci load balancer with region %s", region)
 

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -14,7 +14,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -26,52 +25,11 @@ func (o *mqlOciLogging) id() (string, error) {
 func (o *mqlOciLogging) logGroups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci logging with region %s", region)
 
-	return ociRunRegionPool(o.getLogGroups(conn, list.Data))
-}
-
-func (o *mqlOciLogging) getLogGroupsForRegion(ctx context.Context, client *logging.LoggingManagementClient, compartmentID string) ([]logging.LogGroupSummary, error) {
-	entries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]logging.LogGroupSummary, *string, error) {
-		request := logging.ListLogGroupsRequest{
-			CompartmentId:            common.String(compartmentID),
-			IsCompartmentIdInSubtree: common.Bool(true),
-			Page:                     page,
-		}
-
-		response, err := client.ListLogGroups(ctx, request)
-		if err != nil {
-			return nil, nil, err
-		}
-		return response.Items, response.OpcNextPage, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return entries, nil
-}
-
-func (o *mqlOciLogging) getLogGroups(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci logging with region %s", regionResource.Id.Data)
-
-			svc, err := conn.LoggingClient(regionResource.Id.Data)
+			svc, err := conn.LoggingClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -103,15 +61,33 @@ func (o *mqlOciLogging) getLogGroups(conn *connection.OciConnection, regions []a
 					return nil, err
 				}
 				// Store the region internally so logs() knows which region to query
-				mqlInstance.(*mqlOciLoggingLogGroup).region = regionResource.Id.Data
+				mqlInstance.(*mqlOciLoggingLogGroup).region = region
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
+			return res, nil
+		})
+}
+
+func (o *mqlOciLogging) getLogGroupsForRegion(ctx context.Context, client *logging.LoggingManagementClient, compartmentID string) ([]logging.LogGroupSummary, error) {
+	entries, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]logging.LogGroupSummary, *string, error) {
+		request := logging.ListLogGroupsRequest{
+			CompartmentId:            common.String(compartmentID),
+			IsCompartmentIdInSubtree: common.Bool(true),
+			Page:                     page,
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+
+		response, err := client.ListLogGroups(ctx, request)
+		if err != nil {
+			return nil, nil, err
+		}
+		return response.Items, response.OpcNextPage, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return tasks
+
+	return entries, nil
 }
 
 type mqlOciLoggingLogGroupInternal struct {

--- a/providers/oci/resources/messaging.go
+++ b/providers/oci/resources/messaging.go
@@ -29,12 +29,7 @@ func (o *mqlOciStreaming) id() (string, error) {
 func (o *mqlOciStreaming) streams() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.StreamAdminClient(region)
 			if err != nil {
@@ -85,12 +80,7 @@ func (o *mqlOciStreaming) streams() ([]any, error) {
 func (o *mqlOciStreaming) streamPools() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.StreamAdminClient(region)
 			if err != nil {
@@ -350,12 +340,7 @@ func (o *mqlOciQueue) id() (string, error) {
 func (o *mqlOciQueue) queues() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.QueueAdminClient(region)
 			if err != nil {
@@ -513,12 +498,7 @@ func (o *mqlOciKafka) id() (string, error) {
 func (o *mqlOciKafka) clusters() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.KafkaClusterClient(region)
 			if err != nil {

--- a/providers/oci/resources/monitoring.go
+++ b/providers/oci/resources/monitoring.go
@@ -5,13 +5,11 @@ package resources
 
 import (
 	"context"
-	"errors"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/monitoring"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -23,38 +21,18 @@ func (o *mqlOciMonitoring) id() (string, error) {
 func (o *mqlOciMonitoring) alarms() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci monitoring with region %s", region)
 
-	return ociRunRegionPool(o.getAlarms(conn, list.Data))
-}
-
-func (o *mqlOciMonitoring) getAlarms(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci monitoring with region %s", regionResource.Id.Data)
-
-			svc, err := conn.MonitoringClient(regionResource.Id.Data)
+			svc, err := conn.MonitoringClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			alarms, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]monitoring.AlarmSummary, *string, error) {
 				response, err := svc.ListAlarms(ctx, monitoring.ListAlarmsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					// Alarms are normally created in a workload compartment,
 					// not the tenancy root.
 					CompartmentIdInSubtree: common.Bool(true),
@@ -96,11 +74,8 @@ func (o *mqlOciMonitoring) getAlarms(conn *connection.OciConnection, regions []a
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func (o *mqlOciMonitoringAlarm) id() (string, error) {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -16,7 +16,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -28,22 +27,12 @@ func (o *mqlOciNetwork) id() (string, error) {
 func (o *mqlOciNetwork) vcns() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// ListVcns takes one compartment and has no subtree flag, so asking only for
 	// the tenancy root returned an empty VCN list for anyone who keeps their
 	// networking in a child compartment. Walking the compartment tree is what
 	// makes the whole network graph, subnets and route tables and gateways
 	// included, hang off something that actually exists.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci with region %s", region)
 
@@ -160,22 +149,12 @@ func (o *mqlOciNetworkVcn) id() (string, error) {
 func (o *mqlOciNetwork) securityLists() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Security lists live in the same compartment as the VCN they protect, and
 	// ListSecurityLists cannot search below the compartment it is given. Scanning
 	// only the tenancy root therefore reported a tenancy with no ingress rules
 	// anywhere, which reads as "nothing is exposed" when the truth is that
 	// nothing was looked at.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci with region %s", region)
 
@@ -465,22 +444,12 @@ func anyRuleStateless(rules []any, key string) bool {
 func (o *mqlOciNetwork) subnets() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Fanned out over the compartment tree, not just the tenancy root. The core
 	// list APIs have no subtree flag, so listing the root alone reported no
 	// subnets at all for any tenancy that groups its networking into child
 	// compartments - and left every typed reference to a subnet (load balancer
 	// exposure, database placement, stream pool networking) unable to resolve.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci subnets with region %s", region)
 
@@ -609,22 +578,12 @@ func (o *mqlOciNetworkSubnet) vcn() (*mqlOciNetworkVcn, error) {
 func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Network security groups are attached to VNICs that almost never live in the
 	// tenancy root, and ListNetworkSecurityGroups takes a single compartment with
 	// no way to descend. Enumerating per compartment is what lets an instance's
 	// nsgs resolve at all, instead of coming back empty and making every host
 	// look unprotected.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci NSGs with region %s", region)
 
@@ -1059,38 +1018,18 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci internet gateways with region %s", region)
 
-	return ociRunRegionPool(o.getInternetGateways(conn, list.Data))
-}
-
-func (o *mqlOciNetwork) getInternetGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci internet gateways with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			igws, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.InternetGateway, *string, error) {
 				response, err := svc.ListInternetGateways(ctx, core.ListInternetGatewaysRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -1139,11 +1078,8 @@ func (o *mqlOciNetwork) getInternetGateways(conn *connection.OciConnection, regi
 				res = append(res, mqlIgw)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkInternetGatewayInternal struct {
@@ -1173,38 +1109,18 @@ func (o *mqlOciNetworkInternetGateway) vcn() (*mqlOciNetworkVcn, error) {
 func (o *mqlOciNetwork) natGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci NAT gateways with region %s", region)
 
-	return ociRunRegionPool(o.getNatGateways(conn, list.Data))
-}
-
-func (o *mqlOciNetwork) getNatGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci NAT gateways with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			natGws, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.NatGateway, *string, error) {
 				response, err := svc.ListNatGateways(ctx, core.ListNatGatewaysRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -1254,11 +1170,8 @@ func (o *mqlOciNetwork) getNatGateways(conn *connection.OciConnection, regions [
 				res = append(res, mqlNgw)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkNatGatewayInternal struct {
@@ -1302,22 +1215,12 @@ type routeRule struct {
 func (o *mqlOciNetwork) routeTables() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// A route table is created alongside the VCN it belongs to, so a tenancy that
 	// puts its VCNs in child compartments has no route tables in the root at all.
 	// ListRouteTables offers no subtree search, so the fan-out below is the only
 	// way a subnet's routeTable reference finds its target and egress paths stay
 	// auditable.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci route tables with region %s", region)
 
@@ -1469,31 +1372,11 @@ func (o *mqlOciNetworkSubnet) routeTable() (*mqlOciNetworkRouteTable, error) {
 func (o *mqlOciNetwork) publicIps() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci public ips with region %s", region)
 
-	return ociRunRegionPool(o.getPublicIps(conn, list.Data))
-}
-
-func (o *mqlOciNetwork) getPublicIps(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci public ips with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkClient(regionResource.Id.Data)
+			svc, err := conn.NetworkClient(region)
 			if err != nil {
 				return nil, err
 			}
@@ -1510,7 +1393,7 @@ func (o *mqlOciNetwork) getPublicIps(conn *connection.OciConnection, regions []a
 				perLifetime, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.PublicIp, *string, error) {
 					response, err := svc.ListPublicIps(ctx, core.ListPublicIpsRequest{
 						Scope:         core.ListPublicIpsScopeRegion,
-						CompartmentId: common.String(conn.TenantID()),
+						CompartmentId: common.String(compartmentID),
 						Lifetime:      lifetime,
 						Page:          page,
 					})
@@ -1553,11 +1436,8 @@ func (o *mqlOciNetwork) getPublicIps(conn *connection.OciConnection, regions []a
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func (o *mqlOciNetworkPublicIp) id() (string, error) {

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -27,38 +26,18 @@ func (o *mqlOciNetworkFirewall) id() (string, error) {
 func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci network firewall with region %s", region)
 
-	return ociRunRegionPool(o.getFirewalls(conn, list.Data))
-}
-
-func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci network firewall with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkFirewallClient(regionResource.Id.Data)
+			svc, err := conn.NetworkFirewallClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			firewalls, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkfirewall.NetworkFirewallSummary, *string, error) {
 				response, err := svc.ListNetworkFirewalls(ctx, networkfirewall.ListNetworkFirewallsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -102,15 +81,12 @@ func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, reg
 				mqlFw := mqlInstance.(*mqlOciNetworkFirewallFirewall)
 				mqlFw.cacheSubnetId = stringValue(fw.SubnetId)
 				mqlFw.cachePolicyId = stringValue(fw.NetworkFirewallPolicyId)
-				mqlFw.region = regionResource.Id.Data
+				mqlFw.region = region
 				res = append(res, mqlFw)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkFirewallFirewallInternal struct {
@@ -169,38 +145,18 @@ func (o *mqlOciNetworkFirewallFirewall) policy() (*mqlOciNetworkFirewallPolicy, 
 func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci network firewall policies with region %s", region)
 
-	return ociRunRegionPool(o.getPolicies(conn, list.Data))
-}
-
-func (o *mqlOciNetworkFirewall) getPolicies(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci network firewall policies with region %s", regionResource.Id.Data)
-
-			svc, err := conn.NetworkFirewallClient(regionResource.Id.Data)
+			svc, err := conn.NetworkFirewallClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			policies, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]networkfirewall.NetworkFirewallPolicySummary, *string, error) {
 				response, err := svc.ListNetworkFirewallPolicies(ctx, networkfirewall.ListNetworkFirewallPoliciesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -232,15 +188,12 @@ func (o *mqlOciNetworkFirewall) getPolicies(conn *connection.OciConnection, regi
 				if err != nil {
 					return nil, err
 				}
-				mqlInstance.(*mqlOciNetworkFirewallPolicy).region = regionResource.Id.Data
+				mqlInstance.(*mqlOciNetworkFirewallPolicy).region = region
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciNetworkFirewallPolicyInternal struct {

--- a/providers/oci/resources/networkloadbalancer.go
+++ b/providers/oci/resources/networkloadbalancer.go
@@ -25,16 +25,7 @@ func (o *mqlOciNetworkLoadBalancer) id() (string, error) {
 func (o *mqlOciNetworkLoadBalancer) loadBalancers() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	regions := ociResource.(*mqlOci).GetRegions()
-	if regions.Error != nil {
-		return nil, regions.Error
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.NetworkLoadBalancerClient(region)
 			if err != nil {

--- a/providers/oci/resources/ociscope.go
+++ b/providers/oci/resources/ociscope.go
@@ -1,0 +1,278 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
+	"go.mondoo.com/mql/v13/providers/oci/connection"
+)
+
+// Almost every OCI list API answers for exactly one compartment in one region,
+// so a lister has to be fanned out over both. This is the one place that does
+// that fanning out.
+//
+// It replaces two separate idioms. One walked the compartment tree; the other
+// passed the tenancy OCID as the compartment and so listed only the tenancy
+// root, which returns nothing at all for any tenancy that organizes its
+// resources into child compartments - the normal way to run OCI. Both compiled,
+// both returned a plausible list, and nothing at the call site distinguished
+// them: the difference was a `conn.TenantID()` buried in a request struct.
+//
+// Naming the scope is the point. A lister now has to say which set of
+// compartments it means, so the root-only choice is a visible, greppable token
+// instead of an accident.
+
+// ociScope selects the compartments a lister is fanned out over.
+type ociScope int
+
+const (
+	// ociScopeTenancyRoot lists the tenancy root compartment only.
+	//
+	// This is what the older listers did implicitly. It is correct for a
+	// genuinely tenancy-wide API, and wrong for anything a customer can place in
+	// a child compartment - which is most things. Sites carrying this scope are
+	// the migration list.
+	ociScopeTenancyRoot ociScope = iota
+
+	// ociScopeAllCompartments walks the tenancy root plus every active
+	// compartment beneath it.
+	//
+	// Needed because most OCI list APIs have no `compartmentIdInSubtree` flag.
+	// The few services that do offer one (Cloud Guard, Data Safe, Logging,
+	// Monitoring) set it on the request instead and stay on the root scope.
+	ociScopeAllCompartments
+)
+
+// ociListerConcurrency bounds how many (region, compartment) list calls run at
+// once, per scope.
+//
+// The compartment scope multiplies the request count by the size of the
+// compartment tree, so it is deliberately higher while still staying well inside
+// OCI's per-tenancy rate limits. The two values are kept distinct rather than
+// unified because changing either changes how a scan behaves under throttling.
+func (s ociScope) concurrency() int {
+	if s == ociScopeAllCompartments {
+		return 10
+	}
+	return 5
+}
+
+// ociLister lists resources of a single type inside one compartment in one
+// region, returning the already-constructed MQL resources.
+//
+// The region arrives as its key rather than as the oci.region resource because
+// that is all most listers need - they hand it to a client constructor. The few
+// that set a typed `region` field index the collection with ociRegionsByID.
+type ociLister func(ctx context.Context, region string, compartmentID string) ([]any, error)
+
+// ociCollect fans a lister out over every (region, compartment) pair the scope
+// selects and joins the results.
+func ociCollect(runtime *plugin.Runtime, scope ociScope, list ociLister) ([]any, error) {
+	conn := runtime.Connection.(*connection.OciConnection)
+	ctx := context.Background()
+
+	regions, err := ociRegionsFor(runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	compartmentIDs, err := scope.compartmentIDs(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]*jobpool.Job, 0, len(regions)*len(compartmentIDs))
+	for _, raw := range regions {
+		region, ok := raw.(*mqlOciRegion)
+		if !ok {
+			return nil, errors.New("invalid region type")
+		}
+		regionID := region.Id.Data
+
+		for _, compartmentID := range compartmentIDs {
+			jobs = append(jobs, jobpool.NewJob(func() (jobpool.JobResult, error) {
+				items, err := list(ctx, regionID, compartmentID)
+				if err != nil {
+					return nil, err
+				}
+				return jobpool.JobResult(items), nil
+			}))
+		}
+	}
+
+	return scope.join(jobs)
+}
+
+// compartmentIDs resolves the scope to the compartments to ask.
+func (s ociScope) compartmentIDs(ctx context.Context, conn *connection.OciConnection) ([]string, error) {
+	if s == ociScopeTenancyRoot {
+		return []string{conn.TenantID()}, nil
+	}
+
+	compartments, err := conn.GetCompartments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(compartments))
+	for i := range compartments {
+		if id := stringValue(compartments[i].Id); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// join collects the fan-out under the scope's error policy.
+//
+// The two policies are NOT interchangeable, which is why the scope carries its
+// own rather than sharing one. Under the root scope a 404 carrying
+// NotAuthorizedOrNotFound is read as an absent regional endpoint and skipped;
+// under the compartment scope the same error is a per-compartment denial, which
+// is counted and tolerated unless every compartment refuses. Swapping them would
+// change what a tenancy-wide IAM gap returns - today an empty list, under the
+// compartment policy an error. That is arguably the better answer, but it is a
+// different answer, so the choice stays with the scope until it is made
+// deliberately.
+func (s ociScope) join(jobs []*jobpool.Job) ([]any, error) {
+	if s == ociScopeAllCompartments {
+		return ociJoinCompartmentJobs(jobs, s.concurrency())
+	}
+	return ociJoinRegionJobs(jobs, s.concurrency())
+}
+
+// ociJoinRegionJobs returns the union of the jobs that succeeded, skipping only
+// the regions where the service genuinely has no endpoint.
+//
+// The distinction matters in both directions. Failing the whole collection when
+// any region errors turned one unsubscribed or undeployed region into a
+// tenancy-wide failure. But skipping every error is just as wrong the other way:
+// a 403 from an IAM gap, a 429 throttle or a 500 would silently under-report
+// resources, and an authoritative-looking short list is worse than an error in an
+// inventory tool.
+//
+// So ociRegionServiceUnavailable decides. An absent endpoint is expected and is
+// skipped; anything else is reported, joined across regions so a broken token
+// names every region it affected.
+func ociJoinRegionJobs(jobs []*jobpool.Job, concurrency int) ([]any, error) {
+	if len(jobs) == 0 {
+		return []any{}, nil
+	}
+
+	poolOfJobs := jobpool.CreatePool(jobs, concurrency)
+	poolOfJobs.Run()
+
+	res := []any{}
+	var hardErr error
+	for i := range poolOfJobs.Jobs {
+		job := poolOfJobs.Jobs[i]
+		if job.Err != nil {
+			if ociRegionServiceUnavailable(job.Err) {
+				log.Debug().Err(job.Err).Msg("skipping oci region where the service is unavailable")
+				continue
+			}
+			hardErr = errors.Join(hardErr, job.Err)
+			continue
+		}
+		items, ok := job.Result.([]any)
+		if !ok {
+			continue
+		}
+		res = append(res, items...)
+	}
+
+	if hardErr != nil {
+		return nil, hardErr
+	}
+	return res, nil
+}
+
+// ociJoinCompartmentJobs joins a compartment fan-out.
+//
+// Error handling has to distinguish three cases that all surface as an error
+// from a single job:
+//
+//   - The service has no endpoint in this region. Expected; skipped, matching
+//     ociJoinRegionJobs.
+//   - The caller cannot read this one compartment. Also expected: OCI policies
+//     are routinely written per-compartment, so a scanning principal that can
+//     read ten of fifty compartments is correctly configured, not broken. The
+//     compartment is skipped and counted.
+//   - Anything else (throttling, 5xx, malformed request) is a real fault and is
+//     returned, because silently dropping it would under-report resources.
+//
+// The one case that must not be swallowed is *every* compartment refusing
+// access. That is an under-scoped token, and reporting it as an empty tenancy
+// would turn a broken credential into a clean scan.
+func ociJoinCompartmentJobs(jobs []*jobpool.Job, concurrency int) ([]any, error) {
+	if len(jobs) == 0 {
+		return []any{}, nil
+	}
+
+	poolOfJobs := jobpool.CreatePool(jobs, concurrency)
+	poolOfJobs.Run()
+
+	res := []any{}
+	var (
+		hardErr   error
+		deniedErr error
+		denied    int
+		succeeded int
+	)
+	for i := range poolOfJobs.Jobs {
+		job := poolOfJobs.Jobs[i]
+		if job.Err != nil {
+			// Order matters. OCI answers an authorization failure with 404
+			// NotAuthorizedOrNotFound, and ociRegionServiceUnavailable treats
+			// any 404 as an absent regional endpoint - so asking it first
+			// consumed every denial before it could be counted, and the
+			// all-denied guard below could never fire. The denial test is
+			// narrower (it matches on the error code, not just the status), so
+			// it goes first and the region test keeps the rest.
+			if ociCompartmentInaccessible(job.Err) {
+				denied++
+				if deniedErr == nil {
+					deniedErr = job.Err
+				}
+				continue
+			}
+			if ociRegionServiceUnavailable(job.Err) {
+				log.Debug().Err(job.Err).Msg("skipping oci region where the service is unavailable")
+				continue
+			}
+			hardErr = errors.Join(hardErr, job.Err)
+			continue
+		}
+
+		succeeded++
+		items, ok := job.Result.([]any)
+		if !ok {
+			continue
+		}
+		res = append(res, items...)
+	}
+
+	if hardErr != nil {
+		return nil, hardErr
+	}
+
+	if succeeded == 0 && denied > 0 {
+		return nil, deniedErr
+	}
+
+	if denied > 0 {
+		// Visible rather than silent: the result is a partial view of the
+		// tenancy and the operator should know how partial.
+		log.Warn().
+			Int("compartments_denied", denied).
+			Int("compartments_read", succeeded).
+			Msg("oci: listed a partial view of the tenancy, some compartments were not readable")
+	}
+
+	return res, nil
+}

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -16,7 +16,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -28,38 +27,18 @@ func (o *mqlOciOke) id() (string, error) {
 func (o *mqlOciOke) clusters() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci oke with region %s", region)
 
-	return ociRunRegionPool(o.getClusters(conn, list.Data))
-}
-
-func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci oke with region %s", regionResource.Id.Data)
-
-			svc, err := conn.ContainerEngineClient(regionResource.Id.Data)
+			svc, err := conn.ContainerEngineClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			clusters, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]containerengine.ClusterSummary, *string, error) {
 				response, err := svc.ListClusters(ctx, containerengine.ListClustersRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -155,15 +134,12 @@ func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) [
 				}
 				mqlCluster := mqlInstance.(*mqlOciOkeCluster)
 				mqlCluster.cacheVcnId = stringValue(cluster.VcnId)
-				mqlCluster.region = regionResource.Id.Data
+				mqlCluster.region = region
 				res = append(res, mqlCluster)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciOkeClusterInternal struct {

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -23,21 +23,11 @@ func (o *mqlOciOns) id() (string, error) {
 func (o *mqlOciOns) topics() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Notification topics are created next to the alarms and connectors that
 	// publish to them, which puts them in child compartments. ListTopics has no
 	// subtree option, so a root-only sweep reported no topics and broke the alarm
 	// and Connector Hub destination references that point at them.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci with region %s", region)
 

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -25,38 +24,18 @@ func (o *mqlOciRedis) id() (string, error) {
 func (o *mqlOciRedis) clusters() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	regions := oci.GetRegions()
-	if regions.Error != nil {
-		return nil, regions.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci redis cluster with region %s", region)
 
-	return ociRunRegionPool(o.getClusters(conn, regions.Data))
-}
-
-func (o *mqlOciRedis) getClusters(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci redis cluster with region %s", regionResource.Id.Data)
-
-			svc, err := conn.RedisClusterClient(regionResource.Id.Data)
+			svc, err := conn.RedisClusterClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			clusters, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]redis.RedisClusterSummary, *string, error) {
 				response, err := svc.ListRedisClusters(ctx, redis.ListRedisClustersRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -122,15 +101,12 @@ func (o *mqlOciRedis) getClusters(conn *connection.OciConnection, regions []any)
 				mqlClusterTyped := mqlCluster.(*mqlOciRedisCluster)
 				mqlClusterTyped.cacheSubnetId = stringValue(c.SubnetId)
 				mqlClusterTyped.cacheNsgIds = c.NsgIds
-				mqlClusterTyped.cacheRegion = regionResource.Id.Data
+				mqlClusterTyped.cacheRegion = region
 				res = append(res, mqlClusterTyped)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciRedisClusterInternal struct {

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -27,12 +27,7 @@ func (o *mqlOciResourceManager) id() (string, error) {
 func (o *mqlOciResourceManager) stacks() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	regions, err := ociRegionsFor(o.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.ResourceManagerClient(region)
 			if err != nil {

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -25,22 +25,12 @@ func (o *mqlOciVault) id() (string, error) {
 func (o *mqlOciVault) secrets() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-
 	// Secrets sit in the compartment of the application that consumes them, and
 	// ListSecrets accepts one compartment with no recursion. Asking only about
 	// the tenancy root left rotation status, expiry, and auto-generation checks
 	// with nothing to evaluate, which looked like a tenancy with no secrets
 	// rather than a scan that never reached them.
-	return ociRunCompartmentRegionPool(conn, list.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci vault secrets with region %s", region)
 

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -25,16 +25,7 @@ func (o *mqlOciServiceConnectorHub) id() (string, error) {
 func (o *mqlOciServiceConnectorHub) connectors() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	regions := ociResource.(*mqlOci).GetRegions()
-	if regions.Error != nil {
-		return nil, regions.Error
-	}
-
-	return ociRunCompartmentRegionPool(conn, regions.Data,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			client, err := conn.ServiceConnectorClient(region)
 			if err != nil {

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -14,24 +14,9 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
-
-// regionResources returns the tenancy's subscribed regions as []*mqlOciRegion
-// wrapped in []any, ready to hand to a jobpool fan-out.
-func (o *mqlOciNetwork) regionResources() ([]any, error) {
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	list := ociResource.(*mqlOci).GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
-	return list.Data, nil
-}
 
 // Dynamic Routing Gateways
 
@@ -41,23 +26,9 @@ type mqlOciNetworkDrgInternal struct {
 
 func (o *mqlOciNetwork) drgs() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := o.regionResources()
-	if err != nil {
-		return nil, err
-	}
-	return ociRunRegionPool(o.getDrgs(conn, regions))
-}
-
-func (o *mqlOciNetwork) getDrgs(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			regionKey := regionResource.Id.Data
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			regionKey := region
 			log.Debug().Msgf("calling oci DRGs with region %s", regionKey)
 
 			svc, err := conn.NetworkClient(regionKey)
@@ -67,7 +38,7 @@ func (o *mqlOciNetwork) getDrgs(conn *connection.OciConnection, regions []any) [
 
 			drgs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Drg, *string, error) {
 				response, err := svc.ListDrgs(ctx, core.ListDrgsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -105,11 +76,8 @@ func (o *mqlOciNetwork) getDrgs(conn *connection.OciConnection, regions []any) [
 				res = append(res, mqlDrg)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciNetworkDrg(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -418,23 +386,9 @@ type mqlOciNetworkLocalPeeringGatewayInternal struct {
 
 func (o *mqlOciNetwork) localPeeringGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := o.regionResources()
-	if err != nil {
-		return nil, err
-	}
-	return ociRunRegionPool(o.getLocalPeeringGateways(conn, regions))
-}
-
-func (o *mqlOciNetwork) getLocalPeeringGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			regionKey := regionResource.Id.Data
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			regionKey := region
 			log.Debug().Msgf("calling oci local peering gateways with region %s", regionKey)
 
 			svc, err := conn.NetworkClient(regionKey)
@@ -444,7 +398,7 @@ func (o *mqlOciNetwork) getLocalPeeringGateways(conn *connection.OciConnection, 
 
 			lpgs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.LocalPeeringGateway, *string, error) {
 				response, err := svc.ListLocalPeeringGateways(ctx, core.ListLocalPeeringGatewaysRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -487,11 +441,8 @@ func (o *mqlOciNetwork) getLocalPeeringGateways(conn *connection.OciConnection, 
 				res = append(res, mqlLpg)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciNetworkLocalPeeringGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -584,23 +535,9 @@ type mqlOciNetworkServiceGatewayInternal struct {
 
 func (o *mqlOciNetwork) serviceGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := o.regionResources()
-	if err != nil {
-		return nil, err
-	}
-	return ociRunRegionPool(o.getServiceGateways(conn, regions))
-}
-
-func (o *mqlOciNetwork) getServiceGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			regionKey := regionResource.Id.Data
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			regionKey := region
 			log.Debug().Msgf("calling oci service gateways with region %s", regionKey)
 
 			svc, err := conn.NetworkClient(regionKey)
@@ -610,7 +547,7 @@ func (o *mqlOciNetwork) getServiceGateways(conn *connection.OciConnection, regio
 
 			sgws, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.ServiceGateway, *string, error) {
 				response, err := svc.ListServiceGateways(ctx, core.ListServiceGatewaysRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -657,11 +594,8 @@ func (o *mqlOciNetwork) getServiceGateways(conn *connection.OciConnection, regio
 				res = append(res, mqlSgw)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciNetworkServiceGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -15,7 +15,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -24,23 +23,9 @@ import (
 
 func (o *mqlOciNetwork) cpes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := o.regionResources()
-	if err != nil {
-		return nil, err
-	}
-	return ociRunRegionPool(o.getCpes(conn, regions))
-}
-
-func (o *mqlOciNetwork) getCpes(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			regionKey := regionResource.Id.Data
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			regionKey := region
 			log.Debug().Msgf("calling oci CPEs with region %s", regionKey)
 
 			svc, err := conn.NetworkClient(regionKey)
@@ -50,7 +35,7 @@ func (o *mqlOciNetwork) getCpes(conn *connection.OciConnection, regions []any) [
 
 			cpes, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.Cpe, *string, error) {
 				response, err := svc.ListCpes(ctx, core.ListCpesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -88,11 +73,8 @@ func (o *mqlOciNetwork) getCpes(conn *connection.OciConnection, regions []any) [
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciNetworkCpe(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -141,23 +123,9 @@ type mqlOciNetworkIpsecConnectionInternal struct {
 
 func (o *mqlOciNetwork) ipsecConnections() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := o.regionResources()
-	if err != nil {
-		return nil, err
-	}
-	return ociRunRegionPool(o.getIpsecConnections(conn, regions))
-}
-
-func (o *mqlOciNetwork) getIpsecConnections(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			regionKey := regionResource.Id.Data
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			regionKey := region
 			log.Debug().Msgf("calling oci IPSec connections with region %s", regionKey)
 
 			svc, err := conn.NetworkClient(regionKey)
@@ -167,7 +135,7 @@ func (o *mqlOciNetwork) getIpsecConnections(conn *connection.OciConnection, regi
 
 			conns, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.IpSecConnection, *string, error) {
 				response, err := svc.ListIPSecConnections(ctx, core.ListIPSecConnectionsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -211,11 +179,8 @@ func (o *mqlOciNetwork) getIpsecConnections(conn *connection.OciConnection, regi
 				res = append(res, mqlIpsc)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciNetworkIpsecConnection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -663,23 +628,9 @@ type crossConnectMapping struct {
 
 func (o *mqlOciNetwork) virtualCircuits() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := o.regionResources()
-	if err != nil {
-		return nil, err
-	}
-	return ociRunRegionPool(o.getVirtualCircuits(conn, regions))
-}
-
-func (o *mqlOciNetwork) getVirtualCircuits(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			regionKey := regionResource.Id.Data
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			regionKey := region
 			log.Debug().Msgf("calling oci virtual circuits with region %s", regionKey)
 
 			svc, err := conn.NetworkClient(regionKey)
@@ -689,7 +640,7 @@ func (o *mqlOciNetwork) getVirtualCircuits(conn *connection.OciConnection, regio
 
 			vcs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.VirtualCircuit, *string, error) {
 				response, err := svc.ListVirtualCircuits(ctx, core.ListVirtualCircuitsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -756,11 +707,8 @@ func (o *mqlOciNetwork) getVirtualCircuits(conn *connection.OciConnection, regio
 				res = append(res, mqlVc)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciNetworkVirtualCircuit(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -817,23 +765,9 @@ func (o *mqlOciNetworkVirtualCircuit) drg() (*mqlOciNetworkDrg, error) {
 
 func (o *mqlOciNetwork) crossConnects() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	regions, err := o.regionResources()
-	if err != nil {
-		return nil, err
-	}
-	return ociRunRegionPool(o.getCrossConnects(conn, regions))
-}
-
-func (o *mqlOciNetwork) getCrossConnects(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			regionKey := regionResource.Id.Data
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			regionKey := region
 			log.Debug().Msgf("calling oci cross-connects with region %s", regionKey)
 
 			svc, err := conn.NetworkClient(regionKey)
@@ -843,7 +777,7 @@ func (o *mqlOciNetwork) getCrossConnects(conn *connection.OciConnection, regions
 
 			xcs, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.CrossConnect, *string, error) {
 				response, err := svc.ListCrossConnects(ctx, core.ListCrossConnectsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -883,11 +817,8 @@ func (o *mqlOciNetwork) getCrossConnects(conn *connection.OciConnection, regions
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func (o *mqlOciNetworkCrossConnect) id() (string, error) {

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -25,38 +24,18 @@ func (o *mqlOciWaf) id() (string, error) {
 func (o *mqlOciWaf) firewalls() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci WAF firewalls with region %s", region)
 
-	return ociRunRegionPool(o.getFirewalls(conn, list.Data))
-}
-
-func (o *mqlOciWaf) getFirewalls(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci WAF firewalls with region %s", regionResource.Id.Data)
-
-			svc, err := conn.WafClient(regionResource.Id.Data)
+			svc, err := conn.WafClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]waf.WebAppFirewallSummary, *string, error) {
 				response, err := svc.ListWebAppFirewalls(ctx, waf.ListWebAppFirewallsRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -114,11 +93,8 @@ func (o *mqlOciWaf) getFirewalls(conn *connection.OciConnection, regions []any) 
 				res = append(res, mqlFw)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 type mqlOciWafFirewallInternal struct {
@@ -161,38 +137,18 @@ func (o *mqlOciWafFirewall) loadBalancer() (*mqlOciLoadBalancerLoadBalancer, err
 func (o *mqlOciWaf) policies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	ociResource, err := CreateResource(o.MqlRuntime, "oci", nil)
-	if err != nil {
-		return nil, err
-	}
-	oci := ociResource.(*mqlOci)
-	list := oci.GetRegions()
-	if list.Error != nil {
-		return nil, list.Error
-	}
+	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
+			log.Debug().Msgf("calling oci WAF policies with region %s", region)
 
-	return ociRunRegionPool(o.getPolicies(conn, list.Data))
-}
-
-func (o *mqlOciWaf) getPolicies(conn *connection.OciConnection, regions []any) []*jobpool.Job {
-	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	for _, region := range regions {
-		regionResource, ok := region.(*mqlOciRegion)
-		if !ok {
-			return jobErr(errors.New("invalid region type"))
-		}
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci WAF policies with region %s", regionResource.Id.Data)
-
-			svc, err := conn.WafClient(regionResource.Id.Data)
+			svc, err := conn.WafClient(region)
 			if err != nil {
 				return nil, err
 			}
 
 			items, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]waf.WebAppFirewallPolicySummary, *string, error) {
 				response, err := svc.ListWebAppFirewallPolicies(ctx, waf.ListWebAppFirewallPoliciesRequest{
-					CompartmentId: common.String(conn.TenantID()),
+					CompartmentId: common.String(compartmentID),
 					Page:          page,
 				})
 				if err != nil {
@@ -243,11 +199,8 @@ func (o *mqlOciWaf) getPolicies(conn *connection.OciConnection, regions []any) [
 				res = append(res, mqlInstance)
 			}
 
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+			return res, nil
+		})
 }
 
 func initOciWafPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {


### PR DESCRIPTION
## The problem

This provider had **two ways to fan a lister out over the tenancy, and they disagreed about where OCI resources live.**

`ociRunCompartmentRegionPool` walked the compartment tree. The other passed the tenancy OCID as the compartment — which lists the **tenancy root only**, and returns nothing at all for any tenancy that organizes its resources into child compartments, the normal way to run OCI.

Both compiled. Both returned a plausible list. **Nothing at the call site told them apart**, because the difference was a `conn.TenantID()` buried in a request struct. `compute.go` contained both, for the same resource family — `instances()` walked the tree; `images()`, `blockVolumes()` and `bootVolumes()` did not.

## The change

One entry point, and the choice has to say its name:

```go
return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
    func(ctx context.Context, region string, compartmentID string) ([]any, error) {
        ...
    })
```

**41 listers carry `ociScopeTenancyRoot`; 39 carry `ociScopeAllCompartments`.**

Nothing any of them returns has changed — the root scope asks exactly the one compartment the old code asked. What changed is that the root-only choice is now a **greppable token instead of an accident**, so migrating those 41 becomes a one-word edit per lister rather than a rewrite. That migration is deliberately **not** in this PR: it changes what already-shipped resources return.

## Why behavior is preserved

The error policy and concurrency stay **bound to the scope** rather than being unified. They are not interchangeable:

| | `ociScopeTenancyRoot` | `ociScopeAllCompartments` |
|---|---|---|
| 404 `NotAuthorizedOrNotFound` | absent regional endpoint → skipped | per-compartment denial → counted, tolerated unless *all* refuse |
| concurrency | 5 | 10 |

Merging them would change what a tenancy-wide IAM gap returns — today an empty list, under the compartment policy an error. That is arguably the better answer, but it is a *different* answer, so it stays a separate, deliberate decision.

## Scaffolding that went away

Folding the fan-out into one place removed everything that existed only to feed it:

- **40** `get<Thing>(conn, regions) []*jobpool.Job` builders
- **49** hand-rolled `jobpool.NewJob` closures
- **33** copies of the `CreateResource(runtime, "oci", nil)` → `GetRegions()` → check-error preamble

Net **−1247 lines** across 37 files.

It also turned up **three byte-identical copies of the same region fetch**: `ociRegionsFor`, `ociAgentRegions`, and `(*mqlOciNetwork).regionResources`. The duplicates are deleted. Worth calling out because the existence of `ociAgentRegions` implied the AI services queried a *restricted* set of regions — they do not. Their region-limiting lives in the fail-fast client (#9650) and `ociRegionServiceUnavailable`, not in a filtered region list.

## The escape hatch

`ociRunRegionPool` survives for collections that are genuinely **not** a (region, compartment) fan-out, and now delegates to the shared join instead of carrying its own copy of the policy:

- **OCI IAM is global within a realm**, so users, groups and policies run as a single job. Fanning them out over regions returned each one once per subscribed region — and since `CreateResource` hands back the cached instance for a repeated `__id`, the result held N copies of one pointer and every count was inflated N-fold.
- **The AI services** wrap their per-region fetch in their own helper so an undeployed region is skipped per-region rather than per-job.

One idiom plus two named escape hatches, rather than two idioms that look alike.

## Verification

Beyond `go build`, `go vet`, `go test -race ./...`:

- `compartments_test.go` and `region_degrade_test.go` already encode both error taxonomies. They now exercise them through the shared joins and still pass.
- **The same per-file audit used for the pagination sweep** confirms the error-handling shape (swallow vs. return), the set of SDK `List*` calls, and the set of resource names passed to `CreateResource`/`NewResource` are unchanged against the base commit.
- Two audit hits were investigated and are **accounting artifacts, not behavior**: a lister that returned `jobpool.JobResult([]any{})` now returns `[]any{}` because `ociCollect` does the wrapping; and the `oci` resource is no longer created per-lister because that call moved into `ociRegionsFor`.
- **6 `conn.TenantID()` uses were left in place** rather than renamed to `compartmentID`. They are arguments to per-region helpers where the value is identical today but is not necessarily *the compartment*, and silently renaming one would mislead whoever flips the scope later. They are listed in the commit message.

## Context

PR 3 of six behavior-preserving PRs restructuring this provider's internals (#9650, #9655 merged). The user-facing surface — the `.lr` schema, all 211 resources, field names and types, discovery targets, CLI flags — does not move in any of them.

Remaining: mapping helpers, a generic typed-ref resolver, a table-driven discovery registry.

**Quarantined behavior-changing follow-ups**, now three:
1. Flip the 41 `ociScopeTenancyRoot` listers to `ociScopeAllCompartments` — this PR is what makes that a one-word change.
2. Converge the two error policies.
3. The 16 sites that swallow a list error and report an empty collection (found in #9655).

## Verification owed

Live validation against a real tenancy is still outstanding for this provider (carried from #9573–#9578). The highest-value things to exercise here are the compartment-scope denial accounting against a token with partial compartment access, and the AI listers' per-region skip.
