### PR TITLE
🐛 digitalocean: do not fail Spaces listing on unimplemented S3 APIs

### DIFF
--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -272,7 +272,12 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 		}
 	} else if isAccessDenied(err) {
 		log.Warn().Err(err).Str("bucket", name).Msg("digitalocean> ACL access denied; bucket reported with no grants — audit results may be incomplete")
-	} else if !isUnsupportedOperation(err) {
+	} else if isUnsupportedOperation(err) {
+		// The grants feed publicReadAcl, authenticatedReadAcl and isPublic, so a
+		// bucket reported with none reads as "not public". Say so when the read
+		// did not happen, rather than letting the absence pass for a finding.
+		log.Warn().Err(err).Str("bucket", name).Msg("digitalocean> ACL API not implemented; bucket reported with no grants — audit results may be incomplete")
+	} else {
 		return nil, err
 	}
 

--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -410,26 +410,6 @@ var noSuchConfigurationCodes = []string{
 // the bucket has never been configured for that property. Both the
 // typed APIError code and the raw error string are checked because
 // Spaces sometimes surfaces the code only in the body text.
-// isUnsupportedOperation reports whether err is the S3 API answering that it
-// does not implement the operation at all. Spaces implements a subset of the
-// S3 API, so calls that exist only on AWS (GetPublicAccessBlock, for one)
-// come back 501 NotImplemented on every account. That is a statement about
-// the service, not about the bucket, so the caller keeps its default and
-// carries on rather than failing the whole listing.
-func isUnsupportedOperation(err error) bool {
-	if err == nil {
-		return false
-	}
-	var ae smithy.APIError
-	if errors.As(err, &ae) {
-		switch ae.ErrorCode() {
-		case "NotImplemented", "MethodNotAllowed":
-			return true
-		}
-	}
-	return strings.Contains(err.Error(), "NotImplemented")
-}
-
 func isNoSuchConfiguration(err error) bool {
 	if err == nil {
 		return false
@@ -449,6 +429,26 @@ func isNoSuchConfiguration(err error) bool {
 		}
 	}
 	return false
+}
+
+// isUnsupportedOperation returns true when the S3 API answers that it does
+// not implement the operation at all. Spaces implements a subset of the S3
+// API, so calls that exist only on AWS (GetPublicAccessBlock, for one) come
+// back 501 NotImplemented on every account. That describes the service
+// rather than the bucket, so the caller keeps its default and carries on
+// instead of failing the whole listing.
+func isUnsupportedOperation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		switch ae.ErrorCode() {
+		case "NotImplemented", "MethodNotAllowed":
+			return true
+		}
+	}
+	return strings.Contains(err.Error(), "NotImplemented")
 }
 
 func isAccessDenied(err error) bool {

--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -234,7 +234,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 				aws.ToBool(cfg.IgnorePublicAcls) &&
 				aws.ToBool(cfg.RestrictPublicBuckets)
 		}
-	} else if !isNoSuchConfiguration(err) {
+	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
@@ -272,7 +272,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 		}
 	} else if isAccessDenied(err) {
 		log.Warn().Err(err).Str("bucket", name).Msg("digitalocean> ACL access denied; bucket reported with no grants — audit results may be incomplete")
-	} else {
+	} else if !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
@@ -288,7 +288,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 				encryptionKmsKeyId = aws.ToString(rule.ApplyServerSideEncryptionByDefault.KMSMasterKeyID)
 			}
 		}
-	} else if !isNoSuchConfiguration(err) {
+	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
@@ -297,7 +297,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 	if v, err := client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(name)}); err == nil {
 		versioningStatus = string(v.Status)
 		mfaDeleteEnabled = v.MFADelete == s3types.MFADeleteStatusEnabled
-	} else if !isAccessDenied(err) {
+	} else if !isAccessDenied(err) && !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
@@ -312,7 +312,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 				policyDict = raw
 			}
 		}
-	} else if !isNoSuchConfiguration(err) {
+	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
@@ -321,7 +321,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 		for _, rule := range c.CORSRules {
 			corsRules = append(corsRules, spacesCorsRuleDict(rule))
 		}
-	} else if !isNoSuchConfiguration(err) {
+	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
@@ -330,7 +330,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 		for _, rule := range l.Rules {
 			lifecycleRules = append(lifecycleRules, spacesLifecycleRuleDict(rule))
 		}
-	} else if !isNoSuchConfiguration(err) {
+	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
@@ -410,6 +410,26 @@ var noSuchConfigurationCodes = []string{
 // the bucket has never been configured for that property. Both the
 // typed APIError code and the raw error string are checked because
 // Spaces sometimes surfaces the code only in the body text.
+// isUnsupportedOperation reports whether err is the S3 API answering that it
+// does not implement the operation at all. Spaces implements a subset of the
+// S3 API, so calls that exist only on AWS (GetPublicAccessBlock, for one)
+// come back 501 NotImplemented on every account. That is a statement about
+// the service, not about the bucket, so the caller keeps its default and
+// carries on rather than failing the whole listing.
+func isUnsupportedOperation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		switch ae.ErrorCode() {
+		case "NotImplemented", "MethodNotAllowed":
+			return true
+		}
+	}
+	return strings.Contains(err.Error(), "NotImplemented")
+}
+
 func isNoSuchConfiguration(err error) bool {
 	if err == nil {
 		return false


### PR DESCRIPTION
Found while live-verifying the digitalocean provider against real provisioned infrastructure.

## The bug

`digitalocean.spacesBuckets` returns **no data on every account**.

Spaces implements a subset of the S3 API. `GetPublicAccessBlock` exists only on AWS, so Spaces answers `501 NotImplemented` for every bucket. That error is neither a missing-configuration code nor an access denial, so `newSpacesBucket` fell through to `return nil, err` and the whole listing failed:

```
digitalocean.spacesBuckets { name }

operation error S3: GetPublicAccessBlock, https response error StatusCode: 501,
api error NotImplemented: Server does not support the functionality required to
fulfill the request. Please see
https://developers.digitalocean.com/documentation/spaces/#aws-s3-compatibility

digitalocean.spacesBuckets: no data available
```

The failure is in the constructor, not in a queried field, so selecting fewer fields does not avoid it — I confirmed the same failure querying only `name` and `region`. Every one of the resource's 18 fields plus the `isPublic` and `hasWildcardPolicy` predicates was unreachable.

## The fix

Add `isUnsupportedOperation` and treat it like the existing missing-configuration case: keep the default and carry on.

A 501 says the *service* does not implement the call — a statement about Spaces, not about the bucket. So `publicAccessBlocked` stays `false`, which is what a platform with no public-access-block feature actually means; there is no block in place. The ACL and policy based predicates (`isPublic`, `hasWildcardPolicy`) are unaffected because Spaces does implement those calls.

Applied at every guarded S3 call in the constructor (7 sites), not only the one that fails today, since any of them may be absent from the Spaces subset.

## Verification

Provisioned a real Spaces bucket and configured CORS, a lifecycle rule and versioning on it. Before the fix, the listing failed as above. After:

```
digitalocean.spacesBuckets { name region versioningStatus publicAccessBlocked
                             corsRules lifecycleRules isPublic hasWildcardPolicy }

name:               "…-bkt"
region:             "nyc3"
versioningStatus:   "Enabled"
publicAccessBlocked: false
isPublic:           false
hasWildcardPolicy:  false
corsRules:      [{allowedMethods: ["GET","PUT"], allowedOrigins: ["https://example.com"],
                  exposeHeaders: ["ETag"], maxAgeSeconds: 3000, allowedHeaders: ["*"]}]
lifecycleRules: [{id: "expire-old", prefix: "logs/", status: "Enabled",
                  expirationDays: 30, noncurrentVersionExpirationDays: 7}]
```

Both rule sets match exactly what was configured on the bucket, which also exercises the `corsRules` / `lifecycleRules` dict normalization from #9366 against real data for the first time.

Provider unit tests pass. All test infrastructure has been destroyed.

No schema change, so no `.lr.versions` entry.
