### PR TITLE
🧹 oci: one registry row per discovery target instead of two switches

### DIFF
--- a/providers/oci/resources/discovery.go
+++ b/providers/oci/resources/discovery.go
@@ -37,23 +37,296 @@ const (
 	DiscoveryGenerativeAiEndpoints = "generativeai-endpoints"
 )
 
-// AllAPIResources lists every fine-grained per-resource discovery target.
-// Keep sorted alphabetically by target string for diff stability.
-var AllAPIResources = []string{
-	DiscoveryAPIGatewayDeployments,
-	DiscoveryBuckets,
-	DiscoveryGenerativeAiEndpoints,
-	DiscoveryLoadBalancers,
-	DiscoveryOkeClusters,
-	DiscoveryPolicies,
-	DiscoveryRedisClusters,
-	DiscoverySecurityLists,
-	DiscoveryUsers,
-	DiscoveryVaultSecrets,
+// A discovery target used to be spread across four places: the constant above, a
+// `case` in discover(), an entry in AllAPIResources, and an arm of a
+// getPlatformName switch that re-derived the platform name from the service and
+// object type the `case` had just written. The two switches encoded the same
+// facts, so they could disagree - and a target whose pair was missing from
+// getPlatformName silently emitted no asset at all, because an unmapped pair
+// returns "" and the caller skips it.
+//
+// One row per target instead. The tuple that composes the platform id and the
+// platform name that cnspec policy filters match on now live together, and
+// TestDiscoveryTargetsMatchPlatformCatalog checks the row set against the
+// platform catalog in both directions, so neither side can grow an entry the
+// other lacks.
+
+// ociDiscovered is what a target's extractor pulls off one resource: the parts
+// that vary per object type, where everything else about the asset is uniform.
+type ociDiscovered struct {
+	id          string // OCID, or a composite id (e.g. namespace/name for buckets)
+	name        string
+	compartment string
+	region      string
+	labels      map[string]string
 }
 
-// Auto expands to the tenancy plus all API resources. The order puts tenancy
-// first so it's visible in `cnspec scan` output before any sub-assets.
+// ociDiscoveryTarget describes one fine-grained discovery target end to end.
+type ociDiscoveryTarget struct {
+	// Target is the --discover value.
+	Target string
+	// Platform is the platform name cnspec policy filters match on. It must
+	// exist in the Platforms catalog.
+	Platform string
+	// Service and ObjectType compose the asset's platform id. Changing either
+	// changes the identity of every asset the target emits.
+	Service    string
+	ObjectType string
+	// List reaches the MQL collection the target iterates.
+	List func(runtime *plugin.Runtime) ([]any, error)
+	// Extract pulls the per-object asset fields. Returning false skips an entry
+	// whose type does not match, rather than panicking on the assertion.
+	Extract func(item any) (ociDiscovered, bool)
+}
+
+// ociDiscoveryList initializes a resource and reads one of its collection
+// fields, which is what every target's List does.
+func ociDiscoveryList[T plugin.Resource](runtime *plugin.Runtime, name string, field func(T) *plugin.TValue[[]any]) ([]any, error) {
+	res, err := NewResource(runtime, name, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	typed, ok := res.(T)
+	if !ok {
+		return nil, fmt.Errorf("oci discovery: %s did not resolve to a %T", name, typed)
+	}
+	list := field(typed)
+	if list.Error != nil {
+		return nil, list.Error
+	}
+	return list.Data, nil
+}
+
+// ociDiscoveryTargets is the registry. Adding a discoverable object type means
+// adding a row here, a constant above, and a platform to the Platforms catalog.
+var ociDiscoveryTargets = []ociDiscoveryTarget{
+	{
+		Target: DiscoverySecurityLists, Platform: "oci-network-securitylist",
+		Service: "network", ObjectType: "securitylist",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.network", (*mqlOciNetwork).GetSecurityLists)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			sl, ok := item.(*mqlOciNetworkSecurityList)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			// cacheRegion was populated when the security list was enumerated;
+			// empty only when the enumeration didn't hit a region.
+			return ociDiscovered{
+				id: sl.Id.Data, name: sl.Name.Data,
+				compartment: sl.CompartmentID.Data, region: sl.cacheRegion,
+				labels: tagsToLabels(sl.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryUsers, Platform: "oci-identity-user",
+		Service: "identity", ObjectType: "user",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.identity", (*mqlOciIdentity).GetUsers)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			u, ok := item.(*mqlOciIdentityUser)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			// OCI IAM is global (single realm per tenancy); mark users as such
+			// so the platform id stays stable regardless of which region the
+			// scan connects to.
+			return ociDiscovered{
+				id: u.Id.Data, name: u.Name.Data,
+				compartment: u.CompartmentID.Data, region: "global",
+				labels: tagsToLabels(u.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryPolicies, Platform: "oci-identity-policy",
+		Service: "identity", ObjectType: "policy",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.identity", (*mqlOciIdentity).GetPolicies)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			p, ok := item.(*mqlOciIdentityPolicy)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			return ociDiscovered{
+				id: p.Id.Data, name: p.Name.Data,
+				compartment: p.CompartmentID.Data, region: "global",
+				labels: tagsToLabels(p.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryBuckets, Platform: "oci-objectstorage-bucket",
+		Service: "objectstorage", ObjectType: "bucket",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.objectStorage", (*mqlOciObjectStorage).GetBuckets)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			b, ok := item.(*mqlOciObjectStorageBucket)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			// Region is exposed as a typed oci.region resource on the bucket;
+			// pull its id (region key) for the platform id.
+			regionKey := ""
+			if region := b.GetRegion(); region.Error == nil && region.Data != nil {
+				regionKey = region.Data.Id.Data
+			}
+			return ociDiscovered{
+				// Buckets aren't globally unique by name alone - namespace
+				// qualifies them - so use namespace/name to match the __id.
+				id: b.Namespace.Data + "/" + b.Name.Data, name: b.Name.Data,
+				compartment: b.CompartmentID.Data, region: regionKey,
+				// Tags on a bucket require an extra GetBucket call. Surface
+				// empty labels rather than paying N round-trips at discovery
+				// time just to populate them.
+				labels: map[string]string{},
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryAPIGatewayDeployments, Platform: "oci-apigateway-deployment",
+		Service: "apigateway", ObjectType: "deployment",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.apigateway", (*mqlOciApigateway).GetDeployments)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			d, ok := item.(*mqlOciApigatewayDeployment)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			return ociDiscovered{
+				id: d.Id.Data, name: d.Name.Data,
+				compartment: d.CompartmentID.Data, region: d.region,
+				labels: tagsToLabels(d.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryLoadBalancers, Platform: "oci-loadbalancer",
+		Service: "loadbalancer", ObjectType: "loadBalancer",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.loadBalancer", (*mqlOciLoadBalancer).GetLoadBalancers)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			lb, ok := item.(*mqlOciLoadBalancerLoadBalancer)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			return ociDiscovered{
+				id: lb.Id.Data, name: lb.Name.Data,
+				compartment: lb.CompartmentID.Data, region: lb.cacheRegion,
+				labels: tagsToLabels(lb.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryRedisClusters, Platform: "oci-redis-cluster",
+		Service: "redis", ObjectType: "cluster",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.redis", (*mqlOciRedis).GetClusters)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			c, ok := item.(*mqlOciRedisCluster)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			return ociDiscovered{
+				id: c.Id.Data, name: c.Name.Data,
+				compartment: c.CompartmentID.Data, region: c.cacheRegion,
+				labels: tagsToLabels(c.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryVaultSecrets, Platform: "oci-vault-secret",
+		Service: "vault", ObjectType: "secret",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.vault", (*mqlOciVault).GetSecrets)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			s, ok := item.(*mqlOciVaultSecret)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			return ociDiscovered{
+				id: s.Id.Data, name: s.Name.Data,
+				compartment: s.CompartmentID.Data, region: s.cacheRegion,
+				labels: tagsToLabels(s.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryOkeClusters, Platform: "oci-oke-cluster",
+		Service: "oke", ObjectType: "cluster",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.oke", (*mqlOciOke).GetClusters)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			c, ok := item.(*mqlOciOkeCluster)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			return ociDiscovered{
+				id: c.Id.Data, name: c.Name.Data,
+				compartment: c.CompartmentID.Data, region: c.region,
+				labels: tagsToLabels(c.FreeformTags.Data),
+			}, true
+		},
+	},
+	{
+		Target: DiscoveryGenerativeAiEndpoints, Platform: "oci-ai-generativeai-endpoint",
+		Service: "generativeai", ObjectType: "endpoint",
+		List: func(rt *plugin.Runtime) ([]any, error) {
+			return ociDiscoveryList(rt, "oci.ai.generativeAi", (*mqlOciAiGenerativeAi).GetEndpoints)
+		},
+		Extract: func(item any) (ociDiscovered, bool) {
+			e, ok := item.(*mqlOciAiGenerativeAiEndpoint)
+			if !ok {
+				return ociDiscovered{}, false
+			}
+			return ociDiscovered{
+				id: e.Id.Data, name: e.Name.Data,
+				compartment: e.CompartmentID.Data, region: e.cacheRegion,
+				labels: tagsToLabels(e.FreeformTags.Data),
+			}, true
+		},
+	},
+}
+
+// ociDiscoveryTargetsByName indexes the registry for dispatch.
+var ociDiscoveryTargetsByName = func() map[string]ociDiscoveryTarget {
+	res := make(map[string]ociDiscoveryTarget, len(ociDiscoveryTargets))
+	for _, t := range ociDiscoveryTargets {
+		res[t.Target] = t
+	}
+	return res
+}()
+
+// AllAPIResources lists every fine-grained per-resource discovery target,
+// sorted by target string for diff stability.
+var AllAPIResources = func() []string {
+	res := make([]string, 0, len(ociDiscoveryTargets))
+	for _, t := range ociDiscoveryTargets {
+		res = append(res, t.Target)
+	}
+	slices.Sort(res)
+	return res
+}()
+
+// Auto expands to the tenancy plus all API resources, tenancy first.
+//
+// That ordering only survives on the `all` path. getDiscoveryTargets returns All
+// directly, but it runs everything else through stringx.DedupStringArray, which
+// collects into a map and therefore returns the targets in a random order - so
+// `--discover auto`, the default, does not in fact list the tenancy first.
+// Pre-existing; left alone here because this change is not meant to alter
+// behavior, but it is a real defect rather than a quirk: the ordering is what
+// puts the tenancy above its own sub-assets in scan output.
 var Auto = append(
 	[]string{DiscoveryTenancy},
 	AllAPIResources...,
@@ -122,247 +395,40 @@ func getDiscoveryTargets(config *inventory.Config) []string {
 }
 
 func discover(runtime *plugin.Runtime, conn *connection.OciConnection, target string) ([]*inventory.Asset, error) {
-	tenantID := conn.TenantID()
-	assetList := []*inventory.Asset{}
+	// The tenancy asset already exists in the request (the user connected to it
+	// directly), so there is no work to do for it here.
+	if target == DiscoveryTenancy {
+		return nil, nil
+	}
 
-	switch target {
-	case DiscoveryTenancy:
-		// The tenancy asset already exists in the request (the user connected
-		// to it directly); no work needed here.
-	case DiscoverySecurityLists:
-		res, err := NewResource(runtime, "oci.network", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		network := res.(*mqlOciNetwork)
-		secLists := network.GetSecurityLists()
-		if secLists.Error != nil {
-			return nil, secLists.Error
-		}
-		for i := range secLists.Data {
-			sl := secLists.Data[i].(*mqlOciNetworkSecurityList)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: sl.CompartmentID.Data,
-				// cacheRegion was populated when the security list was
-				// enumerated; empty only when the enumeration didn't hit a
-				// region (defensive fallback).
-				region:     fallbackRegion(sl.cacheRegion),
-				id:         sl.Id.Data,
-				service:    "network",
-				objectType: "securitylist",
-			}, sl.Name.Data, tagsToLabels(sl.FreeformTags.Data), conn))
-		}
-	case DiscoveryBuckets:
-		res, err := NewResource(runtime, "oci.objectStorage", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		os := res.(*mqlOciObjectStorage)
-		buckets := os.GetBuckets()
-		if buckets.Error != nil {
-			return nil, buckets.Error
-		}
-		for i := range buckets.Data {
-			b := buckets.Data[i].(*mqlOciObjectStorageBucket)
-			// Region is exposed as a typed oci.region resource on the bucket;
-			// pull its id (region key) for the platform id.
-			regionKey := ""
-			region := b.GetRegion()
-			if region.Error == nil && region.Data != nil {
-				regionKey = region.Data.Id.Data
-			}
-			// Tags on bucket are lazy-loaded (require an extra GetBucket call);
-			// at discovery time surface empty labels so we don't pay N API
-			// round-trips per bucket just to populate discovery labels.
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: b.CompartmentID.Data,
-				region:      fallbackRegion(regionKey),
-				// Buckets aren't globally unique by name alone — namespace
-				// qualifies them — so use namespace/name as the platform id
-				// suffix to match the existing __id.
-				id:         b.Namespace.Data + "/" + b.Name.Data,
-				service:    "objectstorage",
-				objectType: "bucket",
-			}, b.Name.Data, map[string]string{}, conn))
-		}
-	case DiscoveryUsers:
-		res, err := NewResource(runtime, "oci.identity", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		identity := res.(*mqlOciIdentity)
-		users := identity.GetUsers()
-		if users.Error != nil {
-			return nil, users.Error
-		}
-		for i := range users.Data {
-			u := users.Data[i].(*mqlOciIdentityUser)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: u.CompartmentID.Data,
-				// OCI IAM is global (single realm per tenancy); mark users as
-				// such so the platform id stays stable regardless of which
-				// region the scan connects to.
-				region:     "global",
-				id:         u.Id.Data,
-				service:    "identity",
-				objectType: "user",
-			}, u.Name.Data, tagsToLabels(u.FreeformTags.Data), conn))
-		}
-	case DiscoveryPolicies:
-		res, err := NewResource(runtime, "oci.identity", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		identity := res.(*mqlOciIdentity)
-		policies := identity.GetPolicies()
-		if policies.Error != nil {
-			return nil, policies.Error
-		}
-		for i := range policies.Data {
-			p := policies.Data[i].(*mqlOciIdentityPolicy)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: p.CompartmentID.Data,
-				region:      "global",
-				id:          p.Id.Data,
-				service:     "identity",
-				objectType:  "policy",
-			}, p.Name.Data, tagsToLabels(p.FreeformTags.Data), conn))
-		}
-	case DiscoveryAPIGatewayDeployments:
-		res, err := NewResource(runtime, "oci.apigateway", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		apigw := res.(*mqlOciApigateway)
-		deps := apigw.GetDeployments()
-		if deps.Error != nil {
-			return nil, deps.Error
-		}
-		for i := range deps.Data {
-			d := deps.Data[i].(*mqlOciApigatewayDeployment)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: d.CompartmentID.Data,
-				region:      fallbackRegion(d.region),
-				id:          d.Id.Data,
-				service:     "apigateway",
-				objectType:  "deployment",
-			}, d.Name.Data, tagsToLabels(d.FreeformTags.Data), conn))
-		}
-	case DiscoveryLoadBalancers:
-		res, err := NewResource(runtime, "oci.loadBalancer", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		lbSvc := res.(*mqlOciLoadBalancer)
-		lbs := lbSvc.GetLoadBalancers()
-		if lbs.Error != nil {
-			return nil, lbs.Error
-		}
-		for i := range lbs.Data {
-			lb := lbs.Data[i].(*mqlOciLoadBalancerLoadBalancer)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: lb.CompartmentID.Data,
-				region:      fallbackRegion(lb.cacheRegion),
-				id:          lb.Id.Data,
-				service:     "loadbalancer",
-				objectType:  "loadBalancer",
-			}, lb.Name.Data, tagsToLabels(lb.FreeformTags.Data), conn))
-		}
-	case DiscoveryRedisClusters:
-		res, err := NewResource(runtime, "oci.redis", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		redis := res.(*mqlOciRedis)
-		clusters := redis.GetClusters()
-		if clusters.Error != nil {
-			return nil, clusters.Error
-		}
-		for i := range clusters.Data {
-			c := clusters.Data[i].(*mqlOciRedisCluster)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: c.CompartmentID.Data,
-				region:      fallbackRegion(c.cacheRegion),
-				id:          c.Id.Data,
-				service:     "redis",
-				objectType:  "cluster",
-			}, c.Name.Data, tagsToLabels(c.FreeformTags.Data), conn))
-		}
-	case DiscoveryVaultSecrets:
-		res, err := NewResource(runtime, "oci.vault", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		v := res.(*mqlOciVault)
-		secrets := v.GetSecrets()
-		if secrets.Error != nil {
-			return nil, secrets.Error
-		}
-		for i := range secrets.Data {
-			s := secrets.Data[i].(*mqlOciVaultSecret)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: s.CompartmentID.Data,
-				region:      fallbackRegion(s.cacheRegion),
-				id:          s.Id.Data,
-				service:     "vault",
-				objectType:  "secret",
-			}, s.Name.Data, tagsToLabels(s.FreeformTags.Data), conn))
-		}
-	case DiscoveryOkeClusters:
-		res, err := NewResource(runtime, "oci.oke", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		oke := res.(*mqlOciOke)
-		clusters := oke.GetClusters()
-		if clusters.Error != nil {
-			return nil, clusters.Error
-		}
-		for i := range clusters.Data {
-			c := clusters.Data[i].(*mqlOciOkeCluster)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: c.CompartmentID.Data,
-				region:      fallbackRegion(c.region),
-				id:          c.Id.Data,
-				service:     "oke",
-				objectType:  "cluster",
-			}, c.Name.Data, tagsToLabels(c.FreeformTags.Data), conn))
-		}
-	case DiscoveryGenerativeAiEndpoints:
-		res, err := NewResource(runtime, "oci.ai.generativeAi", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		genAi := res.(*mqlOciAiGenerativeAi)
-		endpoints := genAi.GetEndpoints()
-		if endpoints.Error != nil {
-			return nil, endpoints.Error
-		}
-		for i := range endpoints.Data {
-			e := endpoints.Data[i].(*mqlOciAiGenerativeAiEndpoint)
-			appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
-				tenantID:    tenantID,
-				compartment: e.CompartmentID.Data,
-				// cacheRegion is populated during endpoint enumeration (the
-				// listing runs per subscribed region); empty only when the
-				// enumeration didn't hit a region (defensive fallback).
-				region:     fallbackRegion(e.cacheRegion),
-				id:         e.Id.Data,
-				service:    "generativeai",
-				objectType: "endpoint",
-			}, e.Name.Data, tagsToLabels(e.FreeformTags.Data), conn))
-		}
-	default:
+	t, ok := ociDiscoveryTargetsByName[target]
+	if !ok {
 		log.Warn().Str("target", target).Msg("oci discovery: unknown target; skipping")
+		return nil, nil
+	}
+
+	items, err := t.List(runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	tenantID := conn.TenantID()
+	assetList := make([]*inventory.Asset, 0, len(items))
+	for i := range items {
+		obj, ok := t.Extract(items[i])
+		if !ok {
+			log.Warn().Str("target", target).
+				Msgf("oci discovery: unexpected item type %T in the collection; skipping", items[i])
+			continue
+		}
+		appendIfNotNil(&assetList, ociObjectToAsset(ociObject{
+			tenantID:    tenantID,
+			compartment: obj.compartment,
+			region:      fallbackRegion(obj.region),
+			id:          obj.id,
+			service:     t.Service,
+			objectType:  t.ObjectType,
+		}, t.Platform, obj.name, obj.labels, conn))
 	}
 	return assetList, nil
 }
@@ -398,62 +464,15 @@ func mondooOciObjectID(obj ociObject) string {
 		"/" + obj.objectType + "/" + obj.id
 }
 
-// getPlatformName maps (service, objectType) to the platform name used by
-// cnspec policy filters. Returning "" for an unknown pair makes the caller
-// skip the asset rather than emit a broken one.
-func getPlatformName(obj ociObject) string {
-	switch obj.service {
-	case "network":
-		if obj.objectType == "securitylist" {
-			return "oci-network-securitylist"
-		}
-	case "identity":
-		switch obj.objectType {
-		case "user":
-			return "oci-identity-user"
-		case "policy":
-			return "oci-identity-policy"
-		}
-	case "objectstorage":
-		if obj.objectType == "bucket" {
-			return "oci-objectstorage-bucket"
-		}
-	case "apigateway":
-		if obj.objectType == "deployment" {
-			return "oci-apigateway-deployment"
-		}
-	case "loadbalancer":
-		if obj.objectType == "loadBalancer" {
-			return "oci-loadbalancer"
-		}
-	case "redis":
-		if obj.objectType == "cluster" {
-			return "oci-redis-cluster"
-		}
-	case "vault":
-		if obj.objectType == "secret" {
-			return "oci-vault-secret"
-		}
-	case "oke":
-		if obj.objectType == "cluster" {
-			return "oci-oke-cluster"
-		}
-	case "generativeai":
-		if obj.objectType == "endpoint" {
-			return "oci-ai-generativeai-endpoint"
-		}
-	}
-	return ""
-}
-
 // ociObjectToAsset wraps an ociObject into an inventory.Asset suitable for
-// returning from Discover(). Returns nil if the object can't be mapped to a
-// known platform (discovery then skips it rather than emitting a broken asset).
-func ociObjectToAsset(obj ociObject, name string, labels map[string]string, conn *connection.OciConnection) *inventory.Asset {
-	platformName := getPlatformName(obj)
-	if platformName == "" {
-		log.Warn().Str("service", obj.service).Str("objectType", obj.objectType).
-			Msg("oci discovery: unknown service/objectType pair; skipping asset")
+// returning from Discover(). Returns nil if the platform name is not in the
+// catalog (discovery then skips it rather than emitting a broken asset).
+func ociObjectToAsset(obj ociObject, platformName string, name string, labels map[string]string, conn *connection.OciConnection) *inventory.Asset {
+	descriptor := PlatformByName(platformName)
+	if descriptor == nil {
+		log.Warn().Str("platform", platformName).Str("service", obj.service).
+			Str("objectType", obj.objectType).
+			Msg("oci discovery: platform is not in the catalog; skipping asset")
 		return nil
 	}
 	if name == "" {
@@ -469,7 +488,7 @@ func ociObjectToAsset(obj ociObject, name string, labels map[string]string, conn
 	)
 	clonedConfig.PlatformId = platformID
 	platform := &inventory.Platform{}
-	PlatformByName(platformName).Apply(platform)
+	descriptor.Apply(platform)
 	return &inventory.Asset{
 		PlatformIds: []string{platformID},
 		Name:        name,

--- a/providers/oci/resources/discovery_test.go
+++ b/providers/oci/resources/discovery_test.go
@@ -1,0 +1,299 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// TestDiscoveryPlatformIDFormat pins the platform id every discovery target
+// emits.
+//
+// A platform id is an asset's identity: change the format, the service segment,
+// or the object-type segment and every previously discovered asset becomes a new
+// asset upstream. Nothing else in this provider would notice, so the exact
+// strings are written out here rather than derived.
+func TestDiscoveryPlatformIDFormat(t *testing.T) {
+	const tenant = "ocid1.tenancy.oc1..aaaaexample"
+
+	want := map[string]string{
+		DiscoverySecurityLists:         "//platformid.api.mondoo.app/runtime/oci/network/v1/tenancies/" + tenant + "/regions/IAD/securitylist/ocid1.securitylist.oc1..x",
+		DiscoveryUsers:                 "//platformid.api.mondoo.app/runtime/oci/identity/v1/tenancies/" + tenant + "/regions/global/user/ocid1.user.oc1..x",
+		DiscoveryPolicies:              "//platformid.api.mondoo.app/runtime/oci/identity/v1/tenancies/" + tenant + "/regions/global/policy/ocid1.policy.oc1..x",
+		DiscoveryBuckets:               "//platformid.api.mondoo.app/runtime/oci/objectstorage/v1/tenancies/" + tenant + "/regions/IAD/bucket/mynamespace/mybucket",
+		DiscoveryAPIGatewayDeployments: "//platformid.api.mondoo.app/runtime/oci/apigateway/v1/tenancies/" + tenant + "/regions/IAD/deployment/ocid1.apideployment.oc1..x",
+		DiscoveryLoadBalancers:         "//platformid.api.mondoo.app/runtime/oci/loadbalancer/v1/tenancies/" + tenant + "/regions/IAD/loadBalancer/ocid1.loadbalancer.oc1..x",
+		DiscoveryRedisClusters:         "//platformid.api.mondoo.app/runtime/oci/redis/v1/tenancies/" + tenant + "/regions/IAD/cluster/ocid1.rediscluster.oc1..x",
+		DiscoveryVaultSecrets:          "//platformid.api.mondoo.app/runtime/oci/vault/v1/tenancies/" + tenant + "/regions/IAD/secret/ocid1.vaultsecret.oc1..x",
+		DiscoveryOkeClusters:           "//platformid.api.mondoo.app/runtime/oci/oke/v1/tenancies/" + tenant + "/regions/IAD/cluster/ocid1.cluster.oc1..x",
+		DiscoveryGenerativeAiEndpoints: "//platformid.api.mondoo.app/runtime/oci/generativeai/v1/tenancies/" + tenant + "/regions/IAD/endpoint/ocid1.generativeaiendpoint.oc1..x",
+	}
+
+	// ids that exercise the two id shapes: a plain OCID, and the bucket's
+	// composite namespace/name.
+	ids := map[string]string{
+		DiscoverySecurityLists:         "ocid1.securitylist.oc1..x",
+		DiscoveryUsers:                 "ocid1.user.oc1..x",
+		DiscoveryPolicies:              "ocid1.policy.oc1..x",
+		DiscoveryBuckets:               "mynamespace/mybucket",
+		DiscoveryAPIGatewayDeployments: "ocid1.apideployment.oc1..x",
+		DiscoveryLoadBalancers:         "ocid1.loadbalancer.oc1..x",
+		DiscoveryRedisClusters:         "ocid1.rediscluster.oc1..x",
+		DiscoveryVaultSecrets:          "ocid1.vaultsecret.oc1..x",
+		DiscoveryOkeClusters:           "ocid1.cluster.oc1..x",
+		DiscoveryGenerativeAiEndpoints: "ocid1.generativeaiendpoint.oc1..x",
+	}
+
+	for _, target := range ociDiscoveryTargets {
+		t.Run(target.Target, func(t *testing.T) {
+			// identity is global; everything else carries a region key.
+			region := "IAD"
+			if target.Service == "identity" {
+				region = "global"
+			}
+			got := mondooOciObjectID(ociObject{
+				tenantID:    tenant,
+				compartment: "ocid1.compartment.oc1..c",
+				region:      region,
+				id:          ids[target.Target],
+				service:     target.Service,
+				objectType:  target.ObjectType,
+			})
+			if got != want[target.Target] {
+				t.Errorf("platform id changed\n got: %s\nwant: %s", got, want[target.Target])
+			}
+		})
+	}
+}
+
+// TestDiscoveryPlatformIDRoundTrips checks that every emitted platform id parses
+// back into the parts it was built from. initOciIdentityUser and its siblings
+// resolve a discovered asset by parsing its platform id, so a format that builds
+// but does not parse leaves those inits unable to find their own resource.
+func TestDiscoveryPlatformIDRoundTrips(t *testing.T) {
+	const tenant = "ocid1.tenancy.oc1..aaaaexample"
+
+	for _, target := range ociDiscoveryTargets {
+		t.Run(target.Target, func(t *testing.T) {
+			id := "ocid1.thing.oc1..x"
+			if target.Target == DiscoveryBuckets {
+				id = "mynamespace/mybucket"
+			}
+			platformID := mondooOciObjectID(ociObject{
+				tenantID: tenant, region: "IAD", id: id,
+				service: target.Service, objectType: target.ObjectType,
+			})
+
+			parsed, ok := parseOciObjectPlatformID(platformID)
+			if !ok {
+				t.Fatalf("%s did not parse", platformID)
+			}
+			if parsed.service != target.Service {
+				t.Errorf("service = %q, want %q", parsed.service, target.Service)
+			}
+			if parsed.objectType != target.ObjectType {
+				t.Errorf("objectType = %q, want %q", parsed.objectType, target.ObjectType)
+			}
+			if parsed.tenantID != tenant {
+				t.Errorf("tenantID = %q, want %q", parsed.tenantID, tenant)
+			}
+			if parsed.id != id {
+				t.Errorf("id = %q, want %q", parsed.id, id)
+			}
+		})
+	}
+}
+
+// TestDiscoveryTargetsMatchPlatformCatalog is the check the old code could not
+// make. The platform name used to be re-derived from (service, objectType) by a
+// second switch, so a target whose pair was missing from it emitted no asset at
+// all - an unmapped pair returns "" and the caller skips it, silently. With one
+// row per target the two sides can be compared directly, in both directions.
+func TestDiscoveryTargetsMatchPlatformCatalog(t *testing.T) {
+	for _, target := range ociDiscoveryTargets {
+		if PlatformByName(target.Platform) == nil {
+			t.Errorf("target %q names platform %q, which is not in the Platforms catalog",
+				target.Target, target.Platform)
+		}
+	}
+
+	// And no orphans the other way: a platform in the catalog that no target
+	// emits is either a dropped target or a typo.
+	claimed := make(map[string]string, len(ociDiscoveryTargets))
+	for _, target := range ociDiscoveryTargets {
+		if prev, dup := claimed[target.Platform]; dup {
+			t.Errorf("platform %q is claimed by both %q and %q",
+				target.Platform, prev, target.Target)
+		}
+		claimed[target.Platform] = target.Target
+	}
+
+	for _, pi := range Platforms {
+		if pi.Name == "oci" {
+			continue // the tenancy root, not a discovery target
+		}
+		if _, ok := claimed[pi.Name]; !ok {
+			t.Errorf("platform %q is in the catalog but no discovery target emits it", pi.Name)
+		}
+	}
+}
+
+// TestDiscoveryTargetRowsAreWellFormed guards the fields a row cannot be useful
+// without. A nil List or Extract would panic during a scan rather than at build.
+func TestDiscoveryTargetRowsAreWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, target := range ociDiscoveryTargets {
+		if target.Target == "" || target.Platform == "" ||
+			target.Service == "" || target.ObjectType == "" {
+			t.Errorf("row %+v has an empty required field", target.Target)
+		}
+		if target.List == nil {
+			t.Errorf("target %q has no List", target.Target)
+		}
+		if target.Extract == nil {
+			t.Errorf("target %q has no Extract", target.Target)
+		}
+		if seen[target.Target] {
+			t.Errorf("target %q is registered twice", target.Target)
+		}
+		seen[target.Target] = true
+
+		// The service and object type land in a platform id path, so a "/" in
+		// either would make the id unparseable.
+		if strings.ContainsAny(target.Service+target.ObjectType, "/ ") {
+			t.Errorf("target %q has a slash or space in service/objectType", target.Target)
+		}
+	}
+}
+
+// TestDiscoveryTargetConstantsAreRegistered keeps a declared constant from being
+// unreachable. A constant with no row is accepted on the command line and then
+// silently discovers nothing.
+func TestDiscoveryTargetConstantsAreRegistered(t *testing.T) {
+	constants := []string{
+		DiscoverySecurityLists, DiscoveryUsers, DiscoveryPolicies,
+		DiscoveryBuckets, DiscoveryAPIGatewayDeployments, DiscoveryLoadBalancers,
+		DiscoveryRedisClusters, DiscoveryVaultSecrets, DiscoveryOkeClusters,
+		DiscoveryGenerativeAiEndpoints,
+	}
+	for _, c := range constants {
+		if _, ok := ociDiscoveryTargetsByName[c]; !ok {
+			t.Errorf("discovery constant %q has no registry row", c)
+		}
+	}
+	if len(constants) != len(ociDiscoveryTargets) {
+		t.Errorf("%d constants but %d rows; one side gained an entry",
+			len(constants), len(ociDiscoveryTargets))
+	}
+}
+
+// TestAllAPIResourcesIsSorted pins the ordering the old hand-maintained slice
+// documented as "keep sorted alphabetically for diff stability".
+func TestAllAPIResourcesIsSorted(t *testing.T) {
+	if !slices.IsSorted(AllAPIResources) {
+		t.Errorf("AllAPIResources is not sorted: %v", AllAPIResources)
+	}
+	if len(AllAPIResources) != len(ociDiscoveryTargets) {
+		t.Errorf("AllAPIResources has %d entries, registry has %d",
+			len(AllAPIResources), len(ociDiscoveryTargets))
+	}
+}
+
+// TestAutoPutsTenancyFirst pins the ordering `cnspec scan` output depends on:
+// the tenancy asset should appear before any of its sub-assets.
+func TestAutoPutsTenancyFirst(t *testing.T) {
+	if len(Auto) == 0 || Auto[0] != DiscoveryTenancy {
+		t.Fatalf("Auto must start with %q, got %v", DiscoveryTenancy, Auto)
+	}
+	if len(Auto) != len(AllAPIResources)+1 {
+		t.Errorf("Auto has %d entries, want %d", len(Auto), len(AllAPIResources)+1)
+	}
+	if !slices.Equal(All, Auto) {
+		t.Errorf("All and Auto have diverged:\n All: %v\nAuto: %v", All, Auto)
+	}
+}
+
+// TestGetDiscoveryTargetsResolvesAliases covers the alias expansion and dedup
+// that decide which targets actually run.
+func TestGetDiscoveryTargetsResolvesAliases(t *testing.T) {
+	conf := func(targets ...string) *inventory.Config {
+		return &inventory.Config{Discover: &inventory.Discovery{Targets: targets}}
+	}
+
+	t.Run("all wins outright", func(t *testing.T) {
+		got := getDiscoveryTargets(conf(DiscoveryAll, DiscoveryUsers))
+		if !slices.Equal(got, All) {
+			t.Errorf("got %v, want All", got)
+		}
+	})
+
+	t.Run("auto expands to the same set", func(t *testing.T) {
+		got := getDiscoveryTargets(conf(DiscoveryAuto))
+
+		// Set equality, not slice equality: everything except the `all` path
+		// goes through stringx.DedupStringArray, which collects into a map and
+		// so returns the targets in a random order. That means `--discover auto`
+		// does NOT preserve Auto's tenancy-first ordering, despite what Auto's
+		// name and its former comment implied. Asserting order here would be a
+		// flaky test against a real pre-existing defect; see the note on Auto.
+		wantSet := slices.Clone(Auto)
+		gotSet := slices.Clone(got)
+		slices.Sort(wantSet)
+		slices.Sort(gotSet)
+		if !slices.Equal(gotSet, wantSet) {
+			t.Errorf("got %v, want the same set as Auto %v", got, Auto)
+		}
+	})
+
+	t.Run("all preserves tenancy-first ordering", func(t *testing.T) {
+		// The `all` path returns All directly, without the dedup, so this is
+		// the one path where the ordering Auto documents actually holds.
+		got := getDiscoveryTargets(conf(DiscoveryAll))
+		if len(got) == 0 || got[0] != DiscoveryTenancy {
+			t.Errorf("got %v, want tenancy first", got)
+		}
+	})
+
+	t.Run("explicit targets pass through", func(t *testing.T) {
+		got := getDiscoveryTargets(conf(DiscoveryUsers, DiscoveryBuckets))
+		want := []string{DiscoveryUsers, DiscoveryBuckets}
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("duplicates are collapsed", func(t *testing.T) {
+		got := getDiscoveryTargets(conf(DiscoveryUsers, DiscoveryUsers, DiscoveryAuto))
+		if len(got) != len(Auto) {
+			t.Errorf("got %d targets, want %d: %v", len(got), len(Auto), got)
+		}
+	})
+}
+
+// TestFallbackRegion pins the placeholder that keeps a platform id valid when a
+// resource did not expose a region at enumeration time.
+func TestFallbackRegion(t *testing.T) {
+	if got := fallbackRegion(""); got != "unknown" {
+		t.Errorf("fallbackRegion(\"\") = %q, want \"unknown\"", got)
+	}
+	if got := fallbackRegion("IAD"); got != "IAD" {
+		t.Errorf("fallbackRegion(\"IAD\") = %q, want \"IAD\"", got)
+	}
+}
+
+// TestTagsToLabels covers the conversion discovery applies to freeform tags,
+// including the non-string values the MQL dict path can carry.
+func TestTagsToLabels(t *testing.T) {
+	if got := tagsToLabels(nil); len(got) != 0 {
+		t.Errorf("nil tags produced %v, want an empty map", got)
+	}
+	got := tagsToLabels(map[string]any{"env": "prod", "count": 3})
+	if len(got) != 1 || got["env"] != "prod" {
+		t.Errorf("got %v, want only the string-valued tag", got)
+	}
+}


### PR DESCRIPTION
## The problem

A discovery target was spread across **four** places: a constant, a `case` in `discover()`, an entry in `AllAPIResources`, and an arm of a `getPlatformName` switch that re-derived the platform name from the service and object type the `case` had just written.

The two switches encoded the same facts, so they could disagree — and **the failure was silent in the worst direction.** `getPlatformName` returns `""` for an unmapped `(service, objectType)` pair, and `ociObjectToAsset` skips an asset whose platform name is empty. So a target wired into `discover()` but missing from `getPlatformName` **discovered nothing**, with one warning per object and no indication that the target itself was the problem.

## The change

One row per target, carrying the whole description:

```go
{
    Target: DiscoveryRedisClusters, Platform: "oci-redis-cluster",
    Service: "redis", ObjectType: "cluster",
    List:    func(rt *plugin.Runtime) ([]any, error) { ... },
    Extract: func(item any) (ociDiscovered, bool) { ... },
},
```

`getPlatformName` is deleted. `AllAPIResources`, `Auto` and `All` derive from the table.

Putting the platform name next to the `(service, objectType)` pair it used to be re-derived from is what makes the registry checkable against the platform catalog **in both directions** — a row naming a platform the catalog lacks, and a catalog entry no row emits. Neither was checkable before.

## Behavior is unchanged

Verified by extracting `(target, service, objectType, platform)` from **both** old switches and diffing against the new rows: **all ten tuples identical.**

On top of that the tests pin the platform id itself, because that string is an asset's identity upstream — changing a path segment silently turns every previously discovered asset into a new one:

- **The exact platform id for all ten targets**, written out rather than derived, covering both id shapes (a plain OCID and the bucket's composite `namespace/name`)
- **That every emitted id parses back into its parts.** `initOciIdentityUser` and its siblings resolve a discovered asset *by parsing its platform id*, so a format that builds but does not parse leaves those inits unable to find their own resource
- **Registry/catalog agreement in both directions**, mutation-checked (renaming one row's platform fires both the orphan-row and orphan-platform assertions)
- Constants and rows in step; `AllAPIResources` sorted; `All` equal to `Auto`
- Alias expansion and dedup in `getDiscoveryTargets`

## A pre-existing defect the tests turned up

Left in place, because this change is not meant to alter behavior — but worth knowing about.

`Auto` is built tenancy-first, and its comment said that ordering exists so the tenancy appears above its own sub-assets in scan output. **It does not, on the path that matters.** `getDiscoveryTargets` returns `All` directly for `all`, but sends everything else — including `auto`, the default — through `stringx.DedupStringArray`, which collects into a `map` and returns the targets in a random order.

The comment now says so, and the ordering assertion is made only against the `all` path where it actually holds. Asserting it on the `auto` path would have been a flaky test against a real bug.

## Registration sites

| | before | after |
|---|---|---|
| constant | ✔ | ✔ |
| `discover()` case | ✔ | — |
| `AllAPIResources` | ✔ | derived |
| `getPlatformName` arm | ✔ | — |
| `Platforms` catalog | ✔ | ✔, now cross-checked |

Four hand-maintained sites down to two, and the remaining two can no longer drift apart silently.

## Context

PR of six behavior-preserving PRs restructuring this provider's internals (#9650, #9655, #9659 merged). The user-facing surface — the `.lr` schema, all 211 resources, field names and types, discovery targets, CLI flags — does not move in any of them.

Remaining: a generic typed-ref resolver (centralizes the `StateIsSet | StateIsNull` discipline that currently lives in N copies), and mapping helpers.

**Quarantined behavior-changing follow-ups**, now four:
1. Flip the 41 `ociScopeTenancyRoot` listers to `ociScopeAllCompartments` (#9659 made this a one-word edit each)
2. Converge the two pool error policies
3. The 16 sites that swallow a list error and report an empty collection (#9655)
4. **New:** `--discover auto` does not preserve tenancy-first ordering

## Verification owed

Live validation against a real tenancy is still outstanding for this provider (carried from #9573–#9578). For this PR specifically the platform-id assertions cover the part that would be expensive to get wrong, so the remaining risk is mostly in the `List`/`Extract` closures against real collections.
