### PR TITLE
🐛 gcp: stop a disabled Cloud Scheduler API failing the jobs listing

### DIFF
--- a/providers/gcp/resources/cloudscheduler.go
+++ b/providers/gcp/resources/cloudscheduler.go
@@ -6,16 +6,24 @@ package resources
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	scheduler "cloud.google.com/go/scheduler/apiv1"
 	"cloud.google.com/go/scheduler/apiv1/schedulerpb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
+
+type mqlGcpProjectCloudSchedulerServiceInternal struct {
+	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
+}
 
 func (g *mqlGcpProject) cloudScheduler() (*mqlGcpProjectCloudSchedulerService, error) {
 	if g.Id.Error != nil {
@@ -27,7 +35,41 @@ func (g *mqlGcpProject) cloudScheduler() (*mqlGcpProjectCloudSchedulerService, e
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectCloudSchedulerService), nil
+
+	serviceEnabled, err := g.isServiceEnabled(service_cloudscheduler)
+	if err != nil {
+		return nil, err
+	}
+	schedulerService := res.(*mqlGcpProjectCloudSchedulerService)
+	schedulerService.serviceEnabled = serviceEnabled
+	return schedulerService, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// The flag is only set by the accessor above, but this resource is reachable
+// without going through it - a resource init can build it with CreateResource.
+// Resolving it here makes every construction path agree, rather than leaving
+// the Go zero value false to report an empty list as fact.
+func (g *mqlGcpProjectCloudSchedulerService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_cloudscheduler)
+	})
+	return g.serviceEnabled, g.serviceErr
 }
 
 func (g *mqlGcpProjectCloudSchedulerService) id() (string, error) {
@@ -42,6 +84,21 @@ func (g *mqlGcpProjectCloudSchedulerService) jobs() ([]any, error) {
 		return nil, g.ProjectId.Error
 	}
 	projectId := g.ProjectId.Data
+
+	// A project that never turned Cloud Scheduler on answers ListJobs with
+	// PermissionDenied "API has not been used in project ... or it is disabled",
+	// which failed the field outright. Not having enabled a service is the
+	// ordinary state of most projects, and the answer it deserves is "no jobs",
+	// not an error, so the gate every other service resource uses applies here
+	// too.
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		log.Debug().Str("service", service_cloudscheduler).Msg("gcp service is not enabled, skipping")
+		return []any{}, nil
+	}
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 	creds, err := conn.Credentials(scheduler.DefaultAuthScopes()...)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -76945,7 +76945,7 @@ func (c *mqlGcpProjectCloudTasksServiceQueue) GetIamPolicy() *plugin.TValue[[]an
 type mqlGcpProjectCloudSchedulerService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectCloudSchedulerServiceInternal it will be used here
+	mqlGcpProjectCloudSchedulerServiceInternal
 	ProjectId plugin.TValue[string]
 	Jobs      plugin.TValue[[]any]
 }

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -58,6 +58,7 @@ const (
 	service_networksecurity     = "networksecurity.googleapis.com"
 	service_dataplex            = "dataplex.googleapis.com"
 	service_workflows           = "workflows.googleapis.com"
+	service_cloudscheduler      = "cloudscheduler.googleapis.com"
 	service_clouddomains        = "domains.googleapis.com"
 	service_cloudasset          = "cloudasset.googleapis.com"
 	service_pam                 = "privilegedaccessmanager.googleapis.com"


### PR DESCRIPTION
Found by running all **248 GCP list entry points** — reached by walking the schema from `gcp.project` — against a live project.

## The bug

`gcp.project.cloudScheduler.jobs` had **no service-enabled gate at all**. A project that never turned the API on answers `ListJobs` with:

```
rpc error: code = PermissionDenied desc = Cloud Scheduler API has not been used
in project <project> before or it is disabled.
```

so the field failed outright rather than reporting what the disabled API means: there are no scheduler jobs. Not having enabled a service is the ordinary state of most projects — every other GCP service resource gates on this, `cloudscheduler.go` was simply missed.

## Why the lazy gate rather than the bare bool

The obvious fix — set `serviceEnabled` in the `gcp.project.cloudScheduler()` accessor and read it in `jobs()` — is the pattern that had to be repaired in #9436. The flag is only set by that accessor, and the service resource is reachable without it (a resource init can build it with `CreateResource`). On those paths the Go zero value `false` makes the collection return an **empty list with no error** — an authoritative "there is nothing here" that makes an audit pass vacuously, which is worse than the failure being fixed.

So this uses the same lazy `isEnabled()` helper (`serviceOnce sync.Once` + `isServiceEnabled`) that `bigquery.go` and `storage.go` carry, which makes every construction path agree.

## Verification

Live, against a project with the Cloud Scheduler API disabled:

| Query | Before | After |
|---|---|---|
| `gcp.project.cloudScheduler.jobs.length` | `no data available` (PermissionDenied) | `0` |

The other 247 entry points returned without error. The only other non-empty result was `gcp.project.accessApprovalSettings.*`, which correctly reports `null` because Access Approval is not configured — MQL null propagation, not a defect.

`gcp.lr.go` is regenerated because the new `Internal` struct has to be embedded; `gcp.lr.versions` and `gcp.permissions.json` are unchanged (no schema or API-surface change).

## Related, not fixed here

This is one instance of a broader gap: the audit behind #9436 counted **62 bare `if !g.serviceEnabled` sites across 23 files** still using the zero-value-prone form. This PR fixes the one entry point that actually failed against a live project rather than converting all of them blind.
