### PR TITLE
✨ digitalocean: reachability verdicts across the exposed surfaces

### DIFF
--- a/providers/digitalocean/README.md
+++ b/providers/digitalocean/README.md
@@ -126,6 +126,26 @@ digitalocean.gradientai.agents.where(isPublic) { name deploymentUrl }
 digitalocean.apps.where(isPublic) { name liveUrl }
 ```
 
+Find load balancer listeners accepting traffic in the clear, and inspect the
+certificate each TLS listener presents:
+
+```mql
+digitalocean.loadBalancers.listeners.where(entryProtocol == "http" || entryProtocol == "tcp")
+digitalocean.loadBalancers { name listeners { entryProtocol entryPort certificate { name notAfter state } } }
+```
+
+Find CORS policies that allow credentials from a permissive origin:
+
+```mql
+digitalocean.apps.where(corsPolicies.any(_["allowCredentials"] == true))
+```
+
+Find app environment variables held in plain text rather than encrypted:
+
+```mql
+digitalocean.apps { name envVars.where(_["type"] == "GENERAL") }
+```
+
 You can also run a policy scan:
 
 ```bash

--- a/providers/digitalocean/README.md
+++ b/providers/digitalocean/README.md
@@ -100,6 +100,32 @@ Inspect Kubernetes clusters and their node pools:
 digitalocean.kubernetesClusters { name version nodePools { name size count } }
 ```
 
+Find Kubernetes API servers reachable from any address:
+
+```mql
+digitalocean.kubernetesClusters.where(exposure.internetReachable) { name endpoint controlPlaneFirewallEnabled }
+```
+
+Find Spaces buckets anyone can read, and separate out those opened by policy
+rather than by ACL:
+
+```mql
+digitalocean.spacesBuckets.where(isPublic) { name region publicReadAcl hasWildcardPolicy }
+```
+
+Find functions anyone on the internet can invoke, with the endpoint they answer on:
+
+```mql
+digitalocean.functionNamespaces.functions.where(isPublic) { name webUrl }
+```
+
+Find GradientAI agents and App Platform apps serving the internet:
+
+```mql
+digitalocean.gradientai.agents.where(isPublic) { name deploymentUrl }
+digitalocean.apps.where(isPublic) { name liveUrl }
+```
+
 You can also run a policy scan:
 
 ```bash

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -762,10 +762,20 @@ digitalocean.loadBalancer @defaults("id name status") {
   tags []string
   // Forwarding rules
   //
-  // Listener mappings from incoming connections to backend targets. Each
-  // dict has keys entryProtocol, entryPort, targetProtocol, targetPort,
-  // certificateId, and tlsPassthrough.
-  forwardingRules []dict
+  // Deprecated in favor of listeners, which resolves the certificate each
+  // rule presents. Listener mappings from incoming connections to backend
+  // targets. Each dict has keys entryProtocol, entryPort, targetProtocol,
+  // targetPort, certificateId, and tlsPassthrough.
+  forwardingRules @maturity("deprecated") []dict
+  // Listeners the load balancer accepts connections on
+  //
+  // One entry per forwarding rule, carrying the protocol and port traffic
+  // arrives on, the protocol and port it is forwarded to, and the
+  // certificate the listener presents. Reaching the certificate makes the
+  // full TLS posture queryable in one place: a plaintext listener, a
+  // certificate about to expire, or a rule that passes TLS straight
+  // through to the backend.
+  listeners() []digitalocean.loadBalancer.listener
   // Health check configuration
   //
   // Probe used to decide whether a backend is healthy. Dict with keys
@@ -811,6 +821,31 @@ digitalocean.loadBalancer @defaults("id name status") {
   targetLoadBalancers() []digitalocean.loadBalancer
   // Internet-exposure breakdown (public IP combined with the load balancer firewall)
   exposure() digitalocean.network.exposure
+}
+
+// DigitalOcean load balancer listener
+//
+// A single forwarding rule on a load balancer: the protocol and port
+// connections arrive on, the protocol and port they are forwarded to on
+// the backend, and the certificate the listener presents. A listener on
+// http or tcp carries no certificate and moves traffic in the clear,
+// while tlsPassthrough hands the encrypted connection to the backend
+// untouched, so the load balancer presents no certificate of its own.
+private digitalocean.loadBalancer.listener @defaults("entryProtocol entryPort targetProtocol targetPort") {
+  // ID of the load balancer the listener belongs to
+  loadBalancerId string
+  // Protocol connections arrive on (http, https, http2, http3, tcp, udp)
+  entryProtocol string
+  // Port connections arrive on
+  entryPort int
+  // Protocol traffic is forwarded to the backend with (http, https, http2, tcp, udp)
+  targetProtocol string
+  // Port traffic is forwarded to on the backend
+  targetPort int
+  // Whether the encrypted connection is handed to the backend untouched, leaving the load balancer without a certificate of its own
+  tlsPassthrough bool
+  // Certificate the listener presents; null when it terminates no TLS
+  certificate() digitalocean.certificate
 }
 
 // DigitalOcean VPC
@@ -1338,6 +1373,34 @@ digitalocean.app @defaults("id name") {
   // a service, a static site, or a functions component. An app built only
   // from workers and jobs runs without a public route.
   isPublic() bool
+  // Whether enhanced threat control is enabled
+  //
+  // Layer 7 denial-of-service protection that answers suspicious API
+  // requests with 403 Forbidden.
+  enhancedThreatControlEnabled bool
+  // Name of the response header the ingress sets, or of the request header it strips; empty when no secure header is configured
+  secureHeaderKey string
+  // Value the ingress sets the secure header to; empty when the header is stripped rather than set
+  secureHeaderValue string
+  // Whether the secure header is stripped from incoming requests instead of set on responses
+  secureHeaderRemoved bool
+  // CORS policies configured on the app's ingress routes
+  //
+  // Each entry: path (the route the policy applies to), allowOrigins,
+  // allowMethods, allowHeaders, exposeHeaders, maxAge, allowCredentials.
+  // Each allowOrigins entry is written as "<kind>:<value>" where kind is
+  // exact, prefix, or regex, because the kind decides how broadly the
+  // origin matches. A policy that allows credentials alongside a
+  // permissive origin lets any site read authenticated responses.
+  corsPolicies []dict
+  // Environment variables defined for the app and its components
+  //
+  // Each entry: component (empty for variables shared by the whole app),
+  // key, scope, and type. A type of SECRET means the value is encrypted at
+  // rest, GENERAL means it is stored in plain text. Values are never
+  // exposed, so this reports where a credential is held rather than what
+  // it is.
+  envVars []dict
 }
 
 // DigitalOcean App Platform deployment

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -961,6 +961,17 @@ digitalocean.kubernetes.cluster @defaults("id name version") {
   availableUpgradeVersions() []string
   // Node pools
   nodePools() []digitalocean.kubernetes.nodePool
+  // Internet reachability of the cluster's API server
+  //
+  // Managed Kubernetes control planes are published on a public endpoint,
+  // so the API server is reachable from any address unless the
+  // control-plane firewall is enabled and its allowed source addresses
+  // exclude the whole internet. hasPublicIp reflects the published
+  // endpoint, and firewallAllowsIngress is true when the firewall is off
+  // or admits 0.0.0.0/0 or ::/0. openIngressRules stays empty because the
+  // control-plane firewall is a source address list rather than a set of
+  // cloud-firewall rules.
+  exposure() digitalocean.network.exposure
 }
 
 // DigitalOcean Kubernetes node pool
@@ -1320,6 +1331,13 @@ digitalocean.app @defaults("id name") {
   //
   // Each entry: componentName, componentType (SERVICE, WORKER, JOB), instanceName, instanceAlias.
   instances() []dict
+  // Whether the app serves traffic to the internet
+  //
+  // True when the app has a live URL or a default ingress hostname and its
+  // spec declares at least one component that App Platform routes publicly:
+  // a service, a static site, or a functions component. An app built only
+  // from workers and jobs runs without a public route.
+  isPublic() bool
 }
 
 // DigitalOcean App Platform deployment
@@ -1596,6 +1614,24 @@ digitalocean.spacesBucket @defaults("name region publicAccessBlocked encryptionE
   //
   // Each entry: id, status, prefix, expirationDays, noncurrentVersionExpirationDays, abortIncompleteMultipartUploadDays.
   lifecycleRules []dict
+  // Whether the bucket's contents are reachable by anyone on the internet
+  //
+  // True when an ACL grant targets the all-users or authenticated-users
+  // group, or the bucket policy allows the wildcard principal, and public
+  // access is not blocked. The authenticated-users group covers every
+  // account on the platform rather than only this one, so it counts as
+  // public. publicAccessBlocked is only set when all four block-public-access
+  // settings are on, so a bucket with a public grant and partial blocking is
+  // reported as public.
+  isPublic() bool
+  // Whether the bucket policy allows the wildcard principal
+  //
+  // True when any Allow statement in the bucket policy names "*" as its
+  // principal, which grants the action to every requester. This describes
+  // the policy alone; isPublic combines it with the ACL grants and the
+  // block-public-access settings to say whether the bucket is actually
+  // reachable.
+  hasWildcardPolicy() bool
 }
 
 // DigitalOcean image
@@ -1810,6 +1846,15 @@ private digitalocean.function.action @defaults("name runtime updatedAt") {
   concurrency int
   // Time the action was last updated
   updatedAt time
+  // Web endpoint the action is published on; empty when the action is not web-exported
+  webUrl string
+  // Whether anyone on the internet can invoke the action
+  //
+  // True when the action is web-exported and does not require an API key,
+  // which leaves the webUrl endpoint open to unauthenticated callers. A
+  // web-exported action that requires a key is still published, but only
+  // answers callers holding that key.
+  isPublic() bool
 }
 
 // DigitalOcean Functions trigger
@@ -2213,6 +2258,13 @@ digitalocean.gradientai.agent @defaults("uuid name region") {
   versions() []digitalocean.gradientai.agent.version
   // API keys issued for the agent (secret values are never exposed)
   apiKeys() []digitalocean.gradientai.agent.apiKey
+  // Whether the agent's deployment answers anyone on the internet
+  //
+  // True when deploymentVisibility marks the deployment public, which
+  // publishes deploymentUrl as an endpoint anyone can send prompts to
+  // without credentials. A private deployment is reachable only with an
+  // agent API key.
+  isPublic() bool
 }
 
 // DigitalOcean GradientAI agent guardrail

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -1414,6 +1414,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.kubernetes.cluster.nodePools": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesCluster).GetNodePools()).ToDataRes(types.Array(types.Resource("digitalocean.kubernetes.nodePool")))
 	},
+	"digitalocean.kubernetes.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanKubernetesCluster).GetExposure()).ToDataRes(types.Resource("digitalocean.network.exposure"))
+	},
 	"digitalocean.kubernetes.nodePool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesNodePool).GetId()).ToDataRes(types.String)
 	},
@@ -1741,6 +1744,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.app.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanApp).GetInstances()).ToDataRes(types.Array(types.Dict))
 	},
+	"digitalocean.app.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetIsPublic()).ToDataRes(types.Bool)
+	},
 	"digitalocean.app.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanAppDeployment).GetId()).ToDataRes(types.String)
 	},
@@ -1987,6 +1993,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.spacesBucket.lifecycleRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanSpacesBucket).GetLifecycleRules()).ToDataRes(types.Array(types.Dict))
 	},
+	"digitalocean.spacesBucket.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSpacesBucket).GetIsPublic()).ToDataRes(types.Bool)
+	},
+	"digitalocean.spacesBucket.hasWildcardPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSpacesBucket).GetHasWildcardPolicy()).ToDataRes(types.Bool)
+	},
 	"digitalocean.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanImage).GetId()).ToDataRes(types.Int)
 	},
@@ -2181,6 +2193,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.function.action.updatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFunctionAction).GetUpdatedAt()).ToDataRes(types.Time)
+	},
+	"digitalocean.function.action.webUrl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAction).GetWebUrl()).ToDataRes(types.String)
+	},
+	"digitalocean.function.action.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanFunctionAction).GetIsPublic()).ToDataRes(types.Bool)
 	},
 	"digitalocean.function.trigger.namespace": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFunctionTrigger).GetNamespace()).ToDataRes(types.String)
@@ -2577,6 +2595,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.gradientai.agent.apiKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiAgent).GetApiKeys()).ToDataRes(types.Array(types.Resource("digitalocean.gradientai.agent.apiKey")))
+	},
+	"digitalocean.gradientai.agent.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanGradientaiAgent).GetIsPublic()).ToDataRes(types.Bool)
 	},
 	"digitalocean.gradientai.agent.guardrail.uuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanGradientaiAgentGuardrail).GetUuid()).ToDataRes(types.String)
@@ -4606,6 +4627,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanKubernetesCluster).NodePools, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.kubernetes.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanKubernetesCluster).Exposure, ok = plugin.RawToTValue[*mqlDigitaloceanNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"digitalocean.kubernetes.nodePool.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanKubernetesNodePool).__id, ok = v.Value.(string)
 		return
@@ -5090,6 +5115,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanApp).Instances, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.app.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"digitalocean.app.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanAppDeployment).__id, ok = v.Value.(string)
 		return
@@ -5450,6 +5479,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanSpacesBucket).LifecycleRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.spacesBucket.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSpacesBucket).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.spacesBucket.hasWildcardPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSpacesBucket).HasWildcardPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"digitalocean.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanImage).__id, ok = v.Value.(string)
 		return
@@ -5732,6 +5769,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.function.action.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanFunctionAction).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.action.webUrl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAction).WebUrl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.function.action.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanFunctionAction).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"digitalocean.function.trigger.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6296,6 +6341,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.gradientai.agent.apiKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanGradientaiAgent).ApiKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.gradientai.agent.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanGradientaiAgent).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"digitalocean.gradientai.agent.guardrail.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10526,6 +10575,7 @@ type mqlDigitaloceanKubernetesCluster struct {
 	ClusterAutoscaler                        plugin.TValue[any]
 	AvailableUpgradeVersions                 plugin.TValue[[]any]
 	NodePools                                plugin.TValue[[]any]
+	Exposure                                 plugin.TValue[*mqlDigitaloceanNetworkExposure]
 }
 
 // createDigitaloceanKubernetesCluster creates a new instance of this resource
@@ -10736,6 +10786,22 @@ func (c *mqlDigitaloceanKubernetesCluster) GetNodePools() *plugin.TValue[[]any] 
 		}
 
 		return c.nodePools()
+	})
+}
+
+func (c *mqlDigitaloceanKubernetesCluster) GetExposure() *plugin.TValue[*mqlDigitaloceanNetworkExposure] {
+	return plugin.GetOrCompute[*mqlDigitaloceanNetworkExposure](&c.Exposure, func() (*mqlDigitaloceanNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.kubernetes.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -11829,6 +11895,7 @@ type mqlDigitaloceanApp struct {
 	ActiveDeployment       plugin.TValue[*mqlDigitaloceanAppDeployment]
 	Alerts                 plugin.TValue[[]any]
 	Instances              plugin.TValue[[]any]
+	IsPublic               plugin.TValue[bool]
 }
 
 // createDigitaloceanApp creates a new instance of this resource
@@ -11991,6 +12058,12 @@ func (c *mqlDigitaloceanApp) GetAlerts() *plugin.TValue[[]any] {
 func (c *mqlDigitaloceanApp) GetInstances() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Instances, func() ([]any, error) {
 		return c.instances()
+	})
+}
+
+func (c *mqlDigitaloceanApp) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
 	})
 }
 
@@ -12727,6 +12800,8 @@ type mqlDigitaloceanSpacesBucket struct {
 	Policy               plugin.TValue[any]
 	CorsRules            plugin.TValue[[]any]
 	LifecycleRules       plugin.TValue[[]any]
+	IsPublic             plugin.TValue[bool]
+	HasWildcardPolicy    plugin.TValue[bool]
 }
 
 // createDigitaloceanSpacesBucket creates a new instance of this resource
@@ -12828,6 +12903,18 @@ func (c *mqlDigitaloceanSpacesBucket) GetCorsRules() *plugin.TValue[[]any] {
 
 func (c *mqlDigitaloceanSpacesBucket) GetLifecycleRules() *plugin.TValue[[]any] {
 	return &c.LifecycleRules
+}
+
+func (c *mqlDigitaloceanSpacesBucket) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
+	})
+}
+
+func (c *mqlDigitaloceanSpacesBucket) GetHasWildcardPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasWildcardPolicy, func() (bool, error) {
+		return c.hasWildcardPolicy()
+	})
 }
 
 // mqlDigitaloceanImage for the digitalocean.image resource
@@ -13387,6 +13474,8 @@ type mqlDigitaloceanFunctionAction struct {
 	LogSizeMb      plugin.TValue[int64]
 	Concurrency    plugin.TValue[int64]
 	UpdatedAt      plugin.TValue[*time.Time]
+	WebUrl         plugin.TValue[string]
+	IsPublic       plugin.TValue[bool]
 }
 
 // createDigitaloceanFunctionAction creates a new instance of this resource
@@ -13467,6 +13556,16 @@ func (c *mqlDigitaloceanFunctionAction) GetConcurrency() *plugin.TValue[int64] {
 
 func (c *mqlDigitaloceanFunctionAction) GetUpdatedAt() *plugin.TValue[*time.Time] {
 	return &c.UpdatedAt
+}
+
+func (c *mqlDigitaloceanFunctionAction) GetWebUrl() *plugin.TValue[string] {
+	return &c.WebUrl
+}
+
+func (c *mqlDigitaloceanFunctionAction) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
+	})
 }
 
 // mqlDigitaloceanFunctionTrigger for the digitalocean.function.trigger resource
@@ -14526,6 +14625,7 @@ type mqlDigitaloceanGradientaiAgent struct {
 	Functions               plugin.TValue[[]any]
 	Versions                plugin.TValue[[]any]
 	ApiKeys                 plugin.TValue[[]any]
+	IsPublic                plugin.TValue[bool]
 }
 
 // createDigitaloceanGradientaiAgent creates a new instance of this resource
@@ -14869,6 +14969,12 @@ func (c *mqlDigitaloceanGradientaiAgent) GetApiKeys() *plugin.TValue[[]any] {
 		}
 
 		return c.apiKeys()
+	})
+}
+
+func (c *mqlDigitaloceanGradientaiAgent) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
 	})
 }
 

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -34,6 +34,7 @@ const (
 	ResourceDigitaloceanDomainRecord                                    string = "digitalocean.domain.record"
 	ResourceDigitaloceanVolume                                          string = "digitalocean.volume"
 	ResourceDigitaloceanLoadBalancer                                    string = "digitalocean.loadBalancer"
+	ResourceDigitaloceanLoadBalancerListener                            string = "digitalocean.loadBalancer.listener"
 	ResourceDigitaloceanVpc                                             string = "digitalocean.vpc"
 	ResourceDigitaloceanVpcPeering                                      string = "digitalocean.vpcPeering"
 	ResourceDigitaloceanKubernetesCluster                               string = "digitalocean.kubernetes.cluster"
@@ -170,6 +171,10 @@ func init() {
 		"digitalocean.loadBalancer": {
 			Init:   initDigitaloceanLoadBalancer,
 			Create: createDigitaloceanLoadBalancer,
+		},
+		"digitalocean.loadBalancer.listener": {
+			// to override args, implement: initDigitaloceanLoadBalancerListener(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDigitaloceanLoadBalancerListener,
 		},
 		"digitalocean.vpc": {
 			// to override args, implement: initDigitaloceanVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1204,6 +1209,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.loadBalancer.forwardingRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetForwardingRules()).ToDataRes(types.Array(types.Dict))
 	},
+	"digitalocean.loadBalancer.listeners": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancer).GetListeners()).ToDataRes(types.Array(types.Resource("digitalocean.loadBalancer.listener")))
+	},
 	"digitalocean.loadBalancer.healthCheck": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetHealthCheck()).ToDataRes(types.Dict)
 	},
@@ -1260,6 +1268,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.loadBalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetExposure()).ToDataRes(types.Resource("digitalocean.network.exposure"))
+	},
+	"digitalocean.loadBalancer.listener.loadBalancerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetLoadBalancerId()).ToDataRes(types.String)
+	},
+	"digitalocean.loadBalancer.listener.entryProtocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetEntryProtocol()).ToDataRes(types.String)
+	},
+	"digitalocean.loadBalancer.listener.entryPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetEntryPort()).ToDataRes(types.Int)
+	},
+	"digitalocean.loadBalancer.listener.targetProtocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetTargetProtocol()).ToDataRes(types.String)
+	},
+	"digitalocean.loadBalancer.listener.targetPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetTargetPort()).ToDataRes(types.Int)
+	},
+	"digitalocean.loadBalancer.listener.tlsPassthrough": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetTlsPassthrough()).ToDataRes(types.Bool)
+	},
+	"digitalocean.loadBalancer.listener.certificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetCertificate()).ToDataRes(types.Resource("digitalocean.certificate"))
 	},
 	"digitalocean.vpc.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpc).GetId()).ToDataRes(types.String)
@@ -1746,6 +1775,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.app.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanApp).GetIsPublic()).ToDataRes(types.Bool)
+	},
+	"digitalocean.app.enhancedThreatControlEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetEnhancedThreatControlEnabled()).ToDataRes(types.Bool)
+	},
+	"digitalocean.app.secureHeaderKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetSecureHeaderKey()).ToDataRes(types.String)
+	},
+	"digitalocean.app.secureHeaderValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetSecureHeaderValue()).ToDataRes(types.String)
+	},
+	"digitalocean.app.secureHeaderRemoved": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetSecureHeaderRemoved()).ToDataRes(types.Bool)
+	},
+	"digitalocean.app.corsPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetCorsPolicies()).ToDataRes(types.Array(types.Dict))
+	},
+	"digitalocean.app.envVars": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetEnvVars()).ToDataRes(types.Array(types.Dict))
 	},
 	"digitalocean.app.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanAppDeployment).GetId()).ToDataRes(types.String)
@@ -4335,6 +4382,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanLoadBalancer).ForwardingRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.loadBalancer.listeners": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancer).Listeners, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"digitalocean.loadBalancer.healthCheck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanLoadBalancer).HealthCheck, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -4409,6 +4460,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.loadBalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanLoadBalancer).Exposure, ok = plugin.RawToTValue[*mqlDigitaloceanNetworkExposure](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).__id, ok = v.Value.(string)
+		return
+	},
+	"digitalocean.loadBalancer.listener.loadBalancerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).LoadBalancerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.entryProtocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).EntryProtocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.entryPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).EntryPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.targetProtocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).TargetProtocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.targetPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).TargetPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.tlsPassthrough": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).TlsPassthrough, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.certificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).Certificate, ok = plugin.RawToTValue[*mqlDigitaloceanCertificate](v.Value, v.Error)
 		return
 	},
 	"digitalocean.vpc.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5117,6 +5200,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.app.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanApp).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.enhancedThreatControlEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).EnhancedThreatControlEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.secureHeaderKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).SecureHeaderKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.secureHeaderValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).SecureHeaderValue, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.secureHeaderRemoved": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).SecureHeaderRemoved, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.corsPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).CorsPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.envVars": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).EnvVars, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.app.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10105,6 +10212,7 @@ type mqlDigitaloceanLoadBalancer struct {
 	Droplets                     plugin.TValue[[]any]
 	Tags                         plugin.TValue[[]any]
 	ForwardingRules              plugin.TValue[[]any]
+	Listeners                    plugin.TValue[[]any]
 	HealthCheck                  plugin.TValue[any]
 	StickySessions               plugin.TValue[any]
 	DisableLetsEncryptDnsRecords plugin.TValue[bool]
@@ -10251,6 +10359,22 @@ func (c *mqlDigitaloceanLoadBalancer) GetForwardingRules() *plugin.TValue[[]any]
 	return &c.ForwardingRules
 }
 
+func (c *mqlDigitaloceanLoadBalancer) GetListeners() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Listeners, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.loadBalancer", c.__id, "listeners")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.listeners()
+	})
+}
+
 func (c *mqlDigitaloceanLoadBalancer) GetHealthCheck() *plugin.TValue[any] {
 	return &c.HealthCheck
 }
@@ -10360,6 +10484,92 @@ func (c *mqlDigitaloceanLoadBalancer) GetExposure() *plugin.TValue[*mqlDigitaloc
 		}
 
 		return c.exposure()
+	})
+}
+
+// mqlDigitaloceanLoadBalancerListener for the digitalocean.loadBalancer.listener resource
+type mqlDigitaloceanLoadBalancerListener struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlDigitaloceanLoadBalancerListenerInternal
+	LoadBalancerId plugin.TValue[string]
+	EntryProtocol  plugin.TValue[string]
+	EntryPort      plugin.TValue[int64]
+	TargetProtocol plugin.TValue[string]
+	TargetPort     plugin.TValue[int64]
+	TlsPassthrough plugin.TValue[bool]
+	Certificate    plugin.TValue[*mqlDigitaloceanCertificate]
+}
+
+// createDigitaloceanLoadBalancerListener creates a new instance of this resource
+func createDigitaloceanLoadBalancerListener(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDigitaloceanLoadBalancerListener{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("digitalocean.loadBalancer.listener", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) MqlName() string {
+	return "digitalocean.loadBalancer.listener"
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetLoadBalancerId() *plugin.TValue[string] {
+	return &c.LoadBalancerId
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetEntryProtocol() *plugin.TValue[string] {
+	return &c.EntryProtocol
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetEntryPort() *plugin.TValue[int64] {
+	return &c.EntryPort
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetTargetProtocol() *plugin.TValue[string] {
+	return &c.TargetProtocol
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetTargetPort() *plugin.TValue[int64] {
+	return &c.TargetPort
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetTlsPassthrough() *plugin.TValue[bool] {
+	return &c.TlsPassthrough
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetCertificate() *plugin.TValue[*mqlDigitaloceanCertificate] {
+	return plugin.GetOrCompute[*mqlDigitaloceanCertificate](&c.Certificate, func() (*mqlDigitaloceanCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.loadBalancer.listener", c.__id, "certificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanCertificate), nil
+			}
+		}
+
+		return c.certificate()
 	})
 }
 
@@ -11876,26 +12086,32 @@ type mqlDigitaloceanApp struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanAppInternal it will be used here
-	Id                     plugin.TValue[string]
-	Name                   plugin.TValue[string]
-	LiveUrl                plugin.TValue[string]
-	CreatedAt              plugin.TValue[*time.Time]
-	UpdatedAt              plugin.TValue[*time.Time]
-	ActiveDeploymentStatus plugin.TValue[string]
-	Spec                   plugin.TValue[any]
-	Region                 plugin.TValue[string]
-	TierSlug               plugin.TValue[string]
-	DefaultIngress         plugin.TValue[string]
-	LiveDomain             plugin.TValue[string]
-	ProjectId              plugin.TValue[string]
-	Project                plugin.TValue[*mqlDigitaloceanProject]
-	ActiveDeploymentId     plugin.TValue[string]
-	Domains                plugin.TValue[[]any]
-	Deployments            plugin.TValue[[]any]
-	ActiveDeployment       plugin.TValue[*mqlDigitaloceanAppDeployment]
-	Alerts                 plugin.TValue[[]any]
-	Instances              plugin.TValue[[]any]
-	IsPublic               plugin.TValue[bool]
+	Id                           plugin.TValue[string]
+	Name                         plugin.TValue[string]
+	LiveUrl                      plugin.TValue[string]
+	CreatedAt                    plugin.TValue[*time.Time]
+	UpdatedAt                    plugin.TValue[*time.Time]
+	ActiveDeploymentStatus       plugin.TValue[string]
+	Spec                         plugin.TValue[any]
+	Region                       plugin.TValue[string]
+	TierSlug                     plugin.TValue[string]
+	DefaultIngress               plugin.TValue[string]
+	LiveDomain                   plugin.TValue[string]
+	ProjectId                    plugin.TValue[string]
+	Project                      plugin.TValue[*mqlDigitaloceanProject]
+	ActiveDeploymentId           plugin.TValue[string]
+	Domains                      plugin.TValue[[]any]
+	Deployments                  plugin.TValue[[]any]
+	ActiveDeployment             plugin.TValue[*mqlDigitaloceanAppDeployment]
+	Alerts                       plugin.TValue[[]any]
+	Instances                    plugin.TValue[[]any]
+	IsPublic                     plugin.TValue[bool]
+	EnhancedThreatControlEnabled plugin.TValue[bool]
+	SecureHeaderKey              plugin.TValue[string]
+	SecureHeaderValue            plugin.TValue[string]
+	SecureHeaderRemoved          plugin.TValue[bool]
+	CorsPolicies                 plugin.TValue[[]any]
+	EnvVars                      plugin.TValue[[]any]
 }
 
 // createDigitaloceanApp creates a new instance of this resource
@@ -12065,6 +12281,30 @@ func (c *mqlDigitaloceanApp) GetIsPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
 		return c.isPublic()
 	})
+}
+
+func (c *mqlDigitaloceanApp) GetEnhancedThreatControlEnabled() *plugin.TValue[bool] {
+	return &c.EnhancedThreatControlEnabled
+}
+
+func (c *mqlDigitaloceanApp) GetSecureHeaderKey() *plugin.TValue[string] {
+	return &c.SecureHeaderKey
+}
+
+func (c *mqlDigitaloceanApp) GetSecureHeaderValue() *plugin.TValue[string] {
+	return &c.SecureHeaderValue
+}
+
+func (c *mqlDigitaloceanApp) GetSecureHeaderRemoved() *plugin.TValue[bool] {
+	return &c.SecureHeaderRemoved
+}
+
+func (c *mqlDigitaloceanApp) GetCorsPolicies() *plugin.TValue[[]any] {
+	return &c.CorsPolicies
+}
+
+func (c *mqlDigitaloceanApp) GetEnvVars() *plugin.TValue[[]any] {
+	return &c.EnvVars
 }
 
 // mqlDigitaloceanAppDeployment for the digitalocean.app.deployment resource

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -47,6 +47,7 @@ digitalocean.app.alert.slackWebhookCount 13.10.2
 digitalocean.app.alert.value 13.10.2
 digitalocean.app.alert.window 13.10.2
 digitalocean.app.alerts 13.10.2
+digitalocean.app.corsPolicies 13.14.5
 digitalocean.app.createdAt 13.0.1
 digitalocean.app.defaultIngress 13.6.2
 digitalocean.app.deployment 13.10.2
@@ -72,6 +73,8 @@ digitalocean.app.deployment.updatedAt 13.10.2
 digitalocean.app.deployment.workers 13.10.2
 digitalocean.app.deployments 13.10.2
 digitalocean.app.domains 13.6.2
+digitalocean.app.enhancedThreatControlEnabled 13.14.5
+digitalocean.app.envVars 13.14.5
 digitalocean.app.id 13.0.1
 digitalocean.app.instances 13.10.2
 digitalocean.app.isPublic 13.14.5
@@ -81,6 +84,9 @@ digitalocean.app.name 13.0.1
 digitalocean.app.project 13.6.2
 digitalocean.app.projectId 13.6.2
 digitalocean.app.region 13.6.2
+digitalocean.app.secureHeaderKey 13.14.5
+digitalocean.app.secureHeaderRemoved 13.14.5
+digitalocean.app.secureHeaderValue 13.14.5
 digitalocean.app.spec 13.0.1
 digitalocean.app.tierSlug 13.6.2
 digitalocean.app.updatedAt 13.0.1
@@ -698,6 +704,15 @@ digitalocean.loadBalancer.httpIdleTimeoutSeconds 13.6.2
 digitalocean.loadBalancer.id 13.0.1
 digitalocean.loadBalancer.ip 13.0.1
 digitalocean.loadBalancer.ipv6 13.6.2
+digitalocean.loadBalancer.listener 13.14.5
+digitalocean.loadBalancer.listener.certificate 13.14.5
+digitalocean.loadBalancer.listener.entryPort 13.14.5
+digitalocean.loadBalancer.listener.entryProtocol 13.14.5
+digitalocean.loadBalancer.listener.loadBalancerId 13.14.5
+digitalocean.loadBalancer.listener.targetPort 13.14.5
+digitalocean.loadBalancer.listener.targetProtocol 13.14.5
+digitalocean.loadBalancer.listener.tlsPassthrough 13.14.5
+digitalocean.loadBalancer.listeners 13.14.5
 digitalocean.loadBalancer.name 13.0.1
 digitalocean.loadBalancer.network 13.6.2
 digitalocean.loadBalancer.networkStack 13.6.2

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -74,6 +74,7 @@ digitalocean.app.deployments 13.10.2
 digitalocean.app.domains 13.6.2
 digitalocean.app.id 13.0.1
 digitalocean.app.instances 13.10.2
+digitalocean.app.isPublic 13.14.5
 digitalocean.app.liveDomain 13.6.2
 digitalocean.app.liveUrl 13.0.1
 digitalocean.app.name 13.0.1
@@ -315,6 +316,7 @@ digitalocean.function.accessKey.namespaceUuid 13.10.2
 digitalocean.function.accessKey.updatedAt 13.10.2
 digitalocean.function.action 13.10.2
 digitalocean.function.action.concurrency 13.10.2
+digitalocean.function.action.isPublic 13.14.5
 digitalocean.function.action.logSizeMb 13.10.2
 digitalocean.function.action.memoryMb 13.10.2
 digitalocean.function.action.name 13.10.2
@@ -326,6 +328,7 @@ digitalocean.function.action.timeoutMs 13.10.2
 digitalocean.function.action.updatedAt 13.10.2
 digitalocean.function.action.version 13.10.2
 digitalocean.function.action.webExported 13.10.2
+digitalocean.function.action.webUrl 13.14.5
 digitalocean.function.namespace 13.1.7
 digitalocean.function.namespace.accessKeys 13.10.2
 digitalocean.function.namespace.apiHost 13.1.7
@@ -396,6 +399,7 @@ digitalocean.gradientai.agent.guardrail.uuid 13.4.2
 digitalocean.gradientai.agent.guardrails 13.4.2
 digitalocean.gradientai.agent.ifCase 13.4.2
 digitalocean.gradientai.agent.instruction 13.4.2
+digitalocean.gradientai.agent.isPublic 13.14.5
 digitalocean.gradientai.agent.k 13.4.2
 digitalocean.gradientai.agent.knowledgeBases 13.4.2
 digitalocean.gradientai.agent.maxTokens 13.4.2
@@ -623,6 +627,7 @@ digitalocean.kubernetes.cluster.controlPlaneFirewallEnabled 13.6.2
 digitalocean.kubernetes.cluster.corednsAutoscalerEnabled 13.6.2
 digitalocean.kubernetes.cluster.createdAt 13.0.1
 digitalocean.kubernetes.cluster.endpoint 13.6.2
+digitalocean.kubernetes.cluster.exposure 13.14.5
 digitalocean.kubernetes.cluster.ha 13.0.1
 digitalocean.kubernetes.cluster.id 13.0.1
 digitalocean.kubernetes.cluster.ipv4 13.6.2
@@ -894,6 +899,8 @@ digitalocean.spacesBucket.createdAt 13.2.1
 digitalocean.spacesBucket.encryptionAlgorithm 13.2.1
 digitalocean.spacesBucket.encryptionEnabled 13.2.1
 digitalocean.spacesBucket.encryptionKmsKeyId 13.2.1
+digitalocean.spacesBucket.hasWildcardPolicy 13.14.5
+digitalocean.spacesBucket.isPublic 13.14.5
 digitalocean.spacesBucket.lifecycleRules 13.2.1
 digitalocean.spacesBucket.mfaDeleteEnabled 13.2.1
 digitalocean.spacesBucket.name 13.2.1

--- a/providers/digitalocean/resources/digitalocean_edge.go
+++ b/providers/digitalocean/resources/digitalocean_edge.go
@@ -1,0 +1,230 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strconv"
+
+	"github.com/digitalocean/godo"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// listeners builds one resource per forwarding rule so the certificate a
+// listener presents can be reached from the rule itself.
+//
+// The rules are read back out of the forwardingRules field rather than cached
+// off the godo object, because a load balancer is built from two paths (the
+// account listing and the discovered-asset init) that both go through
+// loadBalancerArgs. A cache populated in only one of them would leave the
+// other's listeners silently empty.
+func (l *mqlDigitaloceanLoadBalancer) listeners() ([]interface{}, error) {
+	id := l.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+	rules := l.GetForwardingRules()
+	if rules.Error != nil {
+		return nil, rules.Error
+	}
+
+	all := make([]interface{}, 0, len(rules.Data))
+	for _, r := range rules.Data {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		entryProtocol, _ := rule["entryProtocol"].(string)
+		entryPort := dictInt(rule["entryPort"])
+		targetProtocol, _ := rule["targetProtocol"].(string)
+		targetPort := dictInt(rule["targetPort"])
+		certificateId, _ := rule["certificateId"].(string)
+		tlsPassthrough, _ := rule["tlsPassthrough"].(bool)
+
+		res, err := CreateResource(l.MqlRuntime, "digitalocean.loadBalancer.listener", map[string]*llx.RawData{
+			// An entry port can only be bound once per load balancer, so the
+			// protocol and port pair is a stable key.
+			"__id":           llx.StringData("digitalocean.loadBalancer.listener/" + id.Data + "/" + entryProtocol + ":" + strconv.FormatInt(entryPort, 10)),
+			"loadBalancerId": llx.StringData(id.Data),
+			"entryProtocol":  llx.StringData(entryProtocol),
+			"entryPort":      llx.IntData(entryPort),
+			"targetProtocol": llx.StringData(targetProtocol),
+			"targetPort":     llx.IntData(targetPort),
+			"tlsPassthrough": llx.BoolData(tlsPassthrough),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res.(*mqlDigitaloceanLoadBalancerListener).cacheCertificateID = certificateId
+		all = append(all, res)
+	}
+	return all, nil
+}
+
+type mqlDigitaloceanLoadBalancerListenerInternal struct {
+	// cacheCertificateID holds the certificate the listener presents, so
+	// certificate() can resolve it without refetching the load balancer.
+	cacheCertificateID string
+}
+
+// certificate resolves the certificate the listener presents. A listener on a
+// plaintext protocol, or one that passes TLS through to the backend, has none.
+func (l *mqlDigitaloceanLoadBalancerListener) certificate() (*mqlDigitaloceanCertificate, error) {
+	if l.cacheCertificateID == "" {
+		l.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	parent, err := parentDigitalocean(l.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := parent.certificateByID(l.cacheCertificateID)
+	if err != nil {
+		return nil, err
+	}
+	if cert == nil {
+		l.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return cert, nil
+}
+
+// dictInt reads a number out of a dict. Values stored in a dict are JSON-native,
+// so a port arrives as a float64, but tolerate the integer forms too.
+func dictInt(v any) int64 {
+	switch t := v.(type) {
+	case float64:
+		return int64(t)
+	case int64:
+		return t
+	case int:
+		return int64(t)
+	}
+	return 0
+}
+
+// appCorsPolicies flattens the CORS policy on each ingress route.
+//
+// Origins are written "<kind>:<value>" because the kind (exact, prefix, or
+// regex) decides how broadly the origin matches, and a broad origin combined
+// with allowCredentials is the misconfiguration worth finding.
+func appCorsPolicies(spec *godo.AppSpec) []any {
+	if spec == nil || spec.Ingress == nil {
+		return []any{}
+	}
+
+	policies := []any{}
+	for _, rule := range spec.Ingress.Rules {
+		if rule == nil || rule.CORS == nil {
+			continue
+		}
+
+		origins := []any{}
+		for _, o := range rule.CORS.AllowOrigins {
+			if o == nil {
+				continue
+			}
+			switch {
+			case o.Exact != "":
+				origins = append(origins, "exact:"+o.Exact)
+			case o.Prefix != "":
+				origins = append(origins, "prefix:"+o.Prefix)
+			case o.Regex != "":
+				origins = append(origins, "regex:"+o.Regex)
+			}
+		}
+
+		path := ""
+		if rule.Match != nil && rule.Match.Path != nil && rule.Match.Path.Prefix != nil {
+			path = *rule.Match.Path.Prefix
+		}
+
+		policies = append(policies, map[string]any{
+			"path":             path,
+			"allowOrigins":     origins,
+			"allowMethods":     toAnySlice(rule.CORS.AllowMethods),
+			"allowHeaders":     toAnySlice(rule.CORS.AllowHeaders),
+			"exposeHeaders":    toAnySlice(rule.CORS.ExposeHeaders),
+			"maxAge":           rule.CORS.MaxAge,
+			"allowCredentials": rule.CORS.AllowCredentials,
+		})
+	}
+	return policies
+}
+
+// appEnvVars lists the environment variables defined for the app and each of
+// its components, reporting where each value is held and whether it is stored
+// encrypted. Values themselves are never included.
+func appEnvVars(spec *godo.AppSpec) []any {
+	if spec == nil {
+		return []any{}
+	}
+
+	vars := []any{}
+	appendVars := func(component string, envs []*godo.AppVariableDefinition) {
+		for _, e := range envs {
+			if e == nil {
+				continue
+			}
+			vars = append(vars, map[string]any{
+				"component": component,
+				"key":       e.Key,
+				"scope":     string(e.Scope),
+				"type":      string(e.Type),
+			})
+		}
+	}
+
+	// An empty component name marks a variable shared by the whole app.
+	appendVars("", spec.Envs)
+	// ForEachAppComponentSpec never returns an error when the callback doesn't.
+	_ = spec.ForEachAppComponentSpec(func(c godo.AppComponentSpec) error {
+		appendVars(c.GetName(), componentEnvs(c))
+		return nil
+	})
+	return vars
+}
+
+// componentEnvs returns the environment variables declared on a component.
+//
+// AppComponentSpec exposes only the name and type, and the env vars live on
+// each concrete spec, so this switches over the component types that carry
+// them. Database components declare none. TestAppComponentEnvsCoverage fails if
+// the SDK grows a component type this misses.
+func componentEnvs(c godo.AppComponentSpec) []*godo.AppVariableDefinition {
+	switch t := c.(type) {
+	case *godo.AppServiceSpec:
+		return t.Envs
+	case *godo.AppWorkerSpec:
+		return t.Envs
+	case *godo.AppJobSpec:
+		return t.Envs
+	case *godo.AppStaticSiteSpec:
+		return t.Envs
+	case *godo.AppFunctionsSpec:
+		return t.Envs
+	}
+	return nil
+}
+
+// appSecureHeader returns the header the ingress sets or strips, as a key,
+// value, and whether it is removed rather than set.
+func appSecureHeader(spec *godo.AppSpec) (key, value string, removed bool) {
+	if spec == nil || spec.Ingress == nil || spec.Ingress.SecureHeader == nil {
+		return "", "", false
+	}
+	h := spec.Ingress.SecureHeader
+	return h.Key, h.Value, h.RemoveHeader
+}
+
+// toAnySlice widens a string slice for storage in a dict.
+func toAnySlice(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}

--- a/providers/digitalocean/resources/digitalocean_edge_test.go
+++ b/providers/digitalocean/resources/digitalocean_edge_test.go
@@ -1,0 +1,177 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDictInt(t *testing.T) {
+	// Dict values are JSON-native, so a port arrives as a float64.
+	assert.Equal(t, int64(443), dictInt(float64(443)))
+	assert.Equal(t, int64(443), dictInt(int64(443)))
+	assert.Equal(t, int64(443), dictInt(443))
+	assert.Equal(t, int64(0), dictInt("443"))
+	assert.Equal(t, int64(0), dictInt(nil))
+}
+
+func TestAppSecureHeader(t *testing.T) {
+	t.Run("reads a header the ingress sets", func(t *testing.T) {
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{
+			SecureHeader: &godo.AppSecureHeaderSpec{Key: "X-Frame-Options", Value: "DENY"},
+		}}
+		key, value, removed := appSecureHeader(spec)
+		assert.Equal(t, "X-Frame-Options", key)
+		assert.Equal(t, "DENY", value)
+		assert.False(t, removed)
+	})
+
+	t.Run("reads a header the ingress strips", func(t *testing.T) {
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{
+			SecureHeader: &godo.AppSecureHeaderSpec{Key: "X-Powered-By", RemoveHeader: true},
+		}}
+		key, value, removed := appSecureHeader(spec)
+		assert.Equal(t, "X-Powered-By", key)
+		assert.Empty(t, value)
+		assert.True(t, removed)
+	})
+
+	t.Run("is empty with no ingress or no header", func(t *testing.T) {
+		for _, spec := range []*godo.AppSpec{nil, {}, {Ingress: &godo.AppIngressSpec{}}} {
+			key, value, removed := appSecureHeader(spec)
+			assert.Empty(t, key)
+			assert.Empty(t, value)
+			assert.False(t, removed)
+		}
+	})
+}
+
+func TestAppCorsPolicies(t *testing.T) {
+	t.Run("flattens a policy and tags each origin with its match kind", func(t *testing.T) {
+		prefix := "/api"
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{Rules: []*godo.AppIngressSpecRule{{
+			Match: &godo.AppIngressSpecRuleMatch{Path: &godo.AppIngressSpecRuleStringMatch{Prefix: &prefix}},
+			CORS: &godo.AppCORSPolicy{
+				AllowOrigins: []*godo.AppStringMatch{
+					{Exact: "https://example.com"},
+					{Prefix: "https://"},
+					{Regex: ".*"},
+				},
+				AllowMethods:     []string{"GET", "POST"},
+				AllowHeaders:     []string{"Authorization"},
+				ExposeHeaders:    []string{"X-Request-Id"},
+				MaxAge:           "5h30m",
+				AllowCredentials: true,
+			},
+		}}}}
+
+		policies := appCorsPolicies(spec)
+		require.Len(t, policies, 1)
+
+		p, ok := policies[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "/api", p["path"])
+		assert.Equal(t, []any{"exact:https://example.com", "prefix:https://", "regex:.*"}, p["allowOrigins"])
+		assert.Equal(t, []any{"GET", "POST"}, p["allowMethods"])
+		assert.Equal(t, []any{"Authorization"}, p["allowHeaders"])
+		assert.Equal(t, []any{"X-Request-Id"}, p["exposeHeaders"])
+		assert.Equal(t, "5h30m", p["maxAge"])
+		assert.Equal(t, true, p["allowCredentials"])
+	})
+
+	t.Run("skips rules without a CORS policy", func(t *testing.T) {
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{Rules: []*godo.AppIngressSpecRule{
+			nil,
+			{Match: &godo.AppIngressSpecRuleMatch{}},
+		}}}
+		assert.Empty(t, appCorsPolicies(spec))
+	})
+
+	t.Run("is empty with no ingress", func(t *testing.T) {
+		assert.Empty(t, appCorsPolicies(nil))
+		assert.Empty(t, appCorsPolicies(&godo.AppSpec{}))
+	})
+}
+
+func TestAppEnvVars(t *testing.T) {
+	t.Run("collects app-level and component variables without values", func(t *testing.T) {
+		spec := &godo.AppSpec{
+			Envs: []*godo.AppVariableDefinition{
+				{Key: "SHARED", Value: "plaintext", Scope: "RUN_TIME", Type: "GENERAL"},
+			},
+			Services: []*godo.AppServiceSpec{{
+				Name: "api",
+				Envs: []*godo.AppVariableDefinition{
+					{Key: "DB_PASSWORD", Value: "encrypted", Scope: "RUN_TIME", Type: "SECRET"},
+				},
+			}},
+		}
+
+		vars := appEnvVars(spec)
+		require.Len(t, vars, 2)
+
+		// An empty component name marks a variable shared by the whole app.
+		assert.Equal(t, map[string]any{
+			"component": "", "key": "SHARED", "scope": "RUN_TIME", "type": "GENERAL",
+		}, vars[0])
+		assert.Equal(t, map[string]any{
+			"component": "api", "key": "DB_PASSWORD", "scope": "RUN_TIME", "type": "SECRET",
+		}, vars[1])
+
+		// Values must never be reported.
+		for _, v := range vars {
+			entry, ok := v.(map[string]any)
+			require.True(t, ok)
+			assert.NotContains(t, entry, "value")
+		}
+	})
+
+	t.Run("skips nil definitions", func(t *testing.T) {
+		spec := &godo.AppSpec{Envs: []*godo.AppVariableDefinition{nil, {Key: "K"}}}
+		assert.Len(t, appEnvVars(spec), 1)
+	})
+
+	t.Run("is empty with no spec", func(t *testing.T) {
+		assert.Empty(t, appEnvVars(nil))
+	})
+}
+
+// TestAppComponentEnvsCoverage guards componentEnvs against SDK drift. It walks
+// every component type ForEachAppComponentSpec visits and asserts that any type
+// declaring an Envs field is one componentEnvs actually handles, so a new
+// component type in a future godo release fails here rather than silently
+// dropping that component's environment variables.
+func TestAppComponentEnvsCoverage(t *testing.T) {
+	spec := &godo.AppSpec{
+		Services:    []*godo.AppServiceSpec{{Name: "svc"}},
+		Workers:     []*godo.AppWorkerSpec{{Name: "worker"}},
+		Jobs:        []*godo.AppJobSpec{{Name: "job"}},
+		StaticSites: []*godo.AppStaticSiteSpec{{Name: "site"}},
+		Functions:   []*godo.AppFunctionsSpec{{Name: "fn"}},
+		Databases:   []*godo.AppDatabaseSpec{{Name: "db"}},
+	}
+
+	visited := 0
+	err := spec.ForEachAppComponentSpec(func(c godo.AppComponentSpec) error {
+		visited++
+		field := reflect.ValueOf(c).Elem().FieldByName("Envs")
+		if !field.IsValid() {
+			// This component type declares no environment variables.
+			assert.Nil(t, componentEnvs(c), "componentEnvs returned vars for %T, which has no Envs field", c)
+			return nil
+		}
+
+		field.Set(reflect.ValueOf([]*godo.AppVariableDefinition{{Key: "PROBE"}}))
+		assert.Len(t, componentEnvs(c), 1, "componentEnvs does not handle %T, so its env vars are dropped", c)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 6, visited, "godo changed the set of app component types; revisit componentEnvs")
+}

--- a/providers/digitalocean/resources/digitalocean_exposure.go
+++ b/providers/digitalocean/resources/digitalocean_exposure.go
@@ -230,3 +230,233 @@ func (l *mqlDigitaloceanLoadBalancer) exposure() (*mqlDigitaloceanNetworkExposur
 	}
 	return res.(*mqlDigitaloceanNetworkExposure), nil
 }
+
+// exposure breaks down whether the cluster's API server is reachable from the
+// internet. A managed control plane is published on a public endpoint, so it
+// answers every address unless the control-plane firewall is enabled and its
+// allowed source addresses exclude the internet. An unset firewall flag counts
+// as "no firewall", which reports the cluster as reachable rather than quietly
+// clearing it on missing data.
+func (c *mqlDigitaloceanKubernetesCluster) exposure() (*mqlDigitaloceanNetworkExposure, error) {
+	id := c.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+
+	endpoint := c.GetEndpoint()
+	if endpoint.Error != nil {
+		return nil, endpoint.Error
+	}
+	ipv4 := c.GetIpv4()
+	if ipv4.Error != nil {
+		return nil, ipv4.Error
+	}
+	hasPublicIp := endpoint.Data != "" || ipv4.Data != ""
+
+	firewallEnabled := c.GetControlPlaneFirewallEnabled()
+	if firewallEnabled.Error != nil {
+		return nil, firewallEnabled.Error
+	}
+	allowed := c.GetControlPlaneFirewallAllowedAddresses()
+	if allowed.Error != nil {
+		return nil, allowed.Error
+	}
+
+	firewallAllowsIngress := !firewallEnabled.Data || anyAddressInList(allowed.Data)
+	internetReachable := hasPublicIp && firewallAllowsIngress
+
+	res, err := CreateResource(c.MqlRuntime, "digitalocean.network.exposure", map[string]*llx.RawData{
+		"__id":                  llx.StringData("digitalocean.kubernetes.cluster/" + id.Data + "/exposure"),
+		"internetReachable":     llx.BoolData(internetReachable),
+		"hasPublicIp":           llx.BoolData(hasPublicIp),
+		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
+		// The control-plane firewall is a source address list rather than a set
+		// of cloud-firewall rules, so there are no ingress rules to report.
+		"openIngressRules": llx.ArrayData([]any{}, types.Resource("digitalocean.firewall.ingressRule")),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDigitaloceanNetworkExposure), nil
+}
+
+// anyAddressInList reports whether a list of source CIDRs admits every address.
+func anyAddressInList(addresses []any) bool {
+	for _, a := range addresses {
+		cidr, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if isAnyAddress(cidr) {
+			return true
+		}
+	}
+	return false
+}
+
+// spacesPolicyGrantsWildcard reports whether a parsed bucket policy has an Allow
+// statement naming the wildcard principal. The policy arrives as decoded JSON,
+// so every step uses the comma-ok form: an unparseable policy is stored as a
+// plain string, and a hand-written document can put any shape in any field.
+func spacesPolicyGrantsWildcard(policy any) bool {
+	doc, ok := policy.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, statement := range asSlice(doc["Statement"]) {
+		s, ok := statement.(map[string]any)
+		if !ok {
+			continue
+		}
+		effect, _ := s["Effect"].(string)
+		if !strings.EqualFold(effect, "Allow") {
+			continue
+		}
+		if principalIsWildcard(s["Principal"]) {
+			return true
+		}
+	}
+	return false
+}
+
+// principalIsWildcard reports whether a policy principal names "*". A principal
+// is either the bare string "*" or a map keyed by principal type, whose values
+// are a single string or a list of them.
+func principalIsWildcard(principal any) bool {
+	switch p := principal.(type) {
+	case string:
+		return p == "*"
+	case map[string]any:
+		for _, v := range p {
+			for _, entry := range asSlice(v) {
+				if s, ok := entry.(string); ok && s == "*" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// asSlice normalizes a JSON field that may hold either a single value or a list
+// into a list, so callers can iterate it either way.
+func asSlice(v any) []any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case []any:
+		return t
+	default:
+		return []any{v}
+	}
+}
+
+// hasWildcardPolicy reports whether the bucket policy allows the wildcard
+// principal, which grants the action to every requester.
+func (b *mqlDigitaloceanSpacesBucket) hasWildcardPolicy() (bool, error) {
+	policy := b.GetPolicy()
+	if policy.Error != nil {
+		return false, policy.Error
+	}
+	return spacesPolicyGrantsWildcard(policy.Data), nil
+}
+
+// isPublic reports whether the bucket's contents are reachable by anyone on the
+// internet: a public ACL grant or a wildcard bucket policy, with public access
+// not blocked.
+//
+// The authenticated-users grant counts as public because it covers every
+// account on the platform rather than only this one. publicAccessBlocked is
+// only true when all four block-public-access settings are on, so a bucket with
+// a public grant and partial blocking is reported as public rather than
+// silently cleared.
+func (b *mqlDigitaloceanSpacesBucket) isPublic() (bool, error) {
+	blocked := b.GetPublicAccessBlocked()
+	if blocked.Error != nil {
+		return false, blocked.Error
+	}
+	if blocked.Data {
+		return false, nil
+	}
+
+	publicRead := b.GetPublicReadAcl()
+	if publicRead.Error != nil {
+		return false, publicRead.Error
+	}
+	publicWrite := b.GetPublicWriteAcl()
+	if publicWrite.Error != nil {
+		return false, publicWrite.Error
+	}
+	authenticatedRead := b.GetAuthenticatedReadAcl()
+	if authenticatedRead.Error != nil {
+		return false, authenticatedRead.Error
+	}
+	wildcardPolicy := b.GetHasWildcardPolicy()
+	if wildcardPolicy.Error != nil {
+		return false, wildcardPolicy.Error
+	}
+
+	return publicRead.Data || publicWrite.Data || authenticatedRead.Data || wildcardPolicy.Data, nil
+}
+
+// isPublic reports whether anyone on the internet can invoke the action: it is
+// published as a web endpoint and does not require an API key.
+func (a *mqlDigitaloceanFunctionAction) isPublic() (bool, error) {
+	webExported := a.GetWebExported()
+	if webExported.Error != nil {
+		return false, webExported.Error
+	}
+	requiresApiKey := a.GetRequiresApiKey()
+	if requiresApiKey.Error != nil {
+		return false, requiresApiKey.Error
+	}
+	return webExported.Data && !requiresApiKey.Data, nil
+}
+
+// isPublic reports whether the agent's deployment answers anyone on the
+// internet. DigitalOcean spells the visibility either as a bare "public" or as
+// a "VISIBILITY_PUBLIC" enum name depending on the endpoint, so the check looks
+// for the word rather than matching one spelling.
+func (a *mqlDigitaloceanGradientaiAgent) isPublic() (bool, error) {
+	visibility := a.GetDeploymentVisibility()
+	if visibility.Error != nil {
+		return false, visibility.Error
+	}
+	return strings.Contains(strings.ToLower(visibility.Data), "public"), nil
+}
+
+// publiclyRoutedComponents are the app spec component lists App Platform serves
+// over HTTP. Workers and jobs run without a public route.
+var publiclyRoutedComponents = []string{"services", "staticSites", "functions"}
+
+// isPublic reports whether the app serves traffic to the internet: it has a
+// live URL or a default ingress hostname, and its spec declares at least one
+// publicly routed component.
+func (a *mqlDigitaloceanApp) isPublic() (bool, error) {
+	liveUrl := a.GetLiveUrl()
+	if liveUrl.Error != nil {
+		return false, liveUrl.Error
+	}
+	defaultIngress := a.GetDefaultIngress()
+	if defaultIngress.Error != nil {
+		return false, defaultIngress.Error
+	}
+	if liveUrl.Data == "" && defaultIngress.Data == "" {
+		return false, nil
+	}
+
+	spec := a.GetSpec()
+	if spec.Error != nil {
+		return false, spec.Error
+	}
+	s, ok := spec.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	for _, key := range publiclyRoutedComponents {
+		if len(asSlice(s[key])) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/providers/digitalocean/resources/digitalocean_functions.go
+++ b/providers/digitalocean/resources/digitalocean_functions.go
@@ -72,6 +72,20 @@ func owTruthy(v interface{}) bool {
 	}
 }
 
+// openWhiskWebUrl builds the endpoint a web-exported action is published on.
+// OpenWhisk serves web actions at /api/v1/web/<namespace>/<package>/<action>,
+// and places actions that are not in a package in the "default" package.
+// Actions that are not web-exported have no such endpoint and return "".
+func openWhiskWebUrl(apiHost, namespace, pkg, action string, webExported bool) string {
+	if !webExported || apiHost == "" || namespace == "" {
+		return ""
+	}
+	if pkg == "" {
+		pkg = "default"
+	}
+	return strings.TrimRight(apiHost, "/") + "/api/v1/web/" + namespace + "/" + pkg + "/" + action
+}
+
 func owString(v interface{}) string {
 	if s, ok := v.(string); ok {
 		return s
@@ -181,10 +195,11 @@ func (r *mqlDigitaloceanFunctionNamespace) functions() ([]interface{}, error) {
 
 	all := make([]interface{}, 0, len(actions))
 	for _, a := range actions {
-		// The action's namespace field is "<nsUuid>" or "<nsUuid>/<package>".
-		pkg := ""
+		// The action's namespace field is "<namespace>" or
+		// "<namespace>/<package>".
+		nsName, pkg := a.Namespace, ""
 		if idx := strings.IndexByte(a.Namespace, '/'); idx >= 0 {
-			pkg = a.Namespace[idx+1:]
+			nsName, pkg = a.Namespace[:idx], a.Namespace[idx+1:]
 		}
 
 		runtime := ""
@@ -223,6 +238,7 @@ func (r *mqlDigitaloceanFunctionNamespace) functions() ([]interface{}, error) {
 			"runtime":        llx.StringData(runtime),
 			"webExported":    llx.BoolData(webExported),
 			"requiresApiKey": llx.BoolData(requiresApiKey),
+			"webUrl":         llx.StringData(openWhiskWebUrl(ns.ApiHost, nsName, pkg, a.Name, webExported)),
 			"timeoutMs":      llx.IntData(timeoutMs),
 			"memoryMb":       llx.IntData(memoryMb),
 			"logSizeMb":      llx.IntData(logSizeMb),

--- a/providers/digitalocean/resources/digitalocean_reachability_test.go
+++ b/providers/digitalocean/resources/digitalocean_reachability_test.go
@@ -1,0 +1,147 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnyAddressInList(t *testing.T) {
+	cases := []struct {
+		name      string
+		addresses []any
+		want      bool
+	}{
+		{"empty list allows nothing", []any{}, false},
+		{"specific CIDRs only", []any{"10.0.0.0/8", "203.0.113.5/32"}, false},
+		{"any-address IPv4", []any{"10.0.0.0/8", "0.0.0.0/0"}, true},
+		{"any-address IPv6", []any{"::/0"}, true},
+		{"non-string entries are skipped", []any{42, nil, "0.0.0.0/0"}, true},
+		{"only non-string entries", []any{42, nil}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, anyAddressInList(c.addresses))
+		})
+	}
+}
+
+// parsePolicy decodes a bucket policy the way newSpacesBucket does, so the
+// tests exercise the same shapes the resource actually stores.
+func parsePolicy(t *testing.T, raw string) any {
+	t.Helper()
+	var parsed any
+	require.NoError(t, json.Unmarshal([]byte(raw), &parsed))
+	return parsed
+}
+
+func TestSpacesPolicyGrantsWildcard(t *testing.T) {
+	cases := []struct {
+		name   string
+		policy string
+		want   bool
+	}{
+		{
+			name:   "wildcard principal as a bare string",
+			policy: `{"Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject"}]}`,
+			want:   true,
+		},
+		{
+			name:   "wildcard principal under the AWS key",
+			policy: `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject"}]}`,
+			want:   true,
+		},
+		{
+			name:   "wildcard principal in an AWS list",
+			policy: `{"Statement":[{"Effect":"Allow","Principal":{"AWS":["arn:aws:iam::1:root","*"]}}]}`,
+			want:   true,
+		},
+		{
+			name:   "a single statement object rather than a list",
+			policy: `{"Statement":{"Effect":"Allow","Principal":"*"}}`,
+			want:   true,
+		},
+		{
+			name:   "lowercase effect still matches",
+			policy: `{"Statement":[{"Effect":"allow","Principal":"*"}]}`,
+			want:   true,
+		},
+		{
+			name:   "named principal is not a wildcard",
+			policy: `{"Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::1:root"}}]}`,
+			want:   false,
+		},
+		{
+			name:   "wildcard on a Deny statement does not grant access",
+			policy: `{"Statement":[{"Effect":"Deny","Principal":"*"}]}`,
+			want:   false,
+		},
+		{
+			name:   "no statements",
+			policy: `{"Version":"2012-10-17"}`,
+			want:   false,
+		},
+		{
+			name:   "statement entries of the wrong shape are skipped",
+			policy: `{"Statement":["not-a-statement",{"Effect":"Allow","Principal":"*"}]}`,
+			want:   true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, spacesPolicyGrantsWildcard(parsePolicy(t, c.policy)))
+		})
+	}
+
+	t.Run("an unparseable policy is stored as a string and grants nothing", func(t *testing.T) {
+		assert.False(t, spacesPolicyGrantsWildcard("not json"))
+	})
+
+	t.Run("a missing policy grants nothing", func(t *testing.T) {
+		assert.False(t, spacesPolicyGrantsWildcard(nil))
+	})
+}
+
+func TestOpenWhiskWebUrl(t *testing.T) {
+	const host = "https://faas-nyc1-2ef2e6cc.doserverless.co"
+
+	t.Run("packaged action", func(t *testing.T) {
+		assert.Equal(t,
+			host+"/api/v1/web/fn-abc/mypkg/hello",
+			openWhiskWebUrl(host, "fn-abc", "mypkg", "hello", true))
+	})
+
+	t.Run("unpackaged action falls into the default package", func(t *testing.T) {
+		assert.Equal(t,
+			host+"/api/v1/web/fn-abc/default/hello",
+			openWhiskWebUrl(host, "fn-abc", "", "hello", true))
+	})
+
+	t.Run("a trailing slash on the API host is not doubled", func(t *testing.T) {
+		assert.Equal(t,
+			host+"/api/v1/web/fn-abc/default/hello",
+			openWhiskWebUrl(host+"/", "fn-abc", "", "hello", true))
+	})
+
+	t.Run("an action that is not web-exported has no endpoint", func(t *testing.T) {
+		assert.Empty(t, openWhiskWebUrl(host, "fn-abc", "mypkg", "hello", false))
+	})
+
+	t.Run("missing host or namespace yields no endpoint", func(t *testing.T) {
+		assert.Empty(t, openWhiskWebUrl("", "fn-abc", "", "hello", true))
+		assert.Empty(t, openWhiskWebUrl(host, "", "", "hello", true))
+	})
+}
+
+func TestAsSlice(t *testing.T) {
+	assert.Nil(t, asSlice(nil))
+	assert.Equal(t, []any{"a", "b"}, asSlice([]any{"a", "b"}))
+	assert.Equal(t, []any{"a"}, asSlice("a"))
+	assert.Equal(t, []any{}, asSlice([]any{}))
+}

--- a/providers/digitalocean/resources/resources.go
+++ b/providers/digitalocean/resources/resources.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 // --- Database sub-resources ---
@@ -702,6 +703,8 @@ func (r *mqlDigitalocean) apps() ([]interface{}, error) {
 				activeDeploymentId = app.ActiveDeployment.ID
 			}
 
+			secureHeaderKey, secureHeaderValue, secureHeaderRemoved := appSecureHeader(app.Spec)
+
 			domains := make([]interface{}, len(app.Domains))
 			for i, d := range app.Domains {
 				domainName := ""
@@ -731,6 +734,13 @@ func (r *mqlDigitalocean) apps() ([]interface{}, error) {
 				"projectId":              llx.StringData(app.ProjectID),
 				"activeDeploymentId":     llx.StringData(activeDeploymentId),
 				"domains":                llx.ArrayData(domains, "\x13"),
+
+				"enhancedThreatControlEnabled": llx.BoolData(app.Spec != nil && app.Spec.EnhancedThreatControlEnabled),
+				"secureHeaderKey":              llx.StringData(secureHeaderKey),
+				"secureHeaderValue":            llx.StringData(secureHeaderValue),
+				"secureHeaderRemoved":          llx.BoolData(secureHeaderRemoved),
+				"corsPolicies":                 llx.ArrayData(appCorsPolicies(app.Spec), types.Dict),
+				"envVars":                      llx.ArrayData(appEnvVars(app.Spec), types.Dict),
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## What

The provider already derives internet reachability for droplets and load balancers (`digitalocean.network.exposure`) and managed databases (`internetReachable`). Every other surface that can face the internet left the user to assemble the verdict by hand from raw fields.

This extends the same spine to the five surfaces where reachability actually **varies**:

| Resource | New | Verdict |
|---|---|---|
| `kubernetes.cluster` | `exposure()` | Control plane is on a public endpoint unless the control-plane firewall is on **and** its allowed sources exclude `0.0.0.0/0` / `::/0` |
| `spacesBucket` | `isPublic()`, `hasWildcardPolicy()` | Public ACL grant or wildcard-principal policy, with public access not blocked |
| `function.action` | `isPublic()`, `webUrl` | Web-exported **and** no API key required — plus the endpoint it answers on |
| `gradientai.agent` | `isPublic()` | Deployment visibility is public, so the endpoint takes prompts without credentials |
| `app` | `isPublic()` | Live URL or default ingress **and** ≥1 publicly routed component |

```mql
digitalocean.kubernetesClusters.where(exposure.internetReachable) { name endpoint controlPlaneFirewallEnabled }
digitalocean.spacesBuckets.where(isPublic) { name region publicReadAcl hasWildcardPolicy }
digitalocean.functionNamespaces.functions.where(isPublic) { name webUrl }
digitalocean.gradientai.agents.where(isPublic) { name deploymentUrl }
digitalocean.apps.where(isPublic) { name liveUrl }
```

## Decisions worth reviewing

**Consistency with AWS.** `spacesPolicyGrantsWildcard` mirrors `s3PolicyGrantsPublicAccess` in `aws_s3.go` (Allow + `Principal` naming `*`), and `isPublic` counts the **authenticated-users** ACL grant as public for the same reason the AWS provider does — that group covers every account on the platform, not just this one.

**Missing data errs toward reporting exposure, not hiding it.** `controlPlaneFirewallEnabled` is documented as null when unset; an unset flag is treated as "no firewall" so the cluster is reported reachable. Likewise `publicAccessBlocked` is only true when **all four** block-public-access settings are on, so a bucket with a public grant and partial blocking is reported public rather than silently cleared. Both are documented in the `.lr` descriptions and the Go doc comments.

**Naming.** `isPublic()` keeps its established fleet-wide meaning of "reachable from the internet" (~20 resources), so the open-**policy** condition on Spaces is named `hasWildcardPolicy()` instead of overloading it.

**Three candidates deliberately skipped.** `cdn` and `nfs.accessPoint` have no private mode, so an `isPublic()` there would be a constant; and `reservedIp` exposure would duplicate `droplet.exposure`, since DO surfaces a reserved IP in its droplet's own addresses.

## Known limitation (follow-up)

`spacesBucket.publicAccessBlocked` collapses all four S3 block-public-access flags into one AND. AWS's real semantics are per-flag (`IgnorePublicAcls` neutralizes an existing public ACL; `RestrictPublicBuckets` neutralizes an existing public policy) — `aws_s3.go: s3BucketIsPublic` models this properly. Exposing the four flags individually on `spacesBucket` and refining `isPublic` accordingly is worth a follow-up; the current behavior only over-reports, never under-reports.

## Testing

- `gofmt -l` clean, `go build ./...`, `go vet ./...` pass
- `./mqlr generate` re-run; 7 new `.lr.versions` entries at **13.14.5** (provider is at 13.14.4, `config.go` untouched)
- `go test ./...` passes; **22 new subtests** covering the policy-wildcard parser (bare-string / `{"AWS":"*"}` / list / single-statement-object / Deny / malformed-entry shapes), the web-URL builder, and the any-address list check
- **Not verified against a live account** — no `DIGITALOCEAN_TOKEN` available in the dev environment. Codegen/build/unit-test only.
