### PR TITLE
🧹 oci: one spelling per cache field

### DIFF
--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -89,10 +89,10 @@ func (o *mqlOciApigateway) gateways() ([]any, error) {
 					return nil, err
 				}
 				mqlGw := mqlInstance.(*mqlOciApigatewayGateway)
-				mqlGw.region = region
-				mqlGw.cacheSubnetId = stringValue(g.SubnetId)
-				mqlGw.cacheCertificateId = stringValue(g.CertificateId)
-				mqlGw.cacheNsgIds = append([]string(nil), g.NetworkSecurityGroupIds...)
+				mqlGw.cacheRegion = region
+				mqlGw.cacheSubnetID = stringValue(g.SubnetId)
+				mqlGw.cacheCertificateID = stringValue(g.CertificateId)
+				mqlGw.cacheNsgIDs = append([]string(nil), g.NetworkSecurityGroupIds...)
 				res = append(res, mqlGw)
 			}
 
@@ -101,10 +101,10 @@ func (o *mqlOciApigateway) gateways() ([]any, error) {
 }
 
 type mqlOciApigatewayGatewayInternal struct {
-	region             string
-	cacheSubnetId      string
-	cacheCertificateId string
-	cacheNsgIds        []string
+	cacheRegion        string
+	cacheSubnetID      string
+	cacheCertificateID string
+	cacheNsgIDs        []string
 
 	// details fetched lazily from GetGateway (ip addresses, CA bundles,
 	// response cache) — not in the list summary.
@@ -116,12 +116,12 @@ func (o *mqlOciApigatewayGateway) id() (string, error) {
 }
 
 func (o *mqlOciApigatewayGateway) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" {
+	if o.cacheSubnetID == "" {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSubnetId),
+		"id": llx.StringData(o.cacheSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -130,8 +130,8 @@ func (o *mqlOciApigatewayGateway) subnet() (*mqlOciNetworkSubnet, error) {
 }
 
 func (o *mqlOciApigatewayGateway) networkSecurityGroups() ([]any, error) {
-	res := make([]any, 0, len(o.cacheNsgIds))
-	for _, nsgId := range o.cacheNsgIds {
+	res := make([]any, 0, len(o.cacheNsgIDs))
+	for _, nsgId := range o.cacheNsgIDs {
 		if nsgId == "" {
 			continue
 		}
@@ -147,12 +147,12 @@ func (o *mqlOciApigatewayGateway) networkSecurityGroups() ([]any, error) {
 }
 
 func (o *mqlOciApigatewayGateway) certificate() (*mqlOciApigatewayCertificate, error) {
-	if o.cacheCertificateId == "" {
+	if o.cacheCertificateID == "" {
 		o.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.apigateway.certificate", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheCertificateId),
+		"id": llx.StringData(o.cacheCertificateID),
 	})
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func (o *mqlOciApigatewayGateway) certificate() (*mqlOciApigatewayCertificate, e
 func (o *mqlOciApigatewayGateway) fetchDetails() error {
 	return o.details.do(func() error {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.ApiGatewayGatewayClient(o.region)
+		svc, err := conn.ApiGatewayGatewayClient(o.cacheRegion)
 		if err != nil {
 			return err
 		}
@@ -296,8 +296,8 @@ func (o *mqlOciApigateway) deployments() ([]any, error) {
 					return nil, err
 				}
 				mqlDep := mqlInstance.(*mqlOciApigatewayDeployment)
-				mqlDep.region = region
-				mqlDep.cacheGatewayId = stringValue(d.GatewayId)
+				mqlDep.cacheRegion = region
+				mqlDep.cacheGatewayID = stringValue(d.GatewayId)
 				res = append(res, mqlDep)
 			}
 
@@ -306,8 +306,8 @@ func (o *mqlOciApigateway) deployments() ([]any, error) {
 }
 
 type mqlOciApigatewayDeploymentInternal struct {
-	region         string
-	cacheGatewayId string
+	cacheRegion    string
+	cacheGatewayID string
 
 	// the deployment spec backs the request-policy-derived fields.
 	spec ociRetryLazy[*apigateway.ApiSpecification]
@@ -360,12 +360,12 @@ func initOciApigatewayDeployment(runtime *plugin.Runtime, args map[string]*llx.R
 }
 
 func (o *mqlOciApigatewayDeployment) gateway() (*mqlOciApigatewayGateway, error) {
-	if o.cacheGatewayId == "" {
+	if o.cacheGatewayID == "" {
 		o.Gateway.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.apigateway.gateway", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheGatewayId),
+		"id": llx.StringData(o.cacheGatewayID),
 	})
 	if err != nil {
 		return nil, err
@@ -380,7 +380,7 @@ func (o *mqlOciApigatewayDeployment) gateway() (*mqlOciApigatewayGateway, error)
 func (o *mqlOciApigatewayDeployment) getSpec() (*apigateway.ApiSpecification, error) {
 	return o.spec.get(func() (*apigateway.ApiSpecification, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.ApiGatewayDeploymentClient(o.region)
+		svc, err := conn.ApiGatewayDeploymentClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/oci/resources/audit.go
+++ b/providers/oci/resources/audit.go
@@ -202,7 +202,7 @@ func (o *mqlOciAudit) newAuditEvents(events []audit.AuditEvent) ([]any, error) {
 			return nil, err
 		}
 		mqlEventTyped := mqlEvent.(*mqlOciAuditEvent)
-		mqlEventTyped.cacheCompartmentId = stringValue(data.CompartmentId)
+		mqlEventTyped.cacheCompartmentID = stringValue(data.CompartmentId)
 		res = append(res, mqlEventTyped)
 	}
 
@@ -210,7 +210,7 @@ func (o *mqlOciAudit) newAuditEvents(events []audit.AuditEvent) ([]any, error) {
 }
 
 type mqlOciAuditEventInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 }
 
 func (o *mqlOciAuditEvent) id() (string, error) {
@@ -218,7 +218,7 @@ func (o *mqlOciAuditEvent) id() (string, error) {
 }
 
 func (o *mqlOciAuditEvent) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciAuditEvent) principal() (*mqlOciIdentityUser, error) {

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -74,9 +74,9 @@ func (o *mqlOciBastion) bastions() ([]any, error) {
 					return nil, err
 				}
 				mqlB := mqlInstance.(*mqlOciBastionInstance)
-				mqlB.cacheTargetVcnId = stringValue(b.TargetVcnId)
-				mqlB.cacheTargetSubnetId = stringValue(b.TargetSubnetId)
-				mqlB.region = region
+				mqlB.cacheTargetVcnID = stringValue(b.TargetVcnId)
+				mqlB.cacheTargetSubnetID = stringValue(b.TargetSubnetId)
+				mqlB.cacheRegion = region
 				res = append(res, mqlB)
 			}
 
@@ -85,9 +85,9 @@ func (o *mqlOciBastion) bastions() ([]any, error) {
 }
 
 type mqlOciBastionInstanceInternal struct {
-	cacheTargetVcnId    string
-	cacheTargetSubnetId string
-	region              string
+	cacheTargetVcnID    string
+	cacheTargetSubnetID string
+	cacheRegion         string
 
 	bastion ociRetryLazy[*bastion.Bastion]
 }
@@ -104,7 +104,7 @@ func (o *mqlOciBastionInstance) id() (string, error) {
 func (o *mqlOciBastionInstance) getBastionDetails() (*bastion.Bastion, error) {
 	return o.bastion.get(func() (*bastion.Bastion, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		region := o.region
+		region := o.cacheRegion
 		if region == "" {
 			region = ociRegionFromOCID(o.Id.Data)
 		}
@@ -175,12 +175,12 @@ func (o *mqlOciBastionInstance) privateEndpointIpAddress() (string, error) {
 }
 
 func (o *mqlOciBastionInstance) targetSubnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheTargetSubnetId == "" {
+	if o.cacheTargetSubnetID == "" {
 		o.TargetSubnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlSubnet, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheTargetSubnetId),
+		"id": llx.StringData(o.cacheTargetSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -189,12 +189,12 @@ func (o *mqlOciBastionInstance) targetSubnet() (*mqlOciNetworkSubnet, error) {
 }
 
 func (o *mqlOciBastionInstance) targetVcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheTargetVcnId == "" {
+	if o.cacheTargetVcnID == "" {
 		o.TargetVcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheTargetVcnId),
+		"id": llx.StringData(o.cacheTargetVcnID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -122,7 +122,7 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 					return nil, err
 				}
 				mqlCert := mqlInstance.(*mqlOciCertificatesCertificate)
-				mqlCert.cacheIssuerCaId = stringValue(c.IssuerCertificateAuthorityId)
+				mqlCert.cacheIssuerCaID = stringValue(c.IssuerCertificateAuthorityId)
 				res = append(res, mqlCert)
 			}
 			return res, nil
@@ -130,7 +130,7 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 }
 
 type mqlOciCertificatesCertificateInternal struct {
-	cacheIssuerCaId string
+	cacheIssuerCaID string
 }
 
 func (o *mqlOciCertificatesCertificate) id() (string, error) {
@@ -169,12 +169,12 @@ func initOciCertificatesCertificate(runtime *plugin.Runtime, args map[string]*ll
 }
 
 func (o *mqlOciCertificatesCertificate) issuerCertificateAuthority() (*mqlOciCertificatesCertificateAuthority, error) {
-	if o.cacheIssuerCaId == "" || !isOcid(o.cacheIssuerCaId) {
+	if o.cacheIssuerCaID == "" || !isOcid(o.cacheIssuerCaID) {
 		o.IssuerCertificateAuthority.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.certificates.certificateAuthority", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheIssuerCaId),
+		"id": llx.StringData(o.cacheIssuerCaID),
 	})
 	if err != nil {
 		return nil, err
@@ -292,8 +292,8 @@ func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 					return nil, err
 				}
 				mqlCa := mqlInstance.(*mqlOciCertificatesCertificateAuthority)
-				mqlCa.cacheIssuerCaId = stringValue(ca.IssuerCertificateAuthorityId)
-				mqlCa.cacheKmsKeyId = stringValue(ca.KmsKeyId)
+				mqlCa.cacheIssuerCaID = stringValue(ca.IssuerCertificateAuthorityId)
+				mqlCa.cacheKmsKeyID = stringValue(ca.KmsKeyId)
 				res = append(res, mqlCa)
 			}
 			return res, nil
@@ -301,8 +301,8 @@ func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 }
 
 type mqlOciCertificatesCertificateAuthorityInternal struct {
-	cacheIssuerCaId string
-	cacheKmsKeyId   string
+	cacheIssuerCaID string
+	cacheKmsKeyID   string
 }
 
 func (o *mqlOciCertificatesCertificateAuthority) id() (string, error) {
@@ -313,12 +313,12 @@ func (o *mqlOciCertificatesCertificateAuthority) issuerCertificateAuthority() (*
 	// Root CAs report themselves as their own issuer; treat that as
 	// "no separate issuer" to keep the typed traversal useful for
 	// subordinate-only queries.
-	if o.cacheIssuerCaId == "" || o.cacheIssuerCaId == o.Id.Data || !isOcid(o.cacheIssuerCaId) {
+	if o.cacheIssuerCaID == "" || o.cacheIssuerCaID == o.Id.Data || !isOcid(o.cacheIssuerCaID) {
 		o.IssuerCertificateAuthority.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.certificates.certificateAuthority", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheIssuerCaId),
+		"id": llx.StringData(o.cacheIssuerCaID),
 	})
 	if err != nil {
 		return nil, err
@@ -327,12 +327,12 @@ func (o *mqlOciCertificatesCertificateAuthority) issuerCertificateAuthority() (*
 }
 
 func (o *mqlOciCertificatesCertificateAuthority) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" || !isOcid(o.cacheKmsKeyId) {
+	if o.cacheKmsKeyID == "" || !isOcid(o.cacheKmsKeyID) {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -286,8 +286,8 @@ func (o *mqlOciCloudGuard) problems() ([]any, error) {
 			return nil, err
 		}
 		mqlProblemTyped := mqlProblem.(*mqlOciCloudGuardProblem)
-		mqlProblemTyped.cacheCompartmentId = stringValue(problem.CompartmentId)
-		mqlProblemTyped.cacheTargetId = stringValue(problem.TargetId)
+		mqlProblemTyped.cacheCompartmentID = stringValue(problem.CompartmentId)
+		mqlProblemTyped.cacheTargetID = stringValue(problem.TargetId)
 		res = append(res, mqlProblemTyped)
 	}
 
@@ -295,8 +295,8 @@ func (o *mqlOciCloudGuard) problems() ([]any, error) {
 }
 
 type mqlOciCloudGuardProblemInternal struct {
-	cacheCompartmentId string
-	cacheTargetId      string
+	cacheCompartmentID string
+	cacheTargetID      string
 }
 
 func (o *mqlOciCloudGuardProblem) id() (string, error) {
@@ -304,11 +304,11 @@ func (o *mqlOciCloudGuardProblem) id() (string, error) {
 }
 
 func (o *mqlOciCloudGuardProblem) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciCloudGuardProblem) target() (*mqlOciCloudGuardTarget, error) {
-	if o.cacheTargetId == "" {
+	if o.cacheTargetID == "" {
 		o.Target.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -327,7 +327,7 @@ func (o *mqlOciCloudGuardProblem) target() (*mqlOciCloudGuardTarget, error) {
 
 	for _, raw := range rawTargets.Data {
 		t, ok := raw.(*mqlOciCloudGuardTarget)
-		if ok && t.Id.Data == o.cacheTargetId {
+		if ok && t.Id.Data == o.cacheTargetID {
 			return t, nil
 		}
 	}
@@ -361,7 +361,7 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 			// field, which is marked deprecated in favour of compartment().
 			// Removing that field in a later major version would otherwise
 			// quietly scope this listing to the empty string.
-			CompartmentId: common.String(o.cacheCompartmentId),
+			CompartmentId: common.String(o.cacheCompartmentID),
 			Page:          page,
 		})
 		if err != nil {
@@ -495,7 +495,7 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 			return nil, err
 		}
 		mqlRecipe := mqlInstance.(*mqlOciCloudGuardDetectorRecipe)
-		mqlRecipe.cacheCompartmentId = stringValue(recipe.CompartmentId)
+		mqlRecipe.cacheCompartmentID = stringValue(recipe.CompartmentId)
 		res = append(res, mqlRecipe)
 	}
 
@@ -503,7 +503,7 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 }
 
 type mqlOciCloudGuardDetectorRecipeInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 }
 
 func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
@@ -561,7 +561,7 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 			return nil, err
 		}
 		mqlZone := mqlInstance.(*mqlOciCloudGuardSecurityZone)
-		mqlZone.cacheRecipeId = stringValue(zone.SecurityZoneRecipeId)
+		mqlZone.cacheRecipeID = stringValue(zone.SecurityZoneRecipeId)
 		res = append(res, mqlZone)
 	}
 
@@ -619,7 +619,7 @@ func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 			return nil, err
 		}
 		mqlRecipe := mqlInstance.(*mqlOciCloudGuardSecurityZoneRecipe)
-		mqlRecipe.cachePolicyIds = recipe.SecurityPolicies
+		mqlRecipe.cachePolicyIDs = recipe.SecurityPolicies
 		res = append(res, mqlRecipe)
 	}
 
@@ -691,11 +691,11 @@ func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 }
 
 type mqlOciCloudGuardSecurityZoneInternal struct {
-	cacheRecipeId string
+	cacheRecipeID string
 }
 
 type mqlOciCloudGuardSecurityZoneRecipeInternal struct {
-	cachePolicyIds []string
+	cachePolicyIDs []string
 }
 
 func (o *mqlOciCloudGuardTarget) id() (string, error) {
@@ -711,7 +711,7 @@ func (o *mqlOciCloudGuardSecurityZone) id() (string, error) {
 }
 
 func (o *mqlOciCloudGuardSecurityZone) securityZoneRecipe() (*mqlOciCloudGuardSecurityZoneRecipe, error) {
-	if o.cacheRecipeId == "" {
+	if o.cacheRecipeID == "" {
 		o.SecurityZoneRecipe.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -729,7 +729,7 @@ func (o *mqlOciCloudGuardSecurityZone) securityZoneRecipe() (*mqlOciCloudGuardSe
 
 	for _, raw := range rawRecipes.Data {
 		r := raw.(*mqlOciCloudGuardSecurityZoneRecipe)
-		if r.Id.Data == o.cacheRecipeId {
+		if r.Id.Data == o.cacheRecipeID {
 			return r, nil
 		}
 	}
@@ -743,7 +743,7 @@ func (o *mqlOciCloudGuardSecurityZoneRecipe) id() (string, error) {
 }
 
 func (o *mqlOciCloudGuardSecurityZoneRecipe) securityPolicies() ([]any, error) {
-	if len(o.cachePolicyIds) == 0 {
+	if len(o.cachePolicyIDs) == 0 {
 		return []any{}, nil
 	}
 
@@ -764,8 +764,8 @@ func (o *mqlOciCloudGuardSecurityZoneRecipe) securityPolicies() ([]any, error) {
 		byId[p.Id.Data] = p
 	}
 
-	res := make([]any, 0, len(o.cachePolicyIds))
-	for _, id := range o.cachePolicyIds {
+	res := make([]any, 0, len(o.cachePolicyIDs))
+	for _, id := range o.cachePolicyIDs {
 		if p, ok := byId[id]; ok {
 			res = append(res, p)
 		}

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -310,7 +310,7 @@ func (o *mqlOciComputeInstance) vnics() ([]any, error) {
 }
 
 type mqlOciComputeVnicInternal struct {
-	cacheSubnetId string
+	cacheSubnetID string
 }
 
 func (o *mqlOciComputeVnic) id() (string, error) {
@@ -318,12 +318,12 @@ func (o *mqlOciComputeVnic) id() (string, error) {
 }
 
 func (o *mqlOciComputeVnic) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" {
+	if o.cacheSubnetID == "" {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlSubnet, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSubnetId),
+		"id": llx.StringData(o.cacheSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -495,7 +495,7 @@ func (o *mqlOciCompute) blockVolumes() ([]any, error) {
 					return nil, err
 				}
 				mqlBV := mqlInstance.(*mqlOciComputeBlockVolume)
-				mqlBV.cacheKmsKeyId = stringValue(vol.KmsKeyId)
+				mqlBV.cacheKmsKeyID = stringValue(vol.KmsKeyId)
 				mqlBV.cacheSourceVolumeID = sourceVolumeID
 				res = append(res, mqlBV)
 			}
@@ -525,7 +525,7 @@ func (o *mqlOciCompute) getBlockVolumesForRegion(ctx context.Context, client *co
 }
 
 type mqlOciComputeBlockVolumeInternal struct {
-	cacheKmsKeyId       string
+	cacheKmsKeyID       string
 	cacheSourceVolumeID string
 }
 
@@ -534,12 +534,12 @@ func (o *mqlOciComputeBlockVolume) id() (string, error) {
 }
 
 func (o *mqlOciComputeBlockVolume) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" {
+	if o.cacheKmsKeyID == "" {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlKey, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err
@@ -597,7 +597,7 @@ func (o *mqlOciCompute) bootVolumes() ([]any, error) {
 					return nil, err
 				}
 				mqlBV := mqlInstance.(*mqlOciComputeBootVolume)
-				mqlBV.cacheKmsKeyId = stringValue(bv.KmsKeyId)
+				mqlBV.cacheKmsKeyID = stringValue(bv.KmsKeyId)
 				mqlBV.cacheSourceBootVolumeID = sourceBootVolumeID
 				res = append(res, mqlBV)
 			}
@@ -627,7 +627,7 @@ func (o *mqlOciCompute) getBootVolumesForRegion(ctx context.Context, client *cor
 }
 
 type mqlOciComputeBootVolumeInternal struct {
-	cacheKmsKeyId           string
+	cacheKmsKeyID           string
 	cacheSourceBootVolumeID string
 }
 
@@ -636,12 +636,12 @@ func (o *mqlOciComputeBootVolume) id() (string, error) {
 }
 
 func (o *mqlOciComputeBootVolume) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" {
+	if o.cacheKmsKeyID == "" {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlKey, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -139,7 +139,7 @@ func (o *mqlOciContainerInstances) instances() ([]any, error) {
 					return nil, err
 				}
 				mqlCI := mqlInstance.(*mqlOciContainerInstancesInstance)
-				mqlCI.region = region
+				mqlCI.cacheRegion = region
 				res = append(res, mqlCI)
 			}
 
@@ -148,7 +148,7 @@ func (o *mqlOciContainerInstances) instances() ([]any, error) {
 }
 
 type mqlOciContainerInstancesInstanceInternal struct {
-	region string
+	cacheRegion string
 }
 
 func (o *mqlOciContainerInstancesInstance) id() (string, error) {
@@ -159,7 +159,7 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	ctx := context.Background()
 
-	svc, err := conn.ContainerInstanceClient(o.region)
+	svc, err := conn.ContainerInstanceClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -96,9 +96,9 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 					return nil, err
 				}
 				mqlDb := mqlInstance.(*mqlOciDatabaseDbSystem)
-				mqlDb.cacheKmsKeyId = stringValue(s.KmsKeyId)
-				mqlDb.cacheSubnetId = stringValue(s.SubnetId)
-				mqlDb.cacheSourceDbSystemId = stringValue(s.SourceDbSystemId)
+				mqlDb.cacheKmsKeyID = stringValue(s.KmsKeyId)
+				mqlDb.cacheSubnetID = stringValue(s.SubnetId)
+				mqlDb.cacheSourceDbSystemID = stringValue(s.SourceDbSystemId)
 				res = append(res, mqlDb)
 			}
 
@@ -107,9 +107,9 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 }
 
 type mqlOciDatabaseDbSystemInternal struct {
-	cacheKmsKeyId         string
-	cacheSubnetId         string
-	cacheSourceDbSystemId string
+	cacheKmsKeyID         string
+	cacheSubnetID         string
+	cacheSourceDbSystemID string
 }
 
 func (o *mqlOciDatabaseDbSystem) id() (string, error) {
@@ -117,12 +117,12 @@ func (o *mqlOciDatabaseDbSystem) id() (string, error) {
 }
 
 func (o *mqlOciDatabaseDbSystem) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" || !isOcid(o.cacheKmsKeyId) {
+	if o.cacheKmsKeyID == "" || !isOcid(o.cacheKmsKeyID) {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err
@@ -131,12 +131,12 @@ func (o *mqlOciDatabaseDbSystem) kmsKey() (*mqlOciKmsKey, error) {
 }
 
 func (o *mqlOciDatabaseDbSystem) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" || !isOcid(o.cacheSubnetId) {
+	if o.cacheSubnetID == "" || !isOcid(o.cacheSubnetID) {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSubnetId),
+		"id": llx.StringData(o.cacheSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -247,10 +247,10 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 					return nil, err
 				}
 				mqlAdb := mqlInstance.(*mqlOciDatabaseAutonomousDatabase)
-				mqlAdb.cacheKmsKeyId = stringValue(a.KmsKeyId)
-				mqlAdb.cacheVaultId = stringValue(a.VaultId)
-				mqlAdb.cacheSubnetId = stringValue(a.SubnetId)
-				mqlAdb.cacheSourceId = stringValue(a.SourceId)
+				mqlAdb.cacheKmsKeyID = stringValue(a.KmsKeyId)
+				mqlAdb.cacheVaultID = stringValue(a.VaultId)
+				mqlAdb.cacheSubnetID = stringValue(a.SubnetId)
+				mqlAdb.cacheSourceID = stringValue(a.SourceId)
 				res = append(res, mqlAdb)
 			}
 
@@ -259,10 +259,10 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 }
 
 type mqlOciDatabaseAutonomousDatabaseInternal struct {
-	cacheKmsKeyId string
-	cacheVaultId  string
-	cacheSubnetId string
-	cacheSourceId string
+	cacheKmsKeyID string
+	cacheVaultID  string
+	cacheSubnetID string
+	cacheSourceID string
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) id() (string, error) {
@@ -270,12 +270,12 @@ func (o *mqlOciDatabaseAutonomousDatabase) id() (string, error) {
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" || !isOcid(o.cacheKmsKeyId) {
+	if o.cacheKmsKeyID == "" || !isOcid(o.cacheKmsKeyID) {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err
@@ -284,12 +284,12 @@ func (o *mqlOciDatabaseAutonomousDatabase) kmsKey() (*mqlOciKmsKey, error) {
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) kmsVault() (*mqlOciKmsVault, error) {
-	if o.cacheVaultId == "" || !isOcid(o.cacheVaultId) {
+	if o.cacheVaultID == "" || !isOcid(o.cacheVaultID) {
 		o.KmsVault.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVaultId),
+		"id": llx.StringData(o.cacheVaultID),
 	})
 	if err != nil {
 		return nil, err
@@ -298,12 +298,12 @@ func (o *mqlOciDatabaseAutonomousDatabase) kmsVault() (*mqlOciKmsVault, error) {
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" || !isOcid(o.cacheSubnetId) {
+	if o.cacheSubnetID == "" || !isOcid(o.cacheSubnetID) {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSubnetId),
+		"id": llx.StringData(o.cacheSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -383,8 +383,8 @@ func (o *mqlOciDatabase) backups() ([]any, error) {
 					return nil, err
 				}
 				mqlBackup := mqlInstance.(*mqlOciDatabaseBackup)
-				mqlBackup.cacheKmsKeyId = stringValue(b.KmsKeyId)
-				mqlBackup.cacheVaultId = stringValue(b.VaultId)
+				mqlBackup.cacheKmsKeyID = stringValue(b.KmsKeyId)
+				mqlBackup.cacheVaultID = stringValue(b.VaultId)
 				res = append(res, mqlBackup)
 			}
 
@@ -393,8 +393,8 @@ func (o *mqlOciDatabase) backups() ([]any, error) {
 }
 
 type mqlOciDatabaseBackupInternal struct {
-	cacheKmsKeyId string
-	cacheVaultId  string
+	cacheKmsKeyID string
+	cacheVaultID  string
 }
 
 func (o *mqlOciDatabaseBackup) id() (string, error) {
@@ -402,12 +402,12 @@ func (o *mqlOciDatabaseBackup) id() (string, error) {
 }
 
 func (o *mqlOciDatabaseBackup) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" || !isOcid(o.cacheKmsKeyId) {
+	if o.cacheKmsKeyID == "" || !isOcid(o.cacheKmsKeyID) {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err
@@ -416,12 +416,12 @@ func (o *mqlOciDatabaseBackup) kmsKey() (*mqlOciKmsKey, error) {
 }
 
 func (o *mqlOciDatabaseBackup) kmsVault() (*mqlOciKmsVault, error) {
-	if o.cacheVaultId == "" || !isOcid(o.cacheVaultId) {
+	if o.cacheVaultID == "" || !isOcid(o.cacheVaultID) {
 		o.KmsVault.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVaultId),
+		"id": llx.StringData(o.cacheVaultID),
 	})
 	if err != nil {
 		return nil, err
@@ -501,9 +501,9 @@ func (o *mqlOciDatabase) autonomousDatabaseBackups() ([]any, error) {
 					return nil, err
 				}
 				mqlBackup := mqlInstance.(*mqlOciDatabaseAutonomousDatabaseBackup)
-				mqlBackup.cacheAutonomousDatabaseId = stringValue(b.AutonomousDatabaseId)
-				mqlBackup.cacheKmsKeyId = stringValue(b.KmsKeyId)
-				mqlBackup.cacheVaultId = stringValue(b.VaultId)
+				mqlBackup.cacheAutonomousDatabaseID = stringValue(b.AutonomousDatabaseId)
+				mqlBackup.cacheKmsKeyID = stringValue(b.KmsKeyId)
+				mqlBackup.cacheVaultID = stringValue(b.VaultId)
 				res = append(res, mqlBackup)
 			}
 
@@ -529,7 +529,7 @@ func (o *mqlOciDatabaseAutonomousDatabase) backups() ([]any, error) {
 	res := []any{}
 	for _, r := range raw.Data {
 		b := r.(*mqlOciDatabaseAutonomousDatabaseBackup)
-		if b.cacheAutonomousDatabaseId == dbID {
+		if b.cacheAutonomousDatabaseID == dbID {
 			res = append(res, b)
 		}
 	}
@@ -537,9 +537,9 @@ func (o *mqlOciDatabaseAutonomousDatabase) backups() ([]any, error) {
 }
 
 type mqlOciDatabaseAutonomousDatabaseBackupInternal struct {
-	cacheAutonomousDatabaseId string
-	cacheKmsKeyId             string
-	cacheVaultId              string
+	cacheAutonomousDatabaseID string
+	cacheKmsKeyID             string
+	cacheVaultID              string
 }
 
 func (o *mqlOciDatabaseAutonomousDatabaseBackup) id() (string, error) {
@@ -547,12 +547,12 @@ func (o *mqlOciDatabaseAutonomousDatabaseBackup) id() (string, error) {
 }
 
 func (o *mqlOciDatabaseAutonomousDatabaseBackup) autonomousDatabase() (*mqlOciDatabaseAutonomousDatabase, error) {
-	if o.cacheAutonomousDatabaseId == "" || !isOcid(o.cacheAutonomousDatabaseId) {
+	if o.cacheAutonomousDatabaseID == "" || !isOcid(o.cacheAutonomousDatabaseID) {
 		o.AutonomousDatabase.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.database.autonomousDatabase", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheAutonomousDatabaseId),
+		"id": llx.StringData(o.cacheAutonomousDatabaseID),
 	})
 	if err != nil {
 		return nil, err
@@ -561,12 +561,12 @@ func (o *mqlOciDatabaseAutonomousDatabaseBackup) autonomousDatabase() (*mqlOciDa
 }
 
 func (o *mqlOciDatabaseAutonomousDatabaseBackup) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" || !isOcid(o.cacheKmsKeyId) {
+	if o.cacheKmsKeyID == "" || !isOcid(o.cacheKmsKeyID) {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err
@@ -575,12 +575,12 @@ func (o *mqlOciDatabaseAutonomousDatabaseBackup) kmsKey() (*mqlOciKmsKey, error)
 }
 
 func (o *mqlOciDatabaseAutonomousDatabaseBackup) kmsVault() (*mqlOciKmsVault, error) {
-	if o.cacheVaultId == "" || !isOcid(o.cacheVaultId) {
+	if o.cacheVaultID == "" || !isOcid(o.cacheVaultID) {
 		o.KmsVault.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVaultId),
+		"id": llx.StringData(o.cacheVaultID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/databases.go
+++ b/providers/oci/resources/databases.go
@@ -114,7 +114,7 @@ func (o *mqlOciMysql) dbSystems() ([]any, error) {
 					return nil, err
 				}
 				mqlSystemTyped := mqlSystem.(*mqlOciMysqlDbSystem)
-				mqlSystemTyped.cacheCompartmentId = stringValue(s.CompartmentId)
+				mqlSystemTyped.cacheCompartmentID = stringValue(s.CompartmentId)
 				mqlSystemTyped.cacheRegion = region
 				res = append(res, mqlSystemTyped)
 			}
@@ -127,7 +127,7 @@ func (o *mqlOciMysql) dbSystems() ([]any, error) {
 // subnet, security groups, the data-at-rest key and the TLS certificate all
 // come from one shared detail call rather than four.
 type mqlOciMysqlDbSystemInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 
 	// ociLazy, not ociRetryLazy: a DB system we are not allowed to read is
@@ -140,7 +140,7 @@ func (o *mqlOciMysqlDbSystem) id() (string, error) {
 }
 
 func (o *mqlOciMysqlDbSystem) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciMysqlDbSystem) getDetail() (*mysql.DbSystem, error) {
@@ -293,7 +293,7 @@ func (o *mqlOciPostgresql) dbSystems() ([]any, error) {
 					return nil, err
 				}
 				mqlSystemTyped := mqlSystem.(*mqlOciPostgresqlDbSystem)
-				mqlSystemTyped.cacheCompartmentId = stringValue(s.CompartmentId)
+				mqlSystemTyped.cacheCompartmentID = stringValue(s.CompartmentId)
 				mqlSystemTyped.cacheRegion = region
 				res = append(res, mqlSystemTyped)
 			}
@@ -306,7 +306,7 @@ func (o *mqlOciPostgresql) dbSystems() ([]any, error) {
 // admin user, storage and the backup policy - everything the security posture
 // depends on - are detail-only, so they share one fetch.
 type mqlOciPostgresqlDbSystemInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 
 	detail ociLazy[*psql.DbSystem]
@@ -317,7 +317,7 @@ func (o *mqlOciPostgresqlDbSystem) id() (string, error) {
 }
 
 func (o *mqlOciPostgresqlDbSystem) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciPostgresqlDbSystem) getDetail() (*psql.DbSystem, error) {
@@ -490,7 +490,7 @@ func (o *mqlOciNosql) tables() ([]any, error) {
 					return nil, err
 				}
 				mqlTableTyped := mqlTable.(*mqlOciNosqlTable)
-				mqlTableTyped.cacheCompartmentId = stringValue(t.CompartmentId)
+				mqlTableTyped.cacheCompartmentID = stringValue(t.CompartmentId)
 				res = append(res, mqlTableTyped)
 			}
 
@@ -499,7 +499,7 @@ func (o *mqlOciNosql) tables() ([]any, error) {
 }
 
 type mqlOciNosqlTableInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 }
 
 func (o *mqlOciNosqlTable) id() (string, error) {
@@ -507,7 +507,7 @@ func (o *mqlOciNosqlTable) id() (string, error) {
 }
 
 func (o *mqlOciNosqlTable) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 // ----- Search with OpenSearch -----
@@ -580,7 +580,7 @@ func (o *mqlOciOpensearch) clusters() ([]any, error) {
 					return nil, err
 				}
 				mqlClusterTyped := mqlCluster.(*mqlOciOpensearchCluster)
-				mqlClusterTyped.cacheCompartmentId = stringValue(c.CompartmentId)
+				mqlClusterTyped.cacheCompartmentID = stringValue(c.CompartmentId)
 				mqlClusterTyped.cacheRegion = region
 				res = append(res, mqlClusterTyped)
 			}
@@ -593,7 +593,7 @@ func (o *mqlOciOpensearch) clusters() ([]any, error) {
 // or what it answers on, so the network placement and endpoints share a detail
 // call. securityMasterUserPasswordHash is deliberately not exposed.
 type mqlOciOpensearchClusterInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 
 	detail ociLazy[*opensearch.OpensearchCluster]
@@ -604,7 +604,7 @@ func (o *mqlOciOpensearchCluster) id() (string, error) {
 }
 
 func (o *mqlOciOpensearchCluster) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciOpensearchCluster) getDetail() (*opensearch.OpensearchCluster, error) {
@@ -755,9 +755,9 @@ func (o *mqlOciGoldenGate) deployments() ([]any, error) {
 					return nil, err
 				}
 				mqlDeploymentTyped := mqlDeployment.(*mqlOciGoldenGateDeployment)
-				mqlDeploymentTyped.cacheCompartmentId = stringValue(d.CompartmentId)
-				mqlDeploymentTyped.cacheSubnetId = stringValue(d.SubnetId)
-				mqlDeploymentTyped.cacheLoadBalancerId = stringValue(d.LoadBalancerId)
+				mqlDeploymentTyped.cacheCompartmentID = stringValue(d.CompartmentId)
+				mqlDeploymentTyped.cacheSubnetID = stringValue(d.SubnetId)
+				mqlDeploymentTyped.cacheLoadBalancerID = stringValue(d.LoadBalancerId)
 				mqlDeploymentTyped.cacheRegion = region
 				res = append(res, mqlDeploymentTyped)
 			}
@@ -769,9 +769,9 @@ func (o *mqlOciGoldenGate) deployments() ([]any, error) {
 // The deployment listing carries the subnet but not the network security
 // groups, so only securityGroups needs the detail call.
 type mqlOciGoldenGateDeploymentInternal struct {
-	cacheCompartmentId  string
-	cacheSubnetId       string
-	cacheLoadBalancerId string
+	cacheCompartmentID  string
+	cacheSubnetID       string
+	cacheLoadBalancerID string
 	cacheRegion         string
 
 	detail ociLazy[*goldengate.Deployment]
@@ -782,20 +782,20 @@ func (o *mqlOciGoldenGateDeployment) id() (string, error) {
 }
 
 func (o *mqlOciGoldenGateDeployment) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciGoldenGateDeployment) subnet() (*mqlOciNetworkSubnet, error) {
-	return resolveOciSubnet(o.MqlRuntime, o.cacheSubnetId, &o.Subnet)
+	return resolveOciSubnet(o.MqlRuntime, o.cacheSubnetID, &o.Subnet)
 }
 
 func (o *mqlOciGoldenGateDeployment) loadBalancer() (*mqlOciLoadBalancerLoadBalancer, error) {
-	if o.cacheLoadBalancerId == "" {
+	if o.cacheLoadBalancerID == "" {
 		o.LoadBalancer.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.loadBalancer.loadBalancer", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheLoadBalancerId),
+		"id": llx.StringData(o.cacheLoadBalancerID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/discovery.go
+++ b/providers/oci/resources/discovery.go
@@ -201,7 +201,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: d.Id.Data, name: d.Name.Data,
-				compartment: d.CompartmentID.Data, region: d.region,
+				compartment: d.CompartmentID.Data, region: d.cacheRegion,
 				labels: tagsToLabels(d.FreeformTags.Data),
 			}, true
 		},
@@ -273,7 +273,7 @@ var ociDiscoveryTargets = []ociDiscoveryTarget{
 			}
 			return ociDiscovered{
 				id: c.Id.Data, name: c.Name.Data,
-				compartment: c.CompartmentID.Data, region: c.region,
+				compartment: c.CompartmentID.Data, region: c.cacheRegion,
 				labels: tagsToLabels(c.FreeformTags.Data),
 			}, true
 		},

--- a/providers/oci/resources/dns.go
+++ b/providers/oci/resources/dns.go
@@ -110,7 +110,7 @@ func (o *mqlOciDns) newZones(region string, zones []dns.ZoneSummary) ([]any, err
 			return nil, err
 		}
 		mqlZoneTyped := mqlZone.(*mqlOciDnsZone)
-		mqlZoneTyped.cacheCompartmentId = stringValue(zone.CompartmentId)
+		mqlZoneTyped.cacheCompartmentID = stringValue(zone.CompartmentId)
 		mqlZoneTyped.cacheRegion = region
 		mqlZoneTyped.cacheScope = zone.Scope
 		res = append(res, mqlZoneTyped)
@@ -173,7 +173,7 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 					return nil, err
 				}
 				mqlPolicyTyped := mqlPolicy.(*mqlOciDnsSteeringPolicy)
-				mqlPolicyTyped.cacheCompartmentId = stringValue(policy.CompartmentId)
+				mqlPolicyTyped.cacheCompartmentID = stringValue(policy.CompartmentId)
 				res = append(res, mqlPolicyTyped)
 			}
 
@@ -186,7 +186,7 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 }
 
 type mqlOciDnsZoneInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 	cacheScope         dns.ScopeEnum
 }
@@ -196,7 +196,7 @@ func (o *mqlOciDnsZone) id() (string, error) {
 }
 
 func (o *mqlOciDnsZone) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 // records fetches the zone's resource records on demand.
@@ -261,7 +261,7 @@ func (o *mqlOciDnsZone) records() ([]any, error) {
 }
 
 type mqlOciDnsSteeringPolicyInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 }
 
 func (o *mqlOciDnsSteeringPolicy) id() (string, error) {
@@ -269,5 +269,5 @@ func (o *mqlOciDnsSteeringPolicy) id() (string, error) {
 }
 
 func (o *mqlOciDnsSteeringPolicy) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }

--- a/providers/oci/resources/events.go
+++ b/providers/oci/resources/events.go
@@ -59,7 +59,7 @@ func (o *mqlOciEvents) rules() ([]any, error) {
 				}
 
 				mqlRule := mqlInstance.(*mqlOciEventsRule)
-				mqlRule.region = region
+				mqlRule.cacheRegion = region
 
 				res = append(res, mqlInstance)
 			}
@@ -89,8 +89,8 @@ func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *event
 }
 
 type mqlOciEventsRuleInternal struct {
-	rule   ociRetryLazy[*events.Rule]
-	region string
+	rule        ociRetryLazy[*events.Rule]
+	cacheRegion string
 }
 
 func (o *mqlOciEventsRule) id() (string, error) {
@@ -103,7 +103,7 @@ func (o *mqlOciEventsRule) getRuleDetails() (*events.Rule, error) {
 	return o.rule.get(func() (*events.Rule, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-		client, err := conn.EventsClient(o.region)
+		client, err := conn.EventsClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -85,8 +85,8 @@ func (o *mqlOciFileStorage) fileSystems() ([]any, error) {
 						return nil, err
 					}
 					mqlFs := mqlInstance.(*mqlOciFileStorageFileSystem)
-					mqlFs.cacheKmsKeyId = stringValue(fs.KmsKeyId)
-					mqlFs.cacheParentFileSystemId = parentFileSystemId
+					mqlFs.cacheKmsKeyID = stringValue(fs.KmsKeyId)
+					mqlFs.cacheParentFileSystemID = parentFileSystemId
 					res = append(res, mqlFs)
 				}
 			}
@@ -117,8 +117,8 @@ func (o *mqlOciFileStorage) getFileSystemsForAD(ctx context.Context, fsClient *f
 }
 
 type mqlOciFileStorageFileSystemInternal struct {
-	cacheKmsKeyId           string
-	cacheParentFileSystemId string
+	cacheKmsKeyID           string
+	cacheParentFileSystemID string
 }
 
 func (o *mqlOciFileStorageFileSystem) id() (string, error) {
@@ -126,12 +126,12 @@ func (o *mqlOciFileStorageFileSystem) id() (string, error) {
 }
 
 func (o *mqlOciFileStorageFileSystem) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" || !isOcid(o.cacheKmsKeyId) {
+	if o.cacheKmsKeyID == "" || !isOcid(o.cacheKmsKeyID) {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlKey, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKmsKeyId),
+		"id": llx.StringData(o.cacheKmsKeyID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -95,9 +95,9 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 					return nil, err
 				}
 				mqlApp := mqlInstance.(*mqlOciFunctionsApplication)
-				mqlApp.region = region
-				mqlApp.cacheSubnetIds = app.SubnetIds
-				mqlApp.cacheNsgIds = app.NetworkSecurityGroupIds
+				mqlApp.cacheRegion = region
+				mqlApp.cacheSubnetIDs = app.SubnetIds
+				mqlApp.cacheNsgIDs = app.NetworkSecurityGroupIds
 				res = append(res, mqlApp)
 			}
 
@@ -107,9 +107,9 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 
 type mqlOciFunctionsApplicationInternal struct {
 	app            ociRetryLazy[*functions.Application]
-	region         string
-	cacheSubnetIds []string
-	cacheNsgIds    []string
+	cacheRegion    string
+	cacheSubnetIDs []string
+	cacheNsgIDs    []string
 }
 
 func (o *mqlOciFunctionsApplication) id() (string, error) {
@@ -120,7 +120,7 @@ func (o *mqlOciFunctionsApplication) fetchApplication() (*functions.Application,
 	return o.app.get(func() (*functions.Application, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-		svc, err := conn.FunctionsManagementClient(o.region)
+		svc, err := conn.FunctionsManagementClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -157,8 +157,8 @@ func (o *mqlOciFunctionsApplication) syslogUrl() (string, error) {
 }
 
 func (o *mqlOciFunctionsApplication) subnets() ([]any, error) {
-	res := make([]any, 0, len(o.cacheSubnetIds))
-	for _, id := range o.cacheSubnetIds {
+	res := make([]any, 0, len(o.cacheSubnetIDs))
+	for _, id := range o.cacheSubnetIDs {
 		mqlSubnet, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})
@@ -174,8 +174,8 @@ func (o *mqlOciFunctionsApplication) subnets() ([]any, error) {
 }
 
 func (o *mqlOciFunctionsApplication) networkSecurityGroups() ([]any, error) {
-	res := make([]any, 0, len(o.cacheNsgIds))
-	for _, id := range o.cacheNsgIds {
+	res := make([]any, 0, len(o.cacheNsgIDs))
+	for _, id := range o.cacheNsgIDs {
 		mqlNsg, err := NewResource(o.MqlRuntime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})
@@ -194,7 +194,7 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	ctx := context.Background()
 
-	svc, err := conn.FunctionsManagementClient(o.region)
+	svc, err := conn.FunctionsManagementClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 			return nil, err
 		}
 		mqlFn := mqlInstance.(*mqlOciFunctionsFunction)
-		mqlFn.region = o.region
+		mqlFn.cacheRegion = o.cacheRegion
 		res = append(res, mqlFn)
 	}
 
@@ -270,8 +270,8 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 }
 
 type mqlOciFunctionsFunctionInternal struct {
-	fn     ociRetryLazy[*functions.Function]
-	region string
+	fn          ociRetryLazy[*functions.Function]
+	cacheRegion string
 }
 
 func (o *mqlOciFunctionsFunction) id() (string, error) {
@@ -282,7 +282,7 @@ func (o *mqlOciFunctionsFunction) fetchFunction() (*functions.Function, error) {
 	return o.fn.get(func() (*functions.Function, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-		svc, err := conn.FunctionsManagementClient(o.region)
+		svc, err := conn.FunctionsManagementClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -195,7 +195,7 @@ func (o *mqlOciAiAgents) agentEndpoints() ([]any, error) {
 					return nil, err
 				}
 				mqlEndpointTyped := mqlEndpoint.(*mqlOciAiAgentsEndpoint)
-				mqlEndpointTyped.cacheAgentId = stringValue(e.AgentId)
+				mqlEndpointTyped.cacheAgentID = stringValue(e.AgentId)
 				res = append(res, mqlEndpointTyped)
 			}
 			return res, nil
@@ -203,7 +203,7 @@ func (o *mqlOciAiAgents) agentEndpoints() ([]any, error) {
 }
 
 type mqlOciAiAgentsEndpointInternal struct {
-	cacheAgentId string
+	cacheAgentID string
 }
 
 func initOciAiAgentsEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -240,7 +240,7 @@ func (o *mqlOciAiAgentsEndpoint) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciAiAgentsEndpoint) agent() (*mqlOciAiAgentsAgent, error) {
-	return resolveOciAiAgent(o.MqlRuntime, o.cacheAgentId, &o.Agent)
+	return resolveOciAiAgent(o.MqlRuntime, o.cacheAgentID, &o.Agent)
 }
 
 // ----- knowledge bases -----
@@ -380,7 +380,7 @@ func (o *mqlOciAiAgents) dataSources() ([]any, error) {
 					return nil, err
 				}
 				mqlDsTyped := mqlDs.(*mqlOciAiAgentsDataSource)
-				mqlDsTyped.cacheKnowledgeBaseId = stringValue(ds.KnowledgeBaseId)
+				mqlDsTyped.cacheKnowledgeBaseID = stringValue(ds.KnowledgeBaseId)
 				res = append(res, mqlDsTyped)
 			}
 			return res, nil
@@ -388,7 +388,7 @@ func (o *mqlOciAiAgents) dataSources() ([]any, error) {
 }
 
 type mqlOciAiAgentsDataSourceInternal struct {
-	cacheKnowledgeBaseId string
+	cacheKnowledgeBaseID string
 }
 
 func initOciAiAgentsDataSource(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -425,12 +425,12 @@ func (o *mqlOciAiAgentsDataSource) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciAiAgentsDataSource) knowledgeBase() (*mqlOciAiAgentsKnowledgeBase, error) {
-	if o.cacheKnowledgeBaseId == "" {
+	if o.cacheKnowledgeBaseID == "" {
 		o.KnowledgeBase.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.ai.agents.knowledgeBase", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKnowledgeBaseId),
+		"id": llx.StringData(o.cacheKnowledgeBaseID),
 	})
 	if err != nil {
 		return nil, err
@@ -495,7 +495,7 @@ func (o *mqlOciAiAgents) tools() ([]any, error) {
 					return nil, err
 				}
 				mqlToolTyped := mqlTool.(*mqlOciAiAgentsTool)
-				mqlToolTyped.cacheAgentId = stringValue(t.AgentId)
+				mqlToolTyped.cacheAgentID = stringValue(t.AgentId)
 				res = append(res, mqlToolTyped)
 			}
 			return res, nil
@@ -503,7 +503,7 @@ func (o *mqlOciAiAgents) tools() ([]any, error) {
 }
 
 type mqlOciAiAgentsToolInternal struct {
-	cacheAgentId string
+	cacheAgentID string
 }
 
 func initOciAiAgentsTool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -540,7 +540,7 @@ func (o *mqlOciAiAgentsTool) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciAiAgentsTool) agent() (*mqlOciAiAgentsAgent, error) {
-	return resolveOciAiAgent(o.MqlRuntime, o.cacheAgentId, &o.Agent)
+	return resolveOciAiAgent(o.MqlRuntime, o.cacheAgentID, &o.Agent)
 }
 
 // ----- helpers -----

--- a/providers/oci/resources/identitydomains.go
+++ b/providers/oci/resources/identitydomains.go
@@ -173,8 +173,8 @@ func (o *mqlOciIdentity) domains() ([]any, error) {
 			return nil, err
 		}
 		mqlDomainTyped := mqlDomain.(*mqlOciIdentityDomain)
-		mqlDomainTyped.cacheCompartmentId = stringValue(d.CompartmentId)
-		mqlDomainTyped.cacheUrl = stringValue(d.Url)
+		mqlDomainTyped.cacheCompartmentID = stringValue(d.CompartmentId)
+		mqlDomainTyped.cacheURL = stringValue(d.Url)
 		res = append(res, mqlDomainTyped)
 	}
 
@@ -182,10 +182,10 @@ func (o *mqlOciIdentity) domains() ([]any, error) {
 }
 
 type mqlOciIdentityDomainInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	// The domain's own SCIM endpoint. Every sub-collection is served from
 	// here rather than from a regional endpoint.
-	cacheUrl string
+	cacheURL string
 
 	// Every sub-collection accessor needs a client for this domain, so it is
 	// built once rather than per accessor.
@@ -203,7 +203,7 @@ func (o *mqlOciIdentityDomain) id() (string, error) {
 }
 
 func (o *mqlOciIdentityDomain) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciIdentityDomain) domainClient() (*identitydomains.IdentityDomainsClient, error) {
@@ -219,11 +219,11 @@ func (o *mqlOciIdentityDomain) domainClient() (*identitydomains.IdentityDomainsC
 		return client, nil
 	}
 
-	if o.cacheUrl == "" {
+	if o.cacheURL == "" {
 		return nil, errors.New("identity domain has no endpoint url: " + o.Id.Data)
 	}
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	client, err := conn.IdentityDomainsClient(o.cacheUrl)
+	client, err := conn.IdentityDomainsClient(o.cacheURL)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -64,7 +64,7 @@ func (o *mqlOciKms) vaults() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
-				mqlInstance.(*mqlOciKmsVault).region = region
+				mqlInstance.(*mqlOciKmsVault).cacheRegion = region
 				res = append(res, mqlInstance)
 			}
 
@@ -93,7 +93,7 @@ func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagemen
 }
 
 type mqlOciKmsVaultInternal struct {
-	region string
+	cacheRegion string
 }
 
 func initOciKmsVault(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -207,28 +207,28 @@ func (o *mqlOciLoadBalancerLoadBalancer) listeners() ([]any, error) {
 			return nil, err
 		}
 		mqlListener := mqlInstance.(*mqlOciLoadBalancerListener)
-		mqlListener.cacheCertificateIds = certificateIds
-		mqlListener.cacheTrustedCaIds = trustedCaIds
+		mqlListener.cacheCertificateIDs = certificateIds
+		mqlListener.cacheTrustedCaIDs = trustedCaIds
 		res = append(res, mqlInstance)
 	}
 	return res, nil
 }
 
 type mqlOciLoadBalancerListenerInternal struct {
-	cacheCertificateIds []any
-	cacheTrustedCaIds   []any
+	cacheCertificateIDs []any
+	cacheTrustedCaIDs   []any
 }
 
 func (o *mqlOciLoadBalancerListener) certificates() ([]any, error) {
-	return resolveOciCertificates(o.MqlRuntime, o.cacheCertificateIds)
+	return resolveOciCertificates(o.MqlRuntime, o.cacheCertificateIDs)
 }
 
 func (o *mqlOciLoadBalancerListener) trustedCertificateAuthorities() ([]any, error) {
-	return resolveOciCertRefsByType(o.MqlRuntime, o.cacheTrustedCaIds, "certificateauthority", "oci.certificates.certificateAuthority")
+	return resolveOciCertRefsByType(o.MqlRuntime, o.cacheTrustedCaIDs, "certificateauthority", "oci.certificates.certificateAuthority")
 }
 
 func (o *mqlOciLoadBalancerListener) trustedCaBundles() ([]any, error) {
-	return resolveOciCertRefsByType(o.MqlRuntime, o.cacheTrustedCaIds, "cabundle", "oci.certificates.caBundle")
+	return resolveOciCertRefsByType(o.MqlRuntime, o.cacheTrustedCaIDs, "cabundle", "oci.certificates.caBundle")
 }
 
 func (o *mqlOciLoadBalancerLoadBalancer) backendSets() ([]any, error) {

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -61,7 +61,7 @@ func (o *mqlOciLogging) logGroups() ([]any, error) {
 					return nil, err
 				}
 				// Store the region internally so logs() knows which region to query
-				mqlInstance.(*mqlOciLoggingLogGroup).region = region
+				mqlInstance.(*mqlOciLoggingLogGroup).cacheRegion = region
 				res = append(res, mqlInstance)
 			}
 
@@ -91,7 +91,7 @@ func (o *mqlOciLogging) getLogGroupsForRegion(ctx context.Context, client *loggi
 }
 
 type mqlOciLoggingLogGroupInternal struct {
-	region string
+	cacheRegion string
 }
 
 func initOciLoggingLogGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -135,7 +135,7 @@ func (o *mqlOciLoggingLogGroup) logs() ([]any, error) {
 
 	logGroupId := o.Id.Data
 
-	svc, err := conn.LoggingClient(o.region)
+	svc, err := conn.LoggingClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (o *mqlOciLoggingLogGroup) logs() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		mqlInstance.(*mqlOciLoggingLog).cacheLogGroupId = stringValue(l.LogGroupId)
+		mqlInstance.(*mqlOciLoggingLog).cacheLogGroupID = stringValue(l.LogGroupId)
 		res = append(res, mqlInstance)
 	}
 
@@ -210,7 +210,7 @@ func (o *mqlOciLoggingLogGroup) getLogsForGroup(ctx context.Context, client *log
 }
 
 type mqlOciLoggingLogInternal struct {
-	cacheLogGroupId string
+	cacheLogGroupID string
 }
 
 func (o *mqlOciLoggingLog) id() (string, error) {
@@ -218,12 +218,12 @@ func (o *mqlOciLoggingLog) id() (string, error) {
 }
 
 func (o *mqlOciLoggingLog) logGroup() (*mqlOciLoggingLogGroup, error) {
-	if o.cacheLogGroupId == "" {
+	if o.cacheLogGroupID == "" {
 		o.LogGroup.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlLg, err := NewResource(o.MqlRuntime, "oci.logging.logGroup", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheLogGroupId),
+		"id": llx.StringData(o.cacheLogGroupID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/messaging.go
+++ b/providers/oci/resources/messaging.go
@@ -66,8 +66,8 @@ func (o *mqlOciStreaming) streams() ([]any, error) {
 					return nil, err
 				}
 				mqlStreamTyped := mqlStream.(*mqlOciStreamingStream)
-				mqlStreamTyped.cacheCompartmentId = stringValue(s.CompartmentId)
-				mqlStreamTyped.cacheStreamPoolId = stringValue(s.StreamPoolId)
+				mqlStreamTyped.cacheCompartmentID = stringValue(s.CompartmentId)
+				mqlStreamTyped.cacheStreamPoolID = stringValue(s.StreamPoolId)
 				res = append(res, mqlStreamTyped)
 			}
 
@@ -117,7 +117,7 @@ func (o *mqlOciStreaming) streamPools() ([]any, error) {
 					return nil, err
 				}
 				mqlPoolTyped := mqlPool.(*mqlOciStreamingStreamPool)
-				mqlPoolTyped.cacheCompartmentId = stringValue(p.CompartmentId)
+				mqlPoolTyped.cacheCompartmentID = stringValue(p.CompartmentId)
 				mqlPoolTyped.cacheRegion = region
 				res = append(res, mqlPoolTyped)
 			}
@@ -127,8 +127,8 @@ func (o *mqlOciStreaming) streamPools() ([]any, error) {
 }
 
 type mqlOciStreamingStreamInternal struct {
-	cacheCompartmentId string
-	cacheStreamPoolId  string
+	cacheCompartmentID string
+	cacheStreamPoolID  string
 }
 
 func (o *mqlOciStreamingStream) id() (string, error) {
@@ -136,16 +136,16 @@ func (o *mqlOciStreamingStream) id() (string, error) {
 }
 
 func (o *mqlOciStreamingStream) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciStreamingStream) streamPool() (*mqlOciStreamingStreamPool, error) {
-	if o.cacheStreamPoolId == "" {
+	if o.cacheStreamPoolID == "" {
 		o.StreamPool.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.streaming.streamPool", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheStreamPoolId),
+		"id": llx.StringData(o.cacheStreamPoolID),
 	})
 	if err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func (o *mqlOciStreamingStream) streamPool() (*mqlOciStreamingStreamPool, error)
 // private-endpoint placement and the Kafka settings are detail-only, so they
 // share one fetch.
 type mqlOciStreamingStreamPoolInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 
 	detail ociLazy[*streaming.StreamPool]
@@ -206,7 +206,7 @@ func (o *mqlOciStreamingStreamPool) id() (string, error) {
 }
 
 func (o *mqlOciStreamingStreamPool) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciStreamingStreamPool) getDetail() (*streaming.StreamPool, error) {
@@ -365,7 +365,7 @@ func (o *mqlOciQueue) queues() ([]any, error) {
 					return nil, err
 				}
 				mqlQueueTyped := mqlQueue.(*mqlOciQueueQueue)
-				mqlQueueTyped.cacheCompartmentId = stringValue(q.CompartmentId)
+				mqlQueueTyped.cacheCompartmentID = stringValue(q.CompartmentId)
 				mqlQueueTyped.cacheRegion = region
 				res = append(res, mqlQueueTyped)
 			}
@@ -377,7 +377,7 @@ func (o *mqlOciQueue) queues() ([]any, error) {
 // The queue listing omits the encryption key and every timer, so all five
 // detail-backed fields share one fetch.
 type mqlOciQueueQueueInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 
 	detail ociLazy[*queue.Queue]
@@ -388,7 +388,7 @@ func (o *mqlOciQueueQueue) id() (string, error) {
 }
 
 func (o *mqlOciQueueQueue) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciQueueQueue) getDetail() (*queue.Queue, error) {
@@ -512,9 +512,9 @@ func (o *mqlOciKafka) clusters() ([]any, error) {
 					return nil, err
 				}
 				mqlClusterTyped := mqlCluster.(*mqlOciKafkaCluster)
-				mqlClusterTyped.cacheCompartmentId = stringValue(c.CompartmentId)
+				mqlClusterTyped.cacheCompartmentID = stringValue(c.CompartmentId)
 				mqlClusterTyped.cacheRegion = region
-				mqlClusterTyped.cacheSubnetIds = ociKafkaAccessSubnetIds(c.AccessSubnets)
+				mqlClusterTyped.cacheSubnetIDs = ociKafkaAccessSubnetIds(c.AccessSubnets)
 				res = append(res, mqlClusterTyped)
 			}
 
@@ -535,9 +535,9 @@ func ociKafkaAccessSubnetIds(sets []managedkafka.SubnetSet) []string {
 
 // The bootstrap URLs and the superuser secret are detail-only.
 type mqlOciKafkaClusterInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
-	cacheSubnetIds     []string
+	cacheSubnetIDs     []string
 
 	detail ociLazy[*managedkafka.KafkaCluster]
 }
@@ -547,12 +547,12 @@ func (o *mqlOciKafkaCluster) id() (string, error) {
 }
 
 func (o *mqlOciKafkaCluster) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciKafkaCluster) subnets() ([]any, error) {
-	res := make([]any, 0, len(o.cacheSubnetIds))
-	for _, id := range o.cacheSubnetIds {
+	res := make([]any, 0, len(o.cacheSubnetIDs))
+	for _, id := range o.cacheSubnetIDs {
 		if id == "" {
 			continue
 		}

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -259,7 +259,7 @@ func (o *mqlOciNetwork) securityLists() ([]any, error) {
 					return nil, err
 				}
 				sl := mqlInstance.(*mqlOciNetworkSecurityList)
-				sl.cacheVcnId = stringValue(securityList.VcnId)
+				sl.cacheVcnID = stringValue(securityList.VcnId)
 				sl.cacheRegion = region
 				res = append(res, mqlInstance)
 			}
@@ -331,7 +331,7 @@ type ingressSecurityRule struct {
 }
 
 type mqlOciNetworkSecurityListInternal struct {
-	cacheVcnId string
+	cacheVcnID string
 	// cacheRegion is the region key (e.g. "IAD") discovered when the security
 	// list was enumerated. Used by discovery to emit per-region platform IDs
 	// without re-parsing the OCID.
@@ -382,12 +382,12 @@ func (o *mqlOciNetworkSecurityList) id() (string, error) {
 }
 
 func (o *mqlOciNetworkSecurityList) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
+	if o.cacheVcnID == "" || !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -508,9 +508,9 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 					return nil, err
 				}
 				mqlSub := mqlInstance.(*mqlOciNetworkSubnet)
-				mqlSub.cacheVcnId = stringValue(subnet.VcnId)
-				mqlSub.cacheRouteTableId = stringValue(subnet.RouteTableId)
-				mqlSub.cacheSecurityListIds = subnet.SecurityListIds
+				mqlSub.cacheVcnID = stringValue(subnet.VcnId)
+				mqlSub.cacheRouteTableID = stringValue(subnet.RouteTableId)
+				mqlSub.cacheSecurityListIDs = subnet.SecurityListIds
 				res = append(res, mqlSub)
 			}
 
@@ -519,9 +519,9 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 }
 
 type mqlOciNetworkSubnetInternal struct {
-	cacheVcnId           string
-	cacheRouteTableId    string
-	cacheSecurityListIds []string
+	cacheVcnID           string
+	cacheRouteTableID    string
+	cacheSecurityListIDs []string
 }
 
 func initOciNetworkSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -560,12 +560,12 @@ func (o *mqlOciNetworkSubnet) id() (string, error) {
 }
 
 func (o *mqlOciNetworkSubnet) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
+	if o.cacheVcnID == "" || !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -627,8 +627,8 @@ func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 					return nil, err
 				}
 				mqlNsg := mqlInstance.(*mqlOciNetworkNetworkSecurityGroup)
-				mqlNsg.region = region
-				mqlNsg.cacheVcnId = stringValue(nsg.VcnId)
+				mqlNsg.cacheRegion = region
+				mqlNsg.cacheVcnID = stringValue(nsg.VcnId)
 				res = append(res, mqlInstance)
 			}
 
@@ -657,9 +657,9 @@ func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *cor
 }
 
 type mqlOciNetworkNetworkSecurityGroupInternal struct {
-	region     string
-	cacheVcnId string
-	rules      ociOnce
+	cacheRegion string
+	cacheVcnID  string
+	rules       ociOnce
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) id() (string, error) {
@@ -739,18 +739,18 @@ func initOciNetworkNetworkSecurityGroup(runtime *plugin.Runtime, args map[string
 		return nil, nil, err
 	}
 	mqlNsg := mqlInstance.(*mqlOciNetworkNetworkSecurityGroup)
-	mqlNsg.region = region
-	mqlNsg.cacheVcnId = stringValue(nsg.VcnId)
+	mqlNsg.cacheRegion = region
+	mqlNsg.cacheVcnID = stringValue(nsg.VcnId)
 	return args, mqlNsg, nil
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
+	if o.cacheVcnID == "" || !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -801,7 +801,7 @@ func (o *mqlOciNetworkNetworkSecurityGroup) fetchSecurityRules() error {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 		ctx := context.Background()
 
-		svc, err := conn.NetworkClient(o.region)
+		svc, err := conn.NetworkClient(o.cacheRegion)
 		if err != nil {
 			return err
 		}
@@ -915,7 +915,7 @@ func (o *mqlOciNetworkNetworkSecurityGroup) attachedVnics() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	ctx := context.Background()
 
-	networkClient, err := conn.NetworkClient(o.region)
+	networkClient, err := conn.NetworkClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -991,7 +991,7 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 		return nil, err
 	}
 	mqlVnic := res.(*mqlOciComputeVnic)
-	mqlVnic.cacheSubnetId = stringValue(vnic.SubnetId)
+	mqlVnic.cacheSubnetID = stringValue(vnic.SubnetId)
 	return mqlVnic, nil
 }
 
@@ -1056,7 +1056,7 @@ func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 					return nil, err
 				}
 				mqlIgw := mqlInstance.(*mqlOciNetworkInternetGateway)
-				mqlIgw.cacheVcnId = stringValue(igw.VcnId)
+				mqlIgw.cacheVcnID = stringValue(igw.VcnId)
 				res = append(res, mqlIgw)
 			}
 
@@ -1065,7 +1065,7 @@ func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 }
 
 type mqlOciNetworkInternetGatewayInternal struct {
-	cacheVcnId string
+	cacheVcnID string
 }
 
 func (o *mqlOciNetworkInternetGateway) id() (string, error) {
@@ -1073,12 +1073,12 @@ func (o *mqlOciNetworkInternetGateway) id() (string, error) {
 }
 
 func (o *mqlOciNetworkInternetGateway) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
+	if o.cacheVcnID == "" || !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -1148,7 +1148,7 @@ func (o *mqlOciNetwork) natGateways() ([]any, error) {
 					return nil, err
 				}
 				mqlNgw := mqlInstance.(*mqlOciNetworkNatGateway)
-				mqlNgw.cacheVcnId = stringValue(ngw.VcnId)
+				mqlNgw.cacheVcnID = stringValue(ngw.VcnId)
 				res = append(res, mqlNgw)
 			}
 
@@ -1157,7 +1157,7 @@ func (o *mqlOciNetwork) natGateways() ([]any, error) {
 }
 
 type mqlOciNetworkNatGatewayInternal struct {
-	cacheVcnId string
+	cacheVcnID string
 }
 
 func (o *mqlOciNetworkNatGateway) id() (string, error) {
@@ -1165,12 +1165,12 @@ func (o *mqlOciNetworkNatGateway) id() (string, error) {
 }
 
 func (o *mqlOciNetworkNatGateway) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
+	if o.cacheVcnID == "" || !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -1274,7 +1274,7 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 					return nil, err
 				}
 				mqlRt := mqlInstance.(*mqlOciNetworkRouteTable)
-				mqlRt.cacheVcnId = stringValue(rt.VcnId)
+				mqlRt.cacheVcnID = stringValue(rt.VcnId)
 				res = append(res, mqlRt)
 			}
 
@@ -1283,7 +1283,7 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 }
 
 type mqlOciNetworkRouteTableInternal struct {
-	cacheVcnId string
+	cacheVcnID string
 }
 
 func initOciNetworkRouteTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -1322,12 +1322,12 @@ func (o *mqlOciNetworkRouteTable) id() (string, error) {
 }
 
 func (o *mqlOciNetworkRouteTable) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
+	if o.cacheVcnID == "" || !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -1338,12 +1338,12 @@ func (o *mqlOciNetworkRouteTable) vcn() (*mqlOciNetworkVcn, error) {
 // Subnet route table reference
 
 func (o *mqlOciNetworkSubnet) routeTable() (*mqlOciNetworkRouteTable, error) {
-	if o.cacheRouteTableId == "" || !isOcid(o.cacheRouteTableId) {
+	if o.cacheRouteTableID == "" || !isOcid(o.cacheRouteTableID) {
 		o.RouteTable.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlRt, err := NewResource(o.MqlRuntime, "oci.network.routeTable", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheRouteTableId),
+		"id": llx.StringData(o.cacheRouteTableID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/network_vcn_children.go
+++ b/providers/oci/resources/network_vcn_children.go
@@ -45,37 +45,37 @@ func vcnChildren[T any](o *mqlOciNetworkVcn, list func(*mqlOciNetwork) *plugin.T
 func (o *mqlOciNetworkVcn) subnets() ([]any, error) {
 	return vcnChildren(o,
 		func(n *mqlOciNetwork) *plugin.TValue[[]any] { return n.GetSubnets() },
-		func(s *mqlOciNetworkSubnet) string { return s.cacheVcnId })
+		func(s *mqlOciNetworkSubnet) string { return s.cacheVcnID })
 }
 
 func (o *mqlOciNetworkVcn) routeTables() ([]any, error) {
 	return vcnChildren(o,
 		func(n *mqlOciNetwork) *plugin.TValue[[]any] { return n.GetRouteTables() },
-		func(r *mqlOciNetworkRouteTable) string { return r.cacheVcnId })
+		func(r *mqlOciNetworkRouteTable) string { return r.cacheVcnID })
 }
 
 func (o *mqlOciNetworkVcn) securityLists() ([]any, error) {
 	return vcnChildren(o,
 		func(n *mqlOciNetwork) *plugin.TValue[[]any] { return n.GetSecurityLists() },
-		func(s *mqlOciNetworkSecurityList) string { return s.cacheVcnId })
+		func(s *mqlOciNetworkSecurityList) string { return s.cacheVcnID })
 }
 
 func (o *mqlOciNetworkVcn) networkSecurityGroups() ([]any, error) {
 	return vcnChildren(o,
 		func(n *mqlOciNetwork) *plugin.TValue[[]any] { return n.GetNetworkSecurityGroups() },
-		func(g *mqlOciNetworkNetworkSecurityGroup) string { return g.cacheVcnId })
+		func(g *mqlOciNetworkNetworkSecurityGroup) string { return g.cacheVcnID })
 }
 
 func (o *mqlOciNetworkVcn) internetGateways() ([]any, error) {
 	return vcnChildren(o,
 		func(n *mqlOciNetwork) *plugin.TValue[[]any] { return n.GetInternetGateways() },
-		func(g *mqlOciNetworkInternetGateway) string { return g.cacheVcnId })
+		func(g *mqlOciNetworkInternetGateway) string { return g.cacheVcnID })
 }
 
 func (o *mqlOciNetworkVcn) natGateways() ([]any, error) {
 	return vcnChildren(o,
 		func(n *mqlOciNetwork) *plugin.TValue[[]any] { return n.GetNatGateways() },
-		func(g *mqlOciNetworkNatGateway) string { return g.cacheVcnId })
+		func(g *mqlOciNetworkNatGateway) string { return g.cacheVcnID })
 }
 
 // defaultRouteTable is the route table OCI applies to subnets that name none of

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -77,9 +77,9 @@ func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 					return nil, err
 				}
 				mqlFw := mqlInstance.(*mqlOciNetworkFirewallFirewall)
-				mqlFw.cacheSubnetId = stringValue(fw.SubnetId)
-				mqlFw.cachePolicyId = stringValue(fw.NetworkFirewallPolicyId)
-				mqlFw.region = region
+				mqlFw.cacheSubnetID = stringValue(fw.SubnetId)
+				mqlFw.cachePolicyID = stringValue(fw.NetworkFirewallPolicyId)
+				mqlFw.cacheRegion = region
 				res = append(res, mqlFw)
 			}
 
@@ -88,9 +88,9 @@ func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 }
 
 type mqlOciNetworkFirewallFirewallInternal struct {
-	cacheSubnetId string
-	cachePolicyId string
-	region        string
+	cacheSubnetID string
+	cachePolicyID string
+	cacheRegion   string
 }
 
 func (o *mqlOciNetworkFirewallFirewall) id() (string, error) {
@@ -99,7 +99,7 @@ func (o *mqlOciNetworkFirewallFirewall) id() (string, error) {
 
 func (o *mqlOciNetworkFirewallFirewall) healthStatus() (string, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.NetworkFirewallClient(o.region)
+	svc, err := conn.NetworkFirewallClient(o.cacheRegion)
 	if err != nil {
 		return "", err
 	}
@@ -113,12 +113,12 @@ func (o *mqlOciNetworkFirewallFirewall) healthStatus() (string, error) {
 }
 
 func (o *mqlOciNetworkFirewallFirewall) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" {
+	if o.cacheSubnetID == "" {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlSubnet, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSubnetId),
+		"id": llx.StringData(o.cacheSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -127,12 +127,12 @@ func (o *mqlOciNetworkFirewallFirewall) subnet() (*mqlOciNetworkSubnet, error) {
 }
 
 func (o *mqlOciNetworkFirewallFirewall) policy() (*mqlOciNetworkFirewallPolicy, error) {
-	if o.cachePolicyId == "" {
+	if o.cachePolicyID == "" {
 		o.Policy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlPolicy, err := NewResource(o.MqlRuntime, "oci.networkFirewall.policy", map[string]*llx.RawData{
-		"id": llx.StringData(o.cachePolicyId),
+		"id": llx.StringData(o.cachePolicyID),
 	})
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
-				mqlInstance.(*mqlOciNetworkFirewallPolicy).region = region
+				mqlInstance.(*mqlOciNetworkFirewallPolicy).cacheRegion = region
 				res = append(res, mqlInstance)
 			}
 
@@ -195,14 +195,14 @@ func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 }
 
 type mqlOciNetworkFirewallPolicyInternal struct {
-	region string
-	detail ociRetryLazy[*networkfirewall.NetworkFirewallPolicy]
+	cacheRegion string
+	detail      ociRetryLazy[*networkfirewall.NetworkFirewallPolicy]
 }
 
 func (o *mqlOciNetworkFirewallPolicy) fetchDetail() (*networkfirewall.NetworkFirewallPolicy, error) {
 	return o.detail.get(func() (*networkfirewall.NetworkFirewallPolicy, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.NetworkFirewallClient(o.region)
+		svc, err := conn.NetworkFirewallClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -272,7 +272,7 @@ func (o *mqlOciNetworkFirewallPolicy) id() (string, error) {
 
 func (o *mqlOciNetworkFirewallPolicy) decryptionProfiles() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.NetworkFirewallClient(o.region)
+	svc, err := conn.NetworkFirewallClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func (o *mqlOciNetworkFirewallPolicy) decryptionProfiles() ([]any, error) {
 // with no rules at all was indistinguishable from a restrictive one.
 func (o *mqlOciNetworkFirewallPolicy) securityRules() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.NetworkFirewallClient(o.region)
+	svc, err := conn.NetworkFirewallClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +367,7 @@ func (o *mqlOciNetworkFirewallPolicy) securityRules() ([]any, error) {
 // sessions are decrypted for inspection and under which profile.
 func (o *mqlOciNetworkFirewallPolicy) decryptionRules() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.NetworkFirewallClient(o.region)
+	svc, err := conn.NetworkFirewallClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/networkloadbalancer.go
+++ b/providers/oci/resources/networkloadbalancer.go
@@ -106,9 +106,9 @@ func (o *mqlOciNetworkLoadBalancer) newNetworkLoadBalancers(nlbs []networkloadba
 			return nil, err
 		}
 		mqlNlbTyped := mqlNlb.(*mqlOciNetworkLoadBalancerLoadBalancer)
-		mqlNlbTyped.cacheCompartmentId = stringValue(nlb.CompartmentId)
-		mqlNlbTyped.cacheSubnetId = stringValue(nlb.SubnetId)
-		mqlNlbTyped.cacheNsgIds = nlb.NetworkSecurityGroupIds
+		mqlNlbTyped.cacheCompartmentID = stringValue(nlb.CompartmentId)
+		mqlNlbTyped.cacheSubnetID = stringValue(nlb.SubnetId)
+		mqlNlbTyped.cacheNsgIDs = nlb.NetworkSecurityGroupIds
 		res = append(res, mqlNlbTyped)
 	}
 
@@ -224,7 +224,7 @@ func (o *mqlOciNetworkLoadBalancer) newBackends(backendSetID string, backends []
 			return nil, err
 		}
 		mqlBackendTyped := mqlBackend.(*mqlOciNetworkLoadBalancerBackend)
-		mqlBackendTyped.cacheTargetId = stringValue(backend.TargetId)
+		mqlBackendTyped.cacheTargetID = stringValue(backend.TargetId)
 		res = append(res, mqlBackendTyped)
 	}
 
@@ -232,9 +232,9 @@ func (o *mqlOciNetworkLoadBalancer) newBackends(backendSetID string, backends []
 }
 
 type mqlOciNetworkLoadBalancerLoadBalancerInternal struct {
-	cacheCompartmentId string
-	cacheSubnetId      string
-	cacheNsgIds        []string
+	cacheCompartmentID string
+	cacheSubnetID      string
+	cacheNsgIDs        []string
 }
 
 func (o *mqlOciNetworkLoadBalancerLoadBalancer) id() (string, error) {
@@ -242,16 +242,16 @@ func (o *mqlOciNetworkLoadBalancerLoadBalancer) id() (string, error) {
 }
 
 func (o *mqlOciNetworkLoadBalancerLoadBalancer) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciNetworkLoadBalancerLoadBalancer) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" {
+	if o.cacheSubnetID == "" {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSubnetId),
+		"id": llx.StringData(o.cacheSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -260,11 +260,11 @@ func (o *mqlOciNetworkLoadBalancerLoadBalancer) subnet() (*mqlOciNetworkSubnet, 
 }
 
 func (o *mqlOciNetworkLoadBalancerLoadBalancer) securityGroups() ([]any, error) {
-	return resolveOciSecurityGroups(o.MqlRuntime, stringsToAny(o.cacheNsgIds))
+	return resolveOciSecurityGroups(o.MqlRuntime, stringsToAny(o.cacheNsgIDs))
 }
 
 type mqlOciNetworkLoadBalancerBackendInternal struct {
-	cacheTargetId string
+	cacheTargetID string
 }
 
 func (o *mqlOciNetworkLoadBalancerBackend) instance() (*mqlOciComputeInstance, error) {
@@ -272,12 +272,12 @@ func (o *mqlOciNetworkLoadBalancerBackend) instance() (*mqlOciComputeInstance, e
 	// may point at something other than a compute instance. Only resolve what
 	// is actually an instance; anything else is reported as null rather than
 	// forced through a lookup that would fail.
-	if !strings.HasPrefix(o.cacheTargetId, "ocid1.instance.") {
+	if !strings.HasPrefix(o.cacheTargetID, "ocid1.instance.") {
 		o.Instance.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.compute.instance", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheTargetId),
+		"id": llx.StringData(o.cacheTargetID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -131,8 +131,8 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 					return nil, err
 				}
 				mqlCluster := mqlInstance.(*mqlOciOkeCluster)
-				mqlCluster.cacheVcnId = stringValue(cluster.VcnId)
-				mqlCluster.region = region
+				mqlCluster.cacheVcnID = stringValue(cluster.VcnId)
+				mqlCluster.cacheRegion = region
 				res = append(res, mqlCluster)
 			}
 
@@ -141,9 +141,9 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 }
 
 type mqlOciOkeClusterInternal struct {
-	cluster    ociRetryLazy[*containerengine.Cluster]
-	cacheVcnId string
-	region     string
+	cluster     ociRetryLazy[*containerengine.Cluster]
+	cacheVcnID  string
+	cacheRegion string
 }
 
 func (o *mqlOciOkeCluster) id() (string, error) {
@@ -193,12 +193,12 @@ func initOciOkeCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 }
 
 func (o *mqlOciOkeCluster) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
+	if o.cacheVcnID == "" || !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVcn, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func (o *mqlOciOkeCluster) fetchCluster() (*containerengine.Cluster, error) {
 	return o.cluster.get(func() (*containerengine.Cluster, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-		svc, err := conn.ContainerEngineClient(o.region)
+		svc, err := conn.ContainerEngineClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -249,7 +249,7 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	ctx := context.Background()
 
-	svc, err := conn.ContainerEngineClient(o.region)
+	svc, err := conn.ContainerEngineClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -322,10 +322,10 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 			return nil, err
 		}
 		mqlPool := mqlInstance.(*mqlOciOkeNodePool)
-		mqlPool.cacheSubnetIds = subnetIds
-		mqlPool.cacheNsgIds = nsgIds
+		mqlPool.cacheSubnetIDs = subnetIds
+		mqlPool.cacheNsgIDs = nsgIds
 		mqlPool.cacheClusterID = stringValue(np.ClusterId)
-		mqlPool.cacheNodeImageId = nodeImageId
+		mqlPool.cacheNodeImageID = nodeImageId
 		res = append(res, mqlPool)
 	}
 
@@ -333,10 +333,10 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 }
 
 type mqlOciOkeNodePoolInternal struct {
-	cacheSubnetIds   []string
-	cacheNsgIds      []string
+	cacheSubnetIDs   []string
+	cacheNsgIDs      []string
 	cacheClusterID   string
-	cacheNodeImageId string
+	cacheNodeImageID string
 }
 
 func (o *mqlOciOkeNodePool) id() (string, error) {
@@ -344,12 +344,12 @@ func (o *mqlOciOkeNodePool) id() (string, error) {
 }
 
 func (o *mqlOciOkeNodePool) nodeImage() (*mqlOciComputeImage, error) {
-	return resolveOciImage(o.MqlRuntime, o.cacheNodeImageId, &o.NodeImage)
+	return resolveOciImage(o.MqlRuntime, o.cacheNodeImageID, &o.NodeImage)
 }
 
 func (o *mqlOciOkeNodePool) subnets() ([]any, error) {
-	res := make([]any, 0, len(o.cacheSubnetIds))
-	for _, id := range o.cacheSubnetIds {
+	res := make([]any, 0, len(o.cacheSubnetIDs))
+	for _, id := range o.cacheSubnetIDs {
 		mqlSubnet, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})
@@ -365,8 +365,8 @@ func (o *mqlOciOkeNodePool) subnets() ([]any, error) {
 }
 
 func (o *mqlOciOkeNodePool) networkSecurityGroups() ([]any, error) {
-	res := make([]any, 0, len(o.cacheNsgIds))
-	for _, id := range o.cacheNsgIds {
+	res := make([]any, 0, len(o.cacheNsgIDs))
+	for _, id := range o.cacheNsgIDs {
 		mqlNsg, err := NewResource(o.MqlRuntime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -63,7 +63,7 @@ func (o *mqlOciOns) topics() ([]any, error) {
 				}
 
 				mqlTopic := mqlInstance.(*mqlOciOnsTopic)
-				mqlTopic.region = region
+				mqlTopic.cacheRegion = region
 
 				res = append(res, mqlInstance)
 			}
@@ -93,7 +93,7 @@ func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.Notifica
 }
 
 type mqlOciOnsTopicInternal struct {
-	region string
+	cacheRegion string
 }
 
 func initOciOnsTopic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -134,7 +134,7 @@ func (o *mqlOciOnsTopic) id() (string, error) {
 func (o *mqlOciOnsTopic) subscriptions() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	client, err := conn.NotificationDataPlaneClient(o.region)
+	client, err := conn.NotificationDataPlaneClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (o *mqlOciOnsTopic) subscriptions() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		mqlInstance.(*mqlOciOnsSubscription).cacheTopicId = stringValue(sub.TopicId)
+		mqlInstance.(*mqlOciOnsSubscription).cacheTopicID = stringValue(sub.TopicId)
 		res = append(res, mqlInstance)
 	}
 
@@ -187,7 +187,7 @@ func (o *mqlOciOnsTopic) subscriptions() ([]any, error) {
 }
 
 type mqlOciOnsSubscriptionInternal struct {
-	cacheTopicId string
+	cacheTopicID string
 }
 
 func (o *mqlOciOnsSubscription) id() (string, error) {
@@ -195,12 +195,12 @@ func (o *mqlOciOnsSubscription) id() (string, error) {
 }
 
 func (o *mqlOciOnsSubscription) topic() (*mqlOciOnsTopic, error) {
-	if o.cacheTopicId == "" {
+	if o.cacheTopicID == "" {
 		o.Topic.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlTopic, err := NewResource(o.MqlRuntime, "oci.ons.topic", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheTopicId),
+		"id": llx.StringData(o.cacheTopicID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -99,8 +99,8 @@ func (o *mqlOciRedis) clusters() ([]any, error) {
 					return nil, err
 				}
 				mqlClusterTyped := mqlCluster.(*mqlOciRedisCluster)
-				mqlClusterTyped.cacheSubnetId = stringValue(c.SubnetId)
-				mqlClusterTyped.cacheNsgIds = c.NsgIds
+				mqlClusterTyped.cacheSubnetID = stringValue(c.SubnetId)
+				mqlClusterTyped.cacheNsgIDs = c.NsgIds
 				mqlClusterTyped.cacheRegion = region
 				res = append(res, mqlClusterTyped)
 			}
@@ -110,8 +110,8 @@ func (o *mqlOciRedis) clusters() ([]any, error) {
 }
 
 type mqlOciRedisClusterInternal struct {
-	cacheSubnetId string
-	cacheNsgIds   []string
+	cacheSubnetID string
+	cacheNsgIDs   []string
 	cacheRegion   string
 }
 
@@ -159,12 +159,12 @@ func (o *mqlOciRedisCluster) id() (string, error) {
 }
 
 func (o *mqlOciRedisCluster) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" {
+	if o.cacheSubnetID == "" {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlSubnet, err := NewResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSubnetId),
+		"id": llx.StringData(o.cacheSubnetID),
 	})
 	if err != nil {
 		return nil, err
@@ -173,11 +173,11 @@ func (o *mqlOciRedisCluster) subnet() (*mqlOciNetworkSubnet, error) {
 }
 
 func (o *mqlOciRedisCluster) networkSecurityGroups() ([]any, error) {
-	if len(o.cacheNsgIds) == 0 {
+	if len(o.cacheNsgIDs) == 0 {
 		return []any{}, nil
 	}
-	res := make([]any, 0, len(o.cacheNsgIds))
-	for _, nsgId := range o.cacheNsgIds {
+	res := make([]any, 0, len(o.cacheNsgIDs))
+	for _, nsgId := range o.cacheNsgIDs {
 		mqlNsg, err := NewResource(o.MqlRuntime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
 			"id": llx.StringData(nsgId),
 		})

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -65,7 +65,7 @@ func (o *mqlOciResourceManager) stacks() ([]any, error) {
 					return nil, err
 				}
 				mqlStackTyped := mqlStack.(*mqlOciResourceManagerStack)
-				mqlStackTyped.cacheCompartmentId = stringValue(s.CompartmentId)
+				mqlStackTyped.cacheCompartmentID = stringValue(s.CompartmentId)
 				mqlStackTyped.cacheRegion = region
 				res = append(res, mqlStackTyped)
 			}
@@ -77,7 +77,7 @@ func (o *mqlOciResourceManager) stacks() ([]any, error) {
 // Drift status, the config source and the variable names are all detail-only,
 // so they share one fetch.
 type mqlOciResourceManagerStackInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 
 	detail ociLazy[*resourcemanager.Stack]
@@ -88,7 +88,7 @@ func (o *mqlOciResourceManagerStack) id() (string, error) {
 }
 
 func (o *mqlOciResourceManagerStack) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciResourceManagerStack) getDetail() (*resourcemanager.Stack, error) {
@@ -216,8 +216,8 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 			return nil, err
 		}
 		mqlJobTyped := mqlJob.(*mqlOciResourceManagerJob)
-		mqlJobTyped.cacheCompartmentId = stringValue(job.CompartmentId)
-		mqlJobTyped.cacheStackId = stringValue(job.StackId)
+		mqlJobTyped.cacheCompartmentID = stringValue(job.CompartmentId)
+		mqlJobTyped.cacheStackID = stringValue(job.StackId)
 		res = append(res, mqlJobTyped)
 	}
 
@@ -225,8 +225,8 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 }
 
 type mqlOciResourceManagerJobInternal struct {
-	cacheCompartmentId string
-	cacheStackId       string
+	cacheCompartmentID string
+	cacheStackID       string
 }
 
 func (o *mqlOciResourceManagerJob) id() (string, error) {
@@ -234,16 +234,16 @@ func (o *mqlOciResourceManagerJob) id() (string, error) {
 }
 
 func (o *mqlOciResourceManagerJob) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciResourceManagerJob) stack() (*mqlOciResourceManagerStack, error) {
-	if o.cacheStackId == "" {
+	if o.cacheStackID == "" {
 		o.Stack.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.resourceManager.stack", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheStackId),
+		"id": llx.StringData(o.cacheStackID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -98,8 +98,8 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 					return nil, err
 				}
 				mqlS := mqlInstance.(*mqlOciVaultSecret)
-				mqlS.cacheKeyId = stringValue(s.KeyId)
-				mqlS.cacheVaultId = stringValue(s.VaultId)
+				mqlS.cacheKeyID = stringValue(s.KeyId)
+				mqlS.cacheVaultID = stringValue(s.VaultId)
 				mqlS.cacheRegion = region
 				if s.RotationConfig != nil {
 					mqlS.cacheRotationInterval = stringValue(s.RotationConfig.RotationInterval)
@@ -117,8 +117,8 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 }
 
 type mqlOciVaultSecretInternal struct {
-	cacheKeyId   string
-	cacheVaultId string
+	cacheKeyID   string
+	cacheVaultID string
 	cacheRegion  string
 
 	// Rotation config fields from SecretSummary.RotationConfig
@@ -174,12 +174,12 @@ func initOciVaultSecret(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 }
 
 func (o *mqlOciVaultSecret) kmsVault() (*mqlOciKmsVault, error) {
-	if o.cacheVaultId == "" {
+	if o.cacheVaultID == "" {
 		o.KmsVault.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlVault, err := NewResource(o.MqlRuntime, "oci.kms.vault", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVaultId),
+		"id": llx.StringData(o.cacheVaultID),
 	})
 	if err != nil {
 		return nil, err
@@ -188,12 +188,12 @@ func (o *mqlOciVaultSecret) kmsVault() (*mqlOciKmsVault, error) {
 }
 
 func (o *mqlOciVaultSecret) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKeyId == "" {
+	if o.cacheKeyID == "" {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlKey, err := NewResource(o.MqlRuntime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheKeyId),
+		"id": llx.StringData(o.cacheKeyID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -65,7 +65,7 @@ func (o *mqlOciServiceConnectorHub) connectors() ([]any, error) {
 					return nil, err
 				}
 				mqlConnectorTyped := mqlConnector.(*mqlOciServiceConnectorHubConnector)
-				mqlConnectorTyped.cacheCompartmentId = stringValue(c.CompartmentId)
+				mqlConnectorTyped.cacheCompartmentID = stringValue(c.CompartmentId)
 				mqlConnectorTyped.cacheRegion = region
 				res = append(res, mqlConnectorTyped)
 			}
@@ -82,7 +82,7 @@ func (o *mqlOciServiceConnectorHub) connectors() ([]any, error) {
 // ociLazy, not ociRetryLazy: the five fields sharing this fetch would each
 // repeat the same failing request if only successes were remembered.
 type mqlOciServiceConnectorHubConnectorInternal struct {
-	cacheCompartmentId string
+	cacheCompartmentID string
 	cacheRegion        string
 
 	detail ociLazy[*sch.ServiceConnector]
@@ -93,7 +93,7 @@ func (o *mqlOciServiceConnectorHubConnector) id() (string, error) {
 }
 
 func (o *mqlOciServiceConnectorHubConnector) compartment() (*mqlOciCompartment, error) {
-	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentId, &o.Compartment)
+	return resolveOciCompartment(o.MqlRuntime, o.cacheCompartmentID, &o.Compartment)
 }
 
 func (o *mqlOciServiceConnectorHubConnector) getDetail() (*sch.ServiceConnector, error) {

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -21,7 +21,7 @@ import (
 // Dynamic Routing Gateways
 
 type mqlOciNetworkDrgInternal struct {
-	region string
+	cacheRegion string
 }
 
 func (o *mqlOciNetwork) drgs() ([]any, error) {
@@ -72,7 +72,7 @@ func (o *mqlOciNetwork) drgs() ([]any, error) {
 					return nil, err
 				}
 				mqlDrg := mqlInstance.(*mqlOciNetworkDrg)
-				mqlDrg.region = regionKey
+				mqlDrg.cacheRegion = regionKey
 				res = append(res, mqlDrg)
 			}
 
@@ -117,8 +117,8 @@ func (o *mqlOciNetworkDrg) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciNetworkDrg) drgRegion() string {
-	if o.region != "" {
-		return o.region
+	if o.cacheRegion != "" {
+		return o.cacheRegion
 	}
 	return ociRegionFromOCID(o.Id.Data)
 }
@@ -211,12 +211,12 @@ func (o *mqlOciNetworkDrg) newDrgAttachment(att core.DrgAttachment) (*mqlOciNetw
 		return nil, err
 	}
 	mqlAtt := mqlInstance.(*mqlOciNetworkDrgAttachment)
-	mqlAtt.cacheDrgId = stringValue(att.DrgId)
+	mqlAtt.cacheDrgID = stringValue(att.DrgId)
 	if networkType == "VCN" {
-		mqlAtt.cacheVcnId = networkID
+		mqlAtt.cacheVcnID = networkID
 	}
-	mqlAtt.cacheIpsecConnectionId = ipsecConnID
-	mqlAtt.cacheVirtualCircuitId = virtualCircuitID
+	mqlAtt.cacheIpsecConnectionID = ipsecConnID
+	mqlAtt.cacheVirtualCircuitID = virtualCircuitID
 	return mqlAtt, nil
 }
 
@@ -269,7 +269,7 @@ func (o *mqlOciNetworkDrg) remotePeeringConnections() ([]any, error) {
 			return nil, err
 		}
 		mqlRpc := mqlInstance.(*mqlOciNetworkRemotePeeringConnection)
-		mqlRpc.cacheDrgId = stringValue(rpc.DrgId)
+		mqlRpc.cacheDrgID = stringValue(rpc.DrgId)
 		res = append(res, mqlRpc)
 	}
 	return res, nil
@@ -278,10 +278,10 @@ func (o *mqlOciNetworkDrg) remotePeeringConnections() ([]any, error) {
 // DRG attachments
 
 type mqlOciNetworkDrgAttachmentInternal struct {
-	cacheDrgId             string
-	cacheVcnId             string
-	cacheIpsecConnectionId string
-	cacheVirtualCircuitId  string
+	cacheDrgID             string
+	cacheVcnID             string
+	cacheIpsecConnectionID string
+	cacheVirtualCircuitID  string
 }
 
 func (o *mqlOciNetworkDrgAttachment) id() (string, error) {
@@ -293,12 +293,12 @@ func (o *mqlOciNetworkDrgAttachment) compartment() (*mqlOciCompartment, error) {
 }
 
 func (o *mqlOciNetworkDrgAttachment) drg() (*mqlOciNetworkDrg, error) {
-	if !isOcid(o.cacheDrgId) {
+	if !isOcid(o.cacheDrgID) {
 		o.Drg.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.drg", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheDrgId),
+		"id": llx.StringData(o.cacheDrgID),
 	})
 	if err != nil {
 		return nil, err
@@ -307,12 +307,12 @@ func (o *mqlOciNetworkDrgAttachment) drg() (*mqlOciNetworkDrg, error) {
 }
 
 func (o *mqlOciNetworkDrgAttachment) vcn() (*mqlOciNetworkVcn, error) {
-	if !isOcid(o.cacheVcnId) {
+	if !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -321,12 +321,12 @@ func (o *mqlOciNetworkDrgAttachment) vcn() (*mqlOciNetworkVcn, error) {
 }
 
 func (o *mqlOciNetworkDrgAttachment) ipsecConnection() (*mqlOciNetworkIpsecConnection, error) {
-	if !isOcid(o.cacheIpsecConnectionId) {
+	if !isOcid(o.cacheIpsecConnectionID) {
 		o.IpsecConnection.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.ipsecConnection", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheIpsecConnectionId),
+		"id": llx.StringData(o.cacheIpsecConnectionID),
 	})
 	if err != nil {
 		return nil, err
@@ -335,12 +335,12 @@ func (o *mqlOciNetworkDrgAttachment) ipsecConnection() (*mqlOciNetworkIpsecConne
 }
 
 func (o *mqlOciNetworkDrgAttachment) virtualCircuit() (*mqlOciNetworkVirtualCircuit, error) {
-	if !isOcid(o.cacheVirtualCircuitId) {
+	if !isOcid(o.cacheVirtualCircuitID) {
 		o.VirtualCircuit.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.virtualCircuit", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVirtualCircuitId),
+		"id": llx.StringData(o.cacheVirtualCircuitID),
 	})
 	if err != nil {
 		return nil, err
@@ -351,7 +351,7 @@ func (o *mqlOciNetworkDrgAttachment) virtualCircuit() (*mqlOciNetworkVirtualCirc
 // Remote peering connections
 
 type mqlOciNetworkRemotePeeringConnectionInternal struct {
-	cacheDrgId string
+	cacheDrgID string
 }
 
 func (o *mqlOciNetworkRemotePeeringConnection) id() (string, error) {
@@ -363,12 +363,12 @@ func (o *mqlOciNetworkRemotePeeringConnection) compartment() (*mqlOciCompartment
 }
 
 func (o *mqlOciNetworkRemotePeeringConnection) drg() (*mqlOciNetworkDrg, error) {
-	if !isOcid(o.cacheDrgId) {
+	if !isOcid(o.cacheDrgID) {
 		o.Drg.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.drg", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheDrgId),
+		"id": llx.StringData(o.cacheDrgID),
 	})
 	if err != nil {
 		return nil, err
@@ -379,9 +379,9 @@ func (o *mqlOciNetworkRemotePeeringConnection) drg() (*mqlOciNetworkDrg, error) 
 // Local peering gateways
 
 type mqlOciNetworkLocalPeeringGatewayInternal struct {
-	cacheVcnId        string
-	cachePeerId       string
-	cacheRouteTableId string
+	cacheVcnID        string
+	cachePeerID       string
+	cacheRouteTableID string
 }
 
 func (o *mqlOciNetwork) localPeeringGateways() ([]any, error) {
@@ -435,9 +435,9 @@ func (o *mqlOciNetwork) localPeeringGateways() ([]any, error) {
 					return nil, err
 				}
 				mqlLpg := mqlInstance.(*mqlOciNetworkLocalPeeringGateway)
-				mqlLpg.cacheVcnId = stringValue(lpg.VcnId)
-				mqlLpg.cachePeerId = stringValue(lpg.PeerId)
-				mqlLpg.cacheRouteTableId = stringValue(lpg.RouteTableId)
+				mqlLpg.cacheVcnID = stringValue(lpg.VcnId)
+				mqlLpg.cachePeerID = stringValue(lpg.PeerId)
+				mqlLpg.cacheRouteTableID = stringValue(lpg.RouteTableId)
 				res = append(res, mqlLpg)
 			}
 
@@ -482,12 +482,12 @@ func (o *mqlOciNetworkLocalPeeringGateway) compartment() (*mqlOciCompartment, er
 }
 
 func (o *mqlOciNetworkLocalPeeringGateway) vcn() (*mqlOciNetworkVcn, error) {
-	if !isOcid(o.cacheVcnId) {
+	if !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -497,12 +497,12 @@ func (o *mqlOciNetworkLocalPeeringGateway) vcn() (*mqlOciNetworkVcn, error) {
 
 func (o *mqlOciNetworkLocalPeeringGateway) peer() (*mqlOciNetworkLocalPeeringGateway, error) {
 	// A cross-tenancy peer lives outside this tenancy and cannot be resolved.
-	if !isOcid(o.cachePeerId) || o.IsCrossTenancyPeering.Data {
+	if !isOcid(o.cachePeerID) || o.IsCrossTenancyPeering.Data {
 		o.Peer.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.localPeeringGateway", map[string]*llx.RawData{
-		"id": llx.StringData(o.cachePeerId),
+		"id": llx.StringData(o.cachePeerID),
 	})
 	if err != nil {
 		return nil, err
@@ -511,12 +511,12 @@ func (o *mqlOciNetworkLocalPeeringGateway) peer() (*mqlOciNetworkLocalPeeringGat
 }
 
 func (o *mqlOciNetworkLocalPeeringGateway) routeTable() (*mqlOciNetworkRouteTable, error) {
-	if !isOcid(o.cacheRouteTableId) {
+	if !isOcid(o.cacheRouteTableID) {
 		o.RouteTable.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.routeTable", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheRouteTableId),
+		"id": llx.StringData(o.cacheRouteTableID),
 	})
 	if err != nil {
 		return nil, err
@@ -527,10 +527,10 @@ func (o *mqlOciNetworkLocalPeeringGateway) routeTable() (*mqlOciNetworkRouteTabl
 // Service gateways
 
 type mqlOciNetworkServiceGatewayInternal struct {
-	region            string
-	cacheVcnId        string
-	cacheRouteTableId string
-	cacheServiceIds   []string
+	cacheRegion       string
+	cacheVcnID        string
+	cacheRouteTableID string
+	cacheServiceIDs   []string
 }
 
 func (o *mqlOciNetwork) serviceGateways() ([]any, error) {
@@ -587,10 +587,10 @@ func (o *mqlOciNetwork) serviceGateways() ([]any, error) {
 					return nil, err
 				}
 				mqlSgw := mqlInstance.(*mqlOciNetworkServiceGateway)
-				mqlSgw.region = regionKey
-				mqlSgw.cacheVcnId = stringValue(sgw.VcnId)
-				mqlSgw.cacheRouteTableId = stringValue(sgw.RouteTableId)
-				mqlSgw.cacheServiceIds = serviceIDs
+				mqlSgw.cacheRegion = regionKey
+				mqlSgw.cacheVcnID = stringValue(sgw.VcnId)
+				mqlSgw.cacheRouteTableID = stringValue(sgw.RouteTableId)
+				mqlSgw.cacheServiceIDs = serviceIDs
 				res = append(res, mqlSgw)
 			}
 
@@ -635,12 +635,12 @@ func (o *mqlOciNetworkServiceGateway) compartment() (*mqlOciCompartment, error) 
 }
 
 func (o *mqlOciNetworkServiceGateway) vcn() (*mqlOciNetworkVcn, error) {
-	if !isOcid(o.cacheVcnId) {
+	if !isOcid(o.cacheVcnID) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheVcnId),
+		"id": llx.StringData(o.cacheVcnID),
 	})
 	if err != nil {
 		return nil, err
@@ -649,12 +649,12 @@ func (o *mqlOciNetworkServiceGateway) vcn() (*mqlOciNetworkVcn, error) {
 }
 
 func (o *mqlOciNetworkServiceGateway) routeTable() (*mqlOciNetworkRouteTable, error) {
-	if !isOcid(o.cacheRouteTableId) {
+	if !isOcid(o.cacheRouteTableID) {
 		o.RouteTable.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.routeTable", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheRouteTableId),
+		"id": llx.StringData(o.cacheRouteTableID),
 	})
 	if err != nil {
 		return nil, err
@@ -664,7 +664,7 @@ func (o *mqlOciNetworkServiceGateway) routeTable() (*mqlOciNetworkRouteTable, er
 
 func (o *mqlOciNetworkServiceGateway) services() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	region := o.region
+	region := o.cacheRegion
 	if region == "" {
 		region = ociRegionFromOCID(o.Id.Data)
 	}
@@ -674,8 +674,8 @@ func (o *mqlOciNetworkServiceGateway) services() ([]any, error) {
 	}
 	ctx := context.Background()
 
-	res := make([]any, 0, len(o.cacheServiceIds))
-	for _, sid := range o.cacheServiceIds {
+	res := make([]any, 0, len(o.cacheServiceIDs))
+	for _, sid := range o.cacheServiceIDs {
 		if !isOcid(sid) {
 			continue
 		}

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -584,8 +584,8 @@ func (o *mqlOciLoadBalancerLoadBalancer) subnets() ([]any, error) {
 }
 
 func (o *mqlOciNetworkSubnet) securityLists() ([]any, error) {
-	out := make([]any, 0, len(o.cacheSecurityListIds))
-	for _, id := range o.cacheSecurityListIds {
+	out := make([]any, 0, len(o.cacheSecurityListIDs))
+	for _, id := range o.cacheSecurityListIDs {
 		if id == "" {
 			continue
 		}
@@ -601,12 +601,12 @@ func (o *mqlOciNetworkSubnet) securityLists() ([]any, error) {
 }
 
 func (o *mqlOciFileStorageFileSystem) parentFileSystem() (*mqlOciFileStorageFileSystem, error) {
-	if o.cacheParentFileSystemId == "" || !isOcid(o.cacheParentFileSystemId) {
+	if o.cacheParentFileSystemID == "" || !isOcid(o.cacheParentFileSystemID) {
 		o.ParentFileSystem.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.fileStorage.fileSystem", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheParentFileSystemId),
+		"id": llx.StringData(o.cacheParentFileSystemID),
 	})
 	if err != nil {
 		return nil, err
@@ -615,12 +615,12 @@ func (o *mqlOciFileStorageFileSystem) parentFileSystem() (*mqlOciFileStorageFile
 }
 
 func (o *mqlOciDatabaseDbSystem) sourceDbSystem() (*mqlOciDatabaseDbSystem, error) {
-	if o.cacheSourceDbSystemId == "" || !isOcid(o.cacheSourceDbSystemId) {
+	if o.cacheSourceDbSystemID == "" || !isOcid(o.cacheSourceDbSystemID) {
 		o.SourceDbSystem.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.database.dbSystem", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSourceDbSystemId),
+		"id": llx.StringData(o.cacheSourceDbSystemID),
 	})
 	if err != nil {
 		return nil, err
@@ -629,12 +629,12 @@ func (o *mqlOciDatabaseDbSystem) sourceDbSystem() (*mqlOciDatabaseDbSystem, erro
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) sourceDatabase() (*mqlOciDatabaseAutonomousDatabase, error) {
-	if o.cacheSourceId == "" || !isOcid(o.cacheSourceId) {
+	if o.cacheSourceID == "" || !isOcid(o.cacheSourceID) {
 		o.SourceDatabase.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(o.MqlRuntime, "oci.database.autonomousDatabase", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSourceId),
+		"id": llx.StringData(o.cacheSourceID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -115,9 +115,9 @@ func (o *mqlOciNetworkCpe) compartment() (*mqlOciCompartment, error) {
 // IPSec connections
 
 type mqlOciNetworkIpsecConnectionInternal struct {
-	region     string
-	cacheCpeId string
-	cacheDrgId string
+	cacheRegion string
+	cacheCpeID  string
+	cacheDrgID  string
 }
 
 func (o *mqlOciNetwork) ipsecConnections() ([]any, error) {
@@ -172,9 +172,9 @@ func (o *mqlOciNetwork) ipsecConnections() ([]any, error) {
 					return nil, err
 				}
 				mqlIpsc := mqlInstance.(*mqlOciNetworkIpsecConnection)
-				mqlIpsc.region = regionKey
-				mqlIpsc.cacheCpeId = stringValue(ipsc.CpeId)
-				mqlIpsc.cacheDrgId = stringValue(ipsc.DrgId)
+				mqlIpsc.cacheRegion = regionKey
+				mqlIpsc.cacheCpeID = stringValue(ipsc.CpeId)
+				mqlIpsc.cacheDrgID = stringValue(ipsc.DrgId)
 				res = append(res, mqlIpsc)
 			}
 
@@ -219,12 +219,12 @@ func (o *mqlOciNetworkIpsecConnection) compartment() (*mqlOciCompartment, error)
 }
 
 func (o *mqlOciNetworkIpsecConnection) cpe() (*mqlOciNetworkCpe, error) {
-	if !isOcid(o.cacheCpeId) {
+	if !isOcid(o.cacheCpeID) {
 		o.Cpe.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.cpe", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheCpeId),
+		"id": llx.StringData(o.cacheCpeID),
 	})
 	if err != nil {
 		return nil, err
@@ -233,12 +233,12 @@ func (o *mqlOciNetworkIpsecConnection) cpe() (*mqlOciNetworkCpe, error) {
 }
 
 func (o *mqlOciNetworkIpsecConnection) drg() (*mqlOciNetworkDrg, error) {
-	if !isOcid(o.cacheDrgId) {
+	if !isOcid(o.cacheDrgID) {
 		o.Drg.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.drg", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheDrgId),
+		"id": llx.StringData(o.cacheDrgID),
 	})
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func (o *mqlOciNetworkIpsecConnection) drg() (*mqlOciNetworkDrg, error) {
 
 func (o *mqlOciNetworkIpsecConnection) tunnels() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	region := o.region
+	region := o.cacheRegion
 	if region == "" {
 		region = ociRegionFromOCID(o.Id.Data)
 	}
@@ -306,7 +306,7 @@ func (o *mqlOciNetworkIpsecConnection) tunnels() ([]any, error) {
 			return nil, err
 		}
 		tun := mqlInstance.(*mqlOciNetworkIpsecConnectionTunnel)
-		tun.cacheIpscId = o.Id.Data
+		tun.cacheIpscID = o.Id.Data
 		tun.cacheRegion = region
 		res = append(res, tun)
 	}
@@ -318,7 +318,7 @@ func (o *mqlOciNetworkIpsecConnectionTunnel) id() (string, error) {
 }
 
 type mqlOciNetworkIpsecConnectionTunnelInternal struct {
-	cacheIpscId string
+	cacheIpscID string
 	cacheRegion string
 	details     ociOnce
 	phaseOne    *core.TunnelPhaseOneDetails
@@ -332,7 +332,7 @@ type mqlOciNetworkIpsecConnectionTunnelInternal struct {
 // forever.
 func (o *mqlOciNetworkIpsecConnectionTunnel) fetchDetails() error {
 	return o.details.do(func() error {
-		if o.cacheIpscId == "" {
+		if o.cacheIpscID == "" {
 			return nil
 		}
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
@@ -345,7 +345,7 @@ func (o *mqlOciNetworkIpsecConnectionTunnel) fetchDetails() error {
 			return err
 		}
 		resp, err := svc.GetIPSecConnectionTunnel(context.Background(), core.GetIPSecConnectionTunnelRequest{
-			IpscId:   common.String(o.cacheIpscId),
+			IpscId:   common.String(o.cacheIpscID),
 			TunnelId: common.String(o.Id.Data),
 		})
 		if err != nil {
@@ -605,7 +605,7 @@ func (o *mqlOciNetworkIpsecConnectionTunnel) compartment() (*mqlOciCompartment, 
 // FastConnect virtual circuits
 
 type mqlOciNetworkVirtualCircuitInternal struct {
-	cacheDrgId string
+	cacheDrgID string
 }
 
 // crossConnectMapping is the subset of an OCI virtual-circuit cross-connect
@@ -695,7 +695,7 @@ func (o *mqlOciNetwork) virtualCircuits() ([]any, error) {
 				}
 				mqlVc := mqlInstance.(*mqlOciNetworkVirtualCircuit)
 				if gw := stringValue(vc.GatewayId); ociResourceTypeFromOCID(gw) == "drg" {
-					mqlVc.cacheDrgId = gw
+					mqlVc.cacheDrgID = gw
 				}
 				res = append(res, mqlVc)
 			}
@@ -741,12 +741,12 @@ func (o *mqlOciNetworkVirtualCircuit) compartment() (*mqlOciCompartment, error) 
 }
 
 func (o *mqlOciNetworkVirtualCircuit) drg() (*mqlOciNetworkDrg, error) {
-	if !isOcid(o.cacheDrgId) {
+	if !isOcid(o.cacheDrgID) {
 		o.Drg.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	r, err := NewResource(o.MqlRuntime, "oci.network.drg", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheDrgId),
+		"id": llx.StringData(o.cacheDrgID),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/oci/resources/vulnerabilityscanning.go
+++ b/providers/oci/resources/vulnerabilityscanning.go
@@ -589,8 +589,8 @@ func initOciVulnerabilityScanningContainerScanTarget(runtime *plugin.Runtime, ar
 // ----- host agent scan results -----
 
 type mqlOciVulnerabilityScanningHostAgentScanResultInternal struct {
-	region string
-	detail ociLazy[*vulnerabilityscanning.HostAgentScanResult]
+	cacheRegion string
+	detail      ociLazy[*vulnerabilityscanning.HostAgentScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostAgentScanResults() ([]any, error) {
@@ -646,7 +646,7 @@ func (o *mqlOciVulnerabilityScanning) fetchHostAgentScanResults(conn *connection
 				if err != nil {
 					return nil, err
 				}
-				mqlInst.(*mqlOciVulnerabilityScanningHostAgentScanResult).region = regionId
+				mqlInst.(*mqlOciVulnerabilityScanningHostAgentScanResult).cacheRegion = regionId
 				res = append(res, mqlInst)
 			}
 			return jobpool.JobResult(res), nil
@@ -681,7 +681,7 @@ func (o *mqlOciVulnerabilityScanningHostAgentScanResult) instance() (*mqlOciComp
 func (o *mqlOciVulnerabilityScanningHostAgentScanResult) fetchDetail() (*vulnerabilityscanning.HostAgentScanResult, error) {
 	return o.detail.get(func() (*vulnerabilityscanning.HostAgentScanResult, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.VulnerabilityScanningClient(o.region)
+		svc, err := conn.VulnerabilityScanningClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -779,8 +779,8 @@ func (o *mqlOciVulnerabilityScanningHostAgentScanResultProblem) vulnerability() 
 // ----- host port scan results -----
 
 type mqlOciVulnerabilityScanningHostPortScanResultInternal struct {
-	region string
-	detail ociLazy[*vulnerabilityscanning.HostPortScanResult]
+	cacheRegion string
+	detail      ociLazy[*vulnerabilityscanning.HostPortScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostPortScanResults() ([]any, error) {
@@ -835,7 +835,7 @@ func (o *mqlOciVulnerabilityScanning) fetchHostPortScanResults(conn *connection.
 				if err != nil {
 					return nil, err
 				}
-				mqlInst.(*mqlOciVulnerabilityScanningHostPortScanResult).region = regionId
+				mqlInst.(*mqlOciVulnerabilityScanningHostPortScanResult).cacheRegion = regionId
 				res = append(res, mqlInst)
 			}
 			return jobpool.JobResult(res), nil
@@ -870,7 +870,7 @@ func (o *mqlOciVulnerabilityScanningHostPortScanResult) instance() (*mqlOciCompu
 func (o *mqlOciVulnerabilityScanningHostPortScanResult) fetchDetail() (*vulnerabilityscanning.HostPortScanResult, error) {
 	return o.detail.get(func() (*vulnerabilityscanning.HostPortScanResult, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.VulnerabilityScanningClient(o.region)
+		svc, err := conn.VulnerabilityScanningClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -931,8 +931,8 @@ func (o *mqlOciVulnerabilityScanningHostPortScanResultOpenPort) vnic() (*mqlOciC
 // ----- host cis benchmark scan results -----
 
 type mqlOciVulnerabilityScanningHostCisBenchmarkScanResultInternal struct {
-	region string
-	detail ociLazy[*vulnerabilityscanning.HostCisBenchmarkScanResult]
+	cacheRegion string
+	detail      ociLazy[*vulnerabilityscanning.HostCisBenchmarkScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostCisBenchmarkScanResults() ([]any, error) {
@@ -986,7 +986,7 @@ func (o *mqlOciVulnerabilityScanning) fetchHostCisBenchmarkScanResults(conn *con
 				if err != nil {
 					return nil, err
 				}
-				mqlInst.(*mqlOciVulnerabilityScanningHostCisBenchmarkScanResult).region = regionId
+				mqlInst.(*mqlOciVulnerabilityScanningHostCisBenchmarkScanResult).cacheRegion = regionId
 				res = append(res, mqlInst)
 			}
 			return jobpool.JobResult(res), nil
@@ -1021,7 +1021,7 @@ func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) instance() (*mql
 func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) fetchDetail() (*vulnerabilityscanning.HostCisBenchmarkScanResult, error) {
 	return o.detail.get(func() (*vulnerabilityscanning.HostCisBenchmarkScanResult, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.VulnerabilityScanningClient(o.region)
+		svc, err := conn.VulnerabilityScanningClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -1054,8 +1054,8 @@ func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) scores() ([]any,
 // ----- host endpoint protection scan results -----
 
 type mqlOciVulnerabilityScanningHostEndpointProtectionScanResultInternal struct {
-	region string
-	detail ociLazy[*vulnerabilityscanning.HostEndpointProtectionScanResult]
+	cacheRegion string
+	detail      ociLazy[*vulnerabilityscanning.HostEndpointProtectionScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) hostEndpointProtectionScanResults() ([]any, error) {
@@ -1110,7 +1110,7 @@ func (o *mqlOciVulnerabilityScanning) fetchHostEndpointProtectionScanResults(con
 				if err != nil {
 					return nil, err
 				}
-				mqlInst.(*mqlOciVulnerabilityScanningHostEndpointProtectionScanResult).region = regionId
+				mqlInst.(*mqlOciVulnerabilityScanningHostEndpointProtectionScanResult).cacheRegion = regionId
 				res = append(res, mqlInst)
 			}
 			return jobpool.JobResult(res), nil
@@ -1145,7 +1145,7 @@ func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) instance()
 func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) fetchDetail() (*vulnerabilityscanning.HostEndpointProtectionScanResult, error) {
 	return o.detail.get(func() (*vulnerabilityscanning.HostEndpointProtectionScanResult, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.VulnerabilityScanningClient(o.region)
+		svc, err := conn.VulnerabilityScanningClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -1188,8 +1188,8 @@ func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) endpointPr
 // ----- container scan results -----
 
 type mqlOciVulnerabilityScanningContainerScanResultInternal struct {
-	region string
-	detail ociLazy[*vulnerabilityscanning.ContainerScanResult]
+	cacheRegion string
+	detail      ociLazy[*vulnerabilityscanning.ContainerScanResult]
 }
 
 func (o *mqlOciVulnerabilityScanning) containerScanResults() ([]any, error) {
@@ -1244,7 +1244,7 @@ func (o *mqlOciVulnerabilityScanning) fetchContainerScanResults(conn *connection
 				if err != nil {
 					return nil, err
 				}
-				mqlInst.(*mqlOciVulnerabilityScanningContainerScanResult).region = regionId
+				mqlInst.(*mqlOciVulnerabilityScanningContainerScanResult).cacheRegion = regionId
 				res = append(res, mqlInst)
 			}
 			return jobpool.JobResult(res), nil
@@ -1279,7 +1279,7 @@ func (o *mqlOciVulnerabilityScanningContainerScanResult) target() (*mqlOciVulner
 func (o *mqlOciVulnerabilityScanningContainerScanResult) fetchDetail() (*vulnerabilityscanning.ContainerScanResult, error) {
 	return o.detail.get(func() (*vulnerabilityscanning.ContainerScanResult, error) {
 		conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-		svc, err := conn.VulnerabilityScanningClient(o.region)
+		svc, err := conn.VulnerabilityScanningClient(o.cacheRegion)
 		if err != nil {
 			return nil, err
 		}
@@ -1366,7 +1366,7 @@ func (o *mqlOciVulnerabilityScanningContainerScanResultProblem) vulnerability() 
 // ----- vulnerability rollup -----
 
 type mqlOciVulnerabilityScanningVulnerabilityInternal struct {
-	region string
+	cacheRegion string
 }
 
 func (o *mqlOciVulnerabilityScanning) vulnerabilities() ([]any, error) {
@@ -1484,7 +1484,7 @@ func (o *mqlOciVulnerabilityScanning) fetchVulnerabilities(conn *connection.OciC
 				if err != nil {
 					return nil, err
 				}
-				mqlInst.(*mqlOciVulnerabilityScanningVulnerability).region = regionId
+				mqlInst.(*mqlOciVulnerabilityScanningVulnerability).cacheRegion = regionId
 				res = append(res, mqlInst)
 			}
 			return jobpool.JobResult(res), nil
@@ -1533,7 +1533,7 @@ func initOciVulnerabilityScanningVulnerability(runtime *plugin.Runtime, args map
 
 func (o *mqlOciVulnerabilityScanningVulnerability) impactedHosts() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.VulnerabilityScanningClient(o.region)
+	svc, err := conn.VulnerabilityScanningClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -1569,7 +1569,7 @@ func (o *mqlOciVulnerabilityScanningVulnerability) impactedHosts() ([]any, error
 
 func (o *mqlOciVulnerabilityScanningVulnerability) impactedContainerImages() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	svc, err := conn.VulnerabilityScanningClient(o.region)
+	svc, err := conn.VulnerabilityScanningClient(o.cacheRegion)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -88,8 +88,8 @@ func (o *mqlOciWaf) firewalls() ([]any, error) {
 					return nil, err
 				}
 				mqlFw := mqlInstance.(*mqlOciWafFirewall)
-				mqlFw.cachePolicyId = stringValue(lbWaf.WebAppFirewallPolicyId)
-				mqlFw.cacheLoadBalancerId = stringValue(lbWaf.LoadBalancerId)
+				mqlFw.cachePolicyID = stringValue(lbWaf.WebAppFirewallPolicyId)
+				mqlFw.cacheLoadBalancerID = stringValue(lbWaf.LoadBalancerId)
 				res = append(res, mqlFw)
 			}
 
@@ -98,8 +98,8 @@ func (o *mqlOciWaf) firewalls() ([]any, error) {
 }
 
 type mqlOciWafFirewallInternal struct {
-	cachePolicyId       string
-	cacheLoadBalancerId string
+	cachePolicyID       string
+	cacheLoadBalancerID string
 }
 
 func (o *mqlOciWafFirewall) id() (string, error) {
@@ -107,12 +107,12 @@ func (o *mqlOciWafFirewall) id() (string, error) {
 }
 
 func (o *mqlOciWafFirewall) policy() (*mqlOciWafPolicy, error) {
-	if o.cachePolicyId == "" {
+	if o.cachePolicyID == "" {
 		o.Policy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlPolicy, err := NewResource(o.MqlRuntime, "oci.waf.policy", map[string]*llx.RawData{
-		"id": llx.StringData(o.cachePolicyId),
+		"id": llx.StringData(o.cachePolicyID),
 	})
 	if err != nil {
 		return nil, err
@@ -121,12 +121,12 @@ func (o *mqlOciWafFirewall) policy() (*mqlOciWafPolicy, error) {
 }
 
 func (o *mqlOciWafFirewall) loadBalancer() (*mqlOciLoadBalancerLoadBalancer, error) {
-	if o.cacheLoadBalancerId == "" {
+	if o.cacheLoadBalancerID == "" {
 		o.LoadBalancer.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	mqlLb, err := NewResource(o.MqlRuntime, "oci.loadBalancer.loadBalancer", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheLoadBalancerId),
+		"id": llx.StringData(o.cacheLoadBalancerID),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Continues the OCI internals sequence (#9650, #9655, #9659, #9661, #9663). Rename only.

## The drift

The `Internal`-struct cache fields had settled into two naming camps, and one concept had picked up **four** spellings:

| concept | spellings in tree |
|---|---|
| subnet id | `cacheSubnetId` (33), `cacheSubnetIds` (12), `cacheSubnetID` (4), `cacheSubnetIDs` (4) |
| compartment id | `cacheCompartmentId` (57), `cacheCompartmentID` (3) |
| region | `region` (23 structs), `cacheRegion` (17 structs) |

## Which camp is right

The schema settles it. `.lr` declares `compartmentID`, so the generated field is `CompartmentID`. A cache of that value spelled `cacheCompartmentId` disagrees with the field it caches — in the same struct. So the `ID` camp wins: every `cache*Id`/`cache*Ids` becomes `cache*ID`/`cache*IDs` (40 identifiers), plus `cacheUrl` → `cacheURL`.

The `region` case is separate and worth calling out: the resource has a **schema** field named `region` too, so `mqlInst.region = region` sitting next to `"region": llx.ResourceData(...)` reads as if one feeds the other. They are unrelated — one is the cached region key, the other the typed `oci.region` resource. All 23 move to `cacheRegion`, matching the 17 that already had it.

## Three things the mechanical pass had to avoid

Each was found by taking an inventory *before* editing, not by cleaning up after:

1. **`"oci.region"`** — 16 hits, all the resource-name string literal or comments naming that resource. A regex on `.region` rewrites the string and breaks resource resolution silently.
2. **`parsedOciPlatformID` / `ociDiscovered` / `ociObject`** — plain data carriers in `discovery.go` whose `region` field is correctly named and must stay. I still over-renamed two of their uses; the compiler caught both, which is why the declarations were renamed first and the accessors left to the type checker.
3. **`oci.lr.go`** — generated, and its schema-path literals (`"oci.dataSafe.userAssessment.region"`) are indistinguishable from field accesses by regex. My first inventory included it and inflated the count; excluding it changed the picture. The file ends up byte-identical.

Worth noting for anyone repeating this on macOS: BSD `sed` has no `\b`, so the first attempt matched nothing and reported success. The working tree being clean is what caught it. The scripts use `perl`.

## Verification

Because "it still builds" is weak evidence for a rename, the branch is audited by **replaying the same transform onto `main`'s files in a scratch directory and diffing against this branch** — identical, so the branch carries the mechanical rename and nothing else.

- `go build ./...`, `go vet ./...`, `gofmt -l`, `go test -race ./...` all clean
- No schema, generated code, or permissions manifest touched
- 478 insertions / 478 deletions — symmetric, as a pure rename should be

## Follow-up

The `resolveRef[T]` / `resolveRefs[T]` generic (collapsing the 8 near-identical `resolveOci*` helpers in `typed_refs.go`) was the other half of this item. It is an actual code change rather than a rename, so it goes in its own PR to keep this one trivially reviewable.
