### PR TITLE
🐛 oci: stop Cloud Guard and dangling connector targets failing queries

### DIFF
--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -59,6 +59,14 @@ var ociCloudGuardProblemStates = []cloudguard.ListProblemsLifecycleStateEnum{
 // Only a 404 counts. A 401 is a credential problem and a 403 is the usual IAM
 // policy gap; reporting either as "Cloud Guard is off" would turn an
 // under-scoped token into a clean bill of health, which is worse than an error.
+//
+// The status alone is deliberately the whole test, without also matching the
+// message text or the error code. The code is NotAuthorizedOrNotFound, which
+// Cloud Guard returns for a missing resource and an IAM gap alike, so it does
+// not discriminate; the message is prose and free to change. That leaves one
+// caller where a 404 could mean something else - rules, which names a specific
+// recipe and so can 404 because that recipe was deleted between listing it and
+// reading its rules. Empty rules is the right answer to that too.
 func ociCloudGuardNotSubscribed(err error) bool {
 	svcErr, ok := common.IsServiceError(err)
 	return ok && svcErr.GetHTTPStatusCode() == 404
@@ -86,6 +94,15 @@ func (o *mqlOciCloudGuard) getHomeRegion() (string, error) {
 	})
 }
 
+// getConfig returns the tenancy's Cloud Guard configuration, or (nil, nil) when
+// the tenancy never onboarded Cloud Guard.
+//
+// The nil-without-error case is what every caller has to handle, and it is
+// deliberately absorbed here rather than at each accessor. o.config remembers
+// only successes, so reporting not-subscribed as an error meant re-issuing
+// GetConfiguration for every field that read it - three identical 404s to
+// answer status, reportingRegion and selfManageResources. Answering nil makes
+// it a cached success, so the tenancy is asked once.
 func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 	// Resolve the home region before entering config's own critical section:
 	// getHomeRegion takes a lock of its own, and nesting it inside this one
@@ -111,6 +128,9 @@ func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 			CompartmentId: common.String(conn.TenantID()),
 		})
 		if err != nil {
+			if ociCloudGuardNotSubscribed(err) {
+				return nil, nil
+			}
 			return nil, err
 		}
 		return &response.Configuration, nil
@@ -134,12 +154,12 @@ func (o *mqlOciCloudGuard) getServiceRegion() (string, error) {
 	return o.getHomeRegion()
 }
 
+// A nil configuration below means the tenancy is not subscribed, which is a
+// real answer rather than a failure: Cloud Guard is off. See getConfig.
+
 func (o *mqlOciCloudGuard) status() (bool, error) {
 	cfg, err := o.getConfig()
-	if err != nil {
-		if ociCloudGuardNotSubscribed(err) {
-			return false, nil
-		}
+	if err != nil || cfg == nil {
 		return false, err
 	}
 	return cfg.Status == cloudguard.CloudGuardStatusEnabled, nil
@@ -147,10 +167,7 @@ func (o *mqlOciCloudGuard) status() (bool, error) {
 
 func (o *mqlOciCloudGuard) reportingRegion() (string, error) {
 	cfg, err := o.getConfig()
-	if err != nil {
-		if ociCloudGuardNotSubscribed(err) {
-			return "", nil
-		}
+	if err != nil || cfg == nil {
 		return "", err
 	}
 	return stringValue(cfg.ReportingRegion), nil
@@ -158,10 +175,7 @@ func (o *mqlOciCloudGuard) reportingRegion() (string, error) {
 
 func (o *mqlOciCloudGuard) selfManageResources() (bool, error) {
 	cfg, err := o.getConfig()
-	if err != nil {
-		if ociCloudGuardNotSubscribed(err) {
-			return false, nil
-		}
+	if err != nil || cfg == nil {
 		return false, err
 	}
 	return boolValue(cfg.SelfManageResources), nil

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -46,6 +46,24 @@ var ociCloudGuardProblemStates = []cloudguard.ListProblemsLifecycleStateEnum{
 	cloudguard.ListProblemsLifecycleStateInactive,
 }
 
+// ociCloudGuardNotSubscribed reports whether the error means the tenancy never
+// onboarded Cloud Guard, which the service answers with a 404 carrying
+// "Cloudguard subscription is not available".
+//
+// A tenancy that has not enabled Cloud Guard is the single most likely state to
+// query, and it is exactly the state the resource exists to report. Surfacing
+// the 404 as a query error means status - the field whose whole job is to say
+// whether Cloud Guard is on - fails precisely when the answer is "it is not",
+// and takes the rest of the tenancy scan down with it.
+//
+// Only a 404 counts. A 401 is a credential problem and a 403 is the usual IAM
+// policy gap; reporting either as "Cloud Guard is off" would turn an
+// under-scoped token into a clean bill of health, which is worse than an error.
+func ociCloudGuardNotSubscribed(err error) bool {
+	svcErr, ok := common.IsServiceError(err)
+	return ok && svcErr.GetHTTPStatusCode() == 404
+}
+
 func (o *mqlOciCloudGuard) id() (string, error) {
 	return "oci.cloudGuard", nil
 }
@@ -119,6 +137,9 @@ func (o *mqlOciCloudGuard) getServiceRegion() (string, error) {
 func (o *mqlOciCloudGuard) status() (bool, error) {
 	cfg, err := o.getConfig()
 	if err != nil {
+		if ociCloudGuardNotSubscribed(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	return cfg.Status == cloudguard.CloudGuardStatusEnabled, nil
@@ -127,6 +148,9 @@ func (o *mqlOciCloudGuard) status() (bool, error) {
 func (o *mqlOciCloudGuard) reportingRegion() (string, error) {
 	cfg, err := o.getConfig()
 	if err != nil {
+		if ociCloudGuardNotSubscribed(err) {
+			return "", nil
+		}
 		return "", err
 	}
 	return stringValue(cfg.ReportingRegion), nil
@@ -135,6 +159,9 @@ func (o *mqlOciCloudGuard) reportingRegion() (string, error) {
 func (o *mqlOciCloudGuard) selfManageResources() (bool, error) {
 	cfg, err := o.getConfig()
 	if err != nil {
+		if ociCloudGuardNotSubscribed(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	return boolValue(cfg.SelfManageResources), nil
@@ -160,7 +187,12 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 			// Cloud Guard targets are attached to sub-compartments far more
 			// often than to the tenancy root.
 			CompartmentIdInSubtree: common.Bool(true),
-			Page:                   page,
+			// Cloud Guard rejects the subtree flag outright unless an access
+			// level comes with it, so this is required rather than an
+			// optimization. ACCESSIBLE degrades to the compartments the caller
+			// can read instead of failing on the first one it cannot.
+			AccessLevel: cloudguard.ListTargetsAccessLevelAccessible,
+			Page:        page,
 		})
 		if err != nil {
 			return nil, nil, err
@@ -168,6 +200,9 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 		return response.Items, response.OpcNextPage, nil
 	})
 	if err != nil {
+		if ociCloudGuardNotSubscribed(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 
@@ -251,6 +286,9 @@ func (o *mqlOciCloudGuard) problems() ([]any, error) {
 			return response.Items, response.OpcNextPage, nil
 		})
 		if err != nil {
+			if ociCloudGuardNotSubscribed(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
 		problems = append(problems, perState...)
@@ -370,6 +408,13 @@ func (o *mqlOciCloudGuardDetectorRecipe) rules() ([]any, error) {
 		return response.Items, response.OpcNextPage, nil
 	})
 	if err != nil {
+		// The recipe listing itself is answerable without a Cloud Guard
+		// subscription - Oracle-managed recipes come back either way - but the
+		// per-recipe rules endpoint is not. Without this the recipes resolve
+		// and then every one of them fails on its rules.
+		if ociCloudGuardNotSubscribed(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 
@@ -460,7 +505,10 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 		response, err := client.ListDetectorRecipes(ctx, cloudguard.ListDetectorRecipesRequest{
 			CompartmentId:          common.String(conn.TenantID()),
 			CompartmentIdInSubtree: common.Bool(true),
-			Page:                   page,
+			// Required whenever the subtree flag is set: Cloud Guard rejects
+			// the combination without it. See targets for the full reasoning.
+			AccessLevel: cloudguard.ListDetectorRecipesAccessLevelAccessible,
+			Page:        page,
 		})
 		if err != nil {
 			return nil, nil, err
@@ -468,6 +516,9 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 		return response.Items, response.OpcNextPage, nil
 	})
 	if err != nil {
+		if ociCloudGuardNotSubscribed(err) {
+			return []any{}, nil
+		}
 		return nil, err
 	}
 

--- a/providers/oci/resources/cloudguard_test.go
+++ b/providers/oci/resources/cloudguard_test.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ociTestServiceError is a stand-in for the SDK's service error. The SDK's own
+// type is unexported behind common.IsServiceError, which matches on this
+// interface, so implementing it is the only way to build one in a test.
+type ociTestServiceError struct {
+	status int
+	code   string
+	msg    string
+}
+
+func (e ociTestServiceError) Error() string           { return e.msg }
+func (e ociTestServiceError) GetHTTPStatusCode() int  { return e.status }
+func (e ociTestServiceError) GetMessage() string      { return e.msg }
+func (e ociTestServiceError) GetCode() string         { return e.code }
+func (e ociTestServiceError) GetOpcRequestID() string { return "test-request-id" }
+
+func TestOciCloudGuardNotSubscribed(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The regression this guards. A tenancy that never onboarded Cloud
+			// Guard answers every call this way, and it is the most common state
+			// to query, so it has to read as "off" rather than as a failure.
+			name: "not subscribed",
+			err: ociTestServiceError{
+				status: http.StatusNotFound,
+				code:   "NotAuthorizedOrNotFound",
+				msg:    "Cloudguard subscription is not available",
+			},
+			want: true,
+		},
+		{
+			// Must NOT be swallowed: an under-scoped token would otherwise be
+			// reported as a clean "Cloud Guard is disabled".
+			name: "authorization failure",
+			err: ociTestServiceError{
+				status: http.StatusForbidden,
+				code:   "NotAuthorizedOrNotFound",
+				msg:    "not authorized",
+			},
+			want: false,
+		},
+		{
+			name: "bad credentials",
+			err:  ociTestServiceError{status: http.StatusUnauthorized, code: "NotAuthenticated", msg: "bad key"},
+			want: false,
+		},
+		{
+			name: "throttled",
+			err:  ociTestServiceError{status: http.StatusTooManyRequests, code: "TooManyRequests", msg: "slow down"},
+			want: false,
+		},
+		{
+			name: "malformed request",
+			err:  ociTestServiceError{status: http.StatusBadRequest, code: "InvalidParameter", msg: "bad params"},
+			want: false,
+		},
+		{"transport error", errors.New("connection refused"), false},
+		{"no error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ociCloudGuardNotSubscribed(tt.err))
+		})
+	}
+}
+
+func TestOciReferentGone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "service 404",
+			err:  ociTestServiceError{status: http.StatusNotFound, code: "BucketNotFound", msg: "gone"},
+			want: true,
+		},
+		{
+			// An ONS topic is resolved by scanning the listing, not by a GET, so
+			// its absence arrives as a sentinel with no HTTP status attached.
+			// Before this was recognised, one connector pointing at a deleted
+			// topic failed the whole connector listing.
+			name: "ons topic sentinel",
+			err:  fmt.Errorf("%w: %s", errOciOnsTopicNotFound, "ocid1.onstopic.oc1.phx.example"),
+			want: true,
+		},
+		{"bare sentinel", errOciOnsTopicNotFound, true},
+		{
+			name: "authorization failure is not absence",
+			err:  ociTestServiceError{status: http.StatusForbidden, code: "NotAuthorizedOrNotFound", msg: "denied"},
+			want: false,
+		},
+		{"unrelated error", errors.New("connection refused"), false},
+		{"no error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ociReferentGone(tt.err))
+		})
+	}
+}

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -124,8 +125,17 @@ func initOciOnsTopic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		}
 	}
 
-	return nil, nil, errors.New("oci.ons.topic not found: " + idVal)
+	return nil, nil, fmt.Errorf("%w: %s", errOciOnsTopicNotFound, idVal)
 }
+
+// errOciOnsTopicNotFound marks a topic OCID that is not in the listing, which
+// normally means the topic was deleted while something that points at it - a
+// Connector Hub target, a monitoring alarm destination - outlived it.
+//
+// It is a sentinel rather than a bare errors.New so callers holding a single
+// such reference can tell "the referent is gone" (answer null) apart from "the
+// lookup itself failed" (answer with the error). See ociReferentGone.
+var errOciOnsTopicNotFound = errors.New("oci.ons.topic not found")
 
 func (o *mqlOciOnsTopic) id() (string, error) {
 	return "oci.ons.topic/" + o.Id.Data, nil

--- a/providers/oci/resources/serviceconnectorhub.go
+++ b/providers/oci/resources/serviceconnectorhub.go
@@ -215,6 +215,14 @@ func (o *mqlOciServiceConnectorHubConnector) targetBucket() (*mqlOciObjectStorag
 // BucketNotFound, and the shared NotAuthorizedOrNotFound covers the case where
 // the resource is gone or was never visible.
 func ociReferentGone(err error) bool {
+	// Not every referent reports its absence as a service error. A resource
+	// resolved by scanning a listing rather than by a direct GET - an ONS topic
+	// is the one that reaches here - has no HTTP response to carry a 404, so it
+	// reports the miss with a sentinel instead.
+	if errors.Is(err, errOciOnsTopicNotFound) {
+		return true
+	}
+
 	var svcErr common.ServiceError
 	if !errors.As(err, &svcErr) {
 		return false
@@ -238,6 +246,16 @@ func (o *mqlOciServiceConnectorHubConnector) targetTopic() (*mqlOciOnsTopic, err
 		"id": llx.StringData(stringValue(target.TopicId)),
 	})
 	if err != nil {
+		// Same outliving problem as targetBucket: deleting the topic leaves the
+		// connector pointing at an OCID that is no longer in the listing. A
+		// connector in that state is a real tenancy state, so the reference
+		// reads as null rather than failing every connector in the listing.
+		if ociReferentGone(err) {
+			log.Debug().Str("topic", stringValue(target.TopicId)).
+				Msg("service connector target topic no longer exists")
+			o.TargetTopic.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return res.(*mqlOciOnsTopic), nil


### PR DESCRIPTION
Found while running the **entire OCI resource surface** (117 list entry points across 47 namespaces) against a live tenancy. All four defects surface as a *failed query* rather than as data, and none is visible to a compile check or unit test.

## 1. Cloud Guard rejects the subtree flag without an access level

`ListTargets` and `ListDetectorRecipes` passed `compartmentIdInSubtree=true` with no `accessLevel`. OCI validates that pair before anything else, so both returned **400 InvalidParameter in every tenancy**, subscribed or not:

```
Message: AccessLevel Param should be passed only when compartmentIdInSubtree
         is passed and is set - params: null, true
Operation Name: ListDetectorRecipes
```

`ListProblems` already passed both and was unaffected — the subtree flag was added to three listers in #9573 and only one of them got the access level it requires.

This is not just error suppression: with `accessLevel` supplied, `detectorRecipes` returns its **six Oracle-managed recipes** where it previously returned nothing but a 400.

## 2. A tenancy without Cloud Guard could not report that fact

A tenancy that never onboarded Cloud Guard answers `404 NotAuthorizedOrNotFound / "Cloudguard subscription is not available"`. That propagated out of `getConfig`, so `oci.cloudGuard.status` — the field whose entire purpose is to say whether Cloud Guard is on — **failed precisely when the answer was "it is not"**, and took `reportingRegion` and `selfManageResources` with it.

Not-subscribed now reads as disabled/empty. **Only 404 counts**: swallowing 401 or 403 would turn an under-scoped token into a clean bill of health, which is worse than an error. The per-recipe `rules` endpoint requires the subscription even though the recipe listing does not, so it is guarded too — otherwise the recipes resolve and then every one of them fails on its rules.

## 3. A deleted ONS topic failed the whole connector listing

A Connector Hub connector outlives its target. `targetBucket` already treated a deleted referent as null (#9667); its sibling `targetTopic`, twenty lines below doing the identical job, did not — so **one** connector pointing at a deleted topic failed the **entire** `oci.serviceConnectorHub.connectors` listing:

```
1 error occurred:
	* oci.ons.topic not found: ocid1.onstopic.oc1.us-sanjose-1.amaaaaaa...
```

An ONS topic resolves by scanning the listing rather than by a GET, so its absence carries no HTTP status for `ociReferentGone` to match. It now reports a sentinel that `ociReferentGone` recognises alongside a service 404. The list-valued path (`resolveOciTopics`) already skipped unresolvable topics; this brings the singular reference in line.

## Live verification

Same tenancy, before and after.

| Query | Before | After |
|---|---|---|
| `oci.cloudGuard.status` | 404 error | `false` |
| `oci.cloudGuard.reportingRegion` | 404 error | `""` |
| `oci.cloudGuard.selfManageResources` | 404 error | `false` |
| `oci.cloudGuard.targets` | **400 error** | `0` |
| `oci.cloudGuard.detectorRecipes` | **400 error** | **6 recipes** |
| `oci.cloudGuard.detectorRecipe.rules` | 404 error | `0`, clean |
| `oci.cloudGuard.problems` | 404 error | `0` |
| `oci.serviceConnectorHub.connectors` | **whole listing failed** | 5 connectors; live ones resolve to real bucket + topic |

After the fix the live connectors resolve their targets for real — `mqlv-sch-to-bucket` → bucket `mqlv-sch-sink`, `mqlv-sch-to-topic` → topic `mqlv-sch-topic` — while the dangling one reads null instead of failing its neighbours.

The full 117-entry sweep returns **zero errors** with this branch, against **3 hard failures** before it.

## Tests

`cloudguard_test.go` covers both predicates as table tests, including the cases that must *not* be swallowed (401 / 403 / 429 / transport errors) — the guard's whole risk is over-matching.

No `.lr` change, so no `.lr.versions` or `permissions.json` churn.
