### PR TITLE
🧹 alicloud: review follow-ups on the policy analysis fields

### DIFF
--- a/providers/alicloud/resources/oss.go
+++ b/providers/alicloud/resources/oss.go
@@ -12,6 +12,7 @@ import (
 
 	tea "github.com/alibabacloud-go/tea/tea"
 	oss "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -485,7 +486,11 @@ func (a *mqlAlicloudOssBucket) isPublic() (bool, error) {
 	statements, err := parsePolicyDocument(policy.Data)
 	if err != nil {
 		// an unparseable policy is not evidence of exposure, and the raw
-		// document stays available through the policy field
+		// document stays available through the policy field. Warn rather than
+		// stay silent: the verdict below is skipped, so a bucket opened by its
+		// policy alone would read as not public.
+		log.Warn().Err(err).Str("bucket", a.Name.Data).
+			Msg("alicloud: could not parse bucket policy, isPublic reflects the acl only")
 		return false, nil
 	}
 	return policyGrantsAnonymousAccess(statements), nil

--- a/providers/alicloud/resources/policy.go
+++ b/providers/alicloud/resources/policy.go
@@ -236,6 +236,9 @@ func resourceIsUnscoped(resource string) bool {
 	if !ok {
 		return false
 	}
+	// the limit of 4 is deliberate, not an off-by-one: it stops the split at
+	// the relative-id so a relative-id that itself contains colons, as in
+	// "acs:ram::123:role/admin:extra", stays whole in the final field
 	fields := strings.SplitN(rest, ":", 4)
 	if len(fields) < 4 {
 		// a truncated name such as "acs:*" carries no relative-id to narrow it

--- a/providers/alicloud/resources/policy_test.go
+++ b/providers/alicloud/resources/policy_test.go
@@ -188,8 +188,14 @@ func TestResourceIsUnscoped(t *testing.T) {
 		assert.False(t, resourceIsUnscoped("acs:oss:*:*:mybucket/*"))
 		assert.False(t, resourceIsUnscoped("acs:oss:*:*:mybucket"))
 	})
-	t.Run("a relative-id containing colons is kept whole", func(t *testing.T) {
+	t.Run("an empty region field does not shift the relative-id", func(t *testing.T) {
 		assert.False(t, resourceIsUnscoped("acs:ram::123:user/alice"))
+	})
+	t.Run("a relative-id containing colons is kept whole", func(t *testing.T) {
+		// the SplitN limit of 4 must not split inside the relative-id, which
+		// would leave a bare "*" tail looking like a whole-service grant
+		assert.False(t, resourceIsUnscoped("acs:ram::123:role/admin:extra"))
+		assert.False(t, resourceIsUnscoped("acs:oss:*:*:bucket/prefix:*"))
 	})
 	t.Run("a non-ACS string is not a wildcard", func(t *testing.T) {
 		assert.False(t, resourceIsUnscoped("mybucket"))

--- a/providers/alicloud/resources/ram.go
+++ b/providers/alicloud/resources/ram.go
@@ -1131,9 +1131,13 @@ func initAlicloudRamPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData
 
 	// GetPolicy already returned the default version's document, so hand it to
 	// the resource rather than making statements re-fetch what we just read.
+	// The seeded flag is set even when there is no default version, because a
+	// repeat call would return the same nothing.
+	policy := res.(*mqlAlicloudRamPolicy)
 	if v := resp.Body.DefaultPolicyVersion; v != nil {
-		res.(*mqlAlicloudRamPolicy).cacheDocument = ramStrVal(v.PolicyDocument)
+		policy.cacheDocument = ramStrVal(v.PolicyDocument)
 	}
+	policy.documentSeeded = true
 	return nil, res, nil
 }
 
@@ -1160,7 +1164,11 @@ func resolveRamPolicy(runtime *plugin.Runtime, policyName, policyType *string) (
 // so a policy reached through an attachment answers policyDocument and
 // statements without a second call.
 type mqlAlicloudRamPolicyInternal struct {
-	documentOnce    sync.Once
+	documentOnce sync.Once
+	// documentSeeded records that init already read the document, which an
+	// empty cacheDocument cannot: a policy whose default version carries no
+	// document is seeded with "" and must not trigger a repeat GetPolicy.
+	documentSeeded  bool
 	cacheDocument   string
 	documentErr     error
 	statementsOnce  sync.Once
@@ -1172,7 +1180,7 @@ type mqlAlicloudRamPolicyInternal struct {
 // GetPolicy at most once per policy across every field that needs it.
 func (r *mqlAlicloudRamPolicy) fetchDocument() (string, error) {
 	r.documentOnce.Do(func() {
-		if r.cacheDocument != "" {
+		if r.documentSeeded {
 			return
 		}
 


### PR DESCRIPTION
Addresses the three review notes on #9680, which merged before they could be folded in.

## 1. `documentSeeded` instead of an emptiness check (warning)

`fetchDocument` guarded on `cacheDocument != ""`, which cannot tell "init already read the document and it was empty" from "init never ran". A policy whose default version carries no document paid a redundant `GetPolicy` on first access.

A `documentSeeded` flag separates the two. Init sets it **even when the response has no default version at all** — slightly beyond the review note, but a repeat call would return the same nothing, so that path was paying for a redundant round-trip too.

## 2. `isPublic` warns on an unparseable bucket policy (suggestion)

The parse error was swallowed silently. The verdict still falls back to the ACL, so a bucket opened by its *policy alone* would read as not public — a false negative on an exposure check is worth a log line:

```go
log.Warn().Err(err).Str("bucket", a.Name.Data).
    Msg("alicloud: could not parse bucket policy, isPublic reflects the acl only")
```

`Warn` rather than the provider's usual `Debug` for tolerated failures, because this one degrades a security verdict rather than just dropping an optional detail. The suggested `a.__id` isn't reachable from Go; `a.Name.Data` is the bucket name and is the same value.

## 3. Why `SplitN(rest, ":", 4)` (suggestion)

Comment added, since the `4` reads like an off-by-one:

```go
// the limit of 4 is deliberate, not an off-by-one: it stops the split at
// the relative-id so a relative-id that itself contains colons, as in
// "acs:ram::123:role/admin:extra", stays whole in the final field
```

Writing that comment turned up a real gap: the existing test named *"a relative-id containing colons is kept whole"* used `acs:ram::123:user/alice`, which **contains no colon in its relative-id**. It was testing the empty-region case under the wrong name. Both cases are now covered separately, and the colon case uses inputs that would actually regress if the limit changed:

```go
assert.False(t, resourceIsUnscoped("acs:ram::123:role/admin:extra"))
assert.False(t, resourceIsUnscoped("acs:oss:*:*:bucket/prefix:*"))
```

Without the limit, that second input splits to a trailing `*` and the resource reads as a whole-service grant — a false positive on `hasUnscopedResource`.

## Verification

`gofmt`, `go vet ./...`, `go build ./...` and `go test ./resources/` pass. No schema change, so no codegen and no new `.lr.versions` entries.
