### PR TITLE
🧹 digitalocean: honor --filters during discovery and listing

### DIFF
--- a/providers/digitalocean/README.md
+++ b/providers/digitalocean/README.md
@@ -29,13 +29,13 @@ export DIGITALOCEAN_SPACES_REGION="nyc3"
 ### CLI flag
 
 ```bash
-mql shell digitalocean --token <api-token>
+cnspec shell digitalocean --token <api-token>
 ```
 
 If `DIGITALOCEAN_TOKEN` is set, you can omit the flag:
 
 ```bash
-mql shell digitalocean
+cnspec shell digitalocean
 ```
 
 ## Discovery
@@ -51,17 +51,43 @@ The provider connects to the account as a single asset and can expand it into ch
 | `loadbalancers` | Load balancers |
 | `firewalls` | Cloud firewalls |
 | `spaces-buckets` | Spaces buckets (requires Spaces credentials) |
+| `gradientai-agents` | GradientAI agents |
 
 ```bash
-mql shell digitalocean --discover all
+cnspec shell digitalocean --discover all
 ```
+
+### Filters
+
+`--filters` narrows which objects become assets. The same filters apply to the
+corresponding MQL listings, so a filtered scan and a plain query return the same
+resources.
+
+| Filter | Selects |
+|---|---|
+| `regions=nyc1,sfo3` | Only resources in the listed regions |
+| `exclude:regions=ams3` | Drops resources in the listed regions |
+| `tags=production,web` | Only resources carrying at least one of the listed tags |
+| `exclude:tags=temporary` | Drops resources carrying any of the listed tags |
+
+```bash
+cnspec scan digitalocean --discover all --filters tags=production --filters exclude:regions=ams3
+```
+
+DigitalOcean tags are flat labels rather than key/value pairs, so the tag filters
+take a list of tag names. Two consequences are worth knowing:
+
+- **Cloud firewalls are account-global** and have no region, so a region filter
+  never drops them — a global firewall applies in every selected region.
+- **Spaces buckets cannot be tagged**, so an include-tag filter (`tags=...`)
+  excludes every bucket.
 
 ## Examples
 
 Launch an interactive shell and run queries:
 
 ```bash
-mql shell digitalocean
+cnspec shell digitalocean
 ```
 
 List Droplets and flag any without a firewall:

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -23,8 +23,9 @@ var Config = plugin.Provider{
 			Long: `Use the digitalocean provider to query resources in a DigitalOcean account.
 
 Examples:
-  mql shell digitalocean --token <api-token>
-  mql shell digitalocean
+  cnspec shell digitalocean --token <api-token>
+  cnspec shell digitalocean
+  cnspec scan digitalocean --discover all --filters tags=production
 
 Notes:
   If you set the DIGITALOCEAN_TOKEN environment variable, you can omit the token flag.
@@ -47,6 +48,12 @@ Notes:
 					Type:    plugin.FlagType_String,
 					Default: "",
 					Desc:    "DigitalOcean personal access token (env: DIGITALOCEAN_TOKEN)",
+				},
+				{
+					Long:    "filters",
+					Type:    plugin.FlagType_KeyValue,
+					Default: "",
+					Desc:    "Filter discovered assets, e.g., --filters regions=nyc1,sfo3 --filters exclude:regions=ams3 --filters tags=production,web --filters exclude:tags=temporary",
 				},
 			},
 		},

--- a/providers/digitalocean/connection/connection.go
+++ b/providers/digitalocean/connection/connection.go
@@ -22,8 +22,11 @@ import (
 
 type DigitaloceanConnection struct {
 	plugin.Connection
-	Conf            *inventory.Config
-	asset           *inventory.Asset
+	Conf  *inventory.Config
+	asset *inventory.Asset
+	// Filters narrows which objects the listers return, and therefore which
+	// objects discovery turns into assets.
+	Filters         DiscoveryFilters
 	client          *godo.Client
 	spacesKey       string
 	spacesSecret    string
@@ -72,6 +75,8 @@ func NewDigitaloceanConnection(id uint32, asset *inventory.Asset, conf *inventor
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	oauthClient := oauth2.NewClient(context.Background(), tokenSource)
 	conn.client = godo.NewClient(oauthClient)
+
+	conn.Filters = DiscoveryFiltersFromOpts(conf.Options)
 
 	conn.spacesKey = os.Getenv("DIGITALOCEAN_SPACES_KEY")
 	conn.spacesSecret = os.Getenv("DIGITALOCEAN_SPACES_SECRET")

--- a/providers/digitalocean/connection/filters.go
+++ b/providers/digitalocean/connection/filters.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"slices"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/filteropts"
+)
+
+// DiscoveryFilters narrows which objects discovery turns into assets, and which
+// objects the corresponding MQL listings return, so a scan and a plain query see
+// the same set.
+//
+// DigitalOcean's Discover() enumerates each service directly rather than reading
+// back through the MQL listers, so both call sites share the predicates below
+// instead of relying on a single choke point.
+type DiscoveryFilters struct {
+	General GeneralDiscoveryFilters
+}
+
+// GeneralDiscoveryFilters holds the filters that apply to every service.
+//
+// DigitalOcean tags are flat labels rather than key/value pairs, so the tag
+// filters take a list of tag names and match a resource carrying any of them.
+type GeneralDiscoveryFilters struct {
+	Regions        []string
+	ExcludeRegions []string
+	Tags           []string
+	ExcludeTags    []string
+}
+
+// DiscoveryFiltersFromOpts reads the filter set out of the connection options
+// that ParseCLI populated from --filters.
+func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
+	return DiscoveryFilters{
+		General: GeneralDiscoveryFilters{
+			Regions:        filteropts.ParseCsvSliceOpt(opts, "regions"),
+			ExcludeRegions: filteropts.ParseCsvSliceOpt(opts, "exclude:regions"),
+			Tags:           filteropts.ParseCsvSliceOpt(opts, "tags"),
+			ExcludeTags:    filteropts.ParseCsvSliceOpt(opts, "exclude:tags"),
+		},
+	}
+}
+
+// HasFilters reports whether any filter was set. Callers gate optional lookups
+// on this so an unfiltered scan does not pay for data nobody asked for.
+func (f GeneralDiscoveryFilters) HasFilters() bool {
+	return len(f.Regions) > 0 || len(f.ExcludeRegions) > 0 ||
+		len(f.Tags) > 0 || len(f.ExcludeTags) > 0
+}
+
+// IsFilteredOut reports whether a resource in the given region and carrying the
+// given tags should be skipped.
+//
+// An empty region means the resource has no region dimension at all (cloud
+// firewalls are account-global), and region filters leave those alone — a
+// global resource applies in every selected region. Tags are matched for every
+// resource, so a resource that carries no tags cannot satisfy an include-tag
+// filter and is dropped by one.
+func (f GeneralDiscoveryFilters) IsFilteredOut(region string, tags []string) bool {
+	return f.isFilteredOutByRegion(region) || f.isFilteredOutByTags(tags)
+}
+
+// isFilteredOutByRegion reports whether the region fails the region filters.
+func (f GeneralDiscoveryFilters) isFilteredOutByRegion(region string) bool {
+	if region == "" {
+		return false
+	}
+	if len(f.Regions) > 0 && !slices.Contains(f.Regions, region) {
+		return true
+	}
+	return slices.Contains(f.ExcludeRegions, region)
+}
+
+// isFilteredOutByTags reports whether the tag set fails the tag filters. An
+// exclude match drops the resource regardless of the include filters.
+func (f GeneralDiscoveryFilters) isFilteredOutByTags(tags []string) bool {
+	if len(f.Tags) > 0 && !containsAny(tags, f.Tags) {
+		return true
+	}
+	return containsAny(tags, f.ExcludeTags)
+}
+
+// containsAny reports whether tags holds at least one of the wanted labels.
+func containsAny(tags, wanted []string) bool {
+	for _, w := range wanted {
+		if slices.Contains(tags, w) {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/digitalocean/connection/filters_test.go
+++ b/providers/digitalocean/connection/filters_test.go
@@ -1,0 +1,139 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscoveryFiltersFromOpts(t *testing.T) {
+	f := DiscoveryFiltersFromOpts(map[string]string{
+		"regions":         "nyc1,sfo3",
+		"exclude:regions": "ams3",
+		"tags":            "production,web",
+		"exclude:tags":    "temporary",
+		"unrelated":       "ignored",
+	}).General
+
+	assert.Equal(t, []string{"nyc1", "sfo3"}, f.Regions)
+	assert.Equal(t, []string{"ams3"}, f.ExcludeRegions)
+	assert.Equal(t, []string{"production", "web"}, f.Tags)
+	assert.Equal(t, []string{"temporary"}, f.ExcludeTags)
+}
+
+func TestGeneralDiscoveryFiltersHasFilters(t *testing.T) {
+	assert.False(t, GeneralDiscoveryFilters{}.HasFilters())
+	assert.True(t, GeneralDiscoveryFilters{Regions: []string{"nyc1"}}.HasFilters())
+	assert.True(t, GeneralDiscoveryFilters{ExcludeRegions: []string{"nyc1"}}.HasFilters())
+	assert.True(t, GeneralDiscoveryFilters{Tags: []string{"web"}}.HasFilters())
+	assert.True(t, GeneralDiscoveryFilters{ExcludeTags: []string{"web"}}.HasFilters())
+}
+
+func TestIsFilteredOut(t *testing.T) {
+	tests := []struct {
+		name     string
+		filters  GeneralDiscoveryFilters
+		region   string
+		tags     []string
+		expected bool
+	}{
+		{
+			name:     "no filters keeps everything",
+			filters:  GeneralDiscoveryFilters{},
+			region:   "nyc1",
+			tags:     nil,
+			expected: false,
+		},
+		{
+			name:     "region in include list is kept",
+			filters:  GeneralDiscoveryFilters{Regions: []string{"nyc1", "sfo3"}},
+			region:   "sfo3",
+			expected: false,
+		},
+		{
+			name:     "region outside include list is dropped",
+			filters:  GeneralDiscoveryFilters{Regions: []string{"nyc1"}},
+			region:   "ams3",
+			expected: true,
+		},
+		{
+			name:     "excluded region is dropped",
+			filters:  GeneralDiscoveryFilters{ExcludeRegions: []string{"ams3"}},
+			region:   "ams3",
+			expected: true,
+		},
+		{
+			name:     "exclude wins over include for the same region",
+			filters:  GeneralDiscoveryFilters{Regions: []string{"nyc1"}, ExcludeRegions: []string{"nyc1"}},
+			region:   "nyc1",
+			expected: true,
+		},
+		{
+			name:     "region filters leave account-global resources alone",
+			filters:  GeneralDiscoveryFilters{Regions: []string{"nyc1"}},
+			region:   "",
+			expected: false,
+		},
+		{
+			name:     "any matching tag satisfies the include filter",
+			filters:  GeneralDiscoveryFilters{Tags: []string{"production", "web"}},
+			region:   "nyc1",
+			tags:     []string{"database", "web"},
+			expected: false,
+		},
+		{
+			name:     "no matching tag drops the resource",
+			filters:  GeneralDiscoveryFilters{Tags: []string{"production"}},
+			region:   "nyc1",
+			tags:     []string{"staging"},
+			expected: true,
+		},
+		{
+			name:     "an untagged resource cannot match an include-tag filter",
+			filters:  GeneralDiscoveryFilters{Tags: []string{"production"}},
+			region:   "nyc1",
+			tags:     nil,
+			expected: true,
+		},
+		{
+			name:     "an untagged resource survives an exclude-only tag filter",
+			filters:  GeneralDiscoveryFilters{ExcludeTags: []string{"temporary"}},
+			region:   "nyc1",
+			tags:     nil,
+			expected: false,
+		},
+		{
+			name:     "excluded tag drops the resource",
+			filters:  GeneralDiscoveryFilters{ExcludeTags: []string{"temporary"}},
+			region:   "nyc1",
+			tags:     []string{"web", "temporary"},
+			expected: true,
+		},
+		{
+			name: "exclude tag wins over a matching include tag",
+			filters: GeneralDiscoveryFilters{
+				Tags:        []string{"web"},
+				ExcludeTags: []string{"temporary"},
+			},
+			region:   "nyc1",
+			tags:     []string{"web", "temporary"},
+			expected: true,
+		},
+		{
+			name:     "region and tag filters both have to pass",
+			filters:  GeneralDiscoveryFilters{Regions: []string{"nyc1"}, Tags: []string{"web"}},
+			region:   "ams3",
+			tags:     []string{"web"},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.filters.IsFilteredOut(test.region, test.tags))
+		})
+	}
+}

--- a/providers/digitalocean/provider/provider.go
+++ b/providers/digitalocean/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"slices"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -20,6 +21,33 @@ import (
 const (
 	DefaultConnectionType = "digitalocean"
 )
+
+// filterOptPrefixes are the --filters keys the provider understands. Anything
+// else is dropped rather than silently stored, so a typo surfaces as a filter
+// that plainly did nothing instead of one that appears accepted.
+var filterOptPrefixes = []string{
+	"regions",
+	"exclude:regions",
+	"tags",
+	"exclude:tags",
+}
+
+// parseFlagsToFiltersOpts flattens the --filters key-value flag into connection
+// options the connection reads back through DiscoveryFiltersFromOpts.
+func parseFlagsToFiltersOpts(flags map[string]*llx.Primitive) map[string]string {
+	opts := map[string]string{}
+
+	x, ok := flags["filters"]
+	if !ok || len(x.Map) == 0 {
+		return opts
+	}
+	for k, v := range x.Map {
+		if slices.Contains(filterOptPrefixes, k) {
+			opts[k] = string(v.Value)
+		}
+	}
+	return opts
+}
 
 type Service struct {
 	*plugin.Service
@@ -66,6 +94,10 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		}
 	}
 	conf.Discover = &inventory.Discovery{Targets: discoverTargets}
+
+	for k, v := range parseFlagsToFiltersOpts(flags) {
+		conf.Options[k] = v
+	}
 
 	asset := inventory.Asset{
 		Connections: []*inventory.Config{conf},

--- a/providers/digitalocean/provider/provider_test.go
+++ b/providers/digitalocean/provider/provider_test.go
@@ -1,0 +1,48 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// filtersFlag builds the --filters key-value flag the CLI hands to ParseCLI.
+func filtersFlag(kv map[string]string) map[string]*llx.Primitive {
+	m := map[string]*llx.Primitive{}
+	for k, v := range kv {
+		m[k] = llx.StringPrimitive(v)
+	}
+	return map[string]*llx.Primitive{"filters": {Map: m}}
+}
+
+func TestParseFlagsToFiltersOpts(t *testing.T) {
+	t.Run("returns no options when the flag is absent", func(t *testing.T) {
+		assert.Empty(t, parseFlagsToFiltersOpts(map[string]*llx.Primitive{}))
+	})
+
+	t.Run("returns no options for an empty filter map", func(t *testing.T) {
+		assert.Empty(t, parseFlagsToFiltersOpts(filtersFlag(nil)))
+	})
+
+	t.Run("keeps the supported filter keys", func(t *testing.T) {
+		want := map[string]string{
+			"regions":         "nyc1,sfo3",
+			"exclude:regions": "ams3",
+			"tags":            "production",
+			"exclude:tags":    "temporary",
+		}
+		assert.Equal(t, want, parseFlagsToFiltersOpts(filtersFlag(want)))
+	})
+
+	t.Run("drops unknown keys so a typo does not look accepted", func(t *testing.T) {
+		opts := parseFlagsToFiltersOpts(filtersFlag(map[string]string{
+			"region": "nyc1",
+			"tag":    "production",
+		}))
+		assert.Empty(t, opts)
+	})
+}

--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -271,6 +271,9 @@ func (r *mqlDigitalocean) firewalls() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, fw := range firewalls {
+			if skipFirewall(conn.Filters.General, &fw) {
+				continue
+			}
 			res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall", firewallArgs(&fw))
 			if err != nil {
 				return nil, err
@@ -305,6 +308,9 @@ func (r *mqlDigitalocean) databases() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, db := range dbs {
+			if skipDatabase(conn.Filters.General, &db) {
+				continue
+			}
 			res, err := CreateResource(r.MqlRuntime, "digitalocean.database", databaseArgs(&db))
 			if err != nil {
 				return nil, err
@@ -500,6 +506,9 @@ func (r *mqlDigitalocean) loadBalancers() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, lb := range lbs {
+			if skipLoadBalancer(conn.Filters.General, &lb) {
+				continue
+			}
 			res, err := CreateResource(r.MqlRuntime, "digitalocean.loadBalancer", loadBalancerArgs(&lb))
 			if err != nil {
 				return nil, err
@@ -585,6 +594,9 @@ func (r *mqlDigitalocean) kubernetesClusters() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, c := range clusters {
+			if skipKubernetesCluster(conn.Filters.General, c) {
+				continue
+			}
 			res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.cluster", kubernetesClusterArgs(c))
 			if err != nil {
 				return nil, err

--- a/providers/digitalocean/resources/digitalocean_filters.go
+++ b/providers/digitalocean/resources/digitalocean_filters.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/digitalocean/godo"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+)
+
+// The helpers below decide whether a discovery-target object survives the
+// --filters selection. Discovery enumerates each service itself rather than
+// reading back through the MQL listers, so both paths call these shims to
+// guarantee they derive the same region and tag set from a given object. A
+// filtered scan and a plain query therefore return the same resources.
+//
+// Objects with no region (cloud firewalls are account-global) pass "" so
+// region filters leave them alone; see GeneralDiscoveryFilters.IsFilteredOut.
+
+func skipDatabase(f connection.GeneralDiscoveryFilters, db *godo.Database) bool {
+	return f.IsFilteredOut(db.RegionSlug, db.Tags)
+}
+
+func skipKubernetesCluster(f connection.GeneralDiscoveryFilters, c *godo.KubernetesCluster) bool {
+	if c == nil {
+		return false
+	}
+	return f.IsFilteredOut(c.RegionSlug, c.Tags)
+}
+
+func skipLoadBalancer(f connection.GeneralDiscoveryFilters, lb *godo.LoadBalancer) bool {
+	region := ""
+	if lb.Region != nil {
+		region = lb.Region.Slug
+	}
+	return f.IsFilteredOut(region, lb.Tags)
+}
+
+// skipFirewall filters on tags only. Cloud firewalls are account-global, so
+// they carry no region to match against.
+func skipFirewall(f connection.GeneralDiscoveryFilters, fw *godo.Firewall) bool {
+	return f.IsFilteredOut("", fw.Tags)
+}
+
+func skipGradientaiAgent(f connection.GeneralDiscoveryFilters, a *godo.Agent) bool {
+	return f.IsFilteredOut(a.Region, a.Tags)
+}
+
+// skipSpacesBucket filters on region only. DigitalOcean Spaces does not support
+// bucket tagging, so a bucket carries no tags and an include-tag filter drops
+// every bucket.
+func skipSpacesBucket(f connection.GeneralDiscoveryFilters, region string) bool {
+	return f.IsFilteredOut(region, nil)
+}

--- a/providers/digitalocean/resources/digitalocean_gradientai.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai.go
@@ -151,6 +151,9 @@ func (r *mqlDigitaloceanGradientai) agents() ([]interface{}, error) {
 			return nil, err
 		}
 		for _, a := range agents {
+			if a != nil && skipGradientaiAgent(conn.Filters.General, a) {
+				continue
+			}
 			res, err := newMqlGradientaiAgent(r.MqlRuntime, a)
 			if err != nil {
 				return nil, err

--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -144,6 +144,12 @@ func listSpacesBucketRefs(conn *connection.DigitaloceanConnection, regions []str
 	)
 	jobs := make([]*jobpool.Job, 0, len(regions))
 	for _, region := range regions {
+		// Filtering here rather than per bucket skips the ListBuckets call for
+		// regions nothing can match. Buckets carry no tags, so an include-tag
+		// filter rules out every region.
+		if skipSpacesBucket(conn.Filters.General, region) {
+			continue
+		}
 		jobs = append(jobs, jobpool.NewJob(func() (jobpool.JobResult, error) {
 			client, err := conn.SpacesClient(region)
 			if err != nil {

--- a/providers/digitalocean/resources/discovery.go
+++ b/providers/digitalocean/resources/discovery.go
@@ -57,6 +57,9 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 				return nil, err
 			}
 			for _, db := range dbs {
+				if skipDatabase(conn.Filters.General, &db) {
+					continue
+				}
 				assets = append(assets, childAsset(
 					connection.DatabasePlatform(),
 					connection.NewDatabaseIdentifier(accountUUID, db.ID),
@@ -83,6 +86,9 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 				return nil, err
 			}
 			for _, c := range clusters {
+				if skipKubernetesCluster(conn.Filters.General, c) {
+					continue
+				}
 				assets = append(assets, childAsset(
 					connection.KubernetesPlatform(),
 					connection.NewKubernetesIdentifier(accountUUID, c.ID),
@@ -109,6 +115,9 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 				return nil, err
 			}
 			for _, lb := range lbs {
+				if skipLoadBalancer(conn.Filters.General, &lb) {
+					continue
+				}
 				assets = append(assets, childAsset(
 					connection.LoadBalancerPlatform(),
 					connection.NewLoadBalancerIdentifier(accountUUID, lb.ID),
@@ -135,6 +144,9 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 				return nil, err
 			}
 			for _, fw := range firewalls {
+				if skipFirewall(conn.Filters.General, &fw) {
+					continue
+				}
 				assets = append(assets, childAsset(
 					connection.FirewallPlatform(),
 					connection.NewFirewallIdentifier(accountUUID, fw.ID),
@@ -192,7 +204,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 				return nil, err
 			}
 			for _, a := range agents {
-				if a == nil {
+				if a == nil || skipGradientaiAgent(conn.Filters.General, a) {
 					continue
 				}
 				assets = append(assets, childAsset(


### PR DESCRIPTION
## What

The `digitalocean` provider exposes six discovery targets but had **no filter support anywhere** — no `Filters` struct in `connection/`, no `--filters` flag, no lister ever consulting one. `--filters` parsed and was silently ignored.

This adds the flag and wires it through:

| Filter | Selects |
|---|---|
| `regions=nyc1,sfo3` | Only resources in the listed regions |
| `exclude:regions=ams3` | Drops resources in the listed regions |
| `tags=production,web` | Only resources carrying at least one of the listed tags |
| `exclude:tags=temporary` | Drops resources carrying any of the listed tags |

```bash
cnspec scan digitalocean --discover all --filters tags=production --filters exclude:regions=ams3
```

## Design notes

**Flat tags, not key/value.** DigitalOcean tags are bare labels (`Tags []string`), not the `tag:key=value` pairs the AWS/alicloud filters use. The filter keys are therefore `tags` / `exclude:tags` taking a list of tag names, matching a resource that carries any of them.

**Two asymmetries, deliberate and documented** (README + the predicate's doc comment):
- **Cloud firewalls are account-global** and carry no region, so a region filter never drops them — a global firewall applies in every selected region.
- **Spaces buckets cannot be tagged** (DO Spaces has no bucket-tagging API), so an include-tag filter excludes every bucket. Filtering is applied per region *before* `ListBuckets`, so this costs no API calls.

**Deviation from CLAUDE.md §3.5, on purpose.** The guidance says apply filters in the lister and never in `discovery.go`, because discovery normally reaches assets through the same accessor a plain MQL query uses. That premise doesn't hold here — DO's `Discover()` makes its own `client.Databases.List(...)` calls. A lister-only check would filter MQL queries and leave discovery unfiltered.

Rather than refactor six listers in a hygiene PR, both paths call shared per-type shims in `resources/digitalocean_filters.go` (`skipDatabase`, `skipKubernetesCluster`, `skipLoadBalancer`, `skipFirewall`, `skipGradientaiAgent`, `skipSpacesBucket`). The shims are the single place region and tags are derived from a godo object, so the two call sites cannot drift. A filtered scan and a plain query return the same set.

**Unknown filter keys are dropped** rather than stored, so a typo (`region=` instead of `regions=`) surfaces as a filter that plainly did nothing instead of one that appears accepted.

## Also

- Adds the missing `gradientai-agents` row to the README discovery table.
- Switches the README and `config.go` CLI examples from `mql` to `cnspec`.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test ./...` passes; 17 new subtests covering the filter predicate (include/exclude precedence, the region-less and tag-less cases) and the `--filters` flag parsing including unknown-key rejection
- `go mod tidy` produces no diff
- **Not verified against a live account** — no `DIGITALOCEAN_TOKEN` available in the dev environment. Codegen/build/unit-test only.
