### PR TITLE
🐛 claude: derive model family from the id instead of a fixed list

### DIFF
--- a/providers/claude/resources/claude_workspace.go
+++ b/providers/claude/resources/claude_workspace.go
@@ -140,11 +140,22 @@ func rawJSONToDict(raw string) (interface{}, error) {
 	return res, nil
 }
 
+// parseFamily derives the model family from the model id, because the Models
+// API does not return one. The family follows the `claude-` prefix, either
+// directly (`claude-sonnet-5`) or after a version in the older scheme
+// (`claude-3-5-sonnet-20241022`), so it is the first segment that does not
+// start with a digit. Deriving the value instead of matching a fixed list of
+// families keeps a newly released one from silently reporting as empty.
 func parseFamily(id string) string {
-	for _, f := range []string{"opus", "sonnet", "haiku"} {
-		if strings.Contains(id, f) {
-			return f
+	rest, ok := strings.CutPrefix(id, "claude-")
+	if !ok {
+		return ""
+	}
+	for _, seg := range strings.Split(rest, "-") {
+		if seg == "" || (seg[0] >= '0' && seg[0] <= '9') {
+			continue
 		}
+		return seg
 	}
 	return ""
 }

--- a/providers/claude/resources/helpers_test.go
+++ b/providers/claude/resources/helpers_test.go
@@ -22,6 +22,12 @@ func TestParseFamily(t *testing.T) {
 		{"claude-3-5-sonnet-20241022", "sonnet"},
 		{"some-unknown-model", ""},
 		{"", ""},
+		// A family the provider has no prior knowledge of still resolves, so a
+		// newly released one is never reported as an empty family.
+		{"claude-fable-5", "fable"},
+		{"claude-3-5-newfamily-20260101", "newfamily"},
+		// An id carrying only a version has no family to report.
+		{"claude-2.1", ""},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Found while live-verifying the claude provider against a real account.

## The bug

`parseFamily` matched the model id against a hardcoded allowlist:

```go
for _, f := range []string{"opus", "sonnet", "haiku"} {
	if strings.Contains(id, f) {
		return f
	}
}
return ""
```

`claude-fable-5` matches none of them, so it reported `family: ""`:

```
claude.models { id family }
  id: "claude-opus-5"    family: "opus"
  id: "claude-sonnet-5"  family: "sonnet"
  id: "claude-fable-5"   family: ""      <-- here
```

The Models API returns **no `family` field at all** (confirmed against the live API: every entry is null), so the value is entirely provider-derived. That makes the allowlist a maintenance trap that quietly rots each time a new family ships.

The failure mode is silence, not an error. Nothing fails, the field is just empty, so a query like `.where(family == "opus")` or any grouping by family drops the affected models with no indication they were skipped.

## The fix

Derive the family from the id structure rather than enumerating known values. The family follows the `claude-` prefix, either directly (`claude-sonnet-5`) or after a version in the older scheme (`claude-3-5-sonnet-20241022`), so it is the first segment that does not start with a digit.

This covers every id the allowlist covered, plus families that do not exist yet. Ids carrying only a version (`claude-2.1`) still correctly report no family.

## Verification

All six pre-existing test cases still pass unchanged; three added for the new behaviour (`claude-fable-5`, an invented future family, and a version-only id).

Live against the Models API after the fix:

```
id: "claude-opus-5"                 family: "opus"
id: "claude-sonnet-5"               family: "sonnet"
id: "claude-fable-5"                family: "fable"
id: "claude-opus-4-8"               family: "opus"
id: "claude-opus-4-7"               family: "opus"
id: "claude-sonnet-4-6"             family: "sonnet"
id: "claude-opus-4-6"               family: "opus"
id: "claude-opus-4-5-20251101"      family: "opus"
id: "claude-haiku-4-5-20251001"     family: "haiku"
id: "claude-sonnet-4-5-20250929"    family: "sonnet"
```

`claude-fable-5` resolves and the other nine are unchanged, including the legacy date-suffixed ids.

No schema change, so no `.lr.versions` entry.
