### PR TITLE
🎉 aws-13.53.0, gcp-13.35.0, azure-13.34.0, oci-13.18.0, proxmox-0.4.0, alicloud-13.3.0, digitalocean-13.15.0, openstack-13.8.0

### DIFF
--- a/providers/alicloud/config/config.go
+++ b/providers/alicloud/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "alicloud",
 	ID:              "go.mondoo.com/mql/providers/alicloud",
-	Version:         "13.2.4",
+	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.52.1",
+	Version:         "13.53.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.33.7",
+	Version:   "13.34.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.14.4",
+	Version:         "13.15.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.34.1",
+	Version: "13.35.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.17.1",
+	Version:         "13.18.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.7.5",
+	Version:         "13.8.0",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
-	Version:         "0.3.5",
+	Version:         "0.4.0",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor release for eight providers. Everything below landed since the last release ([a94aa193e](https://github.com/mondoohq/mql/commit/a94aa193e), 2026-08-03).

| Provider | From | To |
| --- | --- | --- |
| aws | 13.52.1 | **13.53.0** |
| gcp | 13.34.1 | **13.35.0** |
| azure | 13.33.7 | **13.34.0** |
| oci | 13.17.1 | **13.18.0** |
| proxmox | 0.3.5 | **0.4.0** |
| alicloud | 13.2.4 | **13.3.0** |
| digitalocean | 13.14.4 | **13.15.0** |
| openstack | 13.7.5 | **13.8.0** |

### aws (13.53.0)

Features
- ✨ expose IAM inline policy documents (#9550)
- ✨ expose IAM service last-accessed and unused-access findings (#9551)
- ✨ add `aws.detectionCoverage` per-region roll-up (#9554)
- ✨ add RDS pending maintenance and recommendations (#9549)
- ✨ resolve subnet internet reachability and transit gateway routes (#9557)
- ✨ evaluate effective inbound reachability across security groups and network ACLs (#9562)
- ✨ flag unrestricted VPC endpoint policies, type endpoint subnets (#9563)
- ✨ extend `exposure()` to EKS, ECS services, App Runner, and SageMaker notebooks (#9565)
- ✨ add Global Accelerator and Direct Connect (#9571)
- ✨ add VPC Lattice service networks, services, and target groups (#9579)
- ✨ model new SDK capabilities across six services (#9586)
- ✨ expose ASG operator, AgentCore rate limits and capacity providers, and Backup access points (#9620)
- 🌟 type the security group references on a rule (#9640)

Fixes and docs
- 🐛 populate `aws.organization` and stop Shared VPC erroring on non-hosts (#9602)
- 🐛 correct `serviceLastAccessed` entity field docs (#9555)
- 📄 add `InfrastructureHealth` to ecs task `stopCode` values (#9572)

### gcp (13.35.0)

Features
- 🌟 expose effective IAM access, effective org policy, and usage insights (#9566)
- 🌟 expose Shared VPC, hierarchical firewall policies, and connectivity fabric (#9568)
- 🌟 key firewall ports by protocol and give the network its rules (#9636)

Fixes
- 🐛 fix fabricated-absence bugs that make posture checks pass vacuously (#9604)
- 🐛 fix fields that return wrong or mis-encoded values (#9607)
- 🐛 fix cache-key collisions, discarded partial results, and hard-failing listers (#9611)
- 🐛 keep partial results when a listing is truncated mid-pagination (#9584)
- 🐛 populate `aws.organization` and stop Shared VPC erroring on non-hosts (#9602)

### azure (13.34.0)

Features
- ✨ resolve RBAC principals, model management groups and resource locks (#9559)
- ✨ expose WAF rule enforcement, gateway policy, and event destinations (#9570)
- ✨ bump Front Door and management groups SDKs to v2 and expose new WAF settings (#9593)
- 🌟 type the effective NSG rules and routes on a network interface (#9638)

Fixes
- 🐛 stop reporting fabricated and aliased data (#9605)
- 🐛 close failed-open gaps in the exposure verdicts (#9608)
- 🐛 stop truncating the hand-rolled ARM collections (#9617)
- 🐛 guard the derefs that crash a whole scan (#9616)

### oci (13.18.0)

Features
- ✨ expose Cloud Guard findings, audit events, and log export (#9573)
- ⭐ parse IAM policy statements into queryable parts (#9600)
- 🌟 type security rules and give the VCN its children (#9624)

Fixes
- 🐛 stop reporting fabricated data as fact (#9603)
- 🐛 stop DNS steering policies and dangling SCH buckets failing queries (#9667)
- 📄 reattach the `ociAnySubnetAdmitsInternet` doc comment (#9621)

Internals
- 🧹 build each service client once per region instead of per job (#9650)
- 🧹 make pagination a property of the call, not something each author remembers (#9655)
- 🧹 one fan-out, with the compartment scope named at the call site (#9659)
- 🧹 one registry row per discovery target instead of two switches (#9661)
- 🧹 one deferred-detail guard instead of 24 hand-rolled copies (#9663)
- 🧹 one spelling per cache field (#9665)
- 🧹 one typed-reference resolver (#9666)
- 🧹 stop hand-copying tag maps at every lister (#9677)
- 🧹 cache failed detail fetches and stop over-counting global DNS (#9609)

### proxmox (0.4.0)

- ⭐ add Ceph cluster resources (#9629)
- ⭐ add storage volumes and per-guest backup history (#9634)

### alicloud (13.3.0)

- 🌟 type the RAM identity graph (#9641)
- 🌟 ECS instance RAM role, metadata hardening, typed DB security groups (#9643)
- 🌟 add Cloud Enterprise Network and VPN gateway resources (#9647)
- 🌟 effective permissions and public-bucket verdicts (#9680)
- 🌟 user data and Auto Scaling launch configuration (#9684)
- 🧹 review follow-ups on the policy analysis fields (#9695)

### digitalocean (13.15.0)

- ✨ expose droplet automated-backup policy (#9581)
- ✨ reachability verdicts across the exposed surfaces (#9708)
- ⭐ data-plane authorization for managed database users (#9712)
- 🧹 honor `--filters` during discovery and listing (#9702)

### openstack (13.8.0)

- ⭐ model the federation, data-movement, and audit surfaces (#9687)
- 🐛 close three security blind spots in exposure and identity (#9682)
- 🟢 drop the key-shaped PEM block from the certificate test (#9694)

### Shared maintenance

Repo-wide changes that touched these providers:

- 🧹 deps: bump provider SDKs and refresh azure/gcp permission manifests (#9560)
- 🧹 Update deps for mql and providers (#9580, #9601, #9619, #9651)
- 📄 providers: standardize developer READMEs + scaffold template (#9614)
