### PR TITLE
🐛 datadog: regenerate resources so integration ids are computed

### DIFF
--- a/providers/datadog/resources/datadog.lr.go
+++ b/providers/datadog/resources/datadog.lr.go
@@ -7132,7 +7132,12 @@ func createDatadogIntegrationGcp(runtime *plugin.Runtime, args map[string]*llx.R
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("datadog.integration.gcp", res.__id)
@@ -7336,7 +7341,12 @@ func createDatadogIntegrationOkta(runtime *plugin.Runtime, args map[string]*llx.
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("datadog.integration.okta", res.__id)
@@ -7400,7 +7410,12 @@ func createDatadogIntegrationCloudflare(runtime *plugin.Runtime, args map[string
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("datadog.integration.cloudflare", res.__id)
@@ -7462,7 +7477,12 @@ func createDatadogIntegrationFastly(runtime *plugin.Runtime, args map[string]*ll
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("datadog.integration.fastly", res.__id)
@@ -7516,7 +7536,12 @@ func createDatadogIntegrationConfluent(runtime *plugin.Runtime, args map[string]
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("datadog.integration.confluent", res.__id)


### PR DESCRIPTION
Five `datadog.integration.*` resources gained an `id()` method without `datadog.lr.go` being regenerated. Their creators still carry the

```go
// to override __id implement: id() (string, error)
```

placeholder instead of the generated call, so `__id` is never computed for `datadog.integration.gcp`, `okta`, `cloudflare`, `fastly`, and `confluent`.

An empty `__id` is not inert. The runtime keys the resource cache on `resourceName + "\x00" + __id`, so all five collide on `<resource>\x00""` and a lookup returns whichever instance landed in the cache first rather than the one that was asked for.

Regenerating with `mqlr` emits the `id()` call for all five. The diff is entirely the generated `__id` block, and a repeat run is idempotent.

This also unblocks CI: `generated-files` currently fails on every open PR because the committed file does not match what `mqlr` produces from the current generator, and the diff it reports is this one.

## Verification

- `./mqlr generate providers/datadog/resources/datadog.lr --dist providers/datadog/resources` produces exactly this diff, and re-running it produces no further change
- `go build ./...` and `go test ./...` pass in `providers/datadog`
