### PR TITLE
⭐ digitalocean: edge and HTTP security posture

### DIFF
--- a/providers/digitalocean/README.md
+++ b/providers/digitalocean/README.md
@@ -126,6 +126,26 @@ digitalocean.gradientai.agents.where(isPublic) { name deploymentUrl }
 digitalocean.apps.where(isPublic) { name liveUrl }
 ```
 
+Find load balancer listeners accepting traffic in the clear, and inspect the
+certificate each TLS listener presents:
+
+```mql
+digitalocean.loadBalancers.listeners.where(entryProtocol == "http" || entryProtocol == "tcp")
+digitalocean.loadBalancers { name listeners { entryProtocol entryPort certificate { name notAfter state } } }
+```
+
+Find CORS policies that allow credentials from a permissive origin:
+
+```mql
+digitalocean.apps.where(corsPolicies.any(_["allowCredentials"] == true))
+```
+
+Find app environment variables held in plain text rather than encrypted:
+
+```mql
+digitalocean.apps { name envVars.where(_["type"] == "GENERAL") }
+```
+
 You can also run a policy scan:
 
 ```bash

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -762,10 +762,20 @@ digitalocean.loadBalancer @defaults("id name status") {
   tags []string
   // Forwarding rules
   //
-  // Listener mappings from incoming connections to backend targets. Each
-  // dict has keys entryProtocol, entryPort, targetProtocol, targetPort,
-  // certificateId, and tlsPassthrough.
-  forwardingRules []dict
+  // Deprecated in favor of listeners, which resolves the certificate each
+  // rule presents. Listener mappings from incoming connections to backend
+  // targets. Each dict has keys entryProtocol, entryPort, targetProtocol,
+  // targetPort, certificateId, and tlsPassthrough.
+  forwardingRules @maturity("deprecated") []dict
+  // Listeners the load balancer accepts connections on
+  //
+  // One entry per forwarding rule, carrying the protocol and port traffic
+  // arrives on, the protocol and port it is forwarded to, and the
+  // certificate the listener presents. Reaching the certificate makes the
+  // full TLS posture queryable in one place: a plaintext listener, a
+  // certificate about to expire, or a rule that passes TLS straight
+  // through to the backend.
+  listeners() []digitalocean.loadBalancer.listener
   // Health check configuration
   //
   // Probe used to decide whether a backend is healthy. Dict with keys
@@ -811,6 +821,31 @@ digitalocean.loadBalancer @defaults("id name status") {
   targetLoadBalancers() []digitalocean.loadBalancer
   // Internet-exposure breakdown (public IP combined with the load balancer firewall)
   exposure() digitalocean.network.exposure
+}
+
+// DigitalOcean load balancer listener
+//
+// A single forwarding rule on a load balancer: the protocol and port
+// connections arrive on, the protocol and port they are forwarded to on
+// the backend, and the certificate the listener presents. A listener on
+// http or tcp carries no certificate and moves traffic in the clear,
+// while tlsPassthrough hands the encrypted connection to the backend
+// untouched, so the load balancer presents no certificate of its own.
+private digitalocean.loadBalancer.listener @defaults("entryProtocol entryPort targetProtocol targetPort") {
+  // ID of the load balancer the listener belongs to
+  loadBalancerId string
+  // Protocol connections arrive on (http, https, http2, http3, tcp, udp)
+  entryProtocol string
+  // Port connections arrive on
+  entryPort int
+  // Protocol traffic is forwarded to the backend with (http, https, http2, tcp, udp)
+  targetProtocol string
+  // Port traffic is forwarded to on the backend
+  targetPort int
+  // Whether the encrypted connection is handed to the backend untouched, leaving the load balancer without a certificate of its own
+  tlsPassthrough bool
+  // Certificate the listener presents; null when it terminates no TLS
+  certificate() digitalocean.certificate
 }
 
 // DigitalOcean VPC
@@ -1338,6 +1373,34 @@ digitalocean.app @defaults("id name") {
   // a service, a static site, or a functions component. An app built only
   // from workers and jobs runs without a public route.
   isPublic() bool
+  // Whether enhanced threat control is enabled
+  //
+  // Layer 7 denial-of-service protection that answers suspicious API
+  // requests with 403 Forbidden.
+  enhancedThreatControlEnabled bool
+  // Name of the response header the ingress sets, or of the request header it strips; empty when no secure header is configured
+  secureHeaderKey string
+  // Value the ingress sets the secure header to; empty when the header is stripped rather than set
+  secureHeaderValue string
+  // Whether the secure header is stripped from incoming requests instead of set on responses
+  secureHeaderRemoved bool
+  // CORS policies configured on the app's ingress routes
+  //
+  // Each entry: path (the route the policy applies to), allowOrigins,
+  // allowMethods, allowHeaders, exposeHeaders, maxAge, allowCredentials.
+  // Each allowOrigins entry is written as "<kind>:<value>" where kind is
+  // exact, prefix, or regex, because the kind decides how broadly the
+  // origin matches. A policy that allows credentials alongside a
+  // permissive origin lets any site read authenticated responses.
+  corsPolicies []dict
+  // Environment variables defined for the app and its components
+  //
+  // Each entry: component (empty for variables shared by the whole app),
+  // key, scope, and type. A type of SECRET means the value is encrypted at
+  // rest, GENERAL means it is stored in plain text. Values are never
+  // exposed, so this reports where a credential is held rather than what
+  // it is.
+  envVars []dict
 }
 
 // DigitalOcean App Platform deployment

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -34,6 +34,7 @@ const (
 	ResourceDigitaloceanDomainRecord                                    string = "digitalocean.domain.record"
 	ResourceDigitaloceanVolume                                          string = "digitalocean.volume"
 	ResourceDigitaloceanLoadBalancer                                    string = "digitalocean.loadBalancer"
+	ResourceDigitaloceanLoadBalancerListener                            string = "digitalocean.loadBalancer.listener"
 	ResourceDigitaloceanVpc                                             string = "digitalocean.vpc"
 	ResourceDigitaloceanVpcPeering                                      string = "digitalocean.vpcPeering"
 	ResourceDigitaloceanKubernetesCluster                               string = "digitalocean.kubernetes.cluster"
@@ -170,6 +171,10 @@ func init() {
 		"digitalocean.loadBalancer": {
 			Init:   initDigitaloceanLoadBalancer,
 			Create: createDigitaloceanLoadBalancer,
+		},
+		"digitalocean.loadBalancer.listener": {
+			// to override args, implement: initDigitaloceanLoadBalancerListener(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDigitaloceanLoadBalancerListener,
 		},
 		"digitalocean.vpc": {
 			// to override args, implement: initDigitaloceanVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1204,6 +1209,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.loadBalancer.forwardingRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetForwardingRules()).ToDataRes(types.Array(types.Dict))
 	},
+	"digitalocean.loadBalancer.listeners": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancer).GetListeners()).ToDataRes(types.Array(types.Resource("digitalocean.loadBalancer.listener")))
+	},
 	"digitalocean.loadBalancer.healthCheck": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetHealthCheck()).ToDataRes(types.Dict)
 	},
@@ -1260,6 +1268,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.loadBalancer.exposure": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanLoadBalancer).GetExposure()).ToDataRes(types.Resource("digitalocean.network.exposure"))
+	},
+	"digitalocean.loadBalancer.listener.loadBalancerId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetLoadBalancerId()).ToDataRes(types.String)
+	},
+	"digitalocean.loadBalancer.listener.entryProtocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetEntryProtocol()).ToDataRes(types.String)
+	},
+	"digitalocean.loadBalancer.listener.entryPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetEntryPort()).ToDataRes(types.Int)
+	},
+	"digitalocean.loadBalancer.listener.targetProtocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetTargetProtocol()).ToDataRes(types.String)
+	},
+	"digitalocean.loadBalancer.listener.targetPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetTargetPort()).ToDataRes(types.Int)
+	},
+	"digitalocean.loadBalancer.listener.tlsPassthrough": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetTlsPassthrough()).ToDataRes(types.Bool)
+	},
+	"digitalocean.loadBalancer.listener.certificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanLoadBalancerListener).GetCertificate()).ToDataRes(types.Resource("digitalocean.certificate"))
 	},
 	"digitalocean.vpc.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpc).GetId()).ToDataRes(types.String)
@@ -1746,6 +1775,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.app.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanApp).GetIsPublic()).ToDataRes(types.Bool)
+	},
+	"digitalocean.app.enhancedThreatControlEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetEnhancedThreatControlEnabled()).ToDataRes(types.Bool)
+	},
+	"digitalocean.app.secureHeaderKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetSecureHeaderKey()).ToDataRes(types.String)
+	},
+	"digitalocean.app.secureHeaderValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetSecureHeaderValue()).ToDataRes(types.String)
+	},
+	"digitalocean.app.secureHeaderRemoved": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetSecureHeaderRemoved()).ToDataRes(types.Bool)
+	},
+	"digitalocean.app.corsPolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetCorsPolicies()).ToDataRes(types.Array(types.Dict))
+	},
+	"digitalocean.app.envVars": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanApp).GetEnvVars()).ToDataRes(types.Array(types.Dict))
 	},
 	"digitalocean.app.deployment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanAppDeployment).GetId()).ToDataRes(types.String)
@@ -4335,6 +4382,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanLoadBalancer).ForwardingRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.loadBalancer.listeners": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancer).Listeners, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"digitalocean.loadBalancer.healthCheck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanLoadBalancer).HealthCheck, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -4409,6 +4460,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.loadBalancer.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanLoadBalancer).Exposure, ok = plugin.RawToTValue[*mqlDigitaloceanNetworkExposure](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).__id, ok = v.Value.(string)
+		return
+	},
+	"digitalocean.loadBalancer.listener.loadBalancerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).LoadBalancerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.entryProtocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).EntryProtocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.entryPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).EntryPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.targetProtocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).TargetProtocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.targetPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).TargetPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.tlsPassthrough": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).TlsPassthrough, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.loadBalancer.listener.certificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanLoadBalancerListener).Certificate, ok = plugin.RawToTValue[*mqlDigitaloceanCertificate](v.Value, v.Error)
 		return
 	},
 	"digitalocean.vpc.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5117,6 +5200,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.app.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanApp).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.enhancedThreatControlEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).EnhancedThreatControlEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.secureHeaderKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).SecureHeaderKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.secureHeaderValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).SecureHeaderValue, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.secureHeaderRemoved": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).SecureHeaderRemoved, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.corsPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).CorsPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.app.envVars": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanApp).EnvVars, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.app.deployment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10105,6 +10212,7 @@ type mqlDigitaloceanLoadBalancer struct {
 	Droplets                     plugin.TValue[[]any]
 	Tags                         plugin.TValue[[]any]
 	ForwardingRules              plugin.TValue[[]any]
+	Listeners                    plugin.TValue[[]any]
 	HealthCheck                  plugin.TValue[any]
 	StickySessions               plugin.TValue[any]
 	DisableLetsEncryptDnsRecords plugin.TValue[bool]
@@ -10251,6 +10359,22 @@ func (c *mqlDigitaloceanLoadBalancer) GetForwardingRules() *plugin.TValue[[]any]
 	return &c.ForwardingRules
 }
 
+func (c *mqlDigitaloceanLoadBalancer) GetListeners() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Listeners, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.loadBalancer", c.__id, "listeners")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.listeners()
+	})
+}
+
 func (c *mqlDigitaloceanLoadBalancer) GetHealthCheck() *plugin.TValue[any] {
 	return &c.HealthCheck
 }
@@ -10360,6 +10484,92 @@ func (c *mqlDigitaloceanLoadBalancer) GetExposure() *plugin.TValue[*mqlDigitaloc
 		}
 
 		return c.exposure()
+	})
+}
+
+// mqlDigitaloceanLoadBalancerListener for the digitalocean.loadBalancer.listener resource
+type mqlDigitaloceanLoadBalancerListener struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlDigitaloceanLoadBalancerListenerInternal
+	LoadBalancerId plugin.TValue[string]
+	EntryProtocol  plugin.TValue[string]
+	EntryPort      plugin.TValue[int64]
+	TargetProtocol plugin.TValue[string]
+	TargetPort     plugin.TValue[int64]
+	TlsPassthrough plugin.TValue[bool]
+	Certificate    plugin.TValue[*mqlDigitaloceanCertificate]
+}
+
+// createDigitaloceanLoadBalancerListener creates a new instance of this resource
+func createDigitaloceanLoadBalancerListener(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDigitaloceanLoadBalancerListener{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("digitalocean.loadBalancer.listener", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) MqlName() string {
+	return "digitalocean.loadBalancer.listener"
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetLoadBalancerId() *plugin.TValue[string] {
+	return &c.LoadBalancerId
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetEntryProtocol() *plugin.TValue[string] {
+	return &c.EntryProtocol
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetEntryPort() *plugin.TValue[int64] {
+	return &c.EntryPort
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetTargetProtocol() *plugin.TValue[string] {
+	return &c.TargetProtocol
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetTargetPort() *plugin.TValue[int64] {
+	return &c.TargetPort
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetTlsPassthrough() *plugin.TValue[bool] {
+	return &c.TlsPassthrough
+}
+
+func (c *mqlDigitaloceanLoadBalancerListener) GetCertificate() *plugin.TValue[*mqlDigitaloceanCertificate] {
+	return plugin.GetOrCompute[*mqlDigitaloceanCertificate](&c.Certificate, func() (*mqlDigitaloceanCertificate, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.loadBalancer.listener", c.__id, "certificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanCertificate), nil
+			}
+		}
+
+		return c.certificate()
 	})
 }
 
@@ -11876,26 +12086,32 @@ type mqlDigitaloceanApp struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanAppInternal it will be used here
-	Id                     plugin.TValue[string]
-	Name                   plugin.TValue[string]
-	LiveUrl                plugin.TValue[string]
-	CreatedAt              plugin.TValue[*time.Time]
-	UpdatedAt              plugin.TValue[*time.Time]
-	ActiveDeploymentStatus plugin.TValue[string]
-	Spec                   plugin.TValue[any]
-	Region                 plugin.TValue[string]
-	TierSlug               plugin.TValue[string]
-	DefaultIngress         plugin.TValue[string]
-	LiveDomain             plugin.TValue[string]
-	ProjectId              plugin.TValue[string]
-	Project                plugin.TValue[*mqlDigitaloceanProject]
-	ActiveDeploymentId     plugin.TValue[string]
-	Domains                plugin.TValue[[]any]
-	Deployments            plugin.TValue[[]any]
-	ActiveDeployment       plugin.TValue[*mqlDigitaloceanAppDeployment]
-	Alerts                 plugin.TValue[[]any]
-	Instances              plugin.TValue[[]any]
-	IsPublic               plugin.TValue[bool]
+	Id                           plugin.TValue[string]
+	Name                         plugin.TValue[string]
+	LiveUrl                      plugin.TValue[string]
+	CreatedAt                    plugin.TValue[*time.Time]
+	UpdatedAt                    plugin.TValue[*time.Time]
+	ActiveDeploymentStatus       plugin.TValue[string]
+	Spec                         plugin.TValue[any]
+	Region                       plugin.TValue[string]
+	TierSlug                     plugin.TValue[string]
+	DefaultIngress               plugin.TValue[string]
+	LiveDomain                   plugin.TValue[string]
+	ProjectId                    plugin.TValue[string]
+	Project                      plugin.TValue[*mqlDigitaloceanProject]
+	ActiveDeploymentId           plugin.TValue[string]
+	Domains                      plugin.TValue[[]any]
+	Deployments                  plugin.TValue[[]any]
+	ActiveDeployment             plugin.TValue[*mqlDigitaloceanAppDeployment]
+	Alerts                       plugin.TValue[[]any]
+	Instances                    plugin.TValue[[]any]
+	IsPublic                     plugin.TValue[bool]
+	EnhancedThreatControlEnabled plugin.TValue[bool]
+	SecureHeaderKey              plugin.TValue[string]
+	SecureHeaderValue            plugin.TValue[string]
+	SecureHeaderRemoved          plugin.TValue[bool]
+	CorsPolicies                 plugin.TValue[[]any]
+	EnvVars                      plugin.TValue[[]any]
 }
 
 // createDigitaloceanApp creates a new instance of this resource
@@ -12065,6 +12281,30 @@ func (c *mqlDigitaloceanApp) GetIsPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
 		return c.isPublic()
 	})
+}
+
+func (c *mqlDigitaloceanApp) GetEnhancedThreatControlEnabled() *plugin.TValue[bool] {
+	return &c.EnhancedThreatControlEnabled
+}
+
+func (c *mqlDigitaloceanApp) GetSecureHeaderKey() *plugin.TValue[string] {
+	return &c.SecureHeaderKey
+}
+
+func (c *mqlDigitaloceanApp) GetSecureHeaderValue() *plugin.TValue[string] {
+	return &c.SecureHeaderValue
+}
+
+func (c *mqlDigitaloceanApp) GetSecureHeaderRemoved() *plugin.TValue[bool] {
+	return &c.SecureHeaderRemoved
+}
+
+func (c *mqlDigitaloceanApp) GetCorsPolicies() *plugin.TValue[[]any] {
+	return &c.CorsPolicies
+}
+
+func (c *mqlDigitaloceanApp) GetEnvVars() *plugin.TValue[[]any] {
+	return &c.EnvVars
 }
 
 // mqlDigitaloceanAppDeployment for the digitalocean.app.deployment resource

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -47,6 +47,7 @@ digitalocean.app.alert.slackWebhookCount 13.10.2
 digitalocean.app.alert.value 13.10.2
 digitalocean.app.alert.window 13.10.2
 digitalocean.app.alerts 13.10.2
+digitalocean.app.corsPolicies 13.14.5
 digitalocean.app.createdAt 13.0.1
 digitalocean.app.defaultIngress 13.6.2
 digitalocean.app.deployment 13.10.2
@@ -72,6 +73,8 @@ digitalocean.app.deployment.updatedAt 13.10.2
 digitalocean.app.deployment.workers 13.10.2
 digitalocean.app.deployments 13.10.2
 digitalocean.app.domains 13.6.2
+digitalocean.app.enhancedThreatControlEnabled 13.14.5
+digitalocean.app.envVars 13.14.5
 digitalocean.app.id 13.0.1
 digitalocean.app.instances 13.10.2
 digitalocean.app.isPublic 13.14.5
@@ -81,6 +84,9 @@ digitalocean.app.name 13.0.1
 digitalocean.app.project 13.6.2
 digitalocean.app.projectId 13.6.2
 digitalocean.app.region 13.6.2
+digitalocean.app.secureHeaderKey 13.14.5
+digitalocean.app.secureHeaderRemoved 13.14.5
+digitalocean.app.secureHeaderValue 13.14.5
 digitalocean.app.spec 13.0.1
 digitalocean.app.tierSlug 13.6.2
 digitalocean.app.updatedAt 13.0.1
@@ -698,6 +704,15 @@ digitalocean.loadBalancer.httpIdleTimeoutSeconds 13.6.2
 digitalocean.loadBalancer.id 13.0.1
 digitalocean.loadBalancer.ip 13.0.1
 digitalocean.loadBalancer.ipv6 13.6.2
+digitalocean.loadBalancer.listener 13.14.5
+digitalocean.loadBalancer.listener.certificate 13.14.5
+digitalocean.loadBalancer.listener.entryPort 13.14.5
+digitalocean.loadBalancer.listener.entryProtocol 13.14.5
+digitalocean.loadBalancer.listener.loadBalancerId 13.14.5
+digitalocean.loadBalancer.listener.targetPort 13.14.5
+digitalocean.loadBalancer.listener.targetProtocol 13.14.5
+digitalocean.loadBalancer.listener.tlsPassthrough 13.14.5
+digitalocean.loadBalancer.listeners 13.14.5
 digitalocean.loadBalancer.name 13.0.1
 digitalocean.loadBalancer.network 13.6.2
 digitalocean.loadBalancer.networkStack 13.6.2

--- a/providers/digitalocean/resources/digitalocean_edge.go
+++ b/providers/digitalocean/resources/digitalocean_edge.go
@@ -1,0 +1,230 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strconv"
+
+	"github.com/digitalocean/godo"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// listeners builds one resource per forwarding rule so the certificate a
+// listener presents can be reached from the rule itself.
+//
+// The rules are read back out of the forwardingRules field rather than cached
+// off the godo object, because a load balancer is built from two paths (the
+// account listing and the discovered-asset init) that both go through
+// loadBalancerArgs. A cache populated in only one of them would leave the
+// other's listeners silently empty.
+func (l *mqlDigitaloceanLoadBalancer) listeners() ([]interface{}, error) {
+	id := l.GetId()
+	if id.Error != nil {
+		return nil, id.Error
+	}
+	rules := l.GetForwardingRules()
+	if rules.Error != nil {
+		return nil, rules.Error
+	}
+
+	all := make([]interface{}, 0, len(rules.Data))
+	for _, r := range rules.Data {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		entryProtocol, _ := rule["entryProtocol"].(string)
+		entryPort := dictInt(rule["entryPort"])
+		targetProtocol, _ := rule["targetProtocol"].(string)
+		targetPort := dictInt(rule["targetPort"])
+		certificateId, _ := rule["certificateId"].(string)
+		tlsPassthrough, _ := rule["tlsPassthrough"].(bool)
+
+		res, err := CreateResource(l.MqlRuntime, "digitalocean.loadBalancer.listener", map[string]*llx.RawData{
+			// An entry port can only be bound once per load balancer, so the
+			// protocol and port pair is a stable key.
+			"__id":           llx.StringData("digitalocean.loadBalancer.listener/" + id.Data + "/" + entryProtocol + ":" + strconv.FormatInt(entryPort, 10)),
+			"loadBalancerId": llx.StringData(id.Data),
+			"entryProtocol":  llx.StringData(entryProtocol),
+			"entryPort":      llx.IntData(entryPort),
+			"targetProtocol": llx.StringData(targetProtocol),
+			"targetPort":     llx.IntData(targetPort),
+			"tlsPassthrough": llx.BoolData(tlsPassthrough),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res.(*mqlDigitaloceanLoadBalancerListener).cacheCertificateID = certificateId
+		all = append(all, res)
+	}
+	return all, nil
+}
+
+type mqlDigitaloceanLoadBalancerListenerInternal struct {
+	// cacheCertificateID holds the certificate the listener presents, so
+	// certificate() can resolve it without refetching the load balancer.
+	cacheCertificateID string
+}
+
+// certificate resolves the certificate the listener presents. A listener on a
+// plaintext protocol, or one that passes TLS through to the backend, has none.
+func (l *mqlDigitaloceanLoadBalancerListener) certificate() (*mqlDigitaloceanCertificate, error) {
+	if l.cacheCertificateID == "" {
+		l.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	parent, err := parentDigitalocean(l.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := parent.certificateByID(l.cacheCertificateID)
+	if err != nil {
+		return nil, err
+	}
+	if cert == nil {
+		l.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return cert, nil
+}
+
+// dictInt reads a number out of a dict. Values stored in a dict are JSON-native,
+// so a port arrives as a float64, but tolerate the integer forms too.
+func dictInt(v any) int64 {
+	switch t := v.(type) {
+	case float64:
+		return int64(t)
+	case int64:
+		return t
+	case int:
+		return int64(t)
+	}
+	return 0
+}
+
+// appCorsPolicies flattens the CORS policy on each ingress route.
+//
+// Origins are written "<kind>:<value>" because the kind (exact, prefix, or
+// regex) decides how broadly the origin matches, and a broad origin combined
+// with allowCredentials is the misconfiguration worth finding.
+func appCorsPolicies(spec *godo.AppSpec) []any {
+	if spec == nil || spec.Ingress == nil {
+		return []any{}
+	}
+
+	policies := []any{}
+	for _, rule := range spec.Ingress.Rules {
+		if rule == nil || rule.CORS == nil {
+			continue
+		}
+
+		origins := []any{}
+		for _, o := range rule.CORS.AllowOrigins {
+			if o == nil {
+				continue
+			}
+			switch {
+			case o.Exact != "":
+				origins = append(origins, "exact:"+o.Exact)
+			case o.Prefix != "":
+				origins = append(origins, "prefix:"+o.Prefix)
+			case o.Regex != "":
+				origins = append(origins, "regex:"+o.Regex)
+			}
+		}
+
+		path := ""
+		if rule.Match != nil && rule.Match.Path != nil && rule.Match.Path.Prefix != nil {
+			path = *rule.Match.Path.Prefix
+		}
+
+		policies = append(policies, map[string]any{
+			"path":             path,
+			"allowOrigins":     origins,
+			"allowMethods":     toAnySlice(rule.CORS.AllowMethods),
+			"allowHeaders":     toAnySlice(rule.CORS.AllowHeaders),
+			"exposeHeaders":    toAnySlice(rule.CORS.ExposeHeaders),
+			"maxAge":           rule.CORS.MaxAge,
+			"allowCredentials": rule.CORS.AllowCredentials,
+		})
+	}
+	return policies
+}
+
+// appEnvVars lists the environment variables defined for the app and each of
+// its components, reporting where each value is held and whether it is stored
+// encrypted. Values themselves are never included.
+func appEnvVars(spec *godo.AppSpec) []any {
+	if spec == nil {
+		return []any{}
+	}
+
+	vars := []any{}
+	appendVars := func(component string, envs []*godo.AppVariableDefinition) {
+		for _, e := range envs {
+			if e == nil {
+				continue
+			}
+			vars = append(vars, map[string]any{
+				"component": component,
+				"key":       e.Key,
+				"scope":     string(e.Scope),
+				"type":      string(e.Type),
+			})
+		}
+	}
+
+	// An empty component name marks a variable shared by the whole app.
+	appendVars("", spec.Envs)
+	// ForEachAppComponentSpec never returns an error when the callback doesn't.
+	_ = spec.ForEachAppComponentSpec(func(c godo.AppComponentSpec) error {
+		appendVars(c.GetName(), componentEnvs(c))
+		return nil
+	})
+	return vars
+}
+
+// componentEnvs returns the environment variables declared on a component.
+//
+// AppComponentSpec exposes only the name and type, and the env vars live on
+// each concrete spec, so this switches over the component types that carry
+// them. Database components declare none. TestAppComponentEnvsCoverage fails if
+// the SDK grows a component type this misses.
+func componentEnvs(c godo.AppComponentSpec) []*godo.AppVariableDefinition {
+	switch t := c.(type) {
+	case *godo.AppServiceSpec:
+		return t.Envs
+	case *godo.AppWorkerSpec:
+		return t.Envs
+	case *godo.AppJobSpec:
+		return t.Envs
+	case *godo.AppStaticSiteSpec:
+		return t.Envs
+	case *godo.AppFunctionsSpec:
+		return t.Envs
+	}
+	return nil
+}
+
+// appSecureHeader returns the header the ingress sets or strips, as a key,
+// value, and whether it is removed rather than set.
+func appSecureHeader(spec *godo.AppSpec) (key, value string, removed bool) {
+	if spec == nil || spec.Ingress == nil || spec.Ingress.SecureHeader == nil {
+		return "", "", false
+	}
+	h := spec.Ingress.SecureHeader
+	return h.Key, h.Value, h.RemoveHeader
+}
+
+// toAnySlice widens a string slice for storage in a dict.
+func toAnySlice(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}

--- a/providers/digitalocean/resources/digitalocean_edge_test.go
+++ b/providers/digitalocean/resources/digitalocean_edge_test.go
@@ -1,0 +1,177 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDictInt(t *testing.T) {
+	// Dict values are JSON-native, so a port arrives as a float64.
+	assert.Equal(t, int64(443), dictInt(float64(443)))
+	assert.Equal(t, int64(443), dictInt(int64(443)))
+	assert.Equal(t, int64(443), dictInt(443))
+	assert.Equal(t, int64(0), dictInt("443"))
+	assert.Equal(t, int64(0), dictInt(nil))
+}
+
+func TestAppSecureHeader(t *testing.T) {
+	t.Run("reads a header the ingress sets", func(t *testing.T) {
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{
+			SecureHeader: &godo.AppSecureHeaderSpec{Key: "X-Frame-Options", Value: "DENY"},
+		}}
+		key, value, removed := appSecureHeader(spec)
+		assert.Equal(t, "X-Frame-Options", key)
+		assert.Equal(t, "DENY", value)
+		assert.False(t, removed)
+	})
+
+	t.Run("reads a header the ingress strips", func(t *testing.T) {
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{
+			SecureHeader: &godo.AppSecureHeaderSpec{Key: "X-Powered-By", RemoveHeader: true},
+		}}
+		key, value, removed := appSecureHeader(spec)
+		assert.Equal(t, "X-Powered-By", key)
+		assert.Empty(t, value)
+		assert.True(t, removed)
+	})
+
+	t.Run("is empty with no ingress or no header", func(t *testing.T) {
+		for _, spec := range []*godo.AppSpec{nil, {}, {Ingress: &godo.AppIngressSpec{}}} {
+			key, value, removed := appSecureHeader(spec)
+			assert.Empty(t, key)
+			assert.Empty(t, value)
+			assert.False(t, removed)
+		}
+	})
+}
+
+func TestAppCorsPolicies(t *testing.T) {
+	t.Run("flattens a policy and tags each origin with its match kind", func(t *testing.T) {
+		prefix := "/api"
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{Rules: []*godo.AppIngressSpecRule{{
+			Match: &godo.AppIngressSpecRuleMatch{Path: &godo.AppIngressSpecRuleStringMatch{Prefix: &prefix}},
+			CORS: &godo.AppCORSPolicy{
+				AllowOrigins: []*godo.AppStringMatch{
+					{Exact: "https://example.com"},
+					{Prefix: "https://"},
+					{Regex: ".*"},
+				},
+				AllowMethods:     []string{"GET", "POST"},
+				AllowHeaders:     []string{"Authorization"},
+				ExposeHeaders:    []string{"X-Request-Id"},
+				MaxAge:           "5h30m",
+				AllowCredentials: true,
+			},
+		}}}}
+
+		policies := appCorsPolicies(spec)
+		require.Len(t, policies, 1)
+
+		p, ok := policies[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "/api", p["path"])
+		assert.Equal(t, []any{"exact:https://example.com", "prefix:https://", "regex:.*"}, p["allowOrigins"])
+		assert.Equal(t, []any{"GET", "POST"}, p["allowMethods"])
+		assert.Equal(t, []any{"Authorization"}, p["allowHeaders"])
+		assert.Equal(t, []any{"X-Request-Id"}, p["exposeHeaders"])
+		assert.Equal(t, "5h30m", p["maxAge"])
+		assert.Equal(t, true, p["allowCredentials"])
+	})
+
+	t.Run("skips rules without a CORS policy", func(t *testing.T) {
+		spec := &godo.AppSpec{Ingress: &godo.AppIngressSpec{Rules: []*godo.AppIngressSpecRule{
+			nil,
+			{Match: &godo.AppIngressSpecRuleMatch{}},
+		}}}
+		assert.Empty(t, appCorsPolicies(spec))
+	})
+
+	t.Run("is empty with no ingress", func(t *testing.T) {
+		assert.Empty(t, appCorsPolicies(nil))
+		assert.Empty(t, appCorsPolicies(&godo.AppSpec{}))
+	})
+}
+
+func TestAppEnvVars(t *testing.T) {
+	t.Run("collects app-level and component variables without values", func(t *testing.T) {
+		spec := &godo.AppSpec{
+			Envs: []*godo.AppVariableDefinition{
+				{Key: "SHARED", Value: "plaintext", Scope: "RUN_TIME", Type: "GENERAL"},
+			},
+			Services: []*godo.AppServiceSpec{{
+				Name: "api",
+				Envs: []*godo.AppVariableDefinition{
+					{Key: "DB_PASSWORD", Value: "encrypted", Scope: "RUN_TIME", Type: "SECRET"},
+				},
+			}},
+		}
+
+		vars := appEnvVars(spec)
+		require.Len(t, vars, 2)
+
+		// An empty component name marks a variable shared by the whole app.
+		assert.Equal(t, map[string]any{
+			"component": "", "key": "SHARED", "scope": "RUN_TIME", "type": "GENERAL",
+		}, vars[0])
+		assert.Equal(t, map[string]any{
+			"component": "api", "key": "DB_PASSWORD", "scope": "RUN_TIME", "type": "SECRET",
+		}, vars[1])
+
+		// Values must never be reported.
+		for _, v := range vars {
+			entry, ok := v.(map[string]any)
+			require.True(t, ok)
+			assert.NotContains(t, entry, "value")
+		}
+	})
+
+	t.Run("skips nil definitions", func(t *testing.T) {
+		spec := &godo.AppSpec{Envs: []*godo.AppVariableDefinition{nil, {Key: "K"}}}
+		assert.Len(t, appEnvVars(spec), 1)
+	})
+
+	t.Run("is empty with no spec", func(t *testing.T) {
+		assert.Empty(t, appEnvVars(nil))
+	})
+}
+
+// TestAppComponentEnvsCoverage guards componentEnvs against SDK drift. It walks
+// every component type ForEachAppComponentSpec visits and asserts that any type
+// declaring an Envs field is one componentEnvs actually handles, so a new
+// component type in a future godo release fails here rather than silently
+// dropping that component's environment variables.
+func TestAppComponentEnvsCoverage(t *testing.T) {
+	spec := &godo.AppSpec{
+		Services:    []*godo.AppServiceSpec{{Name: "svc"}},
+		Workers:     []*godo.AppWorkerSpec{{Name: "worker"}},
+		Jobs:        []*godo.AppJobSpec{{Name: "job"}},
+		StaticSites: []*godo.AppStaticSiteSpec{{Name: "site"}},
+		Functions:   []*godo.AppFunctionsSpec{{Name: "fn"}},
+		Databases:   []*godo.AppDatabaseSpec{{Name: "db"}},
+	}
+
+	visited := 0
+	err := spec.ForEachAppComponentSpec(func(c godo.AppComponentSpec) error {
+		visited++
+		field := reflect.ValueOf(c).Elem().FieldByName("Envs")
+		if !field.IsValid() {
+			// This component type declares no environment variables.
+			assert.Nil(t, componentEnvs(c), "componentEnvs returned vars for %T, which has no Envs field", c)
+			return nil
+		}
+
+		field.Set(reflect.ValueOf([]*godo.AppVariableDefinition{{Key: "PROBE"}}))
+		assert.Len(t, componentEnvs(c), 1, "componentEnvs does not handle %T, so its env vars are dropped", c)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 6, visited, "godo changed the set of app component types; revisit componentEnvs")
+}

--- a/providers/digitalocean/resources/resources.go
+++ b/providers/digitalocean/resources/resources.go
@@ -11,6 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 // --- Database sub-resources ---
@@ -702,6 +703,8 @@ func (r *mqlDigitalocean) apps() ([]interface{}, error) {
 				activeDeploymentId = app.ActiveDeployment.ID
 			}
 
+			secureHeaderKey, secureHeaderValue, secureHeaderRemoved := appSecureHeader(app.Spec)
+
 			domains := make([]interface{}, len(app.Domains))
 			for i, d := range app.Domains {
 				domainName := ""
@@ -731,6 +734,13 @@ func (r *mqlDigitalocean) apps() ([]interface{}, error) {
 				"projectId":              llx.StringData(app.ProjectID),
 				"activeDeploymentId":     llx.StringData(activeDeploymentId),
 				"domains":                llx.ArrayData(domains, "\x13"),
+
+				"enhancedThreatControlEnabled": llx.BoolData(app.Spec != nil && app.Spec.EnhancedThreatControlEnabled),
+				"secureHeaderKey":              llx.StringData(secureHeaderKey),
+				"secureHeaderValue":            llx.StringData(secureHeaderValue),
+				"secureHeaderRemoved":          llx.BoolData(secureHeaderRemoved),
+				"corsPolicies":                 llx.ArrayData(appCorsPolicies(app.Spec), types.Dict),
+				"envVars":                      llx.ArrayData(appEnvVars(app.Spec), types.Dict),
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
> **Stacked on #9708** (`digitalocean-reachability`) — both branches touch `digitalocean.app`. Review/merge that one first; this PR's diff is the second commit.

## What

Two edge surfaces held security-relevant configuration that nothing could query.

### Load balancer listeners

`forwardingRules` was a `[]dict`, so there was no path from a listener to the certificate it presents — the TLS posture of a load balancer took two queries and a manual join on `certificateId`.

```
digitalocean.loadBalancer.listener {
  loadBalancerId, entryProtocol, entryPort, targetProtocol, targetPort,
  tlsPassthrough,
  certificate() digitalocean.certificate   // ← the nested typed ref
}
```

```mql
digitalocean.loadBalancers.listeners.where(entryProtocol == "http" || entryProtocol == "tcp")
digitalocean.loadBalancers { name listeners { entryProtocol entryPort certificate { name notAfter state } } }
```

`forwardingRules` is now `@maturity("deprecated")`. The accessor is named `listeners` rather than `forwardingRulesRefs` because the shipped field already holds the obvious name and "listener" is standard load-balancer vocabulary — not an invented suffix. Its `.lr.versions` entry stays at its original version, since deprecation doesn't bump.

### App Platform ingress and environment

App Platform kept its ingress and environment configuration inside `spec dict`, which only surfaced component **name** lists.

| Field | What it makes findable |
|---|---|
| `corsPolicies` | Per-route CORS. Broad origin + `allowCredentials` lets any site read authenticated responses |
| `envVars` | App- and component-level variables with `scope` and `type` — a credential stored `GENERAL` (plain text) instead of `SECRET` |
| `enhancedThreatControlEnabled` | Layer 7 denial-of-service protection |
| `secureHeaderKey` / `Value` / `Removed` | The header the ingress sets or strips |

```mql
digitalocean.apps.where(corsPolicies.any(_["allowCredentials"] == true))
digitalocean.apps { name envVars.where(_["type"] == "GENERAL") }
```

`envVars` reports **where** a credential is held, never the value.

## Decisions worth reviewing

**Listeners read back from `forwardingRules`, not from a cache.** A load balancer is built from two paths — the account listing and `initDigitaloceanLoadBalancer` — that both go through `loadBalancerArgs`. An Internal cache populated only in the lister would leave the discovered-asset's listeners **silently empty**, which is the failure mode that doesn't surface as an error. Reading the already-populated field covers both paths and recordings.

**`secureHeader` is a single struct in the SDK, not a list**, so it's flattened into three prefixed scalars on the app rather than becoming a dict — per the sub-resource bar's "flatten scalars into the parent" guidance.

**`corsPolicies` origins are encoded `"<kind>:<value>"`.** `AllowOrigins` is a list of `{exact|prefix|regex}` match objects; storing them raw would make `corsPolicies` a *nested* dict rather than a flat scalar bag. Encoding the kind inline keeps the security-relevant distinction (a `regex:.*` origin is not an `exact:` one) while staying flat. A sub-resource wasn't an option — a CORS policy has no stable ID and no nested typed ref, so it doesn't clear the bar.

**SDK drift guard.** `godo.AppComponentSpec` exposes only `GetName`/`GetType`; env vars live as fields on each concrete spec, so `componentEnvs` type-switches. `TestAppComponentEnvsCoverage` reflects over every component `ForEachAppComponentSpec` visits and fails if one declares an `Envs` field the switch drops. I verified it genuinely fails by temporarily removing the `*godo.AppWorkerSpec` case:

```
--- FAIL: TestAppComponentEnvsCoverage
    componentEnvs does not handle *godo.AppWorkerSpec, so its env vars are dropped
```

## Testing

- `gofmt -l` clean, `go build ./...`, `go vet ./...` pass
- `./mqlr generate` re-run; 15 new `.lr.versions` entries at **13.14.5** (provider at 13.14.4, `config.go` untouched); `forwardingRules` keeps its original version
- `go test ./...` passes; new subtests covering CORS flattening and origin-kind encoding, env-var collection with values excluded, secure-header set-vs-strip, the nil-spec paths, dict number coercion, and the drift guard
- **Not verified against a live account** — no `DIGITALOCEAN_TOKEN` available in the dev environment. Codegen/build/unit-test only.
