### PR TITLE
🧹 digitalocean: adopt paginate in the listers that take arguments

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -121,137 +121,127 @@ func (r *mqlDigitalocean) droplets() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		droplets, resp, err := client.Droplets.List(context.Background(), opt)
+	droplets, err := paginate(context.Background(), client.Droplets.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(droplets))
+	for _, d := range droplets {
+		publicIPv4 := ""
+		privateIPv4 := ""
+		publicIPv6 := ""
+		if d.Networks != nil {
+			for _, v4 := range d.Networks.V4 {
+				if v4.Type == "public" && publicIPv4 == "" {
+					publicIPv4 = v4.IPAddress
+				}
+				if v4.Type == "private" && privateIPv4 == "" {
+					privateIPv4 = v4.IPAddress
+				}
+			}
+			for _, v6 := range d.Networks.V6 {
+				if v6.Type == "public" && publicIPv6 == "" {
+					publicIPv6 = v6.IPAddress
+				}
+			}
+		}
+
+		tags := make([]interface{}, len(d.Tags))
+		for i, t := range d.Tags {
+			tags[i] = t
+		}
+
+		features := make([]interface{}, len(d.Features))
+		for i, f := range d.Features {
+			features[i] = f
+		}
+
+		backupsEnabled := false
+		monitoringEnabled := false
+		for _, f := range d.Features {
+			if f == "backups" {
+				backupsEnabled = true
+			}
+			if f == "monitoring" {
+				monitoringEnabled = true
+			}
+		}
+
+		imageDict := map[string]interface{}{}
+		if d.Image != nil {
+			imageDict["id"] = float64(d.Image.ID)
+			imageDict["name"] = d.Image.Name
+			imageDict["distribution"] = d.Image.Distribution
+			imageDict["slug"] = d.Image.Slug
+		}
+
+		regionSlug := ""
+		if d.Region != nil {
+			regionSlug = d.Region.Slug
+		}
+		sizeSlug := ""
+		if d.Size != nil {
+			sizeSlug = d.Size.Slug
+		}
+
+		var kernelDict map[string]interface{}
+		if d.Kernel != nil {
+			kernelDict = map[string]interface{}{
+				"id":      float64(d.Kernel.ID),
+				"name":    d.Kernel.Name,
+				"version": d.Kernel.Version,
+			}
+		}
+
+		var nextBackupStart, nextBackupEnd *time.Time
+		if d.NextBackupWindow != nil {
+			if d.NextBackupWindow.Start != nil {
+				nextBackupStart = &d.NextBackupWindow.Start.Time
+			}
+			if d.NextBackupWindow.End != nil {
+				nextBackupEnd = &d.NextBackupWindow.End.Time
+			}
+		}
+
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.droplet", map[string]*llx.RawData{
+			"id":                    llx.IntData(int64(d.ID)),
+			"name":                  llx.StringData(d.Name),
+			"memory":                llx.IntData(int64(d.Memory)),
+			"vcpus":                 llx.IntData(int64(d.Vcpus)),
+			"disk":                  llx.IntData(int64(d.Disk)),
+			"region":                llx.StringData(regionSlug),
+			"size":                  llx.StringData(sizeSlug),
+			"gpuPartitionMode":      llx.StringData(d.GPUPartitionMode),
+			"status":                llx.StringData(d.Status),
+			"locked":                llx.BoolData(d.Locked),
+			"createdAt":             llx.TimeDataPtr(parseDoTime(d.Created)),
+			"publicIpv4":            llx.StringData(publicIPv4),
+			"privateIpv4":           llx.StringData(privateIPv4),
+			"publicIpv6":            llx.StringData(publicIPv6),
+			"tags":                  llx.ArrayData(tags, "\x02"),
+			"vpcUuid":               llx.StringData(d.VPCUUID),
+			"features":              llx.ArrayData(features, "\x02"),
+			"backupsEnabled":        llx.BoolData(backupsEnabled),
+			"monitoringEnabled":     llx.BoolData(monitoringEnabled),
+			"image":                 llx.DictData(imageDict),
+			"kernel":                llx.DictData(kernelDict),
+			"nextBackupWindowStart": llx.TimeDataPtr(nextBackupStart),
+			"nextBackupWindowEnd":   llx.TimeDataPtr(nextBackupEnd),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, d := range droplets {
-			publicIPv4 := ""
-			privateIPv4 := ""
-			publicIPv6 := ""
-			if d.Networks != nil {
-				for _, v4 := range d.Networks.V4 {
-					if v4.Type == "public" && publicIPv4 == "" {
-						publicIPv4 = v4.IPAddress
-					}
-					if v4.Type == "private" && privateIPv4 == "" {
-						privateIPv4 = v4.IPAddress
-					}
-				}
-				for _, v6 := range d.Networks.V6 {
-					if v6.Type == "public" && publicIPv6 == "" {
-						publicIPv6 = v6.IPAddress
-					}
-				}
-			}
-
-			tags := make([]interface{}, len(d.Tags))
-			for i, t := range d.Tags {
-				tags[i] = t
-			}
-
-			features := make([]interface{}, len(d.Features))
-			for i, f := range d.Features {
-				features[i] = f
-			}
-
-			backupsEnabled := false
-			monitoringEnabled := false
-			for _, f := range d.Features {
-				if f == "backups" {
-					backupsEnabled = true
-				}
-				if f == "monitoring" {
-					monitoringEnabled = true
-				}
-			}
-
-			imageDict := map[string]interface{}{}
-			if d.Image != nil {
-				imageDict["id"] = float64(d.Image.ID)
-				imageDict["name"] = d.Image.Name
-				imageDict["distribution"] = d.Image.Distribution
-				imageDict["slug"] = d.Image.Slug
-			}
-
-			regionSlug := ""
-			if d.Region != nil {
-				regionSlug = d.Region.Slug
-			}
-			sizeSlug := ""
-			if d.Size != nil {
-				sizeSlug = d.Size.Slug
-			}
-
-			var kernelDict map[string]interface{}
-			if d.Kernel != nil {
-				kernelDict = map[string]interface{}{
-					"id":      float64(d.Kernel.ID),
-					"name":    d.Kernel.Name,
-					"version": d.Kernel.Version,
-				}
-			}
-
-			var nextBackupStart, nextBackupEnd *time.Time
-			if d.NextBackupWindow != nil {
-				if d.NextBackupWindow.Start != nil {
-					nextBackupStart = &d.NextBackupWindow.Start.Time
-				}
-				if d.NextBackupWindow.End != nil {
-					nextBackupEnd = &d.NextBackupWindow.End.Time
-				}
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.droplet", map[string]*llx.RawData{
-				"id":                    llx.IntData(int64(d.ID)),
-				"name":                  llx.StringData(d.Name),
-				"memory":                llx.IntData(int64(d.Memory)),
-				"vcpus":                 llx.IntData(int64(d.Vcpus)),
-				"disk":                  llx.IntData(int64(d.Disk)),
-				"region":                llx.StringData(regionSlug),
-				"size":                  llx.StringData(sizeSlug),
-				"gpuPartitionMode":      llx.StringData(d.GPUPartitionMode),
-				"status":                llx.StringData(d.Status),
-				"locked":                llx.BoolData(d.Locked),
-				"createdAt":             llx.TimeDataPtr(parseDoTime(d.Created)),
-				"publicIpv4":            llx.StringData(publicIPv4),
-				"privateIpv4":           llx.StringData(privateIPv4),
-				"publicIpv6":            llx.StringData(publicIPv6),
-				"tags":                  llx.ArrayData(tags, "\x02"),
-				"vpcUuid":               llx.StringData(d.VPCUUID),
-				"features":              llx.ArrayData(features, "\x02"),
-				"backupsEnabled":        llx.BoolData(backupsEnabled),
-				"monitoringEnabled":     llx.BoolData(monitoringEnabled),
-				"image":                 llx.DictData(imageDict),
-				"kernel":                llx.DictData(kernelDict),
-				"nextBackupWindowStart": llx.TimeDataPtr(nextBackupStart),
-				"nextBackupWindowEnd":   llx.TimeDataPtr(nextBackupEnd),
-			})
-			if err != nil {
-				return nil, err
-			}
-			// Cache the godo image for the typed baseImage() accessor, plus the
-			// volume / snapshot / backup image IDs for the typed volumes(),
-			// snapshots(), and backups() accessors — all without a refetch.
-			mqlDroplet := res.(*mqlDigitaloceanDroplet)
-			mqlDroplet.image = d.Image
-			mqlDroplet.size = d.Size
-			mqlDroplet.cacheVolumeIDs = d.VolumeIDs
-			mqlDroplet.cacheSnapshotIDs = d.SnapshotIDs
-			mqlDroplet.cacheBackupIDs = d.BackupIDs
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		// Cache the godo image for the typed baseImage() accessor, plus the
+		// volume / snapshot / backup image IDs for the typed volumes(),
+		// snapshots(), and backups() accessors — all without a refetch.
+		mqlDroplet := res.(*mqlDigitaloceanDroplet)
+		mqlDroplet.image = d.Image
+		mqlDroplet.size = d.Size
+		mqlDroplet.cacheVolumeIDs = d.VolumeIDs
+		mqlDroplet.cacheSnapshotIDs = d.SnapshotIDs
+		mqlDroplet.cacheBackupIDs = d.BackupIDs
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -264,31 +254,21 @@ func (r *mqlDigitalocean) firewalls() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		firewalls, resp, err := client.Firewalls.List(context.Background(), opt)
+	firewalls, err := paginate(context.Background(), client.Firewalls.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(firewalls))
+	for _, fw := range firewalls {
+		if skipFirewall(conn.Filters.General, &fw) {
+			continue
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall", firewallArgs(&fw))
 		if err != nil {
 			return nil, err
 		}
-		for _, fw := range firewalls {
-			if skipFirewall(conn.Filters.General, &fw) {
-				continue
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.firewall", firewallArgs(&fw))
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -301,31 +281,21 @@ func (r *mqlDigitalocean) databases() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		dbs, resp, err := client.Databases.List(context.Background(), opt)
+	dbs, err := paginate(context.Background(), client.Databases.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(dbs))
+	for _, db := range dbs {
+		if skipDatabase(conn.Filters.General, &db) {
+			continue
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.database", databaseArgs(&db))
 		if err != nil {
 			return nil, err
 		}
-		for _, db := range dbs {
-			if skipDatabase(conn.Filters.General, &db) {
-				continue
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.database", databaseArgs(&db))
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -397,38 +367,30 @@ func (r *mqlDigitaloceanDomain) records() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		records, resp, err := client.Domains.Records(context.Background(), r.Name.Data, opt)
+	records, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
+		return client.Domains.Records(c, r.Name.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(records))
+	for _, rec := range records {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.domain.record", map[string]*llx.RawData{
+			"domainName": llx.StringData(r.Name.Data),
+			"id":         llx.IntData(int64(rec.ID)),
+			"type":       llx.StringData(rec.Type),
+			"name":       llx.StringData(rec.Name),
+			"data":       llx.StringData(rec.Data),
+			"ttl":        llx.IntData(int64(rec.TTL)),
+			"priority":   llx.IntData(int64(rec.Priority)),
+			"port":       llx.IntData(int64(rec.Port)),
+			"weight":     llx.IntData(int64(rec.Weight)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, rec := range records {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.domain.record", map[string]*llx.RawData{
-				"domainName": llx.StringData(r.Name.Data),
-				"id":         llx.IntData(int64(rec.ID)),
-				"type":       llx.StringData(rec.Type),
-				"name":       llx.StringData(rec.Name),
-				"data":       llx.StringData(rec.Data),
-				"ttl":        llx.IntData(int64(rec.TTL)),
-				"priority":   llx.IntData(int64(rec.Priority)),
-				"port":       llx.IntData(int64(rec.Port)),
-				"weight":     llx.IntData(int64(rec.Weight)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -499,32 +461,22 @@ func (r *mqlDigitalocean) loadBalancers() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		lbs, resp, err := client.LoadBalancers.List(context.Background(), opt)
+	lbs, err := paginate(context.Background(), client.LoadBalancers.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(lbs))
+	for _, lb := range lbs {
+		if skipLoadBalancer(conn.Filters.General, &lb) {
+			continue
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.loadBalancer", loadBalancerArgs(&lb))
 		if err != nil {
 			return nil, err
 		}
-		for _, lb := range lbs {
-			if skipLoadBalancer(conn.Filters.General, &lb) {
-				continue
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.loadBalancer", loadBalancerArgs(&lb))
-			if err != nil {
-				return nil, err
-			}
-			res.(*mqlDigitaloceanLoadBalancer).cacheTargetLoadBalancerIDs = lb.TargetLoadBalancerIDs
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		res.(*mqlDigitaloceanLoadBalancer).cacheTargetLoadBalancerIDs = lb.TargetLoadBalancerIDs
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -544,37 +496,27 @@ func (r *mqlDigitalocean) vpcs() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		vpcs, resp, err := client.VPCs.List(context.Background(), opt)
+	vpcs, err := paginate(context.Background(), client.VPCs.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(vpcs))
+	for _, v := range vpcs {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.vpc", map[string]*llx.RawData{
+			"id":          llx.StringData(v.ID),
+			"name":        llx.StringData(v.Name),
+			"description": llx.StringData(v.Description),
+			"ipRange":     llx.StringData(v.IPRange),
+			"region":      llx.StringData(v.RegionSlug),
+			"createdAt":   llx.TimeData(v.CreatedAt),
+			"default":     llx.BoolData(v.Default),
+			"urn":         llx.StringData(v.URN),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, v := range vpcs {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.vpc", map[string]*llx.RawData{
-				"id":          llx.StringData(v.ID),
-				"name":        llx.StringData(v.Name),
-				"description": llx.StringData(v.Description),
-				"ipRange":     llx.StringData(v.IPRange),
-				"region":      llx.StringData(v.RegionSlug),
-				"createdAt":   llx.TimeData(v.CreatedAt),
-				"default":     llx.BoolData(v.Default),
-				"urn":         llx.StringData(v.URN),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -587,31 +529,21 @@ func (r *mqlDigitalocean) kubernetesClusters() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		clusters, resp, err := client.Kubernetes.List(context.Background(), opt)
+	clusters, err := paginate(context.Background(), client.Kubernetes.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(clusters))
+	for _, c := range clusters {
+		if skipKubernetesCluster(conn.Filters.General, c) {
+			continue
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.cluster", kubernetesClusterArgs(c))
 		if err != nil {
 			return nil, err
 		}
-		for _, c := range clusters {
-			if skipKubernetesCluster(conn.Filters.General, c) {
-				continue
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.cluster", kubernetesClusterArgs(c))
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -637,35 +569,27 @@ func (r *mqlDigitaloceanProject) resources() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		items, resp, err := client.Projects.ListResources(context.Background(), r.Id.Data, opt)
+	items, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.ProjectResource, *godo.Response, error) {
+		return client.Projects.ListResources(c, r.Id.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.project.resource", map[string]*llx.RawData{
+			"__id":         llx.StringData("digitalocean.project.resource/" + r.Id.Data + "/" + item.URN),
+			"urn":          llx.StringData(item.URN),
+			"projectId":    llx.StringData(r.Id.Data),
+			"resourceType": llx.StringData(projectResourceType(item.URN)),
+			"assignedAt":   llx.TimeDataPtr(parseDoTime(item.AssignedAt)),
+			"status":       llx.StringData(item.Status),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, item := range items {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.project.resource", map[string]*llx.RawData{
-				"__id":         llx.StringData("digitalocean.project.resource/" + r.Id.Data + "/" + item.URN),
-				"urn":          llx.StringData(item.URN),
-				"projectId":    llx.StringData(r.Id.Data),
-				"resourceType": llx.StringData(projectResourceType(item.URN)),
-				"assignedAt":   llx.TimeDataPtr(parseDoTime(item.AssignedAt)),
-				"status":       llx.StringData(item.Status),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -674,38 +598,28 @@ func (r *mqlDigitalocean) projects() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		projects, resp, err := client.Projects.List(context.Background(), opt)
+	projects, err := paginate(context.Background(), client.Projects.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(projects))
+	for _, p := range projects {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.project", map[string]*llx.RawData{
+			"id":          llx.StringData(p.ID),
+			"name":        llx.StringData(p.Name),
+			"description": llx.StringData(p.Description),
+			"purpose":     llx.StringData(p.Purpose),
+			"environment": llx.StringData(p.Environment),
+			"createdAt":   llx.TimeDataPtr(parseDoTime(p.CreatedAt)),
+			"updatedAt":   llx.TimeDataPtr(parseDoTime(p.UpdatedAt)),
+			"isDefault":   llx.BoolData(p.IsDefault),
+			"ownerUuid":   llx.StringData(p.OwnerUUID),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, p := range projects {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.project", map[string]*llx.RawData{
-				"id":          llx.StringData(p.ID),
-				"name":        llx.StringData(p.Name),
-				"description": llx.StringData(p.Description),
-				"purpose":     llx.StringData(p.Purpose),
-				"environment": llx.StringData(p.Environment),
-				"createdAt":   llx.TimeDataPtr(parseDoTime(p.CreatedAt)),
-				"updatedAt":   llx.TimeDataPtr(parseDoTime(p.UpdatedAt)),
-				"isDefault":   llx.BoolData(p.IsDefault),
-				"ownerUuid":   llx.StringData(p.OwnerUUID),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -718,36 +632,26 @@ func (r *mqlDigitalocean) sshKeys() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		keys, resp, err := client.Keys.List(context.Background(), opt)
+	keys, err := paginate(context.Background(), client.Keys.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(keys))
+	for _, k := range keys {
+		algorithm, bits := sshutil.ParsePublicKey(k.PublicKey)
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.sshKey", map[string]*llx.RawData{
+			"id":          llx.IntData(int64(k.ID)),
+			"name":        llx.StringData(k.Name),
+			"fingerprint": llx.StringData(k.Fingerprint),
+			"publicKey":   llx.StringData(k.PublicKey),
+			"algorithm":   llx.StringData(algorithm),
+			"bits":        llx.IntData(bits),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, k := range keys {
-			algorithm, bits := sshutil.ParsePublicKey(k.PublicKey)
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.sshKey", map[string]*llx.RawData{
-				"id":          llx.IntData(int64(k.ID)),
-				"name":        llx.StringData(k.Name),
-				"fingerprint": llx.StringData(k.Fingerprint),
-				"publicKey":   llx.StringData(k.PublicKey),
-				"algorithm":   llx.StringData(algorithm),
-				"bits":        llx.IntData(bits),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -760,42 +664,32 @@ func (r *mqlDigitalocean) certificates() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		certs, resp, err := client.Certificates.List(context.Background(), opt)
-		if err != nil {
-			return nil, err
-		}
-		for _, c := range certs {
-			dnsNames := make([]interface{}, len(c.DNSNames))
-			for i, n := range c.DNSNames {
-				dnsNames[i] = n
-			}
+	certs, err := paginate(context.Background(), client.Certificates.List)
+	if err != nil {
+		return nil, err
+	}
 
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.certificate", map[string]*llx.RawData{
-				"id":              llx.StringData(c.ID),
-				"name":            llx.StringData(c.Name),
-				"sha1Fingerprint": llx.StringData(c.SHA1Fingerprint),
-				"state":           llx.StringData(c.State),
-				"type":            llx.StringData(c.Type),
-				"dnsNames":        llx.ArrayData(dnsNames, "\x02"),
-				"notAfter":        llx.TimeDataPtr(parseDoTime(c.NotAfter)),
-				"createdAt":       llx.TimeDataPtr(parseDoTime(c.Created)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
+	all := make([]interface{}, 0, len(certs))
+	for _, c := range certs {
+		dnsNames := make([]interface{}, len(c.DNSNames))
+		for i, n := range c.DNSNames {
+			dnsNames[i] = n
 		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
+
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.certificate", map[string]*llx.RawData{
+			"id":              llx.StringData(c.ID),
+			"name":            llx.StringData(c.Name),
+			"sha1Fingerprint": llx.StringData(c.SHA1Fingerprint),
+			"state":           llx.StringData(c.State),
+			"type":            llx.StringData(c.Type),
+			"dnsNames":        llx.ArrayData(dnsNames, "\x02"),
+			"notAfter":        llx.TimeDataPtr(parseDoTime(c.NotAfter)),
+			"createdAt":       llx.TimeDataPtr(parseDoTime(c.Created)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -578,8 +578,12 @@ func (r *mqlDigitaloceanProject) resources() ([]interface{}, error) {
 
 	all := make([]interface{}, 0, len(items))
 	for _, item := range items {
+		id, err := resourceID("digitalocean.project.resource", r.Id.Data, item.URN)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.project.resource", map[string]*llx.RawData{
-			"__id":         llx.StringData("digitalocean.project.resource/" + r.Id.Data + "/" + item.URN),
+			"__id":         llx.StringData(id),
 			"urn":          llx.StringData(item.URN),
 			"projectId":    llx.StringData(r.Id.Data),
 			"resourceType": llx.StringData(projectResourceType(item.URN)),

--- a/providers/digitalocean/resources/digitalocean_app_platform.go
+++ b/providers/digitalocean/resources/digitalocean_app_platform.go
@@ -112,31 +112,23 @@ func (r *mqlDigitaloceanApp) deployments() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		deployments, resp, err := client.Apps.ListDeployments(context.Background(), r.Id.Data, opt)
+	deployments, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+		return client.Apps.ListDeployments(c, r.Id.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(deployments))
+	for _, d := range deployments {
+		if d == nil {
+			continue
+		}
+		res, err := newAppDeployment(r.MqlRuntime, r.Id.Data, d)
 		if err != nil {
 			return nil, err
 		}
-		for _, d := range deployments {
-			if d == nil {
-				continue
-			}
-			res, err := newAppDeployment(r.MqlRuntime, r.Id.Data, d)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/digitalocean_app_platform.go
+++ b/providers/digitalocean/resources/digitalocean_app_platform.go
@@ -42,8 +42,12 @@ func newAppDeployment(runtime *plugin.Runtime, appID string, d *godo.Deployment)
 		totalSteps = int64(d.Progress.TotalSteps)
 	}
 
+	id, err := resourceID("digitalocean.app.deployment", appID, d.ID)
+	if err != nil {
+		return nil, err
+	}
 	res, err := CreateResource(runtime, "digitalocean.app.deployment", map[string]*llx.RawData{
-		"__id":                 llx.StringData("digitalocean.app.deployment/" + appID + "/" + d.ID),
+		"__id":                 llx.StringData(id),
 		"id":                   llx.StringData(d.ID),
 		"appId":                llx.StringData(appID),
 		"cause":                llx.StringData(d.Cause),
@@ -182,8 +186,12 @@ func (r *mqlDigitaloceanApp) alerts() ([]interface{}, error) {
 		for i, e := range a.Emails {
 			emails[i] = e
 		}
+		id, err := resourceID("digitalocean.app.alert", r.Id.Data, a.ID)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.app.alert", map[string]*llx.RawData{
-			"__id":              llx.StringData("digitalocean.app.alert/" + r.Id.Data + "/" + a.ID),
+			"__id":              llx.StringData(id),
 			"id":                llx.StringData(a.ID),
 			"appId":             llx.StringData(r.Id.Data),
 			"componentName":     llx.StringData(a.ComponentName),

--- a/providers/digitalocean/resources/digitalocean_functions.go
+++ b/providers/digitalocean/resources/digitalocean_functions.go
@@ -150,8 +150,12 @@ func (r *mqlDigitaloceanFunctionNamespace) accessKeys() ([]interface{}, error) {
 
 	all := make([]interface{}, 0, len(keys))
 	for _, k := range keys {
+		id, err := resourceID("digitalocean.function.accessKey", r.Namespace.Data, k.ID)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.function.accessKey", map[string]*llx.RawData{
-			"__id":          llx.StringData("digitalocean.function.accessKey/" + r.Namespace.Data + "/" + k.ID),
+			"__id":          llx.StringData(id),
 			"namespaceUuid": llx.StringData(r.Uuid.Data),
 			"id":            llx.StringData(k.ID),
 			"name":          llx.StringData(k.Name),
@@ -235,8 +239,12 @@ func (r *mqlDigitaloceanFunctionNamespace) functions() ([]interface{}, error) {
 			updatedAt = &t
 		}
 
+		id, err := resourceID("digitalocean.function.action", r.Namespace.Data, pkg, a.Name)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.function.action", map[string]*llx.RawData{
-			"__id": llx.StringData("digitalocean.function.action/" + r.Namespace.Data + "/" + pkg + "/" + a.Name),
+			"__id": llx.StringData(id),
 			// The namespace listing leaves uuid empty; the single-namespace
 			// read above is where the real one comes from.
 			"namespaceUuid":  llx.StringData(ns.UUID),

--- a/providers/digitalocean/resources/digitalocean_gradientai.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai.go
@@ -422,56 +422,48 @@ func (r *mqlDigitaloceanGradientaiAgent) versions() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		versions, resp, err := client.GradientAI.ListAgentVersions(context.Background(), r.Uuid.Data, opt)
+	versions, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.AgentVersion, *godo.Response, error) {
+		return client.GradientAI.ListAgentVersions(c, r.Uuid.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(versions))
+	for _, v := range versions {
+		if v == nil {
+			continue
+		}
+		tags := make([]interface{}, len(v.Tags))
+		for i, t := range v.Tags {
+			tags[i] = t
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.agent.version", map[string]*llx.RawData{
+			"__id":             llx.StringData(r.Uuid.Data + "/" + v.ID),
+			"id":               llx.StringData(v.ID),
+			"agentUuid":        llx.StringData(v.AgentUuid),
+			"name":             llx.StringData(v.Name),
+			"description":      llx.StringData(v.Description),
+			"instruction":      llx.StringData(v.Instruction),
+			"modelName":        llx.StringData(v.ModelName),
+			"versionHash":      llx.StringData(v.VersionHash),
+			"currentlyApplied": llx.BoolData(v.CurrentlyApplied),
+			"canRollback":      llx.BoolData(v.CanRollback),
+			"createdByEmail":   llx.StringData(v.CreatedByEmail),
+			"temperature":      llx.FloatData(v.Temperature),
+			"topP":             llx.FloatData(v.TopP),
+			"maxTokens":        llx.IntData(v.MaxTokens),
+			"k":                llx.IntData(v.K),
+			"provideCitations": llx.BoolData(v.ProvideCitations),
+			"retrievalMethod":  llx.StringData(v.RetrievalMethod),
+			"triggerAction":    llx.StringData(v.TriggerAction),
+			"tags":             llx.ArrayData(tags, types.String),
+			"createdAt":        llx.TimeDataPtr(gradientaiTime(v.CreatedAt)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, v := range versions {
-			if v == nil {
-				continue
-			}
-			tags := make([]interface{}, len(v.Tags))
-			for i, t := range v.Tags {
-				tags[i] = t
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.agent.version", map[string]*llx.RawData{
-				"__id":             llx.StringData(r.Uuid.Data + "/" + v.ID),
-				"id":               llx.StringData(v.ID),
-				"agentUuid":        llx.StringData(v.AgentUuid),
-				"name":             llx.StringData(v.Name),
-				"description":      llx.StringData(v.Description),
-				"instruction":      llx.StringData(v.Instruction),
-				"modelName":        llx.StringData(v.ModelName),
-				"versionHash":      llx.StringData(v.VersionHash),
-				"currentlyApplied": llx.BoolData(v.CurrentlyApplied),
-				"canRollback":      llx.BoolData(v.CanRollback),
-				"createdByEmail":   llx.StringData(v.CreatedByEmail),
-				"temperature":      llx.FloatData(v.Temperature),
-				"topP":             llx.FloatData(v.TopP),
-				"maxTokens":        llx.IntData(v.MaxTokens),
-				"k":                llx.IntData(v.K),
-				"provideCitations": llx.BoolData(v.ProvideCitations),
-				"retrievalMethod":  llx.StringData(v.RetrievalMethod),
-				"triggerAction":    llx.StringData(v.TriggerAction),
-				"tags":             llx.ArrayData(tags, types.String),
-				"createdAt":        llx.TimeDataPtr(gradientaiTime(v.CreatedAt)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -480,40 +472,32 @@ func (r *mqlDigitaloceanGradientaiAgent) apiKeys() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		keys, resp, err := client.GradientAI.ListAgentAPIKeys(context.Background(), r.Uuid.Data, opt)
+	keys, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.ApiKeyInfo, *godo.Response, error) {
+		return client.GradientAI.ListAgentAPIKeys(c, r.Uuid.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(keys))
+	for _, k := range keys {
+		if k == nil {
+			continue
+		}
+		// SecretKey is deliberately not surfaced.
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.agent.apiKey", map[string]*llx.RawData{
+			"__id":      llx.StringData(r.Uuid.Data + "/" + k.Uuid),
+			"uuid":      llx.StringData(k.Uuid),
+			"agentUuid": llx.StringData(r.Uuid.Data),
+			"name":      llx.StringData(k.Name),
+			"createdBy": llx.StringData(k.CreatedBy),
+			"createdAt": llx.TimeDataPtr(gradientaiTime(k.CreatedAt)),
+			"deletedAt": llx.TimeDataPtr(gradientaiTime(k.DeletedAt)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, k := range keys {
-			if k == nil {
-				continue
-			}
-			// SecretKey is deliberately not surfaced.
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.agent.apiKey", map[string]*llx.RawData{
-				"__id":      llx.StringData(r.Uuid.Data + "/" + k.Uuid),
-				"uuid":      llx.StringData(k.Uuid),
-				"agentUuid": llx.StringData(r.Uuid.Data),
-				"name":      llx.StringData(k.Name),
-				"createdBy": llx.StringData(k.CreatedBy),
-				"createdAt": llx.TimeDataPtr(gradientaiTime(k.CreatedAt)),
-				"deletedAt": llx.TimeDataPtr(gradientaiTime(k.DeletedAt)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/digitalocean_gradientai_inference.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai_inference.go
@@ -61,30 +61,22 @@ func (r *mqlDigitaloceanGradientaiAnthropicApiKey) agents() ([]interface{}, erro
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		agents, resp, err := client.GradientAI.ListAgentsByAnthropicAPIKey(context.Background(), r.Uuid.Data, opt)
+	agents, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.Agent, *godo.Response, error) {
+		return client.GradientAI.ListAgentsByAnthropicAPIKey(c, r.Uuid.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(agents))
+	for _, a := range agents {
+		res, err := newMqlGradientaiAgent(r.MqlRuntime, a)
 		if err != nil {
 			return nil, err
 		}
-		for _, a := range agents {
-			res, err := newMqlGradientaiAgent(r.MqlRuntime, a)
-			if err != nil {
-				return nil, err
-			}
-			if res != nil {
-				all = append(all, res)
-			}
+		if res != nil {
+			all = append(all, res)
 		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
 	}
 	return all, nil
 }
@@ -156,30 +148,22 @@ func (r *mqlDigitaloceanGradientaiOpenaiApiKey) agents() ([]interface{}, error) 
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		agents, resp, err := client.GradientAI.ListAgentsByOpenAIAPIKey(context.Background(), r.Uuid.Data, opt)
+	agents, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.Agent, *godo.Response, error) {
+		return client.GradientAI.ListAgentsByOpenAIAPIKey(c, r.Uuid.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(agents))
+	for _, a := range agents {
+		res, err := newMqlGradientaiAgent(r.MqlRuntime, a)
 		if err != nil {
 			return nil, err
 		}
-		for _, a := range agents {
-			res, err := newMqlGradientaiAgent(r.MqlRuntime, a)
-			if err != nil {
-				return nil, err
-			}
-			if res != nil {
-				all = append(all, res)
-			}
+		if res != nil {
+			all = append(all, res)
 		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
 	}
 	return all, nil
 }
@@ -287,36 +271,28 @@ func (r *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) tokens() ([]interf
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		tokens, resp, err := client.DedicatedInference.ListTokens(context.Background(), r.Id.Data, opt)
+	tokens, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.DedicatedInferenceToken, *godo.Response, error) {
+		return client.DedicatedInference.ListTokens(c, r.Id.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(tokens))
+	for i := range tokens {
+		t := tokens[i]
+		// The token Value is a secret and is deliberately not surfaced.
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.dedicatedInferenceEndpoint.token", map[string]*llx.RawData{
+			"__id":      llx.StringData(r.Id.Data + "/" + t.ID),
+			"id":        llx.StringData(t.ID),
+			"name":      llx.StringData(t.Name),
+			"isManaged": llx.BoolData(t.IsManaged),
+			"createdAt": llx.TimeData(t.CreatedAt),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for i := range tokens {
-			t := tokens[i]
-			// The token Value is a secret and is deliberately not surfaced.
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.dedicatedInferenceEndpoint.token", map[string]*llx.RawData{
-				"__id":      llx.StringData(r.Id.Data + "/" + t.ID),
-				"id":        llx.StringData(t.ID),
-				"name":      llx.StringData(t.Name),
-				"isManaged": llx.BoolData(t.IsManaged),
-				"createdAt": llx.TimeData(t.CreatedAt),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/digitalocean_gradientai_knowledge.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai_knowledge.go
@@ -142,67 +142,59 @@ func (r *mqlDigitaloceanGradientaiKnowledgeBase) dataSources() ([]interface{}, e
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		sources, resp, err := client.GradientAI.ListKnowledgeBaseDataSources(context.Background(), r.Uuid.Data, opt)
+	sources, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.KnowledgeBaseDataSource, *godo.Response, error) {
+		return client.GradientAI.ListKnowledgeBaseDataSources(c, r.Uuid.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(sources))
+	for i := range sources {
+		s := sources[i]
+		sourceType := ""
+		webCrawler := map[string]interface{}{}
+		spaces := map[string]interface{}{}
+		fileUpload := map[string]interface{}{}
+		if s.WebCrawlerDataSource != nil {
+			sourceType = "web_crawler"
+			webCrawler = map[string]interface{}{
+				"baseUrl":        s.WebCrawlerDataSource.BaseUrl,
+				"crawlingOption": s.WebCrawlerDataSource.CrawlingOption,
+				"embedMedia":     s.WebCrawlerDataSource.EmbedMedia,
+			}
+		}
+		if s.SpacesDataSource != nil {
+			sourceType = "spaces"
+			spaces = map[string]interface{}{
+				"bucketName": s.SpacesDataSource.BucketName,
+				"itemPath":   s.SpacesDataSource.ItemPath,
+				"region":     s.SpacesDataSource.Region,
+			}
+		}
+		if s.FileUploadDataSource != nil {
+			sourceType = "file_upload"
+			fileUpload = map[string]interface{}{
+				"originalFileName": s.FileUploadDataSource.OriginalFileName,
+				"size":             s.FileUploadDataSource.Size,
+				"storedObjectKey":  s.FileUploadDataSource.StoredObjectKey,
+			}
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.knowledgeBase.dataSource", map[string]*llx.RawData{
+			"__id":            llx.StringData(r.Uuid.Data + "/" + s.Uuid),
+			"uuid":            llx.StringData(s.Uuid),
+			"type":            llx.StringData(sourceType),
+			"webCrawler":      llx.DictData(webCrawler),
+			"spaces":          llx.DictData(spaces),
+			"fileUpload":      llx.DictData(fileUpload),
+			"lastIndexingJob": llx.DictData(lastIndexingJobDict(s.LastIndexingJob)),
+			"createdAt":       llx.TimeDataPtr(gradientaiTime(s.CreatedAt)),
+			"updatedAt":       llx.TimeDataPtr(gradientaiTime(s.UpdatedAt)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for i := range sources {
-			s := sources[i]
-			sourceType := ""
-			webCrawler := map[string]interface{}{}
-			spaces := map[string]interface{}{}
-			fileUpload := map[string]interface{}{}
-			if s.WebCrawlerDataSource != nil {
-				sourceType = "web_crawler"
-				webCrawler = map[string]interface{}{
-					"baseUrl":        s.WebCrawlerDataSource.BaseUrl,
-					"crawlingOption": s.WebCrawlerDataSource.CrawlingOption,
-					"embedMedia":     s.WebCrawlerDataSource.EmbedMedia,
-				}
-			}
-			if s.SpacesDataSource != nil {
-				sourceType = "spaces"
-				spaces = map[string]interface{}{
-					"bucketName": s.SpacesDataSource.BucketName,
-					"itemPath":   s.SpacesDataSource.ItemPath,
-					"region":     s.SpacesDataSource.Region,
-				}
-			}
-			if s.FileUploadDataSource != nil {
-				sourceType = "file_upload"
-				fileUpload = map[string]interface{}{
-					"originalFileName": s.FileUploadDataSource.OriginalFileName,
-					"size":             s.FileUploadDataSource.Size,
-					"storedObjectKey":  s.FileUploadDataSource.StoredObjectKey,
-				}
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.gradientai.knowledgeBase.dataSource", map[string]*llx.RawData{
-				"__id":            llx.StringData(r.Uuid.Data + "/" + s.Uuid),
-				"uuid":            llx.StringData(s.Uuid),
-				"type":            llx.StringData(sourceType),
-				"webCrawler":      llx.DictData(webCrawler),
-				"spaces":          llx.DictData(spaces),
-				"fileUpload":      llx.DictData(fileUpload),
-				"lastIndexingJob": llx.DictData(lastIndexingJobDict(s.LastIndexingJob)),
-				"createdAt":       llx.TimeDataPtr(gradientaiTime(s.CreatedAt)),
-				"updatedAt":       llx.TimeDataPtr(gradientaiTime(s.UpdatedAt)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/digitalocean_images.go
+++ b/providers/digitalocean/resources/digitalocean_images.go
@@ -57,28 +57,18 @@ func (r *mqlDigitalocean) images() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		images, resp, err := client.Images.ListUser(context.Background(), opt)
+	images, err := paginate(context.Background(), client.Images.ListUser)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(images))
+	for _, img := range images {
+		res, err := newMqlDigitaloceanImage(r.MqlRuntime, img)
 		if err != nil {
 			return nil, err
 		}
-		for _, img := range images {
-			res, err := newMqlDigitaloceanImage(r.MqlRuntime, img)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -93,46 +83,36 @@ func (r *mqlDigitalocean) snapshots() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		snapshots, resp, err := client.Snapshots.List(context.Background(), opt)
+	snapshots, err := paginate(context.Background(), client.Snapshots.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(snapshots))
+	for _, s := range snapshots {
+		regions := make([]interface{}, len(s.Regions))
+		for i, rg := range s.Regions {
+			regions[i] = rg
+		}
+		tags := make([]interface{}, len(s.Tags))
+		for i, t := range s.Tags {
+			tags[i] = t
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.snapshot", map[string]*llx.RawData{
+			"id":            llx.StringData(s.ID),
+			"name":          llx.StringData(s.Name),
+			"resourceId":    llx.StringData(s.ResourceID),
+			"resourceType":  llx.StringData(s.ResourceType),
+			"regions":       llx.ArrayData(regions, "\x02"),
+			"minDiskSize":   llx.IntData(int64(s.MinDiskSize)),
+			"sizeGigabytes": llx.FloatData(s.SizeGigaBytes),
+			"tags":          llx.ArrayData(tags, "\x02"),
+			"createdAt":     llx.TimeDataPtr(parseDoTime(s.Created)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, s := range snapshots {
-			regions := make([]interface{}, len(s.Regions))
-			for i, rg := range s.Regions {
-				regions[i] = rg
-			}
-			tags := make([]interface{}, len(s.Tags))
-			for i, t := range s.Tags {
-				tags[i] = t
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.snapshot", map[string]*llx.RawData{
-				"id":            llx.StringData(s.ID),
-				"name":          llx.StringData(s.Name),
-				"resourceId":    llx.StringData(s.ResourceID),
-				"resourceType":  llx.StringData(s.ResourceType),
-				"regions":       llx.ArrayData(regions, "\x02"),
-				"minDiskSize":   llx.IntData(int64(s.MinDiskSize)),
-				"sizeGigabytes": llx.FloatData(s.SizeGigaBytes),
-				"tags":          llx.ArrayData(tags, "\x02"),
-				"createdAt":     llx.TimeDataPtr(parseDoTime(s.Created)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/digitalocean_sizes.go
+++ b/providers/digitalocean/resources/digitalocean_sizes.go
@@ -72,28 +72,18 @@ func (r *mqlDigitalocean) sizes() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		sizes, resp, err := client.Sizes.List(context.Background(), opt)
+	sizes, err := paginate(context.Background(), client.Sizes.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(sizes))
+	for _, s := range sizes {
+		res, err := newMqlDigitaloceanSize(r.MqlRuntime, s)
 		if err != nil {
 			return nil, err
 		}
-		for _, s := range sizes {
-			res, err := newMqlDigitaloceanSize(r.MqlRuntime, s)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/resource_id.go
+++ b/providers/digitalocean/resources/resource_id.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// resourceID builds a resource's cache key from its kind and the parts that
+// make one instance distinguishable from another.
+//
+// It refuses to build a key from an empty part, which is the whole reason it
+// exists. Every __id collision found in this provider so far came from a
+// component that was empty at runtime and got concatenated anyway: five in
+// #9366, then function actions in #9750, which were keyed on a uuid the
+// namespace listing never populates. The resulting key still looks
+// well-formed, so nothing complains; instances simply alias onto whichever was
+// created first and the inventory is quietly wrong.
+//
+// Returning an error turns that into a visible failure at the creation site,
+// where the missing value can actually be traced.
+func resourceID(kind string, parts ...string) (string, error) {
+	if kind == "" {
+		return "", errors.New("resource id needs a kind")
+	}
+	if len(parts) == 0 {
+		return "", fmt.Errorf("%s: resource id needs at least one distinguishing part", kind)
+	}
+	for i, p := range parts {
+		if p == "" {
+			return "", fmt.Errorf("%s: resource id part %d is empty, so instances would share a cache key", kind, i)
+		}
+	}
+	return kind + "/" + strings.Join(parts, "/"), nil
+}

--- a/providers/digitalocean/resources/resource_id_test.go
+++ b/providers/digitalocean/resources/resource_id_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceID(t *testing.T) {
+	t.Run("joins kind and parts", func(t *testing.T) {
+		got, err := resourceID("digitalocean.app.deployment", "app-1", "dep-9")
+		require.NoError(t, err)
+		assert.Equal(t, "digitalocean.app.deployment/app-1/dep-9", got)
+	})
+
+	t.Run("single part", func(t *testing.T) {
+		got, err := resourceID("digitalocean.droplet", "123")
+		require.NoError(t, err)
+		assert.Equal(t, "digitalocean.droplet/123", got)
+	})
+
+	// This is the case the helper exists for. A namespace uuid that the
+	// listing leaves empty used to be concatenated anyway, producing a
+	// well-formed looking key that every instance shared.
+	t.Run("an empty part is refused", func(t *testing.T) {
+		_, err := resourceID("digitalocean.function.action", "", "pkg", "hello")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "part 0 is empty")
+	})
+
+	t.Run("an empty part in the middle is refused", func(t *testing.T) {
+		_, err := resourceID("digitalocean.function.action", "ns", "", "hello")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "part 1 is empty")
+	})
+
+	t.Run("no parts is refused", func(t *testing.T) {
+		_, err := resourceID("digitalocean.thing")
+		require.Error(t, err)
+	})
+
+	t.Run("no kind is refused", func(t *testing.T) {
+		_, err := resourceID("", "a")
+		require.Error(t, err)
+	})
+
+	// Two instances differing in any part must not share a key.
+	t.Run("distinct parts give distinct keys", func(t *testing.T) {
+		a, err := resourceID("digitalocean.function.action", "ns-1", "default", "hello")
+		require.NoError(t, err)
+		b, err := resourceID("digitalocean.function.action", "ns-2", "default", "hello")
+		require.NoError(t, err)
+		assert.NotEqual(t, a, b, "same action name in different namespaces must not alias")
+	})
+}

--- a/providers/digitalocean/resources/resources.go
+++ b/providers/digitalocean/resources/resources.go
@@ -20,37 +20,29 @@ func (r *mqlDigitaloceanDatabase) users() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		users, resp, err := client.Databases.ListUsers(context.Background(), r.Id.Data, opt)
+	users, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.DatabaseUser, *godo.Response, error) {
+		return client.Databases.ListUsers(c, r.Id.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(users))
+	for _, u := range users {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.database.user", map[string]*llx.RawData{
+			"databaseId":     llx.StringData(r.Id.Data),
+			"name":           llx.StringData(u.Name),
+			"role":           llx.StringData(u.Role),
+			"authPlugin":     llx.StringData(databaseUserAuthPlugin(&u)),
+			"kafkaAcls":      llx.ArrayData(databaseUserKafkaAcls(&u), types.Dict),
+			"opensearchAcls": llx.ArrayData(databaseUserOpenSearchAcls(&u), types.Dict),
+			"mongoDatabases": llx.ArrayData(databaseUserMongoDatabases(&u), types.String),
+			"mongoRole":      llx.StringData(databaseUserMongoRole(&u)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, u := range users {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.database.user", map[string]*llx.RawData{
-				"databaseId":     llx.StringData(r.Id.Data),
-				"name":           llx.StringData(u.Name),
-				"role":           llx.StringData(u.Role),
-				"authPlugin":     llx.StringData(databaseUserAuthPlugin(&u)),
-				"kafkaAcls":      llx.ArrayData(databaseUserKafkaAcls(&u), types.Dict),
-				"opensearchAcls": llx.ArrayData(databaseUserOpenSearchAcls(&u), types.Dict),
-				"mongoDatabases": llx.ArrayData(databaseUserMongoDatabases(&u), types.String),
-				"mongoRole":      llx.StringData(databaseUserMongoRole(&u)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -63,40 +55,32 @@ func (r *mqlDigitaloceanDatabase) replicas() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		replicas, resp, err := client.Databases.ListReplicas(context.Background(), r.Id.Data, opt)
+	replicas, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.DatabaseReplica, *godo.Response, error) {
+		return client.Databases.ListReplicas(c, r.Id.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(replicas))
+	for _, rep := range replicas {
+		tags := make([]interface{}, len(rep.Tags))
+		for i, t := range rep.Tags {
+			tags[i] = t
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.database.replica", map[string]*llx.RawData{
+			"databaseId": llx.StringData(r.Id.Data),
+			"name":       llx.StringData(rep.Name),
+			"region":     llx.StringData(rep.Region),
+			"status":     llx.StringData(rep.Status),
+			"createdAt":  llx.TimeData(rep.CreatedAt),
+			"size":       llx.StringData(rep.Size),
+			"tags":       llx.ArrayData(tags, "\x02"),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, rep := range replicas {
-			tags := make([]interface{}, len(rep.Tags))
-			for i, t := range rep.Tags {
-				tags[i] = t
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.database.replica", map[string]*llx.RawData{
-				"databaseId": llx.StringData(r.Id.Data),
-				"name":       llx.StringData(rep.Name),
-				"region":     llx.StringData(rep.Region),
-				"status":     llx.StringData(rep.Status),
-				"createdAt":  llx.TimeData(rep.CreatedAt),
-				"size":       llx.StringData(rep.Size),
-				"tags":       llx.ArrayData(tags, "\x02"),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -109,35 +93,27 @@ func (r *mqlDigitaloceanDatabase) pools() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		pools, resp, err := client.Databases.ListPools(context.Background(), r.Id.Data, opt)
+	pools, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.DatabasePool, *godo.Response, error) {
+		return client.Databases.ListPools(c, r.Id.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(pools))
+	for _, p := range pools {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.database.pool", map[string]*llx.RawData{
+			"databaseId": llx.StringData(r.Id.Data),
+			"name":       llx.StringData(p.Name),
+			"database":   llx.StringData(p.Database),
+			"user":       llx.StringData(p.User),
+			"size":       llx.IntData(int64(p.Size)),
+			"mode":       llx.StringData(p.Mode),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, p := range pools {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.database.pool", map[string]*llx.RawData{
-				"databaseId": llx.StringData(r.Id.Data),
-				"name":       llx.StringData(p.Name),
-				"database":   llx.StringData(p.Database),
-				"user":       llx.StringData(p.User),
-				"size":       llx.IntData(int64(p.Size)),
-				"mode":       llx.StringData(p.Mode),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -152,38 +128,28 @@ func (r *mqlDigitalocean) vpcPeerings() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		peerings, resp, err := client.VPCs.ListVPCPeerings(context.Background(), opt)
+	peerings, err := paginate(context.Background(), client.VPCs.ListVPCPeerings)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(peerings))
+	for _, p := range peerings {
+		vpcIds := make([]interface{}, len(p.VPCIDs))
+		for i, id := range p.VPCIDs {
+			vpcIds[i] = id
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.vpcPeering", map[string]*llx.RawData{
+			"id":        llx.StringData(p.ID),
+			"name":      llx.StringData(p.Name),
+			"vpcIds":    llx.ArrayData(vpcIds, "\x02"),
+			"status":    llx.StringData(string(p.Status)),
+			"createdAt": llx.TimeData(p.CreatedAt),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, p := range peerings {
-			vpcIds := make([]interface{}, len(p.VPCIDs))
-			for i, id := range p.VPCIDs {
-				vpcIds[i] = id
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.vpcPeering", map[string]*llx.RawData{
-				"id":        llx.StringData(p.ID),
-				"name":      llx.StringData(p.Name),
-				"vpcIds":    llx.ArrayData(vpcIds, "\x02"),
-				"status":    llx.StringData(string(p.Status)),
-				"createdAt": llx.TimeData(p.CreatedAt),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -198,62 +164,54 @@ func (r *mqlDigitaloceanKubernetesCluster) nodePools() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		pools, resp, err := client.Kubernetes.ListNodePools(context.Background(), r.Id.Data, opt)
+	pools, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.KubernetesNodePool, *godo.Response, error) {
+		return client.Kubernetes.ListNodePools(c, r.Id.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(pools))
+	for _, np := range pools {
+		npTags := make([]interface{}, len(np.Tags))
+		for i, t := range np.Tags {
+			npTags[i] = t
+		}
+
+		labels := map[string]interface{}{}
+		for k, v := range np.Labels {
+			labels[k] = v
+		}
+
+		taints := make([]interface{}, len(np.Taints))
+		for i, t := range np.Taints {
+			taints[i] = map[string]interface{}{
+				"key":    t.Key,
+				"value":  t.Value,
+				"effect": t.Effect,
+			}
+		}
+
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.nodePool", map[string]*llx.RawData{
+			"id":        llx.StringData(np.ID),
+			"clusterId": llx.StringData(r.Id.Data),
+			"name":      llx.StringData(np.Name),
+			"size":      llx.StringData(np.Size),
+			"count":     llx.IntData(int64(np.Count)),
+			"autoScale": llx.BoolData(np.AutoScale),
+			"minNodes":  llx.IntData(int64(np.MinNodes)),
+			"maxNodes":  llx.IntData(int64(np.MaxNodes)),
+			"tags":      llx.ArrayData(npTags, "\x02"),
+			"labels":    llx.DictData(labels),
+			"taints":    llx.ArrayData(taints, "\x13"),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, np := range pools {
-			npTags := make([]interface{}, len(np.Tags))
-			for i, t := range np.Tags {
-				npTags[i] = t
-			}
-
-			labels := map[string]interface{}{}
-			for k, v := range np.Labels {
-				labels[k] = v
-			}
-
-			taints := make([]interface{}, len(np.Taints))
-			for i, t := range np.Taints {
-				taints[i] = map[string]interface{}{
-					"key":    t.Key,
-					"value":  t.Value,
-					"effect": t.Effect,
-				}
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.kubernetes.nodePool", map[string]*llx.RawData{
-				"id":        llx.StringData(np.ID),
-				"clusterId": llx.StringData(r.Id.Data),
-				"name":      llx.StringData(np.Name),
-				"size":      llx.StringData(np.Size),
-				"count":     llx.IntData(int64(np.Count)),
-				"autoScale": llx.BoolData(np.AutoScale),
-				"minNodes":  llx.IntData(int64(np.MinNodes)),
-				"maxNodes":  llx.IntData(int64(np.MaxNodes)),
-				"tags":      llx.ArrayData(npTags, "\x02"),
-				"labels":    llx.DictData(labels),
-				"taints":    llx.ArrayData(taints, "\x13"),
-			})
-			if err != nil {
-				return nil, err
-			}
-			// Cache the godo nodes so the typed nodes() accessor can build
-			// digitalocean.kubernetes.node resources without a refetch.
-			res.(*mqlDigitaloceanKubernetesNodePool).cacheNodes = np.Nodes
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		// Cache the godo nodes so the typed nodes() accessor can build
+		// digitalocean.kubernetes.node resources without a refetch.
+		res.(*mqlDigitaloceanKubernetesNodePool).cacheNodes = np.Nodes
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -377,37 +335,29 @@ func (r *mqlDigitaloceanRegistry) garbageCollections() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		gcs, resp, err := client.Registry.ListGarbageCollections(context.Background(), r.Name.Data, opt)
+	gcs, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.GarbageCollection, *godo.Response, error) {
+		return client.Registry.ListGarbageCollections(c, r.Name.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(gcs))
+	for _, gc := range gcs {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.registry.garbageCollection", map[string]*llx.RawData{
+			"uuid":         llx.StringData(gc.UUID),
+			"registryName": llx.StringData(gc.RegistryName),
+			"status":       llx.StringData(gc.Status),
+			"type":         llx.StringData(string(gc.Type)),
+			"createdAt":    llx.TimeData(gc.CreatedAt),
+			"updatedAt":    llx.TimeData(gc.UpdatedAt),
+			"blobsDeleted": llx.IntData(int64(gc.BlobsDeleted)),
+			"freedBytes":   llx.IntData(int64(gc.FreedBytes)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, gc := range gcs {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.registry.garbageCollection", map[string]*llx.RawData{
-				"uuid":         llx.StringData(gc.UUID),
-				"registryName": llx.StringData(gc.RegistryName),
-				"status":       llx.StringData(gc.Status),
-				"type":         llx.StringData(string(gc.Type)),
-				"createdAt":    llx.TimeData(gc.CreatedAt),
-				"updatedAt":    llx.TimeData(gc.UpdatedAt),
-				"blobsDeleted": llx.IntData(int64(gc.BlobsDeleted)),
-				"freedBytes":   llx.IntData(int64(gc.FreedBytes)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -480,36 +430,28 @@ func (r *mqlDigitaloceanRegistryRepository) tags() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		tags, resp, err := client.Registry.ListRepositoryTags(context.Background(), r.RegistryName.Data, r.Name.Data, opt)
+	tags, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.RepositoryTag, *godo.Response, error) {
+		return client.Registry.ListRepositoryTags(c, r.RegistryName.Data, r.Name.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(tags))
+	for _, t := range tags {
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.registry.repository.tag", map[string]*llx.RawData{
+			"registryName":        llx.StringData(t.RegistryName),
+			"repository":          llx.StringData(t.Repository),
+			"tag":                 llx.StringData(t.Tag),
+			"manifestDigest":      llx.StringData(t.ManifestDigest),
+			"compressedSizeBytes": llx.IntData(int64(t.CompressedSizeBytes)),
+			"sizeBytes":           llx.IntData(int64(t.SizeBytes)),
+			"updatedAt":           llx.TimeData(t.UpdatedAt),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, t := range tags {
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.registry.repository.tag", map[string]*llx.RawData{
-				"registryName":        llx.StringData(t.RegistryName),
-				"repository":          llx.StringData(t.Repository),
-				"tag":                 llx.StringData(t.Tag),
-				"manifestDigest":      llx.StringData(t.ManifestDigest),
-				"compressedSizeBytes": llx.IntData(int64(t.CompressedSizeBytes)),
-				"sizeBytes":           llx.IntData(int64(t.SizeBytes)),
-				"updatedAt":           llx.TimeData(t.UpdatedAt),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -518,28 +460,20 @@ func (r *mqlDigitaloceanRegistryRepository) manifests() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		manifests, resp, err := client.Registry.ListRepositoryManifests(context.Background(), r.RegistryName.Data, r.Name.Data, opt)
+	manifests, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.RepositoryManifest, *godo.Response, error) {
+		return client.Registry.ListRepositoryManifests(c, r.RegistryName.Data, r.Name.Data, o)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(manifests))
+	for _, m := range manifests {
+		res, err := newManifestResource(r.MqlRuntime, m)
 		if err != nil {
 			return nil, err
 		}
-		for _, m := range manifests {
-			res, err := newManifestResource(r.MqlRuntime, m)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -597,42 +531,32 @@ func (r *mqlDigitalocean) reservedIPs() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		ips, resp, err := client.ReservedIPs.List(context.Background(), opt)
+	ips, err := paginate(context.Background(), client.ReservedIPs.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(ips))
+	for _, ip := range ips {
+		regionSlug := ""
+		if ip.Region != nil {
+			regionSlug = ip.Region.Slug
+		}
+		dropletId := int64(0)
+		if ip.Droplet != nil {
+			dropletId = int64(ip.Droplet.ID)
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.reservedIp", map[string]*llx.RawData{
+			"ip":        llx.StringData(ip.IP),
+			"region":    llx.StringData(regionSlug),
+			"projectId": llx.StringData(ip.ProjectID),
+			"locked":    llx.BoolData(ip.Locked),
+			"dropletId": llx.IntData(dropletId),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, ip := range ips {
-			regionSlug := ""
-			if ip.Region != nil {
-				regionSlug = ip.Region.Slug
-			}
-			dropletId := int64(0)
-			if ip.Droplet != nil {
-				dropletId = int64(ip.Droplet.ID)
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.reservedIp", map[string]*llx.RawData{
-				"ip":        llx.StringData(ip.IP),
-				"region":    llx.StringData(regionSlug),
-				"projectId": llx.StringData(ip.ProjectID),
-				"locked":    llx.BoolData(ip.Locked),
-				"dropletId": llx.IntData(dropletId),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -647,119 +571,109 @@ func (r *mqlDigitalocean) apps() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		apps, resp, err := client.Apps.List(context.Background(), opt)
+	apps, err := paginate(context.Background(), client.Apps.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(apps))
+	for _, app := range apps {
+		status := ""
+		if !app.LastDeploymentActiveAt.IsZero() {
+			status = "active"
+		}
+		if app.InProgressDeployment != nil {
+			status = "deploying"
+		}
+
+		spec := map[string]interface{}{}
+		if app.Spec != nil {
+			spec["name"] = app.Spec.Name
+			svcNames := make([]interface{}, len(app.Spec.Services))
+			for i, s := range app.Spec.Services {
+				svcNames[i] = s.Name
+			}
+			spec["services"] = svcNames
+			workerNames := make([]interface{}, len(app.Spec.Workers))
+			for i, w := range app.Spec.Workers {
+				workerNames[i] = w.Name
+			}
+			spec["workers"] = workerNames
+			jobNames := make([]interface{}, len(app.Spec.Jobs))
+			for i, j := range app.Spec.Jobs {
+				jobNames[i] = j.Name
+			}
+			spec["jobs"] = jobNames
+			staticNames := make([]interface{}, len(app.Spec.StaticSites))
+			for i, s := range app.Spec.StaticSites {
+				staticNames[i] = s.Name
+			}
+			spec["staticSites"] = staticNames
+			fnNames := make([]interface{}, len(app.Spec.Functions))
+			for i, f := range app.Spec.Functions {
+				fnNames[i] = f.Name
+			}
+			spec["functions"] = fnNames
+		}
+
+		name := ""
+		if app.Spec != nil {
+			name = app.Spec.Name
+		}
+
+		region := ""
+		if app.Region != nil {
+			region = app.Region.Slug
+		}
+
+		activeDeploymentId := ""
+		if app.ActiveDeployment != nil {
+			activeDeploymentId = app.ActiveDeployment.ID
+		}
+
+		secureHeaderKey, secureHeaderValue, secureHeaderRemoved := appSecureHeader(app.Spec)
+
+		domains := make([]interface{}, len(app.Domains))
+		for i, d := range app.Domains {
+			domainName := ""
+			if d.Spec != nil {
+				domainName = d.Spec.Domain
+			}
+			domains[i] = map[string]interface{}{
+				"id":                   d.ID,
+				"name":                 domainName,
+				"phase":                string(d.Phase),
+				"certificateExpiresAt": formatDoTime(d.CertificateExpiresAt),
+			}
+		}
+
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.app", map[string]*llx.RawData{
+			"id":                     llx.StringData(app.ID),
+			"name":                   llx.StringData(name),
+			"liveUrl":                llx.StringData(app.LiveURL),
+			"createdAt":              llx.TimeData(app.CreatedAt),
+			"updatedAt":              llx.TimeData(app.UpdatedAt),
+			"activeDeploymentStatus": llx.StringData(status),
+			"spec":                   llx.DictData(spec),
+			"region":                 llx.StringData(region),
+			"tierSlug":               llx.StringData(app.TierSlug),
+			"defaultIngress":         llx.StringData(app.DefaultIngress),
+			"liveDomain":             llx.StringData(app.LiveDomain),
+			"projectId":              llx.StringData(app.ProjectID),
+			"activeDeploymentId":     llx.StringData(activeDeploymentId),
+			"domains":                llx.ArrayData(domains, "\x13"),
+
+			"enhancedThreatControlEnabled": llx.BoolData(app.Spec != nil && app.Spec.EnhancedThreatControlEnabled),
+			"secureHeaderKey":              llx.StringData(secureHeaderKey),
+			"secureHeaderValue":            llx.StringData(secureHeaderValue),
+			"secureHeaderRemoved":          llx.BoolData(secureHeaderRemoved),
+			"corsPolicies":                 llx.ArrayData(appCorsPolicies(app.Spec), types.Dict),
+			"envVars":                      llx.ArrayData(appEnvVars(app.Spec), types.Dict),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, app := range apps {
-			status := ""
-			if !app.LastDeploymentActiveAt.IsZero() {
-				status = "active"
-			}
-			if app.InProgressDeployment != nil {
-				status = "deploying"
-			}
-
-			spec := map[string]interface{}{}
-			if app.Spec != nil {
-				spec["name"] = app.Spec.Name
-				svcNames := make([]interface{}, len(app.Spec.Services))
-				for i, s := range app.Spec.Services {
-					svcNames[i] = s.Name
-				}
-				spec["services"] = svcNames
-				workerNames := make([]interface{}, len(app.Spec.Workers))
-				for i, w := range app.Spec.Workers {
-					workerNames[i] = w.Name
-				}
-				spec["workers"] = workerNames
-				jobNames := make([]interface{}, len(app.Spec.Jobs))
-				for i, j := range app.Spec.Jobs {
-					jobNames[i] = j.Name
-				}
-				spec["jobs"] = jobNames
-				staticNames := make([]interface{}, len(app.Spec.StaticSites))
-				for i, s := range app.Spec.StaticSites {
-					staticNames[i] = s.Name
-				}
-				spec["staticSites"] = staticNames
-				fnNames := make([]interface{}, len(app.Spec.Functions))
-				for i, f := range app.Spec.Functions {
-					fnNames[i] = f.Name
-				}
-				spec["functions"] = fnNames
-			}
-
-			name := ""
-			if app.Spec != nil {
-				name = app.Spec.Name
-			}
-
-			region := ""
-			if app.Region != nil {
-				region = app.Region.Slug
-			}
-
-			activeDeploymentId := ""
-			if app.ActiveDeployment != nil {
-				activeDeploymentId = app.ActiveDeployment.ID
-			}
-
-			secureHeaderKey, secureHeaderValue, secureHeaderRemoved := appSecureHeader(app.Spec)
-
-			domains := make([]interface{}, len(app.Domains))
-			for i, d := range app.Domains {
-				domainName := ""
-				if d.Spec != nil {
-					domainName = d.Spec.Domain
-				}
-				domains[i] = map[string]interface{}{
-					"id":                   d.ID,
-					"name":                 domainName,
-					"phase":                string(d.Phase),
-					"certificateExpiresAt": formatDoTime(d.CertificateExpiresAt),
-				}
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.app", map[string]*llx.RawData{
-				"id":                     llx.StringData(app.ID),
-				"name":                   llx.StringData(name),
-				"liveUrl":                llx.StringData(app.LiveURL),
-				"createdAt":              llx.TimeData(app.CreatedAt),
-				"updatedAt":              llx.TimeData(app.UpdatedAt),
-				"activeDeploymentStatus": llx.StringData(status),
-				"spec":                   llx.DictData(spec),
-				"region":                 llx.StringData(region),
-				"tierSlug":               llx.StringData(app.TierSlug),
-				"defaultIngress":         llx.StringData(app.DefaultIngress),
-				"liveDomain":             llx.StringData(app.LiveDomain),
-				"projectId":              llx.StringData(app.ProjectID),
-				"activeDeploymentId":     llx.StringData(activeDeploymentId),
-				"domains":                llx.ArrayData(domains, "\x13"),
-
-				"enhancedThreatControlEnabled": llx.BoolData(app.Spec != nil && app.Spec.EnhancedThreatControlEnabled),
-				"secureHeaderKey":              llx.StringData(secureHeaderKey),
-				"secureHeaderValue":            llx.StringData(secureHeaderValue),
-				"secureHeaderRemoved":          llx.BoolData(secureHeaderRemoved),
-				"corsPolicies":                 llx.ArrayData(appCorsPolicies(app.Spec), types.Dict),
-				"envVars":                      llx.ArrayData(appEnvVars(app.Spec), types.Dict),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -774,65 +688,55 @@ func (r *mqlDigitalocean) alertPolicies() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		policies, resp, err := client.Monitoring.ListAlertPolicies(context.Background(), opt)
+	policies, err := paginate(context.Background(), client.Monitoring.ListAlertPolicies)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(policies))
+	for _, p := range policies {
+		entities := make([]interface{}, len(p.Entities))
+		for i, e := range p.Entities {
+			entities[i] = e
+		}
+		pTags := make([]interface{}, len(p.Tags))
+		for i, t := range p.Tags {
+			pTags[i] = t
+		}
+
+		emails := make([]interface{}, 0)
+		slacks := make([]interface{}, 0)
+		if p.Alerts.Email != nil {
+			for _, e := range p.Alerts.Email {
+				emails = append(emails, e)
+			}
+		}
+		if p.Alerts.Slack != nil {
+			for _, s := range p.Alerts.Slack {
+				slacks = append(slacks, map[string]interface{}{
+					"channel": s.Channel,
+					"url":     s.URL,
+				})
+			}
+		}
+
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.alertPolicy", map[string]*llx.RawData{
+			"uuid":        llx.StringData(p.UUID),
+			"type":        llx.StringData(p.Type),
+			"description": llx.StringData(p.Description),
+			"compare":     llx.StringData(string(p.Compare)),
+			"value":       llx.FloatData(float64(p.Value)),
+			"window":      llx.StringData(p.Window),
+			"enabled":     llx.BoolData(p.Enabled),
+			"entities":    llx.ArrayData(entities, "\x02"),
+			"tags":        llx.ArrayData(pTags, "\x02"),
+			"alertEmails": llx.ArrayData(emails, "\x02"),
+			"alertSlack":  llx.ArrayData(slacks, "\x13"),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, p := range policies {
-			entities := make([]interface{}, len(p.Entities))
-			for i, e := range p.Entities {
-				entities[i] = e
-			}
-			pTags := make([]interface{}, len(p.Tags))
-			for i, t := range p.Tags {
-				pTags[i] = t
-			}
-
-			emails := make([]interface{}, 0)
-			slacks := make([]interface{}, 0)
-			if p.Alerts.Email != nil {
-				for _, e := range p.Alerts.Email {
-					emails = append(emails, e)
-				}
-			}
-			if p.Alerts.Slack != nil {
-				for _, s := range p.Alerts.Slack {
-					slacks = append(slacks, map[string]interface{}{
-						"channel": s.Channel,
-						"url":     s.URL,
-					})
-				}
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.alertPolicy", map[string]*llx.RawData{
-				"uuid":        llx.StringData(p.UUID),
-				"type":        llx.StringData(p.Type),
-				"description": llx.StringData(p.Description),
-				"compare":     llx.StringData(string(p.Compare)),
-				"value":       llx.FloatData(float64(p.Value)),
-				"window":      llx.StringData(p.Window),
-				"enabled":     llx.BoolData(p.Enabled),
-				"entities":    llx.ArrayData(entities, "\x02"),
-				"tags":        llx.ArrayData(pTags, "\x02"),
-				"alertEmails": llx.ArrayData(emails, "\x02"),
-				"alertSlack":  llx.ArrayData(slacks, "\x13"),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -847,39 +751,29 @@ func (r *mqlDigitalocean) uptimeChecks() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		checks, resp, err := client.UptimeChecks.List(context.Background(), opt)
+	checks, err := paginate(context.Background(), client.UptimeChecks.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(checks))
+	for _, c := range checks {
+		regions := make([]interface{}, len(c.Regions))
+		for i, r := range c.Regions {
+			regions[i] = r
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.uptimeCheck", map[string]*llx.RawData{
+			"id":      llx.StringData(c.ID),
+			"name":    llx.StringData(c.Name),
+			"type":    llx.StringData(c.Type),
+			"target":  llx.StringData(c.Target),
+			"regions": llx.ArrayData(regions, "\x02"),
+			"enabled": llx.BoolData(c.Enabled),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, c := range checks {
-			regions := make([]interface{}, len(c.Regions))
-			for i, r := range c.Regions {
-				regions[i] = r
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.uptimeCheck", map[string]*llx.RawData{
-				"id":      llx.StringData(c.ID),
-				"name":    llx.StringData(c.Name),
-				"type":    llx.StringData(c.Type),
-				"target":  llx.StringData(c.Target),
-				"regions": llx.ArrayData(regions, "\x02"),
-				"enabled": llx.BoolData(c.Enabled),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }
@@ -938,35 +832,25 @@ func (r *mqlDigitalocean) tags() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
-	var all []interface{}
-	opt := &godo.ListOptions{PerPage: 200}
-	for {
-		tags, resp, err := client.Tags.List(context.Background(), opt)
+	tags, err := paginate(context.Background(), client.Tags.List)
+	if err != nil {
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(tags))
+	for _, t := range tags {
+		count := 0
+		if t.Resources != nil {
+			count = t.Resources.Count
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.tag", map[string]*llx.RawData{
+			"name":          llx.StringData(t.Name),
+			"resourceCount": llx.IntData(int64(count)),
+		})
 		if err != nil {
 			return nil, err
 		}
-		for _, t := range tags {
-			count := 0
-			if t.Resources != nil {
-				count = t.Resources.Count
-			}
-			res, err := CreateResource(r.MqlRuntime, "digitalocean.tag", map[string]*llx.RawData{
-				"name":          llx.StringData(t.Name),
-				"resourceCount": llx.IntData(int64(count)),
-			})
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, res)
-		}
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-		opt.Page = page + 1
+		all = append(all, res)
 	}
 	return all, nil
 }


### PR DESCRIPTION
Second in the stack, **based on #9752** — review that first; this diff is the second commit.

Those listers pass a parent id or filter alongside the page options, so each needs a closure rather than a bare method value. The element types come from godo's own declared signatures, so the closures are mechanical rather than guessed:

```go
users, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]godo.DatabaseUser, *godo.Response, error) {
	return client.Databases.ListUsers(c, r.Id.Data, o)
})
```

**34 loops across 8 files, −308 lines.**

Several also fixed a latent nil-deref on the way. `database.users` tested `resp.Links` with no `resp == nil` in front of it — the exact shape that panicked the provider in #9750.

## What is deliberately left

21 loops remain, in three groups, each a judgement call rather than a repetition:

- **`securityScan.findings`** pages off the returned slice length because `GetScan` never populates `resp.Links` (see #9366). It does not fit the helper.
- **`CDNs.List`, `Domains.List`, `BYOIPPrefixes.GetResources`, `Secrets.List`** do not return `([]T, *Response, error)`, so the helper cannot type them.
- The rest sit **nested inside another loop** and want restructuring, not a mechanical swap.

That is where a sweep should stop.

## Verification

Build and full provider suite pass. Built, installed and queried against a real DigitalOcean account: every migrated lister resolves, and populated collections still return data — `gradientai.models: 96`, `sizes: 16`, `vpcs: 4`, `projects: 1`.

No schema change.