### PR TITLE
🧹 oci: stop hand-copying tag maps at every lister

### DIFF
--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -62,15 +62,6 @@ func (o *mqlOciApigateway) gateways() ([]any, error) {
 					updated = &g.TimeUpdated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(g.FreeformTags))
-				for k, v := range g.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(g.DefinedTags))
-				for k, v := range g.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.apigateway.gateway", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(g.Id),
 					"name":          llx.StringDataPtr(g.DisplayName),
@@ -81,8 +72,8 @@ func (o *mqlOciApigateway) gateways() ([]any, error) {
 					"state":         llx.StringData(string(g.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
 					"timeUpdated":   llx.TimeDataPtr(updated),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(g.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(g.DefinedTags), types.Any),
 					"systemTags":    llx.MapData(definedTagsToAny(g.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -270,15 +261,6 @@ func (o *mqlOciApigateway) deployments() ([]any, error) {
 					updated = &d.TimeUpdated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(d.FreeformTags))
-				for k, v := range d.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(d.DefinedTags))
-				for k, v := range d.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.apigateway.deployment", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(d.Id),
 					"name":          llx.StringDataPtr(d.DisplayName),
@@ -288,8 +270,8 @@ func (o *mqlOciApigateway) deployments() ([]any, error) {
 					"state":         llx.StringData(string(d.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
 					"timeUpdated":   llx.TimeDataPtr(updated),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(d.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(d.DefinedTags), types.Any),
 					"systemTags":    llx.MapData(definedTagsToAny(d.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -650,15 +632,6 @@ func (o *mqlOciApigateway) certificates() ([]any, error) {
 
 				subjectNames := convert.SliceAnyToInterface(c.SubjectNames)
 
-				freeformTags := make(map[string]interface{}, len(c.FreeformTags))
-				for k, v := range c.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(c.DefinedTags))
-				for k, v := range c.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.apigateway.certificate", map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(c.Id),
 					"name":              llx.StringDataPtr(c.DisplayName),
@@ -668,8 +641,8 @@ func (o *mqlOciApigateway) certificates() ([]any, error) {
 					"state":             llx.StringData(string(c.LifecycleState)),
 					"created":           llx.TimeDataPtr(created),
 					"timeUpdated":       llx.TimeDataPtr(updated),
-					"freeformTags":      llx.MapData(freeformTags, types.String),
-					"definedTags":       llx.MapData(definedTags, types.Any),
+					"freeformTags":      llx.MapData(strMapToAny(c.FreeformTags), types.String),
+					"definedTags":       llx.MapData(definedTagsToAny(c.DefinedTags), types.Any),
 					"systemTags":        llx.MapData(definedTagsToAny(c.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -88,15 +88,6 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 
 				autoRenewal, renewalInterval := extractCertificateRenewal(c.CertificateRules)
 
-				freeformTags := make(map[string]interface{}, len(c.FreeformTags))
-				for k, v := range c.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(c.DefinedTags))
-				for k, v := range c.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.certificates.certificate", map[string]*llx.RawData{
 					"id":                 llx.StringDataPtr(c.Id),
 					"name":               llx.StringDataPtr(c.Name),
@@ -115,8 +106,8 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 					"renewalInterval":    llx.StringData(renewalInterval),
 					"state":              llx.StringData(string(c.LifecycleState)),
 					"created":            llx.TimeDataPtr(created),
-					"freeformTags":       llx.MapData(freeformTags, types.String),
-					"definedTags":        llx.MapData(definedTags, types.Any),
+					"freeformTags":       llx.MapData(strMapToAny(c.FreeformTags), types.String),
+					"definedTags":        llx.MapData(definedTagsToAny(c.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -263,15 +254,6 @@ func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 
 				kind := caKindFromConfigType(string(ca.ConfigType))
 
-				freeformTags := make(map[string]interface{}, len(ca.FreeformTags))
-				for k, v := range ca.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(ca.DefinedTags))
-				for k, v := range ca.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.certificates.certificateAuthority", map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(ca.Id),
 					"name":              llx.StringDataPtr(ca.Name),
@@ -285,8 +267,8 @@ func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 					"signingAlgorithm":  llx.StringData(string(ca.SigningAlgorithm)),
 					"state":             llx.StringData(string(ca.LifecycleState)),
 					"created":           llx.TimeDataPtr(created),
-					"freeformTags":      llx.MapData(freeformTags, types.String),
-					"definedTags":       llx.MapData(definedTags, types.Any),
+					"freeformTags":      llx.MapData(strMapToAny(ca.FreeformTags), types.String),
+					"definedTags":       llx.MapData(definedTagsToAny(ca.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -408,15 +390,6 @@ func (o *mqlOciCertificates) caBundles() ([]any, error) {
 					created = &b.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(b.FreeformTags))
-				for k, v := range b.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(b.DefinedTags))
-				for k, v := range b.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.certificates.caBundle", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(b.Id),
 					"name":          llx.StringDataPtr(b.Name),
@@ -424,8 +397,8 @@ func (o *mqlOciCertificates) caBundles() ([]any, error) {
 					"compartmentID": llx.StringDataPtr(b.CompartmentId),
 					"state":         llx.StringData(string(b.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(b.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(b.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -75,16 +75,6 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 					created = &instance.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(instance.FreeformTags))
-				for k, v := range instance.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{}, len(instance.DefinedTags))
-				for k, v := range instance.DefinedTags {
-					definedTags[k] = v
-				}
-
 				metadata := make(map[string]interface{}, len(instance.Metadata))
 				for k, v := range instance.Metadata {
 					metadata[k] = v
@@ -181,8 +171,8 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 					"sourceDetails":               llx.DictData(sourceDetails),
 					"metadata":                    llx.MapData(metadata, types.String),
 					"timeMaintenanceRebootDue":    llx.TimeDataPtr(timeMaintenanceRebootDue),
-					"freeformTags":                llx.MapData(freeformTags, types.String),
-					"definedTags":                 llx.MapData(definedTags, types.Any),
+					"freeformTags":                llx.MapData(strMapToAny(instance.FreeformTags), types.String),
+					"definedTags":                 llx.MapData(definedTagsToAny(instance.DefinedTags), types.Any),
 					"systemTags":                  llx.MapData(definedTagsToAny(instance.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -373,16 +363,6 @@ func (o *mqlOciCompute) images() ([]any, error) {
 					created = &image.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(image.FreeformTags))
-				for k, v := range image.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{}, len(image.DefinedTags))
-				for k, v := range image.DefinedTags {
-					definedTags[k] = v
-				}
-
 				// Create compartment resource reference
 				compartment, err := NewResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
 					"id": llx.StringDataPtr(image.CompartmentId),
@@ -401,8 +381,8 @@ func (o *mqlOciCompute) images() ([]any, error) {
 					"operatingSystem":        llx.StringDataPtr(image.OperatingSystem),
 					"operatingSystemVersion": llx.StringDataPtr(image.OperatingSystemVersion),
 					"sizeInMBs":              llx.IntDataPtr(image.SizeInMBs),
-					"freeformTags":           llx.MapData(freeformTags, types.String),
-					"definedTags":            llx.MapData(definedTags, types.Any),
+					"freeformTags":           llx.MapData(strMapToAny(image.FreeformTags), types.String),
+					"definedTags":            llx.MapData(definedTagsToAny(image.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -107,15 +107,6 @@ func (o *mqlOciContainerInstances) instances() ([]any, error) {
 					return nil, err
 				}
 
-				freeformTags := make(map[string]interface{}, len(ci.FreeformTags))
-				for k, v := range ci.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(ci.DefinedTags))
-				for k, v := range ci.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.containerInstances.instance", map[string]*llx.RawData{
 					"id":                               llx.StringDataPtr(ci.Id),
 					"name":                             llx.StringDataPtr(ci.DisplayName),
@@ -131,8 +122,8 @@ func (o *mqlOciContainerInstances) instances() ([]any, error) {
 					"volumeCount":                      llx.IntData(intValue(ci.VolumeCount)),
 					"created":                          llx.TimeDataPtr(created),
 					"timeUpdated":                      llx.TimeDataPtr(timeUpdated),
-					"freeformTags":                     llx.MapData(freeformTags, types.String),
-					"definedTags":                      llx.MapData(definedTags, types.Any),
+					"freeformTags":                     llx.MapData(strMapToAny(ci.FreeformTags), types.String),
+					"definedTags":                      llx.MapData(definedTagsToAny(ci.DefinedTags), types.Any),
 					"systemTags":                       llx.MapData(definedTagsToAny(ci.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -196,15 +187,6 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 			return nil, err
 		}
 
-		freeformTags := make(map[string]interface{}, len(c.FreeformTags))
-		for k, v := range c.FreeformTags {
-			freeformTags[k] = v
-		}
-		definedTags := make(map[string]interface{}, len(c.DefinedTags))
-		for k, v := range c.DefinedTags {
-			definedTags[k] = v
-		}
-
 		sec := ociContainerSecurityContext(c.SecurityContext)
 
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.containerInstances.container", map[string]*llx.RawData{
@@ -225,8 +207,8 @@ func (o *mqlOciContainerInstancesInstance) containers() ([]any, error) {
 			"droppedCapabilities":         llx.ArrayData(sec.dropped, types.String),
 			"created":                     llx.TimeDataPtr(created),
 			"timeUpdated":                 llx.TimeDataPtr(timeUpdated),
-			"freeformTags":                llx.MapData(freeformTags, types.String),
-			"definedTags":                 llx.MapData(definedTags, types.Any),
+			"freeformTags":                llx.MapData(strMapToAny(c.FreeformTags), types.String),
+			"definedTags":                 llx.MapData(definedTagsToAny(c.DefinedTags), types.Any),
 			"systemTags":                  llx.MapData(definedTagsToAny(c.SystemTags), types.Dict),
 		})
 		if err != nil {

--- a/providers/oci/resources/conversion_test.go
+++ b/providers/oci/resources/conversion_test.go
@@ -177,3 +177,50 @@ func TestStringsToAnyAndStrMapToAny(t *testing.T) {
 	assert.Empty(t, strMapToAny(nil))
 	assert.Equal(t, map[string]any{"k": "v"}, strMapToAny(map[string]string{"k": "v"}))
 }
+
+// The tag helpers replaced a copy loop that had been written out by hand at 64
+// listers. These pin the property that made that replacement safe: the helper
+// returns what the loop returned. Written as the loop, not as a literal, so the
+// comparison keeps meaning if either side is ever changed.
+
+func TestStrMapToAnyMatchesInlineCopy(t *testing.T) {
+	for _, in := range []map[string]string{
+		nil,
+		{},
+		{"env": "prod"},
+		{"env": "prod", "owner": "platform", "": "empty-key"},
+	} {
+		want := make(map[string]interface{}, len(in))
+		for k, v := range in {
+			want[k] = v
+		}
+		assert.Equal(t, want, strMapToAny(in))
+	}
+}
+
+func TestDefinedTagsToAnyMatchesInlineCopy(t *testing.T) {
+	for _, in := range []map[string]map[string]interface{}{
+		nil,
+		{},
+		{"Operations": {"CostCenter": "42"}},
+		{
+			"Operations": {"CostCenter": "42", "Reviewed": true, "Count": 7},
+			"Empty":      {},
+		},
+	} {
+		want := make(map[string]interface{}, len(in))
+		for k, v := range in {
+			want[k] = v
+		}
+
+		got := definedTagsToAny(in)
+
+		// Equal, not Same: the helper rebuilds each namespace map instead of
+		// aliasing the SDK's, so it does not hand MQL a map the SDK still owns.
+		// The contents are what has to match.
+		assert.Equal(t, len(want), len(got))
+		for ns, kv := range want {
+			assert.EqualValues(t, kv, got[ns])
+		}
+	}
+}

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -58,15 +58,6 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 					created = &s.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(s.FreeformTags))
-				for k, v := range s.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(s.DefinedTags))
-				for k, v := range s.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.database.dbSystem", map[string]*llx.RawData{
 					"id":                   llx.StringDataPtr(s.Id),
 					"name":                 llx.StringDataPtr(s.DisplayName),
@@ -88,8 +79,8 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 					"backupNetworkNsgIds":  llx.ArrayData(convert.SliceAnyToInterface(s.BackupNetworkNsgIds), types.String),
 					"state":                llx.StringData(string(s.LifecycleState)),
 					"created":              llx.TimeDataPtr(created),
-					"freeformTags":         llx.MapData(freeformTags, types.String),
-					"definedTags":          llx.MapData(definedTags, types.Any),
+					"freeformTags":         llx.MapData(strMapToAny(s.FreeformTags), types.String),
+					"definedTags":          llx.MapData(definedTagsToAny(s.DefinedTags), types.Any),
 					"systemTags":           llx.MapData(definedTagsToAny(s.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -181,15 +172,6 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 					created = &a.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(a.FreeformTags))
-				for k, v := range a.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(a.DefinedTags))
-				for k, v := range a.DefinedTags {
-					definedTags[k] = v
-				}
-
 				var connectionUrls map[string]any
 				if a.ConnectionUrls != nil {
 					connectionUrls, err = convert.JsonToDict(a.ConnectionUrls)
@@ -239,8 +221,8 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 					"publicConnectionUrls":        llx.DictData(publicConnectionUrls),
 					"state":                       llx.StringData(string(a.LifecycleState)),
 					"created":                     llx.TimeDataPtr(created),
-					"freeformTags":                llx.MapData(freeformTags, types.String),
-					"definedTags":                 llx.MapData(definedTags, types.Any),
+					"freeformTags":                llx.MapData(strMapToAny(a.FreeformTags), types.String),
+					"definedTags":                 llx.MapData(definedTagsToAny(a.DefinedTags), types.Any),
 					"systemTags":                  llx.MapData(definedTagsToAny(a.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -69,15 +69,6 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 					return nil, err
 				}
 
-				freeformTags := make(map[string]interface{}, len(app.FreeformTags))
-				for k, v := range app.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(app.DefinedTags))
-				for k, v := range app.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.functions.application", map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(app.Id),
 					"name":              llx.StringDataPtr(app.DisplayName),
@@ -88,8 +79,8 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 					"imagePolicyConfig": llx.DictData(imagePolicyConfig),
 					"created":           llx.TimeDataPtr(created),
 					"timeUpdated":       llx.TimeDataPtr(timeUpdated),
-					"freeformTags":      llx.MapData(freeformTags, types.String),
-					"definedTags":       llx.MapData(definedTags, types.Any),
+					"freeformTags":      llx.MapData(strMapToAny(app.FreeformTags), types.String),
+					"definedTags":       llx.MapData(definedTagsToAny(app.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -231,15 +222,6 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 			return nil, err
 		}
 
-		freeformTags := make(map[string]interface{}, len(fn.FreeformTags))
-		for k, v := range fn.FreeformTags {
-			freeformTags[k] = v
-		}
-		definedTags := make(map[string]interface{}, len(fn.DefinedTags))
-		for k, v := range fn.DefinedTags {
-			definedTags[k] = v
-		}
-
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.functions.function", map[string]*llx.RawData{
 			"id":               llx.StringDataPtr(fn.Id),
 			"name":             llx.StringDataPtr(fn.DisplayName),
@@ -255,8 +237,8 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 			"traceConfig":      llx.DictData(traceConfig),
 			"created":          llx.TimeDataPtr(created),
 			"timeUpdated":      llx.TimeDataPtr(timeUpdated),
-			"freeformTags":     llx.MapData(freeformTags, types.String),
-			"definedTags":      llx.MapData(definedTags, types.Any),
+			"freeformTags":     llx.MapData(strMapToAny(fn.FreeformTags), types.String),
+			"definedTags":      llx.MapData(definedTagsToAny(fn.DefinedTags), types.Any),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -107,16 +107,6 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 				capabilities["canUseOAuth2ClientCredentials"] = boolValue(user.Capabilities.CanUseOAuth2ClientCredentials)
 			}
 
-			freeformTags := make(map[string]interface{})
-			for k, v := range user.FreeformTags {
-				freeformTags[k] = v
-			}
-
-			definedTags := make(map[string]interface{})
-			for k, v := range user.DefinedTags {
-				definedTags[k] = v
-			}
-
 			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.user", map[string]*llx.RawData{
 				"id":                 llx.StringDataPtr(user.Id),
 				"name":               llx.StringDataPtr(user.Name),
@@ -131,8 +121,8 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 				"capabilities":       llx.MapData(capabilities, types.Bool),
 				"lastLogin":          llx.TimeDataPtr(lastLogin),
 				"previousLogin":      llx.TimeDataPtr(previousLogin),
-				"freeformTags":       llx.MapData(freeformTags, types.String),
-				"definedTags":        llx.MapData(definedTags, types.Any),
+				"freeformTags":       llx.MapData(strMapToAny(user.FreeformTags), types.String),
+				"definedTags":        llx.MapData(definedTagsToAny(user.DefinedTags), types.Any),
 			})
 			if err != nil {
 				return nil, err
@@ -465,16 +455,6 @@ func (o *mqlOciIdentity) getGroups(conn *connection.OciConnection) []*jobpool.Jo
 				created = &grp.TimeCreated.Time
 			}
 
-			freeformTags := make(map[string]interface{})
-			for k, v := range grp.FreeformTags {
-				freeformTags[k] = v
-			}
-
-			definedTags := make(map[string]interface{})
-			for k, v := range grp.DefinedTags {
-				definedTags[k] = v
-			}
-
 			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.group", map[string]*llx.RawData{
 				"id":            llx.StringDataPtr(grp.Id),
 				"name":          llx.StringDataPtr(grp.Name),
@@ -482,8 +462,8 @@ func (o *mqlOciIdentity) getGroups(conn *connection.OciConnection) []*jobpool.Jo
 				"created":       llx.TimeDataPtr(created),
 				"state":         llx.StringData(string(grp.LifecycleState)),
 				"compartmentID": llx.StringDataPtr(grp.CompartmentId),
-				"freeformTags":  llx.MapData(freeformTags, types.String),
-				"definedTags":   llx.MapData(definedTags, types.Any),
+				"freeformTags":  llx.MapData(strMapToAny(grp.FreeformTags), types.String),
+				"definedTags":   llx.MapData(definedTagsToAny(grp.DefinedTags), types.Any),
 			})
 			if err != nil {
 				return nil, err
@@ -558,16 +538,6 @@ func (o *mqlOciIdentity) getPolicies(conn *connection.OciConnection) []*jobpool.
 				versionDate = &policy.VersionDate.Date
 			}
 
-			freeformTags := make(map[string]interface{})
-			for k, v := range policy.FreeformTags {
-				freeformTags[k] = v
-			}
-
-			definedTags := make(map[string]interface{})
-			for k, v := range policy.DefinedTags {
-				definedTags[k] = v
-			}
-
 			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.policy", map[string]*llx.RawData{
 				"id":            llx.StringDataPtr(policy.Id),
 				"name":          llx.StringDataPtr(policy.Name),
@@ -577,8 +547,8 @@ func (o *mqlOciIdentity) getPolicies(conn *connection.OciConnection) []*jobpool.
 				"compartmentID": llx.StringDataPtr(policy.CompartmentId),
 				"statements":    llx.ArrayData(convert.SliceAnyToInterface(policy.Statements), types.String),
 				"versionDate":   llx.TimeDataPtr(versionDate),
-				"freeformTags":  llx.MapData(freeformTags, types.String),
-				"definedTags":   llx.MapData(definedTags, types.Any),
+				"freeformTags":  llx.MapData(strMapToAny(policy.FreeformTags), types.String),
+				"definedTags":   llx.MapData(definedTagsToAny(policy.DefinedTags), types.Any),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -62,15 +62,6 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 					created = &lb.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(lb.FreeformTags))
-				for k, v := range lb.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(lb.DefinedTags))
-				for k, v := range lb.DefinedTags {
-					definedTags[k] = v
-				}
-
 				ipAddresses := make([]any, 0, len(lb.IpAddresses))
 				for _, ip := range lb.IpAddresses {
 					// isPublic is optional on the SDK model, and exposure()
@@ -99,8 +90,8 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 					"isDeleteProtectionEnabled": llx.BoolDataPtr(lb.IsDeleteProtectionEnabled),
 					"state":                     llx.StringData(string(lb.LifecycleState)),
 					"created":                   llx.TimeDataPtr(created),
-					"freeformTags":              llx.MapData(freeformTags, types.String),
-					"definedTags":               llx.MapData(definedTags, types.Any),
+					"freeformTags":              llx.MapData(strMapToAny(lb.FreeformTags), types.String),
+					"definedTags":               llx.MapData(definedTagsToAny(lb.DefinedTags), types.Any),
 					"systemTags":                llx.MapData(definedTagsToAny(lb.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -53,16 +53,6 @@ func (o *mqlOciNetwork) vcns() ([]any, error) {
 					created = &vcn.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{})
-				for k, v := range vcn.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{})
-				for k, v := range vcn.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.vcn", map[string]*llx.RawData{
 					"id":                    llx.StringDataPtr(vcn.Id),
 					"name":                  llx.StringDataPtr(vcn.DisplayName),
@@ -76,8 +66,8 @@ func (o *mqlOciNetwork) vcns() ([]any, error) {
 					"defaultRouteTableId":   llx.StringDataPtr(vcn.DefaultRouteTableId),
 					"defaultSecurityListId": llx.StringDataPtr(vcn.DefaultSecurityListId),
 					"dnsLabel":              llx.StringDataPtr(vcn.DnsLabel),
-					"freeformTags":          llx.MapData(freeformTags, types.String),
-					"definedTags":           llx.MapData(definedTags, types.Any),
+					"freeformTags":          llx.MapData(strMapToAny(vcn.FreeformTags), types.String),
+					"definedTags":           llx.MapData(definedTagsToAny(vcn.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -231,16 +221,6 @@ func (o *mqlOciNetwork) securityLists() ([]any, error) {
 					return nil, err
 				}
 
-				freeformTags := make(map[string]interface{})
-				for k, v := range securityList.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{})
-				for k, v := range securityList.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.securityList", map[string]*llx.RawData{
 					"id":                   llx.StringDataPtr(securityList.Id),
 					"name":                 llx.StringDataPtr(securityList.DisplayName),
@@ -252,8 +232,8 @@ func (o *mqlOciNetwork) securityLists() ([]any, error) {
 					"egressRules":          llx.ArrayData(egressRules, types.Resource("oci.network.securityRule")),
 					"ingressRules":         llx.ArrayData(ingressRules, types.Resource("oci.network.securityRule")),
 					"vcnId":                llx.StringDataPtr(securityList.VcnId),
-					"freeformTags":         llx.MapData(freeformTags, types.String),
-					"definedTags":          llx.MapData(definedTags, types.Any),
+					"freeformTags":         llx.MapData(strMapToAny(securityList.FreeformTags), types.String),
+					"definedTags":          llx.MapData(definedTagsToAny(securityList.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -465,16 +445,6 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 					created = &subnet.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(subnet.FreeformTags))
-				for k, v := range subnet.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{}, len(subnet.DefinedTags))
-				for k, v := range subnet.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.subnet", map[string]*llx.RawData{
 					"id":                      llx.StringDataPtr(subnet.Id),
 					"name":                    llx.StringDataPtr(subnet.DisplayName),
@@ -487,8 +457,8 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 					"prohibitPublicIpOnVnic":  llx.BoolDataPtr(subnet.ProhibitPublicIpOnVnic),
 					"prohibitInternetIngress": llx.BoolDataPtr(subnet.ProhibitInternetIngress),
 					"created":                 llx.TimeDataPtr(created),
-					"freeformTags":            llx.MapData(freeformTags, types.String),
-					"definedTags":             llx.MapData(definedTags, types.Any),
+					"freeformTags":            llx.MapData(strMapToAny(subnet.FreeformTags), types.String),
+					"definedTags":             llx.MapData(definedTagsToAny(subnet.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -590,24 +560,14 @@ func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 					created = &nsg.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{})
-				for k, v := range nsg.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{})
-				for k, v := range nsg.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(nsg.Id),
 					"name":          llx.StringDataPtr(nsg.DisplayName),
 					"compartmentID": llx.StringDataPtr(nsg.CompartmentId),
 					"state":         llx.StringData(string(nsg.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(nsg.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(nsg.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -702,24 +662,14 @@ func initOciNetworkNetworkSecurityGroup(runtime *plugin.Runtime, args map[string
 		created = &nsg.TimeCreated.Time
 	}
 
-	freeformTags := make(map[string]interface{})
-	for k, v := range nsg.FreeformTags {
-		freeformTags[k] = v
-	}
-
-	definedTags := make(map[string]interface{})
-	for k, v := range nsg.DefinedTags {
-		definedTags[k] = v
-	}
-
 	mqlInstance, err := CreateResource(runtime, "oci.network.networkSecurityGroup", map[string]*llx.RawData{
 		"id":            llx.StringDataPtr(nsg.Id),
 		"name":          llx.StringDataPtr(nsg.DisplayName),
 		"compartmentID": llx.StringDataPtr(nsg.CompartmentId),
 		"state":         llx.StringData(string(nsg.LifecycleState)),
 		"created":       llx.TimeDataPtr(created),
-		"freeformTags":  llx.MapData(freeformTags, types.String),
-		"definedTags":   llx.MapData(definedTags, types.Any),
+		"freeformTags":  llx.MapData(strMapToAny(nsg.FreeformTags), types.String),
+		"definedTags":   llx.MapData(definedTagsToAny(nsg.DefinedTags), types.Any),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -947,15 +897,6 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 		created = &vnic.TimeCreated.Time
 	}
 
-	freeformTags := make(map[string]interface{}, len(vnic.FreeformTags))
-	for k, v := range vnic.FreeformTags {
-		freeformTags[k] = v
-	}
-	definedTags := make(map[string]interface{}, len(vnic.DefinedTags))
-	for k, v := range vnic.DefinedTags {
-		definedTags[k] = v
-	}
-
 	res, err := CreateResource(runtime, "oci.compute.vnic", map[string]*llx.RawData{
 		"id":                  llx.StringDataPtr(vnic.Id),
 		"name":                llx.StringDataPtr(vnic.DisplayName),
@@ -970,8 +911,8 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 		"skipSourceDestCheck": llx.BoolDataPtr(vnic.SkipSourceDestCheck),
 		"state":               llx.StringData(string(vnic.LifecycleState)),
 		"created":             llx.TimeDataPtr(created),
-		"freeformTags":        llx.MapData(freeformTags, types.String),
-		"definedTags":         llx.MapData(definedTags, types.Any),
+		"freeformTags":        llx.MapData(strMapToAny(vnic.FreeformTags), types.String),
+		"definedTags":         llx.MapData(definedTagsToAny(vnic.DefinedTags), types.Any),
 	})
 	if err != nil {
 		return nil, err
@@ -1018,16 +959,6 @@ func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 					created = &igw.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(igw.FreeformTags))
-				for k, v := range igw.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{}, len(igw.DefinedTags))
-				for k, v := range igw.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.internetGateway", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(igw.Id),
 					"name":          llx.StringDataPtr(igw.DisplayName),
@@ -1035,8 +966,8 @@ func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 					"isEnabled":     llx.BoolDataPtr(igw.IsEnabled),
 					"state":         llx.StringData(string(igw.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(igw.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(igw.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -1109,16 +1040,6 @@ func (o *mqlOciNetwork) natGateways() ([]any, error) {
 					created = &ngw.TimeCreated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(ngw.FreeformTags))
-				for k, v := range ngw.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{}, len(ngw.DefinedTags))
-				for k, v := range ngw.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.natGateway", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(ngw.Id),
 					"name":          llx.StringDataPtr(ngw.DisplayName),
@@ -1127,8 +1048,8 @@ func (o *mqlOciNetwork) natGateways() ([]any, error) {
 					"natIp":         llx.StringDataPtr(ngw.NatIp),
 					"state":         llx.StringData(string(ngw.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(ngw.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(ngw.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -1236,16 +1157,6 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 					return nil, err
 				}
 
-				freeformTags := make(map[string]interface{}, len(rt.FreeformTags))
-				for k, v := range rt.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{}, len(rt.DefinedTags))
-				for k, v := range rt.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.network.routeTable", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(rt.Id),
 					"name":          llx.StringDataPtr(rt.DisplayName),
@@ -1253,8 +1164,8 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 					"routeRules":    llx.ArrayData(routeRules, types.Dict),
 					"state":         llx.StringData(string(rt.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(rt.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(rt.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -99,15 +99,6 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 					upgrades = append(upgrades, u)
 				}
 
-				freeformTags := make(map[string]interface{}, len(cluster.FreeformTags))
-				for k, v := range cluster.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(cluster.DefinedTags))
-				for k, v := range cluster.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.oke.cluster", map[string]*llx.RawData{
 					"id":                          llx.StringDataPtr(cluster.Id),
 					"name":                        llx.StringDataPtr(cluster.Name),
@@ -122,8 +113,8 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 					"isPodSecurityPolicyEnabled":  llx.BoolData(isPodSecurityPolicyEnabled),
 					"state":                       llx.StringData(string(cluster.LifecycleState)),
 					"created":                     llx.TimeDataPtr(created),
-					"freeformTags":                llx.MapData(freeformTags, types.String),
-					"definedTags":                 llx.MapData(definedTags, types.Any),
+					"freeformTags":                llx.MapData(strMapToAny(cluster.FreeformTags), types.String),
+					"definedTags":                 llx.MapData(definedTagsToAny(cluster.DefinedTags), types.Any),
 					"securityAttributes":          llx.MapData(securityAttributes, types.Dict),
 					"systemTags":                  llx.MapData(definedTagsToAny(cluster.SystemTags), types.Dict),
 				})

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -64,15 +64,6 @@ func (o *mqlOciRedis) clusters() ([]any, error) {
 					nodeMemory = float64(*c.NodeMemoryInGBs)
 				}
 
-				freeformTags := make(map[string]interface{}, len(c.FreeformTags))
-				for k, v := range c.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(c.DefinedTags))
-				for k, v := range c.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlCluster, err := CreateResource(o.MqlRuntime, "oci.redis.cluster", map[string]*llx.RawData{
 					"id":                         llx.StringDataPtr(c.Id),
 					"name":                       llx.StringDataPtr(c.DisplayName),
@@ -91,8 +82,8 @@ func (o *mqlOciRedis) clusters() ([]any, error) {
 					"state":                      llx.StringData(string(c.LifecycleState)),
 					"created":                    llx.TimeDataPtr(created),
 					"timeUpdated":                llx.TimeDataPtr(updated),
-					"freeformTags":               llx.MapData(freeformTags, types.String),
-					"definedTags":                llx.MapData(definedTags, types.Any),
+					"freeformTags":               llx.MapData(strMapToAny(c.FreeformTags), types.String),
+					"definedTags":                llx.MapData(definedTagsToAny(c.DefinedTags), types.Any),
 					"systemTags":                 llx.MapData(definedTagsToAny(c.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -70,15 +70,6 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 					nextRotation = &s.NextRotationTime.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(s.FreeformTags))
-				for k, v := range s.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(s.DefinedTags))
-				for k, v := range s.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.vault.secret", map[string]*llx.RawData{
 					"id":                      llx.StringDataPtr(s.Id),
 					"name":                    llx.StringDataPtr(s.SecretName),
@@ -90,8 +81,8 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 					"nextRotationTime":        llx.TimeDataPtr(nextRotation),
 					"isAutoGenerationEnabled": llx.BoolDataPtr(s.IsAutoGenerationEnabled),
 					"created":                 llx.TimeDataPtr(created),
-					"freeformTags":            llx.MapData(freeformTags, types.String),
-					"definedTags":             llx.MapData(definedTags, types.Any),
+					"freeformTags":            llx.MapData(strMapToAny(s.FreeformTags), types.String),
+					"definedTags":             llx.MapData(definedTagsToAny(s.DefinedTags), types.Any),
 					"systemTags":              llx.MapData(definedTagsToAny(s.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -64,15 +64,6 @@ func (o *mqlOciWaf) firewalls() ([]any, error) {
 					timeUpdated = &lbWaf.TimeUpdated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(lbWaf.FreeformTags))
-				for k, v := range lbWaf.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(lbWaf.DefinedTags))
-				for k, v := range lbWaf.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.waf.firewall", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(lbWaf.Id),
 					"name":          llx.StringDataPtr(lbWaf.DisplayName),
@@ -80,8 +71,8 @@ func (o *mqlOciWaf) firewalls() ([]any, error) {
 					"state":         llx.StringData(string(lbWaf.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
 					"timeUpdated":   llx.TimeDataPtr(timeUpdated),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(lbWaf.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(lbWaf.DefinedTags), types.Any),
 					"systemTags":    llx.MapData(definedTagsToAny(lbWaf.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -173,15 +164,6 @@ func (o *mqlOciWaf) policies() ([]any, error) {
 					timeUpdated = &p.TimeUpdated.Time
 				}
 
-				freeformTags := make(map[string]interface{}, len(p.FreeformTags))
-				for k, v := range p.FreeformTags {
-					freeformTags[k] = v
-				}
-				definedTags := make(map[string]interface{}, len(p.DefinedTags))
-				for k, v := range p.DefinedTags {
-					definedTags[k] = v
-				}
-
 				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.waf.policy", map[string]*llx.RawData{
 					"id":            llx.StringDataPtr(p.Id),
 					"name":          llx.StringDataPtr(p.DisplayName),
@@ -189,8 +171,8 @@ func (o *mqlOciWaf) policies() ([]any, error) {
 					"state":         llx.StringData(string(p.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
 					"timeUpdated":   llx.TimeDataPtr(timeUpdated),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
+					"freeformTags":  llx.MapData(strMapToAny(p.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(p.DefinedTags), types.Any),
 					"systemTags":    llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
 				})
 				if err != nil {


### PR DESCRIPTION
Continues the OCI internals sequence (#9650, #9655, #9659, #9661, #9663, #9665, #9666).

## The duplication

Every lister that reports tags had written out the same copy loop by hand:

```go
freeformTags := make(map[string]interface{}, len(x.FreeformTags))
for k, v := range x.FreeformTags {
    freeformTags[k] = v
}
```

**64 times** — 32 for `freeformTags`, 32 for `definedTags` — to produce exactly what `strMapToAny` and `definedTagsToAny` in `conversion.go` already produce. Several listers even called the helper for `systemTags` on one line while hand-rolling the loop for `definedTags` three lines above it:

```go
"definedTags": llx.MapData(definedTags, types.Any),                          // hand-rolled
"systemTags":  llx.MapData(definedTagsToAny(cluster.SystemTags), types.Dict), // helper
```

**365 lines deleted, 111 added.**

## How it was converted

Scripted, with the script refusing anything it cannot fully parse rather than guessing. A site was rewritten only when all of these held:

- the four-line block matched exactly (decl / `for` / assign / close brace);
- the variable's **only** other use in the **enclosing function** was the single `llx.MapData(...)` call being rewritten;
- that call's llx type tag was the one the family ships today.

The enclosing-function scoping is the part that matters. `freeformTags` recurs in every lister in a file, so a whole-file use count is always > 1 and proves nothing — the check has to be per-function to mean anything.

**64 of 64 converted, zero refused.**

## One honest difference

`definedTagsToAny` is not a byte-for-byte substitute for the loop: the loop shallow-copies, aliasing the SDK's inner namespace maps, while the helper rebuilds each one. The contents handed to MQL are the same, and not handing MQL a map the SDK still owns is the better of the two behaviours.

`conversion_test.go` now pins that equivalence for both helpers — written **as the loop** rather than as a literal, so the comparison keeps its meaning if either side is ever changed.

## Verification

Audited against `main` on the two properties a careless rewrite would have moved:

| invariant | result |
|---|---|
| set of resource field keys → llx constructor | identical |
| multiset of `llx.MapData` type tags | identical |
| inline copy loops remaining | 0 |

The type-tag check is not theoretical: `definedTags` ships as `types.Any` while the `systemTags` call right beside it ships as `types.Dict`. Converting one to the other's tag would have changed what MQL emits, so the script treats a mismatched tag as a refusal rather than something to normalize.

`go build`, `go vet`, `gofmt -l`, `go test -race ./...` all clean. No schema, generated code, or permissions manifest touched.

## Not included

The `var created *time.Time` dance — the third family in this cleanup:

```go
var created *time.Time
if x.TimeCreated != nil {
    created = &x.TimeCreated.Time
}
// ... "created": llx.TimeDataPtr(created)
```

87 single-var sites, but also **9 grouped declarations** (`var created, notBefore, notAfter *time.Time` sharing one `if` block, e.g. `certificates.go:60`, `apigateway.go:640`) that a single-var rewrite cannot handle safely. It gets its own PR with its own classifier.
