### PR TITLE
🐛 vercel: deprecate the project protectionConfig field

### DIFF
--- a/providers/vercel/resources/vercel.lr
+++ b/providers/vercel/resources/vercel.lr
@@ -453,10 +453,13 @@ private vercel.project @defaults("name framework") {
   optionsAllowlistPaths []string
   // Additional deployment protection configuration
   //
-  // Protection settings the project carries beyond the Vercel Authentication,
-  // password, and trusted-IP controls. Null when the project has no additional
-  // protection configuration.
-  protectionConfig dict
+  // Always null. The projects API returns no protectionConfig object on either
+  // the list or the single-project response, so nothing ever populates this
+  // field. Deprecated in favor of ssoProtectionDeploymentType,
+  // passwordProtectionDeploymentType, trustedIpsProtectionMode,
+  // optionsAllowlistPaths, and protectionBypassCount, which carry the
+  // protection settings the API does return.
+  protectionConfig @maturity("deprecated") dict
   // Number of automation bypass secrets registered for the project
   //
   // Each entry is a secret that skips deployment protection for any request


### PR DESCRIPTION
Third of three stacked PRs from a live verification run. **Based on #9742** — review that first; this diff is the third commit.

## The problem

`vercel.project.protectionConfig` was modeled from Vercel's published project schema, and the API does not return it.

It is absent from the `/v9/projects` list payload:

```
protection-ish keys present across all 20 project payloads:
  gitForkProtection, gitProviderOptions, oidcTokenConfig, optionsAllowlist,
  passwordProtection, protectedSourcemaps, protectionBypass,
  skewProtectionMaxAge, ssoProtection, trustedIps
```

and from the single-project response:

```
GET /v9/projects/{id}  →  has protectionConfig: False
```

So the field is null on every project, always. Across a 22-project account, zero have a non-null value:

```
vercel.projects.where(protectionConfig != null).length  →  0
```

## The fix

Mark it `@maturity("deprecated")` and point at the fields that do carry the project's protection settings — `ssoProtectionDeploymentType`, `passwordProtectionDeploymentType`, `trustedIpsProtectionMode`, `optionsAllowlistPaths`, and `protectionBypassCount` (added in #9742).

The field is kept rather than removed because it has shipped. Its `.lr.versions` entry stays at its original version, since deprecation does not bump.

## Note

This and #9742 share a root cause worth flagging for future work on this provider: both fields were modeled from the published schema rather than from a live payload, and that schema is wrong in **both** directions — it omits `protectionBypass` on projects (which exists) and documents `protectionConfig` (which does not). The existing note in this provider's history, "docs schema is incomplete, do not trust *not in the docs* as *not returned*", holds in the inverse direction too.
