### PR TITLE
🧹 digitalocean: build resource cache keys through one helper

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -578,8 +578,12 @@ func (r *mqlDigitaloceanProject) resources() ([]interface{}, error) {
 
 	all := make([]interface{}, 0, len(items))
 	for _, item := range items {
+		id, err := resourceID("digitalocean.project.resource", r.Id.Data, item.URN)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.project.resource", map[string]*llx.RawData{
-			"__id":         llx.StringData("digitalocean.project.resource/" + r.Id.Data + "/" + item.URN),
+			"__id":         llx.StringData(id),
 			"urn":          llx.StringData(item.URN),
 			"projectId":    llx.StringData(r.Id.Data),
 			"resourceType": llx.StringData(projectResourceType(item.URN)),

--- a/providers/digitalocean/resources/digitalocean_app_platform.go
+++ b/providers/digitalocean/resources/digitalocean_app_platform.go
@@ -42,8 +42,12 @@ func newAppDeployment(runtime *plugin.Runtime, appID string, d *godo.Deployment)
 		totalSteps = int64(d.Progress.TotalSteps)
 	}
 
+	id, err := resourceID("digitalocean.app.deployment", appID, d.ID)
+	if err != nil {
+		return nil, err
+	}
 	res, err := CreateResource(runtime, "digitalocean.app.deployment", map[string]*llx.RawData{
-		"__id":                 llx.StringData("digitalocean.app.deployment/" + appID + "/" + d.ID),
+		"__id":                 llx.StringData(id),
 		"id":                   llx.StringData(d.ID),
 		"appId":                llx.StringData(appID),
 		"cause":                llx.StringData(d.Cause),
@@ -182,8 +186,12 @@ func (r *mqlDigitaloceanApp) alerts() ([]interface{}, error) {
 		for i, e := range a.Emails {
 			emails[i] = e
 		}
+		id, err := resourceID("digitalocean.app.alert", r.Id.Data, a.ID)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.app.alert", map[string]*llx.RawData{
-			"__id":              llx.StringData("digitalocean.app.alert/" + r.Id.Data + "/" + a.ID),
+			"__id":              llx.StringData(id),
 			"id":                llx.StringData(a.ID),
 			"appId":             llx.StringData(r.Id.Data),
 			"componentName":     llx.StringData(a.ComponentName),

--- a/providers/digitalocean/resources/digitalocean_functions.go
+++ b/providers/digitalocean/resources/digitalocean_functions.go
@@ -150,8 +150,12 @@ func (r *mqlDigitaloceanFunctionNamespace) accessKeys() ([]interface{}, error) {
 
 	all := make([]interface{}, 0, len(keys))
 	for _, k := range keys {
+		id, err := resourceID("digitalocean.function.accessKey", r.Namespace.Data, k.ID)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.function.accessKey", map[string]*llx.RawData{
-			"__id":          llx.StringData("digitalocean.function.accessKey/" + r.Namespace.Data + "/" + k.ID),
+			"__id":          llx.StringData(id),
 			"namespaceUuid": llx.StringData(r.Uuid.Data),
 			"id":            llx.StringData(k.ID),
 			"name":          llx.StringData(k.Name),
@@ -235,8 +239,12 @@ func (r *mqlDigitaloceanFunctionNamespace) functions() ([]interface{}, error) {
 			updatedAt = &t
 		}
 
+		id, err := resourceID("digitalocean.function.action", r.Namespace.Data, pkg, a.Name)
+		if err != nil {
+			return nil, err
+		}
 		res, err := CreateResource(r.MqlRuntime, "digitalocean.function.action", map[string]*llx.RawData{
-			"__id": llx.StringData("digitalocean.function.action/" + r.Namespace.Data + "/" + pkg + "/" + a.Name),
+			"__id": llx.StringData(id),
 			// The namespace listing leaves uuid empty; the single-namespace
 			// read above is where the real one comes from.
 			"namespaceUuid":  llx.StringData(ns.UUID),

--- a/providers/digitalocean/resources/resource_id.go
+++ b/providers/digitalocean/resources/resource_id.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// resourceID builds a resource's cache key from its kind and the parts that
+// make one instance distinguishable from another.
+//
+// It refuses to build a key from an empty part, which is the whole reason it
+// exists. Every __id collision found in this provider so far came from a
+// component that was empty at runtime and got concatenated anyway: five in
+// #9366, then function actions in #9750, which were keyed on a uuid the
+// namespace listing never populates. The resulting key still looks
+// well-formed, so nothing complains; instances simply alias onto whichever was
+// created first and the inventory is quietly wrong.
+//
+// Returning an error turns that into a visible failure at the creation site,
+// where the missing value can actually be traced.
+func resourceID(kind string, parts ...string) (string, error) {
+	if kind == "" {
+		return "", errors.New("resource id needs a kind")
+	}
+	if len(parts) == 0 {
+		return "", fmt.Errorf("%s: resource id needs at least one distinguishing part", kind)
+	}
+	for i, p := range parts {
+		if p == "" {
+			return "", fmt.Errorf("%s: resource id part %d is empty, so instances would share a cache key", kind, i)
+		}
+	}
+	return kind + "/" + strings.Join(parts, "/"), nil
+}

--- a/providers/digitalocean/resources/resource_id_test.go
+++ b/providers/digitalocean/resources/resource_id_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceID(t *testing.T) {
+	t.Run("joins kind and parts", func(t *testing.T) {
+		got, err := resourceID("digitalocean.app.deployment", "app-1", "dep-9")
+		require.NoError(t, err)
+		assert.Equal(t, "digitalocean.app.deployment/app-1/dep-9", got)
+	})
+
+	t.Run("single part", func(t *testing.T) {
+		got, err := resourceID("digitalocean.droplet", "123")
+		require.NoError(t, err)
+		assert.Equal(t, "digitalocean.droplet/123", got)
+	})
+
+	// This is the case the helper exists for. A namespace uuid that the
+	// listing leaves empty used to be concatenated anyway, producing a
+	// well-formed looking key that every instance shared.
+	t.Run("an empty part is refused", func(t *testing.T) {
+		_, err := resourceID("digitalocean.function.action", "", "pkg", "hello")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "part 0 is empty")
+	})
+
+	t.Run("an empty part in the middle is refused", func(t *testing.T) {
+		_, err := resourceID("digitalocean.function.action", "ns", "", "hello")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "part 1 is empty")
+	})
+
+	t.Run("no parts is refused", func(t *testing.T) {
+		_, err := resourceID("digitalocean.thing")
+		require.Error(t, err)
+	})
+
+	t.Run("no kind is refused", func(t *testing.T) {
+		_, err := resourceID("", "a")
+		require.Error(t, err)
+	})
+
+	// Two instances differing in any part must not share a key.
+	t.Run("distinct parts give distinct keys", func(t *testing.T) {
+		a, err := resourceID("digitalocean.function.action", "ns-1", "default", "hello")
+		require.NoError(t, err)
+		b, err := resourceID("digitalocean.function.action", "ns-2", "default", "hello")
+		require.NoError(t, err)
+		assert.NotEqual(t, a, b, "same action name in different namespaces must not alias")
+	})
+}


### PR DESCRIPTION
Third in the stack, **based on #9756**.

## Why

Every `__id` collision found in this provider came from the same thing: **a component that was empty at runtime and got concatenated anyway.** Five in #9366, then function actions in #9750, keyed on a namespace uuid the listing never populates.

The resulting key still looks well-formed, so nothing complains. Instances alias onto whichever was created first, and the inventory is quietly wrong — the worst failure shape, since the query succeeds.

## The helper

```go
id, err := resourceID("digitalocean.app.deployment", appID, d.ID)
if err != nil {
	return nil, err
}
```

It refuses to build a key when any part is empty, turning a silent aliasing bug into an error at the creation site where the missing value can actually be traced.

## Scope

Adopted at the **5 sites** whose keys are a kind followed by plain parts. **9 composite keys are left alone**: they embed a literal separator other than `/` (`entryProtocol + ":" + port`) or format a number inline, so they want reading rather than a mechanical swap. The helper and its tests are the durable part; those sites can adopt it individually.

## Tests

Seven, including the two shapes that actually occurred:

- an empty leading part is refused (the `#9750` shape)
- the same action name in two namespaces does not alias

The existing `TestResourceIDsAreUniquePerInstance` still passes unchanged.

## Verification

Build, full provider suite, and a live query against a real account (`sizes: 16`, `projects: 1`).

No schema change.