### PR TITLE
🐛 os: fix duplicate python packages and cross-environment dependencies

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -70,6 +70,9 @@ tre = "tre"
 ue = "ue"
 # Company name.
 automattic = "automattic"
+# Python package on PyPI providing Mozilla's CA bundle. The project spells it
+# without the trailing "y", so every reference to it must stay verbatim.
+certifi = "certifi"
 # Misspelled JSON serialization tag kept for wire/persisted-data compatibility
 # (the Go field itself is spelled correctly).
 reciever = "reciever"

--- a/providers/os/resources/languages/python/python.go
+++ b/providers/os/resources/languages/python/python.go
@@ -4,6 +4,7 @@
 package python
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/package-url/packageurl-go"
@@ -28,11 +29,29 @@ type PackageDetails struct {
 	Cpes           []string
 }
 
+// nameSeparators matches any run of the characters PEP 503 treats as
+// equivalent separators in a project name.
+var nameSeparators = regexp.MustCompile(`[-_.]+`)
+
+// NormalizeName returns the PEP 503 normalized form of a project name: any run
+// of "-", "_" or "." collapses to a single "-", and the result is lowercased.
+// "Zope.Interface", "zope_interface" and "zope--interface" all normalize to
+// "zope-interface".
+//
+// Use this whenever a name is compared or used as a key. Names are recorded
+// inconsistently across metadata, manifests and lock files, so comparing the raw
+// strings both misses matches and produces package URLs that do not resolve
+// against vulnerability data.
+//
+// See https://packaging.python.org/en/latest/specifications/name-normalization/
+func NormalizeName(name string) string {
+	return strings.ToLower(nameSeparators.ReplaceAllString(name, "-"))
+}
+
 func NewPackageUrl(name string, version string) string {
 	// ensure the name is according to the PURL spec
 	// see https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#pypi
-	name = strings.ToLower(name)
-	name = strings.ReplaceAll(name, "_", "-")
+	name = NormalizeName(name)
 
 	return packageurl.NewPackageURL(
 		packageurl.TypePyPi,

--- a/providers/os/resources/languages/python/python_test.go
+++ b/providers/os/resources/languages/python/python_test.go
@@ -22,6 +22,21 @@ func TestPurlAndCPE(t *testing.T) {
 			expectedPurl: "pkg:pypi/test@1.0.0",
 			expectedCpes: []string{"cpe:2.3:a:test_project:test:1.0.0:*:*:*:*:*:*:*"},
 		},
+		{
+			// dots are separators under PEP 503 just like hyphens and
+			// underscores; a purl that keeps them does not resolve against
+			// vulnerability data
+			name:         "zope.interface",
+			version:      "7.2",
+			expectedPurl: "pkg:pypi/zope-interface@7.2",
+			expectedCpes: []string{"cpe:2.3:a:zope.interface_project:zope.interface:7.2:*:*:*:*:*:*:*"},
+		},
+		{
+			name:         "ruamel.yaml.clib",
+			version:      "0.2.12",
+			expectedPurl: "pkg:pypi/ruamel-yaml-clib@0.2.12",
+			expectedCpes: []string{"cpe:2.3:a:ruamel.yaml.clib_project:ruamel.yaml.clib:0.2.12:*:*:*:*:*:*:*"},
+		},
 	}
 
 	for i := range tests {
@@ -32,6 +47,35 @@ func TestPurlAndCPE(t *testing.T) {
 
 			cpes := NewCpes(test.name, test.version)
 			assert.Equal(t, test.expectedCpes, cpes)
+		})
+	}
+}
+
+// Names are spelled inconsistently across installed metadata, manifests and lock
+// files. All the spellings of one project have to collapse to a single key, or
+// the same project is reported twice and its purl fails to match.
+func TestNormalizeName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"requests", "requests"},
+		{"Flask", "flask"},
+		{"zope.interface", "zope-interface"},
+		{"zope_interface", "zope-interface"},
+		{"Zope.Interface", "zope-interface"},
+		{"ruamel.yaml.clib", "ruamel-yaml-clib"},
+		{"typing-extensions", "typing-extensions"},
+		{"typing_extensions", "typing-extensions"},
+		// runs of separators collapse to one
+		{"foo--bar", "foo-bar"},
+		{"foo._-bar", "foo-bar"},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeName(tc.in))
 		})
 	}
 }

--- a/providers/os/resources/languages/python/wheelegg/name.go
+++ b/providers/os/resources/languages/python/wheelegg/name.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package wheelegg
+
+import (
+	"strings"
+)
+
+// ParseDistInfoName derives a package name and version from the name of a
+// ".dist-info" or ".egg-info" entry, e.g. "requests-2.32.3.dist-info" ->
+// ("requests", "2.32.3").
+//
+// This is a fallback for installs whose METADATA / PKG-INFO is missing or
+// unparsable. That is common enough to matter: a package removed in a later
+// container image layer leaves the directory in the merged listing without its
+// metadata, and interrupted installs leave the same shape behind. The directory
+// name still carries the identity, so the package can be reported instead of
+// silently dropped from the inventory.
+//
+// The version is only returned when it looks like one (leading digit). Names
+// without a version part, such as a bare "foo.egg-info", yield an empty version.
+func ParseDistInfoName(entry string) (name string, version string) {
+	trimmed := strings.TrimSuffix(strings.TrimSuffix(entry, ".dist-info"), ".egg-info")
+	if trimmed == "" {
+		return "", ""
+	}
+
+	parts := strings.Split(trimmed, "-")
+
+	// egg-info directories may carry build tags after the version, such as
+	// "foo-1.2.3-py3.11.egg-info". Drop them so the version stays the last part.
+	for len(parts) > 1 {
+		last := parts[len(parts)-1]
+		if strings.HasPrefix(last, "py") || strings.HasPrefix(last, "cp") {
+			parts = parts[:len(parts)-1]
+			continue
+		}
+		break
+	}
+
+	if len(parts) < 2 {
+		return trimmed, ""
+	}
+
+	last := parts[len(parts)-1]
+	if last == "" || last[0] < '0' || last[0] > '9' {
+		// not a version; the hyphen belongs to the name
+		return trimmed, ""
+	}
+
+	return strings.Join(parts[:len(parts)-1], "-"), last
+}

--- a/providers/os/resources/languages/python/wheelegg/name_test.go
+++ b/providers/os/resources/languages/python/wheelegg/name_test.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package wheelegg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDistInfoName(t *testing.T) {
+	tests := []struct {
+		entry       string
+		wantName    string
+		wantVersion string
+	}{
+		{"requests-2.32.3.dist-info", "requests", "2.32.3"},
+		{"litellm-1.80.15.dist-info", "litellm", "1.80.15"},
+		// installed metadata records the normalized name, underscores and all
+		{"python_ftp_server-1.3.17.dist-info", "python_ftp_server", "1.3.17"},
+		// hyphens are legal inside a project name; only the last part is a version
+		{"typing-extensions-4.12.2.dist-info", "typing-extensions", "4.12.2"},
+		// calendar versioning
+		{"certifi-2026.7.22.dist-info", "certifi", "2026.7.22"},
+		// egg-info carries an interpreter tag after the version
+		{"python_dateutil-2.6.1-py3.6.egg-info", "python_dateutil", "2.6.1"},
+		{"six-1.11.0-py2.7.egg-info", "six", "1.11.0"},
+		// no version part at all
+		{"mypackage.egg-info", "mypackage", ""},
+		{"setuptools.dist-info", "setuptools", ""},
+		// a hyphen with no version after it belongs to the name
+		{"my-package.egg-info", "my-package", ""},
+		// nothing usable
+		{"", "", ""},
+		{".dist-info", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.entry, func(t *testing.T) {
+			name, version := ParseDistInfoName(tc.entry)
+			assert.Equal(t, tc.wantName, name, "name")
+			assert.Equal(t, tc.wantVersion, version, "version")
+		})
+	}
+}

--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -106,6 +106,12 @@ func initPython(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 }
 
 func (r *mqlPython) id() (string, error) {
+	// The path has to be part of the ID. Without it every python(path: ...)
+	// shares one cache key, so the first one scanned wins and every later
+	// lookup -- with a completely different path -- gets handed its packages.
+	if r.Path.Data != "" {
+		return "python/" + r.Path.Data, nil
+	}
 	return "python", nil
 }
 
@@ -216,11 +222,23 @@ func pythonPackageDetailsWithDependenciesToResource(
 func collectPythonPackagesInPaths(runtime *plugin.Runtime, fs afero.Fs, paths []string) ([]python.PackageDetails, error) {
 	allResults := []python.PackageDetails{}
 
+	// The default paths overlap: /opt/homebrew/lib/python3.11 is matched by both
+	// "/opt/*/lib/python*" and "/opt/homebrew/lib/python*". Without this set the
+	// directory is scanned once per matching pattern and every package inside it
+	// is reported that many times, which inflates the inventory and emits one
+	// duplicate SBOM entry and vulnerability finding per extra match.
+	seen := map[string]struct{}{}
+
 	err := fsutil.WalkGlob(fs, paths, func(fs afero.Fs, walkPath string) error {
 		log.Debug().Str("filepath", walkPath).Msg("found matching python path")
 		packageDirs := []string{"site-packages", "dist-packages"}
 		for _, packageDir := range packageDirs {
 			pythonPackageDir := filepath.Join(walkPath, packageDir)
+			if _, ok := seen[pythonPackageDir]; ok {
+				continue
+			}
+			seen[pythonPackageDir] = struct{}{}
+
 			results, err := collectPythonPackages(runtime, fs, pythonPackageDir)
 			if err != nil {
 				// Skip this directory rather than abandoning the whole search.
@@ -302,8 +320,15 @@ func collectPythonPackages(runtime *plugin.Runtime, fs afero.Fs, path string) ([
 				}
 			}
 			if !foundMeta {
-				// nothing to process (happens when we've traversed a directory
-				// containing the actual python source files)
+				// A .dist-info / .egg-info directory with no METADATA or PKG-INFO
+				// is an incomplete install: the metadata was removed in a later
+				// container image layer, or the install was interrupted. The
+				// directory name still identifies the package, so report it from
+				// that rather than dropping it from the inventory.
+				if ppd := pythonPackageFromDirName(dEntry.Name(), filepath.Join(path, dEntry.Name())); ppd != nil {
+					ppd.IsLeaf = requestedPackage
+					allResults = append(allResults, *ppd)
+				}
 				continue
 			}
 		}
@@ -323,8 +348,13 @@ func collectPythonPackages(runtime *plugin.Runtime, fs afero.Fs, path string) ([
 			return nil, content.Error
 		}
 		ppd, err := wheelegg.ParseMIME(strings.NewReader(content.Data), pythonPackageFilepath)
-		if err != nil {
-			continue
+		if err != nil || ppd.Name == "" {
+			// Unparsable or nameless metadata -- fall back to the identity in the
+			// directory name so a corrupt file does not erase the package.
+			ppd = pythonPackageFromDirName(dEntry.Name(), filepath.Join(path, dEntry.Name()))
+			if ppd == nil {
+				continue
+			}
 		}
 		ppd.IsLeaf = requestedPackage
 
@@ -391,8 +421,40 @@ func newMqlPythonPackage(runtime *plugin.Runtime, ppd python.PackageDetails) (pl
 		log.Error().AnErr("err", err).Msg("error while creating MQL resource")
 		return nil, err
 	}
-	r.(*mqlPythonPackage).deps = ppd.Dependencies
+	pkg := r.(*mqlPythonPackage)
+	pkg.deps = ppd.Dependencies
+	pkg.siteDir = pythonPackageSiteDir(ppd.File)
 	return r, nil
+}
+
+// pythonPackageFromDirName builds package details from a ".dist-info" /
+// ".egg-info" entry name when its metadata file cannot be read. It returns nil
+// when the name carries no usable identity.
+func pythonPackageFromDirName(entry string, file string) *python.PackageDetails {
+	name, version := wheelegg.ParseDistInfoName(entry)
+	if name == "" {
+		return nil
+	}
+	return &python.PackageDetails{
+		Name:    name,
+		Version: version,
+		File:    file,
+		Purl:    python.NewPackageUrl(name, version),
+		Cpes:    python.NewCpes(name, version),
+	}
+}
+
+// pythonPackageSiteDir returns the directory a package was installed into, so
+// dependencies can be resolved among its siblings. For an installed package the
+// metadata path is "<site>/<name>.dist-info/METADATA", so the site directory is
+// two levels up; for a bare ".egg-info" file, and for packages read out of a
+// manifest such as requirements.txt, it is the file's own directory.
+func pythonPackageSiteDir(file string) string {
+	dir := filepath.Dir(file)
+	if base := filepath.Base(dir); strings.HasSuffix(base, ".dist-info") || strings.HasSuffix(base, ".egg-info") {
+		return filepath.Dir(dir)
+	}
+	return dir
 }
 
 func (r *mqlPythonPackage) id() (string, error) {
@@ -435,6 +497,9 @@ func initPythonPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 
 type mqlPythonPackageInternal struct {
 	deps []string
+	// siteDir is the directory this package was installed into. Dependencies are
+	// resolved among its siblings only -- see dependencies().
+	siteDir string
 }
 
 func (r *mqlPythonPackage) dependencies() ([]any, error) {
@@ -448,13 +513,21 @@ func (r *mqlPythonPackage) dependencies() ([]any, error) {
 		return nil, pkgs.Error
 	}
 
+	// A dependency has to be resolved within the environment that declares it. An
+	// asset commonly carries the same package in several environments -- a venv
+	// per application, one site-packages per interpreter version -- and matching
+	// on name alone returns every one of them. That both inflates the list and
+	// silently answers questions about the wrong environment: a check asserting
+	// "this app pulls in a patched certifi" would pass on some other venv's copy.
 	deps := []any{}
 	for _, dep := range r.deps {
-		for i, pyPkgDetails := range pkgs.Data {
-			if pyPkgDetails.(*mqlPythonPackage).Name.Data == dep {
-				depRes := pkgs.Data[i]
-				deps = append(deps, depRes)
+		for i := range pkgs.Data {
+			candidate := pkgs.Data[i].(*mqlPythonPackage)
+			if candidate.Name.Data != dep || candidate.siteDir != r.siteDir {
+				continue
 			}
+			deps = append(deps, pkgs.Data[i])
+			break
 		}
 	}
 	return deps, nil
@@ -596,14 +669,17 @@ func mergePythonPackages(primary, secondary []python.PackageDetails) []python.Pa
 	if len(secondary) == 0 {
 		return primary
 	}
+	// Compare normalized names: installed metadata and manifests spell the same
+	// project differently ("ruamel.yaml" vs "ruamel-yaml"), so a plain lowercase
+	// key reports one project twice.
 	seen := make(map[string]bool, len(primary))
 	for _, p := range primary {
-		seen[strings.ToLower(p.Name)] = true
+		seen[python.NormalizeName(p.Name)] = true
 	}
 	for _, p := range secondary {
-		if !seen[strings.ToLower(p.Name)] {
+		if !seen[python.NormalizeName(p.Name)] {
 			primary = append(primary, p)
-			seen[strings.ToLower(p.Name)] = true
+			seen[python.NormalizeName(p.Name)] = true
 		}
 	}
 	return primary

--- a/providers/os/resources/python_dedup_internal_test.go
+++ b/providers/os/resources/python_dedup_internal_test.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The default paths overlap by design -- a specific pattern such as
+// "/opt/homebrew/lib/python*" sits alongside the general "/opt/*/lib/python*"
+// that also matches it. Every directory must still be scanned exactly once.
+//
+// Regression test for an inventory that was roughly half duplicates: on a macOS
+// host python.packages returned 1085 entries for 546 distinct packages, because
+// each site-packages directory was collected once per matching pattern. Every
+// extra copy became another SBOM entry and another vulnerability finding for a
+// package that is installed only once.
+//
+// These dist-info directories deliberately carry no METADATA, so the packages
+// resolve through the directory-name fallback and the test needs no plugin
+// runtime.
+func TestCollectPythonPackagesInPaths_DeduplicatesOverlappingGlobMatches(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	const siteDir = "/opt/homebrew/lib/python3.11/site-packages"
+	require.NoError(t, fs.MkdirAll(siteDir+"/requests-2.32.3.dist-info", 0o755))
+
+	// precondition: more than one pattern resolves to this directory, which is
+	// what made the duplication possible
+	matches := 0
+	for _, walkPath := range walkedPaths(t, fs) {
+		if walkPath == "/opt/homebrew/lib/python3.11" {
+			matches++
+		}
+	}
+	require.Greater(t, matches, 1, "precondition: the directory must be matched by several patterns")
+
+	results, err := collectPythonPackagesInPaths(nil, fs, defaultPythonPaths)
+	require.NoError(t, err)
+
+	require.Len(t, results, 1, "a directory matched by several patterns must be collected once")
+	assert.Equal(t, "requests", results[0].Name)
+	assert.Equal(t, "2.32.3", results[0].Version)
+}
+
+// An install whose metadata cannot be read still has its identity in the
+// directory name. Dropping it loses a package that is genuinely present -- a
+// silent gap in the inventory rather than a visible error.
+func TestCollectPythonPackages_FallsBackToDistInfoDirName(t *testing.T) {
+	const siteDir = "/usr/lib/python3.13/site-packages"
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(siteDir+"/litellm-1.80.15.dist-info", 0o755))
+
+	results, err := collectPythonPackages(nil, fs, siteDir)
+	require.NoError(t, err)
+
+	require.Len(t, results, 1, "a dist-info without METADATA must still be reported")
+	assert.Equal(t, "litellm", results[0].Name)
+	assert.Equal(t, "1.80.15", results[0].Version)
+	assert.Equal(t, "pkg:pypi/litellm@1.80.15", results[0].Purl)
+	assert.Equal(t, siteDir+"/litellm-1.80.15.dist-info", results[0].File,
+		"the file must point at the directory the identity came from")
+}
+
+// A dist-info directory whose name carries no version must not be turned into a
+// package with a garbage version.
+func TestCollectPythonPackages_DirNameFallbackWithoutVersion(t *testing.T) {
+	const siteDir = "/usr/lib/python3.13/site-packages"
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(siteDir+"/mypackage.egg-info", 0o755))
+
+	results, err := collectPythonPackages(nil, fs, siteDir)
+	require.NoError(t, err)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "mypackage", results[0].Name)
+	assert.Empty(t, results[0].Version)
+}
+
+// Dependencies resolve among the siblings in the environment that declares them,
+// so every package has to know which directory it was installed into.
+func TestPythonPackageSiteDir(t *testing.T) {
+	tests := []struct {
+		name string
+		file string
+		want string
+	}{
+		{
+			"dist-info metadata",
+			"/usr/lib/python3.13/site-packages/requests-2.32.3.dist-info/METADATA",
+			"/usr/lib/python3.13/site-packages",
+		},
+		{
+			"egg-info pkg-info",
+			"/usr/lib/python3.6/site-packages/python_dateutil-2.6.1-py3.6.egg-info/PKG-INFO",
+			"/usr/lib/python3.6/site-packages",
+		},
+		{
+			// the directory-name fallback records the dist-info directory itself
+			"dist-info directory",
+			"/usr/lib/python3.13/site-packages/litellm-1.80.15.dist-info",
+			"/usr/lib/python3.13/site-packages",
+		},
+		{
+			// a bare .egg-info file sits directly in the site directory
+			"egg-info file",
+			"/usr/lib/python3.11/site-packages/setuptools.egg-info",
+			"/usr/lib/python3.11/site-packages",
+		},
+		{
+			// packages read out of a manifest belong to the manifest's directory
+			"requirements manifest",
+			"/srv/app/requirements.txt",
+			"/srv/app",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pythonPackageSiteDir(tc.file))
+		})
+	}
+}


### PR DESCRIPTION
An audit of `python.packages` against the filesystem found the resource was reporting the same package many times and resolving dependencies from the wrong environment. On a macOS host it returned **1085 entries for 546 distinct packages**.

## What's fixed

**Duplicate packages.** The default paths overlap by design — `/opt/homebrew/lib/python*` sits alongside the general `/opt/*/lib/python*` that also matches it — and each matching pattern scanned the directory again, so every package inside it was reported once per match. Each extra copy became another SBOM entry and another vulnerability finding for a package installed only once.

```
$ mql run local -c 'python.packages.where(name == "urllib3") { id }'
   .../python3.11/site-packages/urllib3-2.4.0.dist-info/METADATA
   .../python3.11/site-packages/urllib3-2.4.0.dist-info/METADATA   ← same id, twice
```

**Dependencies resolved from the wrong environment.** An asset commonly carries the same package in several environments — a venv per application, one site-packages per interpreter version — and matching on name alone returned all of them:

```
$ mql run local -c 'python.packages.where(name == "requests") { dependencies { id } }'
requests deps: 14        ← should be 4
   .../python3.11/site-packages/certifi-2025.4.26.dist-info/METADATA
   .../python3.12/site-packages/certifi-2026.7.22.dist-info/METADATA   ← wrong environment
   .../python3.13/site-packages/certifi-2026.7.22.dist-info/METADATA   ← wrong environment
   .../python3.14/site-packages/certifi-2026.7.22.dist-info/METADATA   ← wrong environment
```

Beyond the inflated list this silently answered questions about the wrong environment: a check asserting "this app pulls in a patched certifi" could pass on some other venv's copy.

**`python(path:)` cache collisions.** `id()` returned the constant `"python"`, so every `python(path: ...)` shared one cache key — the first path scanned won and every later lookup, with a completely different path, was handed its packages. Now follows the existing precedent in `conda.go`.

**Packages dropped when metadata is unreadable.** A `.dist-info` whose METADATA was removed in a later container image layer, or whose install was interrupted, was dropped entirely. The directory name still carries the identity, so it is reported from that instead — a silent gap in the inventory became a visible package.

## Package URL change ⚠️

Names are now compared using [PEP 503 normalization](https://packaging.python.org/en/latest/specifications/name-normalization/), so `-`, `_` and `.` are treated as equivalent separators. `zope.interface` previously emitted `pkg:pypi/zope.interface`, which does not resolve against vulnerability data; it now emits `pkg:pypi/zope-interface`.

**This changes purl output for names containing dots**, which moves SBOM content for those packages. It is a correction toward the purl spec and the reason those packages never matched vulnerability data, but it is worth knowing about before this lands.

## Verification

On a live host:

| | before | after |
|---|---|---|
| `python.packages` entries | 1085 | **548** |
| duplicates | 539 | **0** |
| `requests.dependencies` | 14, across 4 interpreter versions | **4**, all one site directory |
| packages recovered from unreadable metadata | — | **3** |

The three recoveries are genuine: `wheel-0.45.1.dist-info` has `RECORD` and `direct_url.json` but no `METADATA`, and the `rpm` egg-info is a symlink whose content does not parse as MIME.

Two different paths in one query now return 15 and 3 packages instead of both getting whichever resolved first.

## Tests

New coverage for the overlapping-glob dedup, the directory-name fallback (with and without a version), site-directory derivation, a 12-case table for `.dist-info` name parsing, an 11-case table for PEP 503 normalization, and dotted-name purl cases. Full `./resources/...` and `./sbom/...` suites pass; `golangci-lint` clean; no generated-file churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)