### PR TITLE
🐛 oci: stop DNS steering policies and dangling SCH buckets failing queries

### DIFF
--- a/providers/oci/resources/dns.go
+++ b/providers/oci/resources/dns.go
@@ -29,13 +29,6 @@ var ociDnsZoneScopes = []dns.ListZonesScopeEnum{
 	dns.ListZonesScopePrivate,
 }
 
-// ociDnsSteeringPolicyScopes are the scopes a steering policy can live in.
-// The listing scopes the same way zones do, so both have to be asked for.
-var ociDnsSteeringPolicyScopes = []dns.ListSteeringPoliciesScopeEnum{
-	dns.ListSteeringPoliciesScopeGlobal,
-	dns.ListSteeringPoliciesScopePrivate,
-}
-
 func (o *mqlOciDns) zones() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
@@ -131,27 +124,22 @@ func (o *mqlOciDns) steeringPolicies() ([]any, error) {
 				return nil, err
 			}
 
-			policies := []dns.SteeringPolicySummary{}
-			// Scoped the same way zones are, and for the same reason: the
-			// listing returns one scope at a time rather than the union, so
-			// asking only for the default reports a tenancy's private traffic
-			// management as absent.
-			for _, scope := range ociDnsSteeringPolicyScopes {
-				perScope, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]dns.SteeringPolicySummary, *string, error) {
-					response, err := client.ListSteeringPolicies(ctx, dns.ListSteeringPoliciesRequest{
-						CompartmentId: common.String(compartmentID),
-						Scope:         scope,
-						Page:          page,
-					})
-					if err != nil {
-						return nil, nil, err
-					}
-					return response.Items, response.OpcNextPage, nil
+			// Unlike zones, steering policies exist only globally: the listing
+			// rejects any other scope with "query param scope must be one of
+			// [GLOBAL]", so asking for PRIVATE fails the whole call.
+			policies, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]dns.SteeringPolicySummary, *string, error) {
+				response, err := client.ListSteeringPolicies(ctx, dns.ListSteeringPoliciesRequest{
+					CompartmentId: common.String(compartmentID),
+					Scope:         dns.ListSteeringPoliciesScopeGlobal,
+					Page:          page,
 				})
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				policies = append(policies, perScope...)
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
 			}
 
 			res := make([]any, 0, len(policies))

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/sch"
@@ -189,9 +190,36 @@ func (o *mqlOciServiceConnectorHubConnector) targetBucket() (*mqlOciObjectStorag
 		"region":    llx.ResourceData(regionRes, "oci.region"),
 	})
 	if err != nil {
+		// A connector outlives its target: deleting the bucket leaves the
+		// connector in place pointing at a name that no longer resolves, and
+		// the bucket's init reports that as a 404. That is a real state of the
+		// tenancy, not a fault, so the reference reads as null instead of
+		// failing every connector in the listing.
+		if ociReferentGone(err) {
+			log.Debug().Str("bucket", stringValue(target.BucketName)).
+				Msg("service connector target bucket no longer exists")
+			o.TargetBucket.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return res.(*mqlOciObjectStorageBucket), nil
+}
+
+// ociReferentGone reports whether an error means a referenced resource no
+// longer exists.
+//
+// The error arrives wrapped by the runtime that ran the referent's init, so
+// this unwraps rather than type-asserting the way ociCompartmentInaccessible
+// can. Both 404 spellings count: services return a specific code such as
+// BucketNotFound, and the shared NotAuthorizedOrNotFound covers the case where
+// the resource is gone or was never visible.
+func ociReferentGone(err error) bool {
+	var svcErr common.ServiceError
+	if !errors.As(err, &svcErr) {
+		return false
+	}
+	return svcErr.GetHTTPStatusCode() == 404
 }
 
 func (o *mqlOciServiceConnectorHubConnector) targetTopic() (*mqlOciOnsTopic, error) {


### PR DESCRIPTION
Found by running the OCI resources changed since `os-13.40.4` against a live tenancy.

## `oci.dns.steeringPolicies` errored in every tenancy

The lister iterated `[GLOBAL, PRIVATE]`, mirroring how zones are listed. Zones genuinely have both scopes; steering policies (Traffic Management) exist only globally, and the API rejects anything else:

```
400 InvalidParameter — query param scope must be one of [GLOBAL]
GET /20180115/steeringPolicies?compartmentId=...&scope=PRIVATE
```

The error escaped `ociCollect`, so the field failed outright instead of returning what the global scope holds. This affected **every tenancy**, not just unusual ones — there was no configuration in which the field worked.

## `oci.serviceConnectorHub.connectors` failed on a dangling target bucket

Deleting a bucket does not delete the connectors that write to it, so the connector survives pointing at a name that no longer resolves and the bucket's `init` reports a 404. `targetBucket()` returned that error, which failed **every** connector in the listing — one stale reference hid all the healthy ones.

A missing referent is a real state of the tenancy rather than a fault, so the reference now reads as null. The unwrapping helper uses `errors.As` because the error arrives wrapped by the runtime that ran the referent's `init`, unlike `ociCompartmentInaccessible` which can type-assert directly.

## Verification

Both confirmed against a live tenancy, before and after:

| Query | Before | After |
|---|---|---|
| `oci.dns { zones steeringPolicies }` | `400 InvalidParameter` on the whole field | `steeringPolicies: []`, `zones` still returns 2 zones |
| `oci.serviceConnectorHub.connectors { name targetBucket }` | `404 BucketNotFound`, entire listing failed | all 3 connectors returned; the dangling one reports `targetBucket: null`, siblings resolve normally |

No schema change, so no `.lr.versions` entry. No permissions change.
