### PR TITLE
🧹 oci: one typed-reference resolver

### DIFF
--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -412,20 +412,6 @@ func (o *mqlOciNetworkSecurityList) hasStatelessRules() (bool, error) {
 	return anyRuleStateless(o.EgressSecurityRules.Data, "stateless"), nil
 }
 
-func resolveOciCompartment(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciCompartment]) (*mqlOciCompartment, error) {
-	if id == "" {
-		field.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(runtime, "oci.compartment", map[string]*llx.RawData{
-		"id": llx.StringData(id),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciCompartment), nil
-}
-
 func anyRuleStateless(rules []any, key string) bool {
 	for _, r := range rules {
 		m, ok := r.(map[string]any)

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -11,70 +12,95 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-// resolveOciImage resolves a typed image resource from an image OCID. Returns
-// (nil, nil) and marks the field as null when the OCID is empty.
+// A resource that points at another one - an instance at its image, a key at
+// its vault - stores the target's OCID and resolves it on read. Every such
+// accessor is the same six steps, and there were thirteen copies of them: five
+// named helpers and eight written out inline.
+//
+// Two of those steps are easy to get wrong in a way nothing catches:
+//
+//   - The null marking. A singular resource accessor that returns (nil, nil)
+//     without first setting StateIsNull leaves the runtime unable to tell the
+//     field was resolved, so it re-fetches or panics on read rather than
+//     reporting null. It has to happen on every empty-id path, in every copy.
+//   - The type assertion. All thirteen ended in a bare res.(*mqlOciX), which
+//     panics if the resource name and the target type ever disagree - and a
+//     panic inside an accessor takes down the whole scan, not one field.
+//
+// resolveRef does both once.
+
+// resolveRef resolves a typed resource from an OCID, marking the field null
+// when there is no id to resolve.
+//
+// A null here is a real answer rather than a missing one: a service using
+// Oracle-managed encryption has no customer key to point at, and an instance
+// not launched from a boot volume has no source. Null is how the absence is
+// reported.
+func resolveRef[T plugin.Resource](runtime *plugin.Runtime, resourceName, id string, field *plugin.TValue[T]) (T, error) {
+	var zero T
+	if id == "" {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return zero, nil
+	}
+
+	res, err := NewResource(runtime, resourceName, map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return zero, err
+	}
+
+	// Reported rather than asserted. This can only fail if resourceName and T
+	// disagree, which is a bug in the caller - but a failed bare assertion is a
+	// panic, and the executor runs accessors in goroutines where a panic ends
+	// the scan instead of the query.
+	typed, ok := any(res).(T)
+	if !ok {
+		return zero, errors.New("oci: " + resourceName + " resolved to an unexpected resource type")
+	}
+	return typed, nil
+}
+
+// ocidOrEmpty reports id, or "" when it is not an OCID.
+//
+// OCI returns placeholder values where an OCID would go - ORACLE_MANAGED_KEY
+// for a service-managed encryption key is the common one. Passing that to
+// resolveRef would send it to an init that cannot find it and surface a
+// not-found error on a field whose honest answer is "nothing is referenced
+// here". Callers whose upstream field carries such placeholders wrap the id in
+// this; the rest pass the id straight through, which is the behaviour those
+// accessors already had.
+func ocidOrEmpty(id string) string {
+	if !isOcid(id) {
+		return ""
+	}
+	return id
+}
+
+// resolveOciImage resolves a typed image resource from an image OCID.
 func resolveOciImage(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciComputeImage]) (*mqlOciComputeImage, error) {
-	if id == "" {
-		field.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(runtime, "oci.compute.image", map[string]*llx.RawData{
-		"id": llx.StringData(id),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciComputeImage), nil
+	return resolveRef(runtime, "oci.compute.image", id, field)
 }
 
-// resolveOciVault resolves a typed vault resource from a vault OCID. Returns
-// (nil, nil) and marks the field as null when the OCID is empty.
+// resolveOciVault resolves a typed vault resource from a vault OCID.
 func resolveOciVault(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciKmsVault]) (*mqlOciKmsVault, error) {
-	if id == "" {
-		field.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(runtime, "oci.kms.vault", map[string]*llx.RawData{
-		"id": llx.StringData(id),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciKmsVault), nil
+	return resolveRef(runtime, "oci.kms.vault", id, field)
 }
 
-// resolveOciKmsKey resolves a typed KMS key resource from a key OCID. Returns
-// (nil, nil) and marks the field as null when the OCID is empty, which is what
-// a service using Oracle-managed encryption reports: there is no customer key
-// to point at, and a null key is the signal that no customer key is in use.
+// resolveOciKmsKey resolves a typed KMS key resource from a key OCID.
 func resolveOciKmsKey(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciKmsKey]) (*mqlOciKmsKey, error) {
-	if id == "" {
-		field.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(runtime, "oci.kms.key", map[string]*llx.RawData{
-		"id": llx.StringData(id),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciKmsKey), nil
+	return resolveRef(runtime, "oci.kms.key", id, field)
 }
 
 // resolveOciSubnet resolves a typed subnet resource from a subnet OCID.
-// Returns (nil, nil) and marks the field as null when the OCID is empty.
 func resolveOciSubnet(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciNetworkSubnet]) (*mqlOciNetworkSubnet, error) {
-	if id == "" {
-		field.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(runtime, "oci.network.subnet", map[string]*llx.RawData{
-		"id": llx.StringData(id),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciNetworkSubnet), nil
+	return resolveRef(runtime, "oci.network.subnet", id, field)
+}
+
+// resolveOciCompartment resolves the compartment a resource lives in. It is by
+// far the most used of these, since almost every resource reports its owner.
+func resolveOciCompartment(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciCompartment]) (*mqlOciCompartment, error) {
+	return resolveRef(runtime, "oci.compartment", id, field)
 }
 
 // resolveOciSecurityGroups resolves a list of typed network security group
@@ -497,73 +523,23 @@ func (o *mqlOciComputeImage) baseImage() (*mqlOciComputeImage, error) {
 }
 
 func (o *mqlOciComputeInstance) bootVolume() (*mqlOciComputeBootVolume, error) {
-	if o.cacheBootVolumeID == "" || !isOcid(o.cacheBootVolumeID) {
-		o.BootVolume.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.compute.bootVolume", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheBootVolumeID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciComputeBootVolume), nil
+	return resolveRef(o.MqlRuntime, "oci.compute.bootVolume", ocidOrEmpty(o.cacheBootVolumeID), &o.BootVolume)
 }
 
 func (o *mqlOciComputeBlockVolume) sourceVolume() (*mqlOciComputeBlockVolume, error) {
-	if o.cacheSourceVolumeID == "" || !isOcid(o.cacheSourceVolumeID) {
-		o.SourceVolume.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.compute.blockVolume", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSourceVolumeID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciComputeBlockVolume), nil
+	return resolveRef(o.MqlRuntime, "oci.compute.blockVolume", ocidOrEmpty(o.cacheSourceVolumeID), &o.SourceVolume)
 }
 
 func (o *mqlOciComputeBootVolume) sourceBootVolume() (*mqlOciComputeBootVolume, error) {
-	if o.cacheSourceBootVolumeID == "" || !isOcid(o.cacheSourceBootVolumeID) {
-		o.SourceBootVolume.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.compute.bootVolume", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSourceBootVolumeID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciComputeBootVolume), nil
+	return resolveRef(o.MqlRuntime, "oci.compute.bootVolume", ocidOrEmpty(o.cacheSourceBootVolumeID), &o.SourceBootVolume)
 }
 
 func (o *mqlOciIdentityUser) identityProvider() (*mqlOciIdentityIdentityProvider, error) {
-	if o.cacheIdentityProviderID == "" || !isOcid(o.cacheIdentityProviderID) {
-		o.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.identity.identityProvider", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheIdentityProviderID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciIdentityIdentityProvider), nil
+	return resolveRef(o.MqlRuntime, "oci.identity.identityProvider", ocidOrEmpty(o.cacheIdentityProviderID), &o.IdentityProvider)
 }
 
 func (o *mqlOciOkeNodePool) cluster() (*mqlOciOkeCluster, error) {
-	if o.cacheClusterID == "" || !isOcid(o.cacheClusterID) {
-		o.Cluster.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.oke.cluster", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheClusterID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciOkeCluster), nil
+	return resolveRef(o.MqlRuntime, "oci.oke.cluster", ocidOrEmpty(o.cacheClusterID), &o.Cluster)
 }
 
 func (o *mqlOciLoadBalancerLoadBalancer) subnets() ([]any, error) {
@@ -601,43 +577,13 @@ func (o *mqlOciNetworkSubnet) securityLists() ([]any, error) {
 }
 
 func (o *mqlOciFileStorageFileSystem) parentFileSystem() (*mqlOciFileStorageFileSystem, error) {
-	if o.cacheParentFileSystemID == "" || !isOcid(o.cacheParentFileSystemID) {
-		o.ParentFileSystem.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.fileStorage.fileSystem", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheParentFileSystemID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciFileStorageFileSystem), nil
+	return resolveRef(o.MqlRuntime, "oci.fileStorage.fileSystem", ocidOrEmpty(o.cacheParentFileSystemID), &o.ParentFileSystem)
 }
 
 func (o *mqlOciDatabaseDbSystem) sourceDbSystem() (*mqlOciDatabaseDbSystem, error) {
-	if o.cacheSourceDbSystemID == "" || !isOcid(o.cacheSourceDbSystemID) {
-		o.SourceDbSystem.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.database.dbSystem", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSourceDbSystemID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciDatabaseDbSystem), nil
+	return resolveRef(o.MqlRuntime, "oci.database.dbSystem", ocidOrEmpty(o.cacheSourceDbSystemID), &o.SourceDbSystem)
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) sourceDatabase() (*mqlOciDatabaseAutonomousDatabase, error) {
-	if o.cacheSourceID == "" || !isOcid(o.cacheSourceID) {
-		o.SourceDatabase.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(o.MqlRuntime, "oci.database.autonomousDatabase", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheSourceID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlOciDatabaseAutonomousDatabase), nil
+	return resolveRef(o.MqlRuntime, "oci.database.autonomousDatabase", ocidOrEmpty(o.cacheSourceID), &o.SourceDatabase)
 }

--- a/providers/oci/resources/typed_refs_test.go
+++ b/providers/oci/resources/typed_refs_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestOcidOrEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"real ocid passes through", "ocid1.vcn.oc1.iad.aaaaaaaa", "ocid1.vcn.oc1.iad.aaaaaaaa"},
+		{"empty stays empty", "", ""},
+		// The reason this helper exists: OCI reports a service-managed key as a
+		// literal placeholder where an OCID would go. Resolving it would report
+		// a not-found error on a field whose honest answer is "no customer key".
+		{"oracle-managed placeholder", "ORACLE_MANAGED_KEY", ""},
+		{"arbitrary non-ocid", "not-an-ocid", ""},
+		{"prefix must be exact", "ocid2.vcn.oc1.iad.aaaa", ""},
+		{"bare prefix is still an ocid", "ocid1.", "ocid1."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ocidOrEmpty(tt.id))
+		})
+	}
+}
+
+// TestResolveRefMarksNull pins the invariant that made this worth centralizing.
+//
+// A singular resource accessor returning (nil, nil) without first setting
+// StateIsNull leaves the runtime unable to tell the field was resolved: it
+// re-fetches or panics on read instead of reporting null. That marking was
+// duplicated at every empty-id path in the provider, which is exactly the kind
+// of step that gets dropped when a new accessor is copied from an old one.
+//
+// The runtime is never touched on this path, so a nil one is a fine stand-in
+// and doubles as a check that the empty case short-circuits before any lookup.
+func TestResolveRefMarksNull(t *testing.T) {
+	t.Run("empty id marks the field null", func(t *testing.T) {
+		var field plugin.TValue[*mqlOciKmsKey]
+
+		got, err := resolveRef(nil, "oci.kms.key", "", &field)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State,
+			"an absent reference must be reported as null, not left unset")
+	})
+
+	t.Run("placeholder id marks the field null", func(t *testing.T) {
+		// ocidOrEmpty at the call site is what turns the placeholder into the
+		// empty case; together they must still produce a null, not an error.
+		var field plugin.TValue[*mqlOciKmsKey]
+
+		got, err := resolveRef(nil, "oci.kms.key", ocidOrEmpty("ORACLE_MANAGED_KEY"), &field)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+
+	t.Run("field state is untouched for a resolvable id", func(t *testing.T) {
+		// A non-empty id must not be pre-marked null: the state has to stay
+		// clear so the runtime records whatever the lookup produces. The
+		// lookup itself needs a live connection, so this stops at the guard.
+		var field plugin.TValue[*mqlOciKmsKey]
+		assert.Equal(t, plugin.State(0), field.State)
+
+		// Guard only: ocidOrEmpty keeps a real OCID, so resolveRef would go on
+		// to NewResource. Assert the classification rather than the lookup.
+		assert.NotEmpty(t, ocidOrEmpty("ocid1.key.oc1.iad.aaaa"))
+	})
+}


### PR DESCRIPTION
Continues the OCI internals sequence (#9650, #9655, #9659, #9661, #9663, #9665). The second half of the naming/refs item — #9665 was the rename, this is the code change.

## The duplication

A resource that points at another one — an instance at its image, a key at its vault — stores the target's OCID and resolves it on read. `typed_refs.go` had **thirteen** copies of that six-step body: five named helpers and eight written out inline.

Two of the six steps are easy to drop when a new accessor is copied from an old one, and nothing catches either:

- **The null marking.** A singular accessor returning `(nil, nil)` without first setting `StateIsNull` leaves the runtime unable to tell the field was resolved — it re-fetches or panics on read instead of reporting null.
- **The type assertion.** All thirteen ended in a bare `res.(*mqlOciX)`. That panics if the resource name and the target type ever disagree, and the executor runs accessors in goroutines, so the panic ends the **scan**, not the query. `resolveRef` reports it as an error.

`resolveRef[T]` does both once.

## What stayed

The five named helpers remain as one-line wrappers. `resolveOciCompartment` alone has **126** call sites and reads better than the generic spelled out at each one. It also moves into `typed_refs.go` from `network.go`, where it had no reason to live.

## The guard difference is preserved, not flattened

The two groups did not guard the same way:

| group | guard |
|---|---|
| 5 named helpers | `id != ""` |
| 8 inline copies | also required `isOcid`, because OCI returns placeholders like `ORACLE_MANAGED_KEY` where an OCID would go |

Collapsing both into one policy would have changed results — either turning placeholder values into not-found errors, or turning genuine errors into nulls. Instead the stricter guard is `ocidOrEmpty(id)` at the call sites that need it, so the distinction is visible at the call site rather than buried inside a body.

## Testing

`typed_refs_test.go` covers the null marking and the placeholder filtering — the two invariants that were being retyped by hand thirteen times. The empty-id path never touches the runtime, so those cases run with a nil one, which also proves the guard short-circuits before any lookup.

## Verification

- The multiset of resource names passed to `NewResource` is **identical to main** in both changed files (diffed).
- `!isOcid(x)` and `x == "" || !isOcid(x)` are equivalent, since `isOcid("")` is false — so the inline sites keep their exact behavior.
- `go build`, `go vet`, `gofmt -l`, `go test -race ./...` all clean.
- No schema, generated code, or permissions manifest touched.

## Found while doing this — deliberately not included

There are **~90 more inline copies of this same shape across 30 other files** (`transit.go` 15, `vulnerabilityscanning.go` 10, `database.go` 10, …). I did not sweep them, because they are not uniform — there are four distinct guard shapes:

```go
if !isOcid(x) { ... }                                  // transit.go
if x == "" || !isOcid(x) { ... }                       // database.go   (equivalent)
if x == "" { ... }                                     // aiservices.go (weaker)
if !isOcid(x) || o.IsCrossTenancyPeering.Data { ... }  // transit.go    (extra condition)
```

A blind script would flatten the third into the first and silently drop the fourth's extra condition. They want the same classify-then-convert treatment #9655 and #9663 used. Worth its own PR.
