### PR TITLE
🟢 openstack: drop the key-shaped PEM block from the certificate test

### DIFF
--- a/providers/openstack/resources/magnum_nodegroups_test.go
+++ b/providers/openstack/resources/magnum_nodegroups_test.go
@@ -18,6 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// csrBlockPEM is a PEM block that is not a certificate, used to check that the
+// parser skips past one. Its body is not a real signing request; the parser
+// never decodes a block it skips, and a well-formed one would only be a
+// credential-shaped string for a scanner to flag.
+const csrBlockPEM = "-----BEGIN CERTIFICATE REQUEST-----\nZm9v\n-----END CERTIFICATE REQUEST-----\n"
+
 // testCertificatePEM builds a self-signed certificate and returns it PEM
 // encoded, so the parser is exercised against a real certificate rather than a
 // checked-in fixture that would eventually expire.
@@ -47,10 +53,12 @@ func TestParseCertificatePEM(t *testing.T) {
 		assert.Equal(t, expiry.Unix(), cert.NotAfter.Unix())
 	})
 
-	// Magnum can hand back a bundle; the authority is the first certificate in
-	// it, and a leading key block must not stop the search.
+	// Magnum returns a signing request alongside the certificate, so a bundle
+	// can lead with one. Its block type starts with "CERTIFICATE" without being
+	// a certificate, which is what makes it the useful case to skip past: it
+	// proves the block type is matched exactly rather than by prefix.
 	t.Run("first certificate of a bundle", func(t *testing.T) {
-		bundle := "-----BEGIN EC PRIVATE KEY-----\nZm9v\n-----END EC PRIVATE KEY-----\n" +
+		bundle := csrBlockPEM +
 			testCertificatePEM(t, "kubernetes-ca", expiry) +
 			testCertificatePEM(t, "intermediate", expiry.Add(24*time.Hour))
 		cert, err := parseCertificatePEM(bundle)
@@ -62,7 +70,7 @@ func TestParseCertificatePEM(t *testing.T) {
 	// A cluster whose authority is withheld reports nothing rather than failing
 	// the whole query.
 	t.Run("no certificate block", func(t *testing.T) {
-		for _, raw := range []string{"", "not pem at all", "-----BEGIN EC PRIVATE KEY-----\nZm9v\n-----END EC PRIVATE KEY-----\n"} {
+		for _, raw := range []string{"", "not pem at all", csrBlockPEM} {
 			cert, err := parseCertificatePEM(raw)
 			require.NoError(t, err)
 			assert.Nil(t, cert)


### PR DESCRIPTION
Follow-up to #9687, which merged before this landed on it. Clears the two code-scanning alerts it opened ([130](https://github.com/mondoohq/mql/security/code-scanning/130), [131](https://github.com/mondoohq/mql/security/code-scanning/131)).

`TestParseCertificatePEM` needed a PEM block that is *not* a certificate, to check the parser skips past one. It used an `EC PRIVATE KEY` header with `Zm9v` (base64 `foo`) as the body. No key material was ever present, but the scanner reads any private-key header as committed key material, and it would keep firing on every run.

A `CERTIFICATE REQUEST` block does the same job and tests more: its type starts with `CERTIFICATE` without being one, so it proves `parseCertificatePEM` matches the block type exactly rather than by prefix. The parser never decodes a block it skips, so the body stays a stub rather than a well-formed request, which would only be another credential-shaped string for a scanner to flag. That reasoning is in a comment on the constant so nobody "fixes" it back into something realistic.
