### PR TITLE
🌟 azure: filter discovery by resource tag, like aws

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -127,7 +127,7 @@ Examples run in the Azure CLI:
 					Long:    "filters",
 					Type:    plugin.FlagType_KeyValue,
 					Default: "",
-					Desc:    "Filter options, e.g., --filters subscriptions=<id1>,<id2> --filters subscriptions-exclude=<id3> --filters propagate-subscription-tags=true --filters subscription-tag:<key>=<value>",
+					Desc:    "Filter options, e.g., --filters subscriptions=<id1>,<id2> --filters subscriptions-exclude=<id3> --filters tag:<key>=<value1>,<value2> --filters exclude:tag:<key>=<value> --filters propagate-subscription-tags=true --filters subscription-tag:<key>=<value>",
 				},
 			},
 		},

--- a/providers/azure/connection/filters.go
+++ b/providers/azure/connection/filters.go
@@ -17,6 +17,9 @@ import (
 // during discovery.
 type DiscoveryFilters struct {
 	Subscriptions SubscriptionsFilter
+	// General holds the filters that apply to every discovered resource,
+	// regardless of service.
+	General GeneralDiscoveryFilters
 	// PropagateSubscriptionTags merges each subscription's tags into every asset
 	// discovered under that subscription (an asset's own labels win on collision).
 	// Off by default. Mirrors the GCP provider's PropagateProjectLabels and the
@@ -50,6 +53,75 @@ func (f SubscriptionsFilter) IsFilteredOut(subscriptionID string) bool {
 	return slices.Contains(f.Exclude, subscriptionID)
 }
 
+// GeneralDiscoveryFilters narrows discovery by ARM resource tag. It mirrors the
+// AWS provider's filter of the same name, including its matching semantics, so
+// that `--filters tag:env=prod` selects the same way on both clouds.
+//
+// Azure applies these client-side. The generic ARM list call already returns
+// each resource's tags, so filtering here costs nothing extra -- unlike AWS,
+// there is no per-resource tag lookup to avoid.
+type GeneralDiscoveryFilters struct {
+	// Tags restricts discovery to resources carrying at least one of these
+	// key/value pairs. Values may be a CSV list, e.g. "env": "prod,staging".
+	Tags map[string]string
+	// ExcludeTags drops resources carrying any of these key/value pairs. It is
+	// applied after Tags, so an excluded resource stays excluded even when it
+	// also matches an include.
+	ExcludeTags map[string]string
+}
+
+// HasTags reports whether any tag filter was requested. Callers use it to skip
+// a tag lookup they would otherwise have to pay for.
+func (f GeneralDiscoveryFilters) HasTags() bool {
+	return len(f.Tags) > 0 || len(f.ExcludeTags) > 0
+}
+
+// IsFilteredOutByTags reports whether a resource carrying resourceTags should be
+// skipped during discovery.
+//
+// note: if this function returns `true`, it means that the resource should be
+// skipped.
+func (f GeneralDiscoveryFilters) IsFilteredOutByTags(resourceTags map[string]string) bool {
+	return !f.MatchesIncludeTags(resourceTags) || f.MatchesExcludeTags(resourceTags)
+}
+
+// MatchesIncludeTags reports whether resourceTags satisfies the include filter.
+// An empty filter matches everything.
+//
+// Matching is ANY, not ALL: a resource is kept when it matches at least one of
+// the requested key/value pairs. This is deliberately the same rule the AWS
+// provider uses -- `--filters tag:env=prod --filters tag:team=infra` reads as
+// "prod or infra" on both providers rather than meaning one thing here and
+// another there.
+func (f GeneralDiscoveryFilters) MatchesIncludeTags(resourceTags map[string]string) bool {
+	if len(f.Tags) == 0 {
+		return true
+	}
+	for k, csv := range f.Tags {
+		for v := range strings.SplitSeq(csv, ",") {
+			if tagValue, ok := resourceTags[k]; ok && tagValue == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// MatchesExcludeTags reports whether resourceTags matches the exclude filter.
+//
+// note: if this function returns `true`, it means that the resource should be
+// skipped.
+func (f GeneralDiscoveryFilters) MatchesExcludeTags(resourceTags map[string]string) bool {
+	for k, csv := range f.ExcludeTags {
+		for v := range strings.SplitSeq(csv, ",") {
+			if tagValue, ok := resourceTags[k]; ok && tagValue == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // DiscoveryFiltersFromOpts parses the raw --filters key/value options into the
 // typed DiscoveryFilters. It is nil-safe: a nil opts map yields empty filters.
 func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
@@ -57,6 +129,10 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 		Subscriptions: SubscriptionsFilter{
 			Include: filteropts.ParseCsvSliceOpt(opts, "subscriptions"),
 			Exclude: filteropts.ParseCsvSliceOpt(opts, "subscriptions-exclude"),
+		},
+		General: GeneralDiscoveryFilters{
+			Tags:        parseMapOpt(opts, "tag:"),
+			ExcludeTags: parseMapOpt(opts, "exclude:tag:"),
 		},
 		PropagateSubscriptionTags: filteropts.ParseBoolOpt(opts, "propagate-subscription-tags", false),
 		SubscriptionTags:          parseMapOpt(opts, "subscription-tag:"),

--- a/providers/azure/connection/filters_test.go
+++ b/providers/azure/connection/filters_test.go
@@ -135,3 +135,131 @@ func TestSubscriptionsFilter_IsFilteredOut(t *testing.T) {
 		})
 	}
 }
+
+func TestGeneralDiscoveryFiltersFromOpts(t *testing.T) {
+	t.Run("nil opts yields no tag filters", func(t *testing.T) {
+		f := DiscoveryFiltersFromOpts(nil)
+		assert.False(t, f.General.HasTags())
+	})
+
+	t.Run("tag and exclude:tag are parsed into separate maps", func(t *testing.T) {
+		f := DiscoveryFiltersFromOpts(map[string]string{
+			"tag:env":          "prod,staging",
+			"tag:team":         "infra",
+			"exclude:tag:temp": "true",
+		})
+		assert.Equal(t, map[string]string{"env": "prod,staging", "team": "infra"}, f.General.Tags)
+		assert.Equal(t, map[string]string{"temp": "true"}, f.General.ExcludeTags)
+		assert.True(t, f.General.HasTags())
+	})
+
+	// "subscription-tag:" selects which tags to propagate onto discovered assets
+	// and has nothing to do with which resources are discovered. Parsing it into
+	// General.Tags would silently turn a propagation request into a filter and
+	// drop every asset that did not carry the tag.
+	t.Run("subscription-tag is not a discovery tag filter", func(t *testing.T) {
+		f := DiscoveryFiltersFromOpts(map[string]string{
+			"subscription-tag:owner": "platform",
+		})
+		assert.Empty(t, f.General.Tags)
+		assert.False(t, f.General.HasTags())
+		assert.Equal(t, map[string]string{"owner": "platform"}, f.SubscriptionTags)
+	})
+}
+
+func TestGeneralDiscoveryFiltersIsFilteredOutByTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  GeneralDiscoveryFilters
+		tags    map[string]string
+		skipped bool
+	}{
+		{
+			name:    "no filter keeps everything",
+			filter:  GeneralDiscoveryFilters{},
+			tags:    map[string]string{"env": "prod"},
+			skipped: false,
+		},
+		{
+			name:    "no filter keeps an untagged resource",
+			filter:  GeneralDiscoveryFilters{},
+			tags:    nil,
+			skipped: false,
+		},
+		{
+			name:    "include matches",
+			filter:  GeneralDiscoveryFilters{Tags: map[string]string{"env": "prod"}},
+			tags:    map[string]string{"env": "prod", "team": "infra"},
+			skipped: false,
+		},
+		{
+			name:    "include does not match on value",
+			filter:  GeneralDiscoveryFilters{Tags: map[string]string{"env": "prod"}},
+			tags:    map[string]string{"env": "dev"},
+			skipped: true,
+		},
+		{
+			name:    "include does not match on missing key",
+			filter:  GeneralDiscoveryFilters{Tags: map[string]string{"env": "prod"}},
+			tags:    map[string]string{"team": "infra"},
+			skipped: true,
+		},
+		{
+			name:    "an untagged resource is dropped by an include filter",
+			filter:  GeneralDiscoveryFilters{Tags: map[string]string{"env": "prod"}},
+			tags:    nil,
+			skipped: true,
+		},
+		{
+			name:    "csv value matches any listed value",
+			filter:  GeneralDiscoveryFilters{Tags: map[string]string{"env": "prod,staging"}},
+			tags:    map[string]string{"env": "staging"},
+			skipped: false,
+		},
+		// Matching is ANY across keys, the same rule the AWS provider uses.
+		// A resource matching one of several requested pairs is kept.
+		{
+			name: "multiple include keys are ORed, not ANDed",
+			filter: GeneralDiscoveryFilters{Tags: map[string]string{
+				"env":  "prod",
+				"team": "infra",
+			}},
+			tags:    map[string]string{"team": "infra"},
+			skipped: false,
+		},
+		{
+			name:    "exclude drops a match",
+			filter:  GeneralDiscoveryFilters{ExcludeTags: map[string]string{"temp": "true"}},
+			tags:    map[string]string{"temp": "true"},
+			skipped: true,
+		},
+		{
+			name:    "exclude ignores a non-match",
+			filter:  GeneralDiscoveryFilters{ExcludeTags: map[string]string{"temp": "true"}},
+			tags:    map[string]string{"temp": "false"},
+			skipped: false,
+		},
+		{
+			name: "exclude wins over include",
+			filter: GeneralDiscoveryFilters{
+				Tags:        map[string]string{"env": "prod"},
+				ExcludeTags: map[string]string{"decommissioned": "true"},
+			},
+			tags:    map[string]string{"env": "prod", "decommissioned": "true"},
+			skipped: true,
+		},
+		{
+			name: "exclude csv value matches any listed value",
+			filter: GeneralDiscoveryFilters{
+				ExcludeTags: map[string]string{"env": "dev,test"},
+			},
+			tags:    map[string]string{"env": "test"},
+			skipped: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.skipped, tt.filter.IsFilteredOutByTags(tt.tags))
+		})
+	}
+}

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -167,6 +167,10 @@ func parseFlagsToFiltersOpts(flags map[string]*llx.Primitive) map[string]string 
 				o[k] = string(v.Value)
 			case strings.HasPrefix(k, "subscription-tag:"):
 				o[k] = string(v.Value)
+			// "tag:" and "exclude:tag:" do not overlap with each other or with
+			// "subscription-tag:", so prefix order here does not matter.
+			case strings.HasPrefix(k, "tag:") || strings.HasPrefix(k, "exclude:tag:"):
+				o[k] = string(v.Value)
 			}
 		}
 	}

--- a/providers/azure/provider/provider_test.go
+++ b/providers/azure/provider/provider_test.go
@@ -249,3 +249,51 @@ func TestParseCLICredentials(t *testing.T) {
 		assert.Empty(t, res.Asset.Connections[0].Credentials)
 	})
 }
+
+// TestParseCLITagFilters guards the allowlist in parseFlagsToFiltersOpts. Tag
+// filters are parsed in the connection layer and applied during discovery, but
+// they only ever get there if ParseCLI copies them out of the --filters flag
+// first. A key missing from the allowlist is dropped silently: the flag is
+// accepted, no error is raised, and discovery behaves as if it were never set.
+func TestParseCLITagFilters(t *testing.T) {
+	s := Init()
+
+	t.Run("tag and exclude:tag survive the allowlist", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Flags: map[string]*llx.Primitive{
+				"filters": {Map: map[string]*llx.Primitive{
+					"tag:env":          llx.StringPrimitive("prod,staging"),
+					"exclude:tag:temp": llx.StringPrimitive("true"),
+				}},
+			},
+		})
+		require.NoError(t, err)
+		f := connFilter(t, res)
+		assert.Equal(t, "prod,staging", f["tag:env"])
+		assert.Equal(t, "true", f["exclude:tag:temp"])
+
+		// and they reach the typed filter the discovery code actually reads
+		parsed := connection.DiscoveryFiltersFromOpts(f)
+		assert.Equal(t, map[string]string{"env": "prod,staging"}, parsed.General.Tags)
+		assert.Equal(t, map[string]string{"temp": "true"}, parsed.General.ExcludeTags)
+	})
+
+	t.Run("tag filters coexist with subscription filters", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Flags: map[string]*llx.Primitive{
+				"filters": {Map: map[string]*llx.Primitive{
+					"subscriptions":          llx.StringPrimitive("sub-a"),
+					"tag:env":                llx.StringPrimitive("prod"),
+					"subscription-tag:owner": llx.StringPrimitive("platform"),
+				}},
+			},
+		})
+		require.NoError(t, err)
+		parsed := connection.DiscoveryFiltersFromOpts(connFilter(t, res))
+		assert.Equal(t, []string{"sub-a"}, parsed.Subscriptions.Include)
+		assert.Equal(t, map[string]string{"env": "prod"}, parsed.General.Tags)
+		// subscription-tag is propagation, not a discovery filter
+		assert.Equal(t, map[string]string{"owner": "platform"}, parsed.SubscriptionTags)
+		assert.Empty(t, parsed.General.ExcludeTags)
+	})
+}

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -270,18 +270,18 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 	// FIXME: do not discover instances as OSes right now, only discover as API representations.
 	if stringx.ContainsAnyOf(targets, DiscoveryInstances) {
 		discover(DiscoveryInstances, func() ([]*inventory.Asset, error) {
-			return discoverInstances(runtime, subsWithConfigs)
+			return discoverInstances(runtime, subsWithConfigs, conn.Filters.General)
 		})
 	}
 	if stringx.ContainsAnyOf(targets, DiscoveryInstancesApi) {
 		discover(DiscoveryInstancesApi, func() ([]*inventory.Asset, error) {
-			return discoverInstancesApi(runtime, subsWithConfigs)
+			return discoverInstancesApi(runtime, subsWithConfigs, conn.Filters.General)
 		})
 	}
 	// FIXME: bring back the storage containers as as part of FF scanning once we can do parallel scanning
 	if stringx.ContainsAnyOf(targets, DiscoveryStorageContainers) {
 		discover(DiscoveryStorageContainers, func() ([]*inventory.Asset, error) {
-			return discoverStorageAccountsContainers(runtime, subsWithConfigs)
+			return discoverStorageAccountsContainers(runtime, subsWithConfigs, conn.Filters.General)
 		})
 	}
 
@@ -303,7 +303,7 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 	}, nil
 }
 
-func discoverInstancesApi(runtime *plugin.Runtime, subsWithConfigs []subWithConfig) ([]*inventory.Asset, error) {
+func discoverInstancesApi(runtime *plugin.Runtime, subsWithConfigs []subWithConfig, filters connection.GeneralDiscoveryFilters) ([]*inventory.Asset, error) {
 	assets := []*inventory.Asset{}
 	for _, subWithConfig := range subsWithConfigs {
 		svc, err := NewResource(runtime, "azure.subscription.computeService", map[string]*llx.RawData{
@@ -323,9 +323,13 @@ func discoverInstancesApi(runtime *plugin.Runtime, subsWithConfigs []subWithConf
 			if props.Error != nil {
 				return nil, props.Error
 			}
+			tags := interfaceMapToStr(vm.Tags.Data)
+			if filters.IsFilteredOutByTags(tags) {
+				continue
+			}
 			asset := mqlObjectToAsset(mqlObject{
 				name:   vm.Name.Data,
-				labels: interfaceMapToStr(vm.Tags.Data),
+				labels: tags,
 				azureObject: azureObject{
 					id:           vm.Id.Data,
 					subscription: *subWithConfig.sub.SubscriptionID,
@@ -346,7 +350,7 @@ func discoverInstancesApi(runtime *plugin.Runtime, subsWithConfigs []subWithConf
 	return assets, nil
 }
 
-func discoverInstances(runtime *plugin.Runtime, subsWithConfigs []subWithConfig) ([]*inventory.Asset, error) {
+func discoverInstances(runtime *plugin.Runtime, subsWithConfigs []subWithConfig, filters connection.GeneralDiscoveryFilters) ([]*inventory.Asset, error) {
 	assets := []*inventory.Asset{}
 	for _, subWithConfig := range subsWithConfigs {
 		svc, err := NewResource(runtime, "azure.subscription.computeService", map[string]*llx.RawData{
@@ -367,13 +371,18 @@ func discoverInstances(runtime *plugin.Runtime, subsWithConfigs []subWithConfig)
 				return nil, props.Error
 			}
 
+			tags := interfaceMapToStr(vm.Tags.Data)
+			if filters.IsFilteredOutByTags(tags) {
+				continue
+			}
+
 			ipAddresses := vm.GetPublicIpAddresses()
 			if ipAddresses.Error != nil {
 				return nil, ipAddresses.Error
 			}
 			asset := mqlObjectToAsset(mqlObject{
 				name:   vm.Name.Data,
-				labels: interfaceMapToStr(vm.Tags.Data),
+				labels: tags,
 				azureObject: azureObject{
 					id:           vm.Id.Data,
 					subscription: *subWithConfig.sub.SubscriptionID,
@@ -475,9 +484,13 @@ func discoverGeneric(conn *connection.AzureConnection, subsWithConfigs []subWith
 				if !ok {
 					continue
 				}
+				tags := convert.PtrMapStrToStr(resource.Tags)
+				if conn.Filters.General.IsFilteredOutByTags(tags) {
+					continue
+				}
 				asset := mqlObjectToAsset(mqlObject{
 					name:   derefStr(resource.Name),
-					labels: convert.PtrMapStrToStr(resource.Tags),
+					labels: tags,
 					azureObject: azureObject{
 						id:           derefStr(resource.ID),
 						subscription: subId,
@@ -514,7 +527,7 @@ func derefStr(s *string) string {
 	return *s
 }
 
-func discoverStorageAccountsContainers(runtime *plugin.Runtime, subsWithConfig []subWithConfig) ([]*inventory.Asset, error) {
+func discoverStorageAccountsContainers(runtime *plugin.Runtime, subsWithConfig []subWithConfig, filters connection.GeneralDiscoveryFilters) ([]*inventory.Asset, error) {
 	assets := []*inventory.Asset{}
 	for _, subWithConfig := range subsWithConfig {
 		svc, err := NewResource(runtime, "azure.subscription.storageService", map[string]*llx.RawData{
@@ -530,6 +543,12 @@ func discoverStorageAccountsContainers(runtime *plugin.Runtime, subsWithConfig [
 		}
 		for _, account := range accounts.Data {
 			a := account.(*mqlAzureSubscriptionStorageServiceAccount)
+			// Blob containers carry no ARM tags of their own, so the tag filter
+			// is applied to the storage account they live in. Skipping the
+			// account also skips the container listing it would have cost.
+			if filters.IsFilteredOutByTags(interfaceMapToStr(a.Tags.Data)) {
+				continue
+			}
 			containers := a.GetContainers()
 			if containers.Error != nil {
 				return nil, containers.Error


### PR DESCRIPTION
## What

The azure provider exposes **28 discovery targets** but only ever filtered by subscription. `--filters tag:env=prod` was accepted at the CLI, silently dropped by the allowlist in `ParseCLI`, and never reached discovery — a scan asked to look at one slice of a tenant walked all of it.

This adds `GeneralDiscoveryFilters` mirroring the aws provider's filter of the same name:

```
mql shell azure --filters tag:env=prod,staging
mql shell azure --filters exclude:tag:decommissioned=true
mql shell azure --filters subscriptions=<id> --filters tag:team=infra
```

Semantics match aws exactly, including the ANY-across-keys include rule (`tag:env=prod tag:team=infra` reads as "prod **or** infra"). That rule is surprising enough on its own that having it differ per provider would be worse than having it be surprising.

## Where it is applied

In the listers, not in `Discover`, so every path that reaches assets gets the same treatment:

| Path | Targets | Tag source |
|---|---|---|
| `discoverGeneric` | 25 of 28 | already had `resource.Tags` from the ARM list call — filtering costs nothing extra |
| `discoverInstances` / `discoverInstancesApi` | VMs | the vm's own tags |
| `discoverStorageAccountsContainers` | containers | the parent storage account — blob containers carry no ARM tags of their own, and skipping the account also skips the container listing it would have cost |

Subscription assets are deliberately **not** tag-filtered: `subscriptions=` selects subscriptions, `tag:` selects resources within them. Same split aws uses between account selection and resource tags.

`subscription-tag:` is unaffected — it is tag *propagation*, not a filter. There is a test asserting it does not leak into `General.Tags`, because parsing it as a filter would turn a propagation request into a silent drop of every untagged asset.

## The part worth reviewing

`parseFlagsToFiltersOpts` has a filter-key allowlist. A key missing from it is dropped with **no error** — the flag reads as working and does nothing. That is how this feature could have shipped as a no-op.

`TestParseCLITagFilters` guards it, and I verified it fails without the allowlist entry:

```
--- FAIL: TestParseCLITagFilters/tag_filters_coexist_with_subscription_filters
    Expected: map[string]string{"env":"prod"}
    actual  : map[string]string{}
```

## Tests

23 new cases across the two layers — parsing (`tag:` / `exclude:tag:` / `subscription-tag:` separation) and matching (csv values, missing keys, untagged resources, exclude-beats-include). Full provider suite passes.

## Context

First of two PRs from an azure provider audit. The follow-up introduces the shared `listPaged` helper. Background: the audit found this gap as one instance of a general pattern — discovery targets get wired up without their filter support, because the two edits live in different files and only the first is what the ticket asks for.
