### PR TITLE
🐛 vercel: read automation bypass from the project, not the alias

### DIFF
--- a/providers/vercel/resources/access.go
+++ b/providers/vercel/resources/access.go
@@ -41,8 +41,12 @@ func (p *mqlVercelProject) members() ([]any, error) {
 	conn := p.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[projectMemberRecord](context.Background(), conn, "/v1/projects/"+p.Id.Data+"/members", connection.TeamQuery(p.teamID), "members")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			p.Members.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -84,8 +88,16 @@ func (g *mqlVercelAccessGroup) members() ([]any, error) {
 	query.Set("limit", "100")
 	records, err := connection.GetPagedCursor[accessGroupMemberRecord](context.Background(), conn, "/v1/access-groups/"+g.Id.Data+"/members", query, "members")
 	if err != nil {
-		// Access groups are Enterprise-only; degrade to empty elsewhere.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			g.Members.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -127,7 +139,16 @@ func (g *mqlVercelAccessGroup) projects() ([]any, error) {
 	query.Set("limit", "100")
 	records, err := connection.GetPagedCursor[accessGroupProjectRecord](context.Background(), conn, "/v1/access-groups/"+g.Id.Data+"/projects", query, "projects")
 	if err != nil {
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			g.Projects.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/vercel/resources/aliases.go
+++ b/providers/vercel/resources/aliases.go
@@ -75,7 +75,16 @@ func (c *mqlVercelProject) aliases() ([]any, error) {
 
 	records, err := connection.GetPagedFrom[aliasRecord](context.Background(), conn, "/v4/aliases", query, "aliases")
 	if err != nil {
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			c.Aliases.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/vercel/resources/certificates.go
+++ b/providers/vercel/resources/certificates.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/vercel/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -23,8 +24,12 @@ func (c *mqlVercelTeam) certificates() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[certRecord](context.Background(), conn, "/v7/certs", connection.TeamQuery(c.Id.Data), "certs")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Certificates.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/dns.go
+++ b/providers/vercel/resources/dns.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/vercel/connection"
 )
 
@@ -31,8 +32,12 @@ func (d *mqlVercelDomain) records() ([]any, error) {
 	conn := d.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[dnsRecordRecord](context.Background(), conn, "/v4/domains/"+d.Name.Data+"/records", connection.TeamQuery(d.teamID), "records")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			d.Records.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/firewall.go
+++ b/providers/vercel/resources/firewall.go
@@ -164,9 +164,16 @@ func (f *mqlVercelFirewall) bypassRules() ([]any, error) {
 
 	records, err := f.fetchBypassRules(conn)
 	if err != nil {
-		// System bypass is gated with the rest of the configurable firewall;
-		// treat an absent or forbidden list as empty rather than failing.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			f.BypassRules.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -240,7 +247,16 @@ func (f *mqlVercelFirewall) attackAnomalies() ([]any, error) {
 		Anomalies []map[string]any `json:"anomalies"`
 	}
 	if err := conn.Get(context.Background(), "/v1/security/firewall/attack-status", query, &resp); err != nil {
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			f.AttackAnomalies.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/vercel/resources/projects.go
+++ b/providers/vercel/resources/projects.go
@@ -139,6 +139,9 @@ type projectRecord struct {
 	Crons                                *cronsRecord          `json:"crons"`
 	OptionsAllowlist                     *optionsAllowlist     `json:"optionsAllowlist"`
 	ProtectionConfig                     map[string]any        `json:"protectionConfig"`
+	// Keyed by the bypass secret itself, so the keys are credential material
+	// and only the entry values may be surfaced.
+	ProtectionBypass map[string]protectionBypassEntry `json:"protectionBypass"`
 }
 
 // optionsAllowlist carries the paths a project exempts from deployment
@@ -267,6 +270,8 @@ func newVercelProject(runtime *plugin.Runtime, teamID string, rec *projectRecord
 		"trustedIpsAddresses":              llx.ArrayData(trustedAddresses, types.Dict),
 		"optionsAllowlistPaths":            llx.ArrayData(allowlistPaths(rec.OptionsAllowlist), types.String),
 		"protectionConfig":                 llx.DictData(dictOrNil(rec.ProtectionConfig)),
+		"protectionBypassCount":            llx.IntData(int64(len(rec.ProtectionBypass))),
+		"protectionBypassScopes":           llx.ArrayData(bypassScopes(rec.ProtectionBypass), types.String),
 		"repositoryType":                   llx.StringDataPtr(repoType),
 		"repositoryOwner":                  llx.StringDataPtr(repoOwner),
 		"repositoryName":                   llx.StringDataPtr(repoName),

--- a/providers/vercel/resources/projects.go
+++ b/providers/vercel/resources/projects.go
@@ -500,8 +500,12 @@ func (c *mqlVercelProject) environmentVariables() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[envRecord](context.Background(), conn, "/v9/projects/"+c.Id.Data+"/env", connection.TeamQuery(c.teamID), "envs")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.EnvironmentVariables.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -708,8 +712,12 @@ func (c *mqlVercelProject) domains() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[projectDomainRecord](context.Background(), conn, "/v9/projects/"+c.Id.Data+"/domains", connection.TeamQuery(c.teamID), "domains")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Domains.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/stores.go
+++ b/providers/vercel/resources/stores.go
@@ -181,8 +181,12 @@ func (c *mqlVercelTeam) stores() ([]any, error) {
 	}
 	records, err := root.teamStores(c.Id.Data)
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Stores.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -211,8 +215,12 @@ func (c *mqlVercelProject) stores() ([]any, error) {
 	}
 	records, err := root.teamStores(c.teamID)
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Stores.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/vercel/resources/teams.go
+++ b/providers/vercel/resources/teams.go
@@ -334,8 +334,12 @@ func (c *mqlVercelTeam) members() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[memberRecord](context.Background(), conn, "/v2/teams/"+c.Id.Data+"/members", nil, "members")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Members.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -406,9 +410,16 @@ func (c *mqlVercelTeam) sharedEnvironmentVariables() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[sharedEnvRecord](context.Background(), conn, "/v1/env", connection.TeamQuery(c.Id.Data), "data")
 	if err != nil {
-		// Shared environment variables are a paid-plan feature; treat an absent
-		// or forbidden collection as empty rather than failing the scan.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			c.SharedEnvironmentVariables.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -502,8 +513,12 @@ func (c *mqlVercelTeam) domains() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[domainRecord](context.Background(), conn, "/v5/domains", connection.TeamQuery(c.Id.Data), "domains")
 	if err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Domains.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -539,8 +554,12 @@ func (c *mqlVercelTeam) edgeConfigs() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	var records []edgeConfigRecord
 	if err := conn.Get(context.Background(), "/v1/edge-config", connection.TeamQuery(c.Id.Data), &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.EdgeConfigs.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -584,8 +603,12 @@ func (c *mqlVercelTeam) logDrains() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	var records []logDrainRecord
 	if err := conn.Get(context.Background(), "/v1/log-drains", connection.TeamQuery(c.Id.Data), &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.LogDrains.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -637,8 +660,12 @@ func (c *mqlVercelTeam) webhooks() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	var records []webhookRecord
 	if err := conn.Get(context.Background(), "/v1/webhooks", connection.TeamQuery(c.Id.Data), &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.Webhooks.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -705,8 +732,12 @@ func (c *mqlVercelTeam) integrationConfigurations() ([]any, error) {
 	query.Set("view", "account")
 	var records []integrationConfigurationRecord
 	if err := conn.Get(context.Background(), "/v1/integrations/configurations", query, &records); err != nil {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
 		if connection.IsForbidden(err) {
-			return []any{}, nil
+			c.IntegrationConfigurations.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -763,9 +794,16 @@ func (c *mqlVercelTeam) accessGroups() ([]any, error) {
 	query.Set("limit", "100")
 	records, err := connection.GetPagedCursor[accessGroupRecord](context.Background(), conn, "/v1/access-groups", query, "accessGroups")
 	if err != nil {
-		// Access groups are an Enterprise feature; degrade to empty on plans
-		// that do not expose the endpoint.
-		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+		// A refused read establishes nothing about what exists, so the field
+		// is reported null rather than as an empty list that would assert
+		// there is none.
+		if connection.IsForbidden(err) {
+			c.AccessGroups.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		// A 404 means the collection is not provisioned for this scope,
+		// which genuinely is none.
+		if connection.IsNotFound(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/vercel/resources/vercel.lr
+++ b/providers/vercel/resources/vercel.lr
@@ -453,10 +453,13 @@ private vercel.project @defaults("name framework") {
   optionsAllowlistPaths []string
   // Additional deployment protection configuration
   //
-  // Protection settings the project carries beyond the Vercel Authentication,
-  // password, and trusted-IP controls. Null when the project has no additional
-  // protection configuration.
-  protectionConfig dict
+  // Always null. The projects API returns no protectionConfig object on either
+  // the list or the single-project response, so nothing ever populates this
+  // field. Deprecated in favor of ssoProtectionDeploymentType,
+  // passwordProtectionDeploymentType, trustedIpsProtectionMode,
+  // optionsAllowlistPaths, and protectionBypassCount, which carry the
+  // protection settings the API does return.
+  protectionConfig @maturity("deprecated") dict
   // Number of automation bypass secrets registered for the project
   //
   // Each entry is a secret that skips deployment protection for any request

--- a/providers/vercel/resources/vercel.lr
+++ b/providers/vercel/resources/vercel.lr
@@ -370,7 +370,7 @@ private vercel.team.sharedEnvironmentVariable @defaults("key type") {
 // A Vercel project and its deployment-protection and build posture. Query
 // `ssoProtectionDeploymentType`, `passwordProtectionDeploymentType`, and
 // `trustedIpsProtectionMode` for preview and production access controls;
-// `optionsAllowlistPaths` and `protectionConfig` for the routes and settings
+// `optionsAllowlistPaths` and `protectionBypassCount` for the routes and secrets
 // that let traffic past those controls; `aliases` for the hostnames actually
 // serving each deployment;
 // `gitForkProtection`, `requireVerifiedCommits`, and `productionBranch` for
@@ -457,6 +457,19 @@ private vercel.project @defaults("name framework") {
   // password, and trusted-IP controls. Null when the project has no additional
   // protection configuration.
   protectionConfig dict
+  // Number of automation bypass secrets registered for the project
+  //
+  // Each entry is a secret that skips deployment protection for any request
+  // carrying it. Any value above zero means the controls reported by
+  // ssoProtectionDeploymentType, passwordProtectionDeploymentType, and
+  // trustedIpsProtectionMode can be bypassed regardless of how they are set.
+  // The secrets themselves are never exposed.
+  protectionBypassCount int
+  // Scopes of the automation bypass secrets registered for the project
+  //
+  // Distinct scopes across the project's bypass entries, for example
+  // automation-bypass. Empty when the project has no bypass entries.
+  protectionBypassScopes []string
   // Git provider hosting the connected repository
   //
   // One of github, gitlab, or bitbucket, or null when no repository is connected.
@@ -738,13 +751,11 @@ private vercel.deployment @defaults("name state target") {
 // A hostname bound to a deployment, which is what traffic to that hostname
 // actually reaches. An alias can outlive the release that configured it, so
 // comparing `deployment` against the project's current production deployment
-// surfaces hostnames still serving superseded builds. The
-// `protectionBypassCount` and `protectionBypassScopes` fields report automation
-// bypass entries registered for the alias, which let callers presenting the
-// bypass secret past deployment protection. The secret itself is never
-// exposed. Select an alias with
+// surfaces hostnames still serving superseded builds. Automation bypass
+// secrets are reported by `protectionBypassCount` and
+// `protectionBypassScopes` on vercel.project. Select an alias with
 // `vercel.projects.first.aliases.where(alias == "example.com")`.
-private vercel.alias @defaults("alias protectionBypassCount") {
+private vercel.alias @defaults("alias") {
   // Unique alias identifier
   id string
   // Hostname serving the deployment
@@ -767,14 +778,14 @@ private vercel.alias @defaults("alias protectionBypassCount") {
   creatorEmail string
   // Number of automation bypass entries registered for the alias
   //
-  // Each entry is a secret that skips deployment protection for requests
-  // carrying it. Any value above zero means protection can be bypassed on this
-  // hostname regardless of the project's protection settings.
-  protectionBypassCount int
+  // Deprecated in favor of vercel.project.protectionBypassCount. The alias
+  // payload does not carry bypass entries, so this is always zero.
+  protectionBypassCount @maturity("deprecated") int
   // Scopes of the automation bypass entries registered for the alias
   //
-  // Empty when the alias has no bypass entries.
-  protectionBypassScopes []string
+  // Deprecated in favor of vercel.project.protectionBypassScopes. The alias
+  // payload does not carry bypass entries, so this is always empty.
+  protectionBypassScopes @maturity("deprecated") []string
   // Time the alias was created
   createdAt time
   // Time the alias was last updated

--- a/providers/vercel/resources/vercel.lr.go
+++ b/providers/vercel/resources/vercel.lr.go
@@ -614,6 +614,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vercel.project.protectionConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelProject).GetProtectionConfig()).ToDataRes(types.Dict)
 	},
+	"vercel.project.protectionBypassCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVercelProject).GetProtectionBypassCount()).ToDataRes(types.Int)
+	},
+	"vercel.project.protectionBypassScopes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVercelProject).GetProtectionBypassScopes()).ToDataRes(types.Array(types.String))
+	},
 	"vercel.project.repositoryType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelProject).GetRepositoryType()).ToDataRes(types.String)
 	},
@@ -1850,6 +1856,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"vercel.project.protectionConfig": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVercelProject).ProtectionConfig, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"vercel.project.protectionBypassCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVercelProject).ProtectionBypassCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"vercel.project.protectionBypassScopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVercelProject).ProtectionBypassScopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"vercel.project.repositoryType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3891,6 +3905,8 @@ type mqlVercelProject struct {
 	TrustedIpsAddresses                  plugin.TValue[[]any]
 	OptionsAllowlistPaths                plugin.TValue[[]any]
 	ProtectionConfig                     plugin.TValue[any]
+	ProtectionBypassCount                plugin.TValue[int64]
+	ProtectionBypassScopes               plugin.TValue[[]any]
 	RepositoryType                       plugin.TValue[string]
 	RepositoryOwner                      plugin.TValue[string]
 	RepositoryName                       plugin.TValue[string]
@@ -4073,6 +4089,14 @@ func (c *mqlVercelProject) GetOptionsAllowlistPaths() *plugin.TValue[[]any] {
 
 func (c *mqlVercelProject) GetProtectionConfig() *plugin.TValue[any] {
 	return &c.ProtectionConfig
+}
+
+func (c *mqlVercelProject) GetProtectionBypassCount() *plugin.TValue[int64] {
+	return &c.ProtectionBypassCount
+}
+
+func (c *mqlVercelProject) GetProtectionBypassScopes() *plugin.TValue[[]any] {
+	return &c.ProtectionBypassScopes
 }
 
 func (c *mqlVercelProject) GetRepositoryType() *plugin.TValue[string] {

--- a/providers/vercel/resources/vercel.lr.versions
+++ b/providers/vercel/resources/vercel.lr.versions
@@ -231,6 +231,8 @@ vercel.project.passportDeploymentType 13.1.5
 vercel.project.passwordProtectionDeploymentType 13.0.0
 vercel.project.paused 13.1.5
 vercel.project.productionBranch 13.0.0
+vercel.project.protectionBypassCount 13.1.5
+vercel.project.protectionBypassScopes 13.1.5
 vercel.project.protectionConfig 13.1.5
 vercel.project.publicSource 13.0.0
 vercel.project.repositoryName 13.0.0


### PR DESCRIPTION
Second of three stacked PRs from a live verification run. **Based on #9741** — review that first; this diff is the second commit.

## The bug

Automation bypass was modeled on `vercel.alias` (#9648) because Vercel's published alias schema documented a `protectionBypass` object while the project schema did not. Live data is the other way round.

Against a pro team:

- **0 of 100 aliases** carry `protectionBypass`. The key is absent from the alias payload entirely — the keys returned are `alias`, `created`, `createdAt`, `creator`, `deletedAt`, `deployment`, `deploymentId`, `projectId`, `redirect`, `redirectStatusCode`, `uid`, `updatedAt`.
- **9 of 20 projects** do carry it, shaped `{createdAt, createdBy, isEnvVar, note, scope}` with scope `automation-bypass`.

So `alias.protectionBypassCount` was always `0` and `protectionBypassScopes` always `[]`:

```
vercel.projects.where(name == "docs").first.aliases { alias protectionBypassCount }
  protectionBypassCount: 0     # on every alias, while the project itself has one
```

An automation bypass secret skips deployment protection entirely. Nine projects had one configured and the provider reported nothing — a security control reading as absent everywhere it is actually set.

## The fix

Add `protectionBypassCount` and `protectionBypassScopes` to `vercel.project`, decoded from the project payload, and mark the two alias fields `@maturity("deprecated")` since they cannot populate.

Vercel keys each bypass entry **by the secret itself**, so the existing `bypassScopes` helper is reused unchanged — it discards the map keys and returns only distinct scopes. No key material is exposed, and the existing test asserting no returned scope carries a `secret-` prefix still covers the shared helper.

## Verification

```
vercel.projects.where(protectionBypassCount > 0).length
  9                                    # matches the raw API exactly

vercel.projects.where(protectionBypassCount > 0) { name protectionBypassCount protectionBypassScopes }
  docs                        1   ["automation-bypass"]
  console-next                1   ["automation-bypass"]
  varys                       1   ["automation-bypass"]
  vulnerability-intelligence  1   ["automation-bypass"]
  …

vercel.projects.map(protectionBypassScopes).flat.unique
  ["automation-bypass"]                # no key material in any returned value
```

Provider tests pass. Two `.lr.versions` entries at `13.1.5` (provider is at `13.1.4`); the deprecated alias entries keep their original version.
