### PR TITLE
🐛 datadog: key the asset on the org, not a shared constant

### DIFF
--- a/providers/datadog/connection/connection.go
+++ b/providers/datadog/connection/connection.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -84,16 +85,60 @@ func NewDatadogConnection(id uint32, asset *inventory.Asset, conf *inventory.Con
 	conn.apiClient = datadog.NewAPIClient(configuration)
 	conn.authCtx = ctx
 
-	// Fetch org public ID for unique platform identification
-	orgApi := datadogV1.NewOrganizationsApi(conn.apiClient)
-	orgResp, _, err := orgApi.ListOrgs(ctx)
+	orgPublicId, err := resolveOrgPublicId(ctx, conn.apiClient)
 	if err != nil {
-		log.Warn().Err(err).Msg("datadog> could not fetch organization info for platform ID")
-	} else if orgs := orgResp.GetOrgs(); len(orgs) > 0 {
-		conn.orgPublicId = orgs[0].GetPublicId()
+		return nil, err
 	}
+	conn.orgPublicId = orgPublicId
 
 	return conn, nil
+}
+
+// resolveOrgPublicId determines the public ID of the organization the supplied
+// credentials belong to. It is what separates one Datadog org from another in
+// the asset's platform ID, so a connection without it is refused rather than
+// left to collide with every other org scanned from this installation.
+//
+// ListOrgs is tried first because it is the authoritative source, but it needs
+// the org_management permission that scoped application keys routinely lack.
+// GetCurrentUser carries the org in its included resources and needs no
+// permission beyond the keys already in use.
+func resolveOrgPublicId(ctx context.Context, client *datadog.APIClient) (string, error) {
+	orgResp, _, err := datadogV1.NewOrganizationsApi(client).ListOrgs(ctx)
+	if err == nil {
+		if orgs := orgResp.GetOrgs(); len(orgs) > 0 {
+			if publicId := orgs[0].GetPublicId(); publicId != "" {
+				return publicId, nil
+			}
+		}
+	} else {
+		log.Debug().Err(err).Msg("datadog> could not list organizations, falling back to the current user")
+	}
+
+	userResp, _, err := datadogV2.NewUsersApi(client).GetCurrentUser(ctx)
+	if err != nil {
+		return "", errors.New("could not determine the Datadog organization: " + err.Error())
+	}
+	if publicId := orgPublicIdFromUser(userResp); publicId != "" {
+		return publicId, nil
+	}
+
+	return "", errors.New("could not determine the Datadog organization from the supplied credentials")
+}
+
+// orgPublicIdFromUser picks the organization out of the current user's included
+// resources. Included is a union of organizations, permissions and roles, so
+// every entry has to be checked for which arm is populated.
+func orgPublicIdFromUser(resp datadogV2.UserResponse) string {
+	for _, included := range resp.GetIncluded() {
+		if included.Organization == nil {
+			continue
+		}
+		if publicId := included.Organization.Attributes.GetPublicId(); publicId != "" {
+			return publicId
+		}
+	}
+	return ""
 }
 
 func (c *DatadogConnection) Name() string {

--- a/providers/datadog/connection/connection_test.go
+++ b/providers/datadog/connection/connection_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func orgItem(publicId string) datadogV2.UserResponseIncludedItem {
+	attrs := datadogV2.NewOrganizationAttributes()
+	if publicId != "" {
+		attrs.SetPublicId(publicId)
+	}
+	org := datadogV2.NewOrganization(datadogV2.ORGANIZATIONSTYPE_ORGS)
+	org.SetAttributes(*attrs)
+	return datadogV2.UserResponseIncludedItem{Organization: org}
+}
+
+func roleItem() datadogV2.UserResponseIncludedItem {
+	return datadogV2.UserResponseIncludedItem{
+		Role: datadogV2.NewRole(datadogV2.ROLESTYPE_ROLES),
+	}
+}
+
+func TestOrgPublicIdFromUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		included []datadogV2.UserResponseIncludedItem
+		want     string
+	}{
+		{
+			name: "organization is the only included item",
+			included: []datadogV2.UserResponseIncludedItem{
+				orgItem("abc123"),
+			},
+			want: "abc123",
+		},
+		{
+			// The included array is a union; roles and permissions come back
+			// alongside the organization and must not stop the search.
+			name: "organization follows other union arms",
+			included: []datadogV2.UserResponseIncludedItem{
+				roleItem(),
+				{Permission: datadogV2.NewPermission(datadogV2.PERMISSIONSTYPE_PERMISSIONS)},
+				orgItem("def456"),
+			},
+			want: "def456",
+		},
+		{
+			name:     "no included items",
+			included: nil,
+			want:     "",
+		},
+		{
+			name:     "no organization among the included items",
+			included: []datadogV2.UserResponseIncludedItem{roleItem()},
+			want:     "",
+		},
+		{
+			// A present organization carrying no public ID must not be
+			// mistaken for a usable identity.
+			name:     "organization without a public id",
+			included: []datadogV2.UserResponseIncludedItem{orgItem("")},
+			want:     "",
+		},
+		{
+			name: "organization without a public id followed by one with",
+			included: []datadogV2.UserResponseIncludedItem{
+				orgItem(""),
+				orgItem("ghi789"),
+			},
+			want: "ghi789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := datadogV2.UserResponse{}
+			if tt.included != nil {
+				resp.SetIncluded(tt.included)
+			}
+			if got := orgPublicIdFromUser(resp); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestOrgPublicIdFromUser_NilAttributes(t *testing.T) {
+	// Organization.Attributes is optional, so an included organization can
+	// arrive with no attributes at all. The generated getters guard a nil
+	// receiver, so this must return empty rather than panic.
+	resp := datadogV2.UserResponse{}
+	resp.SetIncluded([]datadogV2.UserResponseIncludedItem{
+		{Organization: datadogV2.NewOrganization(datadogV2.ORGANIZATIONSTYPE_ORGS)},
+	})
+
+	if got := orgPublicIdFromUser(resp); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}

--- a/providers/datadog/provider/provider.go
+++ b/providers/datadog/provider/provider.go
@@ -132,18 +132,18 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.DatadogConnection) error {
-	asset.Id = conn.Conf.Type
-	asset.Name = "Datadog Account"
+	orgId := conn.OrgPublicId()
+	if orgId == "" {
+		return errors.New("could not determine the Datadog organization public ID")
+	}
+
+	asset.Id = conn.Conf.Type + "/" + orgId
+	asset.Name = "Datadog Account " + orgId
 
 	asset.Platform = &inventory.Platform{}
 	connection.PlatformByName("datadog").Apply(asset.Platform)
 
-	platformId := "//platformid.api.mondoo.app/runtime/datadog"
-	if orgId := conn.OrgPublicId(); orgId != "" {
-		platformId = "//platformid.api.mondoo.app/runtime/datadog/org/" + orgId
-		asset.Name = "Datadog Account " + orgId
-	}
-	asset.PlatformIds = []string{platformId}
+	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/datadog/org/" + orgId}
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`connection.go` fetched the organization public ID via `ListOrgs` and soft-failed on error:

```go
orgResp, _, err := orgApi.ListOrgs(ctx)
if err != nil {
    log.Warn().Err(err).Msg("datadog> could not fetch organization info for platform ID")
}
```

`ListOrgs` requires the `org_management` permission, which scoped application keys routinely do not carry. On a 403 the platform ID fell back to the constant `//platformid.api.mondoo.app/runtime/datadog`, so **two different Datadog organizations scanned as the same asset**. `asset.Id` was `conn.Conf.Type` — the literal string `datadog` — with the same effect.

The failure is silent: a warning in the log, and results from separate orgs merging upstream.

## Fix

Chain a fallback to `UsersApi.GetCurrentUser`, which returns the organization in its `included` resources and needs no permission beyond the API and application keys already in use. `ListOrgs` is still tried first as the authoritative source.

If neither source yields a public ID the connection now fails, rather than proceeding with an identity known to collide. `GetCurrentUser` succeeds for any valid key pair, so reaching that error means authentication is broken regardless.

`asset.Id` and the platform ID are both org-qualified now.

## Note on asset identity

**This re-keys existing Datadog assets.** Anyone previously scanning with a key that could not call `ListOrgs` was writing to the shared constant platform ID; their asset will appear under a new, correct identity after this change. That is the point of the fix, but it is a visible migration rather than a transparent one.

## Tests

`orgPublicIdFromUser` walks a union type (`included` mixes organizations, roles and permissions), so it is factored out and unit-tested directly — covering the organization appearing after other union arms, absent organizations, an organization with no public ID, and nil attributes. Verified non-vacuous by mutation: making the loop return early on a non-organization arm fails the union-ordering case.

## Verification

`go build`, `go vet`, `gofmt` and `go test ./connection/...` pass. **Not live-verified** — no Datadog credentials available in this environment.
