### PR TITLE
🐛 fix array concat with empty and null operands

### DIFF
--- a/llx/builtin_array.go
+++ b/llx/builtin_array.go
@@ -1132,36 +1132,23 @@ func tarrayConcatTarrayV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uin
 		return nil, rref, err
 	}
 
-	if items.Value == nil {
-		return &RawData{Type: items.Type}, 0, nil
-	}
+	// Either side may be empty or null, and either side may be the one carrying
+	// the element type, since `[]` resolves to []unset. Resolving the type from
+	// both operands keeps the result usable regardless of operand order.
+	resType := types.CoalesceArrays(bind.Type, items.Type)
 
-	v, _ := bind.Value.([]any)
-	if v == nil {
-		if items.Value == nil {
-			return &RawData{Type: bind.Type}, 0, nil
-		}
-		return nil, 0, errors.New("cannot add arrays to null")
-	}
+	// A null operand contributes no items, the same as an empty one. Treating it
+	// as empty keeps the other operand's items instead of discarding them or
+	// failing the whole query.
+	left, _ := bind.Value.([]any)
+	right, _ := items.Value.([]any)
 
-	list := items.Value.([]any)
-	if len(list) == 0 {
-		return bind, 0, nil
-	}
-
-	res := make([]any, len(v)+len(list))
-	var idx int
-	for i := range v {
-		res[idx] = v[i]
-		idx++
-	}
-	for i := range list {
-		res[idx] = list[i]
-		idx++
-	}
+	res := make([]any, 0, len(left)+len(right))
+	res = append(res, left...)
+	res = append(res, right...)
 
 	return &RawData{
-		Type:  bind.Type,
+		Type:  resType,
 		Value: res,
 	}, 0, nil
 }

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -488,6 +488,37 @@ func TestCompiler_Arithmetics(t *testing.T) {
 			assert.Equal(t, 1, len(chunks[1].Function.Args))
 		})
 	})
+
+	// An empty array literal compiles to []unset. The concat result must still
+	// report a concrete element type, otherwise any downstream call that needs
+	// one fails to compile, and the value renders with no type information.
+	t.Run("concat with an empty array keeps the element type", func(t *testing.T) {
+		list := []struct {
+			code     string
+			expected types.Type
+		}{
+			{`["a"] + ["b"]`, types.Array(types.String)},
+			{`["a"] + []`, types.Array(types.String)},
+			{`[] + ["a"]`, types.Array(types.String)},
+			{`[] + ["a"] + ["b"]`, types.Array(types.String)},
+			{`[] + [1]`, types.Array(types.Int)},
+			{`[] + []`, types.Array(types.Unset)},
+			// A known element type is never rewritten by the other operand.
+			{`["a"] + [1]`, types.Array(types.String)},
+		}
+
+		for i := range list {
+			cur := list[i]
+			t.Run(cur.code, func(t *testing.T) {
+				compileT(t, cur.code, func(res *llx.CodeBundle) {
+					chunks := res.CodeV2.Blocks[0].Chunks
+					last := chunks[len(chunks)-1]
+					require.Equal(t, "+", last.Id)
+					assert.Equal(t, cur.expected, types.Type(last.Function.Type))
+				})
+			})
+		}
+	})
 }
 
 func TestCompiler_OperatorPrecedence(t *testing.T) {

--- a/mqlc/operators.go
+++ b/mqlc/operators.go
@@ -268,6 +268,12 @@ func compileTransformation(c *compiler, id string, call *parser.Call) (types.Typ
 		}
 	}
 
+	// An empty array literal carries no element type, so `[] + ["a"]` would
+	// otherwise report []unset and break any downstream call that needs a
+	// concrete element type. Resolve it from whichever operand knows it. This is
+	// done after the handler lookup above so the resolved function is unchanged.
+	lt = types.CoalesceArrays(lt, rt)
+
 	returnType := h.Typ
 	if returnType == types.NoType {
 		returnType = lt

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -793,6 +793,53 @@ func TestArray(t *testing.T) {
 			Code:        "[].flat + [9]",
 			Expectation: []any{int64(9)},
 		},
+		// Regression: concatenating an empty array literal must not drop the
+		// other operand's items, and must work on either side of the operator.
+		{
+			Code:        "[1,2,3] + []",
+			Expectation: []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			Code:        "[] + [1,2,3]",
+			Expectation: []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			Code:        "[1] + [] + [2]",
+			Expectation: []any{int64(1), int64(2)},
+		},
+		{
+			Code:        "[] + [1] + [2]",
+			Expectation: []any{int64(1), int64(2)},
+		},
+		{
+			Code:        "[] + []",
+			Expectation: []any{},
+		},
+		// The result of a concat with an empty operand must keep a usable element
+		// type, so downstream calls needing a concrete type still compile.
+		// Previously `[] + [...]` yielded an []unset array, which failed to
+		// compile with "expected string, got: unset". This mirrors the shape used
+		// by CIS policies that build a path list from several sources, any of
+		// which may come back empty.
+		{
+			Code:        "paths = [] + ['a','bb']\npaths.map(_.length)",
+			Expectation: []any{int64(1), int64(2)},
+		},
+		{
+			Code:        "paths = [] + ['/etc/hosts']\npaths.any(_ == '/etc/hosts')",
+			ResultIndex: 1, Expectation: true,
+		},
+		// A null array contributes no items, just like an empty one. It must not
+		// discard the other operand's items (which used to yield null and quietly
+		// evaluate a policy against nothing) or fail the query outright.
+		{
+			Code:        "paths = ['a'] + file('/not/there').content.lines\npaths",
+			Expectation: []any{"a"},
+		},
+		{
+			Code:        "paths = file('/not/there').content.lines + ['a']\npaths",
+			Expectation: []any{"a"},
+		},
 	})
 
 	t.Run("join()", func(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -257,6 +257,32 @@ func Enforce(left, right Type) (Type, bool) {
 	return right, len(left) == len(right)
 }
 
+// CoalesceArrays returns whichever of two array types carries a usable element
+// type. An empty array literal has none: `[]` compiles to []unset. Without this,
+// `[] + ["a"]` would keep the left type and yield an []unset result that fails
+// to compile downstream, while `["a"] + []` works, making operand order matter.
+//
+// Only a genuinely unknown element type is replaced. Mismatched but known types
+// keep the left one, preserving the existing behavior of `["a"] + [1]`.
+// Non-array types are returned unchanged, so arithmetic on scalars is unaffected.
+func CoalesceArrays(left, right Type) Type {
+	if left.IsArray() && right.IsArray() && arrayElemUnset(left) && !arrayElemUnset(right) {
+		return right
+	}
+	return left
+}
+
+// arrayElemUnset reports whether an array type lacks a usable element type,
+// either because it carries none at all (bare ArrayLike) or because the element
+// type is unset/null. Only call this on array types.
+func arrayElemUnset(typ Type) bool {
+	if len(typ) < 2 {
+		return true
+	}
+	child := typ.Child()
+	return child == Unset || child == Nil
+}
+
 // Child returns the child type of arrays and maps
 func (typ Type) Child() Type {
 	switch typ[0] {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -69,3 +69,37 @@ func TestEqual_NilOperands(t *testing.T) {
 		assert.True(t, eq(nil, nil), "%s: nil == nil", c.typ.Label())
 	}
 }
+
+func TestCoalesceArrays(t *testing.T) {
+	list := []struct {
+		title    string
+		left     Type
+		right    Type
+		expected Type
+	}{
+		// An empty array literal compiles to []unset, so the element type has to
+		// come from the other operand no matter which side it sits on.
+		{"unset left takes the right element type", Array(Unset), Array(String), Array(String)},
+		{"unset right keeps the left element type", Array(String), Array(Unset), Array(String)},
+		{"both unset stay unset", Array(Unset), Array(Unset), Array(Unset)},
+		{"null element type is also replaced", Array(Nil), Array(Int), Array(Int)},
+		{"bare array carries no element type", ArrayLike, Array(String), Array(String)},
+
+		// Known element types are never rewritten, mismatched or not.
+		{"matching element types keep left", Array(String), Array(String), Array(String)},
+		{"mismatched element types keep left", Array(String), Array(Int), Array(String)},
+		{"resource arrays keep left", Array(Resource("a")), Array(Unset), Array(Resource("a"))},
+
+		// Arithmetic on scalars must be untouched.
+		{"non-array left is returned unchanged", Int, Array(String), Int},
+		{"non-array right is returned unchanged", Array(Unset), String, Array(Unset)},
+		{"two scalars are returned unchanged", String, String, String},
+	}
+
+	for i := range list {
+		cur := list[i]
+		t.Run(cur.title, func(t *testing.T) {
+			assert.Equal(t, cur.expected, CoalesceArrays(cur.left, cur.right))
+		})
+	}
+}


### PR DESCRIPTION
Concatenating arrays lost data or produced an unusable type, depending on which side the empty or null operand was on:

  [] + ["a"]         ->  []unset, breaking any downstream call
  ["a"] + nullArray  ->  null, silently dropping "a"
  nullArray + ["a"]  ->  error "cannot add arrays to null"

The first case is what renders as the no-type-information placeholder, and it fails to compile as soon as something needs a concrete element type ("expected string, got: unset"). The second is worse: a policy building a path list from a source that resolves to null evaluated against an empty list, so its verdict had nothing to do with the asset.

An empty array literal compiles to []unset, so the element type has to come from whichever operand knows it. types.CoalesceArrays does that, and is applied both in the compiler, so the reported type is right, and at runtime, so the RawData type matches. Only a genuinely unknown element type is replaced, leaving ["a"] + [1] as it was, and non-array types are untouched so scalar arithmetic is unaffected.

Null operands now contribute no items instead of erroring or discarding the other side, which also removes a dead branch and makes operand order irrelevant throughout.

Fixes #5803