### PR TITLE
🐛 vercel: stop reporting denied reads as empty lists

### DIFF
--- a/providers/vercel/resources/access.go
+++ b/providers/vercel/resources/access.go
@@ -41,8 +41,12 @@ func (p *mqlVercelProject) members() ([]any, error) {
 	conn := p.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[projectMemberRecord](context.Background(), conn, "/v1/projects/"+p.Id.Data+"/members", connection.TeamQuery(p.teamID), "members")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			p.Members.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -84,8 +88,16 @@ func (g *mqlVercelAccessGroup) members() ([]any, error) {
 	query.Set("limit", "100")
 	records, err := connection.GetPagedCursor[accessGroupMemberRecord](context.Background(), conn, "/v1/access-groups/"+g.Id.Data+"/members", query, "members")
 	if err != nil {
-		// Access groups are Enterprise-only; degrade to empty elsewhere.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			g.Members.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -127,7 +139,16 @@ func (g *mqlVercelAccessGroup) projects() ([]any, error) {
 	query.Set("limit", "100")
 	records, err := connection.GetPagedCursor[accessGroupProjectRecord](context.Background(), conn, "/v1/access-groups/"+g.Id.Data+"/projects", query, "projects")
 	if err != nil {
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			g.Projects.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/vercel/resources/aliases.go
+++ b/providers/vercel/resources/aliases.go
@@ -75,7 +75,16 @@ func (c *mqlVercelProject) aliases() ([]any, error) {
 
 	records, err := connection.GetPagedFrom[aliasRecord](context.Background(), conn, "/v4/aliases", query, "aliases")
 	if err != nil {
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			c.Aliases.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/vercel/resources/certificates.go
+++ b/providers/vercel/resources/certificates.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/vercel/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -23,8 +24,12 @@ func (c *mqlVercelTeam) certificates() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[certRecord](context.Background(), conn, "/v7/certs", connection.TeamQuery(c.Id.Data), "certs")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Certificates.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/dns.go
+++ b/providers/vercel/resources/dns.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/vercel/connection"
 )
 
@@ -31,8 +32,12 @@ func (d *mqlVercelDomain) records() ([]any, error) {
 	conn := d.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[dnsRecordRecord](context.Background(), conn, "/v4/domains/"+d.Name.Data+"/records", connection.TeamQuery(d.teamID), "records")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			d.Records.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/firewall.go
+++ b/providers/vercel/resources/firewall.go
@@ -164,9 +164,16 @@ func (f *mqlVercelFirewall) bypassRules() ([]any, error) {
 
 	records, err := f.fetchBypassRules(conn)
 	if err != nil {
-		// System bypass is gated with the rest of the configurable firewall;
-		// treat an absent or forbidden list as empty rather than failing.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			f.BypassRules.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -240,7 +247,16 @@ func (f *mqlVercelFirewall) attackAnomalies() ([]any, error) {
 		Anomalies []map[string]any `json:"anomalies"`
 	}
 	if err := conn.Get(context.Background(), "/v1/security/firewall/attack-status", query, &resp); err != nil {
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			f.AttackAnomalies.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/vercel/resources/projects.go
+++ b/providers/vercel/resources/projects.go
@@ -500,8 +500,12 @@ func (c *mqlVercelProject) environmentVariables() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[envRecord](context.Background(), conn, "/v9/projects/"+c.Id.Data+"/env", connection.TeamQuery(c.teamID), "envs")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.EnvironmentVariables.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -708,8 +712,12 @@ func (c *mqlVercelProject) domains() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[projectDomainRecord](context.Background(), conn, "/v9/projects/"+c.Id.Data+"/domains", connection.TeamQuery(c.teamID), "domains")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Domains.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/stores.go
+++ b/providers/vercel/resources/stores.go
@@ -181,8 +181,12 @@ func (c *mqlVercelTeam) stores() ([]any, error) {
 	}
 	records, err := root.teamStores(c.Id.Data)
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Stores.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -211,8 +215,12 @@ func (c *mqlVercelProject) stores() ([]any, error) {
 	}
 	records, err := root.teamStores(c.teamID)
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Stores.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/teams.go
+++ b/providers/vercel/resources/teams.go
@@ -334,8 +334,12 @@ func (c *mqlVercelTeam) members() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[memberRecord](context.Background(), conn, "/v2/teams/"+c.Id.Data+"/members", nil, "members")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Members.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -406,9 +410,16 @@ func (c *mqlVercelTeam) sharedEnvironmentVariables() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[sharedEnvRecord](context.Background(), conn, "/v1/env", connection.TeamQuery(c.Id.Data), "data")
 	if err != nil {
-		// Shared environment variables are a paid-plan feature; treat an absent
-		// or forbidden collection as empty rather than failing the scan.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			c.SharedEnvironmentVariables.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -502,8 +513,12 @@ func (c *mqlVercelTeam) domains() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[domainRecord](context.Background(), conn, "/v5/domains", connection.TeamQuery(c.Id.Data), "domains")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Domains.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -539,8 +554,12 @@ func (c *mqlVercelTeam) edgeConfigs() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	var records []edgeConfigRecord
 	if err := conn.Get(context.Background(), "/v1/edge-config", connection.TeamQuery(c.Id.Data), &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.EdgeConfigs.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -584,8 +603,12 @@ func (c *mqlVercelTeam) logDrains() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	var records []logDrainRecord
 	if err := conn.Get(context.Background(), "/v1/log-drains", connection.TeamQuery(c.Id.Data), &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.LogDrains.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -637,8 +660,12 @@ func (c *mqlVercelTeam) webhooks() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	var records []webhookRecord
 	if err := conn.Get(context.Background(), "/v1/webhooks", connection.TeamQuery(c.Id.Data), &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Webhooks.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -705,8 +732,12 @@ func (c *mqlVercelTeam) integrationConfigurations() ([]any, error) {
 	query.Set("view", "account")
 	var records []integrationConfigurationRecord
 	if err := conn.Get(context.Background(), "/v1/integrations/configurations", query, &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.IntegrationConfigurations.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -763,9 +794,16 @@ func (c *mqlVercelTeam) accessGroups() ([]any, error) {
 	query.Set("limit", "100")
 	records, err := connection.GetPagedCursor[accessGroupRecord](context.Background(), conn, "/v1/access-groups", query, "accessGroups")
 	if err != nil {
-		// Access groups are an Enterprise feature; degrade to empty on plans
-		// that do not expose the endpoint.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			c.AccessGroups.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err


### PR DESCRIPTION
Found while live-verifying the vercel provider against a real account. First of three stacked PRs from that run.

## The bug

Twenty list accessors turned an access-denied response into an empty list:

```go
if connection.IsForbidden(err) || connection.IsNotFound(err) {
    return []any{}, nil
}
```

An empty list is not a neutral result. It asserts the team has no access groups, no webhooks, no log drains, no stores, no certificates; that a project has no members and no environment variables; that a domain has no DNS records. A credential that was refused the read has established none of that.

## Live evidence

`/v1/access-groups` answers **403** on both a hobby team and a pro team (access groups are Enterprise-gated):

```
{"error":{"code":"forbidden","message":"You don't have permission to list the access group.",
          "action":"list","resource":"accessGroup"}}
```

Before, `team.accessGroups` reported `[]`, so this passed while nothing had been read:

```
vercel.teams.all(accessGroups.length == 0)   →  passed
```

After, the field reports null and the same assertion fails:

```
vercel.teams.where(slug == "…").first { slug accessGroups }
  accessGroups: null

vercel.teams.all(accessGroups.length == 0)
  [failed] [].all()
    accessGroups.length: null
```

## Only the denial is reclassified

A 404 still yields an empty list. On these collection endpoints it means the feature is not provisioned for the scope rather than that the caller was refused — the firewall config endpoint answering `{"error":{"code":"not_found","message":"Config not found"}}` for a project with no WAF is exactly the shape that behaviour exists for. So the combined conditions are split rather than moved wholesale.

## Consistency

The singular accessors in this provider already got this right — `project.firewall` marks the field null through `StateIsSet | StateIsNull` on the same conditions. Only the list accessors flattened. This matches the fix applied to mongodbatlas in #9737.

## Verification

Provider tests pass. Live, after the fix, on the same account:

| Collection | Upstream | Reported |
|---|---|---|
| `accessGroups` | 403 | `null` |
| `certificates` | 200 | 9 |
| `stores` | 200 | 4 |
| `domains` | 200 | 6 |
| `members` | 200 | 28 |
| `webhooks` | 200, empty | `0` |

Readable collections still list, genuinely-empty ones still report empty, and only the refused read became null.

No schema change, so no `.lr.versions` entry.
