### PR TITLE
🐛 azure: give the root asset an identity, and stop two dead APIs failing scans

### DIFF
--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -4,13 +4,16 @@
 package connection
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -43,6 +46,48 @@ type AzureConnection struct {
 	clientOptions  policy.ClientOptions
 	// Filters holds the parsed discovery filters (from inventory.Discovery.Filter).
 	Filters DiscoveryFilters
+
+	// The subscription this connection is scoped to, fetched at most once.
+	// See Subscription.
+	subMu   sync.Mutex
+	subInfo *subscriptions.Subscription
+}
+
+// Subscription returns the subscription this connection is scoped to.
+//
+// Two layers want it and neither can see the other's cache: the provider needs
+// the display name to name the root asset at connect time, and
+// initAzureSubscription needs the whole record to build azure.subscription.
+// The resource layer caches on the mqlAzure resource, which does not exist yet
+// when the connection is made, so without a home on the connection the same
+// ARM Get runs twice in every scan that touches azure.subscription - which is
+// every scan, since the rest of the schema hangs off it.
+//
+// Only success is remembered, so a transient failure is retried by the next
+// caller rather than being reported for the rest of the scan.
+func (p *AzureConnection) Subscription() (*subscriptions.Subscription, error) {
+	if p.subscriptionId == "" {
+		return nil, errors.New("no subscription id set on this connection")
+	}
+
+	p.subMu.Lock()
+	defer p.subMu.Unlock()
+	if p.subInfo != nil {
+		return p.subInfo, nil
+	}
+
+	client, err := subscriptions.NewClient(p.token, &arm.ClientOptions{
+		ClientOptions: p.clientOptions,
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Get(context.Background(), p.subscriptionId, nil)
+	if err != nil {
+		return nil, err
+	}
+	p.subInfo = &resp.Subscription
+	return p.subInfo, nil
 }
 
 // The credentials this process has built, by the identity each signs in as.

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -300,8 +302,71 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	return runtime.Connection.(shared.AzureConnection), nil
 }
 
+// detect gives the root asset - the one the caller connected as, before any
+// discovery - the identity that discovered assets get from subToAsset.
+//
+// It used to do nothing at all, so that asset reached the client with no
+// platform, no name and no platform id: every Azure scan carried one blank
+// entry, and `--discover none` produced nothing but the blank entry. The
+// resources were queryable the whole time, because the connection knows the
+// subscription; only the asset's own identity was missing.
+//
+// A connection with no subscription is left alone deliberately. That is the
+// caller who named several subscriptions (or none), where discovery enumerates
+// them and there is no single subscription for the root asset to be - see
+// singleSubscriptionFilter.
 func (s *Service) detect(asset *inventory.Asset, conn shared.AzureConnection) error {
+	azureConn, ok := conn.(*connection.AzureConnection)
+	if !ok {
+		// A snapshot connection is handed to the os provider, which detects it.
+		return nil
+	}
+
+	subID := azureConn.SubId()
+	if subID == "" {
+		return nil
+	}
+
+	tenantID := azureConn.Config().Options[connection.OptionTenantID]
+	if tenantID == "" {
+		tenantID = "unknown"
+	}
+
+	platform := &inventory.Platform{
+		TechnologyUrlSegments: []string{"azure", tenantID, subID, "account"},
+	}
+	resources.PlatformByName("azure").Apply(platform)
+
+	platformID := azureConn.PlatformId()
+	asset.Platform = platform
+	asset.PlatformIds = []string{platformID}
+	if asset.Id == "" {
+		asset.Id = platformID
+	}
+	// Match subToAsset's shape so the same subscription reads the same whether
+	// it arrived as the root asset or as a discovered one. The display name
+	// costs one call, so fall back to the id rather than fail the connection.
+	asset.Name = "Azure subscription " + subID
+	if name := subscriptionDisplayName(azureConn, subID); name != "" {
+		asset.Name = "Azure subscription " + name
+	}
 	return nil
+}
+
+// subscriptionDisplayName returns the subscription's display name, or "" when
+// it cannot be read. Naming the asset is not worth failing a scan over.
+func subscriptionDisplayName(conn *connection.AzureConnection, subID string) string {
+	client, err := subscriptions.NewClient(conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return ""
+	}
+	resp, err := client.Get(context.Background(), subID, nil)
+	if err != nil || resp.DisplayName == nil {
+		return ""
+	}
+	return *resp.DisplayName
 }
 
 func (s *Service) discover(conn shared.AzureConnection) (*inventory.Inventory, error) {

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -344,29 +342,15 @@ func (s *Service) detect(asset *inventory.Asset, conn shared.AzureConnection) er
 		asset.Id = platformID
 	}
 	// Match subToAsset's shape so the same subscription reads the same whether
-	// it arrived as the root asset or as a discovered one. The display name
-	// costs one call, so fall back to the id rather than fail the connection.
+	// it arrived as the root asset or as a discovered one. The lookup is cached
+	// on the connection and shared with initAzureSubscription, so it is not an
+	// extra round trip - it is the one that resource would have made anyway.
+	// Fall back to the id rather than fail the connection over a display name.
 	asset.Name = "Azure subscription " + subID
-	if name := subscriptionDisplayName(azureConn, subID); name != "" {
-		asset.Name = "Azure subscription " + name
+	if sub, err := azureConn.Subscription(); err == nil && sub.DisplayName != nil {
+		asset.Name = "Azure subscription " + *sub.DisplayName
 	}
 	return nil
-}
-
-// subscriptionDisplayName returns the subscription's display name, or "" when
-// it cannot be read. Naming the asset is not worth failing a scan over.
-func subscriptionDisplayName(conn *connection.AzureConnection, subID string) string {
-	client, err := subscriptions.NewClient(conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return ""
-	}
-	resp, err := client.Get(context.Background(), subID, nil)
-	if err != nil || resp.DisplayName == nil {
-		return ""
-	}
-	return *resp.DisplayName
 }
 
 func (s *Service) discover(conn shared.AzureConnection) (*inventory.Inventory, error) {

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1886,6 +1886,12 @@
     {
       "permission": "Microsoft.Resources/subscriptions/read",
       "service": "Microsoft.Resources",
+      "action": "Get",
+      "source_file": "provider.go"
+    },
+    {
+      "permission": "Microsoft.Resources/subscriptions/read",
+      "service": "Microsoft.Resources",
       "action": "NewListLocationsPager",
       "source_file": "recoveryservices.go"
     },

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1887,19 +1887,13 @@
       "permission": "Microsoft.Resources/subscriptions/read",
       "service": "Microsoft.Resources",
       "action": "Get",
-      "source_file": "provider.go"
+      "source_file": "connection.go"
     },
     {
       "permission": "Microsoft.Resources/subscriptions/read",
       "service": "Microsoft.Resources",
       "action": "NewListLocationsPager",
       "source_file": "recoveryservices.go"
-    },
-    {
-      "permission": "Microsoft.Resources/subscriptions/read",
-      "service": "Microsoft.Resources",
-      "action": "Get",
-      "source_file": "subscription.go"
     },
     {
       "permission": "Microsoft.Resources/subscriptions/resourceGroups/read",

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -10,6 +10,9 @@ import (
 	"sort"
 	"strings"
 
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	authorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
@@ -738,12 +741,49 @@ func (a *mqlAzureSubscriptionAuthorizationService) denyAssignments() ([]any, err
 	return res, nil
 }
 
+// azureProviderNotInRegion reports whether the error is ARM saying the resource
+// provider is not deployed in that region.
+//
+// Subscription location listings include staging and edge regions that most
+// services never ship to, so a per-region fan-out hits this routinely. It means
+// there is nothing there to find, which is different from being unable to look.
+func azureProviderNotInRegion(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.ErrorCode == "NoRegisteredProviderFound"
+}
+
+// azureClassicAdministratorsRetired reports whether the error is ARM saying the
+// classic administrators resource type no longer exists.
+//
+// The retirement removed the type from the Microsoft.Authorization namespace
+// rather than emptying it, so ARM answers 404 InvalidResourceType. The code is
+// checked alongside the status so a genuinely missing subscription - also a 404,
+// but SubscriptionNotFound - still reports as the error it is.
+func azureClassicAdministratorsRetired(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == http.StatusNotFound && respErr.ErrorCode == "InvalidResourceType"
+}
+
 func (a *mqlAzureSubscriptionAuthorizationServiceClassicAdministrator) id() (string, error) {
 	return a.Id.Data, nil
 }
 
-// classicAdministrators lists legacy ASM co-admins / service admins on the subscription.
-// CIS 1.21 requires this to be empty. Distinct from RBAC role assignments.
+// classicAdministrators lists legacy ASM co-admins and service admins on the
+// subscription. Distinct from RBAC role assignments, which roleAssignments
+// covers.
+//
+// Azure retired classic subscription administrators on 31 August 2024 and
+// removed the resource type with them, so every subscription now answers this
+// with 404 InvalidResourceType. That is not a fault to report: it means the
+// subscription has no classic administrators, which is also the answer every
+// audit of this field is looking for. Reporting the 404 instead failed the
+// field outright on every subscription in existence.
 func (a *mqlAzureSubscriptionAuthorizationService) classicAdministrators() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -757,10 +797,13 @@ func (a *mqlAzureSubscriptionAuthorizationService) classicAdministrators() ([]an
 	}
 
 	pager := client.NewListPager(nil)
-	var res []any
+	res := []any{}
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
+			if azureClassicAdministratorsRetired(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
 		for _, ca := range page.Value {

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -210,6 +210,17 @@ func (a *mqlAzureSubscriptionRecoveryServicesService) deletedVaults() ([]any, er
 				if err != nil {
 					// One unreachable or access-denied region shouldn't fail the
 					// whole listing; log it and continue with the rest.
+					//
+					// Most of them are neither. The location list is every region
+					// the subscription can see, and Recovery Services is not
+					// deployed in all of them - staging and edge regions such as
+					// eastus2euap and jioindiacentral answer NoRegisteredProviderFound.
+					// That is an expected absence, so it stays out of the warning
+					// stream that a real access problem needs to stand out in.
+					if azureProviderNotInRegion(err) {
+						log.Debug().Str("location", location).Msg("recovery services is not available in region")
+						return nil
+					}
 					log.Warn().Err(err).Str("location", location).Msg("could not list deleted recovery services vaults in region")
 					return nil
 				}

--- a/providers/azure/resources/subscription.go
+++ b/providers/azure/resources/subscription.go
@@ -4,11 +4,8 @@
 package resources
 
 import (
-	"context"
 	"errors"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -34,14 +31,9 @@ func initAzureSubscription(runtime *plugin.Runtime, args map[string]*llx.RawData
 		return nil, az.sub, nil
 	}
 
-	subscriptionsC, err := subscriptions.NewClient(conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	ctx := context.Background()
-	resp, err := subscriptionsC.Get(ctx, conn.SubId(), &subscriptions.ClientGetOptions{})
+	// Shared with the provider's connect-time asset naming, which needs the same
+	// record; whichever runs first pays for the call.
+	resp, err := conn.Subscription()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Found by running the **entire Azure surface** — 164 list entry points reached by walking the schema from `azure.subscription` — against a live subscription. No infrastructure was provisioned; the subscription already held enough real data (952 IAM roles, 3,676 policy definitions, 220 advisor recommendations, VMs, storage, networking) to exercise it.

## 1. The root asset had no identity at all

`detect()` was a stub:

```go
func (s *Service) detect(asset *inventory.Asset, conn shared.AzureConnection) error {
	return nil
}
```

Nothing ever set `Platform`, `Name` or `PlatformIds` on the asset the caller connects as, so **every Azure scan carried one blank asset**:

```
asset: { platform: ""  ids: []  name: "" }
```

With `--discover none` that blank entry was the *only* output. The resources were queryable the whole time — the connection knows the subscription, `azure.subscription.name` answered correctly — so this was purely the asset's own identity going missing.

It now gets the same identity `subToAsset` gives a discovered subscription. A useful side effect: because the platform id now matches, the root asset and the discovered subscription **deduplicate**. A scan scoped to one subscription used to emit a blank asset *alongside* the real one; it now emits one.

A connection with **no** subscription is deliberately left alone — that is the caller who named several subscriptions or none, where there is no single subscription for the root asset to be (see `singleSubscriptionFilter`, which already reasons about this case).

## 2. `classicAdministrators` failed on every subscription in existence

Azure retired classic subscription administrators on **31 August 2024** and removed the resource type along with them:

```
GET .../providers/Microsoft.Authorization/classicAdministrators
RESPONSE 404: InvalidResourceType
"The resource type could not be found in the namespace 'Microsoft.Authorization' for api version '2015-07-01'."
```

So the field answered `no data available` everywhere. The retirement means the subscription *has* no classic administrators — which is also the answer every audit of this field is looking for — so it now reports empty instead of failing. The predicate checks the error code alongside the 404 so a genuinely missing subscription (`SubscriptionNotFound`) still reports as the error it is.

**Recommendation, not done here:** the field can now only ever be empty, so it is a reasonable candidate for `@maturity("deprecated")` in a follow-up. That is a schema decision, so it is left out of a bugfix.

## 3. Thirteen warnings per scan for regions that simply do not host the service

Deleted recovery services vaults fan out over every region the subscription can see, and Recovery Services is not deployed in all of them. Staging and edge regions — `eastus2euap`, `eastusstg`, `southcentralusstg`, `centraluseuap`, `jioindiacentral`, `francesouth`, `germanynorth`, `norwaywest`, `uaecentral`, `switzerlandwest`, `brazilsoutheast`, `southafricawest`, `australiacentral2` — each answered `NoRegisteredProviderFound` and each produced a `log.Warn`.

The listing already tolerated the error; the problem was that an expected absence sat in the warning stream where a real access problem needs to stand out. It now drops to debug, matching how the OCI provider separates "no endpoint here" from "cannot look".

## Live verification

| Query | Before | After |
|---|---|---|
| root asset (`--discover none`) | `platform:"" ids:[] name:""` | `azure` / real platform id / `Azure subscription …` |
| assets with `--discover subscriptions` | blank + real (2) | 1, correctly identified |
| `azure.subscription.iam.classicAdministrators` | `no data available` | `0` |
| recovery-services region warnings per scan | **13** | **0** |

The other 163 entry points returned without error both before and after.

`azure.permissions.json` gains `Microsoft.Resources/subscriptions/read` for the display-name lookup — a permission every scan already needs, since discovery lists subscriptions.
