### PR TITLE
🐛 okta: fix build — roleTargets used removed ApiExtension.Token field

### DIFF
--- a/providers/okta/resources/roleTargets.go
+++ b/providers/okta/resources/roleTargets.go
@@ -11,7 +11,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
-	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
 
 // Administrator role assignments can be narrowed to a set of groups or
@@ -60,7 +59,7 @@ func (o *mqlOktaRole) groupTargets() ([]any, error) {
 		}
 
 	case o.cacheClientID != "":
-		apiSupplement := &sdk.ApiExtension{Host: conn.OrganizationID(), Token: conn.Token()}
+		apiSupplement := conn.ApiExtension()
 		slice, resp, err := apiSupplement.ListClientRoleGroupTargets(ctx, o.cacheClientID, roleID)
 		if err != nil {
 			if isOktaRawFeatureUnavailable(resp) {
@@ -125,7 +124,7 @@ func (o *mqlOktaRole) appTargets() ([]any, error) {
 		}
 
 	case o.cacheClientID != "":
-		apiSupplement := &sdk.ApiExtension{Host: conn.OrganizationID(), Token: conn.Token()}
+		apiSupplement := conn.ApiExtension()
 		slice, resp, err := apiSupplement.ListClientRoleAppTargets(ctx, o.cacheClientID, roleID)
 		if err != nil {
 			if isOktaRawFeatureUnavailable(resp) {


### PR DESCRIPTION
## Problem

`providers/okta` fails to build on main, which fails the **generated-files** CI check on every PR (it builds all providers):

```
resources/roleTargets.go:63:67: unknown field Token in struct literal of type
  "go.mondoo.com/mql/v13/providers/okta/resources/sdk".ApiExtension
resources/roleTargets.go:128:67: ... (same)
make: *** [providers/build/okta] Error 1
```

`sdk.ApiExtension` was refactored from a `Token string` field to an `Authorize func(*http.Request) error` (so the raw path authenticates the same way the generated SDK does — SSWS token *or* private-key JWT), and the connection now builds the extension once as `conn.ApiExtension()`. `roleTargets.go` was missed — it still constructed `&sdk.ApiExtension{Host: ..., Token: conn.Token()}`.

## Fix

Reuse `conn.ApiExtension()` in both branches (matching how the rest of the provider makes raw API calls), and drop the now-unused `sdk` import. Verified `providers/okta` builds `CGO_ENABLED=0` and `go vet` is clean.

This unblocks `generated-files` for open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)