### PR TITLE
🐛 hetzner: stop reporting denied reads as empty lists

### DIFF
--- a/providers/hetzner/resources/helpers.go
+++ b/providers/hetzner/resources/helpers.go
@@ -11,17 +11,21 @@ import (
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/hetzner/connection"
 	"go.mondoo.com/mql/v13/types"
 )
 
-// translateHcloudError handles common hcloud error codes. It returns nil for
-// permission/not-found errors so callers can treat them as "no data" instead
-// of failing the whole query, mirroring the AWS provider's Is400AccessDenied
-// pattern.
+// translateHcloudError decides which hcloud failures are a real answer and
+// which are an error.
+//
+// Only a missing collection is an answer. A denial is not: a token that was
+// refused the read has established nothing about what exists, so reporting an
+// empty list would assert the project has no firewalls, no volumes, no
+// servers, which is a different and unverified claim. Every list in this
+// provider runs through paginate and therefore through here, so the choice
+// applies to all of them at once.
 func translateHcloudError(err error) error {
 	if err == nil {
 		return nil
@@ -29,10 +33,10 @@ func translateHcloudError(err error) error {
 	var hErr hcloud.Error
 	if errors.As(err, &hErr) {
 		switch hErr.Code {
-		case hcloud.ErrorCodeUnauthorized, hcloud.ErrorCodeForbidden:
-			log.Warn().Err(err).Msg("hetzner> permission denied; returning empty result")
-			return nil
 		case hcloud.ErrorCodeNotFound:
+			// A collection endpoint answering 404 means the product is not
+			// provisioned for this project at all, which genuinely is none.
+			// Storage Boxes answer this way on a plain cloud project.
 			return nil
 		}
 	}

--- a/providers/hetzner/resources/helpers_test.go
+++ b/providers/hetzner/resources/helpers_test.go
@@ -20,17 +20,23 @@ func TestTranslateHcloudError(t *testing.T) {
 		assert.NoError(t, translateHcloudError(nil))
 	})
 
-	t.Run("unauthorized swallowed", func(t *testing.T) {
+	// A refused read establishes nothing about what exists. Swallowing it
+	// would report an empty list, which asserts the project holds none of the
+	// resource, and every audit over that list would pass without reading
+	// anything.
+	t.Run("unauthorized propagates", func(t *testing.T) {
 		err := hcloud.Error{Code: hcloud.ErrorCodeUnauthorized, Message: "bad token"}
-		assert.NoError(t, translateHcloudError(err))
+		assert.Error(t, translateHcloudError(err))
 	})
 
-	t.Run("forbidden swallowed", func(t *testing.T) {
+	t.Run("forbidden propagates", func(t *testing.T) {
 		err := hcloud.Error{Code: hcloud.ErrorCodeForbidden, Message: "no access"}
-		assert.NoError(t, translateHcloudError(err))
+		assert.Error(t, translateHcloudError(err))
 	})
 
-	t.Run("not found swallowed", func(t *testing.T) {
+	// A collection endpoint answering 404 means the product is not provisioned
+	// for the project, which genuinely is none.
+	t.Run("not found is an empty collection", func(t *testing.T) {
 		err := hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "gone"}
 		assert.NoError(t, translateHcloudError(err))
 	})
@@ -45,9 +51,16 @@ func TestTranslateHcloudError(t *testing.T) {
 		assert.Equal(t, err, translateHcloudError(err))
 	})
 
-	t.Run("wrapped hcloud error", func(t *testing.T) {
-		// errors.As must unwrap through fmt.Errorf wrapping
+	t.Run("wrapped hcloud error is still classified", func(t *testing.T) {
+		// errors.As must unwrap through wrapping, so a wrapped denial is
+		// recognised as a denial and propagates like a bare one.
 		inner := hcloud.Error{Code: hcloud.ErrorCodeUnauthorized}
+		wrapped := errors.Join(errors.New("context"), inner)
+		assert.Error(t, translateHcloudError(wrapped))
+	})
+
+	t.Run("wrapped not found is still an empty collection", func(t *testing.T) {
+		inner := hcloud.Error{Code: hcloud.ErrorCodeNotFound}
 		wrapped := errors.Join(errors.New("context"), inner)
 		assert.NoError(t, translateHcloudError(wrapped))
 	})
@@ -107,7 +120,9 @@ func TestPaginate(t *testing.T) {
 		assert.ErrorIs(t, err, want)
 	})
 
-	t.Run("returns accumulated rows when an auth error appears mid-stream", func(t *testing.T) {
+	t.Run("an auth error mid-stream fails rather than truncating", func(t *testing.T) {
+		// Returning the rows gathered so far would present a partial list as
+		// a complete one, which reads as "the project holds only these".
 		calls := 0
 		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
 			calls++
@@ -117,6 +132,22 @@ func TestPaginate(t *testing.T) {
 				}, nil
 			}
 			return nil, nil, hcloud.Error{Code: hcloud.ErrorCodeForbidden}
+		})
+		assert.Error(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("a missing collection mid-stream ends the walk", func(t *testing.T) {
+		// 404 means the product is not provisioned, so what was read stands.
+		calls := 0
+		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			calls++
+			if calls == 1 {
+				return []int{1, 2}, &hcloud.Response{
+					Meta: hcloud.Meta{Pagination: &hcloud.Pagination{NextPage: 2}},
+				}, nil
+			}
+			return nil, nil, hcloud.Error{Code: hcloud.ErrorCodeNotFound}
 		})
 		require.NoError(t, err)
 		assert.Equal(t, []int{1, 2}, out)


### PR DESCRIPTION
Found while reviewing this provider as the reference implementation for a DigitalOcean refactor. The irony is that its shared layer, which is what makes it clean, is also what made this bug universal.

## The bug

`translateHcloudError` mapped `Unauthorized` and `Forbidden` to `nil`, and `paginate` then returned the rows accumulated so far. Its own log line said what was happening:

```go
case hcloud.ErrorCodeUnauthorized, hcloud.ErrorCodeForbidden:
    log.Warn().Err(err).Msg("hetzner> permission denied; returning empty result")
    return nil
```

An empty list is not a neutral result. It asserts the project has no firewalls, no volumes, no servers, no load balancers. A token refused the read has established none of that, so every audit over those lists passed with nothing having been read:

```
hetzner.servers.all(firewalls.length > 0)   → passed, on a token that could not read firewalls
```

**Every list in this provider runs through `paginate`, and therefore through this function.** The wrong policy applied to all 30 resources at once — which is also why one line fixes all of them.

## The change

Denials propagate. A missing collection still resolves to empty:

- **401 / 403** — the caller was refused. It has learned nothing, so this is an error.
- **404** — the product is not provisioned for the project, which genuinely is none. Storage Boxes answer exactly this way on a plain cloud project, and `storageBoxes` correctly reporting `0` there depends on it.

This matches the policy the DigitalOcean provider already follows, where `secrets` and `gradientai.batchJobs` both surface a 403 loudly, and the fix applied to Vercel in #9741.

## Tests

Three tests encoded the old behaviour and now assert the new one. The most telling:

```go
- t.Run("returns accumulated rows when an auth error appears mid-stream", …)
-     require.NoError(t, err)
-     assert.Equal(t, []int{1, 2}, out)
+ t.Run("an auth error mid-stream fails rather than truncating", …)
+     assert.Error(t, err)
+     assert.Nil(t, out)
```

That case was a partial list presented as a complete one. Added the matching not-found cases beside each, so the two outcomes stay distinguishable rather than one silently absorbing the other, plus a wrapped-error case for both so `errors.As` unwrapping is still covered.

## Verification

`go build` and the full provider suite pass.

**Not live-verified.** The Hetzner token used for this provider's live verification earlier today has since been rotated — the raw API returns 401 for it now — so I could not re-run the read sweep. The change is provably unrelated to that: token validation happens in `connection.Verify()`, which has its own independent 401/403 handling and is untouched here. Behaviour on a valid token is unchanged for every successful read; only the denial path differs.
