### PR TITLE
🐛 shodan: parse certificate validity dates

### DIFF
--- a/providers/shodan/resources/host.go
+++ b/providers/shodan/resources/host.go
@@ -227,6 +227,10 @@ func parseShodanTime(raw string) *time.Time {
 		time.RFC3339Nano,
 		"2006-01-02T15:04:05.999999",
 		"2006-01-02T15:04:05",
+		// Certificate validity dates arrive as X.509 ASN.1 GeneralizedTime
+		// rather than the ISO-8601 form used for host, banner and DNS
+		// timestamps, so they need their own layout.
+		"20060102150405Z",
 	} {
 		if t, err := time.Parse(layout, raw); err == nil {
 			return &t

--- a/providers/shodan/resources/shodan_test.go
+++ b/providers/shodan/resources/shodan_test.go
@@ -25,6 +25,10 @@ func TestParseShodanTime(t *testing.T) {
 		// The format Shodan actually emits for host/banner/DNS times: no timezone.
 		{"microseconds no tz", "2024-05-01T12:00:00.283713", "2024-05-01T12:00:00.283713Z"},
 		{"seconds no tz", "2024-05-01T12:00:00", "2024-05-01T12:00:00Z"},
+		// The format certificate issued/expires arrive in, which differs from
+		// the host and DNS timestamps above.
+		{"asn1 generalized time", "20260720180833Z", "2026-07-20T18:08:33Z"},
+		{"asn1 generalized time end of year", "20261221192001Z", "2026-12-21T19:20:01Z"},
 		{"garbage", "not-a-time", ""},
 		{"date only unsupported", "2024-05-01", ""},
 	}


### PR DESCRIPTION
Found while live-verifying the shodan provider against a real account.

## The bug

`parseShodanTime` (`resources/host.go:221`) tries four ISO-8601 layouts and returns `nil` when none match:

```go
time.RFC3339,
time.RFC3339Nano,
"2006-01-02T15:04:05.999999",
"2006-01-02T15:04:05",
```

Certificate validity dates do not use that encoding. Shodan returns them as X.509 ASN.1 GeneralizedTime:

```json
"cert": { "issued": "20260720180833Z", "expires": "20261012180832Z", "expired": false }
```

So `shodan.host.cert.issued` and `.expires` were **null for every certificate on every host**:

```
shodan.host("8.8.8.8").services.where(port == 443) { tlsBanner { cert { subjectCN issued expires } } }
  subjectCN: "dns.google"
  issued:    null      <-- raw value is 20260720180833Z
  expires:   null      <-- raw value is 20261012180832Z
```

Confirmed against several hosts; the format is consistent (1.1.1.1 shows it on ports 443, 2083, 2087 and 8443).

## Why it matters

Nothing errors, so the gap is invisible. It also removes most of the reason to read a TLS banner: certificate expiry becomes unauditable. `expires` being null means an "expires within 30 days" filter can never match, and under MQL's three-valued logic a null comparison can pass an assertion that was written to catch an expiring certificate — so the check reports healthy rather than failing.

The sibling `expired` field is unaffected: it comes straight from the API as a boolean.

## The fix

Add the GeneralizedTime layout to the list. One line, no behaviour change for the existing formats.

The existing `TestParseShodanTime` covered the host, banner and DNS timestamp formats but never a certificate one — its own comment says *"the format Shodan actually emits for host/banner/DNS times"* — so it passed against the broken parse. Added cases for the certificate format.

## Verification

All 7 pre-existing test cases pass unchanged, plus 2 added.

Live against the API after the fix:

| Host | Raw `issued` / `expires` | Parsed |
|---|---|---|
| `8.8.8.8:443` (dns.google) | `20260720180833Z` / `20261012180832Z` | 2026-07-20 20:08:33 +0200 / 2026-10-12 20:08:32 +0200 |
| `1.1.1.1:443` (cloudflare-dns.com) | `20251231192001Z` / `20261221192001Z` | 2025-12-31 20:20:01 +0100 / 2026-12-21 20:20:01 +0100 |

Both match the raw UTC values rendered in local time.

No schema change, so no `.lr.versions` entry.
