### PR TITLE
🐛 weaviate: skip 32-bit release targets its dependency can't build

### DIFF
--- a/providers/weaviate/.build-skip
+++ b/providers/weaviate/.build-skip
@@ -1,0 +1,6 @@
+# The weaviate dependency (github.com/weaviate/weaviate) uses a constant that
+# assumes a 64-bit int (math.MaxInt64) and fails to compile on 32-bit targets:
+#   entities/vectorindex/common/config.go:67: constant 9223372036854775807 overflows int
+# Weaviate Cloud has no 32-bit clients, so skip those targets for this provider.
+linux 386
+linux arm 7

--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -118,6 +118,36 @@ BUILDS=(
   "windows arm64"
 )
 
+# A provider may drop build targets its dependencies cannot compile for (for
+# example a dependency that assumes a 64-bit int fails to build on 32-bit
+# targets). List one "GOOS GOARCH [GOARM]" target per line, matching the entries
+# above, in providers/<name>/.build-skip. Blank lines and # comments are ignored.
+SKIP_FILE="${PROVIDER_PATH}/.build-skip"
+if [ -f "$SKIP_FILE" ]; then
+  FILTERED=()
+  for build in "${BUILDS[@]}"; do
+    keep=1
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line%%#*}"
+      # Trim leading and trailing whitespace in pure bash (no subshell, no glob
+      # expansion of * or ? that xargs would perform).
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      [ -z "$line" ] && continue
+      if [ "$build" = "$line" ]; then
+        keep=0
+        break
+      fi
+    done < "$SKIP_FILE"
+    if [ "$keep" -eq 1 ]; then
+      FILTERED+=("$build")
+    else
+      echo "  - Skipping ${build} for ${PROVIDER_NAME} (listed in .build-skip)"
+    fi
+  done
+  BUILDS=("${FILTERED[@]}")
+fi
+
 echo "  - Building ${#BUILDS[@]} architecture targets (max parallel: ${MAX_PARALLEL})..."
 
 # Kill all background build processes on interrupt/termination


### PR DESCRIPTION
## Problem

The **Build & Release Providers** pipeline started failing on `weaviate` ([run](https://github.com/mondoohq/mql/actions/runs/31318646109)) — it was swept into a rebuild by a shared-file change and failed on the 32-bit targets:

```
github.com/weaviate/weaviate@v1.38.9/entities/vectorindex/common/config.go:67:14:
  constant 9223372036854775807 overflows int
```

That constant is `math.MaxInt64`, which the dependency uses as an `int`. On 32-bit targets (`linux/386`, `linux/arm/7`) `int` is 32-bit, so it overflows and the build fails. It's in a third-party dependency, so we can't fix the constant.

## Fix

Add a small **per-provider `.build-skip`** mechanism to `scripts/provider_bundler.sh`: a provider lists `GOOS GOARCH [GOARM]` targets (one per line) that its dependencies can't compile for, and the bundler drops them from the build matrix (blank lines and `#` comments ignored).

`providers/weaviate/.build-skip` skips the two 32-bit targets. Weaviate Cloud has no 32-bit clients, so this loses nothing real.

## Verified

- `CGO_ENABLED=0 GOOS=linux GOARCH=386 go build` on weaviate → reproduces the overflow.
- `GOOS=linux GOARCH=amd64` → builds fine.
- The `.build-skip` filter removes exactly `linux 386` and `linux arm 7`, leaving the 8 remaining (all 64-bit) targets, which build.

This should be merged before further `defaults.go`-touching provider PRs land, since those re-sweep weaviate into the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)