### PR TITLE
🐛 digitalocean: fix panic listing functions in a namespace

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -1873,7 +1873,7 @@ digitalocean.size @defaults("slug vcpus memory priceMonthly") {
 // invoke them, and the access keys issued for the namespace API are all
 // queryable, making this the entry point for inventorying serverless
 // workloads and auditing the credentials that reach them.
-digitalocean.function.namespace @defaults("uuid label region") {
+digitalocean.function.namespace @defaults("namespace label region") {
   // Namespace UUID
   uuid string
   // Internal namespace identifier used in API paths

--- a/providers/digitalocean/resources/digitalocean_functions.go
+++ b/providers/digitalocean/resources/digitalocean_functions.go
@@ -151,7 +151,7 @@ func (r *mqlDigitaloceanFunctionNamespace) accessKeys() ([]interface{}, error) {
 	all := make([]interface{}, 0, len(keys))
 	for _, k := range keys {
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.function.accessKey", map[string]*llx.RawData{
-			"__id":          llx.StringData("digitalocean.function.accessKey/" + r.Uuid.Data + "/" + k.ID),
+			"__id":          llx.StringData("digitalocean.function.accessKey/" + r.Namespace.Data + "/" + k.ID),
 			"namespaceUuid": llx.StringData(r.Uuid.Data),
 			"id":            llx.StringData(k.ID),
 			"name":          llx.StringData(k.Name),
@@ -175,13 +175,19 @@ func (r *mqlDigitaloceanFunctionNamespace) functions() ([]interface{}, error) {
 	ctx := context.Background()
 
 	// The namespace list does not include the API key needed to call the
-	// OpenWhisk host, so fetch the namespace directly to obtain it.
-	ns, _, err := client.Functions.GetNamespace(ctx, r.Uuid.Data)
+	// OpenWhisk host, so fetch the namespace directly to obtain it. The
+	// namespace name is the identifier here: the list endpoint returns an
+	// empty uuid, and requesting an empty id resolves to the collection
+	// endpoint, which decodes to no namespace at all.
+	ns, _, err := client.Functions.GetNamespace(ctx, r.Namespace.Data)
 	if err != nil {
 		if isDoNotFound(err) {
 			return []interface{}{}, nil
 		}
 		return nil, err
+	}
+	if ns == nil {
+		return []interface{}{}, nil
 	}
 	if ns.ApiHost == "" || ns.Key == "" {
 		// Without an API host and key we can't reach the OpenWhisk host.
@@ -230,8 +236,10 @@ func (r *mqlDigitaloceanFunctionNamespace) functions() ([]interface{}, error) {
 		}
 
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.function.action", map[string]*llx.RawData{
-			"__id":           llx.StringData("digitalocean.function.action/" + r.Uuid.Data + "/" + pkg + "/" + a.Name),
-			"namespaceUuid":  llx.StringData(r.Uuid.Data),
+			"__id": llx.StringData("digitalocean.function.action/" + r.Namespace.Data + "/" + pkg + "/" + a.Name),
+			// The namespace listing leaves uuid empty; the single-namespace
+			// read above is where the real one comes from.
+			"namespaceUuid":  llx.StringData(ns.UUID),
 			"name":           llx.StringData(a.Name),
 			"package":        llx.StringData(pkg),
 			"version":        llx.StringData(a.Version),


### PR DESCRIPTION
Found while live-verifying the digitalocean provider against real provisioned infrastructure.

## The bug

`digitalocean.functionNamespaces { functions }` **panics the provider**, taking the scan with it:

```
panic in provider GetData: runtime error: invalid memory address or nil pointer dereference
resources.(*mqlDigitaloceanFunctionNamespace).functions
  providers/digitalocean/resources/digitalocean_functions.go:186
```

The namespace **list** endpoint returns an empty `uuid`; the identifier it does return is the namespace name:

```json
{"uuid": "", "namespace": "fn-b4a5b473-…", "label": "…", "region": "nyc1",
 "api_host": "https://faas-nyc1-….doserverless.co", "key": ""}
```

`functions()` looked the namespace up by `uuid`, so it requested `/v2/functions/namespaces/` with an empty id. That resolves to the **collection** endpoint, which answers `200` with a `namespaces` array, decodes to no single namespace, and hands back a nil namespace with a nil error — which the next line dereferenced.

## The fix

Look the namespace up by name, as `accessKeys()` already did, and guard the nil regardless so an unexpected response can't panic the provider again.

Three related defects fall out of the same empty `uuid`:

- **`__id` collisions.** The empty uuid was written into every accessKey and action `__id`, so actions of the same name in different namespaces collided on `digitalocean.function.action//<pkg>/<name>` and aliased to whichever was created first. Now keyed on the namespace name.
- **`namespaceUuid`** on an action now carries the uuid from the single-namespace read, which *does* return one, instead of the empty listing value. The accessKey path has no such read and still reflects the listing, so it stays empty there — noted as a follow-up rather than faked.
- **`@defaults`** on the namespace led with `uuid`, so the default rendering of every namespace was blank. It now leads with `namespace`.

## Verification

Provisioned a real Functions namespace and deployed an OpenWhisk action to it. Before, the query panicked. After:

```
digitalocean.functionNamespaces { namespace functions { … } }

namespace: "fn-b4a5b473-…"
functions:
  name:          "hello"
  runtime:       "nodejs:18"          # from the exec annotation
  webExported:   true                 # from the web-export annotation
  requiresApiKey: false
  isPublic:      true
  webUrl:        "https://faas-nyc1-….doserverless.co/api/v1/web/fn-b4a5b473-…/default/hello"
  timeoutMs: 3000  memoryMb: 256  logSizeMb: 16  concurrency: 1
  version: "0.0.1"
  namespaceUuid: "c4f9c227-f91e-4b2e-81d3-ea2b65db6c92"
```

This is the first time the OpenWhisk action path has been exercised against a live namespace — the annotation decoding, the web-url construction and the `isPublic` derivation all check out.

Provider tests pass. All test infrastructure has been destroyed.

No new fields, so no `.lr.versions` change (`@defaults` does not bump).
