### PR TITLE
🎫 okta: support service app authentication with a private key JWT

### DIFF
--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -23,11 +23,14 @@ var Config = plugin.Provider{
 			Short: "an Okta organization",
 			Long: `Use the okta provider to query resources in an Okta organization.
 
-To query an Okta organization, you need the organization's domain and an API token to access that domain. To learn how, read https://mondoo.com/docs/cnspec/identity/okta.
+To query an Okta organization, you need the organization's domain and credentials to access that domain. To learn how, read https://mondoo.com/docs/cnspec/identity/okta.
+
+There are two ways to authenticate. An API token is the simplest, but it inherits the privileges of the admin who created it. A service application authenticates with a private key JWT and holds only the scopes it was granted, so it can be limited to read-only access.
 
 Examples:
   cnspec shell okta -organization <okta-domain> -token <api-token>
 	cnspec scan okta -organization <okta-domain> -token <api-token>
+	cnspec scan okta -organization <okta-domain> -client-id <client-id> -private-key <pem-or-path> -private-key-id <key-id> -scopes okta.users.read,okta.groups.read
 `,
 			Discovery: []string{},
 			Flags: []plugin.Flag{
@@ -42,6 +45,30 @@ Examples:
 					Type:    plugin.FlagType_String,
 					Default: "",
 					Desc:    "Access token for the Okta organization",
+				},
+				{
+					Long:    "client-id",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Client ID of the Okta service app to authenticate as",
+				},
+				{
+					Long:    "private-key",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Private key of the Okta service app, either the PEM itself or a path to it",
+				},
+				{
+					Long:    "private-key-id",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "ID of the public key registered with the Okta service app",
+				},
+				{
+					Long:    "scopes",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Okta API scopes to request for the service app, separated by commas",
 				},
 			},
 		},

--- a/providers/okta/connection/auth_test.go
+++ b/providers/okta/connection/auth_test.go
@@ -75,7 +75,10 @@ func TestSswsAuthorizer(t *testing.T) {
 // the service app configuration is reported on its own terms. Okta answers all
 // of them with the same opaque 401, so the check has to happen here.
 func TestNewOktaConnectionRejectsIncompleteServiceApp(t *testing.T) {
-	const pem = "-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----"
+	// Every case here is rejected before the key reaches the SDK, so the
+	// credential only has to be non-empty. A placeholder rather than a
+	// PEM-shaped literal keeps secret scanners from flagging the fixture.
+	const placeholderKey = "test-private-key-material"
 
 	tests := []struct {
 		name    string
@@ -104,7 +107,7 @@ func TestNewOktaConnectionRejectsIncompleteServiceApp(t *testing.T) {
 			conf := &inventory.Config{
 				Type:        "okta",
 				Options:     tt.options,
-				Credentials: []*vault.Credential{vault.NewPrivateKeyCredential("", []byte(pem), "")},
+				Credentials: []*vault.Credential{vault.NewPrivateKeyCredential("", []byte(placeholderKey), "")},
 			}
 
 			_, err := NewOktaConnection(0, &inventory.Asset{}, conf)
@@ -145,6 +148,8 @@ func TestNewOktaConnectionTokenModeAuthorizesRawRequests(t *testing.T) {
 	ext := conn.ApiExtension()
 	require.NotNil(t, ext.Authorize, "the raw path must carry the connection's credential")
 	assert.Equal(t, "dev-12345.okta.com", ext.Host)
+	// The client holds no per-call state, so every caller shares one instance.
+	assert.Same(t, ext, conn.ApiExtension())
 
 	req, err := http.NewRequest(http.MethodGet, "https://dev-12345.okta.com/api/v1/zones", nil)
 	require.NoError(t, err)

--- a/providers/okta/connection/auth_test.go
+++ b/providers/okta/connection/auth_test.go
@@ -1,0 +1,153 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+)
+
+// TestSplitScopes covers the scope list accepted on the CLI. Okta writes scopes
+// space-separated, but a flag reads more naturally comma-separated, so both
+// have to survive the trip.
+func TestSplitScopes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "comma separated",
+			raw:  "okta.users.read,okta.groups.read",
+			want: []string{"okta.users.read", "okta.groups.read"},
+		},
+		{
+			name: "space separated",
+			raw:  "okta.users.read okta.groups.read",
+			want: []string{"okta.users.read", "okta.groups.read"},
+		},
+		{
+			name: "comma with padding",
+			raw:  " okta.users.read , okta.groups.read ",
+			want: []string{"okta.users.read", "okta.groups.read"},
+		},
+		{
+			name: "single scope",
+			raw:  "okta.users.read",
+			want: []string{"okta.users.read"},
+		},
+		{
+			name: "empty",
+			raw:  "",
+			want: []string{},
+		},
+		{
+			name: "separators only",
+			raw:  " , , ",
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, splitScopes(tt.raw))
+		})
+	}
+}
+
+// TestSswsAuthorizer pins the API token scheme. Okta rejects a token sent as a
+// bearer, so the scheme is not interchangeable with the service app's.
+func TestSswsAuthorizer(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://dev-12345.okta.com/api/v1/users", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, sswsAuthorizer("abc123")(req))
+	assert.Equal(t, "SSWS abc123", req.Header.Get("Authorization"))
+}
+
+// TestNewOktaConnectionRejectsIncompleteServiceApp proves each missing piece of
+// the service app configuration is reported on its own terms. Okta answers all
+// of them with the same opaque 401, so the check has to happen here.
+func TestNewOktaConnectionRejectsIncompleteServiceApp(t *testing.T) {
+	const pem = "-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----"
+
+	tests := []struct {
+		name    string
+		options map[string]string
+		wantErr string
+	}{
+		{
+			name:    "missing client id",
+			options: map[string]string{"organization": "dev-12345.okta.com", "private-key-id": "kid1", "scopes": "okta.users.read"},
+			wantErr: "client id",
+		},
+		{
+			name:    "missing private key id",
+			options: map[string]string{"organization": "dev-12345.okta.com", "client-id": "0oa1", "scopes": "okta.users.read"},
+			wantErr: "registered public key",
+		},
+		{
+			name:    "missing scopes",
+			options: map[string]string{"organization": "dev-12345.okta.com", "client-id": "0oa1", "private-key-id": "kid1"},
+			wantErr: "scopes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &inventory.Config{
+				Type:        "okta",
+				Options:     tt.options,
+				Credentials: []*vault.Credential{vault.NewPrivateKeyCredential("", []byte(pem), "")},
+			}
+
+			_, err := NewOktaConnection(0, &inventory.Asset{}, conf)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestNewOktaConnectionRequiresCredentials guards the case where neither
+// authentication method was configured, which otherwise reaches Okta as an
+// unauthenticated request.
+func TestNewOktaConnectionRequiresCredentials(t *testing.T) {
+	conf := &inventory.Config{
+		Type:    "okta",
+		Options: map[string]string{"organization": "dev-12345.okta.com"},
+	}
+
+	_, err := NewOktaConnection(0, &inventory.Asset{}, conf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--token")
+	assert.Contains(t, err.Error(), "--private-key")
+}
+
+// TestNewOktaConnectionTokenModeAuthorizesRawRequests proves the raw HTTP path
+// gets the same credential the generated SDK uses. Without it every hand-rolled
+// endpoint would send an unauthenticated request.
+func TestNewOktaConnectionTokenModeAuthorizesRawRequests(t *testing.T) {
+	conf := &inventory.Config{
+		Type:        "okta",
+		Options:     map[string]string{"organization": "dev-12345.okta.com"},
+		Credentials: []*vault.Credential{vault.NewPasswordCredential("", "abc123")},
+	}
+
+	conn, err := NewOktaConnection(0, &inventory.Asset{}, conf)
+	require.NoError(t, err)
+
+	ext := conn.ApiExtension()
+	require.NotNil(t, ext.Authorize, "the raw path must carry the connection's credential")
+	assert.Equal(t, "dev-12345.okta.com", ext.Host)
+
+	req, err := http.NewRequest(http.MethodGet, "https://dev-12345.okta.com/api/v1/zones", nil)
+	require.NoError(t, err)
+	require.NoError(t, ext.Authorize(req))
+	assert.Equal(t, "SSWS abc123", req.Header.Get("Authorization"))
+}

--- a/providers/okta/connection/connection.go
+++ b/providers/okta/connection/connection.go
@@ -24,10 +24,6 @@ import (
 // orgs prohibit them outright. A service application authenticates with a
 // private key JWT instead and holds only the scopes it was granted, so it can
 // be given read-only access.
-const (
-	authModeSSWS       = "SSWS"
-	authModePrivateKey = "PrivateKey"
-)
 
 // accessTokenCacheTTL bounds how long a minted access token is reused for the
 // requests issued outside the generated SDK. Each entry is also stored under
@@ -46,6 +42,10 @@ type OktaConnection struct {
 	// the generated SDK, so the raw endpoints in resources/sdk authenticate the
 	// same way the SDK-served ones do.
 	authorize func(req *http.Request) error
+	// apiExtension is the client for the endpoints the generated SDK does not
+	// serve correctly. It is immutable once built, so it is shared rather than
+	// rebuilt by each caller.
+	apiExtension *sdk.ApiExtension
 }
 
 func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*OktaConnection, error) {
@@ -85,7 +85,7 @@ func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 
 	orgURL := "https://" + org
 	options := []okta.ConfigSetter{okta.WithOrgUrl(orgURL)}
-	authMode := authModeSSWS
+	serviceApp := false
 
 	switch {
 	case privateKey != "":
@@ -102,9 +102,9 @@ func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 			return nil, errors.New("okta service app authentication requires the scopes to request, pass --scopes or set OKTA_API_SCOPES")
 		}
 
-		authMode = authModePrivateKey
+		serviceApp = true
 		options = append(options,
-			okta.WithAuthorizationMode(authModePrivateKey),
+			okta.WithAuthorizationMode("PrivateKey"),
 			okta.WithClientId(clientID),
 			okta.WithScopes(scopes),
 			okta.WithPrivateKey(privateKey),
@@ -127,7 +127,7 @@ func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	// Build the authorizer from the finished configuration so requests issued
 	// outside the generated SDK carry the same user agent and rate-limit
 	// settings the SDK-served ones do.
-	if authMode == authModePrivateKey {
+	if serviceApp {
 		conn.authorize = privateKeyAuthorizer(config)
 	} else {
 		conn.authorize = sswsAuthorizer(token)
@@ -136,6 +136,9 @@ func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	conn.organization = org
 	conn.client = client
 	conn.token = token
+	// Neither field changes after this point, so the raw-endpoint client is
+	// built once rather than per call.
+	conn.apiExtension = &sdk.ApiExtension{Host: org, Authorize: conn.authorize}
 
 	return conn, nil
 }
@@ -215,14 +218,11 @@ func (c *OktaConnection) Token() string {
 	return c.token
 }
 
-// ApiExtension returns a client for the Okta endpoints the generated SDK does
+// ApiExtension returns the client for the Okta endpoints the generated SDK does
 // not serve correctly. It carries this connection's authorization, so the raw
 // path works under service app credentials as well as an API token.
 func (c *OktaConnection) ApiExtension() *sdk.ApiExtension {
-	return &sdk.ApiExtension{
-		Host:      c.organization,
-		Authorize: c.authorize,
-	}
+	return c.apiExtension
 }
 
 func (c *OktaConnection) Identifier() (string, error) {

--- a/providers/okta/connection/connection.go
+++ b/providers/okta/connection/connection.go
@@ -6,13 +6,33 @@ package connection
 import (
 	"context"
 	"errors"
+	"net/http"
+	"strings"
+	"time"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
+	goCache "github.com/patrickmn/go-cache"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
+
+// Okta accepts two kinds of API credential. An SSWS token belongs to the admin
+// who created it and carries that admin's full privileges, which is why many
+// orgs prohibit them outright. A service application authenticates with a
+// private key JWT instead and holds only the scopes it was granted, so it can
+// be given read-only access.
+const (
+	authModeSSWS       = "SSWS"
+	authModePrivateKey = "PrivateKey"
+)
+
+// accessTokenCacheTTL bounds how long a minted access token is reused for the
+// requests issued outside the generated SDK. Each entry is also stored under
+// the token's own expiry, so this is only an upper bound.
+const accessTokenCacheTTL = 55 * time.Minute
 
 type OktaConnection struct {
 	plugin.Connection
@@ -22,6 +42,10 @@ type OktaConnection struct {
 	organization string
 	client       *okta.APIClient
 	token        string
+	// authorize stamps the Authorization header onto requests issued outside
+	// the generated SDK, so the raw endpoints in resources/sdk authenticate the
+	// same way the SDK-served ones do.
+	authorize func(req *http.Request) error
 }
 
 func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*OktaConnection, error) {
@@ -43,35 +67,132 @@ func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	org := conf.Options["organization"]
 
 	var token string
+	var privateKey string
 	if len(conf.Credentials) > 0 {
 		log.Debug().Int("credentials", len(conf.Credentials)).Msg("credentials")
 		for i := range conf.Credentials {
 			cred := conf.Credentials[i]
-			if cred.Type == vault.CredentialType_password {
+			switch cred.Type {
+			case vault.CredentialType_password:
 				token = string(cred.Secret)
-			} else {
+			case vault.CredentialType_private_key:
+				privateKey = string(cred.Secret)
+			default:
 				log.Warn().Str("credential-type", cred.Type.String()).Msg("unsupported credential type for Okta provider")
 			}
 		}
 	}
-	if token == "" {
-		return nil, errors.New("a valid Okta token is required, pass --token '<yourtoken>' or set OKTA_API_TOKEN environment variable")
+
+	orgURL := "https://" + org
+	options := []okta.ConfigSetter{okta.WithOrgUrl(orgURL)}
+	authMode := authModeSSWS
+
+	switch {
+	case privateKey != "":
+		clientID := conf.Options["client-id"]
+		privateKeyID := conf.Options["private-key-id"]
+		scopes := splitScopes(conf.Options["scopes"])
+		if clientID == "" {
+			return nil, errors.New("okta service app authentication requires a client id, pass --client-id or set OKTA_API_CLIENT_ID")
+		}
+		if privateKeyID == "" {
+			return nil, errors.New("okta service app authentication requires the id of the registered public key, pass --private-key-id or set OKTA_API_PRIVATE_KEY_ID")
+		}
+		if len(scopes) == 0 {
+			return nil, errors.New("okta service app authentication requires the scopes to request, pass --scopes or set OKTA_API_SCOPES")
+		}
+
+		authMode = authModePrivateKey
+		options = append(options,
+			okta.WithAuthorizationMode(authModePrivateKey),
+			okta.WithClientId(clientID),
+			okta.WithScopes(scopes),
+			okta.WithPrivateKey(privateKey),
+			okta.WithPrivateKeyId(privateKeyID),
+		)
+
+	case token != "":
+		options = append(options, okta.WithToken(token))
+
+	default:
+		return nil, errors.New("okta requires either an API token (--token or OKTA_API_TOKEN) or service app credentials (--client-id, --private-key, --private-key-id and --scopes)")
 	}
 
-	config, err := okta.NewConfiguration(
-		okta.WithOrgUrl("https://"+org),
-		okta.WithToken(token),
-	)
+	config, err := okta.NewConfiguration(options...)
 	if err != nil {
 		return nil, err
 	}
 	client := okta.NewAPIClient(config)
+
+	// Build the authorizer from the finished configuration so requests issued
+	// outside the generated SDK carry the same user agent and rate-limit
+	// settings the SDK-served ones do.
+	if authMode == authModePrivateKey {
+		conn.authorize = privateKeyAuthorizer(config)
+	} else {
+		conn.authorize = sswsAuthorizer(token)
+	}
 
 	conn.organization = org
 	conn.client = client
 	conn.token = token
 
 	return conn, nil
+}
+
+// splitScopes accepts the scopes as a single option value, separated by commas
+// or whitespace, since Okta writes them space-separated but a CLI flag reads
+// more naturally comma-separated.
+func splitScopes(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	scopes := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f != "" {
+			scopes = append(scopes, f)
+		}
+	}
+	return scopes
+}
+
+func sswsAuthorizer(token string) func(*http.Request) error {
+	return func(req *http.Request) error {
+		req.Header.Set("Authorization", "SSWS "+token)
+		return nil
+	}
+}
+
+// privateKeyAuthorizer reuses the SDK's private key JWT exchange for requests
+// the generated client does not serve. The SDK keeps its minted access token in
+// a cache private to its APIClient, so this holds its own; the cost is one
+// extra token exchange for the raw path, after which both are cached.
+func privateKeyAuthorizer(config *okta.Configuration) func(*http.Request) error {
+	tokenCache := goCache.New(accessTokenCacheTTL, accessTokenCacheTTL)
+	client := config.Okta.Client
+	userAgent := okta.NewUserAgent(config).String()
+
+	return func(req *http.Request) error {
+		auth := okta.NewPrivateKeyAuth(okta.PrivateKeyAuthConfig{
+			TokenCache:       tokenCache,
+			HttpClient:       config.HTTPClient,
+			PrivateKeySigner: config.PrivateKeySigner,
+			PrivateKey:       client.PrivateKey,
+			PrivateKeyId:     client.PrivateKeyId,
+			ClientId:         client.ClientId,
+			OrgURL:           client.OrgUrl,
+			UserAgent:        userAgent,
+			Scopes:           client.Scopes,
+			MaxRetries:       client.RateLimit.MaxRetries,
+			MaxBackoff:       client.RateLimit.MaxBackoff,
+			Req:              req,
+		})
+		// The SDK signs the DPoP proof against the request URL without its
+		// query string, so strip it here the same way the generated client does.
+		urlWithoutQuery := *req.URL
+		urlWithoutQuery.RawQuery = ""
+		return auth.Authorize(req.Method, urlWithoutQuery.String())
+	}
 }
 
 func (c *OktaConnection) Name() string {
@@ -92,6 +213,16 @@ func (c *OktaConnection) Client() *okta.APIClient {
 
 func (c *OktaConnection) Token() string {
 	return c.token
+}
+
+// ApiExtension returns a client for the Okta endpoints the generated SDK does
+// not serve correctly. It carries this connection's authorization, so the raw
+// path works under service app credentials as well as an API token.
+func (c *OktaConnection) ApiExtension() *sdk.ApiExtension {
+	return &sdk.ApiExtension{
+		Host:      c.organization,
+		Authorize: c.authorize,
+	}
 }
 
 func (c *OktaConnection) Identifier() (string, error) {

--- a/providers/okta/go.mod
+++ b/providers/okta/go.mod
@@ -6,6 +6,7 @@ go 1.26.5
 
 require (
 	github.com/okta/okta-sdk-golang/v5 v5.0.6
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.32.2
@@ -79,7 +80,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/oklog/run v1.2.0 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/providers/okta/provider/provider.go
+++ b/providers/okta/provider/provider.go
@@ -53,10 +53,37 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	if token == "" {
 		token = os.Getenv("OKTA_TOKEN")
 	}
-	if token == "" {
-		return nil, errors.New("no okta token provided, use --token or OKTA_TOKEN")
+
+	// Service app credentials are the alternative to an API token. An SSWS
+	// token carries the full privileges of the admin who minted it, so orgs
+	// that require least privilege authenticate a scoped service app with a
+	// private key JWT instead. The environment variable names match the ones
+	// the Okta Terraform provider reads, so an org that already configures one
+	// does not need a second set.
+	clientID := flagOrEnv(flags, "client-id", "OKTA_API_CLIENT_ID")
+	privateKeyID := flagOrEnv(flags, "private-key-id", "OKTA_API_PRIVATE_KEY_ID")
+	scopes := flagOrEnv(flags, "scopes", "OKTA_API_SCOPES")
+	privateKey := flagOrEnv(flags, "private-key", "OKTA_API_PRIVATE_KEY")
+
+	switch {
+	case privateKey != "":
+		// The value is either the PEM itself or a path to it, matching how the
+		// Okta Terraform provider accepts the same argument.
+		cred, err := privateKeyCredential(privateKey)
+		if err != nil {
+			return nil, err
+		}
+		conf.Credentials = append(conf.Credentials, cred)
+		conf.Options["client-id"] = clientID
+		conf.Options["private-key-id"] = privateKeyID
+		conf.Options["scopes"] = scopes
+
+	case token != "":
+		conf.Credentials = append(conf.Credentials, vault.NewPasswordCredential("", token))
+
+	default:
+		return nil, errors.New("no okta credentials provided, use --token (or OKTA_API_TOKEN) for an API token, or --client-id, --private-key, --private-key-id and --scopes (or OKTA_API_CLIENT_ID, OKTA_API_PRIVATE_KEY, OKTA_API_PRIVATE_KEY_ID and OKTA_API_SCOPES) for a service app")
 	}
-	conf.Credentials = append(conf.Credentials, vault.NewPasswordCredential("", token))
 
 	organization := ""
 	if x, ok := flags["organization"]; ok && len(x.Value) != 0 {
@@ -80,6 +107,31 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	return &plugin.ParseCLIRes{Asset: &asset}, nil
+}
+
+// flagOrEnv reads a CLI flag, falling back to an environment variable when the
+// flag was not given.
+func flagOrEnv(flags map[string]*llx.Primitive, flag, env string) string {
+	if x, ok := flags[flag]; ok && len(x.Value) != 0 {
+		return string(x.Value)
+	}
+	return os.Getenv(env)
+}
+
+// privateKeyCredential accepts the service app's key either as the PEM itself
+// or as a path to a file holding it, matching how the Okta Terraform provider
+// reads the same argument. A value that starts a PEM block is taken literally;
+// anything else is read from disk.
+func privateKeyCredential(value string) (*vault.Credential, error) {
+	if strings.HasPrefix(strings.TrimSpace(value), "-----BEGIN") {
+		return vault.NewPrivateKeyCredential("", []byte(value), ""), nil
+	}
+
+	cred, err := vault.NewPrivateKeyCredentialFromPath("", value, "")
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to read okta private key from "+value), err)
+	}
+	return cred, nil
 }
 
 func (s *Service) MockConnect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*plugin.ConnectRes, error) {

--- a/providers/okta/resources/apiTokens.go
+++ b/providers/okta/resources/apiTokens.go
@@ -9,7 +9,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
-	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
 
 // mqlOktaApiTokenInternal caches the owning user's id so the typed user()
@@ -24,10 +23,7 @@ func (o *mqlOkta) apiTokens() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	tokens, err := apiSupplement.ListApiTokens(ctx, queryLimit)
 	if err != nil {

--- a/providers/okta/resources/appEntitlements.go
+++ b/providers/okta/resources/appEntitlements.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
-	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
 
 type mqlOktaApplicationScopeConsentGrantInternal struct {
@@ -239,10 +238,7 @@ func (a *mqlOktaApplication) adminRoles() ([]any, error) {
 
 	conn := a.MqlRuntime.Connection.(*connection.OktaConnection)
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	roles, resp, err := apiSupplement.ListClientRoles(ctx, clientID)
 	if err != nil {

--- a/providers/okta/resources/authorizationServers.go
+++ b/providers/okta/resources/authorizationServers.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
-	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 	"go.mondoo.com/mql/v13/types"
 )
 
@@ -274,10 +273,7 @@ func (o *mqlOktaAuthorizationServer) keys() ([]any, error) {
 	// v5's typed AuthorizationServerJsonWebKey drops created/lastUpdated/
 	// expiresAt/keyOps/x5c/x5t/x5tS256, so fetch the keys directly to retain the
 	// full JWK shape the v2 SDK exposed.
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 	keys, err := apiSupplement.ListAuthorizationServerKeys(ctx, o.Id.Data)
 	if err != nil {
 		return nil, err

--- a/providers/okta/resources/customRoles.go
+++ b/providers/okta/resources/customRoles.go
@@ -20,10 +20,7 @@ func (o *mqlOkta) customRoles() ([]any, error) {
 	conn := runtime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	respList, resp, err := apiSupplement.ListCustomRoles(ctx)
 	if err != nil {

--- a/providers/okta/resources/network.go
+++ b/providers/okta/resources/network.go
@@ -18,10 +18,7 @@ func (o *mqlOkta) networks() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	zones, err := apiSupplement.ListNetworkZones(ctx, queryLimit)
 	if err != nil {

--- a/providers/okta/resources/organization.go
+++ b/providers/okta/resources/organization.go
@@ -12,7 +12,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
-	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 	"go.mondoo.com/mql/v13/types"
 	"go.mondoo.com/ranger-rpc"
 )
@@ -138,15 +137,11 @@ func (o *mqlOktaOrganization) securityNotificationEmails() (any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	emails, err := apiSupplement.GetSecurityNotificationEmails(
 		ctx,
 		conn.OrganizationID(),
-		conn.Token(),
 		ranger.DefaultHttpClient(),
 	)
 	if err != nil {
@@ -213,10 +208,7 @@ func (o *mqlOktaOrganization) threatInsightSettings() (*mqlOktaThreatsConfigurat
 		return nil, err
 	}
 
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	excludesZones := []any{}
 	for i := range config.ExcludeZones {

--- a/providers/okta/resources/policies.go
+++ b/providers/okta/resources/policies.go
@@ -55,10 +55,7 @@ func listPolicies(runtime *plugin.Runtime, policyType PolicyType) ([]any, error)
 	conn := runtime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	respList, resp, err := apiSupplement.ListPolicies(ctx, string(policyType), queryLimit)
 	if err != nil {
@@ -157,7 +154,7 @@ func (o *mqlOktaPolicy) rules() ([]any, error) {
 	}
 
 	if o.Type.Data == ACCESS_POLICY {
-		return getAccessPolicyRules(ctx, o.MqlRuntime, o.Id.Data, conn.OrganizationID(), conn.Token())
+		return getAccessPolicyRules(ctx, o.MqlRuntime, o.Id.Data, conn.ApiExtension())
 	}
 
 	rules, resp, err := client.PolicyAPI.ListPolicyRules(ctx, o.Id.Data).Execute()
@@ -208,8 +205,8 @@ func (o *mqlOktaPolicy) rules() ([]any, error) {
 	return list, nil
 }
 
-func getAccessPolicyRules(ctx context.Context, runtime *plugin.Runtime, policyId, host, token string) ([]any, error) {
-	rules, err := fetchAccessPolicyRules(ctx, policyId, host, token)
+func getAccessPolicyRules(ctx context.Context, runtime *plugin.Runtime, policyId string, apiSupplement *sdk.ApiExtension) ([]any, error) {
+	rules, err := fetchAccessPolicyRules(ctx, policyId, apiSupplement)
 	if err != nil {
 		return nil, err
 	}
@@ -255,8 +252,7 @@ func (o *mqlOktaPolicyRule) id() (string, error) {
 
 // see https://github.com/okta/okta-sdk-golang/issues/286 for context. okta's sdk doesn't let you fetch
 // type-specific rules which differ between the different policies. as such, we fetch those manually.
-func fetchAccessPolicyRules(ctx context.Context, policyid, host, token string) ([]oktaPolicyRuleRaw, error) {
-	apiSupplement := &sdk.ApiExtension{Host: host, Token: token}
+func fetchAccessPolicyRules(ctx context.Context, policyid string, apiSupplement *sdk.ApiExtension) ([]oktaPolicyRuleRaw, error) {
 	raws, err := apiSupplement.ListPolicyRules(ctx, policyid, queryLimit)
 	if err != nil {
 		return nil, err

--- a/providers/okta/resources/sdk/auth_test.go
+++ b/providers/okta/resources/sdk/auth_test.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAppliesAuthorize proves the raw path stamps whatever credential the
+// connection supplies, rather than assuming the SSWS scheme. A service app
+// authenticates with a bearer token, so hardcoding the scheme here would 401
+// every hand-rolled endpoint while the SDK-served ones kept working.
+func TestGetAppliesAuthorize(t *testing.T) {
+	t.Parallel()
+	rt := &singlePageRoundTripper{body: `[]`}
+	m := &ApiExtension{
+		Host:       "x.okta.com",
+		HTTPClient: &http.Client{Transport: rt},
+		Authorize: func(req *http.Request) error {
+			req.Header.Set("Authorization", "Bearer minted-access-token")
+			return nil
+		},
+	}
+
+	var out []map[string]any
+	resp, err := m.get(context.Background(), m.url("/api/v1/zones"), &out)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "Bearer minted-access-token", resp.Request.Header.Get("Authorization"))
+}
+
+// TestGetFailsWhenAuthorizeFails covers a token exchange that could not be
+// completed. The request must not be sent unauthenticated, which Okta would
+// answer with a 401 that reads as a permissions problem rather than a
+// credential one.
+func TestGetFailsWhenAuthorizeFails(t *testing.T) {
+	t.Parallel()
+	rt := &singlePageRoundTripper{body: `[]`}
+	m := &ApiExtension{
+		Host:       "x.okta.com",
+		HTTPClient: &http.Client{Transport: rt},
+		Authorize: func(req *http.Request) error {
+			return errors.New("private key jwt exchange failed")
+		},
+	}
+
+	_, err := m.get(context.Background(), m.url("/api/v1/zones"), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "private key jwt exchange failed")
+	assert.Zero(t, rt.calls, "the request must not be sent without a credential")
+}

--- a/providers/okta/resources/sdk/notifications.go
+++ b/providers/okta/resources/sdk/notifications.go
@@ -28,7 +28,7 @@ type SecurityNotificationEmails struct {
 }
 
 // GetSecurityNotificationEmails retrieves the security configuration
-func (m *ApiExtension) GetSecurityNotificationEmails(ctx context.Context, orgId string, token string, client *http.Client) (*SecurityNotificationEmails, error) {
+func (m *ApiExtension) GetSecurityNotificationEmails(ctx context.Context, orgId string, client *http.Client) (*SecurityNotificationEmails, error) {
 
 	// we need to split the orgId into orgName and domain because this API uses a different domain
 	orgName, domain, found := strings.Cut(orgId, ".")
@@ -36,12 +36,17 @@ func (m *ApiExtension) GetSecurityNotificationEmails(ctx context.Context, orgId 
 		return nil, errors.New("cound not determine orgName and domain from orgId " + orgId)
 	}
 	url := fmt.Sprintf("https://%s-admin.%s/api/internal/org/settings/security-notification-settings", orgName, domain)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
-	// use okta SSWS authentication
-	req.Header.Add("Authorization", "SSWS "+token)
+	// Authorize through the connection rather than assuming an API token, so
+	// this carries whichever credential the org authenticated with.
+	if m.Authorize != nil {
+		if err := m.Authorize(req); err != nil {
+			return nil, err
+		}
+	}
 	req.Header.Add("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {

--- a/providers/okta/resources/sdk/policies_pagination_test.go
+++ b/providers/okta/resources/sdk/policies_pagination_test.go
@@ -49,7 +49,11 @@ func (rt *pagedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 // fakeClient returns an ApiExtension whose transport is the given round-tripper,
 // so pagination is exercised without touching any global http.Client.
 func fakeClient(rt http.RoundTripper) *ApiExtension {
-	return &ApiExtension{Host: "x.okta.com", Token: "t", HTTPClient: &http.Client{Transport: rt}}
+	return &ApiExtension{
+		Host:       "x.okta.com",
+		Authorize:  func(req *http.Request) error { req.Header.Set("Authorization", "SSWS t"); return nil },
+		HTTPClient: &http.Client{Transport: rt},
+	}
 }
 
 // TestListPolicyRulesFollowsPagination guards the ACCESS_POLICY rule fetch

--- a/providers/okta/resources/sdk/sdk.go
+++ b/providers/okta/resources/sdk/sdk.go
@@ -14,13 +14,17 @@ import (
 
 // ApiExtension handles cases where Okta's SDK doesn't expose a particular API.
 // The v5 SDK no longer ships a public RequestExecutor, so we issue the raw
-// authenticated requests ourselves using the org host and SSWS token carried by
-// the connection.
+// authenticated requests ourselves against the org host carried by the
+// connection.
 type ApiExtension struct {
 	// Host is the org host (e.g. "dev-12345.okta.com"), without scheme.
 	Host string
-	// Token is the Okta API token used for SSWS authorization.
-	Token string
+	// Authorize stamps the Authorization header onto each outgoing request.
+	// The connection supplies it so this path authenticates the same way the
+	// generated SDK does, whether that is an SSWS API token or a service app's
+	// private key JWT. A nil Authorize sends the request unauthenticated,
+	// which Okta answers with a 401.
+	Authorize func(req *http.Request) error
 	// HTTPClient issues the requests. When nil, http.DefaultClient is used.
 	// Tests inject a client with a custom transport so pagination can be
 	// exercised without mutating any global state.
@@ -47,7 +51,11 @@ func (m *ApiExtension) get(ctx context.Context, url string, out any) (*http.Resp
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "SSWS "+m.Token)
+	if m.Authorize != nil {
+		if err := m.Authorize(req); err != nil {
+			return nil, err
+		}
+	}
 
 	resp, err := m.httpClient().Do(req)
 	if err != nil {

--- a/providers/okta/resources/threatPosture.go
+++ b/providers/okta/resources/threatPosture.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
-	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
 
 // --- attack protection (org-level singleton) ---
@@ -30,10 +29,7 @@ func initOktaAttackProtection(runtime *plugin.Runtime, args map[string]*llx.RawD
 
 	conn := runtime.Connection.(*connection.OktaConnection)
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	// Fetched through the extension: the SDK types both attack-protection
 	// endpoints as slices, but each returns a single JSON object, so the SDK's
@@ -54,10 +50,7 @@ func initOktaAttackProtection(runtime *plugin.Runtime, args map[string]*llx.RawD
 func (o *mqlOkta) behaviorRules() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	// Fetched through the extension rather than the SDK: the /api/v1/behaviors
 	// endpoint returns non-RFC3339 timestamps ("2026-07-20 17:34:59.0") that

--- a/providers/okta/resources/userFactors.go
+++ b/providers/okta/resources/userFactors.go
@@ -11,7 +11,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
-	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
 
 // mqlOktaUserFactorInternal caches the owning user's id so the typed user()
@@ -44,10 +43,7 @@ func (o *mqlOktaUser) factors() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	apiSupplement := &sdk.ApiExtension{
-		Host:  conn.OrganizationID(),
-		Token: conn.Token(),
-	}
+	apiSupplement := conn.ApiExtension()
 
 	raw, err := apiSupplement.ListUserFactors(ctx, o.Id.Data)
 	if err != nil {


### PR DESCRIPTION
> Independent of #9679 / #9681 — no schema changes, branched from `main`.

The provider could only authenticate with an SSWS API token. That token belongs to the admin who created it and carries that admin's full privileges, with no way to narrow it — which is why a lot of orgs prohibit them outright. Those orgs could not scan Okta at all.

A service application authenticates with a **private key JWT** and holds only the scopes it was granted, so it can be given read-only access. The SDK has supported this the whole time; the connection just never offered it.

```bash
cnspec scan okta -organization <okta-domain> \
  -client-id <client-id> \
  -private-key <pem-or-path> \
  -private-key-id <key-id> \
  -scopes okta.users.read,okta.groups.read
```

Or via the environment: `OKTA_API_CLIENT_ID`, `OKTA_API_PRIVATE_KEY`, `OKTA_API_PRIVATE_KEY_ID`, `OKTA_API_SCOPES`. Those names — and `--private-key` accepting either a PEM or a path to one — match the [Okta Terraform provider](https://registry.terraform.io/providers/okta/okta/latest/docs), so an org that already configures one needs no second set. API tokens keep working exactly as before.

## The part that isn't the connection

The generated SDK is only half this provider. Ten endpoints are served by hand through `ApiExtension` because the v5 SDK types their responses wrongly, and that path built its header as `"SSWS " + token`.

Under service app credentials the token is empty — so every one of those endpoints would have sent a blank credential and 401 while the SDK-served resources kept working. Half the provider silently failing, in a way that reads as a permissions problem rather than a credential one.

So `ApiExtension` now takes an `Authorize func(*http.Request) error` that the connection supplies, and construction is centralized behind `conn.ApiExtension()` — a call site can no longer forget it. Twelve literal constructions collapse into that one factory.

That includes `GetSecurityNotificationEmails`, which reaches a *different* host (`{org}-admin.{domain}`) and carried its own separate hardcoded SSWS header.

## Notes

- Private-key mode reuses the SDK's own `NewPrivateKeyAuth` for the token exchange rather than reimplementing the JWT assertion, so DPoP and token caching come along with it. The SDK keeps its minted token in a cache private to its `APIClient`, so the raw path holds its own — the cost is one extra exchange, after which both are cached.
- The authorizer is built from the finished `*okta.Configuration`, so the raw path inherits the same user agent and rate-limit settings as the SDK path.
- Each missing piece of the service app configuration is reported on its own terms (`--client-id`, `--private-key-id`, `--scopes`), because Okta answers all of them with the same opaque 401.
- `--scopes` accepts commas or spaces: Okta writes scopes space-separated, but a CLI flag reads more naturally comma-separated.
- `github.com/patrickmn/go-cache` moves from indirect to direct; it was already in the tree as an SDK dependency.

## Tests

- `connection/auth_test.go` — scope-list parsing, the SSWS header scheme (Okta rejects an API token sent as a bearer, so the schemes are not interchangeable), each incomplete-service-app rejection, the no-credentials case, and that `conn.ApiExtension()` actually carries the credential.
- `resources/sdk/auth_test.go` — that `get` stamps whatever the connection supplies, and that a failed token exchange stops the request rather than sending it unauthenticated.

Live verification against a real service app is pending the next batched `provider-verification` run.
