### PR TITLE
🐛 aws: a curly apostrophe defeated the Macie not-enabled guard

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -272,8 +272,9 @@ func IsMacieNotEnabledError(err error) bool {
 
 	var respErr *http.ResponseError
 	if errors.As(err, &respErr) {
+		msg := awsNormalizeApostrophes(respErr.Error())
 		// Macie returns 401 status code with AccessDeniedException when not enabled
-		if respErr.HTTPStatusCode() == 401 && strings.Contains(respErr.Error(), "AccessDeniedException: Macie is not enabled") {
+		if respErr.HTTPStatusCode() == 401 && strings.Contains(msg, "AccessDeniedException: Macie is not enabled") {
 			return true
 		}
 		// Also catch general access denied cases for Macie, but only when the
@@ -282,20 +283,67 @@ func IsMacieNotEnabledError(err error) bool {
 		// enabled", so every Macie resource degraded to empty and any
 		// data-classification policy passed vacuously.
 		if (respErr.HTTPStatusCode() == 400 || respErr.HTTPStatusCode() == 401 || respErr.HTTPStatusCode() == 403) &&
-			(strings.Contains(respErr.Error(), "AccessDeniedException") || strings.Contains(respErr.Error(), "AccessDenied")) &&
-			(strings.Contains(respErr.Error(), "Macie is not enabled") ||
-				strings.Contains(respErr.Error(), "Macie isn't enabled") ||
-				strings.Contains(respErr.Error(), "not enabled for your account")) {
+			(strings.Contains(msg, "AccessDeniedException") || strings.Contains(msg, "AccessDenied")) &&
+			(strings.Contains(msg, "Macie is not enabled") ||
+				strings.Contains(msg, "Macie isn't enabled") ||
+				strings.Contains(msg, "not enabled for your account")) {
 			return true
 		}
 		// GetClassificationExportConfiguration / GetAutomatedDiscoveryConfiguration
 		// return 404 ResourceNotFoundException when Macie isn't enabled in the region.
 		if respErr.HTTPStatusCode() == 404 &&
-			(strings.Contains(respErr.Error(), "Macie isn't enabled") || strings.Contains(respErr.Error(), "Macie is not enabled")) {
+			(strings.Contains(msg, "Macie isn't enabled") || strings.Contains(msg, "Macie is not enabled")) {
+			return true
+		}
+		// The automated-discovery endpoints have a shape of their own that never
+		// names Macie: 403 AccessDeniedException "Account Id: [...] has not been
+		// onboarded". Onboarding state is not a permission gap, so matching it
+		// does not reintroduce the swallowing problem the Macie-named condition
+		// above exists to prevent - no IAM denial is phrased this way.
+		if respErr.HTTPStatusCode() == 403 &&
+			strings.Contains(msg, "AccessDeniedException") &&
+			strings.Contains(msg, "has not been onboarded") {
 			return true
 		}
 	}
 	return false
+}
+
+// awsNormalizeApostrophes rewrites the typographic apostrophe to the ASCII one.
+//
+// Several services write prose error messages with U+2019 RIGHT SINGLE
+// QUOTATION MARK rather than U+0027: Macie answers a region where it is not
+// enabled with "Macie isn't enabled in the specified AWS Region", spelled with
+// the curly one. A guard written with a plain apostrophe - which is what
+// anyone typing the message back out produces - never matches it, and the
+// service-not-enabled case it exists to absorb is reported as a failure
+// instead. Normalising once is cheaper than getting the byte right at every
+// call site, and survives AWS changing its mind about quote style.
+func awsNormalizeApostrophes(s string) string {
+	return strings.ReplaceAll(s, "’", "'")
+}
+
+// IsSecurityLakeNotEnabledError reports whether the error means Security Lake
+// has not been enabled for the account.
+//
+// Security Lake answers a listing with 404 ResourceNotFoundException and "isn't
+// enabled for your account in any Regions" until someone turns it on, which
+// neither the access-denied nor the not-available-in-region guard covers. An
+// account that has not adopted the service has no subscribers, which is the
+// answer to report - not a failed query.
+func IsSecurityLakeNotEnabledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var respErr *http.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	msg := awsNormalizeApostrophes(respErr.Error())
+	return respErr.HTTPStatusCode() == 404 &&
+		strings.Contains(msg, "ResourceNotFoundException") &&
+		(strings.Contains(msg, "Security Lake isn't enabled") ||
+			strings.Contains(msg, "Security Lake is not enabled"))
 }
 
 func Is400InstanceNotFoundError(err error) bool {

--- a/providers/aws/resources/aws_securitylake.go
+++ b/providers/aws/resources/aws_securitylake.go
@@ -199,6 +199,10 @@ func (a *mqlAwsSecuritylake) getSubscribers(conn *connection.AwsConnection) []*j
 						log.Debug().Str("region", region).Msg("security lake is not available in region")
 						return res, nil
 					}
+					if IsSecurityLakeNotEnabledError(err) {
+						log.Debug().Str("region", region).Msg("security lake is not enabled for this account")
+						return res, nil
+					}
 					return nil, err
 				}
 

--- a/providers/aws/resources/aws_test.go
+++ b/providers/aws/resources/aws_test.go
@@ -114,6 +114,64 @@ func TestIsMacieNotEnabledError(t *testing.T) {
 		assert.True(t, IsMacieNotEnabledError(macieHTTPError(404,
 			"ResourceNotFoundException: Amazon Macie isn't enabled for your account")))
 	})
+
+	// The regression. Macie writes this message with U+2019, not the ASCII
+	// apostrophe, so a guard spelled with a plain quote never matched it and
+	// ListAllowLists reported a failure in every account without Macie. The
+	// literals below are deliberately the curly form - normalising them to
+	// ASCII here would test nothing.
+	t.Run("403 with a typographic apostrophe", func(t *testing.T) {
+		assert.True(t, IsMacieNotEnabledError(macieHTTPError(403,
+			"AccessDeniedException: The request failed because Macie isn’t enabled in the specified AWS Region.")))
+	})
+
+	t.Run("404 with a typographic apostrophe", func(t *testing.T) {
+		assert.True(t, IsMacieNotEnabledError(macieHTTPError(404,
+			"ResourceNotFoundException: Amazon Macie isn’t enabled")))
+	})
+
+	// GetAutomatedDiscoveryConfiguration never names Macie at all.
+	t.Run("403 not onboarded", func(t *testing.T) {
+		assert.True(t, IsMacieNotEnabledError(macieHTTPError(403,
+			"AccessDeniedException: Account Id: [123456789012] has not been onboarded")))
+	})
+
+	// The onboarding branch must not widen into the swallowing problem the
+	// Macie-named condition exists to prevent.
+	t.Run("permission gap is still an error under the onboarding branch", func(t *testing.T) {
+		assert.False(t, IsMacieNotEnabledError(macieHTTPError(403,
+			"AccessDeniedException: User is not authorized to perform macie2:GetAutomatedDiscoveryConfiguration")))
+	})
+}
+
+func TestAwsNormalizeApostrophes(t *testing.T) {
+	assert.Equal(t, "isn't", awsNormalizeApostrophes("isn’t"))
+	assert.Equal(t, "isn't", awsNormalizeApostrophes("isn't"), "ASCII input is left alone")
+	assert.Equal(t, "", awsNormalizeApostrophes(""))
+}
+
+// TestIsSecurityLakeNotEnabledError covers the shape neither the access-denied
+// nor the not-available-in-region guard caught, which failed the subscriber
+// listing for every account that has not adopted Security Lake.
+func TestIsSecurityLakeNotEnabledError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsSecurityLakeNotEnabledError(nil))
+	})
+
+	t.Run("404 not enabled for the account", func(t *testing.T) {
+		assert.True(t, IsSecurityLakeNotEnabledError(macieHTTPError(404,
+			"ResourceNotFoundException: The request failed because Security Lake isn’t enabled for your account in any Regions.")))
+	})
+
+	t.Run("permission denial is not a not-enabled signal", func(t *testing.T) {
+		assert.False(t, IsSecurityLakeNotEnabledError(macieHTTPError(403,
+			"AccessDeniedException: User is not authorized to perform securitylake:ListSubscribers")))
+	})
+
+	t.Run("an unrelated 404 is not a not-enabled signal", func(t *testing.T) {
+		assert.False(t, IsSecurityLakeNotEnabledError(macieHTTPError(404,
+			"ResourceNotFoundException: Subscriber not found")))
+	})
 }
 
 func TestFetchTagsConcurrently(t *testing.T) {


### PR DESCRIPTION
Found by running all **444 AWS list entry points** across 102 service roots against a live account (`us-east-1`). 100 entry points returned real data; these are the ones that failed.

## 1. A typographic apostrophe defeated the Macie not-enabled guard

Macie writes its not-enabled message with **U+2019 RIGHT SINGLE QUOTATION MARK**, not the ASCII apostrophe:

```
AccessDeniedException: The request failed because Macie isn’t enabled in the specified AWS Region.
```

`IsMacieNotEnabledError` tested for `"Macie isn't enabled"` spelled with a plain quote — which is what anyone typing the message back out produces — so the branch never matched. `od -c` on the live error:

```
M a c i e   i s n ’ ** **  t   e n a b l e d
```

(`’` is the three-byte `E2 80 99`.)

The existing unit test passed the entire time: it used the ASCII spelling *and* was carried by the neighbouring `"not enabled for your account"` condition, which contains no apostrophe. So the guard was covered by a test that could not fail on the real input. The new cases use the curly bytes deliberately.

Rather than correct the one byte, the message is now **normalised before matching**, so a guard written the natural way keeps working and AWS changing its quote style later does not silently break it again.

## 2. `GetAutomatedDiscoveryConfiguration` never names Macie

```
AccessDeniedException: Account Id: [REDACTED] has not been onboarded
```

Onboarding state is not a permission gap. Matching it does not reintroduce the swallowing problem the Macie-named condition exists to prevent — no IAM denial is phrased this way, and a genuine `macie2:*` denial is still reported as the error it is. There is a test asserting exactly that.

## 3. Security Lake had no not-enabled guard

```
404 ResourceNotFoundException: The request failed because Security Lake isn't enabled
for your account in any Regions.
```

`getSubscribers` handled access-denied and not-available-in-region, but not this, so the subscriber listing failed for every account that has not adopted Security Lake. `dataLakes` was unaffected — it answers empty rather than 404.

## Verification

Live, same account, before and after:

| Query | Before | After |
|---|---|---|
| `aws.macie.allowLists` | `no data available` | `0` |
| `aws.macie.automatedDiscoveryConfigurations` | `no data available` | `0` |
| `aws.securitylake.subscribers` | `no data available` | `0` |
| `aws.macie.findings` / `sessions` / `members` / … | `0` | `0` (unchanged) |

## Found but NOT fixed here

Three failures have no safe provider-side fix and are left alone deliberately:

- **`aws.appstream.images` — real data is being lost.** The Go SDK fails to decode a **200 OK**: `unexpected value type *cbor.Nil` on `DescribeImages`. The AWS CLI decodes the same call fine and returns 5 images, so this is an `aws-sdk-go-v2` CBOR bug, not ours — and we are already on the latest `service/appstream` (v1.64.5). Tracking issue to follow; guessing a workaround here would risk masking real payloads.
- **`aws.sagemaker.associations`** — `ListAssociations` requires a source or destination ARN, so a bare listing can never succeed. Dead as a list entry point; needs a schema decision (arguments or removal), not an error-handling change.
- **`aws.workdocs.users`** — `DescribeUsers` requires an `organizationId`. Same shape as above.

`aws.applicationAutoscaling.scalableTargets` also errors bare, but that one is by design — it asks for a namespace and names the valid ones, the same way `aws.waf` requires a scope.

`aws.permissions.json` is unchanged (no new API calls).
