### PR TITLE
🐛 os: parse macOS uptime's whole-hours form ("up 11 days, 16 hrs")

### DIFF
--- a/providers/os/resources/uptime/unix.go
+++ b/providers/os/resources/uptime/unix.go
@@ -15,7 +15,12 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 )
 
-var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day[s]*),)*(?:\s*(\d+)\s(min[s]*),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
+// UnixUptimeRegex parses `uptime` output across the formats the tools
+// actually print: "up 1 day, 5:29", "up 16 min", and — when the minutes
+// component is exactly zero — "up 11 days, 16 hrs" (macOS prints "N hrs"
+// instead of "N:00" for one minute every hour, so missing that form made
+// the uptime resource error once an hour).
+var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day[s]*),)*(?:\s*(\d+)\s(hr[s]*),)*(?:\s*(\d+)\s(min[s]*),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
 
 type UnixUptimeResult struct {
 	Duration           int64
@@ -37,6 +42,10 @@ func unixDuration(date, measure string) (int64, error) {
 		fallthrough
 	case "days":
 		duration = duration * 24 * int64(time.Hour)
+	case "hr":
+		fallthrough
+	case "hrs":
+		duration = duration * int64(time.Hour)
 	case "min":
 		fallthrough
 	case "mins":
@@ -49,7 +58,7 @@ func ParseUnixUptime(uptime string) (*UnixUptimeResult, error) {
 	log.Debug().Str("uptime", uptime).Msg("parse")
 	m := UnixUptimeRegex.FindStringSubmatch(uptime)
 
-	if len(m) != 10 {
+	if len(m) != 12 {
 		return nil, fmt.Errorf("could not parse uptime: %s", uptime)
 	}
 
@@ -65,7 +74,8 @@ func ParseUnixUptime(uptime string) (*UnixUptimeResult, error) {
 		duration = duration + unixDuration
 	}
 
-	// parse mins
+	// parse whole hours ("16 hrs" — printed instead of "16:00" when the
+	// minutes component is exactly zero)
 	if len(m[4]) > 0 {
 		unixDuration, err := unixDuration(m[3], m[4])
 		if err != nil {
@@ -74,9 +84,18 @@ func ParseUnixUptime(uptime string) (*UnixUptimeResult, error) {
 		duration = duration + unixDuration
 	}
 
+	// parse mins
+	if len(m[6]) > 0 {
+		unixDuration, err := unixDuration(m[5], m[6])
+		if err != nil {
+			return nil, err
+		}
+		duration = duration + unixDuration
+	}
+
 	// add optional hours
-	if len(m[5]) > 0 {
-		hours := strings.Split(m[5], ":")
+	if len(m[7]) > 0 {
+		hours := strings.Split(m[7], ":")
 		if len(hours) == 2 {
 			// log.Debug().Msg("parse hour")
 			hh, err := strconv.ParseInt(hours[0], 10, 64)
@@ -98,24 +117,24 @@ func ParseUnixUptime(uptime string) (*UnixUptimeResult, error) {
 
 	// users is optional and is not returned on alpine
 	users := 0
-	if len(m[6]) > 0 {
-		users, err = strconv.Atoi(m[6])
+	if len(m[8]) > 0 {
+		users, err = strconv.Atoi(m[8])
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	loadOneMinute, err := strconv.ParseFloat(strings.Replace(m[7], ",", ".", 1), 64)
+	loadOneMinute, err := strconv.ParseFloat(strings.Replace(m[9], ",", ".", 1), 64)
 	if err != nil {
 		return nil, err
 	}
 
-	loadFiveMinutes, err := strconv.ParseFloat(strings.Replace(m[8], ",", ".", 1), 64)
+	loadFiveMinutes, err := strconv.ParseFloat(strings.Replace(m[10], ",", ".", 1), 64)
 	if err != nil {
 		return nil, err
 	}
 
-	loadFifteenMinutes, err := strconv.ParseFloat(strings.Replace(m[9], ",", ".", 1), 64)
+	loadFifteenMinutes, err := strconv.ParseFloat(strings.Replace(m[11], ",", ".", 1), 64)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/uptime/unix_test.go
+++ b/providers/os/resources/uptime/unix_test.go
@@ -161,6 +161,34 @@ func TestMacOSUptime(t *testing.T) {
 		LoadFifteenMinutes: float64(2.91),
 	}, duration)
 	assert.Equal(t, "192h13m0s", time.Duration(duration.Duration).String())
+
+	// When the minutes component is exactly zero, macOS prints "N hrs"
+	// instead of "N:00" — for one minute every hour the old regex failed
+	// and the uptime resource errored. Captured verbatim from a real scan.
+	data = "12:18  up 11 days, 16 hrs, 1 user, load averages: 7.12 6.59 4.92"
+	duration, err = uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, &uptime.UnixUptimeResult{
+		Duration:           (11*24 + 16) * int64(time.Hour),
+		Users:              1,
+		LoadOneMinute:      float64(7.12),
+		LoadFiveMinutes:    float64(6.59),
+		LoadFifteenMinutes: float64(4.92),
+	}, duration)
+	assert.Equal(t, "280h0m0s", time.Duration(duration.Duration).String())
+
+	// Singular form, one hour exactly.
+	data = "9:05  up 1 hr, 2 users, load averages: 1.10 0.90 0.80"
+	duration, err = uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, &uptime.UnixUptimeResult{
+		Duration:           int64(time.Hour),
+		Users:              2,
+		LoadOneMinute:      float64(1.10),
+		LoadFiveMinutes:    float64(0.90),
+		LoadFifteenMinutes: float64(0.80),
+	}, duration)
+	assert.Equal(t, "1h0m0s", time.Duration(duration.Duration).String())
 }
 
 func TestFreebsdUptime(t *testing.T) {


### PR DESCRIPTION
## The bug

When the minutes component of uptime is exactly zero, macOS prints `up 11 days, 16 hrs` instead of `up 11 days, 16:00`. `UnixUptimeRegex` had groups for `N days,`, `N mins,`, and `HH:MM,` — but not `N hrs,` — so for **one minute every hour** the uptime resource errored (`could not parse uptime: 12:18  up 11 days, 16 hrs, …`), flipping `mondoo-macos-uptime` and the asset-overview boot-time query into error state and back.

Surfaced by the scan-content digest work (server repo, draft ADR `unchanged-scan-short-circuit`): content digests between otherwise identical scans flagged the score/data churn, and the diff pointed at the exact string.

## The fix

Adds the `hr`/`hrs` group (singular included) between days and mins, shifts the capture indices, and handles the unit in `unixDuration`. Test cases use the **verbatim string from the failing scan** plus the singular one-hour form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HHX819u6q9PngxJfpCaST