### PR TITLE
✨ providers/selfupdate: verified, atomic, self-recovering auto-update

### DIFF
--- a/cli/selfupdate/guard.go
+++ b/cli/selfupdate/guard.go
@@ -1,0 +1,240 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// defaultSelftestTimeout bounds how long the binary health check may run. The
+// selftest does no network I/O, so it completes quickly; the ceiling only
+// guards against a binary that hangs on startup.
+const defaultSelftestTimeout = 30 * time.Second
+
+// healthCheckBinary runs the candidate binary's `selftest` subcommand to prove
+// it can start and initialize before we activate it. A non-zero exit (or a
+// timeout, or a binary that cannot exec at all) means the binary is not safe to
+// activate. Auto-update is disabled for the child so the check cannot recurse.
+func healthCheckBinary(binaryPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultSelftestTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, "selftest")
+	cmd.Env = append(os.Environ(), EnvAutoUpdate+"=false")
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return errors.New("selftest timed out")
+		}
+		return errors.Wrapf(err, "selftest exited non-zero: %s", string(out))
+	}
+	return nil
+}
+
+// Crash-loop startup guard
+//
+// A self-update stages a newer binary in the bin path and execs into it on
+// every invocation. If that newer binary starts far enough to pass its health
+// check but then crashes under the real workload (most importantly `serve`),
+// every restart would re-exec into the same broken binary — a crash loop with
+// no escape, because the launcher keeps preferring the newer version.
+//
+// The guard breaks that loop. It counts how many times a staged version has
+// been activated without ever confirming a healthy run. After a few failed
+// activations it quarantines the staged binary: the bad binary is renamed
+// aside, the version is remembered so it is never re-downloaded, and the
+// launcher falls back to the previous (package-installed) binary, which is
+// known good.
+//
+// The healthy binary confirms itself once it has demonstrably worked (a CLI
+// command completed, or serve finished its first scan cycle). Confirmation
+// stops the counter, so a good update is never quarantined.
+
+const (
+	updateStateFile = "update-state.json"
+
+	stateActivationPending   = "pending"
+	stateActivationConfirmed = "confirmed"
+
+	// maxActivationAttempts is how many times a not-yet-confirmed staged
+	// version may be activated before it is treated as crash-looping and
+	// quarantined. Three gives systemd's default restart a couple of chances to
+	// be a transient hiccup before we give up on the new binary.
+	maxActivationAttempts = 3
+)
+
+// updateState is the on-disk guard state, stored next to the staged binary.
+type updateState struct {
+	// StagedVersion is the version currently staged in the bin path.
+	StagedVersion string `json:"staged_version,omitempty"`
+	// Activation is stateActivationPending or stateActivationConfirmed.
+	Activation string `json:"activation,omitempty"`
+	// Attempts counts activations of StagedVersion without a confirmation.
+	Attempts int `json:"attempts,omitempty"`
+	// Quarantined lists versions proven bad; they are never activated or
+	// re-downloaded.
+	Quarantined []string `json:"quarantined,omitempty"`
+}
+
+func updateStatePath(binPath string) string {
+	return filepath.Join(binPath, updateStateFile)
+}
+
+func readUpdateState(binPath string) *updateState {
+	data, err := os.ReadFile(updateStatePath(binPath))
+	if err != nil {
+		return &updateState{}
+	}
+	var st updateState
+	if err := json.Unmarshal(data, &st); err != nil {
+		log.Debug().Err(err).Msg("self-update: corrupt update-state, resetting")
+		return &updateState{}
+	}
+	return &st
+}
+
+func writeUpdateState(binPath string, st *updateState) error {
+	if err := os.MkdirAll(binPath, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	tmp := updateStatePath(binPath) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, updateStatePath(binPath))
+}
+
+func (st *updateState) isQuarantined(version string) bool {
+	for _, v := range st.Quarantined {
+		if v == version {
+			return true
+		}
+	}
+	return false
+}
+
+// isVersionQuarantined reports whether a version has been marked bad and must
+// not be downloaded or activated.
+func isVersionQuarantined(binPath, version string) bool {
+	return readUpdateState(binPath).isQuarantined(version)
+}
+
+// recordActivationAttempt is called just before the launcher execs into a
+// staged newer binary. It returns proceed=false when the staged version has
+// exceeded its activation budget (crash-looping) or is already quarantined; in
+// that case the caller must not activate it and should fall back to the current
+// binary. It transparently resets the counter when a different version is
+// staged, and never counts a version that has already confirmed healthy.
+func recordActivationAttempt(binPath, version string) (proceed bool) {
+	st := readUpdateState(binPath)
+
+	if st.isQuarantined(version) {
+		return false
+	}
+
+	// A newly staged version resets the counter.
+	if st.StagedVersion != version {
+		st.StagedVersion = version
+		st.Activation = stateActivationPending
+		st.Attempts = 0
+	}
+
+	// A version that already proved healthy is always fine to activate.
+	if st.Activation == stateActivationConfirmed {
+		return true
+	}
+
+	st.Attempts++
+	if st.Attempts > maxActivationAttempts {
+		log.Warn().
+			Str("version", version).
+			Int("attempts", st.Attempts-1).
+			Msg("self-update: staged version failed to confirm healthy; quarantining and falling back")
+		st.Quarantined = append(st.Quarantined, version)
+		st.StagedVersion = ""
+		st.Activation = ""
+		st.Attempts = 0
+		if err := writeUpdateState(binPath, st); err != nil {
+			log.Debug().Err(err).Msg("self-update: failed to persist quarantine state")
+		}
+		return false
+	}
+
+	if err := writeUpdateState(binPath, st); err != nil {
+		log.Debug().Err(err).Msg("self-update: failed to persist activation attempt")
+	}
+	return true
+}
+
+// confirmActivation marks the staged version as healthy so it is never
+// quarantined and future activations skip the crash-loop counter. It is a
+// no-op unless the running version matches the staged, pending version.
+func confirmActivation(binPath, version string) {
+	st := readUpdateState(binPath)
+	if st.StagedVersion != version || st.Activation == stateActivationConfirmed {
+		return
+	}
+	st.Activation = stateActivationConfirmed
+	st.Attempts = 0
+	if err := writeUpdateState(binPath, st); err != nil {
+		log.Debug().Err(err).Msg("self-update: failed to persist activation confirmation")
+	}
+	log.Debug().Str("version", version).Msg("self-update: confirmed staged version healthy")
+}
+
+// quarantineVersion records a version as bad so it is never activated or
+// re-downloaded. Used when a health check proves a binary is broken up front,
+// short-circuiting the attempt counter.
+func quarantineVersion(binPath, version string) {
+	st := readUpdateState(binPath)
+	if st.isQuarantined(version) {
+		return
+	}
+	st.Quarantined = append(st.Quarantined, version)
+	if st.StagedVersion == version {
+		st.StagedVersion = ""
+		st.Activation = ""
+		st.Attempts = 0
+	}
+	if err := writeUpdateState(binPath, st); err != nil {
+		log.Debug().Err(err).Msg("self-update: failed to persist quarantine")
+	}
+}
+
+// quarantineStagedBinary renames a crash-looping staged binary aside so the
+// launcher falls back to the previous binary. Best-effort.
+func quarantineStagedBinary(binPath, binName, version string) {
+	staged := filepath.Join(binPath, binName)
+	aside := filepath.Join(binPath, binName+"."+version+".bad")
+	if err := os.Rename(staged, aside); err != nil {
+		log.Debug().Err(err).Str("path", staged).Msg("self-update: failed to move quarantined binary aside")
+	} else {
+		log.Warn().Str("from", staged).Str("to", aside).Msg("self-update: quarantined crash-looping binary")
+	}
+}
+
+// ConfirmRunningVersion records that the currently running binary version has
+// operated successfully, so a staged update is not mistaken for a crash loop.
+// Callers invoke it once real work has succeeded: a CLI command completed, or
+// serve finished a healthy scan cycle. It is safe to call repeatedly and does
+// nothing when there is no bin path or no pending staged version.
+func ConfirmRunningVersion(version string) {
+	binPath, err := getBinPath()
+	if err != nil {
+		return
+	}
+	confirmActivation(binPath, version)
+}

--- a/cli/selfupdate/guard.go
+++ b/cli/selfupdate/guard.go
@@ -70,6 +70,12 @@ const (
 	// quarantined. Three gives systemd's default restart a couple of chances to
 	// be a transient hiccup before we give up on the new binary.
 	maxActivationAttempts = 3
+
+	// maxQuarantinedVersions caps how many bad versions we remember, so the
+	// state file cannot grow without bound over the lifetime of a host. The
+	// most recent entries are kept; older quarantined versions are unlikely to
+	// be offered again as "latest".
+	maxQuarantinedVersions = 20
 )
 
 // updateState is the on-disk guard state, stored next to the staged binary.
@@ -111,7 +117,26 @@ func writeUpdateState(binPath string, st *updateState) error {
 		return err
 	}
 	tmp := updateStatePath(binPath) + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+
+	// Flush the contents before the rename so a crash can't leave the renamed
+	// state file referencing unwritten (zeroed) bytes, matching the atomic
+	// write in writeCurrentPointerAtomic.
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
 		return err
 	}
 	return os.Rename(tmp, updateStatePath(binPath))
@@ -124,6 +149,18 @@ func (st *updateState) isQuarantined(version string) bool {
 		}
 	}
 	return false
+}
+
+// quarantine records version as bad, keeping the list bounded to the most
+// recent maxQuarantinedVersions entries so the state file cannot grow forever.
+func (st *updateState) quarantine(version string) {
+	if st.isQuarantined(version) {
+		return
+	}
+	st.Quarantined = append(st.Quarantined, version)
+	if n := len(st.Quarantined); n > maxQuarantinedVersions {
+		st.Quarantined = st.Quarantined[n-maxQuarantinedVersions:]
+	}
 }
 
 // isVersionQuarantined reports whether a version has been marked bad and must
@@ -163,7 +200,7 @@ func recordActivationAttempt(binPath, version string) (proceed bool) {
 			Str("version", version).
 			Int("attempts", st.Attempts-1).
 			Msg("self-update: staged version failed to confirm healthy; quarantining and falling back")
-		st.Quarantined = append(st.Quarantined, version)
+		st.quarantine(version)
 		st.StagedVersion = ""
 		st.Activation = ""
 		st.Attempts = 0
@@ -203,7 +240,7 @@ func quarantineVersion(binPath, version string) {
 	if st.isQuarantined(version) {
 		return
 	}
-	st.Quarantined = append(st.Quarantined, version)
+	st.quarantine(version)
 	if st.StagedVersion == version {
 		st.StagedVersion = ""
 		st.Activation = ""

--- a/cli/selfupdate/guard_test.go
+++ b/cli/selfupdate/guard_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package selfupdate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGuard_HealthyUpdateNeverQuarantined(t *testing.T) {
+	bin := t.TempDir()
+
+	// First activation of a new version proceeds.
+	require.True(t, recordActivationAttempt(bin, "13.5.0"))
+	// The new binary confirms it ran healthy.
+	confirmActivation(bin, "13.5.0")
+
+	// Any number of subsequent activations proceed and never increment toward
+	// quarantine, because the version is confirmed.
+	for i := 0; i < 10; i++ {
+		require.True(t, recordActivationAttempt(bin, "13.5.0"))
+	}
+	assert.False(t, isVersionQuarantined(bin, "13.5.0"))
+}
+
+func TestGuard_CrashLoopGetsQuarantined(t *testing.T) {
+	bin := t.TempDir()
+	version := "13.6.0"
+
+	// It is activated repeatedly but never confirms (it keeps crashing).
+	proceed := true
+	activations := 0
+	for i := 0; i < 10 && proceed; i++ {
+		proceed = recordActivationAttempt(bin, version)
+		if proceed {
+			activations++
+		}
+	}
+
+	// After maxActivationAttempts activations it stops proceeding.
+	assert.Equal(t, maxActivationAttempts, activations)
+	assert.False(t, proceed)
+	assert.True(t, isVersionQuarantined(bin, version))
+
+	// A quarantined version never proceeds again.
+	assert.False(t, recordActivationAttempt(bin, version))
+}
+
+func TestGuard_ConfirmBeforeBudgetPreventsQuarantine(t *testing.T) {
+	bin := t.TempDir()
+	version := "13.7.0"
+
+	// Two shaky starts...
+	require.True(t, recordActivationAttempt(bin, version))
+	require.True(t, recordActivationAttempt(bin, version))
+	// ...then it confirms healthy.
+	confirmActivation(bin, version)
+
+	// Now it can never be quarantined.
+	for i := 0; i < 10; i++ {
+		require.True(t, recordActivationAttempt(bin, version))
+	}
+	assert.False(t, isVersionQuarantined(bin, version))
+}
+
+func TestGuard_NewVersionResetsCounter(t *testing.T) {
+	bin := t.TempDir()
+
+	// An old version burns two attempts.
+	require.True(t, recordActivationAttempt(bin, "13.8.0"))
+	require.True(t, recordActivationAttempt(bin, "13.8.0"))
+
+	// A newly staged version starts its own budget from scratch.
+	for i := 0; i < maxActivationAttempts; i++ {
+		require.True(t, recordActivationAttempt(bin, "13.9.0"))
+	}
+	// The (maxAttempts+1)th activation of the new version quarantines it,
+	// proving the counter reset rather than carrying over.
+	assert.False(t, recordActivationAttempt(bin, "13.9.0"))
+	assert.True(t, isVersionQuarantined(bin, "13.9.0"))
+	assert.False(t, isVersionQuarantined(bin, "13.8.0"))
+}
+
+func TestGuard_ConfirmIsVersionScoped(t *testing.T) {
+	bin := t.TempDir()
+
+	require.True(t, recordActivationAttempt(bin, "13.10.0"))
+	// Confirming a different version does nothing to the pending one.
+	confirmActivation(bin, "99.0.0")
+
+	st := readUpdateState(bin)
+	assert.Equal(t, "13.10.0", st.StagedVersion)
+	assert.Equal(t, stateActivationPending, st.Activation)
+}

--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -187,6 +187,15 @@ func CheckAndUpdate(cfg Config) (bool, error) {
 		return false, nil
 	}
 
+	// Never re-download a version we already quarantined as crash-looping.
+	if isVersionQuarantined(binPath, release.Version) {
+		log.Warn().
+			Str("version", release.Version).
+			Msg("self-update: latest version is quarantined (previously failed to run); staying on current binary")
+		updateMarkerFile(binPath, cfg.BinaryName)
+		return false, nil
+	}
+
 	log.Info().
 		Str("current", currentVersion).
 		Str("latest", release.Version).
@@ -211,6 +220,16 @@ func CheckAndUpdate(cfg Config) (bool, error) {
 
 	// Update marker file after successful installation
 	updateMarkerFile(binPath, cfg.BinaryName)
+
+	// Health-check gate: prove the freshly downloaded binary passes its
+	// selftest before we activate it. A binary that fails is quarantined so it
+	// is neither activated now nor re-downloaded next time.
+	if err := healthCheckBinary(binaryPath); err != nil {
+		log.Warn().Err(err).Str("version", release.Version).Msg("self-update: downloaded binary failed selftest; quarantining")
+		quarantineVersion(binPath, release.Version)
+		_ = os.Remove(binaryPath)
+		return false, errors.Wrap(err, "downloaded binary failed selftest")
+	}
 
 	log.Debug().
 		Str("version", release.Version).
@@ -280,6 +299,27 @@ func execLocalIfNewer(binPath, binName, currentVersion string) (bool, error) {
 
 	if cmp <= 0 {
 		// Local binary is not newer
+		return false, nil
+	}
+
+	// Crash-loop guard: before activating the staged binary, make sure it has
+	// not exceeded its activation budget without confirming a healthy run. If
+	// it has, quarantine it and fall back to the current binary.
+	if !recordActivationAttempt(binPath, localVersion) {
+		quarantineStagedBinary(binPath, binName, localVersion)
+		log.Warn().
+			Str("version", localVersion).
+			Msg("auto-update: staged version quarantined after repeated failures; using current binary")
+		return false, nil
+	}
+
+	// Health-check gate: prove the staged binary passes its selftest before we
+	// hand control to it. A binary that fails selftest is quarantined outright
+	// so we neither activate it now nor re-download it later.
+	if err := healthCheckBinary(localBinary); err != nil {
+		log.Warn().Err(err).Str("version", localVersion).Msg("auto-update: staged binary failed selftest; quarantining")
+		quarantineVersion(binPath, localVersion)
+		quarantineStagedBinary(binPath, binName, localVersion)
 		return false, nil
 	}
 
@@ -497,10 +537,20 @@ func downloadAndInstall(ctx context.Context, release *Release, destPath string, 
 	}
 	tmpFile.Close()
 
-	// Verify checksum
+	// Verify checksum against the hash advertised in latest.json (first-line
+	// integrity check).
 	computedHash := hex.EncodeToString(hash.Sum(nil))
 	if file.Hash != "" && computedHash != file.Hash {
 		return "", errors.Newf("checksum mismatch: expected %s, got %s", file.Hash, computedHash)
+	}
+
+	// Verify against the published SHA256SUMS manifest and its detached
+	// signature (integrity + authenticity). Under the default 'auto' policy an
+	// unsigned/absent manifest falls back to the latest.json hash above; under
+	// 'require' the absence of a valid signature fails the update.
+	archiveName := archiveFileName(binaryName, release.Version)
+	if err := verifyDownloadManifest(ctx, downloadURL, archiveName, computedHash); err != nil {
+		return "", errors.Wrap(err, "download verification failed")
 	}
 
 	// Ensure destination directory exists

--- a/cli/selfupdate/verify.go
+++ b/cli/selfupdate/verify.go
@@ -1,0 +1,158 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/utils/verify"
+)
+
+// binarySignaturePolicy controls signature enforcement for engine-binary
+// self-updates. Defaults to 'auto': verify a signature when one is published,
+// otherwise fall back to the checksum. Strict fleets can raise it to
+// verify.SignatureRequire.
+var binarySignaturePolicy = verify.SignatureAuto
+
+// SetBinarySignaturePolicy overrides the signature-enforcement policy for
+// binary self-updates.
+func SetBinarySignaturePolicy(p verify.SignaturePolicy) {
+	binarySignaturePolicy = p
+}
+
+// archiveFileName builds the release archive's base name for the current
+// platform, matching goreleaser's "<name>_<version>_<os>_<arch>.<ext>" layout.
+func archiveFileName(binaryName, version string) string {
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("%s_%s_%s_%s.%s", binaryName, version, runtime.GOOS, runtime.GOARCH, ext)
+}
+
+// checksumManifestName builds the SHA256SUMS manifest name for a binary
+// release, matching goreleaser's checksum name_template
+// "<name>_v<version>_SHA256SUMS".
+func checksumManifestName(binaryName, version string) string {
+	return fmt.Sprintf("%s_v%s_SHA256SUMS", binaryName, version)
+}
+
+// verifyDownloadManifest verifies a downloaded archive (identified by its
+// already-computed SHA256) against the published SHA256SUMS manifest and its
+// optional detached minisign signature.
+//
+// The manifest and signature live in the same release directory as the archive;
+// their URLs are derived from downloadURL. A 404 on the manifest is tolerated
+// under the 'auto' policy (the caller already checked the latest.json hash) but
+// is fatal under 'require'.
+func verifyDownloadManifest(ctx context.Context, downloadURL, archiveName, computedHash string) error {
+	// Derive the binary name and version from the archive name so we can build
+	// the manifest name. archiveName is "<name>_<version>_<os>_<arch>.<ext>".
+	binaryName, version, ok := splitArchiveName(archiveName)
+	if !ok {
+		// If we cannot parse the name we cannot locate the manifest. Under
+		// 'require' this must fail; otherwise fall back to the caller's hash.
+		if binarySignaturePolicy == verify.SignatureRequire {
+			return errors.Newf("cannot derive checksum manifest name from %q", archiveName)
+		}
+		log.Debug().Str("archive", archiveName).Msg("self-update: cannot locate checksum manifest, relying on latest.json hash")
+		return nil
+	}
+
+	baseURL := downloadURL[:strings.LastIndex(downloadURL, "/")+1]
+	manifestURL := baseURL + checksumManifestName(binaryName, version)
+	sigURL := manifestURL + ".sig"
+
+	manifest, notFound, err := fetchBytes(ctx, manifestURL)
+	if err != nil {
+		return err
+	}
+	if notFound {
+		if binarySignaturePolicy == verify.SignatureRequire {
+			return errors.New("no SHA256SUMS manifest published, but verify_signature is 'require'")
+		}
+		log.Debug().Msg("self-update: no SHA256SUMS manifest published, relying on latest.json hash")
+		return nil
+	}
+
+	signature, _, err := fetchBytes(ctx, sigURL)
+	if err != nil {
+		return err
+	}
+
+	v, err := verify.NewVerifier(verify.PinnedPublicKey, binarySignaturePolicy)
+	if err != nil {
+		return err
+	}
+
+	res, err := v.VerifyPrehashed(archiveName, computedHash, manifest, signature)
+	if err != nil {
+		return err
+	}
+
+	log.Debug().
+		Str("archive", archiveName).
+		Str("sha256", res.SHA256).
+		Bool("signature_verified", res.SignatureChecked).
+		Msg("self-update: verified download")
+	return nil
+}
+
+// splitArchiveName parses "<name>_<version>_<os>_<arch>.<ext>" into its name
+// and version. It splits from the right so a binary name containing an
+// underscore would still work, since os/arch/ext are fixed-shape.
+func splitArchiveName(archiveName string) (name, version string, ok bool) {
+	base := archiveName
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i] // drop ".tar.gz" / ".zip"
+	}
+	parts := strings.Split(base, "_")
+	if len(parts) < 4 {
+		return "", "", false
+	}
+	// Last two are os and arch; the one before them is the version.
+	version = parts[len(parts)-3]
+	name = strings.Join(parts[:len(parts)-3], "_")
+	if name == "" || version == "" {
+		return "", "", false
+	}
+	return name, version, true
+}
+
+// fetchBytes GETs a small sidecar file, returning notFound=true on a 404 so the
+// caller can distinguish "not published" from a transport error.
+func fetchBytes(ctx context.Context, url string) (data []byte, notFound bool, err error) {
+	client, err := httpClientWithRetry()
+	if err != nil {
+		return nil, false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, true, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, errors.Newf("unexpected status code %d for %s", resp.StatusCode, url)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false, err
+	}
+	return body, false, nil
+}

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -80,6 +80,14 @@ type UpdateProvidersConfig struct {
 	Enabled bool
 	// seconds until we try to refresh the providers version again
 	RefreshInterval int
+	// Pin maps a provider name to an exact version to hold at. A pinned
+	// provider is installed/kept at exactly that version and never auto-updated
+	// past it, so a bad "latest" cannot roll a pinned fleet.
+	Pin map[string]string
+	// Floor maps a provider name to a minimum acceptable version. A published
+	// "latest" below the floor is refused (the fleet never moves below a
+	// known-good baseline), without pinning an exact version.
+	Floor map[string]string
 }
 
 type ProviderVersions struct {

--- a/providers/healthcheck.go
+++ b/providers/healthcheck.go
@@ -1,0 +1,71 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os/exec"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	pp "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// defaultHealthCheckTimeout bounds how long we wait for a freshly installed
+// provider to launch and complete the plugin handshake. A healthy provider
+// hands off in well under a second; this generous ceiling absorbs slow disks
+// and antivirus scans on Windows without hanging an update indefinitely.
+const defaultHealthCheckTimeout = 30 * time.Second
+
+// healthCheckProvider launches the provider binary exactly the way the
+// coordinator does at runtime (`run_as_plugin` + the hashicorp go-plugin
+// handshake) and verifies it comes up and serves the provider interface, then
+// shuts it back down. It exists so that a newly downloaded version is proven to
+// actually start before we make it the active version.
+//
+// This catches the failure the old "compare the version string" check could
+// not: a binary that is the right version on paper but cannot execute here at
+// all (wrong architecture, a missing shared library, a panic during startup, a
+// corrupt-but-correctly-sized payload). If this returns an error, the caller
+// keeps the previous version active.
+func healthCheckProvider(binPath string) error {
+	pluginCmd := exec.Command(binPath, "run_as_plugin", "--log-level", zerolog.GlobalLevel().String())
+	addColorConfig(pluginCmd)
+
+	pluginLogger := &hclogger{Logger: log.Logger}
+	pluginLogger.SetLevel(hclog.Error)
+
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig: pp.Handshake,
+		Plugins:         pp.PluginMap,
+		Cmd:             pluginCmd,
+		AllowedProtocols: []plugin.Protocol{
+			plugin.ProtocolNetRPC, plugin.ProtocolGRPC,
+		},
+		Logger:       pluginLogger,
+		StartTimeout: defaultHealthCheckTimeout,
+	})
+	// Always tear the probe subprocess down; the caller only wanted to know
+	// whether it *can* start, not to keep it running.
+	defer client.Kill()
+
+	// Client() spawns the subprocess and performs the handshake/protocol
+	// negotiation. Success here already proves the binary launched and speaks
+	// the plugin protocol.
+	rpcClient, err := client.Client()
+	if err != nil {
+		return errors.Wrap(err, "provider failed to start")
+	}
+
+	// Dispense confirms the subprocess actually serves the provider plugin,
+	// not just that a process started and handshook.
+	if _, err := rpcClient.Dispense("provider"); err != nil {
+		return errors.Wrap(err, "provider did not expose the expected plugin interface")
+	}
+
+	return nil
+}

--- a/providers/install_e2e_test.go
+++ b/providers/install_e2e_test.go
@@ -1,0 +1,141 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/ulikunitz/xz"
+)
+
+// makeProviderArchive builds an in-memory .tar.xz holding a fake provider's
+// three payload files (binary + config JSON + resources JSON) for the given
+// name and version, matching what InstallIO expects to unpack.
+func makeProviderArchive(t *testing.T, name, version string) io.ReadCloser {
+	t.Helper()
+
+	var xzBuf bytes.Buffer
+	xzw, err := xz.NewWriter(&xzBuf)
+	require.NoError(t, err)
+	tw := tar.NewWriter(xzw)
+
+	files := map[string]string{
+		name:                     "#!/bin/sh\nexit 0\n",
+		name + ".json":           `{"name":"` + name + `","version":"` + version + `"}`,
+		name + ".resources.json": `{"resources":{}}`,
+	}
+	for fname, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: fname,
+			Mode: 0o755,
+			Size: int64(len(content)),
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, xzw.Close())
+
+	return io.NopCloser(bytes.NewReader(xzBuf.Bytes()))
+}
+
+// TestInstallIO_VersionedLayout exercises the full install path end to end:
+// unpack -> versioned directory -> atomic pointer -> reinstall a newer version
+// -> prune. Health-checking is skipped because a shell-script stub cannot
+// complete the real plugin handshake; the versioning/pointer/rollback logic is
+// what this test covers.
+func TestInstallIO_VersionedLayout(t *testing.T) {
+	dst := t.TempDir()
+	name := "testprov"
+
+	// Install v1.
+	installed, err := InstallIO(makeProviderArchive(t, name, "13.1.0"), InstallConf{
+		Dst:             dst,
+		SkipHealthCheck: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, installed, 1)
+	assert.Equal(t, name, installed[0].Name)
+
+	container := providerContainerDir(dst, name)
+
+	// The pointer names v1, and the payload lives in the versioned directory.
+	v, ok := readCurrentPointer(container)
+	require.True(t, ok)
+	assert.Equal(t, "13.1.0", v)
+	assert.FileExists(t, filepath.Join(container, "13.1.0", name+".json"))
+	// The installed provider resolves to the versioned directory.
+	assert.Equal(t, filepath.Join(container, "13.1.0"), installed[0].Path)
+
+	// readProviderDir (used by ListActive) resolves through the pointer.
+	p, err := readProviderDir(container)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, filepath.Join(container, "13.1.0"), p.Path)
+
+	// Install v2. The pointer flips; v1 is retained for rollback.
+	_, err = InstallIO(makeProviderArchive(t, name, "13.2.0"), InstallConf{
+		Dst:             dst,
+		SkipHealthCheck: true,
+	})
+	require.NoError(t, err)
+	v, _ = readCurrentPointer(container)
+	assert.Equal(t, "13.2.0", v)
+	assert.DirExists(t, filepath.Join(container, "13.2.0"))
+	assert.DirExists(t, filepath.Join(container, "13.1.0"), "previous version retained for rollback")
+
+	// Install v3 with keep=2: the oldest (v1) is pruned, active + previous kept.
+	_, err = InstallIO(makeProviderArchive(t, name, "13.3.0"), InstallConf{
+		Dst:             dst,
+		SkipHealthCheck: true,
+		KeepVersions:    2,
+	})
+	require.NoError(t, err)
+	v, _ = readCurrentPointer(container)
+	assert.Equal(t, "13.3.0", v)
+	assert.DirExists(t, filepath.Join(container, "13.3.0"))
+	assert.DirExists(t, filepath.Join(container, "13.2.0"))
+	assert.NoDirExists(t, filepath.Join(container, "13.1.0"), "oldest version pruned")
+}
+
+// TestInstallIO_MigratesLegacyFlatLayout proves a pre-existing flat install is
+// read correctly and then migrated to the versioned layout by the next install.
+func TestInstallIO_MigratesLegacyFlatLayout(t *testing.T) {
+	dst := t.TempDir()
+	name := "legacyprov"
+	container := providerContainerDir(dst, name)
+	require.NoError(t, os.MkdirAll(container, 0o755))
+
+	// Seed a legacy flat install (files directly in the container).
+	require.NoError(t, os.WriteFile(filepath.Join(container, name), []byte("bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(container, name+".json"), []byte(`{"name":"`+name+`","version":"12.0.0"}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(container, name+".resources.json"), []byte(`{}`), 0o644))
+
+	// The reader resolves the legacy flat layout.
+	p, err := readProviderDir(container)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, container, p.Path, "legacy flat payload read from the container root")
+
+	// Installing a newer version migrates to versioned layout and removes the
+	// stray flat files.
+	_, err = InstallIO(makeProviderArchive(t, name, "13.0.0"), InstallConf{
+		Dst:             dst,
+		SkipHealthCheck: true,
+	})
+	require.NoError(t, err)
+
+	v, ok := readCurrentPointer(container)
+	require.True(t, ok)
+	assert.Equal(t, "13.0.0", v)
+	assert.NoFileExists(t, filepath.Join(container, name+".json"), "legacy flat files removed after migration")
+	assert.DirExists(t, filepath.Join(container, "13.0.0"))
+}

--- a/providers/install_layout.go
+++ b/providers/install_layout.go
@@ -1,0 +1,394 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+	"go.mondoo.com/mql/v13/cli/config"
+)
+
+// Robust provider layout
+//
+// Historically a provider lived flat in <providers>/<name>/, holding the
+// binary and its two JSON files. Overwriting those files in place during an
+// update is not atomic and leaves no way back if the new version is broken.
+//
+// The robust layout installs each version into its own directory and records
+// the active one in a small pointer file:
+//
+//	<providers>/<name>/
+//	  .current                     <- text file containing the active version
+//	  13.4.1/                       <- one directory per installed version
+//	    <name> <name>.json <name>.resources.json
+//	  13.4.2/
+//	    ...
+//
+// Activation is a single atomic rename of the pointer file, so a crash can
+// never expose a half-installed version, and rollback is just re-pointing at
+// the previous version directory (which is kept, not overwritten).
+//
+// The reader is backward compatible: a container without a .current pointer
+// but with the flat files directly inside it is treated as a legacy install
+// and used as-is, so existing installations keep working until their next
+// update migrates them to the versioned layout.
+
+const (
+	// currentPointerFile names the active-version pointer inside a provider's
+	// container directory. Leading dot keeps it out of the version-directory
+	// listing and signals "not a provider payload".
+	currentPointerFile = ".current"
+
+	// stagingDirPrefix marks an in-progress version directory. A crash during
+	// staging leaves a .staging-* directory that the reader ignores and the
+	// next install cleans up.
+	stagingDirPrefix = ".staging-"
+
+	// defaultKeepVersions is how many installed versions we retain per provider
+	// (the active one plus this many previous, for rollback). Older versions
+	// are pruned after a successful activation.
+	defaultKeepVersions = 2
+)
+
+// providerKeepVersions is the effective retention count applied when an
+// InstallConf does not specify one. It lets a long-running host (e.g. serve)
+// configure retention globally without threading InstallConf through every
+// call site. Zero means "use defaultKeepVersions".
+var providerKeepVersions = 0
+
+// SetKeepVersions sets the global provider version retention count used when an
+// install does not specify its own. Values below 1 are ignored.
+func SetKeepVersions(n int) {
+	if n >= 1 {
+		providerKeepVersions = n
+	}
+}
+
+// providerContainerDir returns <dst>/<name>, the directory that holds all
+// installed versions of a provider plus its pointer file.
+func providerContainerDir(dst, name string) string {
+	return filepath.Join(dst, name)
+}
+
+// readCurrentPointer returns the active version recorded in a container's
+// pointer file, or ("", false) if there is no pointer.
+func readCurrentPointer(containerDir string) (string, bool) {
+	data, err := afero.ReadFile(config.AppFs, filepath.Join(containerDir, currentPointerFile))
+	if err != nil {
+		return "", false
+	}
+	v := strings.TrimSpace(string(data))
+	if v == "" {
+		return "", false
+	}
+	return v, true
+}
+
+// resolveActiveDir returns the directory to read a provider's payload from and
+// whether that payload uses the legacy flat layout. Resolution order:
+//
+//  1. If a .current pointer names a version directory that actually contains
+//     the provider's config JSON, use that directory.
+//  2. Otherwise, if the container itself holds the flat <name>.json, treat it
+//     as a legacy install and use the container directory.
+//  3. Otherwise there is no usable provider; return ok=false.
+//
+// name is the provider name (the container's base name); the caller passes it
+// explicitly because the resolved directory may be a version subdirectory
+// whose own base name is the version, not the provider.
+func resolveActiveDir(containerDir, name string) (dir string, legacy bool, ok bool) {
+	confName := name + ".json"
+
+	if version, has := readCurrentPointer(containerDir); has {
+		vdir := filepath.Join(containerDir, version)
+		if config.ProbeFile(filepath.Join(vdir, confName)) {
+			return vdir, false, true
+		}
+		// A dangling pointer (version dir missing or incomplete) is a real
+		// problem worth surfacing, but we still fall back to any legacy flat
+		// payload so the provider keeps working.
+		log.Warn().
+			Str("provider", name).
+			Str("version", version).
+			Msg("provider .current pointer is dangling, falling back")
+	}
+
+	if config.ProbeFile(filepath.Join(containerDir, confName)) {
+		return containerDir, true, true
+	}
+
+	return "", false, false
+}
+
+// writeCurrentPointerAtomic records version as the active version for the
+// container. It writes a temporary file and renames it over the pointer, which
+// is atomic on a single filesystem on every supported OS (Go's os.Rename maps
+// to MoveFileEx with REPLACE_EXISTING on Windows).
+func writeCurrentPointerAtomic(containerDir, version string) error {
+	pointer := filepath.Join(containerDir, currentPointerFile)
+	tmp := pointer + ".tmp"
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return errors.Wrap(err, "failed to write provider pointer")
+	}
+	if _, err := f.WriteString(version + "\n"); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return errors.Wrap(err, "failed to write provider pointer")
+	}
+	// Flush the pointer contents before the rename so a crash can't leave the
+	// renamed pointer referencing unwritten (zeroed) bytes.
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return errors.Wrap(err, "failed to flush provider pointer")
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return errors.Wrap(err, "failed to close provider pointer")
+	}
+
+	if err := osRetry(func() error { return os.Rename(tmp, pointer) }, maxInstallConfRetries); err != nil {
+		os.Remove(tmp)
+		return errors.Wrap(err, "failed to activate provider pointer")
+	}
+	syncDir(containerDir)
+	return nil
+}
+
+// listInstalledVersions returns the version directories inside a container
+// (those holding the provider's config JSON), most-recently-modified first.
+// Staging and pointer entries are skipped.
+func listInstalledVersions(containerDir, name string) []string {
+	entries, err := afero.ReadDir(config.AppFs, containerDir)
+	if err != nil {
+		return nil
+	}
+	confName := name + ".json"
+
+	type verDir struct {
+		version string
+		mtime   int64
+	}
+	var dirs []verDir
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || strings.HasPrefix(e.Name(), stagingDirPrefix) {
+			continue
+		}
+		if !config.ProbeFile(filepath.Join(containerDir, e.Name(), confName)) {
+			continue
+		}
+		dirs = append(dirs, verDir{version: e.Name(), mtime: e.ModTime().UnixNano()})
+	}
+
+	sort.Slice(dirs, func(i, j int) bool { return dirs[i].mtime > dirs[j].mtime })
+	res := make([]string, len(dirs))
+	for i := range dirs {
+		res[i] = dirs[i].version
+	}
+	return res
+}
+
+// pruneOldVersions removes installed version directories beyond the newest
+// keep, never removing any version in protect (the active version and, during
+// an update, the one being replaced). It is best-effort: a failure to remove
+// an old directory is logged, not fatal, because the active version is already
+// committed by the time we prune.
+func pruneOldVersions(containerDir, name string, keep int, protect ...string) {
+	if keep < 1 {
+		keep = 1
+	}
+	protected := map[string]struct{}{}
+	for _, p := range protect {
+		if p != "" {
+			protected[p] = struct{}{}
+		}
+	}
+
+	// versions is newest-first. Keep the newest `keep` outright; beyond the
+	// window remove anything that is not protected. Protected versions (the
+	// active one and the one just replaced) are never removed even when they
+	// fall outside the window, so rollback is always possible.
+	versions := listInstalledVersions(containerDir, name)
+
+	for i, v := range versions {
+		if i < keep {
+			continue
+		}
+		if _, isProtected := protected[v]; isProtected {
+			continue
+		}
+		dir := filepath.Join(containerDir, v)
+		if err := osRetry(func() error { return os.RemoveAll(dir) }, maxInstallConfRetries); err != nil {
+			log.Warn().Err(err).Str("provider", name).Str("version", v).Msg("failed to prune old provider version")
+		} else {
+			log.Debug().Str("provider", name).Str("version", v).Msg("pruned old provider version")
+		}
+	}
+}
+
+// cleanupStagingDirs removes leftover staging directories from interrupted
+// installs. Best-effort.
+func cleanupStagingDirs(containerDir string) {
+	entries, err := afero.ReadDir(config.AppFs, containerDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), stagingDirPrefix) {
+			_ = os.RemoveAll(filepath.Join(containerDir, e.Name()))
+		}
+	}
+}
+
+// readProviderVersion reads the version string out of a staged provider config
+// JSON. The version names the install directory, so it must be present.
+func readProviderVersion(jsonPath string) (string, error) {
+	data, err := afero.ReadFile(config.AppFs, jsonPath)
+	if err != nil {
+		return "", err
+	}
+	var meta struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", errors.Wrap(err, "failed to parse provider config")
+	}
+	version := strings.TrimSpace(meta.Version)
+	if version == "" {
+		return "", errors.New("provider config has no version")
+	}
+	return version, nil
+}
+
+// removeLegacyFlatFiles deletes the old flat-layout payload files from a
+// container root after a versioned install has taken over. Once a .current
+// pointer exists these files are shadowed; removing them keeps the container
+// clean and avoids confusion. Best-effort.
+func removeLegacyFlatFiles(containerDir, providerName, binName string) {
+	for _, f := range []string{binName, providerName + ".json", providerName + ".resources.json"} {
+		p := filepath.Join(containerDir, f)
+		if config.ProbeFile(p) {
+			if err := os.Remove(p); err != nil {
+				log.Debug().Err(err).Str("path", p).Msg("failed to remove legacy flat provider file")
+			}
+		}
+	}
+}
+
+// commitProviderVersion installs one provider from the unpacked staging tree
+// (tmpdir) into its own version directory, health-checks the new binary, and
+// atomically activates it by writing the .current pointer. On any failure
+// before activation the previously active version is left completely
+// untouched, so a bad download or a binary that will not start can never
+// replace a working provider. It returns the provider's container directory,
+// whose pointer now names the newly activated version.
+//
+// binName is the file name of the binary as it appears in the archive (with
+// the .exe suffix on Windows); providerName is that name without the suffix.
+func commitProviderVersion(tmpdir string, conf InstallConf, binName, providerName string) (string, error) {
+	// The version names the install directory; read it from the staged config
+	// before anything is moved.
+	version, err := readProviderVersion(filepath.Join(tmpdir, providerName+".json"))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to determine version for provider "+providerName)
+	}
+
+	containerDir := providerContainerDir(conf.Dst, providerName)
+	if err := os.MkdirAll(containerDir, 0o755); err != nil {
+		return "", err
+	}
+	cleanupStagingDirs(containerDir)
+
+	// Remember what we are replacing so prune keeps the rollback target.
+	previousVersion, _ := readCurrentPointer(containerDir)
+
+	// Stage into a hidden directory first so a crash mid-move never presents a
+	// complete-looking version directory to the reader.
+	stagingDir := filepath.Join(containerDir, stagingDirPrefix+version)
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		return "", err
+	}
+
+	// Move the binary and its two JSON files into the staging directory,
+	// flushing each to disk as the original install did (the per-file Sync
+	// happened during extraction; the directory sync happens below).
+	moves := []struct{ src, dst string }{
+		{filepath.Join(tmpdir, binName), filepath.Join(stagingDir, binName)},
+		{filepath.Join(tmpdir, providerName+".json"), filepath.Join(stagingDir, providerName+".json")},
+		{filepath.Join(tmpdir, providerName+".resources.json"), filepath.Join(stagingDir, providerName+".resources.json")},
+	}
+	// The binary move gets the long retry window (antivirus scans on Windows);
+	// the small JSON files get the shorter one.
+	maxRetry := maxInstallBinaryRetries
+	for _, m := range moves {
+		src, dst := m.src, m.dst
+		if err := osRetry(func() error { return os.Rename(src, dst) }, maxRetry); err != nil {
+			os.RemoveAll(stagingDir)
+			return "", err
+		}
+		maxRetry = maxInstallConfRetries
+	}
+
+	stagedBin := filepath.Join(stagingDir, binName)
+	if err := os.Chmod(stagedBin, 0o755); err != nil {
+		os.RemoveAll(stagingDir)
+		return "", err
+	}
+	syncDir(stagingDir)
+
+	// Health-check gate: prove the freshly staged binary actually starts before
+	// activating it. A version that fails to launch never becomes current.
+	if !conf.SkipHealthCheck {
+		if err := healthCheckProvider(stagedBin); err != nil {
+			os.RemoveAll(stagingDir)
+			return "", errors.Wrap(err, "provider "+providerName+"-"+version+" failed its health check")
+		}
+	}
+
+	// Promote staging -> version directory. A reinstall of the same version
+	// replaces the existing directory.
+	versionDir := filepath.Join(containerDir, version)
+	if err := os.RemoveAll(versionDir); err != nil {
+		os.RemoveAll(stagingDir)
+		return "", err
+	}
+	if err := osRetry(func() error { return os.Rename(stagingDir, versionDir) }, maxInstallConfRetries); err != nil {
+		os.RemoveAll(stagingDir)
+		return "", err
+	}
+	syncDir(containerDir)
+
+	// Atomic activation: this single rename is the commit point.
+	if err := writeCurrentPointerAtomic(containerDir, version); err != nil {
+		// The new version is on disk but not active; the previous pointer (if
+		// any) still governs, so nothing is broken. Surface the error.
+		return "", err
+	}
+
+	// Migrate away from a legacy flat install now that the pointer governs.
+	removeLegacyFlatFiles(containerDir, providerName, binName)
+
+	keep := conf.KeepVersions
+	if keep <= 0 {
+		keep = providerKeepVersions
+	}
+	if keep <= 0 {
+		keep = defaultKeepVersions
+	}
+	pruneOldVersions(containerDir, providerName, keep, version, previousVersion)
+
+	return containerDir, nil
+}

--- a/providers/install_layout.go
+++ b/providers/install_layout.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/cli/config"
+	"go.mondoo.com/mql/v13/providers/core/resources/versions/semver"
 )
 
 // Robust provider layout
@@ -166,8 +167,14 @@ func writeCurrentPointerAtomic(containerDir, version string) error {
 }
 
 // listInstalledVersions returns the version directories inside a container
-// (those holding the provider's config JSON), most-recently-modified first.
-// Staging and pointer entries are skipped.
+// (those holding the provider's config JSON), highest version first. Staging
+// and pointer entries are skipped.
+//
+// Ordering is by semantic version, not modification time: install directories
+// created in the same operation can share an mtime (and on fast filesystems
+// often do), which would make an mtime-based order nondeterministic and let
+// prune keep the wrong versions. Provider versions increase over time, so
+// semver-descending is both deterministic and a faithful "newest first".
 func listInstalledVersions(containerDir, name string) []string {
 	entries, err := afero.ReadDir(config.AppFs, containerDir)
 	if err != nil {
@@ -175,11 +182,7 @@ func listInstalledVersions(containerDir, name string) []string {
 	}
 	confName := name + ".json"
 
-	type verDir struct {
-		version string
-		mtime   int64
-	}
-	var dirs []verDir
+	var versions []string
 	for _, e := range entries {
 		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || strings.HasPrefix(e.Name(), stagingDirPrefix) {
 			continue
@@ -187,15 +190,20 @@ func listInstalledVersions(containerDir, name string) []string {
 		if !config.ProbeFile(filepath.Join(containerDir, e.Name(), confName)) {
 			continue
 		}
-		dirs = append(dirs, verDir{version: e.Name(), mtime: e.ModTime().UnixNano()})
+		versions = append(versions, e.Name())
 	}
 
-	sort.Slice(dirs, func(i, j int) bool { return dirs[i].mtime > dirs[j].mtime })
-	res := make([]string, len(dirs))
-	for i := range dirs {
-		res[i] = dirs[i].version
-	}
-	return res
+	sv := semver.Parser{}
+	sort.Slice(versions, func(i, j int) bool {
+		cmp, err := sv.Compare(versions[i], versions[j])
+		if err != nil {
+			// Unparseable versions fall back to a stable string order so the
+			// result is still deterministic.
+			return versions[i] > versions[j]
+		}
+		return cmp > 0
+	})
+	return versions
 }
 
 // pruneOldVersions removes installed version directories beyond the newest

--- a/providers/install_layout.go
+++ b/providers/install_layout.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
@@ -62,14 +63,15 @@ const (
 // providerKeepVersions is the effective retention count applied when an
 // InstallConf does not specify one. It lets a long-running host (e.g. serve)
 // configure retention globally without threading InstallConf through every
-// call site. Zero means "use defaultKeepVersions".
-var providerKeepVersions = 0
+// call site. Zero means "use defaultKeepVersions". It is atomic so a
+// configure-at-startup goroutine and a concurrent install cannot race.
+var providerKeepVersions atomic.Int32
 
 // SetKeepVersions sets the global provider version retention count used when an
 // install does not specify its own. Values below 1 are ignored.
 func SetKeepVersions(n int) {
 	if n >= 1 {
-		providerKeepVersions = n
+		providerKeepVersions.Store(int32(n))
 	}
 }
 
@@ -184,7 +186,9 @@ func listInstalledVersions(containerDir, name string) []string {
 
 	var versions []string
 	for _, e := range entries {
-		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || strings.HasPrefix(e.Name(), stagingDirPrefix) {
+		// Dot-prefixed entries (the .current pointer and .staging-* dirs) are
+		// never versions.
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
 		if !config.ProbeFile(filepath.Join(containerDir, e.Name(), confName)) {
@@ -391,7 +395,7 @@ func commitProviderVersion(tmpdir string, conf InstallConf, binName, providerNam
 
 	keep := conf.KeepVersions
 	if keep <= 0 {
-		keep = providerKeepVersions
+		keep = int(providerKeepVersions.Load())
 	}
 	if keep <= 0 {
 		keep = defaultKeepVersions

--- a/providers/install_layout_test.go
+++ b/providers/install_layout_test.go
@@ -100,16 +100,17 @@ func TestPruneOldVersions(t *testing.T) {
 		writeVersionDir(t, container, name, v)
 	}
 
-	// Keep 2, protecting the active (13.4.0) and previous (13.3.0). With keep=2
-	// we retain the two newest non-protected as well, but protected are never
-	// removed. Confirm the active + previous always survive.
+	// Keep 2, protecting the active (13.4.0) and previous (13.3.0). Ordering is
+	// by semver, so the result is deterministic: the two newest are kept and
+	// the older two are removed.
 	pruneOldVersions(container, name, 2, "13.4.0", "13.3.0")
 
 	assert.DirExists(t, filepath.Join(container, "13.4.0"), "active must survive")
 	assert.DirExists(t, filepath.Join(container, "13.3.0"), "previous must survive")
+	assert.NoDirExists(t, filepath.Join(container, "13.2.0"), "older version pruned")
+	assert.NoDirExists(t, filepath.Join(container, "13.1.0"), "oldest version pruned")
 
-	remaining := listInstalledVersions(container, name)
-	assert.LessOrEqual(t, len(remaining), 3, "prune should have removed the oldest")
+	assert.Equal(t, []string{"13.4.0", "13.3.0"}, listInstalledVersions(container, name))
 }
 
 func TestPruneNeverRemovesProtected(t *testing.T) {

--- a/providers/install_layout_test.go
+++ b/providers/install_layout_test.go
@@ -1,0 +1,161 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeVersionDir creates a fake installed version directory with the three
+// provider payload files, so layout resolution/pruning can be exercised
+// without a real provider binary.
+func writeVersionDir(t *testing.T, containerDir, name, version string) string {
+	t.Helper()
+	vdir := filepath.Join(containerDir, version)
+	require.NoError(t, os.MkdirAll(vdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(vdir, name), []byte("binary"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(vdir, name+".json"), []byte(`{"name":"`+name+`","version":"`+version+`"}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(vdir, name+".resources.json"), []byte(`{}`), 0o644))
+	return vdir
+}
+
+func TestResolveActiveDir(t *testing.T) {
+	name := "os"
+
+	t.Run("versioned via pointer", func(t *testing.T) {
+		dst := t.TempDir()
+		container := providerContainerDir(dst, name)
+		vdir := writeVersionDir(t, container, name, "13.4.1")
+		require.NoError(t, writeCurrentPointerAtomic(container, "13.4.1"))
+
+		got, legacy, ok := resolveActiveDir(container, name)
+		require.True(t, ok)
+		assert.False(t, legacy)
+		assert.Equal(t, vdir, got)
+	})
+
+	t.Run("legacy flat layout", func(t *testing.T) {
+		dst := t.TempDir()
+		container := providerContainerDir(dst, name)
+		require.NoError(t, os.MkdirAll(container, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(container, name+".json"), []byte(`{"version":"1"}`), 0o644))
+
+		got, legacy, ok := resolveActiveDir(container, name)
+		require.True(t, ok)
+		assert.True(t, legacy)
+		assert.Equal(t, container, got)
+	})
+
+	t.Run("dangling pointer falls back to flat", func(t *testing.T) {
+		dst := t.TempDir()
+		container := providerContainerDir(dst, name)
+		require.NoError(t, os.MkdirAll(container, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(container, name+".json"), []byte(`{"version":"1"}`), 0o644))
+		// Pointer names a version dir that does not exist.
+		require.NoError(t, writeCurrentPointerAtomic(container, "99.0.0"))
+
+		got, legacy, ok := resolveActiveDir(container, name)
+		require.True(t, ok)
+		assert.True(t, legacy)
+		assert.Equal(t, container, got)
+	})
+
+	t.Run("nothing installed", func(t *testing.T) {
+		dst := t.TempDir()
+		container := providerContainerDir(dst, name)
+		require.NoError(t, os.MkdirAll(container, 0o755))
+		_, _, ok := resolveActiveDir(container, name)
+		assert.False(t, ok)
+	})
+}
+
+func TestCurrentPointerRoundTrip(t *testing.T) {
+	container := t.TempDir()
+	_, ok := readCurrentPointer(container)
+	assert.False(t, ok)
+
+	require.NoError(t, writeCurrentPointerAtomic(container, "13.4.2"))
+	v, ok := readCurrentPointer(container)
+	require.True(t, ok)
+	assert.Equal(t, "13.4.2", v)
+
+	// Overwrite is atomic and reflects the latest value.
+	require.NoError(t, writeCurrentPointerAtomic(container, "13.4.3"))
+	v, ok = readCurrentPointer(container)
+	require.True(t, ok)
+	assert.Equal(t, "13.4.3", v)
+}
+
+func TestPruneOldVersions(t *testing.T) {
+	name := "os"
+	dst := t.TempDir()
+	container := providerContainerDir(dst, name)
+	for _, v := range []string{"13.1.0", "13.2.0", "13.3.0", "13.4.0"} {
+		writeVersionDir(t, container, name, v)
+	}
+
+	// Keep 2, protecting the active (13.4.0) and previous (13.3.0). With keep=2
+	// we retain the two newest non-protected as well, but protected are never
+	// removed. Confirm the active + previous always survive.
+	pruneOldVersions(container, name, 2, "13.4.0", "13.3.0")
+
+	assert.DirExists(t, filepath.Join(container, "13.4.0"), "active must survive")
+	assert.DirExists(t, filepath.Join(container, "13.3.0"), "previous must survive")
+
+	remaining := listInstalledVersions(container, name)
+	assert.LessOrEqual(t, len(remaining), 3, "prune should have removed the oldest")
+}
+
+func TestPruneNeverRemovesProtected(t *testing.T) {
+	name := "os"
+	dst := t.TempDir()
+	container := providerContainerDir(dst, name)
+	writeVersionDir(t, container, name, "13.1.0")
+
+	// keep=1 with the only version protected: it must not be deleted.
+	pruneOldVersions(container, name, 1, "13.1.0")
+	assert.DirExists(t, filepath.Join(container, "13.1.0"))
+}
+
+func TestReadProviderVersion(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "os.json")
+	require.NoError(t, os.WriteFile(good, []byte(`{"name":"os","version":"13.4.1"}`), 0o644))
+	v, err := readProviderVersion(good)
+	require.NoError(t, err)
+	assert.Equal(t, "13.4.1", v)
+
+	missing := filepath.Join(dir, "noversion.json")
+	require.NoError(t, os.WriteFile(missing, []byte(`{"name":"os"}`), 0o644))
+	_, err = readProviderVersion(missing)
+	assert.Error(t, err)
+}
+
+func TestRemoveLegacyFlatFiles(t *testing.T) {
+	name := "os"
+	container := t.TempDir()
+	// Legacy flat payload.
+	require.NoError(t, os.WriteFile(filepath.Join(container, name), []byte("bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(container, name+".json"), []byte("{}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(container, name+".resources.json"), []byte("{}"), 0o644))
+	// A versioned install and pointer that now govern.
+	writeVersionDir(t, container, name, "13.4.1")
+	require.NoError(t, writeCurrentPointerAtomic(container, "13.4.1"))
+
+	removeLegacyFlatFiles(container, name, name)
+
+	assert.NoFileExists(t, filepath.Join(container, name))
+	assert.NoFileExists(t, filepath.Join(container, name+".json"))
+	assert.NoFileExists(t, filepath.Join(container, name+".resources.json"))
+	// The versioned payload and pointer are untouched.
+	assert.DirExists(t, filepath.Join(container, "13.4.1"))
+	v, ok := readCurrentPointer(container)
+	require.True(t, ok)
+	assert.Equal(t, "13.4.1", v)
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -30,7 +30,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
-	"go.mondoo.com/mql/v13/providers/core/resources/versions/semver"
 	"golang.org/x/exp/slices"
 )
 
@@ -507,6 +506,13 @@ func installVersion(ctx context.Context, name string, version string) (*Provider
 		return nil, errors.Wrap(err, "failed to install "+name+"-"+version+", failed to read body")
 	}
 
+	// Verify integrity (and authenticity, when available) before we unpack a
+	// single byte. A failure here aborts the install and leaves any currently
+	// installed version untouched.
+	if err := verifyProviderDownload(ctx, name, version, tar); err != nil {
+		return nil, errors.Wrap(err, "failed to verify "+name+"-"+version)
+	}
+
 	reader := io.NopCloser(
 		bytes.NewReader(tar),
 	)
@@ -591,6 +597,16 @@ func PrintInstallResults(providers []*Provider) {
 type InstallConf struct {
 	// Dst specify which path to install into.
 	Dst string
+
+	// SkipHealthCheck disables launching the freshly installed provider to
+	// verify it can start before it is activated. Off by default; set only in
+	// tests, or contexts where launching a subprocess is not possible.
+	SkipHealthCheck bool
+
+	// KeepVersions overrides how many installed versions to retain per provider
+	// for rollback (the active version plus previous ones). Zero uses the
+	// default (defaultKeepVersions).
+	KeepVersions int
 }
 
 func InstallFile(path string, conf InstallConf) ([]*Provider, error) {
@@ -709,7 +725,7 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 		return nil, err
 	}
 
-	log.Debug().Msg("move provider to destination")
+	log.Debug().Msg("install provider versions")
 	providerDirs := []string{}
 	for name := range files {
 		// we only want to identify the binary and then all associated files from it
@@ -730,42 +746,17 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 			return nil, errors.New("cannot find " + providerName + ".resources.json in the archive")
 		}
 
-		dstPath := filepath.Join(conf.Dst, providerName)
-		if err = os.MkdirAll(dstPath, 0o755); err != nil {
+		// Install into a per-version directory, health-check the new binary,
+		// and only then flip the atomic .current pointer. On any failure the
+		// previously active version is left completely untouched.
+		containerDir, err := commitProviderVersion(tmpdir, conf, name, providerName)
+		if err != nil {
 			return nil, err
 		}
 
-		// move the binary and the associated files
-		srcBin := filepath.Join(tmpdir, name)
-		dstBin := filepath.Join(dstPath, name)
-		log.Debug().Str("src", srcBin).Str("dst", dstBin).Msg("move provider binary")
-		if err = osRetry(func() error {
-			return os.Rename(srcBin, dstBin)
-		}, maxInstallBinaryRetries); err != nil {
-			return nil, err
-		}
-		if err = os.Chmod(dstBin, 0o755); err != nil {
-			return nil, err
-		}
-
-		srcMeta := filepath.Join(tmpdir, providerName)
-		dstMeta := filepath.Join(dstPath, providerName)
-		if err = osRetry(func() error {
-			return os.Rename(srcMeta+".json", dstMeta+".json")
-		}, maxInstallConfRetries); err != nil {
-			return nil, err
-		}
-		if err = osRetry(func() error {
-			return os.Rename(srcMeta+".resources.json", dstMeta+".resources.json")
-		}, maxInstallConfRetries); err != nil {
-			return nil, err
-		}
-
-		// Flush the directory entries so the renames above are durable;
-		// otherwise a crash can leave the provider half-installed.
-		syncDir(dstPath)
-
-		providerDirs = append(providerDirs, dstPath)
+		// Track the container; readProviderDir resolves it through the pointer
+		// we just wrote to the freshly activated version directory.
+		providerDirs = append(providerDirs, containerDir)
 	}
 
 	log.Debug().Msg("loading providers")
@@ -904,13 +895,22 @@ func findProviders(path string) ([]*Provider, error) {
 }
 
 func readProviderDir(pdir string) (*Provider, error) {
+	// pdir is the provider's container directory. Resolve the active payload:
+	// the versioned directory named by the .current pointer, or the container
+	// itself for a legacy flat install.
 	name := filepath.Base(pdir)
-	bin := filepath.Join(pdir, name)
+	resolved, _, ok := resolveActiveDir(pdir, name)
+	if !ok {
+		log.Debug().Str("path", pdir).Msg("ignoring provider, no usable payload found")
+		return nil, nil
+	}
+
+	bin := filepath.Join(resolved, name)
 	if runtime.GOOS == "windows" {
 		bin += ".exe"
 	}
-	conf := filepath.Join(pdir, name+".json")
-	resources := filepath.Join(pdir, name+".resources.json")
+	conf := filepath.Join(resolved, name+".json")
+	resources := filepath.Join(resolved, name+".resources.json")
 
 	if !config.ProbeFile(conf) {
 		log.Debug().Str("path", conf).Msg("ignoring provider, can't access the plugin config")
@@ -931,7 +931,7 @@ func readProviderDir(pdir string) (*Provider, error) {
 		// megabytes in total) up front is wasted work for the providers we
 		// never touch.
 		Schema:    nil,
-		Path:      pdir,
+		Path:      resolved,
 		HasBinary: config.ProbeFile(bin),
 	}, nil
 }
@@ -969,12 +969,12 @@ func TryProviderUpdate(provider *Provider, update UpdateProvidersConfig) (*Provi
 		return provider, nil
 	}
 
-	semver := semver.Parser{}
-	diff, err := semver.Compare(provider.Version, latest)
+	// Apply the pin/floor policy to decide what (if anything) to install.
+	target, doUpdate, err := ResolveUpdateTarget(provider.Name, provider.Version, latest, update)
 	if err != nil {
 		return nil, err
 	}
-	if diff >= 0 {
+	if !doUpdate {
 		// Even if the provider doesn't need updating, we should check for any missing dependencies
 		if providers, err := ListActive(); err == nil {
 			err := installDependencies(provider, providers)
@@ -987,9 +987,10 @@ func TryProviderUpdate(provider *Provider, update UpdateProvidersConfig) (*Provi
 
 	log.Info().
 		Str("installed", provider.Version).
+		Str("target", target).
 		Str("latest", latest).
-		Msg("found a new version for '" + provider.Name + "' provider")
-	provider, err = installVersion(ctx, provider.Name, latest)
+		Msg("installing new version for '" + provider.Name + "' provider")
+	provider, err = installVersion(ctx, provider.Name, target)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -37,6 +37,23 @@ type ProviderRegistry interface {
 	DownloadProvider(ctx context.Context, name, version, os, arch string) (io.ReadCloser, error)
 }
 
+// VerifiedRegistry is an optional extension of ProviderRegistry that can supply
+// the verification sidecars (checksum manifest and detached signature) for a
+// provider version. When a registry implements it, installVersion verifies
+// downloads before installing them. Registries that do not implement it (e.g.
+// simple test doubles) skip verification.
+type VerifiedRegistry interface {
+	// DownloadChecksums returns the raw SHA256SUMS manifest for a provider
+	// version.
+	DownloadChecksums(ctx context.Context, name, version string) ([]byte, error)
+
+	// DownloadSignature returns the detached minisign signature over the
+	// checksum manifest. ok is false (with a nil error) when no signature has
+	// been published for this version, so callers can distinguish "unsigned"
+	// from "failed to fetch".
+	DownloadSignature(ctx context.Context, name, version string) (data []byte, ok bool, err error)
+}
+
 // MondooProviderRegistry implements ProviderRegistry for Mondoo's provider registry
 type MondooProviderRegistry struct {
 	BaseURL string
@@ -154,4 +171,78 @@ func (r *MondooProviderRegistry) DownloadProvider(ctx context.Context, name, ver
 	// Wrap with idle timeout so slow-but-active downloads succeed while
 	// truly stalled transfers are detected. Callers just read and close.
 	return httpx.NewIdleTimeoutReader(res.Body, httpx.DownloadTimeout()), nil
+}
+
+// checksumFilename builds the name of the SHA256SUMS manifest for a version.
+// The release pipeline names it "<name>_<version>_SHA256SUMS"
+// (provider_bundler.sh).
+func checksumFilename(name, version string) string {
+	return fmt.Sprintf("%s_%s_SHA256SUMS", name, version)
+}
+
+// DownloadChecksums fetches the SHA256SUMS manifest for a provider version.
+func (r *MondooProviderRegistry) DownloadChecksums(ctx context.Context, name, version string) ([]byte, error) {
+	url, err := url.JoinPath(r.BaseURL, name, version, checksumFilename(name, version))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct checksum URL")
+	}
+	data, _, err := r.fetch(ctx, url)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to download checksum manifest for "+name+"-"+version)
+	}
+	if data == nil {
+		return nil, errors.New("checksum manifest not found for " + name + "-" + version)
+	}
+	return data, nil
+}
+
+// DownloadSignature fetches the detached minisign signature over the checksum
+// manifest. A 404 is reported as ok=false with no error, so an as-yet-unsigned
+// release does not fail verification under the 'auto' policy.
+func (r *MondooProviderRegistry) DownloadSignature(ctx context.Context, name, version string) ([]byte, bool, error) {
+	url, err := url.JoinPath(r.BaseURL, name, version, checksumFilename(name, version)+".sig")
+	if err != nil {
+		return nil, false, errors.Wrap(err, "failed to construct signature URL")
+	}
+	data, notFound, err := r.fetch(ctx, url)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "failed to download signature for "+name+"-"+version)
+	}
+	if notFound || data == nil {
+		return nil, false, nil
+	}
+	return data, true, nil
+}
+
+// fetch GETs a small sidecar file. It returns (nil, true, nil) on 404 so
+// callers can treat "not published" distinctly from a transport error.
+func (r *MondooProviderRegistry) fetch(ctx context.Context, url string) (data []byte, notFound bool, err error) {
+	client, err := httpClientWithRetry()
+	if err != nil {
+		return nil, false, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		return nil, true, nil
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, false, errors.New("received status code " + res.Status + " for " + url)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, false, err
+	}
+	return body, false, nil
 }

--- a/providers/update_policy.go
+++ b/providers/update_policy.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers/core/resources/versions/semver"
+)
+
+// ResolveUpdateTarget decides which version of a provider should be active,
+// given the currently installed version, the latest published version, and the
+// pin/floor policy. It returns the target version and whether an update is
+// needed.
+//
+// Precedence:
+//
+//  1. Pin wins outright: a pinned provider is held at exactly that version. If
+//     it is already installed, no update; otherwise install the pinned version
+//     (which may be a deliberate downgrade).
+//  2. Floor guards the latest: if the published latest is below the configured
+//     minimum, it is refused and the installed version is kept. This stops a
+//     withdrawn or regressed "latest" from rolling the fleet below a known-good
+//     baseline.
+//  3. Otherwise update when latest is newer than what is installed.
+func ResolveUpdateTarget(name, installed, latest string, cfg UpdateProvidersConfig) (target string, update bool, err error) {
+	sv := semver.Parser{}
+
+	if pin, ok := cfg.Pin[name]; ok && pin != "" {
+		if pin == installed {
+			return installed, false, nil
+		}
+		log.Info().
+			Str("provider", name).
+			Str("installed", installed).
+			Str("pin", pin).
+			Msg("provider is pinned; installing the pinned version")
+		return pin, true, nil
+	}
+
+	if floor, ok := cfg.Floor[name]; ok && floor != "" {
+		cmp, err := sv.Compare(latest, floor)
+		if err != nil {
+			return "", false, err
+		}
+		if cmp < 0 {
+			log.Warn().
+				Str("provider", name).
+				Str("latest", latest).
+				Str("floor", floor).
+				Msg("published latest is below the configured version floor; not updating")
+			return installed, false, nil
+		}
+	}
+
+	diff, err := sv.Compare(installed, latest)
+	if err != nil {
+		return "", false, err
+	}
+	if diff >= 0 {
+		return installed, false, nil
+	}
+	return latest, true, nil
+}

--- a/providers/update_policy_test.go
+++ b/providers/update_policy_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveUpdateTarget(t *testing.T) {
+	name := "os"
+
+	t.Run("updates to latest when newer", func(t *testing.T) {
+		target, update, err := ResolveUpdateTarget(name, "13.4.0", "13.4.1", UpdateProvidersConfig{})
+		require.NoError(t, err)
+		assert.True(t, update)
+		assert.Equal(t, "13.4.1", target)
+	})
+
+	t.Run("no update when already latest", func(t *testing.T) {
+		target, update, err := ResolveUpdateTarget(name, "13.4.1", "13.4.1", UpdateProvidersConfig{})
+		require.NoError(t, err)
+		assert.False(t, update)
+		assert.Equal(t, "13.4.1", target)
+	})
+
+	t.Run("no update when installed newer than latest", func(t *testing.T) {
+		_, update, err := ResolveUpdateTarget(name, "13.5.0", "13.4.1", UpdateProvidersConfig{})
+		require.NoError(t, err)
+		assert.False(t, update)
+	})
+
+	t.Run("pin holds exact version, ignoring newer latest", func(t *testing.T) {
+		cfg := UpdateProvidersConfig{Pin: map[string]string{name: "13.4.0"}}
+		target, update, err := ResolveUpdateTarget(name, "13.4.0", "13.9.9", cfg)
+		require.NoError(t, err)
+		assert.False(t, update, "already at pin, no update")
+		assert.Equal(t, "13.4.0", target)
+	})
+
+	t.Run("pin installs pinned version when not present", func(t *testing.T) {
+		cfg := UpdateProvidersConfig{Pin: map[string]string{name: "13.4.0"}}
+		target, update, err := ResolveUpdateTarget(name, "13.2.0", "13.9.9", cfg)
+		require.NoError(t, err)
+		assert.True(t, update)
+		assert.Equal(t, "13.4.0", target, "pin is authoritative, not latest")
+	})
+
+	t.Run("floor refuses a latest below the baseline", func(t *testing.T) {
+		cfg := UpdateProvidersConfig{Floor: map[string]string{name: "13.4.0"}}
+		target, update, err := ResolveUpdateTarget(name, "13.4.0", "13.3.0", cfg)
+		require.NoError(t, err)
+		assert.False(t, update, "latest below floor is refused")
+		assert.Equal(t, "13.4.0", target)
+	})
+
+	t.Run("floor allows a latest at or above the baseline", func(t *testing.T) {
+		cfg := UpdateProvidersConfig{Floor: map[string]string{name: "13.4.0"}}
+		target, update, err := ResolveUpdateTarget(name, "13.4.0", "13.5.0", cfg)
+		require.NoError(t, err)
+		assert.True(t, update)
+		assert.Equal(t, "13.5.0", target)
+	})
+
+	t.Run("pin takes precedence over floor", func(t *testing.T) {
+		cfg := UpdateProvidersConfig{
+			Pin:   map[string]string{name: "13.4.0"},
+			Floor: map[string]string{name: "13.8.0"},
+		}
+		target, update, err := ResolveUpdateTarget(name, "13.2.0", "13.9.0", cfg)
+		require.NoError(t, err)
+		assert.True(t, update)
+		assert.Equal(t, "13.4.0", target)
+	})
+}

--- a/providers/verify_config.go
+++ b/providers/verify_config.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/utils/verify"
+)
+
+// Provider download verification
+//
+// Downloaded provider archives are verified against the published SHA256SUMS
+// manifest and, when available, a detached minisign signature over that
+// manifest. The public key is pinned into the binary at release build time via
+// -ldflags so authenticity does not depend on any network service.
+
+// providerSignaturePolicy controls signature enforcement for provider
+// downloads. It can be tightened to verify.SignatureRequire in strict fleets
+// once signatures are published everywhere.
+var providerSignaturePolicy = verify.SignatureAuto
+
+// SetProviderSignaturePolicy overrides the signature-enforcement policy for
+// provider downloads (auto | require | off). Callers map their config value
+// through verify.ParseSignaturePolicy.
+func SetProviderSignaturePolicy(p verify.SignaturePolicy) {
+	providerSignaturePolicy = p
+}
+
+// providerVerifier builds the verifier for provider downloads from the pinned
+// key and current policy. A nil verifier (returned on an unparsable pinned key)
+// means "cannot verify"; callers treat that as a hard error rather than
+// silently skipping verification.
+func providerVerifier() (*verify.Verifier, error) {
+	return verify.NewVerifier(verify.PinnedPublicKey, providerSignaturePolicy)
+}
+
+// verifyProviderDownload checks the downloaded archive bytes against the
+// published SHA256SUMS manifest and, when available, its detached signature.
+//
+// Verification requires the registry to be able to supply the sidecars
+// (VerifiedRegistry). A registry that cannot (e.g. a test double, or a custom
+// registry) skips verification unless the signature policy is 'require', in
+// which case the absence of verifiable sidecars is a hard failure.
+func verifyProviderDownload(ctx context.Context, name, version string, archive []byte) error {
+	vr, ok := registry.(VerifiedRegistry)
+	if !ok {
+		if providerSignaturePolicy == verify.SignatureRequire {
+			return errors.New("this registry cannot supply checksums, but verify_signature is 'require'")
+		}
+		log.Debug().Str("provider", name).Msg("registry does not supply checksums; skipping download verification")
+		return nil
+	}
+
+	manifest, err := vr.DownloadChecksums(ctx, name, version)
+	if err != nil {
+		return err
+	}
+
+	signature, _, err := vr.DownloadSignature(ctx, name, version)
+	if err != nil {
+		return err
+	}
+
+	v, err := providerVerifier()
+	if err != nil {
+		return err
+	}
+
+	filename := fmt.Sprintf("%s_%s_%s_%s.tar.xz", name, version, runtime.GOOS, runtime.GOARCH)
+	res, err := v.Verify(verify.Inputs{
+		Filename:  filename,
+		Artifact:  archive,
+		Manifest:  manifest,
+		Signature: signature,
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Debug().
+		Str("provider", name).
+		Str("version", version).
+		Str("sha256", res.SHA256).
+		Bool("signature_verified", res.SignatureChecked).
+		Msg("verified provider download")
+	return nil
+}

--- a/utils/verify/checksum.go
+++ b/utils/verify/checksum.go
@@ -1,0 +1,174 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package verify provides integrity (SHA256) and authenticity (minisign)
+// verification for downloaded artifacts (provider plugins and binaries).
+//
+// The two gates are independent and composable:
+//
+//   - Checksum: a published SHA256SUMS manifest lists one hex digest per
+//     file. The caller verifies that the bytes it downloaded hash to the
+//     digest the manifest records for that exact filename.
+//   - Signature: an optional detached minisign signature over the manifest
+//     itself, verified against a public key pinned into the binary at build
+//     time. This upgrades "the bytes match a digest we downloaded" into "the
+//     bytes match a digest signed by us".
+//
+// Neither gate reaches out to the network; callers fetch the manifest and
+// signature and hand the bytes in. This keeps the package pure and trivially
+// unit-testable, and works in air-gapped fleets.
+package verify
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ErrChecksumMismatch is returned when an artifact's computed SHA256 does not
+// match the digest recorded for it in the manifest. It is a distinct error so
+// callers can tell "the download is corrupt/tampered" apart from transport or
+// parsing failures and react accordingly (discard and retry vs. give up).
+var ErrChecksumMismatch = errors.New("artifact checksum does not match the expected value")
+
+// ErrChecksumNotFound is returned when the manifest does not contain an entry
+// for the requested filename. Treated as a hard failure: a manifest that omits
+// the file we downloaded cannot vouch for it.
+var ErrChecksumNotFound = errors.New("no checksum entry for the requested file")
+
+// SHA256SUMS is a parsed checksum manifest: a map from filename to its lower
+// case hex-encoded SHA256 digest. The manifest format is the one emitted by
+// both `shasum -a 256` (provider_bundler.sh) and goreleaser's checksum block:
+// one entry per line, "<64-hex-digest><whitespace>[*]<filename>".
+type SHA256SUMS struct {
+	digests map[string]string
+}
+
+// ParseSHA256SUMS parses a checksum manifest. It is lenient about the exact
+// whitespace and the binary-mode "*" marker that some tools prefix to the
+// filename, and it tolerates blank lines and comments (lines starting with
+// '#'). Only the base name of each recorded path is indexed, so a manifest
+// that lists "dist/os_1.2.3_linux_amd64.tar.xz" still matches a lookup for
+// "os_1.2.3_linux_amd64.tar.xz".
+//
+// A manifest that parses to zero usable entries is rejected: an empty manifest
+// almost always means we fetched an error page or the wrong URL, and silently
+// treating it as "nothing to check" would defeat the whole gate.
+func ParseSHA256SUMS(data []byte) (*SHA256SUMS, error) {
+	res := &SHA256SUMS{digests: map[string]string{}}
+
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Split into the digest and the remainder (the filename, possibly
+		// prefixed with the binary-mode "*" marker). Fields collapses runs of
+		// whitespace so both the two-space GNU format and single-tab variants
+		// parse the same way.
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return nil, errors.Newf("malformed checksum line: %q", rawLine)
+		}
+
+		digest := strings.ToLower(fields[0])
+		if !isHexSHA256(digest) {
+			return nil, errors.Newf("invalid sha256 digest in checksum line: %q", rawLine)
+		}
+
+		// The filename is everything after the first field; rejoin so paths
+		// containing spaces survive. Strip the optional "*" binary marker.
+		name := strings.TrimSpace(strings.TrimPrefix(strings.Join(fields[1:], " "), "*"))
+		if name == "" {
+			return nil, errors.Newf("missing filename in checksum line: %q", rawLine)
+		}
+
+		// Index by base name so callers can look up the plain filename
+		// regardless of whether the manifest recorded a relative path.
+		res.digests[baseName(name)] = digest
+	}
+
+	if len(res.digests) == 0 {
+		return nil, errors.New("checksum manifest contained no valid entries")
+	}
+
+	return res, nil
+}
+
+// Digest returns the recorded lower-case hex SHA256 for the given filename
+// (matched by base name), and whether an entry exists.
+func (s *SHA256SUMS) Digest(filename string) (string, bool) {
+	d, ok := s.digests[baseName(filename)]
+	return d, ok
+}
+
+// Verify streams the artifact from r, computes its SHA256, and compares it to
+// the digest the manifest records for filename. It returns ErrChecksumNotFound
+// if the manifest has no entry for the file, and ErrChecksumMismatch if the
+// digests differ. On success it returns the computed digest so callers can log
+// it.
+//
+// Verify reads r to EOF; callers that need the bytes afterwards should tee or
+// buffer. The whole artifact must be hashed, so there is no early-out.
+func (s *SHA256SUMS) Verify(filename string, r io.Reader) (string, error) {
+	expected, ok := s.Digest(filename)
+	if !ok {
+		return "", errors.Wrapf(ErrChecksumNotFound, "file %q", filename)
+	}
+
+	actual, err := sha256Hex(r)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to hash artifact")
+	}
+
+	if actual != expected {
+		return "", errors.Wrapf(ErrChecksumMismatch,
+			"file %q: expected %s, computed %s", filename, expected, actual)
+	}
+
+	return actual, nil
+}
+
+// VerifyBytes is the in-memory convenience form of Verify.
+func (s *SHA256SUMS) VerifyBytes(filename string, data []byte) (string, error) {
+	return s.Verify(filename, strings.NewReader(string(data)))
+}
+
+// sha256Hex streams r through a SHA256 hasher and returns the lower-case hex
+// digest.
+func sha256Hex(r io.Reader) (string, error) {
+	var h hash.Hash = sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// isHexSHA256 reports whether s is exactly 64 lower-case hex characters.
+func isHexSHA256(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// baseName returns the final path element, handling both '/' and '\'
+// separators so a Windows-style path in a manifest still matches.
+func baseName(p string) string {
+	p = strings.TrimSpace(p)
+	if i := strings.LastIndexAny(p, `/\`); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}

--- a/utils/verify/checksum.go
+++ b/utils/verify/checksum.go
@@ -20,6 +20,7 @@
 package verify
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
@@ -135,7 +136,9 @@ func (s *SHA256SUMS) Verify(filename string, r io.Reader) (string, error) {
 
 // VerifyBytes is the in-memory convenience form of Verify.
 func (s *SHA256SUMS) VerifyBytes(filename string, data []byte) (string, error) {
-	return s.Verify(filename, strings.NewReader(string(data)))
+	// bytes.NewReader wraps the existing slice with no copy; using
+	// strings.NewReader(string(data)) would duplicate a large artifact in memory.
+	return s.Verify(filename, bytes.NewReader(data))
 }
 
 // sha256Hex streams r through a SHA256 hasher and returns the lower-case hex

--- a/utils/verify/checksum.go
+++ b/utils/verify/checksum.go
@@ -22,7 +22,6 @@ package verify
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"hash"
 	"io"
 	"strings"
 
@@ -142,7 +141,7 @@ func (s *SHA256SUMS) VerifyBytes(filename string, data []byte) (string, error) {
 // sha256Hex streams r through a SHA256 hasher and returns the lower-case hex
 // digest.
 func sha256Hex(r io.Reader) (string, error) {
-	var h hash.Hash = sha256.New()
+	h := sha256.New()
 	if _, err := io.Copy(h, r); err != nil {
 		return "", err
 	}

--- a/utils/verify/minisign.go
+++ b/utils/verify/minisign.go
@@ -1,0 +1,210 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package verify
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"golang.org/x/crypto/blake2b"
+)
+
+// minisign is a small, dependency-free implementation of minisign signature
+// verification (https://jedisct1.github.io/minisign/). We verify the detached
+// signature published over the SHA256SUMS manifest against a public key pinned
+// into the binary at build time, so authenticity does not depend on any
+// network service or external tool — important for air-gapped fleets.
+//
+// Wire format (all fields little-endian is irrelevant here; they are opaque
+// byte runs):
+//
+//	Public key (base64, 42 bytes):
+//	  [0:2]   signature algorithm  ("Ed")
+//	  [2:10]  key id               (8 bytes)
+//	  [10:42] Ed25519 public key   (32 bytes)
+//
+//	Signature file (.minisig / .sig, two base64 blocks):
+//	  block 1 (74 bytes):
+//	    [0:2]   signature algorithm  ("Ed" = pure, "ED" = prehashed BLAKE2b-512)
+//	    [2:10]  key id               (8 bytes)
+//	    [10:74] Ed25519 signature    (64 bytes) over the (possibly prehashed) content
+//	  block 2 (64 bytes):
+//	    Ed25519 "global" signature over (block-1 signature || trusted comment)
+//
+// Verification checks: (1) the key id in the signature matches the pinned
+// public key, (2) the content signature is valid under the pinned key, and
+// (3) the global signature is valid, which binds the trusted comment so it
+// cannot be swapped.
+
+const (
+	minisignAlgPure      = "Ed" // Ed25519 over the raw content
+	minisignAlgPrehashed = "ED" // Ed25519 over BLAKE2b-512(content)
+
+	minisignPubKeyLen  = 2 + 8 + ed25519.PublicKeySize // 42
+	minisignSigLen     = 2 + 8 + ed25519.SignatureSize // 74
+	minisignKeyIDLen   = 8
+	minisignKeyIDStart = 2
+	minisignKeyIDEnd   = 10
+)
+
+// ErrSignatureInvalid is returned when a signature does not verify against the
+// pinned public key (bad signature, wrong key, tampered content, or a swapped
+// trusted comment).
+var ErrSignatureInvalid = errors.New("minisign signature verification failed")
+
+// MinisignPublicKey is a parsed minisign public key.
+type MinisignPublicKey struct {
+	keyID [minisignKeyIDLen]byte
+	key   ed25519.PublicKey
+}
+
+// ParseMinisignPublicKey parses a minisign public key. It accepts either the
+// full two-line public-key file (an "untrusted comment:" line followed by the
+// base64 payload) or the bare base64 payload on its own — whichever is more
+// convenient to embed as a build-time constant.
+func ParseMinisignPublicKey(s string) (*MinisignPublicKey, error) {
+	payload, err := lastBase64Line(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read minisign public key")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to base64-decode minisign public key")
+	}
+	if len(raw) != minisignPubKeyLen {
+		return nil, errors.Newf("invalid minisign public key length: got %d, want %d", len(raw), minisignPubKeyLen)
+	}
+	if alg := string(raw[0:2]); alg != minisignAlgPure {
+		return nil, errors.Newf("unsupported minisign public key algorithm: %q", alg)
+	}
+
+	res := &MinisignPublicKey{key: ed25519.PublicKey(raw[10:42])}
+	copy(res.keyID[:], raw[minisignKeyIDStart:minisignKeyIDEnd])
+	return res, nil
+}
+
+// minisignSignature is a parsed minisign signature file.
+type minisignSignature struct {
+	algorithm      string
+	keyID          [minisignKeyIDLen]byte
+	signature      []byte // 64-byte Ed25519 signature over the (prehashed) content
+	trustedComment string
+	globalSig      []byte // 64-byte Ed25519 signature over (signature || trustedComment)
+}
+
+// parseMinisignSignature parses a .minisig / .sig file. The format is:
+//
+//	untrusted comment: <text>
+//	<base64 signature block>
+//	trusted comment: <text>
+//	<base64 global signature>
+func parseMinisignSignature(s string) (*minisignSignature, error) {
+	lines := splitNonEmptyLines(s)
+	if len(lines) < 4 {
+		return nil, errors.New("malformed minisign signature: expected 4 lines")
+	}
+
+	sigRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[1]))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to base64-decode signature block")
+	}
+	if len(sigRaw) != minisignSigLen {
+		return nil, errors.Newf("invalid minisign signature length: got %d, want %d", len(sigRaw), minisignSigLen)
+	}
+
+	trustedComment := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[2]), "trusted comment:"))
+
+	globalSig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[3]))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to base64-decode global signature")
+	}
+	if len(globalSig) != ed25519.SignatureSize {
+		return nil, errors.Newf("invalid global signature length: got %d, want %d", len(globalSig), ed25519.SignatureSize)
+	}
+
+	res := &minisignSignature{
+		algorithm:      string(sigRaw[0:2]),
+		signature:      sigRaw[10:74],
+		trustedComment: trustedComment,
+		globalSig:      globalSig,
+	}
+	copy(res.keyID[:], sigRaw[minisignKeyIDStart:minisignKeyIDEnd])
+	return res, nil
+}
+
+// Verify checks a minisign signature over content against this public key. It
+// verifies both the content signature and the global signature (which binds
+// the trusted comment). content is the exact bytes that were signed (for us,
+// the raw SHA256SUMS manifest).
+func (pk *MinisignPublicKey) Verify(content []byte, signatureFile string) error {
+	sig, err := parseMinisignSignature(signatureFile)
+	if err != nil {
+		return err
+	}
+
+	if sig.keyID != pk.keyID {
+		return errors.Wrapf(ErrSignatureInvalid, "signature key id does not match the pinned public key")
+	}
+
+	// Determine what was actually signed: the raw content ("Ed") or its
+	// BLAKE2b-512 prehash ("ED", minisign's default for large/streamed files).
+	var signed []byte
+	switch sig.algorithm {
+	case minisignAlgPure:
+		signed = content
+	case minisignAlgPrehashed:
+		sum := blake2b.Sum512(content)
+		signed = sum[:]
+	default:
+		return errors.Newf("unsupported minisign signature algorithm: %q", sig.algorithm)
+	}
+
+	if !ed25519.Verify(pk.key, signed, sig.signature) {
+		return errors.Wrap(ErrSignatureInvalid, "content signature is not valid")
+	}
+
+	// The global signature covers the content signature concatenated with the
+	// trusted comment. Verifying it ensures the trusted comment (which may
+	// carry the artifact name/version) was not altered.
+	globalSigned := append(append([]byte{}, sig.signature...), []byte(sig.trustedComment)...)
+	if !ed25519.Verify(pk.key, globalSigned, sig.globalSig) {
+		return errors.Wrap(ErrSignatureInvalid, "global signature (trusted comment) is not valid")
+	}
+
+	return nil
+}
+
+// lastBase64Line returns the last non-empty, non-comment line of s, which for
+// a minisign public key is the base64 payload. A bare payload passes through
+// unchanged.
+func lastBase64Line(s string) (string, error) {
+	lines := splitNonEmptyLines(s)
+	if len(lines) == 0 {
+		return "", errors.New("empty input")
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, "untrusted comment:") || strings.HasPrefix(line, "trusted comment:") {
+			continue
+		}
+		return line, nil
+	}
+	return "", errors.New("no base64 payload found")
+}
+
+// splitNonEmptyLines splits s on newlines and drops purely empty lines,
+// tolerating both LF and CRLF endings.
+func splitNonEmptyLines(s string) []string {
+	raw := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	res := make([]string, 0, len(raw))
+	for _, l := range raw {
+		if strings.TrimSpace(l) != "" {
+			res = append(res, l)
+		}
+	}
+	return res
+}

--- a/utils/verify/minisign.go
+++ b/utils/verify/minisign.go
@@ -116,7 +116,11 @@ func parseMinisignSignature(s string) (*minisignSignature, error) {
 		return nil, errors.Newf("invalid minisign signature length: got %d, want %d", len(sigRaw), minisignSigLen)
 	}
 
-	trustedComment := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[2]), "trusted comment:"))
+	commentLine := strings.TrimSpace(lines[2])
+	if !strings.HasPrefix(commentLine, "trusted comment:") {
+		return nil, errors.New("malformed minisign signature: missing trusted comment line")
+	}
+	trustedComment := strings.TrimSpace(strings.TrimPrefix(commentLine, "trusted comment:"))
 
 	globalSig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[3]))
 	if err != nil {

--- a/utils/verify/pinnedkey.go
+++ b/utils/verify/pinnedkey.go
@@ -1,0 +1,16 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package verify
+
+// PinnedPublicKey is the minisign public key used to verify update downloads
+// (both provider plugins and the engine binary). It is the deployment's trust
+// anchor and is empty in development builds; release builds set it via
+// -ldflags, for example:
+//
+//	-ldflags "-X go.mondoo.com/mql/v13/utils/verify.PinnedPublicKey=RW...=="
+//
+// While it is empty, signature verification is unavailable and, under the
+// default 'auto' policy, downloads are accepted on checksum alone. Integrity
+// (SHA256) is always enforced.
+var PinnedPublicKey = ""

--- a/utils/verify/verify.go
+++ b/utils/verify/verify.go
@@ -1,0 +1,197 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package verify
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// SignaturePolicy controls how the optional manifest signature is treated.
+type SignaturePolicy int
+
+const (
+	// SignatureAuto verifies the signature when both a pinned public key and a
+	// signature are available, and otherwise proceeds on checksum alone
+	// (logging that the artifact was unsigned). This is the default while the
+	// release pipeline is still being extended to publish signatures.
+	SignatureAuto SignaturePolicy = iota
+
+	// SignatureRequire fails closed: verification errors unless a valid
+	// signature is present. Use in strict/critical fleets once signatures are
+	// published fleet-wide.
+	SignatureRequire
+
+	// SignatureOff skips signature verification entirely and relies on the
+	// checksum gate only. Intended for testing and tightly controlled mirrors.
+	SignatureOff
+)
+
+// ParseSignaturePolicy maps the mondoo.yml `verify_signature` string
+// ("auto" | "require" | "off") to a SignaturePolicy. Unknown values fall back
+// to SignatureAuto with a warning, so a config typo never silently disables
+// the checksum gate.
+func ParseSignaturePolicy(s string) SignaturePolicy {
+	switch s {
+	case "", "auto":
+		return SignatureAuto
+	case "require":
+		return SignatureRequire
+	case "off":
+		return SignatureOff
+	default:
+		log.Warn().Str("value", s).Msg("unknown verify_signature policy, defaulting to 'auto'")
+		return SignatureAuto
+	}
+}
+
+// Verifier verifies downloaded artifacts against a checksum manifest and an
+// optional pinned minisign public key. It is safe for concurrent use; it holds
+// only immutable configuration.
+type Verifier struct {
+	// pubKey is the minisign public key pinned into the binary at build time.
+	// Nil means no key is compiled in (signature verification is unavailable).
+	pubKey *MinisignPublicKey
+	// policy controls signature enforcement.
+	policy SignaturePolicy
+}
+
+// NewVerifier builds a Verifier. pinnedPublicKey may be empty when no signing
+// key has been provisioned yet; in that case signature verification is
+// unavailable and, under SignatureAuto, artifacts are accepted on checksum
+// alone. Under SignatureRequire an empty key is a hard configuration error at
+// verification time (fail closed).
+func NewVerifier(pinnedPublicKey string, policy SignaturePolicy) (*Verifier, error) {
+	v := &Verifier{policy: policy}
+	if pinnedPublicKey != "" {
+		pk, err := ParseMinisignPublicKey(pinnedPublicKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid pinned minisign public key")
+		}
+		v.pubKey = pk
+	}
+	return v, nil
+}
+
+// Inputs bundles everything needed to verify one artifact. The caller fetches
+// the pieces (the package does no network I/O):
+//
+//   - Filename is the artifact's base name as it appears in the manifest.
+//   - Artifact is the downloaded bytes to verify.
+//   - Manifest is the raw SHA256SUMS file.
+//   - Signature is the raw detached minisign signature over Manifest, or empty
+//     if none was published.
+type Inputs struct {
+	Filename  string
+	Artifact  []byte
+	Manifest  []byte
+	Signature []byte
+}
+
+// Result reports what was actually checked, for logging and telemetry.
+type Result struct {
+	SHA256           string // the verified digest
+	SignatureChecked bool   // whether a signature was verified
+}
+
+// Verify runs the gates in order — signature over the manifest first (so a
+// tampered manifest is rejected before we trust any digest in it), then the
+// artifact checksum against that manifest.
+//
+// Ordering rationale: the checksum gate only proves "the artifact matches a
+// digest in this manifest". That is worthless if the manifest itself is
+// attacker-controlled. Verifying the manifest signature first turns the
+// checksum into a meaningful authenticity check.
+func (v *Verifier) Verify(in Inputs) (*Result, error) {
+	res := &Result{}
+
+	// Gate 1: manifest signature (authenticity), subject to policy.
+	sigChecked, err := v.verifyManifestSignature(in.Manifest, in.Signature)
+	if err != nil {
+		return nil, err
+	}
+	res.SignatureChecked = sigChecked
+
+	// Gate 2: artifact checksum (integrity), against the now-trusted manifest.
+	sums, err := ParseSHA256SUMS(in.Manifest)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse checksum manifest")
+	}
+	digest, err := sums.VerifyBytes(in.Filename, in.Artifact)
+	if err != nil {
+		return nil, err
+	}
+	res.SHA256 = digest
+
+	return res, nil
+}
+
+// VerifyPrehashed is Verify for artifacts whose SHA256 has already been
+// computed while streaming them to disk (e.g. a large binary download), so the
+// bytes need not be held in memory. sha256Hex is the lower-case hex digest of
+// the artifact. All other semantics — signature-first ordering and the
+// signature policy — match Verify.
+func (v *Verifier) VerifyPrehashed(filename, sha256Hex string, manifest, signature []byte) (*Result, error) {
+	res := &Result{}
+
+	sigChecked, err := v.verifyManifestSignature(manifest, signature)
+	if err != nil {
+		return nil, err
+	}
+	res.SignatureChecked = sigChecked
+
+	sums, err := ParseSHA256SUMS(manifest)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse checksum manifest")
+	}
+	expected, ok := sums.Digest(filename)
+	if !ok {
+		return nil, errors.Wrapf(ErrChecksumNotFound, "file %q", filename)
+	}
+	if !strings.EqualFold(sha256Hex, expected) {
+		return nil, errors.Wrapf(ErrChecksumMismatch,
+			"file %q: expected %s, computed %s", filename, expected, strings.ToLower(sha256Hex))
+	}
+	res.SHA256 = strings.ToLower(sha256Hex)
+	return res, nil
+}
+
+// verifyManifestSignature applies the signature policy to the manifest and its
+// detached signature. It returns whether a signature was actually verified.
+func (v *Verifier) verifyManifestSignature(manifest, signature []byte) (bool, error) {
+	switch v.policy {
+	case SignatureOff:
+		return false, nil
+
+	case SignatureRequire:
+		if v.pubKey == nil {
+			return false, errors.New("verify_signature is 'require' but no signing key is pinned into this build")
+		}
+		if len(signature) == 0 {
+			return false, errors.New("verify_signature is 'require' but no signature was published for this artifact")
+		}
+		if err := v.pubKey.Verify(manifest, string(signature)); err != nil {
+			return false, err
+		}
+		return true, nil
+
+	case SignatureAuto:
+		fallthrough
+	default:
+		// Best-effort: verify when we can, otherwise proceed on checksum alone.
+		if v.pubKey == nil || len(signature) == 0 {
+			log.Debug().Msg("no signature available; verifying artifact by checksum only")
+			return false, nil
+		}
+		if err := v.pubKey.Verify(manifest, string(signature)); err != nil {
+			// A present-but-invalid signature is always fatal, even under
+			// 'auto'. "Auto" relaxes the requirement that a signature exist,
+			// not the requirement that a signature which does exist be valid.
+			return false, err
+		}
+		return true, nil
+	}
+}

--- a/utils/verify/verify_test.go
+++ b/utils/verify/verify_test.go
@@ -1,0 +1,285 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package verify
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/blake2b"
+)
+
+// --- test helpers: build minisign-format keys and signatures in-process -----
+
+type testSigner struct {
+	pub     ed25519.PublicKey
+	priv    ed25519.PrivateKey
+	keyID   [8]byte
+	pubText string
+}
+
+func newTestSigner(t *testing.T) *testSigner {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	s := &testSigner{pub: pub, priv: priv}
+	_, err = rand.Read(s.keyID[:])
+	require.NoError(t, err)
+
+	raw := make([]byte, 0, minisignPubKeyLen)
+	raw = append(raw, []byte(minisignAlgPure)...) // "Ed" is the algorithm tag in the public key
+	raw = append(raw, s.keyID[:]...)
+	raw = append(raw, s.pub...)
+	s.pubText = "untrusted comment: test key\n" + base64.StdEncoding.EncodeToString(raw) + "\n"
+	return s
+}
+
+// sign builds a minisign signature file over content using the given algorithm
+// ("Ed" pure or "ED" prehashed).
+func (s *testSigner) sign(algorithm string, content []byte, trustedComment string) string {
+	var signed []byte
+	switch algorithm {
+	case minisignAlgPure:
+		signed = content
+	case minisignAlgPrehashed:
+		sum := blake2b.Sum512(content)
+		signed = sum[:]
+	default:
+		panic("bad algorithm")
+	}
+
+	sig := ed25519.Sign(s.priv, signed)
+
+	block := make([]byte, 0, minisignSigLen)
+	block = append(block, []byte(algorithm)...)
+	block = append(block, s.keyID[:]...)
+	block = append(block, sig...)
+
+	global := ed25519.Sign(s.priv, append(append([]byte{}, sig...), []byte(trustedComment)...))
+
+	return fmt.Sprintf("untrusted comment: signature\n%s\ntrusted comment: %s\n%s\n",
+		base64.StdEncoding.EncodeToString(block),
+		trustedComment,
+		base64.StdEncoding.EncodeToString(global),
+	)
+}
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// --- checksum tests ---------------------------------------------------------
+
+func TestParseSHA256SUMS(t *testing.T) {
+	artifact := []byte("provider binary contents")
+	digest := sha256hex(artifact)
+
+	t.Run("gnu two-space format", func(t *testing.T) {
+		manifest := []byte(digest + "  os_1.2.3_linux_amd64.tar.xz\n")
+		sums, err := ParseSHA256SUMS(manifest)
+		require.NoError(t, err)
+		got, ok := sums.Digest("os_1.2.3_linux_amd64.tar.xz")
+		assert.True(t, ok)
+		assert.Equal(t, digest, got)
+	})
+
+	t.Run("binary-mode asterisk marker", func(t *testing.T) {
+		manifest := []byte(digest + " *os_1.2.3_linux_amd64.tar.xz\n")
+		sums, err := ParseSHA256SUMS(manifest)
+		require.NoError(t, err)
+		_, ok := sums.Digest("os_1.2.3_linux_amd64.tar.xz")
+		assert.True(t, ok)
+	})
+
+	t.Run("relative path indexed by base name", func(t *testing.T) {
+		manifest := []byte(digest + "  dist/os_1.2.3_linux_amd64.tar.xz\n")
+		sums, err := ParseSHA256SUMS(manifest)
+		require.NoError(t, err)
+		_, ok := sums.Digest("os_1.2.3_linux_amd64.tar.xz")
+		assert.True(t, ok)
+	})
+
+	t.Run("comments and blank lines tolerated", func(t *testing.T) {
+		manifest := []byte("# a comment\n\n" + digest + "  file.tar.xz\n\n")
+		sums, err := ParseSHA256SUMS(manifest)
+		require.NoError(t, err)
+		assert.Len(t, sums.digests, 1)
+	})
+
+	t.Run("empty manifest rejected", func(t *testing.T) {
+		_, err := ParseSHA256SUMS([]byte("# only comments\n\n"))
+		assert.Error(t, err)
+	})
+
+	t.Run("malformed digest rejected", func(t *testing.T) {
+		_, err := ParseSHA256SUMS([]byte("nothex  file.tar.xz\n"))
+		assert.Error(t, err)
+	})
+}
+
+func TestSHA256SUMS_Verify(t *testing.T) {
+	artifact := []byte("provider binary contents")
+	digest := sha256hex(artifact)
+	manifest := []byte(digest + "  os_1.2.3_linux_amd64.tar.xz\n")
+	sums, err := ParseSHA256SUMS(manifest)
+	require.NoError(t, err)
+
+	t.Run("match", func(t *testing.T) {
+		got, err := sums.VerifyBytes("os_1.2.3_linux_amd64.tar.xz", artifact)
+		require.NoError(t, err)
+		assert.Equal(t, digest, got)
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		_, err := sums.VerifyBytes("os_1.2.3_linux_amd64.tar.xz", []byte("tampered"))
+		assert.ErrorIs(t, err, ErrChecksumMismatch)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := sums.VerifyBytes("other.tar.xz", artifact)
+		assert.ErrorIs(t, err, ErrChecksumNotFound)
+	})
+}
+
+// --- minisign tests ---------------------------------------------------------
+
+func TestMinisign_Verify(t *testing.T) {
+	signer := newTestSigner(t)
+	pk, err := ParseMinisignPublicKey(signer.pubText)
+	require.NoError(t, err)
+
+	content := []byte("the sha256sums manifest body")
+
+	t.Run("prehashed (ED) valid", func(t *testing.T) {
+		sig := signer.sign(minisignAlgPrehashed, content, "timestamp:1 file:SHA256SUMS")
+		assert.NoError(t, pk.Verify(content, sig))
+	})
+
+	t.Run("pure (Ed) valid", func(t *testing.T) {
+		sig := signer.sign(minisignAlgPure, content, "timestamp:1 file:SHA256SUMS")
+		assert.NoError(t, pk.Verify(content, sig))
+	})
+
+	t.Run("tampered content rejected", func(t *testing.T) {
+		sig := signer.sign(minisignAlgPrehashed, content, "tc")
+		err := pk.Verify([]byte("different manifest"), sig)
+		assert.ErrorIs(t, err, ErrSignatureInvalid)
+	})
+
+	t.Run("swapped trusted comment rejected", func(t *testing.T) {
+		sig := signer.sign(minisignAlgPrehashed, content, "original")
+		// Tamper with the trusted comment line only; the global signature must fail.
+		tampered := swapTrustedComment(t, sig, "attacker")
+		err := pk.Verify(content, tampered)
+		assert.ErrorIs(t, err, ErrSignatureInvalid)
+	})
+
+	t.Run("wrong key rejected", func(t *testing.T) {
+		other := newTestSigner(t)
+		sig := other.sign(minisignAlgPrehashed, content, "tc")
+		err := pk.Verify(content, sig)
+		assert.ErrorIs(t, err, ErrSignatureInvalid)
+	})
+}
+
+// swapTrustedComment replaces the trusted-comment text while leaving both
+// base64 blocks intact, simulating an attacker editing the human-readable line.
+func swapTrustedComment(t *testing.T, sigFile, replacement string) string {
+	t.Helper()
+	lines := splitNonEmptyLines(sigFile)
+	require.Len(t, lines, 4)
+	lines[2] = "trusted comment: " + replacement
+	return lines[0] + "\n" + lines[1] + "\n" + lines[2] + "\n" + lines[3] + "\n"
+}
+
+// --- Verifier (combined) tests ---------------------------------------------
+
+func TestVerifier_Verify(t *testing.T) {
+	signer := newTestSigner(t)
+	artifact := []byte("os_1.2.3_linux_amd64.tar.xz bytes")
+	filename := "os_1.2.3_linux_amd64.tar.xz"
+	manifest := []byte(sha256hex(artifact) + "  " + filename + "\n")
+	sig := []byte(signer.sign(minisignAlgPrehashed, manifest, "file:SHA256SUMS"))
+
+	t.Run("auto with valid signature checks both gates", func(t *testing.T) {
+		v, err := NewVerifier(signer.pubText, SignatureAuto)
+		require.NoError(t, err)
+		res, err := v.Verify(Inputs{Filename: filename, Artifact: artifact, Manifest: manifest, Signature: sig})
+		require.NoError(t, err)
+		assert.True(t, res.SignatureChecked)
+		assert.Equal(t, sha256hex(artifact), res.SHA256)
+	})
+
+	t.Run("auto without signature proceeds on checksum", func(t *testing.T) {
+		v, err := NewVerifier(signer.pubText, SignatureAuto)
+		require.NoError(t, err)
+		res, err := v.Verify(Inputs{Filename: filename, Artifact: artifact, Manifest: manifest})
+		require.NoError(t, err)
+		assert.False(t, res.SignatureChecked)
+	})
+
+	t.Run("auto with invalid signature fails", func(t *testing.T) {
+		v, err := NewVerifier(signer.pubText, SignatureAuto)
+		require.NoError(t, err)
+		bad := []byte(newTestSigner(t).sign(minisignAlgPrehashed, manifest, "tc"))
+		_, err = v.Verify(Inputs{Filename: filename, Artifact: artifact, Manifest: manifest, Signature: bad})
+		assert.ErrorIs(t, err, ErrSignatureInvalid)
+	})
+
+	t.Run("require without signature fails closed", func(t *testing.T) {
+		v, err := NewVerifier(signer.pubText, SignatureRequire)
+		require.NoError(t, err)
+		_, err = v.Verify(Inputs{Filename: filename, Artifact: artifact, Manifest: manifest})
+		assert.Error(t, err)
+	})
+
+	t.Run("require without pinned key fails closed", func(t *testing.T) {
+		v, err := NewVerifier("", SignatureRequire)
+		require.NoError(t, err)
+		_, err = v.Verify(Inputs{Filename: filename, Artifact: artifact, Manifest: manifest, Signature: sig})
+		assert.Error(t, err)
+	})
+
+	t.Run("tampered artifact fails checksum even with valid manifest signature", func(t *testing.T) {
+		v, err := NewVerifier(signer.pubText, SignatureAuto)
+		require.NoError(t, err)
+		_, err = v.Verify(Inputs{Filename: filename, Artifact: []byte("tampered"), Manifest: manifest, Signature: sig})
+		assert.ErrorIs(t, err, ErrChecksumMismatch)
+	})
+
+	t.Run("off skips signature", func(t *testing.T) {
+		v, err := NewVerifier(signer.pubText, SignatureOff)
+		require.NoError(t, err)
+		res, err := v.Verify(Inputs{Filename: filename, Artifact: artifact, Manifest: manifest, Signature: sig})
+		require.NoError(t, err)
+		assert.False(t, res.SignatureChecked)
+	})
+
+	t.Run("VerifyPrehashed matches Verify semantics", func(t *testing.T) {
+		v, err := NewVerifier(signer.pubText, SignatureAuto)
+		require.NoError(t, err)
+
+		res, err := v.VerifyPrehashed(filename, sha256hex(artifact), manifest, sig)
+		require.NoError(t, err)
+		assert.True(t, res.SignatureChecked)
+		assert.Equal(t, sha256hex(artifact), res.SHA256)
+
+		// Wrong precomputed digest is a mismatch.
+		_, err = v.VerifyPrehashed(filename, sha256hex([]byte("other")), manifest, sig)
+		assert.ErrorIs(t, err, ErrChecksumMismatch)
+
+		// Unknown file is not found.
+		_, err = v.VerifyPrehashed("nope.tar.gz", sha256hex(artifact), manifest, sig)
+		assert.ErrorIs(t, err, ErrChecksumNotFound)
+	})
+}


### PR DESCRIPTION
## What & why

Hardens the auto-update path for super-critical fleets across Linux, macOS, and Windows. The goal: an update can never leave an agent worse off than before it started — verify before trust, commit atomically, prove the new version runs, and always keep a way back.

This is the **mql** half. A companion cnspec PR wires the config surface and `serve` integration on top of these APIs.

## Changes

**Shared verification — `utils/verify` (new)**
- `SHA256SUMS` manifest parsing + streaming checksum verification (`checksum.go`).
- minisign detached-signature verification (`minisign.go`) — Ed25519 + BLAKE2b, no external tool, air-gap friendly; verified against a build-time pinned public key (`verify.PinnedPublicKey`, empty until set via `-ldflags`).
- `Verifier` with `auto`/`require`/`off` policy; the manifest signature is verified **before** any digest in it is trusted (`verify.go`).

**Provider install — `providers`**
- Versioned install dirs (`<name>/<version>/`) + an atomic `.current` pointer; backward compatible with the legacy flat layout, which is migrated on next update (`install_layout.go`).
- Launch-based **health check**: the freshly installed plugin must complete the real go-plugin handshake before it becomes active (`healthcheck.go`).
- Retained rollback + prune-to-N; download verification wired into `installVersion` (`verify_config.go`, `registry.go`, `providers.go`).
- Pin/floor version policy so a bad "latest" cannot roll a pinned fleet (`update_policy.go`).

**Binary self-update — `cli/selfupdate`**
- Signature verification of the downloaded archive (`verify.go`).
- `selftest` health gate before a staged binary is activated.
- Crash-loop **startup guard**: a staged version that never confirms healthy is quarantined and the launcher falls back to the previous binary (`guard.go`).

## Verification

- `GOWORK=off go build ./...` — clean.
- New unit + e2e tests: checksum/minisign gates, versioned install → pointer → prune → legacy migration, pin/floor resolution, crash-loop guard transitions.
- Additive API changes only (new `InstallConf`/`UpdateProvidersConfig` fields, new `verify` package); no existing signatures changed.

## Follow-ups (not in this PR)

- Release pipeline: publish `..._SHA256SUMS.sig` (minisign) and set `verify.PinnedPublicKey` via `-ldflags`. Until then SHA256 integrity is enforced and signatures stay in `auto` (log-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C89PmqUpvqR5PUAEdZVFMz)_