### PR TITLE
🧹 oci: one deferred-detail guard instead of 24 hand-rolled copies

### DIFF
--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -6,8 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/apigateway"
@@ -110,8 +108,7 @@ type mqlOciApigatewayGatewayInternal struct {
 
 	// details fetched lazily from GetGateway (ip addresses, CA bundles,
 	// response cache) — not in the list summary.
-	detailsLock sync.Mutex
-	detailsDone atomic.Bool
+	details ociOnce
 }
 
 func (o *mqlOciApigatewayGateway) id() (string, error) {
@@ -167,58 +164,49 @@ func (o *mqlOciApigatewayGateway) certificate() (*mqlOciApigatewayCertificate, e
 // does not return: ipAddresses, caBundles, responseCacheDetails. Safe for
 // concurrent callers.
 func (o *mqlOciApigatewayGateway) fetchDetails() error {
-	if o.detailsDone.Load() {
-		return nil
-	}
-	o.detailsLock.Lock()
-	defer o.detailsLock.Unlock()
-	if o.detailsDone.Load() {
-		return nil
-	}
+	return o.details.do(func() error {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.ApiGatewayGatewayClient(o.region)
+		if err != nil {
+			return err
+		}
+		resp, err := svc.GetGateway(context.Background(), apigateway.GetGatewayRequest{
+			GatewayId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return err
+		}
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.ApiGatewayGatewayClient(o.region)
-	if err != nil {
-		return err
-	}
-	resp, err := svc.GetGateway(context.Background(), apigateway.GetGatewayRequest{
-		GatewayId: common.String(o.Id.Data),
+		ips := make([]any, 0, len(resp.IpAddresses))
+		for i := range resp.IpAddresses {
+			ips = append(ips, stringValue(resp.IpAddresses[i].IpAddress))
+		}
+		o.IpAddresses = plugin.TValue[[]any]{Data: ips, State: plugin.StateIsSet}
+
+		caBundles := make([]any, 0, len(resp.CaBundles))
+		for i := range resp.CaBundles {
+			switch cb := resp.CaBundles[i].(type) {
+			case apigateway.CertificatesCaBundle:
+				caBundles = append(caBundles, stringValue(cb.CaBundleId))
+			case apigateway.CertificatesCertificateAuthority:
+				caBundles = append(caBundles, stringValue(cb.CertificateAuthorityId))
+			}
+		}
+		o.CaBundleIds = plugin.TValue[[]any]{Data: caBundles, State: plugin.StateIsSet}
+
+		// response cache presence only — the concrete config may hold a
+		// Redis/external endpoint we don't want to expose carte-blanche.
+		hasCache := false
+		if resp.ResponseCacheDetails != nil {
+			// NoCache is modeled as a concrete type; anything else indicates
+			// a cache is configured.
+			if _, isNone := resp.ResponseCacheDetails.(apigateway.NoCache); !isNone {
+				hasCache = true
+			}
+		}
+		o.HasResponseCache = plugin.TValue[bool]{Data: hasCache, State: plugin.StateIsSet}
+		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	ips := make([]any, 0, len(resp.IpAddresses))
-	for i := range resp.IpAddresses {
-		ips = append(ips, stringValue(resp.IpAddresses[i].IpAddress))
-	}
-	o.IpAddresses = plugin.TValue[[]any]{Data: ips, State: plugin.StateIsSet}
-
-	caBundles := make([]any, 0, len(resp.CaBundles))
-	for i := range resp.CaBundles {
-		switch cb := resp.CaBundles[i].(type) {
-		case apigateway.CertificatesCaBundle:
-			caBundles = append(caBundles, stringValue(cb.CaBundleId))
-		case apigateway.CertificatesCertificateAuthority:
-			caBundles = append(caBundles, stringValue(cb.CertificateAuthorityId))
-		}
-	}
-	o.CaBundleIds = plugin.TValue[[]any]{Data: caBundles, State: plugin.StateIsSet}
-
-	// response cache presence only — the concrete config may hold a
-	// Redis/external endpoint we don't want to expose carte-blanche.
-	hasCache := false
-	if resp.ResponseCacheDetails != nil {
-		// NoCache is modeled as a concrete type; anything else indicates
-		// a cache is configured.
-		if _, isNone := resp.ResponseCacheDetails.(apigateway.NoCache); !isNone {
-			hasCache = true
-		}
-	}
-	o.HasResponseCache = plugin.TValue[bool]{Data: hasCache, State: plugin.StateIsSet}
-
-	o.detailsDone.Store(true)
-	return nil
 }
 
 func (o *mqlOciApigatewayGateway) ipAddresses() ([]any, error) {
@@ -321,10 +309,8 @@ type mqlOciApigatewayDeploymentInternal struct {
 	region         string
 	cacheGatewayId string
 
-	// specFetched + spec populate the request-policy-derived fields.
-	specLock    sync.Mutex
-	specFetched atomic.Bool
-	spec        *apigateway.ApiSpecification
+	// the deployment spec backs the request-policy-derived fields.
+	spec ociRetryLazy[*apigateway.ApiSpecification]
 }
 
 func (o *mqlOciApigatewayDeployment) id() (string, error) {
@@ -391,40 +377,32 @@ func (o *mqlOciApigatewayDeployment) gateway() (*mqlOciApigatewayGateway, error)
 // (routes, request policies, mTLS, CORS, rate limits). Subsequent callers
 // use the cached spec. The request is intentionally serialized behind a
 // mutex to avoid N concurrent GetDeployment calls on first access.
-func (o *mqlOciApigatewayDeployment) fetchSpec() error {
-	if o.specFetched.Load() {
-		return nil
-	}
-	o.specLock.Lock()
-	defer o.specLock.Unlock()
-	if o.specFetched.Load() {
-		return nil
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.ApiGatewayDeploymentClient(o.region)
-	if err != nil {
-		return err
-	}
-	resp, err := svc.GetDeployment(context.Background(), apigateway.GetDeploymentRequest{
-		DeploymentId: common.String(o.Id.Data),
+func (o *mqlOciApigatewayDeployment) getSpec() (*apigateway.ApiSpecification, error) {
+	return o.spec.get(func() (*apigateway.ApiSpecification, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.ApiGatewayDeploymentClient(o.region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetDeployment(context.Background(), apigateway.GetDeploymentRequest{
+			DeploymentId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return resp.Specification, nil
 	})
-	if err != nil {
-		return err
-	}
-	o.spec = resp.Specification
-	o.specFetched.Store(true)
-	return nil
 }
 
 func (o *mqlOciApigatewayDeployment) requestPolicies() (*apigateway.ApiSpecificationRequestPolicies, error) {
-	if err := o.fetchSpec(); err != nil {
+	spec, err := o.getSpec()
+	if err != nil {
 		return nil, err
 	}
-	if o.spec == nil {
+	if spec == nil {
 		return nil, nil
 	}
-	return o.spec.RequestPolicies, nil
+	return spec.RequestPolicies, nil
 }
 
 // flattenAuthenticationType maps the SDK's authentication-policy union type

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -5,8 +5,6 @@ package resources
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/bastion"
@@ -91,9 +89,7 @@ type mqlOciBastionInstanceInternal struct {
 	cacheTargetSubnetId string
 	region              string
 
-	lock    sync.Mutex
-	fetched atomic.Bool
-	bastion *bastion.Bastion
+	bastion ociRetryLazy[*bastion.Bastion]
 }
 
 func (o *mqlOciBastionInstance) id() (string, error) {
@@ -106,34 +102,24 @@ func (o *mqlOciBastionInstance) id() (string, error) {
 // they are only reachable through this call. Five accessors share it, and the
 // runtime resolves them concurrently, so the fetch is guarded.
 func (o *mqlOciBastionInstance) getBastionDetails() (*bastion.Bastion, error) {
-	if o.fetched.Load() {
-		return o.bastion, nil
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.bastion, nil
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	region := o.region
-	if region == "" {
-		region = ociRegionFromOCID(o.Id.Data)
-	}
-	svc, err := conn.BastionClient(region)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := svc.GetBastion(context.Background(), bastion.GetBastionRequest{
-		BastionId: common.String(o.Id.Data),
+	return o.bastion.get(func() (*bastion.Bastion, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		region := o.region
+		if region == "" {
+			region = ociRegionFromOCID(o.Id.Data)
+		}
+		svc, err := conn.BastionClient(region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetBastion(context.Background(), bastion.GetBastionRequest{
+			BastionId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.Bastion, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	o.bastion = &resp.Bastion
-	o.fetched.Store(true)
-	return o.bastion, nil
 }
 
 func (o *mqlOciBastionInstance) clientCidrBlockAllowList() ([]any, error) {

--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -157,9 +155,7 @@ func (o *mqlOciObjectStorage) getBuckets(conn *connection.OciConnection, namespa
 }
 
 type mqlOciObjectStorageBucketInternal struct {
-	lock    sync.Mutex
-	fetched atomic.Bool
-	bucket  *objectstorage.Bucket
+	bucket ociRetryLazy[*objectstorage.Bucket]
 }
 
 // ociBucketCacheKey is the bucket's cache key. It is passed explicitly as
@@ -251,64 +247,56 @@ func initOciObjectStorageBucket(runtime *plugin.Runtime, args map[string]*llx.Ra
 // accessors share it, and the runtime resolves them concurrently, so the fetch
 // is guarded rather than racing sixteen identical GetBucket calls.
 func (o *mqlOciObjectStorageBucket) getBucketDetails() (*objectstorage.Bucket, error) {
-	if o.fetched.Load() {
-		return o.bucket, nil
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.bucket, nil
-	}
+	return o.bucket.get(func() (*objectstorage.Bucket, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		region := o.GetRegion()
+		if region.Error != nil {
+			return nil, region.Error
+		}
 
-	region := o.GetRegion()
-	if region.Error != nil {
-		return nil, region.Error
-	}
+		if region.Data == nil {
+			return nil, errors.New("oci.objectStorage.bucket: region is required to fetch bucket details")
+		}
 
-	if region.Data == nil {
-		return nil, errors.New("oci.objectStorage.bucket: region is required to fetch bucket details")
-	}
+		r := region.Data
+		client, err := conn.ObjectStorageClient(r.Id.Data)
+		if err != nil {
+			return nil, err
+		}
 
-	r := region.Data
-	client, err := conn.ObjectStorageClient(r.Id.Data)
-	if err != nil {
-		return nil, err
-	}
+		namespace := o.GetNamespace()
+		if namespace.Error != nil {
+			return nil, namespace.Error
+		}
 
-	namespace := o.GetNamespace()
-	if namespace.Error != nil {
-		return nil, namespace.Error
-	}
+		name := o.GetName()
+		if name.Error != nil {
+			return nil, name.Error
+		}
 
-	name := o.GetName()
-	if name.Error != nil {
-		return nil, name.Error
-	}
+		response, err := client.GetBucket(context.Background(), objectstorage.GetBucketRequest{
+			NamespaceName: common.String(namespace.Data),
+			BucketName:    common.String(name.Data),
+			Fields: []objectstorage.GetBucketFieldsEnum{
+				objectstorage.GetBucketFieldsApproximatecount,
+				objectstorage.GetBucketFieldsApproximatesize,
+				objectstorage.GetBucketFieldsAutotiering,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
 
-	response, err := client.GetBucket(context.Background(), objectstorage.GetBucketRequest{
-		NamespaceName: common.String(namespace.Data),
-		BucketName:    common.String(name.Data),
-		Fields: []objectstorage.GetBucketFieldsEnum{
-			objectstorage.GetBucketFieldsApproximatecount,
-			objectstorage.GetBucketFieldsApproximatesize,
-			objectstorage.GetBucketFieldsAutotiering,
-		},
+		// ListBuckets returns a BucketSummary, which carries no Id at all, so
+		// the bucket OCID is only knowable from this call. Populate it here so
+		// both the collection path and the single-bucket init resolve `id`
+		// identically.
+		if response.Bucket.Id != nil {
+			o.Id = plugin.TValue[string]{Data: *response.Bucket.Id, State: plugin.StateIsSet}
+		}
+		return &response.Bucket, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	o.bucket = &response.Bucket
-	// ListBuckets returns a BucketSummary, which carries no Id at all, so the
-	// bucket OCID is only knowable from this call. Populate it here so both the
-	// collection path and the single-bucket init resolve `id` identically.
-	if o.bucket.Id != nil {
-		o.Id = plugin.TValue[string]{Data: *o.bucket.Id, State: plugin.StateIsSet}
-	}
-	o.fetched.Store(true)
-	return o.bucket, nil
 }
 
 func (o *mqlOciObjectStorageBucket) publicAccessType() (string, error) {

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -6,8 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/cloudguard"
@@ -22,16 +20,12 @@ import (
 // CloudGuard is a tenancy-level service that only operates in the home region,
 // unlike other OCI services that require per-region iteration.
 //
-// The home region and the configuration are guarded by separate mutexes: the
-// configuration fetch needs the home region to build its client, and a single
-// shared mutex would deadlock because sync.Mutex is not reentrant.
+// The home region and the configuration are two separate lazies rather than
+// one: the configuration fetch needs the home region to build its client, and
+// resolving it from inside the configuration's own fetch would deadlock.
 type mqlOciCloudGuardInternal struct {
-	configLock     sync.Mutex
-	configFetched  atomic.Bool
-	config         *cloudguard.Configuration
-	homeRegionLock sync.Mutex
-	homeRegionSet  atomic.Bool
-	homeRegion     string
+	config     ociRetryLazy[*cloudguard.Configuration]
+	homeRegion ociRetryLazy[string]
 }
 
 // ociCloudGuardProblemWindow is how far back the problem listing reaches.
@@ -57,39 +51,27 @@ func (o *mqlOciCloudGuard) id() (string, error) {
 }
 
 func (o *mqlOciCloudGuard) getHomeRegion() (string, error) {
-	if o.homeRegionSet.Load() {
-		return o.homeRegion, nil
-	}
-	o.homeRegionLock.Lock()
-	defer o.homeRegionLock.Unlock()
-	if o.homeRegionSet.Load() {
-		return o.homeRegion, nil
-	}
+	return o.homeRegion.get(func() (string, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		tenancy, err := conn.Tenant(context.Background())
+		if err != nil {
+			return "", err
+		}
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	tenancy, err := conn.Tenant(context.Background())
-	if err != nil {
-		return "", err
-	}
+		if tenancy.HomeRegionKey == nil {
+			return "", errors.New("no home region set")
+		}
 
-	if tenancy.HomeRegionKey == nil {
-		return "", errors.New("no home region set")
-	}
-
-	// HomeRegionKey returns the short region key (e.g., "IAD"), not the region name (e.g., "us-ashburn-1").
-	// The OCI SDK's SetRegion() accepts both formats.
-	o.homeRegion = *tenancy.HomeRegionKey
-	o.homeRegionSet.Store(true)
-	return o.homeRegion, nil
+		// HomeRegionKey returns the short region key (e.g., "IAD"), not the region name (e.g., "us-ashburn-1").
+		// The OCI SDK's SetRegion() accepts both formats.
+		return *tenancy.HomeRegionKey, nil
+	})
 }
 
 func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
-	if o.configFetched.Load() {
-		return o.config, nil
-	}
-
-	// Resolve the home region before taking configLock: getHomeRegion takes its
-	// own lock, and nesting it inside this critical section would deadlock.
+	// Resolve the home region before entering config's own critical section:
+	// getHomeRegion takes a lock of its own, and nesting it inside this one
+	// would deadlock. It caches, so this costs an atomic load once resolved.
 	//
 	// This is the one caller that must not use getServiceRegion. The reporting
 	// region is read *from* this configuration, so asking for it here would
@@ -99,29 +81,22 @@ func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 		return nil, err
 	}
 
-	o.configLock.Lock()
-	defer o.configLock.Unlock()
-	if o.configFetched.Load() {
-		return o.config, nil
-	}
+	return o.config.get(func() (*cloudguard.Configuration, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.CloudGuardClient(homeRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	client, err := conn.CloudGuardClient(homeRegion)
-	if err != nil {
-		return nil, err
-	}
-
-	response, err := client.GetConfiguration(context.Background(), cloudguard.GetConfigurationRequest{
-		CompartmentId: common.String(conn.TenantID()),
+		response, err := client.GetConfiguration(context.Background(), cloudguard.GetConfigurationRequest{
+			CompartmentId: common.String(conn.TenantID()),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.Configuration, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	o.config = &response.Configuration
-	o.configFetched.Store(true)
-	return o.config, nil
 }
 
 // getServiceRegion returns the region Cloud Guard actually serves data from.

--- a/providers/oci/resources/databases.go
+++ b/providers/oci/resources/databases.go
@@ -5,8 +5,6 @@ package resources
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/goldengate"
@@ -132,10 +130,9 @@ type mqlOciMysqlDbSystemInternal struct {
 	cacheCompartmentId string
 	cacheRegion        string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *mysql.DbSystem
-	detailErr     error
+	// ociLazy, not ociRetryLazy: a DB system we are not allowed to read is
+	// asked for once instead of once per field sharing the fetch.
+	detail ociLazy[*mysql.DbSystem]
 }
 
 func (o *mqlOciMysqlDbSystem) id() (string, error) {
@@ -147,38 +144,21 @@ func (o *mqlOciMysqlDbSystem) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciMysqlDbSystem) getDetail() (*mysql.DbSystem, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*mysql.DbSystem, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.MysqlDbSystemClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.MysqlDbSystemClient(o.cacheRegion)
-	if err != nil {
-		// A failed detail call is remembered as well, so a DB system we are
-		// not allowed to read is asked for once instead of once per field.
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetDbSystem(context.Background(), mysql.GetDbSystemRequest{
-		DbSystemId: common.String(o.Id.Data),
+		response, err := client.GetDbSystem(context.Background(), mysql.GetDbSystemRequest{
+			DbSystemId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.DbSystem, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.DbSystem
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciMysqlDbSystem) subnet() (*mqlOciNetworkSubnet, error) {
@@ -329,10 +309,7 @@ type mqlOciPostgresqlDbSystemInternal struct {
 	cacheCompartmentId string
 	cacheRegion        string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *psql.DbSystem
-	detailErr     error
+	detail ociLazy[*psql.DbSystem]
 }
 
 func (o *mqlOciPostgresqlDbSystem) id() (string, error) {
@@ -344,36 +321,21 @@ func (o *mqlOciPostgresqlDbSystem) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciPostgresqlDbSystem) getDetail() (*psql.DbSystem, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*psql.DbSystem, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.PostgresqlClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.PostgresqlClient(o.cacheRegion)
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetDbSystem(context.Background(), psql.GetDbSystemRequest{
-		DbSystemId: common.String(o.Id.Data),
+		response, err := client.GetDbSystem(context.Background(), psql.GetDbSystemRequest{
+			DbSystemId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.DbSystem, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.DbSystem
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciPostgresqlDbSystem) description() (string, error) {
@@ -634,10 +596,7 @@ type mqlOciOpensearchClusterInternal struct {
 	cacheCompartmentId string
 	cacheRegion        string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *opensearch.OpensearchCluster
-	detailErr     error
+	detail ociLazy[*opensearch.OpensearchCluster]
 }
 
 func (o *mqlOciOpensearchCluster) id() (string, error) {
@@ -649,36 +608,21 @@ func (o *mqlOciOpensearchCluster) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciOpensearchCluster) getDetail() (*opensearch.OpensearchCluster, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*opensearch.OpensearchCluster, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.OpensearchClusterClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.OpensearchClusterClient(o.cacheRegion)
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetOpensearchCluster(context.Background(), opensearch.GetOpensearchClusterRequest{
-		OpensearchClusterId: common.String(o.Id.Data),
+		response, err := client.GetOpensearchCluster(context.Background(), opensearch.GetOpensearchClusterRequest{
+			OpensearchClusterId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.OpensearchCluster, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.OpensearchCluster
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciOpensearchCluster) securityMasterUserName() (string, error) {
@@ -830,10 +774,7 @@ type mqlOciGoldenGateDeploymentInternal struct {
 	cacheLoadBalancerId string
 	cacheRegion         string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *goldengate.Deployment
-	detailErr     error
+	detail ociLazy[*goldengate.Deployment]
 }
 
 func (o *mqlOciGoldenGateDeployment) id() (string, error) {
@@ -863,36 +804,21 @@ func (o *mqlOciGoldenGateDeployment) loadBalancer() (*mqlOciLoadBalancerLoadBala
 }
 
 func (o *mqlOciGoldenGateDeployment) getDetail() (*goldengate.Deployment, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*goldengate.Deployment, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.GoldenGateClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.GoldenGateClient(o.cacheRegion)
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetDeployment(context.Background(), goldengate.GetDeploymentRequest{
-		DeploymentId: common.String(o.Id.Data),
+		response, err := client.GetDeployment(context.Background(), goldengate.GetDeploymentRequest{
+			DeploymentId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.Deployment, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.Deployment
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciGoldenGateDeployment) securityGroups() ([]any, error) {

--- a/providers/oci/resources/discovery_test.go
+++ b/providers/oci/resources/discovery_test.go
@@ -260,10 +260,17 @@ func TestGetDiscoveryTargetsResolvesAliases(t *testing.T) {
 	})
 
 	t.Run("explicit targets pass through", func(t *testing.T) {
+		// Set equality, for the same reason the auto case above uses it: this
+		// path also ends in stringx.DedupStringArray, whose result comes out of
+		// a map and so has no stable order. Asserting the slice order made this
+		// subtest a coin flip on two elements rather than a check of anything.
 		got := getDiscoveryTargets(conf(DiscoveryUsers, DiscoveryBuckets))
 		want := []string{DiscoveryUsers, DiscoveryBuckets}
-		if !slices.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+		gotSet := slices.Clone(got)
+		slices.Sort(gotSet)
+		slices.Sort(want)
+		if !slices.Equal(gotSet, want) {
+			t.Errorf("got %v, want the same set as %v", got, want)
 		}
 	})
 

--- a/providers/oci/resources/events.go
+++ b/providers/oci/resources/events.go
@@ -5,8 +5,6 @@ package resources
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -91,10 +89,8 @@ func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *event
 }
 
 type mqlOciEventsRuleInternal struct {
-	lock    sync.Mutex
-	fetched atomic.Bool
-	rule    *events.Rule
-	region  string
+	rule   ociRetryLazy[*events.Rule]
+	region string
 }
 
 func (o *mqlOciEventsRule) id() (string, error) {
@@ -102,37 +98,24 @@ func (o *mqlOciEventsRule) id() (string, error) {
 }
 
 // getRuleDetails lazily loads the rule detail, which carries the actions the
-// list call omits. The lock-free fast path reads an atomic.Bool rather than the
-// pointer itself: the executor resolves fields concurrently, and a plain
-// pointer read racing the locked write has no happens-before edge, so a reader
-// could observe a non-nil rule whose fields were not yet visible.
+// list call omits.
 func (o *mqlOciEventsRule) getRuleDetails() (*events.Rule, error) {
-	if o.fetched.Load() {
-		return o.rule, nil
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.rule, nil
-	}
+	return o.rule.get(func() (*events.Rule, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.EventsClient(o.region)
+		if err != nil {
+			return nil, err
+		}
 
-	client, err := conn.EventsClient(o.region)
-	if err != nil {
-		return nil, err
-	}
-
-	response, err := client.GetRule(context.Background(), events.GetRuleRequest{
-		RuleId: common.String(o.Id.Data),
+		response, err := client.GetRule(context.Background(), events.GetRuleRequest{
+			RuleId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.Rule, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	o.rule = &response.Rule
-	o.fetched.Store(true)
-	return o.rule, nil
 }
 
 func (o *mqlOciEventsRule) actions() ([]any, error) {

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -5,8 +5,6 @@ package resources
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -108,9 +106,7 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 }
 
 type mqlOciFunctionsApplicationInternal struct {
-	lock           sync.Mutex
-	fetched        atomic.Bool
-	app            *functions.Application
+	app            ociRetryLazy[*functions.Application]
 	region         string
 	cacheSubnetIds []string
 	cacheNsgIds    []string
@@ -121,32 +117,22 @@ func (o *mqlOciFunctionsApplication) id() (string, error) {
 }
 
 func (o *mqlOciFunctionsApplication) fetchApplication() (*functions.Application, error) {
-	if o.fetched.Load() {
-		return o.app, nil
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.app, nil
-	}
+	return o.app.get(func() (*functions.Application, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.FunctionsManagementClient(o.region)
+		if err != nil {
+			return nil, err
+		}
 
-	svc, err := conn.FunctionsManagementClient(o.region)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := svc.GetApplication(context.Background(), functions.GetApplicationRequest{
-		ApplicationId: common.String(o.Id.Data),
+		resp, err := svc.GetApplication(context.Background(), functions.GetApplicationRequest{
+			ApplicationId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.Application, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	o.app = &resp.Application
-	o.fetched.Store(true)
-	return o.app, nil
 }
 
 func (o *mqlOciFunctionsApplication) config() (map[string]interface{}, error) {
@@ -284,10 +270,8 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 }
 
 type mqlOciFunctionsFunctionInternal struct {
-	lock    sync.Mutex
-	fetched atomic.Bool
-	fn      *functions.Function
-	region  string
+	fn     ociRetryLazy[*functions.Function]
+	region string
 }
 
 func (o *mqlOciFunctionsFunction) id() (string, error) {
@@ -295,32 +279,22 @@ func (o *mqlOciFunctionsFunction) id() (string, error) {
 }
 
 func (o *mqlOciFunctionsFunction) fetchFunction() (*functions.Function, error) {
-	if o.fetched.Load() {
-		return o.fn, nil
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.fn, nil
-	}
+	return o.fn.get(func() (*functions.Function, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.FunctionsManagementClient(o.region)
+		if err != nil {
+			return nil, err
+		}
 
-	svc, err := conn.FunctionsManagementClient(o.region)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := svc.GetFunction(context.Background(), functions.GetFunctionRequest{
-		FunctionId: common.String(o.Id.Data),
+		resp, err := svc.GetFunction(context.Background(), functions.GetFunctionRequest{
+			FunctionId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.Function, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	o.fn = &resp.Function
-	o.fetched.Store(true)
-	return o.fn, nil
 }
 
 func (o *mqlOciFunctionsFunction) config() (map[string]interface{}, error) {

--- a/providers/oci/resources/messaging.go
+++ b/providers/oci/resources/messaging.go
@@ -6,8 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"sync"
-	"sync/atomic"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/managedkafka"
@@ -162,10 +160,7 @@ type mqlOciStreamingStreamPoolInternal struct {
 	cacheCompartmentId string
 	cacheRegion        string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *streaming.StreamPool
-	detailErr     error
+	detail ociLazy[*streaming.StreamPool]
 }
 
 // initOciStreamingStreamPool resolves a stream pool by OCID.
@@ -215,38 +210,21 @@ func (o *mqlOciStreamingStreamPool) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciStreamingStreamPool) getDetail() (*streaming.StreamPool, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*streaming.StreamPool, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.StreamAdminClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.StreamAdminClient(o.cacheRegion)
-	if err != nil {
-		// Cache the failure next to the value. Otherwise every detail-backed
-		// field on this resource re-issues the same denied or missing lookup.
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetStreamPool(context.Background(), streaming.GetStreamPoolRequest{
-		StreamPoolId: common.String(o.Id.Data),
+		response, err := client.GetStreamPool(context.Background(), streaming.GetStreamPoolRequest{
+			StreamPoolId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.StreamPool, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.StreamPool
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciStreamingStreamPool) endpointFqdn() (string, error) {
@@ -402,10 +380,7 @@ type mqlOciQueueQueueInternal struct {
 	cacheCompartmentId string
 	cacheRegion        string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *queue.Queue
-	detailErr     error
+	detail ociLazy[*queue.Queue]
 }
 
 func (o *mqlOciQueueQueue) id() (string, error) {
@@ -417,36 +392,21 @@ func (o *mqlOciQueueQueue) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciQueueQueue) getDetail() (*queue.Queue, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*queue.Queue, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.QueueAdminClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.QueueAdminClient(o.cacheRegion)
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetQueue(context.Background(), queue.GetQueueRequest{
-		QueueId: common.String(o.Id.Data),
+		response, err := client.GetQueue(context.Background(), queue.GetQueueRequest{
+			QueueId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.Queue, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.Queue
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciQueueQueue) encryptionKey() (*mqlOciKmsKey, error) {
@@ -579,10 +539,7 @@ type mqlOciKafkaClusterInternal struct {
 	cacheRegion        string
 	cacheSubnetIds     []string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *managedkafka.KafkaCluster
-	detailErr     error
+	detail ociLazy[*managedkafka.KafkaCluster]
 }
 
 func (o *mqlOciKafkaCluster) id() (string, error) {
@@ -613,36 +570,21 @@ func (o *mqlOciKafkaCluster) subnets() ([]any, error) {
 }
 
 func (o *mqlOciKafkaCluster) getDetail() (*managedkafka.KafkaCluster, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*managedkafka.KafkaCluster, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.KafkaClusterClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.KafkaClusterClient(o.cacheRegion)
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetKafkaCluster(context.Background(), managedkafka.GetKafkaClusterRequest{
-		KafkaClusterId: common.String(o.Id.Data),
+		response, err := client.GetKafkaCluster(context.Background(), managedkafka.GetKafkaClusterRequest{
+			KafkaClusterId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.KafkaCluster, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.KafkaCluster
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciKafkaCluster) bootstrapUrls() ([]any, error) {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -6,8 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -661,8 +659,7 @@ func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *cor
 type mqlOciNetworkNetworkSecurityGroupInternal struct {
 	region     string
 	cacheVcnId string
-	fetchLock  sync.Mutex
-	fetched    atomic.Bool
+	rules      ociOnce
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) id() (string, error) {
@@ -796,113 +793,105 @@ func (o *mqlOciNetworkNetworkSecurityGroup) getRulesForNSG(ctx context.Context, 
 	return rules, nil
 }
 
-func (o *mqlOciNetworkNetworkSecurityGroup) fetchSecurityRules() (ingress []any, egress []any, err error) {
-	if o.fetched.Load() {
-		return nil, nil, nil
-	}
-	o.fetchLock.Lock()
-	defer o.fetchLock.Unlock()
-	if o.fetched.Load() {
-		return nil, nil, nil
-	}
+// fetchSecurityRules populates the four rule fields from one ListNetworkSecurityGroupSecurityRules
+// call. It reports only an error: once it returns nil the fields are set, so
+// callers read them directly rather than taking a copy back out of the fetch.
+func (o *mqlOciNetworkNetworkSecurityGroup) fetchSecurityRules() error {
+	return o.rules.do(func() error {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		ctx := context.Background()
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	ctx := context.Background()
-
-	svc, err := conn.NetworkClient(o.region)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	rules, err := o.getRulesForNSG(ctx, svc, o.Id.Data)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ingressRules := []nsgSecurityRule{}
-	egressRules := []nsgSecurityRule{}
-	typedIngress := []securityRule{}
-	typedEgress := []securityRule{}
-
-	for i := range rules {
-		rule := rules[i]
-		r := nsgSecurityRule{
-			Direction:       string(rule.Direction),
-			Protocol:        stringValue(rule.Protocol),
-			Description:     stringValue(rule.Description),
-			Source:          stringValue(rule.Source),
-			SourceType:      string(rule.SourceType),
-			Destination:     stringValue(rule.Destination),
-			DestinationType: string(rule.DestinationType),
-			IsStateless:     boolValue(rule.IsStateless),
-			TcpOptions:      rule.TcpOptions,
-			UdpOptions:      rule.UdpOptions,
-			IcmpOptions:     rule.IcmpOptions,
+		svc, err := conn.NetworkClient(o.region)
+		if err != nil {
+			return err
 		}
 
-		if rule.Direction == core.SecurityRuleDirectionIngress {
-			ingressRules = append(ingressRules, r)
-			typedIngress = append(typedIngress, securityRuleFromNsg(rule))
-		} else {
-			egressRules = append(egressRules, r)
-			typedEgress = append(typedEgress, securityRuleFromNsg(rule))
+		rules, err := o.getRulesForNSG(ctx, svc, o.Id.Data)
+		if err != nil {
+			return err
 		}
-	}
 
-	ingress, err = convert.JsonToDictSlice(ingressRules)
-	if err != nil {
-		return nil, nil, err
-	}
+		ingressRules := []nsgSecurityRule{}
+		egressRules := []nsgSecurityRule{}
+		typedIngress := []securityRule{}
+		typedEgress := []securityRule{}
 
-	egress, err = convert.JsonToDictSlice(egressRules)
-	if err != nil {
-		return nil, nil, err
-	}
+		for i := range rules {
+			rule := rules[i]
+			r := nsgSecurityRule{
+				Direction:       string(rule.Direction),
+				Protocol:        stringValue(rule.Protocol),
+				Description:     stringValue(rule.Description),
+				Source:          stringValue(rule.Source),
+				SourceType:      string(rule.SourceType),
+				Destination:     stringValue(rule.Destination),
+				DestinationType: string(rule.DestinationType),
+				IsStateless:     boolValue(rule.IsStateless),
+				TcpOptions:      rule.TcpOptions,
+				UdpOptions:      rule.UdpOptions,
+				IcmpOptions:     rule.IcmpOptions,
+			}
 
-	typedIngressRes, err := newSecurityRules(o.MqlRuntime, o.Id.Data, typedIngress)
-	if err != nil {
-		return nil, nil, err
-	}
+			if rule.Direction == core.SecurityRuleDirectionIngress {
+				ingressRules = append(ingressRules, r)
+				typedIngress = append(typedIngress, securityRuleFromNsg(rule))
+			} else {
+				egressRules = append(egressRules, r)
+				typedEgress = append(typedEgress, securityRuleFromNsg(rule))
+			}
+		}
 
-	typedEgressRes, err := newSecurityRules(o.MqlRuntime, o.Id.Data, typedEgress)
-	if err != nil {
-		return nil, nil, err
-	}
+		ingress, err := convert.JsonToDictSlice(ingressRules)
+		if err != nil {
+			return err
+		}
 
-	o.IngressSecurityRules = plugin.TValue[[]any]{Data: ingress, State: plugin.StateIsSet}
-	o.EgressSecurityRules = plugin.TValue[[]any]{Data: egress, State: plugin.StateIsSet}
-	o.IngressRules = plugin.TValue[[]any]{Data: typedIngressRes, State: plugin.StateIsSet}
-	o.EgressRules = plugin.TValue[[]any]{Data: typedEgressRes, State: plugin.StateIsSet}
-	o.fetched.Store(true)
+		egress, err := convert.JsonToDictSlice(egressRules)
+		if err != nil {
+			return err
+		}
 
-	return ingress, egress, nil
+		typedIngressRes, err := newSecurityRules(o.MqlRuntime, o.Id.Data, typedIngress)
+		if err != nil {
+			return err
+		}
+
+		typedEgressRes, err := newSecurityRules(o.MqlRuntime, o.Id.Data, typedEgress)
+		if err != nil {
+			return err
+		}
+
+		o.IngressSecurityRules = plugin.TValue[[]any]{Data: ingress, State: plugin.StateIsSet}
+		o.EgressSecurityRules = plugin.TValue[[]any]{Data: egress, State: plugin.StateIsSet}
+		o.IngressRules = plugin.TValue[[]any]{Data: typedIngressRes, State: plugin.StateIsSet}
+		o.EgressRules = plugin.TValue[[]any]{Data: typedEgressRes, State: plugin.StateIsSet}
+		return nil
+	})
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) ingressRules() ([]any, error) {
-	if _, _, err := o.fetchSecurityRules(); err != nil {
+	if err := o.fetchSecurityRules(); err != nil {
 		return nil, err
 	}
 	return o.IngressRules.Data, nil
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) egressRules() ([]any, error) {
-	if _, _, err := o.fetchSecurityRules(); err != nil {
+	if err := o.fetchSecurityRules(); err != nil {
 		return nil, err
 	}
 	return o.EgressRules.Data, nil
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) ingressSecurityRules() ([]any, error) {
-	_, _, err := o.fetchSecurityRules()
-	if err != nil {
+	if err := o.fetchSecurityRules(); err != nil {
 		return nil, err
 	}
 	return o.IngressSecurityRules.Data, nil
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) egressSecurityRules() ([]any, error) {
-	_, _, err := o.fetchSecurityRules()
-	if err != nil {
+	if err := o.fetchSecurityRules(); err != nil {
 		return nil, err
 	}
 	return o.EgressSecurityRules.Data, nil
@@ -913,20 +902,13 @@ func (o *mqlOciNetworkNetworkSecurityGroup) compartment() (*mqlOciCompartment, e
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) hasStatelessRules() (bool, error) {
-	ingress, egress, err := o.fetchSecurityRules()
-	if err != nil {
+	if err := o.fetchSecurityRules(); err != nil {
 		return false, err
 	}
-	if ingress == nil {
-		ingress = o.IngressSecurityRules.Data
-	}
-	if egress == nil {
-		egress = o.EgressSecurityRules.Data
-	}
-	if anyRuleStateless(ingress, "isStateless") {
+	if anyRuleStateless(o.IngressSecurityRules.Data, "isStateless") {
 		return true, nil
 	}
-	return anyRuleStateless(egress, "isStateless"), nil
+	return anyRuleStateless(o.EgressSecurityRules.Data, "isStateless"), nil
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) attachedVnics() ([]any, error) {

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -6,8 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -197,35 +195,25 @@ func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 }
 
 type mqlOciNetworkFirewallPolicyInternal struct {
-	region    string
-	fetched   atomic.Bool
-	detail    *networkfirewall.NetworkFirewallPolicy
-	fetchLock sync.Mutex
+	region string
+	detail ociRetryLazy[*networkfirewall.NetworkFirewallPolicy]
 }
 
 func (o *mqlOciNetworkFirewallPolicy) fetchDetail() (*networkfirewall.NetworkFirewallPolicy, error) {
-	if o.fetched.Load() {
-		return o.detail, nil
-	}
-	o.fetchLock.Lock()
-	defer o.fetchLock.Unlock()
-	if o.fetched.Load() {
-		return o.detail, nil
-	}
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.NetworkFirewallClient(o.region)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := svc.GetNetworkFirewallPolicy(context.Background(), networkfirewall.GetNetworkFirewallPolicyRequest{
-		NetworkFirewallPolicyId: common.String(o.Id.Data),
+	return o.detail.get(func() (*networkfirewall.NetworkFirewallPolicy, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.NetworkFirewallClient(o.region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetNetworkFirewallPolicy(context.Background(), networkfirewall.GetNetworkFirewallPolicyRequest{
+			NetworkFirewallPolicyId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.NetworkFirewallPolicy, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	o.detail = &resp.NetworkFirewallPolicy
-	o.fetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciNetworkFirewallPolicy) description() (string, error) {

--- a/providers/oci/resources/ocilazy.go
+++ b/providers/oci/resources/ocilazy.go
@@ -1,0 +1,117 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Most OCI list APIs return a summary. The fields an audit actually wants -
+// a bastion's client CIDR allow list, a tunnel's negotiated crypto, a
+// connector's source and target - come from a per-resource Get call that the
+// listing does not make. So a handful of computed fields on the same resource
+// share one deferred fetch, and because the executor resolves fields
+// concurrently that fetch has to be guarded.
+//
+// Every one of those sites had hand-rolled the same double-checked lock. The
+// three types here are that idiom, written once.
+//
+// The guard is an atomic.Bool rather than a plain bool because the fast path
+// reads it before taking the mutex, and a plain read racing the locked write is
+// a data race. The atomic also carries the happens-before edge that makes the
+// cached value safe to read unlocked: a goroutine observing the flag as true is
+// guaranteed to see every write sequenced before it was stored.
+//
+// The types differ only in what they do with a failure, and that difference is
+// deliberate:
+//
+//   - ociLazy remembers the error. A resource the caller is not allowed to read
+//     is asked for once, not once per field sharing the fetch.
+//   - ociRetryLazy and ociOnce remember only success, so a transient failure is
+//     retried by the next accessor rather than being reported for the rest of
+//     the scan.
+//
+// Both policies were already in the provider, split across files with nothing
+// marking which was which. Picking one for every site would change results, so
+// the choice stays where it is - but it is now stated by the field's type
+// instead of being a property of whoever wrote that file.
+
+// ociOnce guards a fetch that populates the resource's fields directly rather
+// than returning a value. Only success is remembered; see the note above.
+type ociOnce struct {
+	lock sync.Mutex
+	done atomic.Bool
+}
+
+// do runs fetch at most once successfully. Concurrent callers arriving during
+// the fetch block until it finishes and then observe its result.
+func (o *ociOnce) do(fetch func() error) error {
+	if o.done.Load() {
+		return nil
+	}
+
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	if o.done.Load() {
+		return nil
+	}
+
+	if err := fetch(); err != nil {
+		return err
+	}
+	o.done.Store(true)
+	return nil
+}
+
+// ociLazy caches the value of a deferred detail fetch together with its error,
+// so a fetch that fails is not repeated by the other fields sharing it.
+type ociLazy[T any] struct {
+	lock sync.Mutex
+	done atomic.Bool
+	val  T
+	err  error
+}
+
+// get runs fetch at most once and returns its result to every caller.
+func (l *ociLazy[T]) get(fetch func() (T, error)) (T, error) {
+	if l.done.Load() {
+		return l.val, l.err
+	}
+
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	if l.done.Load() {
+		return l.val, l.err
+	}
+
+	l.val, l.err = fetch()
+	l.done.Store(true)
+	return l.val, l.err
+}
+
+// ociRetryLazy caches the value of a deferred detail fetch, remembering only
+// success, so a transient failure is retried by the next accessor.
+type ociRetryLazy[T any] struct {
+	once ociOnce
+	val  T
+}
+
+// get runs fetch until it succeeds once, then returns the cached value to every
+// later caller. A failing fetch returns the zero value alongside its error.
+func (l *ociRetryLazy[T]) get(fetch func() (T, error)) (T, error) {
+	err := l.once.do(func() error {
+		v, err := fetch()
+		if err != nil {
+			return err
+		}
+		l.val = v
+		return nil
+	})
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return l.val, nil
+}

--- a/providers/oci/resources/ocilazy_test.go
+++ b/providers/oci/resources/ocilazy_test.go
@@ -1,0 +1,212 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The executor resolves a resource's fields concurrently, so several accessors
+// sharing one deferred fetch call these helpers at the same time. Run the whole
+// file under -race: the ordering these tests exercise is exactly what the
+// hand-rolled versions got wrong.
+
+const lazyGoroutines = 64
+
+// runConcurrently calls fn from lazyGoroutines goroutines released together, so
+// they contend on the guard rather than arriving one after another.
+func runConcurrently(fn func()) {
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < lazyGoroutines; i++ {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			fn()
+		}()
+	}
+	start.Done()
+	done.Wait()
+}
+
+func TestOciOnceRunsFetchOnce(t *testing.T) {
+	var once ociOnce
+	var calls atomic.Int64
+
+	runConcurrently(func() {
+		require.NoError(t, once.do(func() error {
+			calls.Add(1)
+			return nil
+		}))
+	})
+
+	assert.Equal(t, int64(1), calls.Load(), "fetch must run exactly once across concurrent callers")
+}
+
+func TestOciOnceRetriesAfterFailure(t *testing.T) {
+	var once ociOnce
+	var calls atomic.Int64
+	wantErr := errors.New("boom")
+
+	// Only success is remembered, so a failing fetch is attempted again.
+	for i := 0; i < 3; i++ {
+		err := once.do(func() error {
+			calls.Add(1)
+			return wantErr
+		})
+		require.ErrorIs(t, err, wantErr)
+	}
+	assert.Equal(t, int64(3), calls.Load(), "a failed fetch must not be cached")
+
+	require.NoError(t, once.do(func() error {
+		calls.Add(1)
+		return nil
+	}))
+	assert.Equal(t, int64(4), calls.Load())
+
+	// ...and once it succeeds it is never run again.
+	require.NoError(t, once.do(func() error {
+		t.Error("fetch ran again after success")
+		return nil
+	}))
+}
+
+func TestOciLazyCachesValueAndError(t *testing.T) {
+	t.Run("value", func(t *testing.T) {
+		var lazy ociLazy[*string]
+		var calls atomic.Int64
+		want := "detail"
+
+		runConcurrently(func() {
+			got, err := lazy.get(func() (*string, error) {
+				calls.Add(1)
+				return &want, nil
+			})
+			require.NoError(t, err)
+			// Reading through the returned pointer is the race the atomic
+			// guard exists to prevent: without it a caller can observe the
+			// flag set before the value is visible.
+			require.NotNil(t, got)
+			assert.Equal(t, "detail", *got)
+		})
+
+		assert.Equal(t, int64(1), calls.Load())
+	})
+
+	t.Run("error is cached", func(t *testing.T) {
+		var lazy ociLazy[*string]
+		var calls atomic.Int64
+		wantErr := errors.New("not authorized")
+
+		// A resource the caller cannot read is asked for once, not once per
+		// field sharing the fetch.
+		for i := 0; i < 5; i++ {
+			got, err := lazy.get(func() (*string, error) {
+				calls.Add(1)
+				return nil, wantErr
+			})
+			require.ErrorIs(t, err, wantErr)
+			assert.Nil(t, got)
+		}
+		assert.Equal(t, int64(1), calls.Load(), "a failed fetch must be cached")
+	})
+}
+
+func TestOciRetryLazyCachesOnlySuccess(t *testing.T) {
+	t.Run("value", func(t *testing.T) {
+		var lazy ociRetryLazy[*string]
+		var calls atomic.Int64
+		want := "detail"
+
+		runConcurrently(func() {
+			got, err := lazy.get(func() (*string, error) {
+				calls.Add(1)
+				return &want, nil
+			})
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "detail", *got)
+		})
+
+		assert.Equal(t, int64(1), calls.Load())
+	})
+
+	t.Run("failure is retried then cached", func(t *testing.T) {
+		var lazy ociRetryLazy[*string]
+		var calls atomic.Int64
+		wantErr := errors.New("throttled")
+		want := "detail"
+
+		got, err := lazy.get(func() (*string, error) {
+			calls.Add(1)
+			return nil, wantErr
+		})
+		require.ErrorIs(t, err, wantErr)
+		assert.Nil(t, got, "a failed fetch reports the zero value, not a partial one")
+
+		got, err = lazy.get(func() (*string, error) {
+			calls.Add(1)
+			return &want, nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "detail", *got)
+		assert.Equal(t, int64(2), calls.Load(), "the transient failure must be retried")
+
+		got, err = lazy.get(func() (*string, error) {
+			t.Error("fetch ran again after success")
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "detail", *got)
+	})
+
+	t.Run("nil is a cached result", func(t *testing.T) {
+		// OCI answers some detail calls with an absent sub-struct, so a nil
+		// value is a legitimate success and must not be re-fetched.
+		var lazy ociRetryLazy[*string]
+		var calls atomic.Int64
+
+		for i := 0; i < 3; i++ {
+			got, err := lazy.get(func() (*string, error) {
+				calls.Add(1)
+				return nil, nil
+			})
+			require.NoError(t, err)
+			assert.Nil(t, got)
+		}
+		assert.Equal(t, int64(1), calls.Load())
+	})
+}
+
+// TestOciLazyZeroValueIsUsable pins the property the generated resource structs
+// depend on: an Internal struct is created zero-initialized and never has an
+// explicit constructor, so every guard here has to work as declared.
+func TestOciLazyZeroValueIsUsable(t *testing.T) {
+	type internal struct {
+		once  ociOnce
+		lazy  ociLazy[int]
+		retry ociRetryLazy[int]
+	}
+	var s internal
+
+	require.NoError(t, s.once.do(func() error { return nil }))
+
+	v, err := s.lazy.get(func() (int, error) { return 7, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 7, v)
+
+	v, err = s.retry.get(func() (int, error) { return 9, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 9, v)
+}

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -6,8 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -143,9 +141,7 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 }
 
 type mqlOciOkeClusterInternal struct {
-	lock       sync.Mutex
-	fetched    atomic.Bool
-	cluster    *containerengine.Cluster
+	cluster    ociRetryLazy[*containerengine.Cluster]
 	cacheVcnId string
 	region     string
 }
@@ -211,32 +207,22 @@ func (o *mqlOciOkeCluster) vcn() (*mqlOciNetworkVcn, error) {
 }
 
 func (o *mqlOciOkeCluster) fetchCluster() (*containerengine.Cluster, error) {
-	if o.fetched.Load() {
-		return o.cluster, nil
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.cluster, nil
-	}
+	return o.cluster.get(func() (*containerengine.Cluster, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.ContainerEngineClient(o.region)
+		if err != nil {
+			return nil, err
+		}
 
-	svc, err := conn.ContainerEngineClient(o.region)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := svc.GetCluster(context.Background(), containerengine.GetClusterRequest{
-		ClusterId: common.String(o.Id.Data),
+		resp, err := svc.GetCluster(context.Background(), containerengine.GetClusterRequest{
+			ClusterId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.Cluster, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	o.cluster = &resp.Cluster
-	o.fetched.Store(true)
-	return o.cluster, nil
 }
 
 func (o *mqlOciOkeCluster) kmsKey() (*mqlOciKmsKey, error) {

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 	"sort"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -82,10 +80,7 @@ type mqlOciResourceManagerStackInternal struct {
 	cacheCompartmentId string
 	cacheRegion        string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *resourcemanager.Stack
-	detailErr     error
+	detail ociLazy[*resourcemanager.Stack]
 }
 
 func (o *mqlOciResourceManagerStack) id() (string, error) {
@@ -97,38 +92,21 @@ func (o *mqlOciResourceManagerStack) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciResourceManagerStack) getDetail() (*resourcemanager.Stack, error) {
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*resourcemanager.Stack, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.ResourceManagerClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.ResourceManagerClient(o.cacheRegion)
-	if err != nil {
-		// Hold on to the error as well, so a stack that cannot be read is not
-		// requested again by every field that depends on this call.
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetStack(context.Background(), resourcemanager.GetStackRequest{
-		StackId: common.String(o.Id.Data),
+		response, err := client.GetStack(context.Background(), resourcemanager.GetStackRequest{
+			StackId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.Stack, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.Stack
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciResourceManagerStack) driftStatus() (string, error) {

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -5,8 +5,6 @@ package resources
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/sch"
@@ -81,18 +79,13 @@ func (o *mqlOciServiceConnectorHub) connectors() ([]any, error) {
 // call, so source, target and tasks share one lazy fetch rather than issuing
 // three.
 //
-// detailFetched is an atomic.Bool rather than a plain bool because getDetail
-// reads it once before taking the lock. A plain bool read outside the mutex
-// races with the write inside it - the same reason cloudguard.go uses
-// atomic.Bool for its configFetched and homeRegionSet flags.
+// ociLazy, not ociRetryLazy: the five fields sharing this fetch would each
+// repeat the same failing request if only successes were remembered.
 type mqlOciServiceConnectorHubConnectorInternal struct {
 	cacheCompartmentId string
 	cacheRegion        string
 
-	detailLock    sync.Mutex
-	detailFetched atomic.Bool
-	detail        *sch.ServiceConnector
-	detailErr     error
+	detail ociLazy[*sch.ServiceConnector]
 }
 
 func (o *mqlOciServiceConnectorHubConnector) id() (string, error) {
@@ -104,40 +97,21 @@ func (o *mqlOciServiceConnectorHubConnector) compartment() (*mqlOciCompartment, 
 }
 
 func (o *mqlOciServiceConnectorHubConnector) getDetail() (*sch.ServiceConnector, error) {
-	// Fast path: five computed fields share this fetch, so after the first one
-	// the rest should not queue on the mutex just to read a cached pointer.
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
+	return o.detail.get(func() (*sch.ServiceConnector, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		client, err := conn.ServiceConnectorClient(o.cacheRegion)
+		if err != nil {
+			return nil, err
+		}
 
-	o.detailLock.Lock()
-	defer o.detailLock.Unlock()
-	if o.detailFetched.Load() {
-		return o.detail, o.detailErr
-	}
-
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.ServiceConnectorClient(o.cacheRegion)
-	if err != nil {
-		// The error is kept too. The fields sharing this fetch would each
-		// repeat the same failing request if only successes were remembered.
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	response, err := client.GetServiceConnector(context.Background(), sch.GetServiceConnectorRequest{
-		ServiceConnectorId: common.String(o.Id.Data),
+		response, err := client.GetServiceConnector(context.Background(), sch.GetServiceConnectorRequest{
+			ServiceConnectorId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &response.ServiceConnector, nil
 	})
-	if err != nil {
-		o.detailErr = err
-		o.detailFetched.Store(true)
-		return nil, err
-	}
-
-	o.detail = &response.ServiceConnector
-	o.detailFetched.Store(true)
-	return o.detail, nil
 }
 
 func (o *mqlOciServiceConnectorHubConnector) sourceKind() (string, error) {

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"sync"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -321,8 +320,7 @@ func (o *mqlOciNetworkIpsecConnectionTunnel) id() (string, error) {
 type mqlOciNetworkIpsecConnectionTunnelInternal struct {
 	cacheIpscId string
 	cacheRegion string
-	lock        sync.Mutex
-	fetched     bool
+	details     ociOnce
 	phaseOne    *core.TunnelPhaseOneDetails
 	phaseTwo    *core.TunnelPhaseTwoDetails
 }
@@ -330,38 +328,33 @@ type mqlOciNetworkIpsecConnectionTunnelInternal struct {
 // fetchDetails lazily loads the tunnel detail, which carries the negotiated
 // phase 1/2 crypto that the list call does not populate. The result is cached
 // so the phase accessors share a single API call. A transient failure is not
-// cached (fetched is set only on success), so a later access retries rather
-// than returning the stale error forever.
+// cached, so a later access retries rather than returning the stale error
+// forever.
 func (o *mqlOciNetworkIpsecConnectionTunnel) fetchDetails() error {
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched {
+	return o.details.do(func() error {
+		if o.cacheIpscId == "" {
+			return nil
+		}
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		region := o.cacheRegion
+		if region == "" {
+			region = ociRegionFromOCID(o.Id.Data)
+		}
+		svc, err := conn.NetworkClient(region)
+		if err != nil {
+			return err
+		}
+		resp, err := svc.GetIPSecConnectionTunnel(context.Background(), core.GetIPSecConnectionTunnelRequest{
+			IpscId:   common.String(o.cacheIpscId),
+			TunnelId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return err
+		}
+		o.phaseOne = resp.PhaseOneDetails
+		o.phaseTwo = resp.PhaseTwoDetails
 		return nil
-	}
-	if o.cacheIpscId == "" {
-		o.fetched = true
-		return nil
-	}
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	region := o.cacheRegion
-	if region == "" {
-		region = ociRegionFromOCID(o.Id.Data)
-	}
-	svc, err := conn.NetworkClient(region)
-	if err != nil {
-		return err
-	}
-	resp, err := svc.GetIPSecConnectionTunnel(context.Background(), core.GetIPSecConnectionTunnelRequest{
-		IpscId:   common.String(o.cacheIpscId),
-		TunnelId: common.String(o.Id.Data),
 	})
-	if err != nil {
-		return err
-	}
-	o.phaseOne = resp.PhaseOneDetails
-	o.phaseTwo = resp.PhaseTwoDetails
-	o.fetched = true
-	return nil
 }
 
 // ociTunnelCryptoValue reports a tunnel crypto parameter, marking the field

--- a/providers/oci/resources/vulnerabilityscanning.go
+++ b/providers/oci/resources/vulnerabilityscanning.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -591,11 +589,8 @@ func initOciVulnerabilityScanningContainerScanTarget(runtime *plugin.Runtime, ar
 // ----- host agent scan results -----
 
 type mqlOciVulnerabilityScanningHostAgentScanResultInternal struct {
-	region   string
-	lock     sync.Mutex
-	fetched  atomic.Bool
-	detail   *vulnerabilityscanning.HostAgentScanResult
-	fetchErr error
+	region string
+	detail ociLazy[*vulnerabilityscanning.HostAgentScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostAgentScanResults() ([]any, error) {
@@ -684,31 +679,20 @@ func (o *mqlOciVulnerabilityScanningHostAgentScanResult) instance() (*mqlOciComp
 }
 
 func (o *mqlOciVulnerabilityScanningHostAgentScanResult) fetchDetail() (*vulnerabilityscanning.HostAgentScanResult, error) {
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.VulnerabilityScanningClient(o.region)
-	if err != nil {
-		o.fetched.Store(true)
-		o.fetchErr = err
-		return nil, err
-	}
-	resp, err := svc.GetHostAgentScanResult(context.Background(), vulnerabilityscanning.GetHostAgentScanResultRequest{
-		HostAgentScanResultId: common.String(o.Id.Data),
+	return o.detail.get(func() (*vulnerabilityscanning.HostAgentScanResult, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.VulnerabilityScanningClient(o.region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetHostAgentScanResult(context.Background(), vulnerabilityscanning.GetHostAgentScanResultRequest{
+			HostAgentScanResultId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.HostAgentScanResult, nil
 	})
-	o.fetched.Store(true)
-	if err != nil {
-		o.fetchErr = err
-		return nil, err
-	}
-	o.detail = &resp.HostAgentScanResult
-	return o.detail, nil
 }
 
 func (o *mqlOciVulnerabilityScanningHostAgentScanResult) kernelVersion() (string, error) {
@@ -795,11 +779,8 @@ func (o *mqlOciVulnerabilityScanningHostAgentScanResultProblem) vulnerability() 
 // ----- host port scan results -----
 
 type mqlOciVulnerabilityScanningHostPortScanResultInternal struct {
-	region   string
-	lock     sync.Mutex
-	fetched  atomic.Bool
-	detail   *vulnerabilityscanning.HostPortScanResult
-	fetchErr error
+	region string
+	detail ociLazy[*vulnerabilityscanning.HostPortScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostPortScanResults() ([]any, error) {
@@ -887,31 +868,20 @@ func (o *mqlOciVulnerabilityScanningHostPortScanResult) instance() (*mqlOciCompu
 }
 
 func (o *mqlOciVulnerabilityScanningHostPortScanResult) fetchDetail() (*vulnerabilityscanning.HostPortScanResult, error) {
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.VulnerabilityScanningClient(o.region)
-	if err != nil {
-		o.fetched.Store(true)
-		o.fetchErr = err
-		return nil, err
-	}
-	resp, err := svc.GetHostPortScanResult(context.Background(), vulnerabilityscanning.GetHostPortScanResultRequest{
-		HostPortScanResultId: common.String(o.Id.Data),
+	return o.detail.get(func() (*vulnerabilityscanning.HostPortScanResult, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.VulnerabilityScanningClient(o.region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetHostPortScanResult(context.Background(), vulnerabilityscanning.GetHostPortScanResultRequest{
+			HostPortScanResultId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.HostPortScanResult, nil
 	})
-	o.fetched.Store(true)
-	if err != nil {
-		o.fetchErr = err
-		return nil, err
-	}
-	o.detail = &resp.HostPortScanResult
-	return o.detail, nil
 }
 
 func (o *mqlOciVulnerabilityScanningHostPortScanResult) openPorts() ([]any, error) {
@@ -961,11 +931,8 @@ func (o *mqlOciVulnerabilityScanningHostPortScanResultOpenPort) vnic() (*mqlOciC
 // ----- host cis benchmark scan results -----
 
 type mqlOciVulnerabilityScanningHostCisBenchmarkScanResultInternal struct {
-	region   string
-	lock     sync.Mutex
-	fetched  atomic.Bool
-	detail   *vulnerabilityscanning.HostCisBenchmarkScanResult
-	fetchErr error
+	region string
+	detail ociLazy[*vulnerabilityscanning.HostCisBenchmarkScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostCisBenchmarkScanResults() ([]any, error) {
@@ -1052,31 +1019,20 @@ func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) instance() (*mql
 }
 
 func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) fetchDetail() (*vulnerabilityscanning.HostCisBenchmarkScanResult, error) {
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.VulnerabilityScanningClient(o.region)
-	if err != nil {
-		o.fetched.Store(true)
-		o.fetchErr = err
-		return nil, err
-	}
-	resp, err := svc.GetHostCisBenchmarkScanResult(context.Background(), vulnerabilityscanning.GetHostCisBenchmarkScanResultRequest{
-		HostCisBenchmarkScanResultId: common.String(o.Id.Data),
+	return o.detail.get(func() (*vulnerabilityscanning.HostCisBenchmarkScanResult, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.VulnerabilityScanningClient(o.region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetHostCisBenchmarkScanResult(context.Background(), vulnerabilityscanning.GetHostCisBenchmarkScanResultRequest{
+			HostCisBenchmarkScanResultId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.HostCisBenchmarkScanResult, nil
 	})
-	o.fetched.Store(true)
-	if err != nil {
-		o.fetchErr = err
-		return nil, err
-	}
-	o.detail = &resp.HostCisBenchmarkScanResult
-	return o.detail, nil
 }
 
 func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) scores() ([]any, error) {
@@ -1098,11 +1054,8 @@ func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) scores() ([]any,
 // ----- host endpoint protection scan results -----
 
 type mqlOciVulnerabilityScanningHostEndpointProtectionScanResultInternal struct {
-	region   string
-	lock     sync.Mutex
-	fetched  atomic.Bool
-	detail   *vulnerabilityscanning.HostEndpointProtectionScanResult
-	fetchErr error
+	region string
+	detail ociLazy[*vulnerabilityscanning.HostEndpointProtectionScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostEndpointProtectionScanResults() ([]any, error) {
@@ -1190,31 +1143,20 @@ func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) instance()
 }
 
 func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) fetchDetail() (*vulnerabilityscanning.HostEndpointProtectionScanResult, error) {
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.VulnerabilityScanningClient(o.region)
-	if err != nil {
-		o.fetched.Store(true)
-		o.fetchErr = err
-		return nil, err
-	}
-	resp, err := svc.GetHostEndpointProtectionScanResult(context.Background(), vulnerabilityscanning.GetHostEndpointProtectionScanResultRequest{
-		HostEndpointProtectionScanResultId: common.String(o.Id.Data),
+	return o.detail.get(func() (*vulnerabilityscanning.HostEndpointProtectionScanResult, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.VulnerabilityScanningClient(o.region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetHostEndpointProtectionScanResult(context.Background(), vulnerabilityscanning.GetHostEndpointProtectionScanResultRequest{
+			HostEndpointProtectionScanResultId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.HostEndpointProtectionScanResult, nil
 	})
-	o.fetched.Store(true)
-	if err != nil {
-		o.fetchErr = err
-		return nil, err
-	}
-	o.detail = &resp.HostEndpointProtectionScanResult
-	return o.detail, nil
 }
 
 func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) endpointProtections() ([]any, error) {
@@ -1246,11 +1188,8 @@ func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) endpointPr
 // ----- container scan results -----
 
 type mqlOciVulnerabilityScanningContainerScanResultInternal struct {
-	region   string
-	lock     sync.Mutex
-	fetched  atomic.Bool
-	detail   *vulnerabilityscanning.ContainerScanResult
-	fetchErr error
+	region string
+	detail ociLazy[*vulnerabilityscanning.ContainerScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) containerScanResults() ([]any, error) {
@@ -1338,31 +1277,20 @@ func (o *mqlOciVulnerabilityScanningContainerScanResult) target() (*mqlOciVulner
 }
 
 func (o *mqlOciVulnerabilityScanningContainerScanResult) fetchDetail() (*vulnerabilityscanning.ContainerScanResult, error) {
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.fetched.Load() {
-		return o.detail, o.fetchErr
-	}
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.VulnerabilityScanningClient(o.region)
-	if err != nil {
-		o.fetched.Store(true)
-		o.fetchErr = err
-		return nil, err
-	}
-	resp, err := svc.GetContainerScanResult(context.Background(), vulnerabilityscanning.GetContainerScanResultRequest{
-		ContainerScanResultId: common.String(o.Id.Data),
+	return o.detail.get(func() (*vulnerabilityscanning.ContainerScanResult, error) {
+		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
+		svc, err := conn.VulnerabilityScanningClient(o.region)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := svc.GetContainerScanResult(context.Background(), vulnerabilityscanning.GetContainerScanResultRequest{
+			ContainerScanResultId: common.String(o.Id.Data),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &resp.ContainerScanResult, nil
 	})
-	o.fetched.Store(true)
-	if err != nil {
-		o.fetchErr = err
-		return nil, err
-	}
-	o.detail = &resp.ContainerScanResult
-	return o.detail, nil
 }
 
 func (o *mqlOciVulnerabilityScanningContainerScanResult) registryUrl() (string, error) {


### PR DESCRIPTION
Continues the OCI internals sequence (#9650, #9655, #9659, #9661) with the user-facing surface frozen.

## The finding

Most OCI list APIs return a summary. The fields an audit actually wants — a bastion's client CIDR allow list, a tunnel's negotiated crypto, a connector's source and target — come from a per-resource `Get` that the listing does not make. So a handful of computed fields on the same resource share one deferred fetch, and because the executor resolves fields concurrently that fetch has to be guarded.

All **24 sites had hand-rolled the same double-checked lock**, with the slot named `fetched` / `detailFetched` / `specFetched` / `configFetched` and the value named `detail` / `spec` / `rule` / `config` depending on who wrote the file. None of it was tested.

## The change

Three types in `resources/ocilazy.go`, differing only in what they do with a failure:

| type | on failure |
|---|---|
| `ociLazy[T]` | caches the value **and the error** — a resource you cannot read is asked for once, not once per field |
| `ociRetryLazy[T]` | caches only success — a transient failure is retried by the next accessor |
| `ociOnce` | same, for a fetch that populates the resource's fields directly |

Both policies were **already in the provider**, split across files with nothing marking which was which. Converging them would change results, so each of the 27 migrated slots keeps the policy it had — the 14 error-caching ones are the exact set that carried a `detailErr`/`fetchErr` field. The difference is now stated by the field's type instead of being a property of whoever wrote that file.

Converging the two is a one-line decision now, and a good follow-up — but it changes what a scan returns after a transient failure, so it does not belong here.

## Two races fixed on the way through

- **`vpn.go` guarded its flag with a plain `bool`** — the only one of the 24. The other 23 use `atomic.Bool` precisely so the fast path can read the flag without taking the mutex.
- **The five `vulnerabilityscanning.go` sites stored the flag *before* writing `detail` and `fetchErr`.** The happens-before edge therefore pointed the wrong way: a fast-path reader could observe the flag set and then read a value that had not been published. Each of those files carried a comment explaining why the atomic was needed; none of them got the ordering right.

## Testing

`resources/ocilazy_test.go` exercises all three types under `-race` with 64 goroutines released together, plus the retry/caching policies, the nil-is-a-valid-result case, and the zero-value requirement the generated `Internal` structs depend on (they are never explicitly constructed).

I confirmed the suite has teeth rather than just passing: reproducing the old store-then-write ordering in a scratch type makes `-race` reject it, and the new helpers pass the same harness.

## Behavior preservation

- The set of SDK `Get*` calls is **byte-identical** to `main` (diffed).
- No `.lr` schema, generated code, or permissions manifest touched — 15 resource files plus the new helper and test.
- Every site keeps its existing error policy; counts cross-checked per file against the original classification.
- `go build ./...`, `go vet ./...`, `gofmt -l`, and `go test -race ./...` all clean.

The 27 migrated call sites shed 419 lines; the helper and its tests add 329 back.

## Not live-verified

No OCI tenancy has been available since #9573. This is static-only, consistent with the rest of the sequence — batched for live validation with the others.
