### PR TITLE
mssql: fix unusable --auth flag and report the instance's real listening port

### DIFF
--- a/providers/mssql/config/config.go
+++ b/providers/mssql/config/config.go
@@ -103,6 +103,11 @@ Examples:
 					Type:    plugin.FlagType_String,
 					Default: "sql",
 					Desc:    "Authentication mode: sql, windows, kerberos, or azure",
+					// Not persisted to the CLI config: cnquery's own config
+					// reserves the top-level `auth` key for an authentication
+					// map, and binding a string flag onto it makes every
+					// mssql invocation fail to load the config.
+					ConfigEntry: "-",
 				},
 				{
 					Long:    "encrypt",

--- a/providers/mssql/resources/mssql.lr
+++ b/providers/mssql/resources/mssql.lr
@@ -31,7 +31,12 @@ mssql.server @defaults("name version edition") {
   // Instance name, or MSSQLSERVER for the default instance
   instanceName string
   // TCP port the instance listens on
-  port int
+  //
+  // Read from sys.dm_exec_connections for the scanning session, so it is the
+  // port the instance actually accepts connections on rather than the port the
+  // scan dialed (they differ whenever a proxy or container port mapping sits in
+  // between). Falls back to the connection's port when the DMV is unavailable.
+  port() int
   // Full version banner from @@VERSION
   version string
   // Product version number, for example 16.0.1000.6

--- a/providers/mssql/resources/mssql.lr.go
+++ b/providers/mssql/resources/mssql.lr.go
@@ -1660,7 +1660,9 @@ func (c *mqlMssqlServer) GetInstanceName() *plugin.TValue[string] {
 }
 
 func (c *mqlMssqlServer) GetPort() *plugin.TValue[int64] {
-	return &c.Port
+	return plugin.GetOrCompute[int64](&c.Port, func() (int64, error) {
+		return c.port()
+	})
 }
 
 func (c *mqlMssqlServer) GetVersion() *plugin.TValue[string] {

--- a/providers/mssql/resources/server.go
+++ b/providers/mssql/resources/server.go
@@ -58,7 +58,6 @@ func initMssqlServer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	args["name"] = llx.StringData(name.String)
 	args["machineName"] = llx.StringData(machine.String)
 	args["instanceName"] = llx.StringData(instanceName)
-	args["port"] = llx.IntData(int64(conn.Port()))
 	args["version"] = llx.StringData(version.String)
 	args["productVersion"] = llx.StringData(productVersion.String)
 	args["productLevel"] = llx.StringData(productLevel.String)
@@ -72,6 +71,28 @@ func initMssqlServer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 
 func (c *mqlMssqlServer) instanceID() string {
 	return mssqlConnection(c.MqlRuntime).InstanceID()
+}
+
+// port reports the TCP port the instance is listening on, taken from the
+// scanning session's own row in sys.dm_exec_connections. A session always sees
+// its own connection, so no VIEW SERVER STATE is required. The port the scan
+// dialed is only a fallback: it is the wrong answer whenever a port mapping or
+// proxy sits in front of the instance, which is exactly the case the
+// non-standard-port audit needs to get right.
+func (c *mqlMssqlServer) port() (int64, error) {
+	fallback := int64(mssqlConnection(c.MqlRuntime).Port())
+
+	client, err := mssqlClient(c.MqlRuntime)
+	if err != nil {
+		return fallback, nil
+	}
+	const q = `SELECT local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID`
+	var v sql.NullInt64
+	if err := client.QueryRowContext(mssqlContext(), q).Scan(&v); err != nil || !v.Valid || v.Int64 == 0 {
+		// Shared memory and named-pipe sessions report no TCP port.
+		return fallback, nil
+	}
+	return v.Int64, nil
 }
 
 // --- registry-backed fields -------------------------------------------------


### PR DESCRIPTION
Two fixes found while writing hardening policies against this provider. Both are independent of that work.

## 1. The provider could not be used at all

Every `mssql` invocation failed before connecting:

```
failed to load config ... 'auth' expected a map or struct
```

cnquery's own CLI config reserves the top-level `auth` key for an authentication *map*, and viper-binding the string `--auth` flag onto it collides with that. The flag is now marked `ConfigEntry: "-"` so it is not persisted to the CLI config — the same mechanism already used for `password`, `ask-pass` and `token`.

## 2. `mssql.server.port` reported the wrong port

It echoed the **client side** of the connection rather than the port the instance listens on. Behind any port mapping or proxy the value was meaningless — scanning a container published on 55450 reported `55450` for an instance listening on `1433`.

That makes the "SQL Server is configured to use non-standard ports" control unassessable, since the check compares against 1433.

`port` is now a lazy field reading `local_tcp_port` from `sys.dm_exec_connections` for the scanning session, falling back to the dialed port. A session always sees its own connection row, so this needs **no** `VIEW SERVER STATE` permission.

## Verification

Built and verified against a live SQL Server 2019 instance. With both fixes the provider drives the full SQL Server 2019 hardening policy: all 37 automated controls implemented, 28 asserted in both directions against hardened and deliberately-insecure fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
