### PR TITLE
🐛 mongodbatlas: stop reporting denied reads as empty lists

### DIFF
--- a/providers/mongodbatlas/resources/backup.go
+++ b/providers/mongodbatlas/resources/backup.go
@@ -165,10 +165,13 @@ func (r *mqlMongodbatlas) snapshotExportBuckets() ([]any, error) {
 	for page := 1; ; page++ {
 		resp, httpResp, err := client.CloudBackupsApi.ListExportBuckets(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
-			// A credential without the backup role cannot list export buckets;
-			// degrade to none configured rather than failing the whole query.
+			// An export bucket is a path for backup data to leave Atlas, so an
+			// empty list is read as "no such path exists". A credential without
+			// the backup role has not established that, and must not assert it;
+			// render null instead of failing the whole query.
 			if isAccessDenied(httpResp) {
-				return []any{}, nil
+				r.SnapshotExportBuckets.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
 			}
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/cluster.go
+++ b/providers/mongodbatlas/resources/cluster.go
@@ -32,6 +32,12 @@ func newMqlMongodbatlasCluster(runtime *plugin.Runtime, pid string, c admin.Clus
 				"regionName":   rc.GetRegionName(),
 				"priority":     int64(rc.GetPriority()),
 			}
+			// A shared tier deployment reports providerName as TENANT and names
+			// the cloud actually hosting it here, so without this the hosting
+			// cloud of every shared cluster is unreadable.
+			if backing := rc.GetBackingProviderName(); backing != "" {
+				entry["backingProviderName"] = backing
+			}
 			if es, ok := rc.GetElectableSpecsOk(); ok {
 				entry["instanceSize"] = es.GetInstanceSize()
 				entry["nodeCount"] = int64(es.GetNodeCount())

--- a/providers/mongodbatlas/resources/flex.go
+++ b/providers/mongodbatlas/resources/flex.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
 
@@ -26,8 +27,14 @@ func (r *mqlMongodbatlas) flexClusters() ([]any, error) {
 	for page := 1; ; page++ {
 		resp, httpResp, err := client.FlexClustersApi.ListFlexClusters(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
+			// Flex deployments are invisible in the clusters listing, so this
+			// call is the only thing that reports them. A credential that may
+			// not read it has established nothing, and an empty list would put
+			// the project back to looking Flex-free, which is the exact blind
+			// spot this accessor exists to close. Render null instead.
 			if isAccessDenied(httpResp) {
-				return []any{}, nil
+				r.FlexClusters.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
 			}
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/mongodbatlas.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.go
@@ -21,9 +21,10 @@ type mqlMongodbatlasInternal struct {
 	orgSettingsDone bool
 	orgSettings     *admin.OrganizationSettings
 
-	teamsOnce sync.Once
-	teamsByID map[string]admin.TeamResponse
-	teamsErr  error
+	teamsOnce   sync.Once
+	teamsByID   map[string]admin.TeamResponse
+	teamsErr    error
+	teamsDenied bool
 
 	clustersOnce   sync.Once
 	clustersByName map[string]*mqlMongodbatlasCluster

--- a/providers/mongodbatlas/resources/mongodbatlas.lr
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr
@@ -267,7 +267,12 @@ mongodbatlas.cluster @defaults("name mongoDBMajorVersion encryptionAtRestProvide
   rootCertType string
   // Time the cluster was created
   createDate time
-  // Per-region configuration, each with providerName, regionName, instanceSize, nodeCount, diskSizeGB, and priority
+  // Per-region configuration
+  //
+  // Each entry carries providerName, regionName, instanceSize, nodeCount,
+  // diskSizeGB, and priority. A shared tier deployment reports a providerName
+  // of TENANT and adds backingProviderName naming the cloud that actually
+  // hosts it.
   regionConfigs []dict
   // Resource tags applied to the cluster
   tags map[string]string
@@ -291,13 +296,21 @@ mongodbatlas.cluster @defaults("name mongoDBMajorVersion encryptionAtRestProvide
   employeeAccessGrantType string
   // Time the MongoDB employee access grant expires, null when no grant is active
   employeeAccessGrantExpiration time
-  // Feature compatibility version the cluster is pinned to, null when not pinned
+  // Feature compatibility version in effect for the cluster
+  //
+  // The version whose features the cluster accepts, which lags the running
+  // MongoDB version while an upgrade is being validated. Pinning it to an
+  // older version holds back new features, and only a pinned version carries a
+  // featureCompatibilityVersionExpirationDate.
   featureCompatibilityVersion string
-  // Time the pinned feature compatibility version expires, null when not pinned
+  // Time the pinned feature compatibility version expires, null when the version is not pinned
   featureCompatibilityVersionExpirationDate time
   // Whether the BI Connector for Atlas is enabled
   biConnectorEnabled bool
-  // Nodes the BI Connector reads from (PRIMARY, SECONDARY, or ANALYTICS), null when the BI Connector is disabled
+  // Nodes the BI Connector reads from (PRIMARY, SECONDARY, or ANALYTICS)
+  //
+  // Atlas reports the configured preference whether or not the BI Connector is
+  // enabled, so read biConnectorEnabled to tell whether it is in effect.
   biConnectorReadPreference string
   // Config server management for a sharded cluster (ATLAS_MANAGED or FIXED_TO_DEDICATED), null for a replica set
   configServerManagementMode string

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -210,10 +210,12 @@ func (r *mqlMongodbatlas) orgTeamsByID() (map[string]admin.TeamResponse, error) 
 			resp, httpResp, err := client.TeamsApi.ListOrganizationTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
 			if err != nil {
 				// A project-scoped credential without org privilege cannot list
-				// teams; degrade to no resolvable teams rather than failing every
-				// user's teams() through the cached error.
+				// teams; record the denial rather than failing every user's
+				// teams() through the cached error. Callers render null, since
+				// no team could be resolved rather than none being held.
 				if isAccessDenied(httpResp) {
 					r.teamsByID = map[string]admin.TeamResponse{}
+					r.teamsDenied = true
 					return
 				}
 				r.teamsErr = err
@@ -241,6 +243,13 @@ func (r *mqlMongodbatlasOrgUser) teams() ([]any, error) {
 	teamsByID, err := root.orgTeamsByID()
 	if err != nil {
 		return nil, err
+	}
+	// The team listing was denied, so the member's memberships could not be
+	// resolved. Reporting an empty list here would read as "belongs to no
+	// team", which is a different and unverified claim.
+	if root.teamsDenied {
+		r.Teams.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	out := []any{}

--- a/providers/mongodbatlas/resources/resource_policies.go
+++ b/providers/mongodbatlas/resources/resource_policies.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
 
@@ -18,11 +19,17 @@ func (r *mqlMongodbatlas) resourcePolicies() ([]any, error) {
 	}
 	policies, httpResp, err := atlasClient(r.MqlRuntime).ResourcePoliciesApi.ListOrgResourcePolicies(context.Background(), oid).Execute()
 	if err != nil {
-		// Resource policies are a feature-gated org capability; a credential
-		// without access or an org without the feature degrades to an empty
-		// list rather than failing the scan, matching the singleton settings.
-		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
+		// Resource policies are the org-wide guardrails, so an empty list says
+		// "nothing constrains this organization". A credential without access
+		// has not established that, and returning a nil slice would still
+		// render as empty, so the field is marked null explicitly.
+		if isAccessDenied(httpResp) {
+			r.ResourcePolicies.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
+		}
+		// An org without the feature genuinely has no policies.
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+			return []any{}, nil
 		}
 		return nil, err
 	}

--- a/providers/mongodbatlas/resources/search.go
+++ b/providers/mongodbatlas/resources/search.go
@@ -17,8 +17,7 @@ import (
 // searchIndexes lists the Atlas Search and Atlas Vector Search indexes defined
 // on the cluster. A single cluster-wide call returns every index across all
 // databases and collections, discriminated by the type field ("search" versus
-// "vectorSearch"). Search may be unavailable on some cluster tiers or states;
-// such responses degrade to an empty list rather than failing the scan.
+// "vectorSearch").
 func (c *mqlMongodbatlasCluster) searchIndexes() ([]any, error) {
 	pid, err := projectID(c.MqlRuntime)
 	if err != nil {
@@ -29,9 +28,17 @@ func (c *mqlMongodbatlasCluster) searchIndexes() ([]any, error) {
 	indexes, httpResp, err := atlasClient(c.MqlRuntime).AtlasSearchApi.
 		ListAtlasSearchIndexesCluster(context.Background(), pid, name).Execute()
 	if err != nil {
-		// Atlas Search is not available on every cluster tier or state; degrade
-		// to an empty list rather than failing the scan when it cannot be read.
-		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
+		// A credential that may not read the endpoint has not established
+		// anything about the cluster's indexes, so the field renders null. An
+		// empty list would assert the cluster has none, which is the claim a
+		// search-index audit reads and would wrongly pass on.
+		if isAccessDenied(httpResp) {
+			c.SearchIndexes.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// Atlas Search is not offered on every cluster tier or state. That
+		// genuinely answers the question with "no indexes", so it stays empty.
+		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
 			return []any{}, nil
 		}
 		return nil, err


### PR DESCRIPTION
Found while running the full `mongodbatlas` surface against a live Atlas
organization. Five list accessors turned an access-denied response into an empty
list.

An empty list is not a neutral answer. It asserts that the project has no search
indexes, no Flex deployments, no snapshot export buckets, no resource policies,
and that a member belongs to no team. A credential that was refused the read has
established none of that, so every audit over those lists passed vacuously and
nothing indicated the check had not actually run.

## Reproduced live

The verification organization's key is `ORG_READ_ONLY`, and Atlas answers the
search index endpoint with `401 USER_UNAUTHORIZED`:

```
GET /api/atlas/v2/groups/{id}/clusters/mql-test/search/indexes
-> HTTP 401 {"errorCode":"USER_UNAUTHORIZED"}
```

Before:

```
mongodbatlas.clusters { name searchIndexes }
  searchIndexes: []

mongodbatlas.clusters.all(searchIndexes.length == 0)   # passes, nothing was read
```

After:

```
  searchIndexes: null

mongodbatlas.clusters.all(searchIndexes.length == 0)   # fails, as it should
```

## Why the existing handling looked right but was not

Every singular accessor in this provider already marks its field null through
`StateIsSet | StateIsNull` on a denied read, and `organizationName` and the org
settings scalars do the same. Only the list accessors were missing it.

`resourcePolicies` looked handled because it returned `nil, nil`, but a nil slice
still renders as `[]` — `plugin.GetOrCompute` only preserves a null when the
accessor sets the state proactively. So it had the same bug in a shape that read
as if it did not.

## What changed

Access denied (401/403) and absence (404) are now distinguished:

| Accessor | 401/403 | 404 |
|---|---|---|
| `cluster.searchIndexes` | null | `[]` (tier does not offer Atlas Search) |
| `flexClusters` | null | n/a |
| `snapshotExportBuckets` | null | n/a |
| `resourcePolicies` | null | `[]` (org lacks the feature) |
| `orgUser.teams` | null | n/a |

Absence is a real answer and stays an empty list. Only "I was not allowed to
look" becomes null.

`flexClusters` mattered most here: that accessor exists because Flex deployments
are invisible in the clusters listing, and degrading a denied read to `[]` put
the project straight back to looking Flex-free.

## Also in this PR

`regionConfigs` dropped `backingProviderName`. Shared tier deployments report
`providerName` as `TENANT` and name the cloud actually hosting them in that
field, so the hosting cloud of every shared cluster was unreadable:

```
regionConfigs: [{ providerName: "TENANT", regionName: "US_WEST_2", ... }]   # which cloud?
regionConfigs: [{ providerName: "TENANT", backingProviderName: "AWS", ... }]
```

Three field descriptions promised null where Atlas returns a value:
`biConnectorReadPreference` (reported whether or not the BI Connector is
enabled), `featureCompatibilityVersion` (always present, not only when pinned),
and `regionConfigs` (now documents the added key).

## Verification

Live against the same organization, both planes, full surface:

- `searchIndexes` renders null on the 401; the assertion above now fails.
- `regionConfigs` carries `backingProviderName: "AWS"` on the M0 cluster.
- No regressions: `resourcePolicies`, `serviceAccounts`, `teams`,
  `orgUser.teams`, `flexClusters`, `snapshotExportBuckets`,
  `customDatabaseRoles`, `networkPeerings`, `cloudProviderAccessRoles`, and
  `privateEndpoints` all return HTTP 200 with zero results in this org and still
  render `[]`, not null. Each was confirmed against the REST API directly.
- `go build`, `go test`, and `go vet` pass for the provider.

No schema fields were added or removed, so there is no `.lr.versions` change.
