### PR TITLE
🐛 openstack: close three security blind spots in exposure and identity

### DIFF
--- a/providers/openstack/resources/keystone.go
+++ b/providers/openstack/resources/keystone.go
@@ -4,12 +4,16 @@
 package resources
 
 import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/applicationcredentials"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/domains"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/groups"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/users"
+	"github.com/gophercloud/gophercloud/v2/pagination"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -765,6 +769,74 @@ func roleNamesByID(runtime *plugin.Runtime) map[string]string {
 	return byID
 }
 
+// roleAssignmentEntry mirrors one entry of the Keystone role_assignments
+// response. The client's own RoleAssignment struct models only the project and
+// domain scopes, so a system-scoped grant (the deployment-wide `admin` that
+// outranks every project) and the OS-INHERIT flag (which pushes a domain grant
+// down onto every project inside it) are both absent from it. Decoding the
+// response ourselves keeps those two out of the blind spot.
+type roleAssignmentEntry struct {
+	Role struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"role"`
+	User struct {
+		ID string `json:"id"`
+	} `json:"user"`
+	Group struct {
+		ID string `json:"id"`
+	} `json:"group"`
+	Scope struct {
+		Domain struct {
+			ID string `json:"id"`
+		} `json:"domain"`
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+		System struct {
+			All bool `json:"all"`
+		} `json:"system"`
+		// "projects" when the grant applies to the projects below the scoped
+		// object rather than to the object itself.
+		InheritedTo string `json:"OS-INHERIT:inherited_to"`
+	} `json:"scope"`
+}
+
+// scope reports what the grant applies to and the id of that object. A
+// system-scoped grant names no object, so it reports the fixed id "all", the
+// only system scope Keystone defines.
+func (a *roleAssignmentEntry) scope() (scopeType, scopeID string) {
+	switch {
+	case a.Scope.Project.ID != "":
+		return "project", a.Scope.Project.ID
+	case a.Scope.Domain.ID != "":
+		return "domain", a.Scope.Domain.ID
+	case a.Scope.System.All:
+		return "system", "all"
+	}
+	return "", ""
+}
+
+// listRoleAssignments pages through /role_assignments, decoding each page into
+// roleAssignmentEntry rather than the client's lossy struct.
+func listRoleAssignments(client *gophercloud.ServiceClient, opts roles.ListAssignmentsOpts) ([]roleAssignmentEntry, error) {
+	out := []roleAssignmentEntry{}
+	err := roles.ListAssignments(client, opts).EachPage(ctx(), func(_ context.Context, page pagination.Page) (bool, error) {
+		var body struct {
+			RoleAssignments []roleAssignmentEntry `json:"role_assignments"`
+		}
+		if err := (page.(roles.RoleAssignmentPage)).ExtractInto(&body); err != nil {
+			return false, err
+		}
+		out = append(out, body.RoleAssignments...)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (o *mqlOpenstack) roleAssignments() ([]any, error) {
 	c := conn(o.MqlRuntime)
 	client, err := c.IdentityClient()
@@ -772,17 +844,13 @@ func (o *mqlOpenstack) roleAssignments() ([]any, error) {
 		return nil, err
 	}
 	includeNames := true
-	pages, err := roles.ListAssignments(client, roles.ListAssignmentsOpts{
+	items, err := listRoleAssignments(client, roles.ListAssignmentsOpts{
 		IncludeNames: &includeNames,
-	}).AllPages(ctx())
+	})
 	if err != nil {
 		if translateOpenstackError(err) == nil {
 			return []any{}, nil
 		}
-		return nil, err
-	}
-	items, err := roles.ExtractRoleAssignments(pages)
-	if err != nil {
 		return nil, err
 	}
 
@@ -796,23 +864,23 @@ func (o *mqlOpenstack) roleAssignments() ([]any, error) {
 			actorType = "group"
 			actorID = a.Group.ID
 		}
-		scopeType := ""
-		scopeID := ""
-		if a.Scope.Project.ID != "" {
-			scopeType = "project"
-			scopeID = a.Scope.Project.ID
-		} else if a.Scope.Domain.ID != "" {
-			scopeType = "domain"
-			scopeID = a.Scope.Domain.ID
-		}
+		scopeType, scopeID := a.scope()
+		inherited := a.Scope.InheritedTo != ""
 		roleName := a.Role.Name
 		if roleName == "" {
 			roleName = byID[a.Role.ID]
 		}
+		// The same role, principal, and scope can be granted both directly and
+		// by inheritance, so the flag belongs in the identity.
+		id := "openstack.identity.roleAssignment/" + a.Role.ID + "/" + actorType + "/" + actorID + "/" + scopeType + "/" + scopeID
+		if inherited {
+			id += "/inherited"
+		}
 		res, err := CreateResource(o.MqlRuntime, "openstack.identity.roleAssignment", map[string]*llx.RawData{
-			"__id":      llx.StringData("openstack.identity.roleAssignment/" + a.Role.ID + "/" + actorType + "/" + actorID + "/" + scopeType + "/" + scopeID),
+			"__id":      llx.StringData(id),
 			"actorType": llx.StringData(actorType),
 			"scopeType": llx.StringData(scopeType),
+			"inherited": llx.BoolData(inherited),
 			"roleName":  llx.StringData(roleName),
 		})
 		if err != nil {

--- a/providers/openstack/resources/keystone_test.go
+++ b/providers/openstack/resources/keystone_test.go
@@ -1,0 +1,116 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// keystoneRoleAssignmentsBody is a /v3/role_assignments response covering the
+// four shapes a deployment produces: a direct project grant, a domain grant
+// inherited down to every project inside it, a system-wide grant, and a grant
+// made to a group rather than a user.
+const keystoneRoleAssignmentsBody = `{
+  "role_assignments": [
+    {
+      "role": {"id": "role-member", "name": "member"},
+      "user": {"id": "user-alice"},
+      "scope": {"project": {"id": "project-web"}}
+    },
+    {
+      "role": {"id": "role-admin", "name": "admin"},
+      "user": {"id": "user-bob"},
+      "scope": {
+        "domain": {"id": "domain-default"},
+        "OS-INHERIT:inherited_to": "projects"
+      }
+    },
+    {
+      "role": {"id": "role-admin", "name": "admin"},
+      "user": {"id": "user-carol"},
+      "scope": {"system": {"all": true}}
+    },
+    {
+      "role": {"id": "role-reader", "name": "reader"},
+      "group": {"id": "group-auditors"},
+      "scope": {"project": {"id": "project-web"}}
+    }
+  ]
+}`
+
+func TestRoleAssignmentEntryScope(t *testing.T) {
+	var body struct {
+		RoleAssignments []roleAssignmentEntry `json:"role_assignments"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(keystoneRoleAssignmentsBody), &body))
+	require.Len(t, body.RoleAssignments, 4)
+
+	tests := []struct {
+		name      string
+		scopeType string
+		scopeID   string
+		inherited bool
+		roleName  string
+		userID    string
+		groupID   string
+	}{
+		{
+			name:      "direct project grant",
+			scopeType: "project",
+			scopeID:   "project-web",
+			roleName:  "member",
+			userID:    "user-alice",
+		},
+		{
+			name:      "domain grant inherited to projects",
+			scopeType: "domain",
+			scopeID:   "domain-default",
+			inherited: true,
+			roleName:  "admin",
+			userID:    "user-bob",
+		},
+		{
+			name:      "system-wide grant",
+			scopeType: "system",
+			scopeID:   "all",
+			roleName:  "admin",
+			userID:    "user-carol",
+		},
+		{
+			name:      "grant to a group",
+			scopeType: "project",
+			scopeID:   "project-web",
+			roleName:  "reader",
+			groupID:   "group-auditors",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := body.RoleAssignments[i]
+			scopeType, scopeID := a.scope()
+			assert.Equal(t, tt.scopeType, scopeType)
+			assert.Equal(t, tt.scopeID, scopeID)
+			assert.Equal(t, tt.inherited, a.Scope.InheritedTo != "")
+			assert.Equal(t, tt.roleName, a.Role.Name)
+			assert.Equal(t, tt.userID, a.User.ID)
+			assert.Equal(t, tt.groupID, a.Group.ID)
+		})
+	}
+}
+
+// A grant with no recognizable scope must not be reported as one, so a future
+// scope type Keystone adds shows up as unknown rather than silently landing in
+// the project or domain bucket.
+func TestRoleAssignmentEntryScopeUnknown(t *testing.T) {
+	var a roleAssignmentEntry
+	require.NoError(t, json.Unmarshal([]byte(`{"scope": {"system": {"all": false}}}`), &a))
+	scopeType, scopeID := a.scope()
+	assert.Empty(t, scopeType)
+	assert.Empty(t, scopeID)
+}

--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -11,7 +11,9 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/portforwarding"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/mtu"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsecurity"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portstrustedvif"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/provider"
 	qospolicies "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/qos/policies"
 	neutronquotas "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/quotas"
@@ -45,12 +47,15 @@ type networkExt struct {
 	qospolicies.QoSPolicyExt
 }
 
-// portExt is the base port plus the port-security extension; it lets one list
-// call surface portSecurityEnabled. Clouds without the extension simply leave
-// the field at false.
+// portExt is the base port plus the port-security, port-binding, and trusted-VIF
+// extensions; it lets one list call surface portSecurityEnabled, the binding
+// attributes, and trustedVif. Clouds without a given extension simply leave its
+// fields at their zero value.
 type portExt struct {
 	ports.Port
 	portsecurity.PortSecurityExt
+	portsbinding.PortsBindingExt
+	portstrustedvif.PortTrustedVIFExt
 }
 
 func (r *mqlOpenstackNetwork) id() (string, error) {
@@ -528,6 +533,9 @@ func (o *mqlOpenstack) ports() ([]any, error) {
 			"fixedIps":              dictSliceData(fixedIPsToDict(p.FixedIPs)),
 			"allowedAddressPairs":   dictSliceData(allowedAddressPairsToDict(p.AllowedAddressPairs)),
 			"portSecurityEnabled":   llx.BoolData(p.PortSecurityEnabled),
+			"trustedVif":            llx.BoolDataPtr(p.PortTrustedVIF),
+			"bindingVnicType":       llx.StringData(p.VNICType),
+			"bindingVifType":        llx.StringData(p.VIFType),
 			"propagateUplinkStatus": llx.BoolData(p.PropagateUplinkStatus),
 			"description":           llx.StringData(p.Description),
 			"tags":                  stringSliceData(p.Tags),
@@ -1114,6 +1122,20 @@ func (r *mqlOpenstackSecurityGroupRule) remoteGroup() (*mqlOpenstackSecurityGrou
 		return nil, err
 	}
 	return res.(*mqlOpenstackSecurityGroup), nil
+}
+
+func (r *mqlOpenstackSecurityGroupRule) remoteAddressGroup() (*mqlOpenstackNetworkAddressGroup, error) {
+	if r.cacheRemoteAddressGroupID == "" {
+		r.RemoteAddressGroup.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.network.addressGroup", map[string]*llx.RawData{
+		"id": llx.StringData(r.cacheRemoteAddressGroupID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackNetworkAddressGroup), nil
 }
 
 func (r *mqlOpenstackSecurityGroupRule) project() (*mqlOpenstackProject, error) {

--- a/providers/openstack/resources/network_addressgroups.go
+++ b/providers/openstack/resources/network_addressgroups.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/addressgroups"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -91,8 +93,10 @@ func initOpenstackNetworkAddressGroup(runtime *plugin.Runtime, args map[string]*
 			return args, g, nil
 		}
 	}
-	initSyntheticID("openstack.network.addressGroup", "id", args)
-	return args, nil, nil
+	// Reporting the miss matters more here than elsewhere: a blank group would
+	// answer containsPublicAddress with false, which is the false negative this
+	// resource exists to remove.
+	return nil, nil, fmt.Errorf("openstack.network.addressGroup with id %q not found", id)
 }
 
 // containsPublicAddress reports whether any member address opens a broad slice

--- a/providers/openstack/resources/network_addressgroups.go
+++ b/providers/openstack/resources/network_addressgroups.go
@@ -1,0 +1,116 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/addressgroups"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+type mqlOpenstackNetworkAddressGroupInternal struct {
+	cacheProjectID string
+}
+
+func (r *mqlOpenstackNetworkAddressGroup) id() (string, error) {
+	return "openstack.network.addressGroup/" + r.Id.Data, nil
+}
+
+func (o *mqlOpenstack) addressGroups() ([]any, error) {
+	c := conn(o.MqlRuntime)
+	client, err := c.NetworkClient()
+	if err != nil {
+		return nil, err
+	}
+	pages, err := addressgroups.List(client, addressgroups.ListOpts{}).AllPages(ctx())
+	if err != nil {
+		// A cloud without the address-groups extension (or without access to it)
+		// simply has no address groups rather than failing the query.
+		if translateOpenstackError(err) == nil {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	items, err := addressgroups.ExtractGroups(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, 0, len(items))
+	for i := range items {
+		res, err := newMqlOpenstackAddressGroup(o.MqlRuntime, &items[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func newMqlOpenstackAddressGroup(runtime *plugin.Runtime, g *addressgroups.AddressGroup) (*mqlOpenstackNetworkAddressGroup, error) {
+	res, err := CreateResource(runtime, "openstack.network.addressGroup", map[string]*llx.RawData{
+		"__id":        llx.StringData("openstack.network.addressGroup/" + g.ID),
+		"id":          llx.StringData(g.ID),
+		"name":        llx.StringData(g.Name),
+		"description": llx.StringData(g.Description),
+		"addresses":   stringSliceData(g.Addresses),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlG := res.(*mqlOpenstackNetworkAddressGroup)
+	mqlG.cacheProjectID = g.ProjectID
+	return mqlG, nil
+}
+
+// initOpenstackNetworkAddressGroup resolves a group out of the project's cached
+// list rather than fetching it by id. Every security-group rule that matches an
+// address group resolves through here, so a per-id fetch would issue one call
+// per rule; the list is a single call shared by all of them.
+func initOpenstackNetworkAddressGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		initSyntheticID("openstack.network.addressGroup", "id", args)
+		return args, nil, nil
+	}
+	id, ok := stringArg(args, "id")
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	list := root.(*mqlOpenstack).GetAddressGroups()
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		g, ok := raw.(*mqlOpenstackNetworkAddressGroup)
+		if ok && g.Id.Data == id {
+			return args, g, nil
+		}
+	}
+	initSyntheticID("openstack.network.addressGroup", "id", args)
+	return args, nil, nil
+}
+
+// containsPublicAddress reports whether any member address opens a broad slice
+// of the public internet. Security-group rules that match this group inherit
+// that reach, so widening the group widens every rule referencing it.
+func (r *mqlOpenstackNetworkAddressGroup) containsPublicAddress() (bool, error) {
+	addresses := r.GetAddresses()
+	if addresses.Error != nil {
+		return false, addresses.Error
+	}
+	for _, raw := range addresses.Data {
+		if s, ok := raw.(string); ok && addressIsPublic(s) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *mqlOpenstackNetworkAddressGroup) project() (*mqlOpenstackProject, error) {
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
+}

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -88,6 +88,8 @@ openstack {
   floatingIps() []openstack.floatingIp
   // Neutron security groups (with embedded rules)
   securityGroups() []openstack.securityGroup
+  // Neutron address groups referenced by security group rules
+  addressGroups() []openstack.network.addressGroup
 
   // Cinder block-storage volumes in the scoped project
   volumes() []openstack.blockstorage.volume
@@ -317,16 +319,27 @@ private openstack.group @defaults("id name") {
 // OpenStack Keystone role assignment
 //
 // Flattened record of a single role granted to a single principal (a user or a
-// group) at a single scope (a project or a domain). Enumerating these is how a
-// policy audits who holds privileged roles such as `admin` across the whole
-// cloud, instead of walking each user or group. System-scoped grants and the
-// inherited flag are not reported, because the underlying client does not
-// return them.
+// group) at a single scope (a project, a domain, or the whole deployment).
+// Enumerating these is how a policy audits who holds privileged roles such as
+// `admin` across the whole cloud, instead of walking each user or group. A
+// system-scoped grant carries a role across every project and domain at once,
+// and an inherited domain grant applies to every project underneath, so both
+// reach far past the object named by scopeProject or scopeDomain.
 private openstack.identity.roleAssignment @defaults("roleName actorType scopeType") {
   // Whether the role is granted to a user or a group ("user" or "group")
   actorType string
-  // Whether the grant applies to a project or a domain ("project" or "domain")
+  // What the grant applies to
+  //
+  // One of "project", "domain", or "system". A system grant covers the entire
+  // deployment rather than one object, so neither scopeProject nor scopeDomain
+  // is set for it.
   scopeType string
+  // Whether a domain or project grant also applies to the projects underneath it
+  //
+  // An inherited grant is not held on the named object itself. It is applied to
+  // every project below it, so a single inherited domain grant of `admin`
+  // confers that role on every project in the domain, present and future.
+  inherited bool
   // Name of the granted role; empty when the role catalog is not readable
   roleName string
   // Role granted by this assignment
@@ -335,9 +348,9 @@ private openstack.identity.roleAssignment @defaults("roleName actorType scopeTyp
   user() openstack.user
   // Group the role is granted to; null when the grant is to a user
   group() openstack.group
-  // Project the grant applies to; null when the grant is domain-scoped
+  // Project the grant applies to; null when the grant is domain- or system-scoped
   scopeProject() openstack.project
-  // Domain the grant applies to; null when the grant is project-scoped
+  // Domain the grant applies to; null when the grant is project- or system-scoped
   scopeDomain() openstack.domain
 }
 
@@ -738,6 +751,29 @@ private openstack.port @defaults("id name status macAddress") {
   allowedAddressPairs []dict
   // Whether port security is enabled
   portSecurityEnabled bool
+  // Whether the port is a trusted SR-IOV virtual function
+  //
+  // A trusted virtual function may change its MAC address and enter promiscuous
+  // mode, which lets the guest spoof addresses and observe traffic addressed to
+  // others regardless of security groups or port security. Null when the cloud
+  // does not run the port trusted VIF extension or the attribute is unset, both
+  // of which mean untrusted.
+  trustedVif bool
+  // Virtual interface card type bound to the port
+  //
+  // One of normal, direct, direct-physical, macvtap, baremetal,
+  // virtio-forwarder, vdpa, remote-managed, or smart-nic. Everything other than
+  // normal and macvtap hands the guest a hardware function, so the software
+  // datapath that enforces security groups is bypassed. Empty when the cloud
+  // does not expose port binding attributes to this user.
+  bindingVnicType string
+  // Virtual interface type the mechanism driver bound the port with
+  //
+  // Examples include ovs, bridge, vhostuser, hw_veb, hostdev_physical,
+  // distributed, and other. The values binding_failed and unbound mean no
+  // datapath was established. Empty when the cloud does not expose port binding
+  // attributes to this user.
+  bindingVifType string
   // Whether port uplink status propagation is enabled
   propagateUplinkStatus bool
   // Description
@@ -895,8 +931,12 @@ private openstack.securityGroup.rule @defaults("id direction protocol portRangeM
   portRangeMax int
   // Remote IP prefix (CIDR; empty when matched by remote group instead)
   remoteIpPrefix string
-  // Remote address group ID the rule matches; empty when matched by IP prefix or remote security group instead
-  remoteAddressGroupId string
+  // Remote address group ID the rule matches
+  //
+  // Deprecated in favor of remoteAddressGroup, which resolves the same
+  // value to the address group and its addresses. Empty when the rule
+  // is matched by IP prefix or remote security group instead.
+  remoteAddressGroupId @maturity("deprecated") string
   // Description
   description string
   // Creation timestamp
@@ -907,9 +947,11 @@ private openstack.securityGroup.rule @defaults("id direction protocol portRangeM
   securityGroup() openstack.securityGroup
   // Remote security group the rule matches; null when matched by IP prefix instead
   remoteGroup() openstack.securityGroup
+  // Remote address group the rule matches; null when matched by IP prefix or remote security group instead
+  remoteAddressGroup() openstack.network.addressGroup
   // Whether the rule's source reaches the public internet
   //
-  // True when remoteIpPrefix is a public CIDR (a broad block such as 0.0.0.0/0 or ::/0, excluding private and reserved ranges) or when the rule is unscoped (no remote IP prefix, no remote group, and no remote address group), which Neutron treats as any source. A rule scoped to a remote security group or remote address group is not public. Direction-agnostic, so it also classifies egress destinations.
+  // True when remoteIpPrefix is a public CIDR (a broad block such as 0.0.0.0/0 or ::/0, excluding private and reserved ranges), when the rule matches a remote address group that holds such a range, or when the rule is unscoped (no remote IP prefix, no remote group, and no remote address group), which Neutron treats as any source. A rule scoped to a remote security group is not public. Direction-agnostic, so it also classifies egress destinations.
   includesPublicSource() bool
   // Project that owns this security group rule
   project() openstack.project
@@ -3264,6 +3306,41 @@ private openstack.network.rbacPolicy @defaults("id action objectType targetProje
   // Shared QoS policy; null unless objectType is "qos-policy"
   qosPolicy() openstack.qosPolicy
   // Project that owns the RBAC policy
+  project() openstack.project
+}
+
+// OpenStack Neutron address group
+//
+// Named collection of addresses that security group rules match against
+// instead of a single remote IP prefix. The `addresses` field holds the
+// members, each either a CIDR (`203.0.113.0/24`) or an inclusive IP range
+// (`203.0.113.10-203.0.113.20`), and `containsPublicAddress` reports
+// whether any member opens a broad slice of the public internet. Because
+// one address group can be reused by many rules, widening it silently
+// widens every rule that references it, which makes the group itself the
+// unit worth auditing. Select a group by id with
+// `openstack.network.addressGroup(id: "...")`.
+private openstack.network.addressGroup @defaults("id name addresses") {
+  init(id? string)
+  // Address group ID (UUID)
+  id string
+  // Address group name
+  name string
+  // Description
+  description string
+  // Member addresses
+  //
+  // Each entry is either a CIDR ("203.0.113.0/24", "2001:db8::/64") or an
+  // inclusive IP range ("203.0.113.10-203.0.113.20").
+  addresses []string
+  // Whether any member address reaches the public internet
+  //
+  // True when a member is a broad public block such as 0.0.0.0/0 or ::/0, or an
+  // IP range spanning an equivalent number of addresses, excluding private and
+  // reserved ranges. A single public host or a narrow allow-listed range is not
+  // treated as public.
+  containsPublicAddress() bool
+  // Project that owns the address group
   project() openstack.project
 }
 

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -97,6 +97,7 @@ const (
 	ResourceOpenstackOrchestrationStack              string = "openstack.orchestration.stack"
 	ResourceOpenstackComputeQuotaSet                 string = "openstack.compute.quotaSet"
 	ResourceOpenstackNetworkRbacPolicy               string = "openstack.network.rbacPolicy"
+	ResourceOpenstackNetworkAddressGroup             string = "openstack.network.addressGroup"
 	ResourceOpenstackBlockstorageQosSpec             string = "openstack.blockstorage.qosSpec"
 )
 
@@ -428,6 +429,10 @@ func init() {
 			Init:   initOpenstackNetworkRbacPolicy,
 			Create: createOpenstackNetworkRbacPolicy,
 		},
+		"openstack.network.addressGroup": {
+			Init:   initOpenstackNetworkAddressGroup,
+			Create: createOpenstackNetworkAddressGroup,
+		},
 		"openstack.blockstorage.qosSpec": {
 			Init:   initOpenstackBlockstorageQosSpec,
 			Create: createOpenstackBlockstorageQosSpec,
@@ -601,6 +606,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("openstack.securityGroup")))
+	},
+	"openstack.addressGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstack).GetAddressGroups()).ToDataRes(types.Array(types.Resource("openstack.network.addressGroup")))
 	},
 	"openstack.volumes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetVolumes()).ToDataRes(types.Array(types.Resource("openstack.blockstorage.volume")))
@@ -829,6 +837,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.identity.roleAssignment.scopeType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackIdentityRoleAssignment).GetScopeType()).ToDataRes(types.String)
+	},
+	"openstack.identity.roleAssignment.inherited": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackIdentityRoleAssignment).GetInherited()).ToDataRes(types.Bool)
 	},
 	"openstack.identity.roleAssignment.roleName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackIdentityRoleAssignment).GetRoleName()).ToDataRes(types.String)
@@ -1232,6 +1243,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.port.portSecurityEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackPort).GetPortSecurityEnabled()).ToDataRes(types.Bool)
 	},
+	"openstack.port.trustedVif": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPort).GetTrustedVif()).ToDataRes(types.Bool)
+	},
+	"openstack.port.bindingVnicType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPort).GetBindingVnicType()).ToDataRes(types.String)
+	},
+	"openstack.port.bindingVifType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackPort).GetBindingVifType()).ToDataRes(types.String)
+	},
 	"openstack.port.propagateUplinkStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackPort).GetPropagateUplinkStatus()).ToDataRes(types.Bool)
 	},
@@ -1402,6 +1422,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.securityGroup.rule.remoteGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSecurityGroupRule).GetRemoteGroup()).ToDataRes(types.Resource("openstack.securityGroup"))
+	},
+	"openstack.securityGroup.rule.remoteAddressGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackSecurityGroupRule).GetRemoteAddressGroup()).ToDataRes(types.Resource("openstack.network.addressGroup"))
 	},
 	"openstack.securityGroup.rule.includesPublicSource": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSecurityGroupRule).GetIncludesPublicSource()).ToDataRes(types.Bool)
@@ -3836,6 +3859,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.network.rbacPolicy.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackNetworkRbacPolicy).GetProject()).ToDataRes(types.Resource("openstack.project"))
 	},
+	"openstack.network.addressGroup.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressGroup).GetId()).ToDataRes(types.String)
+	},
+	"openstack.network.addressGroup.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressGroup).GetName()).ToDataRes(types.String)
+	},
+	"openstack.network.addressGroup.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressGroup).GetDescription()).ToDataRes(types.String)
+	},
+	"openstack.network.addressGroup.addresses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressGroup).GetAddresses()).ToDataRes(types.Array(types.String))
+	},
+	"openstack.network.addressGroup.containsPublicAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressGroup).GetContainsPublicAddress()).ToDataRes(types.Bool)
+	},
+	"openstack.network.addressGroup.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressGroup).GetProject()).ToDataRes(types.Resource("openstack.project"))
+	},
 	"openstack.blockstorage.qosSpec.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBlockstorageQosSpec).GetId()).ToDataRes(types.String)
 	},
@@ -3994,6 +4035,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstack).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.addressGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstack).AddressGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"openstack.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4322,6 +4367,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.identity.roleAssignment.scopeType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackIdentityRoleAssignment).ScopeType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.identity.roleAssignment.inherited": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackIdentityRoleAssignment).Inherited, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"openstack.identity.roleAssignment.roleName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4900,6 +4949,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackPort).PortSecurityEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"openstack.port.trustedVif": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPort).TrustedVif, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.port.bindingVnicType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPort).BindingVnicType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.port.bindingVifType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackPort).BindingVifType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"openstack.port.propagateUplinkStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackPort).PropagateUplinkStatus, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -5142,6 +5203,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.securityGroup.rule.remoteGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackSecurityGroupRule).RemoteGroup, ok = plugin.RawToTValue[*mqlOpenstackSecurityGroup](v.Value, v.Error)
+		return
+	},
+	"openstack.securityGroup.rule.remoteAddressGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackSecurityGroupRule).RemoteAddressGroup, ok = plugin.RawToTValue[*mqlOpenstackNetworkAddressGroup](v.Value, v.Error)
 		return
 	},
 	"openstack.securityGroup.rule.includesPublicSource": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8628,6 +8693,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackNetworkRbacPolicy).Project, ok = plugin.RawToTValue[*mqlOpenstackProject](v.Value, v.Error)
 		return
 	},
+	"openstack.network.addressGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressGroup).__id, ok = v.Value.(string)
+		return
+	},
+	"openstack.network.addressGroup.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressGroup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressGroup.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressGroup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressGroup.addresses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressGroup).Addresses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressGroup.containsPublicAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressGroup).ContainsPublicAddress, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressGroup.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressGroup).Project, ok = plugin.RawToTValue[*mqlOpenstackProject](v.Value, v.Error)
+		return
+	},
 	"openstack.blockstorage.qosSpec.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackBlockstorageQosSpec).__id, ok = v.Value.(string)
 		return
@@ -8710,6 +8803,7 @@ type mqlOpenstack struct {
 	Ports                   plugin.TValue[[]any]
 	FloatingIps             plugin.TValue[[]any]
 	SecurityGroups          plugin.TValue[[]any]
+	AddressGroups           plugin.TValue[[]any]
 	Volumes                 plugin.TValue[[]any]
 	Snapshots               plugin.TValue[[]any]
 	Backups                 plugin.TValue[[]any]
@@ -9287,6 +9381,22 @@ func (c *mqlOpenstack) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlOpenstack) GetAddressGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AddressGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack", c.__id, "addressGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.addressGroups()
 	})
 }
 
@@ -10450,6 +10560,7 @@ type mqlOpenstackIdentityRoleAssignment struct {
 	mqlOpenstackIdentityRoleAssignmentInternal
 	ActorType    plugin.TValue[string]
 	ScopeType    plugin.TValue[string]
+	Inherited    plugin.TValue[bool]
 	RoleName     plugin.TValue[string]
 	Role         plugin.TValue[*mqlOpenstackRole]
 	User         plugin.TValue[*mqlOpenstackUser]
@@ -10496,6 +10607,10 @@ func (c *mqlOpenstackIdentityRoleAssignment) GetActorType() *plugin.TValue[strin
 
 func (c *mqlOpenstackIdentityRoleAssignment) GetScopeType() *plugin.TValue[string] {
 	return &c.ScopeType
+}
+
+func (c *mqlOpenstackIdentityRoleAssignment) GetInherited() *plugin.TValue[bool] {
+	return &c.Inherited
 }
 
 func (c *mqlOpenstackIdentityRoleAssignment) GetRoleName() *plugin.TValue[string] {
@@ -11867,6 +11982,9 @@ type mqlOpenstackPort struct {
 	FixedIps              plugin.TValue[[]any]
 	AllowedAddressPairs   plugin.TValue[[]any]
 	PortSecurityEnabled   plugin.TValue[bool]
+	TrustedVif            plugin.TValue[bool]
+	BindingVnicType       plugin.TValue[string]
+	BindingVifType        plugin.TValue[string]
 	PropagateUplinkStatus plugin.TValue[bool]
 	Description           plugin.TValue[string]
 	Tags                  plugin.TValue[[]any]
@@ -11952,6 +12070,18 @@ func (c *mqlOpenstackPort) GetAllowedAddressPairs() *plugin.TValue[[]any] {
 
 func (c *mqlOpenstackPort) GetPortSecurityEnabled() *plugin.TValue[bool] {
 	return &c.PortSecurityEnabled
+}
+
+func (c *mqlOpenstackPort) GetTrustedVif() *plugin.TValue[bool] {
+	return &c.TrustedVif
+}
+
+func (c *mqlOpenstackPort) GetBindingVnicType() *plugin.TValue[string] {
+	return &c.BindingVnicType
+}
+
+func (c *mqlOpenstackPort) GetBindingVifType() *plugin.TValue[string] {
+	return &c.BindingVifType
 }
 
 func (c *mqlOpenstackPort) GetPropagateUplinkStatus() *plugin.TValue[bool] {
@@ -12482,6 +12612,7 @@ type mqlOpenstackSecurityGroupRule struct {
 	UpdatedAt            plugin.TValue[*time.Time]
 	SecurityGroup        plugin.TValue[*mqlOpenstackSecurityGroup]
 	RemoteGroup          plugin.TValue[*mqlOpenstackSecurityGroup]
+	RemoteAddressGroup   plugin.TValue[*mqlOpenstackNetworkAddressGroup]
 	IncludesPublicSource plugin.TValue[bool]
 	Project              plugin.TValue[*mqlOpenstackProject]
 }
@@ -12596,6 +12727,22 @@ func (c *mqlOpenstackSecurityGroupRule) GetRemoteGroup() *plugin.TValue[*mqlOpen
 		}
 
 		return c.remoteGroup()
+	})
+}
+
+func (c *mqlOpenstackSecurityGroupRule) GetRemoteAddressGroup() *plugin.TValue[*mqlOpenstackNetworkAddressGroup] {
+	return plugin.GetOrCompute[*mqlOpenstackNetworkAddressGroup](&c.RemoteAddressGroup, func() (*mqlOpenstackNetworkAddressGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.securityGroup.rule", c.__id, "remoteAddressGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackNetworkAddressGroup), nil
+			}
+		}
+
+		return c.remoteAddressGroup()
 	})
 }
 
@@ -21156,6 +21303,94 @@ func (c *mqlOpenstackNetworkRbacPolicy) GetProject() *plugin.TValue[*mqlOpenstac
 	return plugin.GetOrCompute[*mqlOpenstackProject](&c.Project, func() (*mqlOpenstackProject, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.network.rbacPolicy", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackProject), nil
+			}
+		}
+
+		return c.project()
+	})
+}
+
+// mqlOpenstackNetworkAddressGroup for the openstack.network.addressGroup resource
+type mqlOpenstackNetworkAddressGroup struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlOpenstackNetworkAddressGroupInternal
+	Id                    plugin.TValue[string]
+	Name                  plugin.TValue[string]
+	Description           plugin.TValue[string]
+	Addresses             plugin.TValue[[]any]
+	ContainsPublicAddress plugin.TValue[bool]
+	Project               plugin.TValue[*mqlOpenstackProject]
+}
+
+// createOpenstackNetworkAddressGroup creates a new instance of this resource
+func createOpenstackNetworkAddressGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlOpenstackNetworkAddressGroup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("openstack.network.addressGroup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) MqlName() string {
+	return "openstack.network.addressGroup"
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) GetAddresses() *plugin.TValue[[]any] {
+	return &c.Addresses
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) GetContainsPublicAddress() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.ContainsPublicAddress, func() (bool, error) {
+		return c.containsPublicAddress()
+	})
+}
+
+func (c *mqlOpenstackNetworkAddressGroup) GetProject() *plugin.TValue[*mqlOpenstackProject] {
+	return plugin.GetOrCompute[*mqlOpenstackProject](&c.Project, func() (*mqlOpenstackProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.network.addressGroup", c.__id, "project")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 openstack 13.0.1
+openstack.addressGroups 13.7.6
 openstack.aggregates 13.0.1
 openstack.applicationCredential 13.0.1
 openstack.applicationCredential.accessRules 13.0.1
@@ -514,6 +515,7 @@ openstack.identity.region.parentRegionId 13.1.4
 openstack.identity.roleAssignment 13.4.2
 openstack.identity.roleAssignment.actorType 13.4.2
 openstack.identity.roleAssignment.group 13.4.2
+openstack.identity.roleAssignment.inherited 13.7.6
 openstack.identity.roleAssignment.role 13.4.2
 openstack.identity.roleAssignment.roleName 13.4.2
 openstack.identity.roleAssignment.scopeDomain 13.4.2
@@ -621,6 +623,13 @@ openstack.l7Policies 13.0.1
 openstack.listeners 13.0.1
 openstack.loadBalancers 13.0.1
 openstack.network 13.0.1
+openstack.network.addressGroup 13.7.6
+openstack.network.addressGroup.addresses 13.7.6
+openstack.network.addressGroup.containsPublicAddress 13.7.6
+openstack.network.addressGroup.description 13.7.6
+openstack.network.addressGroup.id 13.7.6
+openstack.network.addressGroup.name 13.7.6
+openstack.network.addressGroup.project 13.7.6
 openstack.network.adminStateUp 13.0.1
 openstack.network.createdAt 13.0.1
 openstack.network.description 13.0.1
@@ -869,6 +878,8 @@ openstack.pools 13.0.1
 openstack.port 13.0.1
 openstack.port.adminStateUp 13.0.1
 openstack.port.allowedAddressPairs 13.4.2
+openstack.port.bindingVifType 13.7.6
+openstack.port.bindingVnicType 13.7.6
 openstack.port.createdAt 13.0.1
 openstack.port.description 13.0.1
 openstack.port.deviceOwner 13.0.1
@@ -887,6 +898,7 @@ openstack.port.server 13.2.1
 openstack.port.status 13.0.1
 openstack.port.subnets 13.2.1
 openstack.port.tags 13.0.1
+openstack.port.trustedVif 13.7.6
 openstack.port.updatedAt 13.0.1
 openstack.ports 13.0.1
 openstack.project 13.0.1
@@ -961,6 +973,7 @@ openstack.securityGroup.rule.portRangeMax 13.0.1
 openstack.securityGroup.rule.portRangeMin 13.0.1
 openstack.securityGroup.rule.project 13.2.1
 openstack.securityGroup.rule.protocol 13.0.1
+openstack.securityGroup.rule.remoteAddressGroup 13.7.6
 openstack.securityGroup.rule.remoteAddressGroupId 13.5.2
 openstack.securityGroup.rule.remoteGroup 13.0.1
 openstack.securityGroup.rule.remoteIpPrefix 13.0.1

--- a/providers/openstack/resources/openstack_cidr.go
+++ b/providers/openstack/resources/openstack_cidr.go
@@ -5,7 +5,10 @@ package resources
 
 import (
 	"fmt"
+	"math/big"
 	"net"
+	"net/netip"
+	"strings"
 )
 
 // privateOrReservedCIDRs are address ranges that are not routable from the
@@ -86,6 +89,74 @@ func cidrWithin(inner, outer *net.IPNet) bool {
 		return false
 	}
 	return outer.Contains(inner.IP)
+}
+
+// addressIsPublic reports whether an address-group member exposes a broad slice
+// of the public internet. Members come in three shapes: a CIDR, an inclusive
+// range written "start-end", or a bare address. A bare address is a single host
+// and so is never broad.
+func addressIsPublic(addr string) bool {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return false
+	}
+	// Splitting on "-" is unambiguous: neither CIDRs nor IPv6 literals use it.
+	if start, end, isRange := strings.Cut(addr, "-"); isRange {
+		return ipRangeIsPublic(start, end)
+	}
+	if strings.Contains(addr, "/") {
+		return cidrIsPublic(addr)
+	}
+	return false
+}
+
+// ipRangeIsPublic applies the same test as cidrIsPublic to an inclusive IP
+// range: the range must span at least as many addresses as a block at the
+// broad-public prefix length, and must not lie wholly inside a private or
+// reserved range.
+func ipRangeIsPublic(startStr, endStr string) bool {
+	start, err := netip.ParseAddr(strings.TrimSpace(startStr))
+	if err != nil {
+		return false
+	}
+	end, err := netip.ParseAddr(strings.TrimSpace(endStr))
+	if err != nil {
+		return false
+	}
+	start, end = start.Unmap(), end.Unmap()
+	if start.Is4() != end.Is4() || end.Less(start) {
+		return false
+	}
+
+	if rangeSize(start, end).Cmp(broadRangeSize(start.Is4())) < 0 {
+		return false
+	}
+
+	// A range is contiguous and so is a CIDR, so both endpoints falling inside
+	// one private or reserved block puts the whole range inside it.
+	startIP, endIP := net.IP(start.AsSlice()), net.IP(end.AsSlice())
+	for _, pr := range privateOrReservedCIDRs {
+		if pr.Contains(startIP) && pr.Contains(endIP) {
+			return false
+		}
+	}
+	return true
+}
+
+// rangeSize returns the inclusive count of addresses from start to end.
+func rangeSize(start, end netip.Addr) *big.Int {
+	s := new(big.Int).SetBytes(start.AsSlice())
+	e := new(big.Int).SetBytes(end.AsSlice())
+	return e.Sub(e, s).Add(e, big.NewInt(1))
+}
+
+// broadRangeSize returns the number of addresses in a block at the broad-public
+// prefix length, the span at which a range counts as internet exposure.
+func broadRangeSize(is4 bool) *big.Int {
+	if is4 {
+		return new(big.Int).Lsh(big.NewInt(1), 32-broadPublicPrefixV4)
+	}
+	return new(big.Int).Lsh(big.NewInt(1), 128-broadPublicPrefixV6)
 }
 
 // anyCidrPublic reports whether any CIDR string in the list exposes the public

--- a/providers/openstack/resources/openstack_cidr_test.go
+++ b/providers/openstack/resources/openstack_cidr_test.go
@@ -46,6 +46,50 @@ func TestCidrIsPublic(t *testing.T) {
 	}
 }
 
+func TestAddressIsPublic(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		// CIDR members follow the same rules as a rule's remote IP prefix
+		{"all addresses", "0.0.0.0/0", true},
+		{"all addresses v6", "::/0", true},
+		{"private block", "10.0.0.0/8", false},
+		{"single host", "203.0.113.5/32", false},
+
+		// ranges: broad enough to count, and outside private space
+		{"range spanning a full /8", "13.0.0.0-13.255.255.255", true},
+		{"range spanning more than a /8", "13.0.0.0-15.255.255.255", true},
+		{"range one short of a /8", "13.0.0.1-13.255.255.255", false},
+		{"private range spanning a /8", "10.0.0.0-10.255.255.255", false},
+		{"loopback range", "127.0.0.0-127.255.255.255", false},
+		{"narrow public range", "203.0.113.10-203.0.113.20", false},
+		{"broad v6 range", "2600:1f00::-2600:1fff:ffff:ffff:ffff:ffff:ffff:ffff", true},
+		{"narrow v6 range", "2600:1f00::1-2600:1f00::ff", false},
+
+		// a range that spans out of private space into public is not contained
+		// by any single reserved block, so it counts
+		{"range crossing out of private space", "10.0.0.0-13.255.255.255", true},
+
+		// whitespace is tolerated; the members come from a JSON list
+		{"padded range", " 13.0.0.0 - 13.255.255.255 ", true},
+
+		// malformed and degenerate inputs
+		{"empty", "", false},
+		{"bare address", "203.0.113.5", false},
+		{"reversed range", "13.255.255.255-13.0.0.0", false},
+		{"mixed family range", "13.0.0.0-2600:1f00::", false},
+		{"garbage range", "not-an-ip-at-all", false},
+		{"half a range", "13.0.0.0-", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, addressIsPublic(tt.addr))
+		})
+	}
+}
+
 func TestAnyCidrPublic(t *testing.T) {
 	assert.True(t, anyCidrPublic([]any{"10.0.0.0/8", "0.0.0.0/1"}))
 	assert.False(t, anyCidrPublic([]any{"10.0.0.0/8", "192.168.1.0/24"}))

--- a/providers/openstack/resources/openstack_exposure.go
+++ b/providers/openstack/resources/openstack_exposure.go
@@ -14,17 +14,37 @@ import (
 // --- security-group source classification ---
 
 // includesPublicSource reports whether the rule's source reaches the public
-// internet: a public remote CIDR, or an unscoped rule (no remote IP prefix and
-// no remote group) which Neutron treats as any source. Direction-agnostic, so
-// it also classifies egress destinations.
+// internet: a public remote CIDR, a remote address group holding a public
+// range, or an unscoped rule (no remote IP prefix, group, or address group)
+// which Neutron treats as any source. Direction-agnostic, so it also classifies
+// egress destinations.
 func (r *mqlOpenstackSecurityGroupRule) includesPublicSource() (bool, error) {
-	prefix := r.RemoteIpPrefix.Data
-	if prefix == "" {
-		// A rule with no IP prefix is "any source" only when it is also not
-		// scoped to a remote security group or remote address group.
-		return r.cacheRemoteGroupID == "" && r.cacheRemoteAddressGroupID == "", nil
+	if prefix := r.RemoteIpPrefix.Data; prefix != "" {
+		return cidrIsPublic(prefix), nil
 	}
-	return cidrIsPublic(prefix), nil
+
+	// An address group carries the addresses in its own right, so the rule is
+	// only as public as the group's members.
+	if r.cacheRemoteAddressGroupID != "" {
+		group := r.GetRemoteAddressGroup()
+		if group.Error != nil {
+			return false, group.Error
+		}
+		if group.Data == nil {
+			// The group could not be resolved (no address-groups extension, or
+			// it is not readable), so there is nothing to judge it on.
+			return false, nil
+		}
+		public := group.Data.GetContainsPublicAddress()
+		if public.Error != nil {
+			return false, public.Error
+		}
+		return public.Data, nil
+	}
+
+	// A rule scoped to a remote security group reaches only that group's
+	// members; one scoped to nothing at all matches any source.
+	return r.cacheRemoteGroupID == "", nil
 }
 
 // allowsPublicIngress reports whether any ingress rule in the security group


### PR DESCRIPTION
Three places where the openstack provider returned a confident answer over data it never fetched. Each one makes a policy assertion pass on configuration that is not actually safe, which is worse than a missing field: a missing field fails loudly, a wrong rollup fails silently.

## 1. Address-group-scoped rules read as non-public

`includesPublicSource` bailed out for any rule matched by a remote address group:

```go
if prefix == "" {
    return r.cacheRemoteGroupID == "" && r.cacheRemoteAddressGroupID == "", nil
}
```

An address group containing `0.0.0.0/0` therefore reported `includesPublicSource == false`. That propagates: the rule's security group reports `allowsPublicIngress == false`, and every instance behind it reports `exposure.internetReachable == false`. The flagship query

```
openstack.compute.servers.where(exposure.internetReachable)
```

silently skipped those instances.

The rule was un-answerable before because the address group was never modeled. This adds `openstack.network.addressGroup` (id, name, description, addresses, project) with a `containsPublicAddress` predicate, and resolves the rule through it.

`remoteAddressGroupId` is deprecated in favor of the new `remoteAddressGroup`, which carries the same value plus the addresses.

**Cost:** one Neutron list call. `initOpenstackNetworkAddressGroup` resolves out of the project's cached list rather than fetching per id, the way `initOpenstackPort` does, so N rules referencing address groups share one call instead of issuing N `GET`s.

**Range members.** Address groups hold CIDRs *or* inclusive IP ranges (`203.0.113.10-203.0.113.20`), so `addressIsPublic` extends the existing broad-block test to ranges rather than inventing a second rule: a range is public when it spans at least as many addresses as a block at the broad-public prefix (a /8 for v4) and does not sit wholly inside a private or reserved range. Reusing the threshold matters. Had a range of two public hosts counted as public, every allow-listed office IP pair would light up the exposure query, and a rollup that cries wolf gets muted.

## 2. System-scoped and inherited role assignments were dropped

`openstack.roleAssignments` mapped only two of the three Keystone scopes:

```go
if a.Scope.Project.ID != "" { scopeType = "project" }
else if a.Scope.Domain.ID != "" { scopeType = "domain" }
```

So a `scope: {system: {all: true}}` grant, the deployment-wide role that outranks every project, came back with an empty `scopeType` and no indication it was the most privileged assignment in the response. Separately, an OS-INHERIT domain grant (which confers the role on every project inside the domain, present and future) was indistinguishable from a grant on the domain object alone.

Neither is a flag we forgot to set: `roles.Scope` in gophercloud v2.13.0 has no `System` field and no `OS-INHERIT:inherited_to` field, so the data never reached us. This decodes the `/role_assignments` response into a local struct that keeps both, paging through gophercloud's own pager. `scopeType` gains `"system"`, and a new `inherited` field carries the flag.

The same role, principal, and scope can be granted both directly and by inheritance, so `inherited` is now part of the `__id`.

The resource doc-comment previously stated this limitation outright; that paragraph is gone.

## 3. Ports did not expose their binding attributes

`portSecurityEnabled` and `allowedAddressPairs` were modeled, but not the two attributes that can make them moot:

- **`trustedVif`** — a trusted SR-IOV virtual function may change its MAC address and enter promiscuous mode, letting the guest spoof addresses and observe traffic addressed to others regardless of security groups. Nullable, matching the API, since unset means untrusted.
- **`bindingVnicType`** — anything other than `normal`/`macvtap` hands the guest a hardware function, bypassing the software datapath that enforces security groups.
- **`bindingVifType`** — which mechanism driver bound the port; `binding_failed` and `unbound` mean no datapath was established.

All three ride the existing `ports.List` call through the port-binding and trusted-VIF extensions, so this costs no additional requests. Clouds not running an extension leave its fields at their zero value.

## Tests

`addressIsPublic` and the role-assignment scope decoding are both pure Go, so both are unit-tested: range broadness and private-space containment (including a range that crosses out of private space), malformed and degenerate inputs, and a `/role_assignments` body covering a direct project grant, an inherited domain grant, a system grant, and a group actor. The unknown-scope case asserts that a scope type Keystone might add later reports as unknown rather than silently landing in the project bucket.

## Verification

Codegen, build, `go test ./resources/...`, and gofmt are clean. Not yet run against a live OpenStack cloud.
