### PR TITLE
🧹 gcp: make the service-enabled gate a type instead of a convention

### DIFF
--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -59,7 +59,7 @@ func (g *mqlGcpOrganization) gcpUserAccessBindings() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -116,7 +116,7 @@ func (g *mqlGcpOrganization) accessPolicies() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -163,7 +163,7 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) accessLevels() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -221,7 +221,7 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) servicePerimeters() ([]any, err
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}

--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -83,7 +83,7 @@ func (g *mqlGcpProjectAlloydbService) clusters() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB clusters")
 				break
 			}
@@ -337,7 +337,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) users() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB users")
 				break
 			}
@@ -486,7 +486,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) instances() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB instances")
 				break
 			}
@@ -647,7 +647,7 @@ func (g *mqlGcpProjectAlloydbServiceCluster) backups() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list AlloyDB backups")
 				break
 			}

--- a/providers/gcp/resources/apigateway.go
+++ b/providers/gcp/resources/apigateway.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -14,7 +13,6 @@ import (
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/apigateway/v1"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -24,21 +22,6 @@ func newApiGatewayService(conn *connection.GcpConnection) (*apigateway.Service, 
 		return nil, err
 	}
 	return apigateway.NewService(context.Background(), option.WithHTTPClient(client))
-}
-
-// apiGatewayServiceDisabled reports whether an error indicates the API Gateway
-// service is not enabled or the caller lacks permission, in which case the
-// list call should degrade gracefully to an empty result.
-func apiGatewayServiceDisabled(err error) bool {
-	if gerr, ok := err.(*googleapi.Error); ok {
-		if gerr.Code == 403 || gerr.Code == 404 {
-			return true
-		}
-		if strings.Contains(gerr.Message, "not enabled") || strings.Contains(gerr.Message, "has not been used") {
-			return true
-		}
-	}
-	return false
 }
 
 func (g *mqlGcpProject) apiGateway() (*mqlGcpProjectApiGatewayService, error) {
@@ -96,7 +79,7 @@ func (g *mqlGcpProjectApiGatewayService) apis() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if apiGatewayServiceDisabled(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -142,7 +125,7 @@ func (g *mqlGcpProjectApiGatewayService) gateways() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if apiGatewayServiceDisabled(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -201,7 +184,7 @@ func (g *mqlGcpProjectApiGatewayServiceApi) configs() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if apiGatewayServiceDisabled(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -125,7 +125,7 @@ func (g *mqlGcpProjectAssetService) resources() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not search Cloud Asset Inventory resources")
 				break
 			}
@@ -201,7 +201,7 @@ func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not search Cloud Asset Inventory IAM policies")
 				break
 			}

--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 
 	asset "cloud.google.com/go/asset/apiv1"
 	"cloud.google.com/go/asset/apiv1/assetpb"
@@ -23,9 +22,7 @@ import (
 )
 
 type mqlGcpProjectAssetServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) assetInventory() (*mqlGcpProjectAssetService, error) {
@@ -47,7 +44,7 @@ func (g *mqlGcpProject) assetInventory() (*mqlGcpProjectAssetService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectAssetService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_cloudasset).Msg("gcp service is not enabled, skipping")
 	}
@@ -243,31 +240,7 @@ func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
 	return res, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectAssetService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_cloudasset)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_cloudasset)
 }

--- a/providers/gcp/resources/asset_access_analysis.go
+++ b/providers/gcp/resources/asset_access_analysis.go
@@ -155,7 +155,7 @@ func (g *mqlGcpProjectAssetServiceWhoCan) fetchAnalysis() (*accessAnalysis, erro
 		},
 	})
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("permission", permission).Str("resource", resource).
 				Msg("could not analyze IAM policy")
 			// A skippable error means the question was not answered, so report

--- a/providers/gcp/resources/backupdr.go
+++ b/providers/gcp/resources/backupdr.go
@@ -18,21 +18,7 @@ import (
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
-
-// isBackupDRSkippable returns true for gRPC errors that indicate the Backup DR API
-// is not enabled or the caller lacks permission.
-func isBackupDRSkippable(err error) bool {
-	if s, ok := status.FromError(err); ok {
-		switch s.Code() {
-		case codes.PermissionDenied, codes.Unimplemented, codes.NotFound:
-			return true
-		}
-	}
-	return false
-}
 
 func (g *mqlGcpProject) backupdr() (*mqlGcpProjectBackupdrService, error) {
 	if g.Id.Error != nil {
@@ -96,7 +82,7 @@ func (g *mqlGcpProjectBackupdrService) managementServers() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isBackupDRSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR management servers")
 				break
 			}
@@ -173,7 +159,7 @@ func (g *mqlGcpProjectBackupdrService) backupVaults() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isBackupDRSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR backup vaults")
 				break
 			}
@@ -240,7 +226,7 @@ func (g *mqlGcpProjectBackupdrServiceBackupVault) dataSources() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isBackupDRSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR data sources")
 				break
 			}
@@ -311,7 +297,7 @@ func (g *mqlGcpProjectBackupdrService) backupPlans() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isBackupDRSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Backup DR backup plans")
 				break
 			}

--- a/providers/gcp/resources/batch.go
+++ b/providers/gcp/resources/batch.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	batch "cloud.google.com/go/batch/apiv1"
 	"cloud.google.com/go/batch/apiv1/batchpb"
@@ -22,9 +21,7 @@ import (
 )
 
 type mqlGcpProjectBatchServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) batch() (*mqlGcpProjectBatchService, error) {
@@ -46,7 +43,7 @@ func (g *mqlGcpProject) batch() (*mqlGcpProjectBatchService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectBatchService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_batch).Msg("gcp service is not enabled, skipping")
 	}
@@ -188,31 +185,7 @@ func (g *mqlGcpProjectBatchService) jobs() ([]any, error) {
 	return res, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectBatchService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_batch)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_batch)
 }

--- a/providers/gcp/resources/batch.go
+++ b/providers/gcp/resources/batch.go
@@ -123,7 +123,7 @@ func (g *mqlGcpProjectBatchService) jobs() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Batch jobs")
 				break
 			}

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -44,38 +44,12 @@ func initGcpProjectBigqueryService(runtime *plugin.Runtime, args map[string]*llx
 }
 
 type mqlGcpProjectBigqueryServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// The flag is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: gcp.bigquery is an
-// alias for it, and resource inits build it with CreateResource. On those paths
-// the Go zero value `false` made every collection return an empty list with no
-// error -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectBigqueryService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_bigquery)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_bigquery)
 }
 
 func (g *mqlGcpProjectBigqueryService) id() (string, error) {
@@ -104,7 +78,7 @@ func (g *mqlGcpProject) bigquery() (*mqlGcpProjectBigqueryService, error) {
 		return nil, err
 	}
 	bqService := res.(*mqlGcpProjectBigqueryService)
-	bqService.serviceEnabled = serviceEnabled
+	bqService.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_bigquery).Msg("gcp service is not enabled, skipping")
 	}

--- a/providers/gcp/resources/bigquery_connection.go
+++ b/providers/gcp/resources/bigquery_connection.go
@@ -93,7 +93,7 @@ func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isGRPCSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("location", location).Msg("could not list BigQuery connections")
 					break
 				}

--- a/providers/gcp/resources/bigquery_reservation.go
+++ b/providers/gcp/resources/bigquery_reservation.go
@@ -61,7 +61,7 @@ func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isGRPCSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("location", location).Msg("could not list BigQuery reservations")
 					break
 				}

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -26,7 +26,7 @@ import (
 // an error in case of some locations are unavailable").
 //
 // It is a plain struct with no GRPCStatus(), so status.FromError does not
-// recognise it and isGRPCSkippable returns false -- the callers therefore took
+// recognise it and isSkippable returns false -- the callers therefore took
 // the hard-error path and threw away the instances, clusters or backups the SDK
 // had just handed them. A transient blip in one region emptied the whole
 // Bigtable inventory.
@@ -157,7 +157,7 @@ func (g *mqlGcpProjectBigtableService) instances() ([]any, error) {
 	instances, err := iac.Instances(ctx)
 	if err != nil {
 		if !bigtablePartialResult(err, "instances") {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Bigtable instances")
 				return nil, nil
 			}
@@ -247,7 +247,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) clusters() ([]any, error) {
 
 	clusters, err := iac.Clusters(ctx, instanceName)
 	if err != nil && !bigtablePartialResult(err, "clusters") {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Bigtable clusters")
 			return nil, nil
 		}
@@ -376,7 +376,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) iamPolicy() ([]any, error) {
 
 	policy, err := iac.InstanceIAM(instanceName).Policy(ctx)
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not get Bigtable instance IAM policy")
 			return nil, nil
 		}
@@ -428,7 +428,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) tables() ([]any, error) {
 
 	tableNames, err := ac.Tables(ctx)
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Bigtable tables")
 			return nil, nil
 		}
@@ -439,7 +439,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) tables() ([]any, error) {
 	for _, tableName := range tableNames {
 		tableInfo, err := ac.TableInfo(ctx, tableName)
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Str("table", tableName).Msg("could not read Bigtable table info")
 				continue
 			}
@@ -553,7 +553,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) appProfiles() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Bigtable app profiles")
 				break
 			}
@@ -634,7 +634,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 
 	clusters, err := iac.Clusters(ctx, instanceName)
 	if err != nil && !bigtablePartialResult(err, "clusters") {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Bigtable clusters for backup lookup")
 			return nil, nil
 		}
@@ -663,7 +663,7 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isGRPCSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("cluster", clusterID).Msg("could not list Bigtable backups")
 					break
 				}

--- a/providers/gcp/resources/binary_authorization.go
+++ b/providers/gcp/resources/binary_authorization.go
@@ -58,7 +58,7 @@ func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorization
 		Name: name,
 	})
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			g.BinaryAuthorization.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	certificatemanager "cloud.google.com/go/certificatemanager/apiv1"
 	"cloud.google.com/go/certificatemanager/apiv1/certificatemanagerpb"
@@ -40,7 +39,7 @@ func (g *mqlGcpProject) certificateManager() (*mqlGcpProjectCertificateManagerSe
 	}
 
 	svc := res.(*mqlGcpProjectCertificateManagerService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_certificatemanager).Msg("gcp service is not enabled, skipping")
 	}
@@ -48,9 +47,7 @@ func (g *mqlGcpProject) certificateManager() (*mqlGcpProjectCertificateManagerSe
 }
 
 type mqlGcpProjectCertificateManagerServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 type mqlGcpProjectCertificateManagerServiceCertificateInternal struct {
@@ -879,31 +876,7 @@ func initGcpProjectCertificateManagerServiceCertificateIssuanceConfig(runtime *p
 	return args, res, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectCertificateManagerService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_certificatemanager)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_certificatemanager)
 }

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -117,7 +117,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificates() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -230,7 +230,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateMaps() ([]any, error
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -297,7 +297,7 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificateMap) entries() ([]any,
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -370,7 +370,7 @@ func (g *mqlGcpProjectCertificateManagerService) dnsAuthorizations() ([]any, err
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -447,7 +447,7 @@ func (g *mqlGcpProjectCertificateManagerService) certificateIssuanceConfigs() ([
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -525,7 +525,7 @@ func (g *mqlGcpProjectCertificateManagerService) trustConfigs() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}

--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -55,7 +55,7 @@ func (g *mqlGcpProject) cloudFunctionsV2() ([]any, error) {
 			// Gracefully skip when the Cloud Functions API is disabled or access
 			// is denied (matches the gRPC-based sibling resources), instead of
 			// failing the whole query with a hard error.
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				break
 			}
 			return nil, err

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -409,7 +409,7 @@ func (g *mqlGcpProjectCloudBuildService) workerPools() ([]any, error) {
 			if s, ok := status.FromError(err); ok && s.Code() == codes.InvalidArgument {
 				break
 			}
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				break
 			}
 			return nil, err
@@ -586,7 +586,7 @@ func (g *mqlGcpProjectCloudBuildService) builds() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				break
 			}
 			return nil, err

--- a/providers/gcp/resources/cloudidentity.go
+++ b/providers/gcp/resources/cloudidentity.go
@@ -59,7 +59,7 @@ func (g *mqlGcpCloudIdentityGroup) securitySettings() (*mqlGcpCloudIdentityGroup
 	settings, err := cloudIdentitySvc.Groups.GetSecuritySettings(groupName + "/securitySettings").
 		ReadMask("memberRestriction").Context(ctx).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("group", groupName).Msg("could not get Cloud Identity group security settings")
 			g.SecuritySettings.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
@@ -91,7 +91,7 @@ func (g *mqlGcpCloudIdentityGroup) securitySettings() (*mqlGcpCloudIdentityGroup
 // organization. Unlike the project-level accessors there is no serviceusage
 // service-enabled pre-check: service enablement is a per-project concept and
 // this resource is organization-scoped, so a disabled API instead surfaces as
-// a 403/404 that isHTTPSkippable handles below.
+// a 403/404 that isSkippable handles below.
 func (g *mqlGcpOrganization) cloudIdentityGroups() ([]any, error) {
 	if g.CustomerId.Error != nil {
 		return nil, g.CustomerId.Error
@@ -141,7 +141,7 @@ func (g *mqlGcpOrganization) cloudIdentityGroups() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Cloud Identity groups")
 			return nil, nil
 		}
@@ -202,7 +202,7 @@ func (g *mqlGcpCloudIdentityGroup) memberships() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("group", groupName).Msg("could not list Cloud Identity group memberships")
 			return nil, nil
 		}

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -51,9 +51,7 @@ func initGcpProjectCloudRunService(runtime *plugin.Runtime, args map[string]*llx
 }
 
 type mqlGcpProjectCloudRunServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) cloudRun() (*mqlGcpProjectCloudRunService, error) {
@@ -75,7 +73,7 @@ func (g *mqlGcpProject) cloudRun() (*mqlGcpProjectCloudRunService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectCloudRunService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_cloudrun).Msg("gcp service is not enabled, skipping")
 	}
@@ -1147,31 +1145,7 @@ func mqlVolumes(volumes []*runpb.Volume) []any {
 	return mqlVolumes
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectCloudRunService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_cloudrun)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_cloudrun)
 }

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -673,7 +673,7 @@ func (g *mqlGcpProjectCloudRunServiceService) iamPolicy() ([]any, error) {
 	resourcePath := fmt.Sprintf("projects/%s/locations/%s/services/%s", projectId, region, name)
 	policy, err := runSvc.Projects.Locations.Services.GetIamPolicy(resourcePath).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -710,7 +710,7 @@ func (g *mqlGcpProjectCloudRunServiceJob) iamPolicy() ([]any, error) {
 	resourcePath := fmt.Sprintf("projects/%s/locations/%s/jobs/%s", projectId, region, name)
 	policy, err := runSvc.Projects.Locations.Jobs.GetIamPolicy(resourcePath).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/providers/gcp/resources/cloudscheduler.go
+++ b/providers/gcp/resources/cloudscheduler.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	scheduler "cloud.google.com/go/scheduler/apiv1"
@@ -20,9 +19,7 @@ import (
 )
 
 type mqlGcpProjectCloudSchedulerServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) cloudScheduler() (*mqlGcpProjectCloudSchedulerService, error) {
@@ -41,35 +38,13 @@ func (g *mqlGcpProject) cloudScheduler() (*mqlGcpProjectCloudSchedulerService, e
 		return nil, err
 	}
 	schedulerService := res.(*mqlGcpProjectCloudSchedulerService)
-	schedulerService.serviceEnabled = serviceEnabled
+	schedulerService.recordEnabled(serviceEnabled)
 	return schedulerService, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// The flag is only set by the accessor above, but this resource is reachable
-// without going through it - a resource init can build it with CreateResource.
-// Resolving it here makes every construction path agree, rather than leaving
-// the Go zero value false to report an empty list as fact.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectCloudSchedulerService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_cloudscheduler)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_cloudscheduler)
 }
 
 func (g *mqlGcpProjectCloudSchedulerService) id() (string, error) {

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -16,9 +16,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 
-	"google.golang.org/api/googleapi"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -225,31 +222,6 @@ func protoToDict(msg proto.Message) (map[string]any, error) {
 		return nil, err
 	}
 	return result, nil
-}
-
-// isHTTPSkippable returns true for REST API errors that indicate the API
-// is not enabled, the caller lacks permission, or the resource is not found.
-func isHTTPSkippable(err error) bool {
-	gerr, ok := err.(*googleapi.Error)
-	if !ok {
-		return false
-	}
-	if gerr.Code == 403 || gerr.Code == 404 {
-		return true
-	}
-	return strings.Contains(gerr.Message, "not enabled") || strings.Contains(gerr.Message, "has not been used")
-}
-
-// isGRPCSkippable returns true for gRPC errors that indicate the API
-// is not enabled, the caller lacks permission, or the resource is not found.
-func isGRPCSkippable(err error) bool {
-	if s, ok := status.FromError(err); ok {
-		switch s.Code() {
-		case codes.PermissionDenied, codes.Unimplemented, codes.NotFound:
-			return true
-		}
-	}
-	return false
 }
 
 func (g *mqlGcpRetryConfig) id() (string, error) {

--- a/providers/gcp/resources/composer.go
+++ b/providers/gcp/resources/composer.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -15,24 +14,8 @@ import (
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/composer/v1"
 	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
-
-// composerServiceDisabled reports whether the error indicates the Cloud
-// Composer API is not enabled for the project. A genuine permission denial
-// (HTTP 403 without a "not enabled" message) is deliberately not treated as
-// disabled so it surfaces to the caller instead of being swallowed.
-func composerServiceDisabled(err error) bool {
-	gerr, ok := err.(*googleapi.Error)
-	if !ok {
-		return false
-	}
-	if strings.Contains(gerr.Message, "not enabled") || strings.Contains(gerr.Message, "has not been used") {
-		return true
-	}
-	return gerr.Code == 404
-}
 
 func (g *mqlGcpProject) composer() (*mqlGcpProjectComposerService, error) {
 	if g.Id.Error != nil {
@@ -138,7 +121,7 @@ func (g *mqlGcpProjectComposerService) environments() ([]any, error) {
 			}
 			return nil
 		}); err != nil {
-			if composerServiceDisabled(err) {
+			if isServiceDisabled(err) {
 				// Cloud Composer is not offered in every Compute region, and
 				// this classifier treats any 404 as "not available here". It is
 				// therefore a PER-REGION signal, not a project-wide one:

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3529,7 +3529,7 @@ func (g *mqlGcpProjectComputeServiceSecurityPolicy) rules() ([]any, error) {
 		policy, err = computeSvc.SecurityPolicies.Get(projectId, policyName).Context(ctx).Do()
 	}
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Str("policy", policyName).Err(err).Msg("could not fetch security policy rules")
 			return nil, nil
 		}

--- a/providers/gcp/resources/compute_shared_vpc.go
+++ b/providers/gcp/resources/compute_shared_vpc.go
@@ -102,7 +102,7 @@ func (g *mqlGcpProjectComputeService) fetchSharedVpc() (*sharedVpcTopology, erro
 	// A project with no host returns an empty project rather than an error, so an
 	// empty name means "not a service project" and is not a failure.
 	if host, err := computeSvc.Projects.GetXpnHost(projectId).Context(ctx).Do(); err != nil {
-		if !isHTTPSkippable(err) {
+		if !isSkippable(err) {
 			return nil, err
 		}
 		log.Debug().Err(err).Str("project", projectId).Msg("could not read Shared VPC host project")
@@ -121,7 +121,7 @@ func (g *mqlGcpProjectComputeService) fetchSharedVpc() (*sharedVpcTopology, erro
 		}
 		return nil
 	}); err != nil {
-		if !isHTTPSkippable(err) && !isNotSharedVpcHost(err) {
+		if !isSkippable(err) && !isNotSharedVpcHost(err) {
 			return nil, err
 		}
 		log.Debug().Err(err).Str("project", projectId).Msg("could not read Shared VPC service projects")

--- a/providers/gcp/resources/container_analysis.go
+++ b/providers/gcp/resources/container_analysis.go
@@ -22,8 +22,7 @@ import (
 )
 
 type mqlGcpProjectContainerAnalysisServiceInternal struct {
-	serviceEnabled bool
-	serviceChecked bool
+	serviceGate
 }
 
 func (g *mqlGcpProject) containerAnalysis() (*mqlGcpProjectContainerAnalysisService, error) {
@@ -45,8 +44,7 @@ func (g *mqlGcpProject) containerAnalysis() (*mqlGcpProjectContainerAnalysisServ
 	}
 
 	svc := res.(*mqlGcpProjectContainerAnalysisService)
-	svc.serviceEnabled = serviceEnabled
-	svc.serviceChecked = true
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_containeranalysis).Msg("gcp service is not enabled, skipping")
 	}
@@ -54,32 +52,9 @@ func (g *mqlGcpProject) containerAnalysis() (*mqlGcpProjectContainerAnalysisServ
 	return svc, nil
 }
 
-// isEnabled reports whether the Container Analysis API is enabled for the
-// project. When the service is reached through gcp.project.containerAnalysis the
-// flag is set by that accessor, but a direct query of
-// gcp.project.containerAnalysisService is built through the init function, which
-// cannot set it. Resolve it lazily here so the direct-query path doesn't
-// silently return empty occurrences/notes.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectContainerAnalysisService) isEnabled() (bool, error) {
-	if g.serviceChecked {
-		return g.serviceEnabled, nil
-	}
-	if g.ProjectId.Error != nil {
-		return false, g.ProjectId.Error
-	}
-	proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-		"id": llx.StringData(g.ProjectId.Data),
-	})
-	if err != nil {
-		return false, err
-	}
-	enabled, err := proj.(*mqlGcpProject).isServiceEnabled(service_containeranalysis)
-	if err != nil {
-		return false, err
-	}
-	g.serviceEnabled = enabled
-	g.serviceChecked = true
-	return enabled, nil
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_containeranalysis)
 }
 
 func initGcpProjectContainerAnalysisService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/gcp/resources/container_analysis.go
+++ b/providers/gcp/resources/container_analysis.go
@@ -154,7 +154,7 @@ func (g *mqlGcpProjectContainerAnalysisService) notes() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Container Analysis notes")
 				break
 			}
@@ -241,7 +241,7 @@ func (g *mqlGcpProjectContainerAnalysisService) occurrences() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Container Analysis occurrences")
 				break
 			}

--- a/providers/gcp/resources/dataflow.go
+++ b/providers/gcp/resources/dataflow.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
-	"google.golang.org/api/dataflow/v1b3"
+	dataflow "google.golang.org/api/dataflow/v1b3"
 	"google.golang.org/api/option"
 )
 

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -197,30 +197,6 @@ func getDiscoveryTargets(config *inventory.Config) []string {
 	return stringx.DedupStringArray(res)
 }
 
-// isDiscoverySkippableErr returns true when a per-service discovery error
-// indicates we lack access or the API is not enabled in this project. Both
-// classes mean "we cannot see anything here" rather than "the system is
-// broken", so callers should log and move on to the next discovery target.
-func isDiscoverySkippableErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	if isHTTPSkippable(err) || isGRPCSkippable(err) {
-		return true
-	}
-	// Some resource fetches rewrap the original error as a plain string
-	// before returning (for example organization.go translates a 403 into
-	// errors.New("403: permission denied")). Match the common signatures
-	// so those rewrapped forms still skip cleanly.
-	msg := err.Error()
-	return strings.Contains(msg, "permission denied") ||
-		strings.Contains(msg, "Error 403") ||
-		strings.Contains(msg, "403:") ||
-		strings.Contains(msg, "has not been used") ||
-		strings.Contains(msg, "API not enabled") ||
-		strings.Contains(msg, "is not enabled")
-}
-
 // gcpAPIServiceRe matches a GCP service-disabled error message of the form
 // "<service> API has not been used in project ...". The captured group is
 // the human-readable service name (e.g. "Memorystore",
@@ -236,7 +212,7 @@ func runDiscoveryStep(target string, fn func() error) error {
 	if err == nil {
 		return nil
 	}
-	if !isDiscoverySkippableErr(err) {
+	if !isSkippable(err) {
 		return err
 	}
 	if m := gcpAPIServiceRe.FindStringSubmatch(err.Error()); len(m) == 2 {

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -188,34 +188,6 @@ func TestGetDiscoveryTargets(t *testing.T) {
 	}
 }
 
-func TestIsDiscoverySkippableErr(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{name: "nil error", err: nil, want: false},
-		{name: "googleapi 403", err: &googleapi.Error{Code: 403, Message: "permission denied"}, want: true},
-		{name: "googleapi 404", err: &googleapi.Error{Code: 404, Message: "not found"}, want: true},
-		{name: "googleapi 500", err: &googleapi.Error{Code: 500, Message: "server error"}, want: false},
-		{name: "googleapi service-disabled message", err: &googleapi.Error{Code: 400, Message: "API has not been used in project 123 before or it is disabled"}, want: true},
-		{name: "gRPC permission denied", err: status.Error(codes.PermissionDenied, "no access"), want: true},
-		{name: "gRPC not found", err: status.Error(codes.NotFound, "missing"), want: true},
-		{name: "gRPC unimplemented", err: status.Error(codes.Unimplemented, "not implemented"), want: true},
-		{name: "gRPC internal", err: status.Error(codes.Internal, "boom"), want: false},
-		{name: "rewrapped 403 string", err: errors.New("403: permission denied"), want: true},
-		{name: "googleapi error stringified", err: errors.New("googleapi: Error 403: permission denied"), want: true},
-		{name: "api-not-enabled phrasing", err: errors.New("Cloud KMS API has not been used in project foo"), want: true},
-		{name: "plain unrelated error", err: errors.New("connection reset by peer"), want: false},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, isDiscoverySkippableErr(tc.err))
-		})
-	}
-}
-
 func TestRunDiscoveryStep(t *testing.T) {
 	t.Run("returns nil and runs fn on success", func(t *testing.T) {
 		called := false

--- a/providers/gcp/resources/discoveryengine.go
+++ b/providers/gcp/resources/discoveryengine.go
@@ -18,8 +18,6 @@ import (
 	googleoauth "golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // discoveryEngineLocations lists the Discovery Engine multi-region locations.
@@ -50,18 +48,6 @@ func discoveryEngineLocationFromName(name string) string {
 		}
 	}
 	return ""
-}
-
-// isDiscoveryEngineSkippable returns true for errors indicating the Discovery
-// Engine API is not enabled or the location is not available for this project.
-func isDiscoveryEngineSkippable(err error) bool {
-	if s, ok := status.FromError(err); ok {
-		switch s.Code() {
-		case codes.PermissionDenied, codes.Unimplemented, codes.InvalidArgument, codes.NotFound:
-			return true
-		}
-	}
-	return false
 }
 
 func (g *mqlGcpProject) discoveryEngine() (*mqlGcpProjectDiscoveryEngineService, error) {
@@ -143,7 +129,7 @@ func (g *mqlGcpProjectDiscoveryEngineService) listDataStoresInLocation(ctx conte
 			break
 		}
 		if err != nil {
-			if isDiscoveryEngineSkippable(err) {
+			if isInapplicable(err) {
 				break
 			}
 			return nil, err
@@ -213,7 +199,7 @@ func (g *mqlGcpProjectDiscoveryEngineService) listEnginesInLocation(ctx context.
 			break
 		}
 		if err != nil {
-			if isDiscoveryEngineSkippable(err) {
+			if isInapplicable(err) {
 				break
 			}
 			return nil, err
@@ -310,7 +296,7 @@ func (g *mqlGcpProjectDiscoveryEngineServiceEngine) dataStores() ([]any, error) 
 			Name: fmt.Sprintf("%s/dataStores/%s", collectionParent, id),
 		})
 		if err != nil {
-			if isDiscoveryEngineSkippable(err) {
+			if isInapplicable(err) {
 				continue
 			}
 			return nil, err

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -124,7 +124,7 @@ func (g *mqlGcpProjectDlpService) inspectTemplates() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP inspect templates")
 				break
 			}
@@ -199,7 +199,7 @@ func (g *mqlGcpProjectDlpService) deidentifyTemplates() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP deidentify templates")
 				break
 			}
@@ -274,7 +274,7 @@ func (g *mqlGcpProjectDlpService) jobTriggers() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP job triggers")
 				break
 			}
@@ -370,7 +370,7 @@ func (g *mqlGcpProjectDlpService) storedInfoTypes() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP stored info types")
 				break
 			}
@@ -499,7 +499,7 @@ func (g *mqlGcpProjectDlpService) dlpJobs() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP jobs")
 				break
 			}
@@ -590,7 +590,7 @@ func (g *mqlGcpProjectDlpService) discoveryConfigs() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isGRPCSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("location", loc).Msg("could not list DLP discovery configs")
 					break
 				}
@@ -687,7 +687,7 @@ func (g *mqlGcpProjectDlpService) connections() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isGRPCSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("location", loc).Msg("could not list DLP connections")
 					break
 				}
@@ -766,7 +766,7 @@ func (g *mqlGcpProjectDlpService) projectDataProfiles() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP project data profiles")
 				break
 			}
@@ -841,7 +841,7 @@ func (g *mqlGcpProjectDlpService) tableDataProfiles() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP table data profiles")
 				break
 			}
@@ -979,7 +979,7 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP table data profiles for column profile enumeration")
 				break
 			}
@@ -1001,7 +1001,7 @@ func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isGRPCSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("table", t.TableId).Msg("could not list DLP column data profiles")
 					break
 				}
@@ -1087,7 +1087,7 @@ func (g *mqlGcpProjectDlpService) fileStoreDataProfiles() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list DLP file-store data profiles")
 				break
 			}
@@ -1216,7 +1216,7 @@ func (g *mqlGcpProjectStorageServiceBucket) dlpDataProfile() (*mqlGcpProjectDlpS
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not look up DLP file-store data profile for bucket")
 				g.DlpDataProfile.State = plugin.StateIsSet | plugin.StateIsNull
 				return nil, nil
@@ -1271,7 +1271,7 @@ func (g *mqlGcpProjectBigqueryServiceTable) dlpDataProfile() (*mqlGcpProjectDlpS
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not look up DLP table data profile for BigQuery table")
 				g.DlpDataProfile.State = plugin.StateIsSet | plugin.StateIsNull
 				return nil, nil

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 
 	dlp "cloud.google.com/go/dlp/apiv2"
 	"cloud.google.com/go/dlp/apiv2/dlppb"
@@ -23,9 +22,7 @@ import (
 )
 
 type mqlGcpProjectDlpServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) dlp() (*mqlGcpProjectDlpService, error) {
@@ -47,7 +44,7 @@ func (g *mqlGcpProject) dlp() (*mqlGcpProjectDlpService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectDlpService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_dlp).Msg("gcp service is not enabled, skipping")
 	}
@@ -1291,31 +1288,7 @@ func (g *mqlGcpProjectBigqueryServiceTable) dlpDataProfile() (*mqlGcpProjectDlpS
 	return nil, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectDlpService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_dlp)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_dlp)
 }

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -80,8 +80,12 @@ func initGcpProjectDnsServiceManagedzone(runtime *plugin.Runtime, args map[strin
 }
 
 type mqlGcpProjectDnsServiceInternal struct {
-	serviceEnabled bool
-	serviceChecked bool
+	serviceGate
+}
+
+// isEnabled reports whether the API is enabled on this project.
+func (g *mqlGcpProjectDnsService) isEnabled() (bool, error) {
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_dns)
 }
 
 // managedZoneDnssecNonExistence returns the DNSSEC proof-of-nonexistence mode
@@ -132,8 +136,7 @@ func (g *mqlGcpProject) dns() (*mqlGcpProjectDnsService, error) {
 	}
 
 	dnsService := res.(*mqlGcpProjectDnsService)
-	dnsService.serviceEnabled = serviceEnabled
-	dnsService.serviceChecked = true
+	dnsService.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_dns).Msg("gcp service is not enabled, skipping")
 	}
@@ -212,8 +215,11 @@ func (g *mqlGcpProjectDnsServiceManagedzone) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDnsService) managedZones() ([]any, error) {
-	// when the service is known to be disabled, we return nil
-	if g.serviceChecked && !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -353,8 +359,11 @@ func (g *mqlGcpProjectDnsServicePolicy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDnsService) policies() ([]any, error) {
-	// when the service is known to be disabled, we return nil
-	if g.serviceChecked && !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -435,8 +444,11 @@ func (g *mqlGcpProjectDnsServiceResponsePolicy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDnsService) responsePolicies() ([]any, error) {
-	// when the service is known to be disabled, we return nil
-	if g.serviceChecked && !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/documentai.go
+++ b/providers/gcp/resources/documentai.go
@@ -17,8 +17,6 @@ import (
 	googleoauth "golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // documentaiLocations lists the Document AI processing locations. Processors
@@ -41,18 +39,6 @@ func documentaiLocationFromName(name string) string {
 		}
 	}
 	return ""
-}
-
-// isDocumentaiSkippable returns true for errors indicating the Document AI API
-// is not enabled or the location is not available for this project.
-func isDocumentaiSkippable(err error) bool {
-	if s, ok := status.FromError(err); ok {
-		switch s.Code() {
-		case codes.PermissionDenied, codes.Unimplemented, codes.InvalidArgument, codes.NotFound:
-			return true
-		}
-	}
-	return false
 }
 
 func (g *mqlGcpProject) documentai() (*mqlGcpProjectDocumentaiService, error) {
@@ -107,7 +93,7 @@ func (g *mqlGcpProjectDocumentaiService) listProcessorsInLocation(ctx context.Co
 			break
 		}
 		if err != nil {
-			if isDocumentaiSkippable(err) {
+			if isInapplicable(err) {
 				break
 			}
 			return nil, err
@@ -209,7 +195,7 @@ func (g *mqlGcpProjectDocumentaiServiceProcessor) versions() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isDocumentaiSkippable(err) {
+			if isInapplicable(err) {
 				break
 			}
 			return nil, err

--- a/providers/gcp/resources/error_wrapping_guard_test.go
+++ b/providers/gcp/resources/error_wrapping_guard_test.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoStringifiedAPIErrors pins the invariant the error classifiers depend on.
+//
+// isServiceDisabled / isSkippable / isInapplicable classify by unwrapping to the
+// transport error: a *googleapi.Error carrying an HTTP status, or a gRPC
+// status.Status carrying a code. Flatten either one into a string and the
+// classification is gone for good -- all that survives is prose.
+//
+// That is not hypothetical. initGcpOrganization used to answer a 403 with
+//
+//	return nil, nil, errors.New("403: permission denied")
+//
+// and discovery had to compensate by substring-matching "403:",
+// "permission denied" and "has not been used" against message text, which then
+// silently failed for every service that phrased its denial differently.
+//
+// So: an error may be wrapped with %w, which preserves the chain, but never
+// rendered with %s / %v and never rebuilt from err.Error().
+func TestNoStringifiedAPIErrors(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			pkg, fn, ok := qualifiedCallName(call.Fun)
+			if !ok {
+				return true
+			}
+
+			switch {
+			case pkg == "errors" && fn == "New":
+				// errors.New(err.Error()) and friends
+				if len(call.Args) == 1 && callsErrorMethod(call.Args[0]) {
+					t.Errorf("%s: errors.New rebuilt from err.Error(); the transport "+
+						"status is discarded and the error can no longer be classified. "+
+						"Return the original error, or wrap it with fmt.Errorf(\"...: %%w\", err)",
+						fset.Position(call.Pos()))
+				}
+			case pkg == "fmt" && (fn == "Errorf"):
+				lit, ok := call.Args[0].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				if strings.Contains(lit.Value, "%w") {
+					return true // properly wrapped
+				}
+				for _, arg := range call.Args[1:] {
+					if isErrorIdent(arg) || callsErrorMethod(arg) {
+						t.Errorf("%s: fmt.Errorf renders an error with %%s/%%v instead of "+
+							"%%w; the transport status is discarded and the error can no "+
+							"longer be classified. Use %%w", fset.Position(call.Pos()))
+						break
+					}
+				}
+			}
+			return true
+		})
+	}
+}
+
+// qualifiedCallName splits a `pkg.Fn` call target.
+func qualifiedCallName(fun ast.Expr) (pkg, fn string, ok bool) {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", "", false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", "", false
+	}
+	return ident.Name, sel.Sel.Name, true
+}
+
+// isErrorIdent reports whether the expression is an identifier that by
+// convention holds an error (`err`, `listErr`, `serviceErr`).
+func isErrorIdent(e ast.Expr) bool {
+	ident, ok := e.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == "err" || strings.HasSuffix(ident.Name, "Err")
+}
+
+// callsErrorMethod reports whether the expression is an `x.Error()` call.
+func callsErrorMethod(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "Error"
+}

--- a/providers/gcp/resources/errors.go
+++ b/providers/gcp/resources/errors.go
@@ -58,8 +58,18 @@ func googleAPIError(err error) (*googleapi.Error, bool) {
 	return nil, false
 }
 
-// grpcStatusOf extracts a gRPC status from err. status.FromError already
-// unwraps, but it reports (nil, true) for a nil error, so guard that first.
+// grpcStatusOf extracts a gRPC status from err.
+//
+// Unlike the googleapi path this does not unwrap by hand, because
+// status.FromError does it internally (errors.As on the GRPCStatus interface)
+// in the grpc-go we pin. That is a property of the dependency rather than of
+// this file, so it is pinned by test rather than trusted: the gRPC cases in
+// TestClassifiersSurviveWrapping go through fmt.Errorf("...: %w", err), and a
+// downgrade to a grpc-go whose FromError used a bare type assertion would fail
+// them here rather than silently stop classifying wrapped errors in production.
+//
+// The one thing FromError does not handle is nil: it reports (nil, true), so
+// guard that first.
 func grpcStatusOf(err error) (*status.Status, bool) {
 	if err == nil {
 		return nil, false

--- a/providers/gcp/resources/errors.go
+++ b/providers/gcp/resources/errors.go
@@ -1,0 +1,160 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Error classification for the two transports GCP client libraries use.
+//
+// google.golang.org/api (REST) reports failures as *googleapi.Error carrying an
+// HTTP status; cloud.google.com/go (gRPC) reports them as a status.Status
+// carrying a codes.Code. The same condition therefore reaches us in two shapes,
+// and this file is the single place that maps both onto one vocabulary:
+//
+//	isServiceDisabled  the API itself is not turned on for this project
+//	isSkippable        ... or we lack permission, or it does not exist
+//	isInapplicable     ... or the request does not apply in this location
+//
+// The three are nested, widest last. Pick the narrowest one that is true for
+// the call site: every code folded into a "degrade to empty" check is a real
+// failure the user will never see.
+//
+// Both lookups unwrap. A classification has to survive fmt.Errorf("...: %w",
+// err), or a caller that wraps for context silently loses its degrade path and
+// fails the whole listing instead of returning what it could read.
+
+// serviceDisabledMarkers are the phrases Google returns when an API has not
+// been enabled on the project, e.g.
+//
+//	Cloud Composer API has not been used in project 1234 before or it is
+//	disabled. Enable it by visiting ...
+//
+// The wording varies per service and the capitalization is not stable, so the
+// match is case-insensitive.
+var serviceDisabledMarkers = []string{
+	"has not been used",
+	"not enabled",
+}
+
+// googleAPIError extracts a *googleapi.Error from err, unwrapping as needed.
+//
+// The unwrapping matters: a bare err.(*googleapi.Error) assertion misses any
+// error a caller wrapped for context, so the degrade path does not fire and a
+// permission gap on one sub-resource fails the entire query.
+func googleAPIError(err error) (*googleapi.Error, bool) {
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		return gerr, true
+	}
+	return nil, false
+}
+
+// grpcStatusOf extracts a gRPC status from err. status.FromError already
+// unwraps, but it reports (nil, true) for a nil error, so guard that first.
+func grpcStatusOf(err error) (*status.Status, bool) {
+	if err == nil {
+		return nil, false
+	}
+	return status.FromError(err)
+}
+
+// saysServiceDisabled matches the not-enabled marker against the rendered
+// error, which covers both transports at once: googleapi.Error.Error() embeds
+// the API message, and a gRPC status message is rendered the same way.
+func saysServiceDisabled(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, marker := range serviceDisabledMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// isServiceDisabled reports whether err means the API itself is not enabled on
+// this project.
+//
+// It deliberately excludes a bare permission denial: a 403 carrying no
+// not-enabled marker is a real access problem, and a caller that only wants to
+// skip a disabled API should still surface it. Use isSkippable when denial
+// should degrade too.
+func isServiceDisabled(err error) bool {
+	if err == nil {
+		return false
+	}
+	if saysServiceDisabled(err) {
+		return true
+	}
+	if gerr, ok := googleAPIError(err); ok {
+		return gerr.Code == http.StatusNotFound
+	}
+	if s, ok := grpcStatusOf(err); ok {
+		return s.Code() == codes.Unimplemented
+	}
+	return false
+}
+
+// isSkippable reports whether err means "this caller cannot see anything here":
+// permission was denied, the resource or its parent does not exist, or the API
+// is not enabled.
+//
+// All three mean there is nothing to read rather than that the system is
+// broken, so callers log one line and degrade to an empty result instead of
+// failing the query. Note what that costs: an empty collection is the most
+// dangerous wrong answer for a posture check, because assertions over it pass
+// vacuously. Only reach for this where an empty result is genuinely the truth.
+func isSkippable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isServiceDisabled(err) {
+		return true
+	}
+	if gerr, ok := googleAPIError(err); ok {
+		return gerr.Code == http.StatusForbidden || gerr.Code == http.StatusNotFound
+	}
+	if s, ok := grpcStatusOf(err); ok {
+		switch s.Code() {
+		case codes.PermissionDenied, codes.NotFound, codes.Unimplemented:
+			return true
+		}
+	}
+	return false
+}
+
+// isInapplicable extends isSkippable with the codes GCP uses for "your request
+// does not apply here": a regional API not offered in the requested location,
+// or a sub-resource the instance's configuration does not have (a Memorystore
+// instance on AUTH_DISABLED has no token auth users to list).
+//
+// Regional services report these as InvalidArgument or FailedPrecondition
+// rather than as an empty result, so a fan-out across regions must treat them
+// as "nothing here" or one unsupported region fails the whole query.
+//
+// This is the widest classifier. InvalidArgument in particular can also mean we
+// built a malformed request, so prefer isSkippable unless the call really is
+// location- or configuration-dependent.
+func isInapplicable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isSkippable(err) {
+		return true
+	}
+	if s, ok := grpcStatusOf(err); ok {
+		switch s.Code() {
+		case codes.InvalidArgument, codes.FailedPrecondition:
+			return true
+		}
+	}
+	return false
+}

--- a/providers/gcp/resources/errors_test.go
+++ b/providers/gcp/resources/errors_test.go
@@ -1,0 +1,197 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// classifierCase is one error and the expected verdict from all three
+// classifiers, so every case documents the full tier picture rather than one
+// slice of it.
+type classifierCase struct {
+	name         string
+	err          error
+	disabled     bool // isServiceDisabled
+	skippable    bool // isSkippable
+	inapplicable bool // isInapplicable
+}
+
+func classifierCases() []classifierCase {
+	return []classifierCase{
+		{name: "nil", err: nil},
+
+		// --- REST / googleapi ---
+		{
+			name:         "http 403 permission denied",
+			err:          &googleapi.Error{Code: 403, Message: "permission denied"},
+			skippable:    true,
+			inapplicable: true,
+		},
+		{
+			name:         "http 404 not found",
+			err:          &googleapi.Error{Code: 404, Message: "not found"},
+			disabled:     true,
+			skippable:    true,
+			inapplicable: true,
+		},
+		{
+			name: "http 500 is a real failure",
+			err:  &googleapi.Error{Code: 500, Message: "backend error"},
+		},
+		{
+			name: "http 400 alone is a real failure",
+			err:  &googleapi.Error{Code: 400, Message: "malformed request"},
+		},
+		{
+			name:         "http 403 carrying the not-enabled marker",
+			err:          &googleapi.Error{Code: 403, Message: "Cloud Composer API has not been used in project 1234 before or it is disabled"},
+			disabled:     true,
+			skippable:    true,
+			inapplicable: true,
+		},
+
+		// --- gRPC ---
+		{
+			name:         "grpc PermissionDenied",
+			err:          status.Error(codes.PermissionDenied, "no access"),
+			skippable:    true,
+			inapplicable: true,
+		},
+		{
+			name:         "grpc NotFound",
+			err:          status.Error(codes.NotFound, "missing"),
+			skippable:    true,
+			inapplicable: true,
+		},
+		{
+			name:         "grpc Unimplemented",
+			err:          status.Error(codes.Unimplemented, "not implemented"),
+			disabled:     true,
+			skippable:    true,
+			inapplicable: true,
+		},
+		{
+			// A regional service saying "not offered here". Only the widest
+			// tier treats it as nothing-to-see; a plain lister must still fail
+			// on it, because it usually means we built a bad request.
+			name:         "grpc InvalidArgument",
+			err:          status.Error(codes.InvalidArgument, "location us-west8 is not supported"),
+			inapplicable: true,
+		},
+		{
+			name:         "grpc FailedPrecondition",
+			err:          status.Error(codes.FailedPrecondition, "RAG data service is not supported in region"),
+			inapplicable: true,
+		},
+		{
+			name: "grpc Internal is a real failure",
+			err:  status.Error(codes.Internal, "boom"),
+		},
+		{
+			name: "grpc Unavailable is a real failure",
+			err:  status.Error(codes.Unavailable, "try again"),
+		},
+
+		// --- plain errors ---
+		{
+			name:         "plain error carrying the not-enabled phrasing",
+			err:          errors.New("Cloud KMS API has not been used in project foo"),
+			disabled:     true,
+			skippable:    true,
+			inapplicable: true,
+		},
+		{
+			name: "unrelated plain error",
+			err:  errors.New("connection reset by peer"),
+		},
+		{
+			// A stringified transport error is deliberately NOT classifiable:
+			// the status is gone and only the prose remains. This is why no
+			// provider code may rewrap an API error as a plain string -- see
+			// TestNoStringifiedAPIErrors and initGcpOrganization, which used
+			// to return errors.New("403: permission denied") and forced
+			// discovery into substring matching to recognize its own denials.
+			name: "stringified 403 is not classifiable",
+			err:  errors.New("403: permission denied"),
+		},
+	}
+}
+
+func TestErrorClassifiers(t *testing.T) {
+	for _, tc := range classifierCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.disabled, isServiceDisabled(tc.err), "isServiceDisabled")
+			require.Equal(t, tc.skippable, isSkippable(tc.err), "isSkippable")
+			require.Equal(t, tc.inapplicable, isInapplicable(tc.err), "isInapplicable")
+		})
+	}
+}
+
+// TestClassifiersSurviveWrapping is the regression guard for the reason this
+// file exists. The predicates this replaced used a bare err.(*googleapi.Error)
+// assertion, which fails on any error a caller wrapped for context -- so the
+// degrade path silently did not fire and a permission gap on one sub-resource
+// failed the entire listing instead of returning what it could read.
+func TestClassifiersSurviveWrapping(t *testing.T) {
+	for _, tc := range classifierCases() {
+		if tc.err == nil {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := fmt.Errorf("listing widgets in project foo: %w", tc.err)
+			require.Equal(t, tc.disabled, isServiceDisabled(wrapped), "isServiceDisabled")
+			require.Equal(t, tc.skippable, isSkippable(wrapped), "isSkippable")
+			require.Equal(t, tc.inapplicable, isInapplicable(wrapped), "isInapplicable")
+
+			// and through two layers, which is what a nested accessor produces
+			twice := fmt.Errorf("resolving parent: %w", wrapped)
+			require.Equal(t, tc.skippable, isSkippable(twice), "isSkippable (double-wrapped)")
+		})
+	}
+}
+
+// TestClassifierTiersNest pins the documented containment:
+// isServiceDisabled implies isSkippable implies isInapplicable. Call sites pick
+// a tier by name on the assumption that a narrower one never matches something
+// the wider one misses; if that inverts, a caller silently widens what it
+// swallows.
+func TestClassifierTiersNest(t *testing.T) {
+	for _, tc := range classifierCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			if isServiceDisabled(tc.err) {
+				require.True(t, isSkippable(tc.err), "service-disabled must also be skippable")
+			}
+			if isSkippable(tc.err) {
+				require.True(t, isInapplicable(tc.err), "skippable must also be inapplicable")
+			}
+		})
+	}
+}
+
+// TestServiceDisabledMarkersAreCaseInsensitive guards a real inconsistency in
+// the predicates this replaced: isHTTPSkippable matched the marker
+// case-sensitively while isNotebooksSkippable lowercased first, so the same
+// disabled-API error classified differently depending on which service the
+// caller happened to be in. Google's capitalization is not stable.
+func TestServiceDisabledMarkersAreCaseInsensitive(t *testing.T) {
+	variants := []string{
+		"Compute Engine API has not been used in project 1234",
+		"compute engine api HAS NOT BEEN USED in project 1234",
+		"Vertex AI API is Not Enabled for this project",
+		"vertex ai api is not enabled for this project",
+	}
+	for _, msg := range variants {
+		t.Run(msg, func(t *testing.T) {
+			require.True(t, isServiceDisabled(&googleapi.Error{Code: 400, Message: msg}))
+		})
+	}
+}

--- a/providers/gcp/resources/essential_contacts.go
+++ b/providers/gcp/resources/essential_contacts.go
@@ -66,7 +66,7 @@ func essentialContactsForParent(runtime *plugin.Runtime, conn *connection.GcpCon
 		// essentialcontacts.contacts.list is a separate grant a project-scoped
 		// principal rarely holds. Degrade so one missing grant at the org node
 		// does not fail the whole query.
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("parent", parent).Msg("could not list essential contacts")
 			return nil, nil
 		}

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	eventarc "cloud.google.com/go/eventarc/apiv1"
 	"cloud.google.com/go/eventarc/apiv1/eventarcpb"
@@ -22,9 +21,7 @@ import (
 )
 
 type mqlGcpProjectEventarcServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) eventarc() (*mqlGcpProjectEventarcService, error) {
@@ -46,7 +43,7 @@ func (g *mqlGcpProject) eventarc() (*mqlGcpProjectEventarcService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectEventarcService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_eventarc).Msg("gcp service is not enabled, skipping")
 	}
@@ -304,31 +301,7 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 	return res, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectEventarcService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_eventarc)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_eventarc)
 }

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -159,7 +159,7 @@ func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Eventarc triggers")
 				break
 			}
@@ -278,7 +278,7 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Eventarc channels")
 				break
 			}

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -132,7 +132,7 @@ func (g *mqlGcpProjectFirestoreService) databases() ([]any, error) {
 		Parent: fmt.Sprintf("projects/%s", projectId),
 	})
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Firestore databases")
 			return nil, nil
 		}
@@ -272,7 +272,7 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) indexes() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Firestore indexes")
 				break
 			}
@@ -327,7 +327,7 @@ func (g *mqlGcpProjectFirestoreServiceDatabase) backupSchedules() ([]any, error)
 		Parent: databaseName,
 	})
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list Firestore backup schedules")
 			return nil, nil
 		}

--- a/providers/gcp/resources/firewall_policies_hierarchical.go
+++ b/providers/gcp/resources/firewall_policies_hierarchical.go
@@ -92,7 +92,7 @@ func listHierarchicalFirewallPolicies(runtime *plugin.Runtime, parent string) ([
 		}
 		return nil
 	}); err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("parent", parent).Msg("could not list hierarchical firewall policies")
 			return nil, nil
 		}

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -24,9 +23,7 @@ import (
 )
 
 type mqlGcpProjectGkeServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProjectGkeService) id() (string, error) {
@@ -56,7 +53,7 @@ func (g *mqlGcpProject) gke() (*mqlGcpProjectGkeService, error) {
 	}
 
 	gkeService := res.(*mqlGcpProjectGkeService)
-	gkeService.serviceEnabled = serviceEnabled
+	gkeService.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_gke).Msg("gcp service is not enabled, skipping")
 	}
@@ -1574,31 +1571,7 @@ func gkeRbacInsecureBindings(cfg *containerpb.RBACBindingConfig) (systemUnauthen
 	return cfg.GetEnableInsecureBindingSystemUnauthenticated(), cfg.GetEnableInsecureBindingSystemAuthenticated()
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectGkeService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_gke)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_gke)
 }

--- a/providers/gcp/resources/gke_backup.go
+++ b/providers/gcp/resources/gke_backup.go
@@ -123,7 +123,7 @@ func (g *mqlGcpProjectGkeBackupService) backupPlans() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list GKE Backup backup plans")
 				break
 			}
@@ -217,7 +217,7 @@ func (g *mqlGcpProjectGkeBackupService) restorePlans() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list GKE Backup restore plans")
 				break
 			}

--- a/providers/gcp/resources/gke_backup.go
+++ b/providers/gcp/resources/gke_backup.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	gkebackup "cloud.google.com/go/gkebackup/apiv1"
 	"cloud.google.com/go/gkebackup/apiv1/gkebackuppb"
@@ -22,9 +21,7 @@ import (
 )
 
 type mqlGcpProjectGkeBackupServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) gkeBackup() (*mqlGcpProjectGkeBackupService, error) {
@@ -46,7 +43,7 @@ func (g *mqlGcpProject) gkeBackup() (*mqlGcpProjectGkeBackupService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectGkeBackupService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_gkebackup).Msg("gcp service is not enabled, skipping")
 	}
@@ -270,31 +267,7 @@ func (g *mqlGcpProjectGkeBackupServiceRestorePlan) backupPlan() (*mqlGcpProjectG
 	return res.(*mqlGcpProjectGkeBackupServiceBackupPlan), nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectGkeBackupService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_gkebackup)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_gkebackup)
 }

--- a/providers/gcp/resources/healthcare.go
+++ b/providers/gcp/resources/healthcare.go
@@ -6,13 +6,11 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/healthcare/v1"
 	"google.golang.org/api/option"
 )
@@ -23,19 +21,6 @@ func newHealthcareService(conn *connection.GcpConnection) (*healthcare.Service, 
 		return nil, err
 	}
 	return healthcare.NewService(context.Background(), option.WithHTTPClient(client))
-}
-
-// healthcareServiceUnavailable reports whether an API error should be treated
-// as graceful degradation (API not enabled or resource not found).
-func healthcareServiceUnavailable(err error) bool {
-	gerr, ok := err.(*googleapi.Error)
-	if !ok {
-		return false
-	}
-	if gerr.Code == 403 || gerr.Code == 404 {
-		return true
-	}
-	return strings.Contains(gerr.Message, "not enabled") || strings.Contains(gerr.Message, "has not been used")
 }
 
 func (g *mqlGcpProject) healthcare() (*mqlGcpProjectHealthcareService, error) {
@@ -101,7 +86,7 @@ func (g *mqlGcpProjectHealthcareService) datasets() ([]any, error) {
 				return nil
 			})
 			if listErr != nil {
-				if healthcareServiceUnavailable(listErr) {
+				if isSkippable(listErr) {
 					continue
 				}
 				return listErr
@@ -109,7 +94,7 @@ func (g *mqlGcpProjectHealthcareService) datasets() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if healthcareServiceUnavailable(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -172,7 +157,7 @@ func (g *mqlGcpProjectHealthcareServiceDataset) dicomStores() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if healthcareServiceUnavailable(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -219,7 +204,7 @@ func (g *mqlGcpProjectHealthcareServiceDataset) fhirStores() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if healthcareServiceUnavailable(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err
@@ -268,7 +253,7 @@ func (g *mqlGcpProjectHealthcareServiceDataset) hl7v2Stores() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if healthcareServiceUnavailable(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -41,9 +41,7 @@ func (g *mqlGcpProjectIamService) id() (string, error) {
 }
 
 type mqlGcpProjectIamServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 type mqlGcpProjectIamServiceServiceAccountInternal struct {
@@ -79,7 +77,7 @@ func (g *mqlGcpProject) iam() (*mqlGcpProjectIamService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectIamService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_iam).Msg("gcp service is not enabled, skipping")
 	}
@@ -895,31 +893,7 @@ func (g *mqlGcpProjectIamServiceServiceAccount) canBeImpersonated() (bool, error
 	return false, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectIamService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_iam)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_iam)
 }

--- a/providers/gcp/resources/iam_pab.go
+++ b/providers/gcp/resources/iam_pab.go
@@ -111,7 +111,7 @@ func (g *mqlGcpOrganization) principalAccessBoundaryPolicies() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				// break rather than discard: an error partway through pagination
 				// should not throw away the policies the API already returned.
 				log.Warn().Err(err).Msg("could not list all principal access boundary policies")
@@ -185,7 +185,7 @@ func (g *mqlGcpOrganization) policyBindings() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				// break rather than discard: keep the bindings already returned.
 				log.Warn().Err(err).Msg("could not list all policy bindings")
 				break

--- a/providers/gcp/resources/identityplatform.go
+++ b/providers/gcp/resources/identityplatform.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -21,9 +20,7 @@ import (
 )
 
 type mqlGcpProjectIdentityPlatformServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) identityPlatform() (*mqlGcpProjectIdentityPlatformService, error) {
@@ -43,7 +40,7 @@ func (g *mqlGcpProject) identityPlatform() (*mqlGcpProjectIdentityPlatformServic
 	}
 
 	svc := res.(*mqlGcpProjectIdentityPlatformService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_identityplatform).Msg("gcp service is not enabled, skipping")
 	}
@@ -336,31 +333,7 @@ func newMqlIdentityPlatformTenant(runtime *plugin.Runtime, t *identitytoolkit.Go
 	return CreateResource(runtime, "gcp.project.identityPlatformService.tenant", args)
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectIdentityPlatformService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_identityplatform)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_identityplatform)
 }

--- a/providers/gcp/resources/identityplatform.go
+++ b/providers/gcp/resources/identityplatform.go
@@ -106,7 +106,7 @@ func (g *mqlGcpProjectIdentityPlatformService) config() (*mqlGcpProjectIdentityP
 
 	cfg, err := svc.Projects.GetConfig(fmt.Sprintf("projects/%s/config", projectId)).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			g.Config.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
@@ -281,7 +281,7 @@ func (g *mqlGcpProjectIdentityPlatformService) tenants() ([]any, error) {
 			return nil
 		})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/providers/gcp/resources/ids.go
+++ b/providers/gcp/resources/ids.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	ids "cloud.google.com/go/ids/apiv1"
 	"cloud.google.com/go/ids/apiv1/idspb"
@@ -22,9 +21,7 @@ import (
 )
 
 type mqlGcpProjectIdsServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) ids() (*mqlGcpProjectIdsService, error) {
@@ -46,7 +43,7 @@ func (g *mqlGcpProject) ids() (*mqlGcpProjectIdsService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectIdsService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_ids).Msg("gcp service is not enabled, skipping")
 	}
@@ -167,31 +164,7 @@ func (g *mqlGcpProjectIdsServiceEndpoint) network() (*mqlGcpProjectComputeServic
 	return network, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectIdsService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_ids)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_ids)
 }

--- a/providers/gcp/resources/ids.go
+++ b/providers/gcp/resources/ids.go
@@ -119,7 +119,7 @@ func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Cloud IDS endpoints")
 				break
 			}

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -115,9 +115,7 @@ func initGcpProjectKmsServiceKeyring(runtime *plugin.Runtime, args map[string]*l
 }
 
 type mqlGcpProjectKmsServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) kms() (*mqlGcpProjectKmsService, error) {
@@ -139,7 +137,7 @@ func (g *mqlGcpProject) kms() (*mqlGcpProjectKmsService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectKmsService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_kms).Msg("gcp service is not enabled, skipping")
 	}
@@ -965,31 +963,7 @@ func (g *mqlGcpProjectKmsServiceKeyring) importJobs() ([]any, error) {
 	return res, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectKmsService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_kms)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_kms)
 }

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -30,9 +29,7 @@ func (g *mqlGcpProjectLoggingservice) id() (string, error) {
 }
 
 type mqlGcpProjectLoggingserviceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) logging() (*mqlGcpProjectLoggingservice, error) {
@@ -54,7 +51,7 @@ func (g *mqlGcpProject) logging() (*mqlGcpProjectLoggingservice, error) {
 	}
 
 	svc := res.(*mqlGcpProjectLoggingservice)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_logging).Msg("gcp service is not enabled, skipping")
 	}
@@ -906,31 +903,7 @@ func (g *mqlGcpFolderLoggingService) sinks() ([]any, error) {
 		"gcp.folder.loggingService.sink", "folderName")
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectLoggingservice) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_logging)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_logging)
 }

--- a/providers/gcp/resources/logging_settings.go
+++ b/providers/gcp/resources/logging_settings.go
@@ -99,7 +99,7 @@ func (g *mqlGcpProjectLoggingservice) settings() (*mqlGcpLoggingSettings, error)
 
 	settings, err := svc.Projects.GetSettings(parent).Context(ctx).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("project", g.ProjectId.Data).Msg("could not read Cloud Logging settings")
 			g.Settings.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
@@ -128,7 +128,7 @@ func (g *mqlGcpOrganizationLoggingService) settings() (*mqlGcpLoggingSettings, e
 
 	settings, err := svc.Organizations.GetSettings(parent).Context(ctx).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("organization", parent).Msg("could not read Cloud Logging settings")
 			g.Settings.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
@@ -157,7 +157,7 @@ func (g *mqlGcpFolderLoggingService) settings() (*mqlGcpLoggingSettings, error) 
 
 	settings, err := svc.Folders.GetSettings(parent).Context(ctx).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("folder", parent).Msg("could not read Cloud Logging settings")
 			g.Settings.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -19,8 +19,6 @@ import (
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func (g *mqlGcpProject) memorystore() (*mqlGcpProjectMemorystoreService, error) {
@@ -381,23 +379,6 @@ func buildMemorystorePscAttachmentDetails(runtime *plugin.Runtime, projectId, in
 // TokenAuthUser
 // =====================
 
-// isMemorystoreAuthSkippable reports gRPC errors that mean the instance simply
-// does not carry token-based authentication, rather than a real failure. An
-// instance using AUTH_DISABLED or IAM_AUTH has no token auth users to list, and
-// a caller without the auth-config permissions must not fail the whole query.
-func isMemorystoreAuthSkippable(err error) bool {
-	if isGRPCSkippable(err) {
-		return true
-	}
-	if s, ok := status.FromError(err); ok {
-		switch s.Code() {
-		case codes.FailedPrecondition, codes.InvalidArgument:
-			return true
-		}
-	}
-	return false
-}
-
 func (g *mqlGcpProjectMemorystoreServiceInstanceTokenAuthUser) id() (string, error) {
 	if g.Name.Error != nil {
 		return "", g.Name.Error
@@ -439,7 +420,7 @@ func (g *mqlGcpProjectMemorystoreServiceInstance) tokenAuthUsers() ([]any, error
 			break
 		}
 		if err != nil {
-			if isMemorystoreAuthSkippable(err) {
+			if isInapplicable(err) {
 				log.Debug().Err(err).Str("instance", instanceName).Msg("gcp> skipping memorystore token auth users")
 				return res, nil
 			}
@@ -504,7 +485,7 @@ func (g *mqlGcpProjectMemorystoreServiceInstanceTokenAuthUser) authTokens() ([]a
 			break
 		}
 		if err != nil {
-			if isMemorystoreAuthSkippable(err) {
+			if isInapplicable(err) {
 				log.Debug().Err(err).Str("tokenAuthUser", userName).Msg("gcp> skipping memorystore auth tokens")
 				return res, nil
 			}

--- a/providers/gcp/resources/modelarmor.go
+++ b/providers/gcp/resources/modelarmor.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	modelarmor "cloud.google.com/go/modelarmor/apiv1"
 	"cloud.google.com/go/modelarmor/apiv1/modelarmorpb"
@@ -24,9 +23,7 @@ import (
 )
 
 type mqlGcpProjectModelArmorServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) modelArmor() (*mqlGcpProjectModelArmorService, error) {
@@ -46,7 +43,7 @@ func (g *mqlGcpProject) modelArmor() (*mqlGcpProjectModelArmorService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectModelArmorService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_modelarmor).Msg("gcp service is not enabled, skipping")
 	}
@@ -284,31 +281,7 @@ func (g *mqlGcpProjectModelArmorService) floorSetting() (*mqlGcpProjectModelArmo
 	return res.(*mqlGcpProjectModelArmorServiceFloorSetting), nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectModelArmorService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_modelarmor)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_modelarmor)
 }

--- a/providers/gcp/resources/network_connectivity.go
+++ b/providers/gcp/resources/network_connectivity.go
@@ -173,7 +173,7 @@ func (g *mqlGcpProjectNetworkConnectivityService) hubs() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				// break rather than discard: an error partway through pagination
 				// should not throw away the hubs the API already returned.
 				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Network Connectivity hubs")
@@ -280,7 +280,7 @@ func (g *mqlGcpProjectNetworkConnectivityService) spokes() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				// break rather than discard: keep the spokes already returned.
 				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Network Connectivity spokes")
 				break

--- a/providers/gcp/resources/network_connectivity.go
+++ b/providers/gcp/resources/network_connectivity.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	networkconnectivity "cloud.google.com/go/networkconnectivity/apiv1"
 	"cloud.google.com/go/networkconnectivity/apiv1/networkconnectivitypb"
@@ -23,9 +22,7 @@ import (
 )
 
 type mqlGcpProjectNetworkConnectivityServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 type mqlGcpProjectNetworkConnectivityServiceHubInternal struct {
@@ -59,7 +56,7 @@ func (g *mqlGcpProject) networkConnectivity() (*mqlGcpProjectNetworkConnectivity
 	}
 
 	svc := res.(*mqlGcpProjectNetworkConnectivityService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_networkconnectivity).Msg("gcp service is not enabled, skipping")
 	}
@@ -91,29 +88,9 @@ func (g *mqlGcpProjectNetworkConnectivityService) id() (string, error) {
 	return fmt.Sprintf("%s/gcp.project.networkConnectivityService", g.ProjectId.Data), nil
 }
 
-// isEnabled resolves the service-enabled gate lazily so every construction path
-// agrees. Without it the Go zero value false would make both collections return
-// an empty list with no error whenever the resource is not reached through the
-// gcp.project accessor, which reads as "there is no connectivity fabric here".
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectNetworkConnectivityService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_networkconnectivity)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_networkconnectivity)
 }
 
 // networkConnectivityCredentials returns credentials scoped for the Network

--- a/providers/gcp/resources/network_management.go
+++ b/providers/gcp/resources/network_management.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	networkmanagement "cloud.google.com/go/networkmanagement/apiv1"
 	"cloud.google.com/go/networkmanagement/apiv1/networkmanagementpb"
@@ -23,9 +22,7 @@ import (
 )
 
 type mqlGcpProjectNetworkManagementServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) networkManagement() (*mqlGcpProjectNetworkManagementService, error) {
@@ -47,7 +44,7 @@ func (g *mqlGcpProject) networkManagement() (*mqlGcpProjectNetworkManagementServ
 	}
 
 	svc := res.(*mqlGcpProjectNetworkManagementService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_networkmanagement).Msg("gcp service is not enabled, skipping")
 	}
@@ -79,28 +76,9 @@ func (g *mqlGcpProjectNetworkManagementService) id() (string, error) {
 	return fmt.Sprintf("%s/gcp.project.networkManagementService", g.ProjectId.Data), nil
 }
 
-// isEnabled resolves the service-enabled gate lazily so every construction path
-// agrees, rather than letting the Go zero value report an empty test list as an
-// authoritative "no reachability evidence exists".
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectNetworkManagementService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_networkmanagement)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_networkmanagement)
 }
 
 // networkManagementCredentials returns credentials scoped for the Network

--- a/providers/gcp/resources/network_management.go
+++ b/providers/gcp/resources/network_management.go
@@ -162,7 +162,7 @@ func (g *mqlGcpProjectNetworkManagementService) connectivityTests() ([]any, erro
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				// break rather than discard: keep the tests already returned.
 				log.Warn().Err(err).Str("project", projectId).Msg("could not list all connectivity tests")
 				break

--- a/providers/gcp/resources/networksecurity.go
+++ b/providers/gcp/resources/networksecurity.go
@@ -169,7 +169,7 @@ func (g *mqlGcpProjectNetworkSecurityService) authorizationPolicies() ([]any, er
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list authorization policies")
 			return nil, nil
 		}
@@ -234,7 +234,7 @@ func (g *mqlGcpProjectNetworkSecurityService) serverTlsPolicies() ([]any, error)
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list server TLS policies")
 			return nil, nil
 		}
@@ -294,7 +294,7 @@ func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error)
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list client TLS policies")
 			return nil, nil
 		}
@@ -352,7 +352,7 @@ func (g *mqlGcpProjectNetworkSecurityService) tlsInspectionPolicies() ([]any, er
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list TLS inspection policies")
 			return nil, nil
 		}
@@ -413,7 +413,7 @@ func (g *mqlGcpProjectNetworkSecurityService) addressGroups() ([]any, error) {
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list address groups")
 			return nil, nil
 		}
@@ -466,7 +466,7 @@ func (g *mqlGcpProjectNetworkSecurityService) urlLists() ([]any, error) {
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list URL lists")
 			return nil, nil
 		}
@@ -478,7 +478,7 @@ func (g *mqlGcpProjectNetworkSecurityService) urlLists() ([]any, error) {
 // networkSecurityProfiles lists organization-scoped network security profiles.
 // Organization-scoped accessors have no serviceusage service-enabled pre-check
 // (enablement is per-project); a disabled API surfaces as a 403/404 that
-// isHTTPSkippable handles below.
+// isSkippable handles below.
 func (g *mqlGcpOrganization) networkSecurityProfiles() ([]any, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -538,7 +538,7 @@ func (g *mqlGcpOrganization) networkSecurityProfiles() ([]any, error) {
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list network security profiles")
 			return nil, nil
 		}
@@ -591,7 +591,7 @@ func (g *mqlGcpOrganization) networkSecurityProfileGroups() ([]any, error) {
 		return nil
 	})
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list network security profile groups")
 			return nil, nil
 		}

--- a/providers/gcp/resources/networksecurity.go
+++ b/providers/gcp/resources/networksecurity.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -20,9 +19,7 @@ import (
 )
 
 type mqlGcpProjectNetworkSecurityServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) networkSecurity() (*mqlGcpProjectNetworkSecurityService, error) {
@@ -47,7 +44,7 @@ func (g *mqlGcpProject) networkSecurity() (*mqlGcpProjectNetworkSecurityService,
 	}
 
 	svc := res.(*mqlGcpProjectNetworkSecurityService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_networksecurity).Msg("gcp service is not enabled, skipping")
 	}
@@ -600,31 +597,7 @@ func (g *mqlGcpOrganization) networkSecurityProfileGroups() ([]any, error) {
 	return res, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectNetworkSecurityService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_networksecurity)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_networksecurity)
 }

--- a/providers/gcp/resources/organization.go
+++ b/providers/gcp/resources/organization.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 )
@@ -69,12 +68,11 @@ func initGcpOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	name := "organizations/" + orgId
 	org, err := svc.Organizations.Get(name).Do()
 	if err != nil {
-		if e, ok := err.(*googleapi.Error); ok {
-			if e.Code == 403 {
-				log.Error().Err(err).Msg("cannot fetch organization info")
-				return nil, nil, errors.New("403: permission denied")
-			}
-		}
+		// Return the error unchanged. Replacing it with a plain string here
+		// used to destroy the *googleapi.Error, which is the only thing
+		// callers can classify: discovery had to fall back to substring
+		// matching on the message to recognize a denial it could skip.
+		log.Error().Err(err).Str("organization", orgId).Msg("cannot fetch organization info")
 		return nil, nil, err
 	}
 

--- a/providers/gcp/resources/osconfig.go
+++ b/providers/gcp/resources/osconfig.go
@@ -24,9 +24,7 @@ import (
 )
 
 type mqlGcpProjectOsConfigServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) osConfig() (*mqlGcpProjectOsConfigService, error) {
@@ -51,7 +49,7 @@ func (g *mqlGcpProject) osConfig() (*mqlGcpProjectOsConfigService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectOsConfigService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_osconfig).Msg("gcp service is not enabled, skipping")
 	}
@@ -569,31 +567,7 @@ func newMqlVulnerabilityReportVulnerability(runtime *plugin.Runtime, reportName 
 	})
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectOsConfigService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_osconfig)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_osconfig)
 }

--- a/providers/gcp/resources/osconfig.go
+++ b/providers/gcp/resources/osconfig.go
@@ -172,7 +172,7 @@ func (g *mqlGcpProjectOsConfigService) patchDeployments() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list OS patch deployments")
 			return nil, nil
 		}
@@ -216,7 +216,7 @@ func (g *mqlGcpProjectOsConfigService) osPolicyAssignments() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list zones for OS policy assignments")
 			return nil, nil
 		}
@@ -254,7 +254,7 @@ func (g *mqlGcpProjectOsConfigService) osPolicyAssignments() ([]any, error) {
 				return nil
 			})
 			if err != nil {
-				if isHTTPSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("zone", zone).Msg("could not list OS policy assignments")
 					return nil
 				}
@@ -347,7 +347,7 @@ func (g *mqlGcpProjectComputeServiceInstance) inventory() (*mqlGcpProjectCompute
 
 	inv, err := osConfigSvc.Projects.Locations.Instances.Inventories.Get(parent + "/inventory").View("FULL").Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			g.Inventory.State = plugin.StateIsNull | plugin.StateIsSet
 			return nil, nil
 		}
@@ -484,7 +484,7 @@ func (g *mqlGcpProjectComputeServiceInstance) vulnerabilityReport() (*mqlGcpProj
 
 	report, err := osConfigSvc.Projects.Locations.Instances.VulnerabilityReports.Get(parent + "/vulnerabilityReport").Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			g.VulnerabilityReport.State = plugin.StateIsNull | plugin.StateIsSet
 			return nil, nil
 		}

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -99,7 +99,7 @@ func (g *mqlGcpProjectCertificateAuthorityService) caPools() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -238,7 +238,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificateAuthorities(
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -373,7 +373,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificates() ([]any, 
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -491,7 +491,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCertificateAuthority) certifica
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}
@@ -568,7 +568,7 @@ func (g *mqlGcpProjectCertificateAuthorityService) certificateTemplates() ([]any
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
 				break
 			}

--- a/providers/gcp/resources/privileged_access_manager.go
+++ b/providers/gcp/resources/privileged_access_manager.go
@@ -168,7 +168,7 @@ func (g *mqlGcpProjectPrivilegedAccessManagerService) entitlements() ([]any, err
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				// break rather than discard: keep the entitlements already returned.
 				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Privileged Access Manager entitlements")
 				break
@@ -301,7 +301,7 @@ func (g *mqlGcpProjectPrivilegedAccessManagerService) grants() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				// break rather than discard: keep the grants already returned.
 				log.Warn().Err(err).Str("project", projectId).Msg("could not list all Privileged Access Manager grants")
 				break

--- a/providers/gcp/resources/privileged_access_manager.go
+++ b/providers/gcp/resources/privileged_access_manager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	pam "cloud.google.com/go/privilegedaccessmanager/apiv1"
 	"cloud.google.com/go/privilegedaccessmanager/apiv1/privilegedaccessmanagerpb"
@@ -23,9 +22,7 @@ import (
 )
 
 type mqlGcpProjectPrivilegedAccessManagerServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) privilegedAccessManager() (*mqlGcpProjectPrivilegedAccessManagerService, error) {
@@ -47,7 +44,7 @@ func (g *mqlGcpProject) privilegedAccessManager() (*mqlGcpProjectPrivilegedAcces
 	}
 
 	svc := res.(*mqlGcpProjectPrivilegedAccessManagerService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_pam).Msg("gcp service is not enabled, skipping")
 	}
@@ -79,30 +76,9 @@ func (g *mqlGcpProjectPrivilegedAccessManagerService) id() (string, error) {
 	return fmt.Sprintf("%s/gcp.project.privilegedAccessManagerService", g.ProjectId.Data), nil
 }
 
-// isEnabled resolves the service-enabled gate lazily, so every construction path
-// agrees. Without it the Go zero value false would make both collections return
-// an empty list with no error on any path that does not go through the
-// gcp.project accessor, which reads as an authoritative "there is no
-// just-in-time elevation configured here".
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectPrivilegedAccessManagerService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_pam)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_pam)
 }
 
 func (g *mqlGcpProjectPrivilegedAccessManagerServiceEntitlement) id() (string, error) {

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
@@ -53,9 +52,7 @@ func initGcpProjectPubsubService(runtime *plugin.Runtime, args map[string]*llx.R
 }
 
 type mqlGcpProjectPubsubServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) pubsub() (*mqlGcpProjectPubsubService, error) {
@@ -77,7 +74,7 @@ func (g *mqlGcpProject) pubsub() (*mqlGcpProjectPubsubService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectPubsubService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_pubsub).Msg("gcp service is not enabled, skipping")
 	}
@@ -1245,31 +1242,7 @@ func (g *mqlGcpProjectPubsubServiceTopicConfig) kmsKey() (*mqlGcpProjectKmsServi
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectPubsubService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_pubsub)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_pubsub)
 }

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	redis "cloud.google.com/go/redis/apiv1"
@@ -26,9 +25,7 @@ import (
 )
 
 type mqlGcpProjectRedisServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 type mqlGcpProjectRedisServiceInstanceInternal struct {
@@ -82,7 +79,7 @@ func (g *mqlGcpProject) redis() (*mqlGcpProjectRedisService, error) {
 	}
 
 	redisSvc := res.(*mqlGcpProjectRedisService)
-	redisSvc.serviceEnabled = serviceEnabled
+	redisSvc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_redis).Msg("gcp service is not enabled, skipping")
 	}
@@ -1311,31 +1308,7 @@ func clusterConvertConnectionDetails(runtime *plugin.Runtime, projectId, cluster
 	return
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectRedisService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_redis)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_redis)
 }

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
@@ -53,9 +52,7 @@ func initGcpProjectSecretmanagerService(runtime *plugin.Runtime, args map[string
 }
 
 type mqlGcpProjectSecretmanagerServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) secretmanager() (*mqlGcpProjectSecretmanagerService, error) {
@@ -77,7 +74,7 @@ func (g *mqlGcpProject) secretmanager() (*mqlGcpProjectSecretmanagerService, err
 	}
 
 	svc := res.(*mqlGcpProjectSecretmanagerService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_secretmanager).Msg("gcp service is not enabled, skipping")
 	}
@@ -568,31 +565,7 @@ func durationToString(d *durationpb.Duration) string {
 	return fmt.Sprintf("%ds", d.Seconds)
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectSecretmanagerService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_secretmanager)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_secretmanager)
 }

--- a/providers/gcp/resources/service_gate_test.go
+++ b/providers/gcp/resources/service_gate_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -11,93 +12,150 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-// TestNoBareServiceEnabledGate pins the service-enabled contract.
+// TestServiceGateRecordWinsTheOnce pins the interaction between the two entry
+// points. recordEnabled stores the answer the gcp.project.<service>() accessor
+// already computed; resolveEnabled computes it for the paths that did not go
+// through that accessor. Both claim the same sync.Once, which is what makes
+// them race-free against each other.
 //
-// `serviceEnabled` is populated only by the gcp.project.<service>() accessor.
-// The same resource is reachable without it -- addressed by its own type name
-// (gcp.project.cloudRunService.services), through an alias (gcp.storage), or
-// built by a resource init with CreateResource. On those paths the Go zero value
-// is `false`, so a bare
+// The nil runtime is the assertion: if the recorded answer did not win the
+// once, resolveEnabled would go build a gcp.project resource and panic.
+func TestServiceGateRecordWinsTheOnce(t *testing.T) {
+	var gate serviceGate
+	gate.recordEnabled(true)
+
+	enabled, err := gate.resolveEnabled(nil, plugin.TValue[string]{Data: "some-project"}, "compute.googleapis.com")
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+// TestServiceGateRecordsDisabled is the same in the other direction: a recorded
+// `false` must also short-circuit. The predecessor of this type re-resolved on
+// a recorded false, because it could not tell "checked, disabled" apart from
+// "never checked".
+func TestServiceGateRecordsDisabled(t *testing.T) {
+	var gate serviceGate
+	gate.recordEnabled(false)
+
+	enabled, err := gate.resolveEnabled(nil, plugin.TValue[string]{Data: "some-project"}, "compute.googleapis.com")
+	require.NoError(t, err)
+	require.False(t, enabled)
+}
+
+// TestServiceGatePropagatesProjectIdError checks that an unresolvable project
+// surfaces as an error rather than as `false`.
 //
-//	if !g.serviceEnabled { return nil, nil }
+// This is the whole point of the gate returning (bool, error). A failed
+// resolution folded into `false` reports "this project has nothing" for a
+// project that was never successfully checked, and every assertion over the
+// resulting empty collection passes vacuously.
+func TestServiceGatePropagatesProjectIdError(t *testing.T) {
+	boom := errors.New("project id unavailable")
+	var gate serviceGate
+
+	enabled, err := gate.resolveEnabled(nil, plugin.TValue[string]{Error: boom}, "compute.googleapis.com")
+	require.ErrorIs(t, err, boom)
+	require.False(t, enabled)
+
+	// a later recordEnabled must not paper over a resolution that already failed
+	gate.recordEnabled(true)
+	enabled, err = gate.resolveEnabled(nil, plugin.TValue[string]{Data: "p"}, "compute.googleapis.com")
+	require.ErrorIs(t, err, boom)
+	require.False(t, enabled)
+}
+
+// TestServiceGateResolvesOnce guards the memoization: repeated reads must not
+// re-resolve. A nil runtime on the second call would panic if they did.
+func TestServiceGateResolvesOnce(t *testing.T) {
+	var gate serviceGate
+	gate.recordEnabled(true)
+	for i := 0; i < 3; i++ {
+		enabled, err := gate.resolveEnabled(nil, plugin.TValue[string]{Data: "p"}, "compute.googleapis.com")
+		require.NoError(t, err)
+		require.True(t, enabled)
+	}
+}
+
+// TestServiceGateIsTheOnlyEnabledMechanism replaces the two AST tests that used
+// to police the hand-copied version of this gate.
 //
-// reports an authoritative "there is nothing here" for a service that is in fact
-// enabled and populated. An empty list is the most dangerous wrong answer for a
-// posture check: it passes vacuously instead of failing or erroring.
-//
-// Verified against a live project: gcp.project.cloudRunService.services returned
-// [] while gcp.project.cloudRun.services returned the real service.
-//
-// Every gate must therefore resolve the flag first, via the isEnabled() helper
-// (bigquery.go, storage.go, ...) or the serviceChecked companion flag (dns.go).
-func TestNoBareServiceEnabledGate(t *testing.T) {
+// Those tests existed because the mechanism was 25 lines duplicated into every
+// service file, so it could be copied wrong or forgotten entirely -- and the
+// failure mode (an unresolved flag reading as `false`) is an authoritative
+// empty collection, which no compiler and no live query complains about. The
+// embedded serviceGate makes the resolution impossible to omit, so what is left
+// to check is that nobody grows a second mechanism alongside it.
+func TestServiceGateIsTheOnlyEnabledMechanism(t *testing.T) {
 	paths, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatalf("glob package sources: %v", err)
 	}
+
+	// Fields the hand-rolled gates used. serviceGate owns this state now; a
+	// resource that re-declares any of them has grown a parallel mechanism
+	// that the gate cannot keep consistent.
+	banned := []string{"serviceEnabled bool", "serviceOnce", "serviceChecked", "serviceErr"}
 
 	fset := token.NewFileSet()
 	for _, path := range paths {
 		if strings.HasSuffix(path, "_test.go") {
 			continue
 		}
-		file, err := parser.ParseFile(fset, path, nil, 0)
+		raw, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
 		}
 
-		ast.Inspect(file, func(n ast.Node) bool {
-			ifs, ok := n.(*ast.IfStmt)
-			if !ok {
-				return true
-			}
-			// match exactly `!<recv>.serviceEnabled`, with no other operand
-			unary, ok := ifs.Cond.(*ast.UnaryExpr)
-			if !ok || unary.Op != token.NOT {
-				return true
-			}
-			sel, ok := unary.X.(*ast.SelectorExpr)
-			if !ok || sel.Sel.Name != "serviceEnabled" {
-				return true
-			}
-			t.Errorf("%s: gates on serviceEnabled without resolving it first; "+
-				"an unresolved flag is false and reports an empty collection for an "+
-				"enabled service. Call isEnabled() (see bigquery.go) instead",
-				fset.Position(ifs.Pos()))
-			return true
-		})
-	}
-}
-
-// TestEveryServiceEnabledFlagHasAResolver checks the other direction: a resource
-// that carries the flag must also carry the machinery to resolve it, so a new
-// service cannot reintroduce the zero-value bug by omission.
-func TestEveryServiceEnabledFlagHasAResolver(t *testing.T) {
-	paths, err := filepath.Glob("*.go")
-	if err != nil {
-		t.Fatalf("glob package sources: %v", err)
-	}
-
-	for _, path := range paths {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
-		}
-		raw, err := os.ReadFile(path)
+		raws, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("read %s: %v", path, err)
 		}
-		src := string(raw)
-		if !strings.Contains(src, "serviceEnabled bool") {
-			continue
+		src := string(raws)
+
+		for _, field := range banned {
+			if strings.Contains(src, field) {
+				t.Errorf("%s: declares %q; serviceGate owns the service-enabled state. "+
+					"Embed serviceGate in the Internal struct and forward isEnabled() to "+
+					"resolveEnabled instead", path, field)
+			}
 		}
-		// either the lazy resolver or the explicit "was it checked" companion
-		if strings.Contains(src, "serviceOnce") || strings.Contains(src, "serviceChecked") {
-			continue
+
+		// every isEnabled() must be a forwarder -- a hand-written body can
+		// reintroduce the zero-value bug the gate exists to prevent
+		for _, decl := range raw.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "isEnabled" || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+			if !isResolveEnabledForwarder(fn) {
+				t.Errorf("%s: isEnabled() is hand-written; it must be a single "+
+					"`return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_x)` so "+
+					"every construction path resolves the gate identically",
+					fset.Position(fn.Pos()))
+			}
 		}
-		t.Errorf("%s: declares serviceEnabled but has neither serviceOnce "+
-			"(the isEnabled() resolver) nor serviceChecked; the flag defaults to "+
-			"false and would report empty collections for an enabled service", path)
 	}
+}
+
+// isResolveEnabledForwarder reports whether fn's body is exactly
+// `return g.resolveEnabled(...)`.
+func isResolveEnabledForwarder(fn *ast.FuncDecl) bool {
+	if len(fn.Body.List) != 1 {
+		return false
+	}
+	ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) != 1 {
+		return false
+	}
+	call, ok := ret.Results[0].(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "resolveEnabled"
 }

--- a/providers/gcp/resources/servicegate.go
+++ b/providers/gcp/resources/servicegate.go
@@ -1,0 +1,86 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// serviceGate answers "is this API enabled on this project" once per service
+// resource, from whichever construction path reaches it first.
+//
+// The problem it exists to make impossible: a gcp.project.<service> resource is
+// reachable three ways -- through the gcp.project.<service>() accessor, by its
+// own type name (gcp.project.cloudRunService.services), or built by another
+// resource's init with CreateResource -- and only the first of those knows
+// whether the API is enabled. A resource that stores that answer in a plain
+// bool therefore reads the Go zero value `false` on the other two paths, and
+// every collection on it returns an empty list with no error.
+//
+// An empty list is the worst possible wrong answer here. It is an authoritative
+// "there is nothing in this project", so a posture check over it passes
+// vacuously rather than failing or erroring. This was verified live: with the
+// bare flag, gcp.project.cloudRunService.services returned [] while
+// gcp.project.cloudRun.services returned the real service.
+//
+// Embed this in the resource's Internal struct and the resolution comes with
+// it, so a new service cannot reintroduce the bug by forgetting to copy 25
+// lines:
+//
+//	type mqlGcpProjectBatchServiceInternal struct {
+//		serviceGate
+//	}
+//
+//	func (g *mqlGcpProjectBatchService) isEnabled() (bool, error) {
+//		return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_batch)
+//	}
+type serviceGate struct {
+	once    sync.Once
+	enabled bool
+	err     error
+}
+
+// resolveEnabled reports whether service is enabled on the project, resolving
+// it at most once. It is safe to call from concurrent field accessors.
+//
+// A resolution failure -- a serviceusage permission gap, the Service Usage API
+// itself disabled, the phantom empty-project-id discovery asset -- is returned,
+// never folded into `false`. Callers must propagate it: reporting "nothing
+// here" for a project that was never successfully checked is the vacuous-pass
+// failure this whole type exists to prevent.
+func (s *serviceGate) resolveEnabled(runtime *plugin.Runtime, projectId plugin.TValue[string], service string) (bool, error) {
+	s.once.Do(func() {
+		if projectId.Error != nil {
+			s.err = projectId.Error
+			return
+		}
+		proj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(projectId.Data),
+		})
+		if err != nil {
+			s.err = err
+			return
+		}
+		s.enabled, s.err = proj.(*mqlGcpProject).isServiceEnabled(service)
+	})
+	return s.enabled, s.err
+}
+
+// recordEnabled stores an answer the gcp.project.<service>() accessor already
+// computed, so the common path does not pay for a second lookup.
+//
+// It claims the same sync.Once rather than writing the field directly, which is
+// what makes it race-free against a concurrent resolveEnabled: whichever call
+// arrives first wins and the other becomes a no-op. Both compute the same
+// answer, so the order does not matter -- except that a resolveEnabled which
+// already failed keeps its error rather than having it overwritten by a later
+// recordEnabled.
+func (s *serviceGate) recordEnabled(enabled bool) {
+	s.once.Do(func() {
+		s.enabled = enabled
+	})
+}

--- a/providers/gcp/resources/sourcerepo.go
+++ b/providers/gcp/resources/sourcerepo.go
@@ -88,7 +88,7 @@ func (g *mqlGcpProjectSourceRepositoriesService) repos() ([]any, error) {
 		// 403 SERVICE_DISABLED is the COMMON case here, not an exceptional one.
 		// service_sourcerepo is declared in services.go but was never wired to
 		// a gate, so this accessor hard-failed on most projects.
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("project", projectId).Msg("could not list Cloud Source Repositories")
 			return nil, nil
 		}

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -145,7 +145,7 @@ func (g *mqlGcpProjectSpannerService) instances() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instances")
 				break
 			}
@@ -257,7 +257,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) databases() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner databases")
 				break
 			}
@@ -515,7 +515,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) ddl() ([]any, error) {
 		Database: dbName,
 	})
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not read Spanner database DDL")
 			return nil, nil
 		}
@@ -559,7 +559,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) backups() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner backups")
 				break
 			}
@@ -679,7 +679,7 @@ func (g *mqlGcpProjectSpannerService) instanceConfigs() ([]any, error) {
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instance configs")
 				break
 			}
@@ -843,7 +843,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) iamPolicy() ([]any, error) {
 
 	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: instanceName, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not read Spanner instance IAM policy")
 			return nil, nil
 		}
@@ -873,7 +873,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) iamPolicy() ([]any, error)
 
 	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: dbName, Options: &iampb.GetPolicyOptions{RequestedPolicyVersion: 3}})
 	if err != nil {
-		if isGRPCSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not read Spanner database IAM policy")
 			return nil, nil
 		}
@@ -920,7 +920,7 @@ func (g *mqlGcpProjectSpannerServiceInstanceDatabase) databaseRoles() ([]any, er
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner database roles")
 				break
 			}
@@ -993,7 +993,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) backupSchedules() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isGRPCSkippable(err) {
+				if isSkippable(err) {
 					log.Warn().Err(err).Str("database", dbName).Msg("could not list Spanner backup schedules")
 					break
 				}
@@ -1090,7 +1090,7 @@ func (g *mqlGcpProjectSpannerServiceInstance) instancePartitions() ([]any, error
 			break
 		}
 		if err != nil {
-			if isGRPCSkippable(err) {
+			if isSkippable(err) {
 				log.Warn().Err(err).Msg("could not list Spanner instance partitions")
 				break
 			}

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -868,7 +868,7 @@ func (g *mqlGcpProjectSqlServiceInstance) databases() ([]any, error) {
 		// A principal often holds cloudsql.instances.list without the
 		// per-instance sub-collection permissions. Degrade to null so the
 		// instance still reports, rather than failing the whole query.
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("instance", instanceName).Msg("could not list Cloud SQL databases")
 			return nil, nil
 		}
@@ -1129,7 +1129,7 @@ func (g *mqlGcpProjectSqlServiceInstance) users() ([]any, error) {
 		// hasBuiltInUsers() and localRootEnabled() both read this collection,
 		// so propagating a 403 here failed the two headline Cloud SQL
 		// hardening checks with an opaque error.
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("instance", instanceName).Msg("could not list Cloud SQL users")
 			return nil, nil
 		}
@@ -1215,7 +1215,7 @@ func (g *mqlGcpProjectSqlServiceInstance) sslCerts() ([]any, error) {
 
 	resp, err := sqladminSvc.SslCerts.List(projectId, instanceName).Do()
 	if err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("instance", instanceName).Msg("could not list Cloud SQL SSL certificates")
 			return nil, nil
 		}

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -262,9 +261,7 @@ func (g *mqlGcpProjectSqlService) id() (string, error) {
 }
 
 type mqlGcpProjectSqlServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
 func (g *mqlGcpProject) sql() (*mqlGcpProjectSqlService, error) {
@@ -286,7 +283,7 @@ func (g *mqlGcpProject) sql() (*mqlGcpProjectSqlService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectSqlService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_sqladmin).Msg("gcp service is not enabled, skipping")
 	}
@@ -1525,31 +1522,7 @@ func (g *mqlGcpProjectSqlServiceInstance) localRootEnabled() (bool, error) {
 	return false, nil
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: it can be addressed by its own
-// type name and resource inits build it with CreateResource. On those paths the
-// Go zero value `false` made every collection return an empty list with no error
-// -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectSqlService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_sqladmin)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_sqladmin)
 }

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -61,38 +61,12 @@ func initGcpProjectStorageService(runtime *plugin.Runtime, args map[string]*llx.
 }
 
 type mqlGcpProjectStorageServiceInternal struct {
-	serviceEnabled bool
-	serviceOnce    sync.Once
-	serviceErr     error
+	serviceGate
 }
 
-// isEnabled resolves the service-enabled gate lazily.
-//
-// The flag is only set by the gcp.project.<service>() accessor, but this
-// resource is reachable without going through it: gcp.storage / gcloud.storage is an
-// alias for it, and resource inits build it with CreateResource. On those paths
-// the Go zero value `false` made every collection return an empty list with no
-// error -- an authoritative "there is nothing here" that makes an audit pass
-// vacuously. Resolving it here makes every construction path agree.
+// isEnabled reports whether the API is enabled on this project.
 func (g *mqlGcpProjectStorageService) isEnabled() (bool, error) {
-	g.serviceOnce.Do(func() {
-		if g.serviceEnabled {
-			return // already set by the parent accessor
-		}
-		if g.ProjectId.Error != nil {
-			g.serviceErr = g.ProjectId.Error
-			return
-		}
-		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
-			"id": llx.StringData(g.ProjectId.Data),
-		})
-		if err != nil {
-			g.serviceErr = err
-			return
-		}
-		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_storage)
-	})
-	return g.serviceEnabled, g.serviceErr
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_storage)
 }
 
 func (g *mqlGcpProject) storage() (*mqlGcpProjectStorageService, error) {
@@ -114,7 +88,7 @@ func (g *mqlGcpProject) storage() (*mqlGcpProjectStorageService, error) {
 	}
 
 	svc := res.(*mqlGcpProjectStorageService)
-	svc.serviceEnabled = serviceEnabled
+	svc.recordEnabled(serviceEnabled)
 	if !serviceEnabled {
 		log.Debug().Str("service", service_storage).Msg("gcp service is not enabled, skipping")
 	}

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -628,7 +628,7 @@ func (g *mqlGcpProjectStorageServiceBucket) iamPolicy() ([]any, error) {
 		// Degrade a permission gap to an empty policy rather than a hard error,
 		// matching sibling IAM-policy accessors, and so public() can still fall
 		// back to its ACL check instead of failing outright.
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/providers/gcp/resources/storage_hmac.go
+++ b/providers/gcp/resources/storage_hmac.go
@@ -100,7 +100,7 @@ func (g *mqlGcpProjectStorageService) hmacKeys() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isHTTPSkippable(err) {
+		if isSkippable(err) {
 			log.Warn().Err(err).Str("project", projectId).Msg("could not list Cloud Storage HMAC keys")
 			return nil, nil
 		}

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -72,26 +72,6 @@ func vertexaiEndpoint(region string) string {
 	return fmt.Sprintf("%s-aiplatform.googleapis.com:443", region)
 }
 
-// isVertexAIRegionSkippable returns true for errors indicating the Vertex AI API
-// is not enabled or the region is not supported for this project.
-func isVertexAIRegionSkippable(err error) bool {
-	if s, ok := status.FromError(err); ok {
-		switch s.Code() {
-		case codes.PermissionDenied, codes.Unimplemented:
-			return true
-		case codes.InvalidArgument, codes.NotFound:
-			// "not enabled" and "is not supported" surface as these codes
-			return true
-		case codes.FailedPrecondition:
-			// some sub-services (e.g. the RAG data service) report
-			// "<service> is not supported in region <region>" as
-			// FailedPrecondition rather than InvalidArgument
-			return true
-		}
-	}
-	return false
-}
-
 type mqlGcpProjectVertexaiServiceInternal struct {
 	// skippedRegions tracks regions where the API is not available, keyed by
 	// resource kind. It MUST be per-kind: Vertex AI sub-services have very
@@ -203,7 +183,7 @@ func (g *mqlGcpProjectVertexaiService) listAcrossRegions(
 	// A single region failing must not discard the ~33 that succeeded. Vertex
 	// AI fans out over one regional endpoint per region, so any one of them can
 	// return Unavailable, DeadlineExceeded or ResourceExhausted independently --
-	// none of which isVertexAIRegionSkippable covers -- and the whole inventory
+	// none of which isInapplicable covers -- and the whole inventory
 	// used to disappear behind it. Only report an error when EVERY region
 	// failed, which is the case that actually means "this did not work".
 	var (
@@ -267,7 +247,7 @@ func (g *mqlGcpProjectVertexaiService) models() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -381,7 +361,7 @@ func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -536,7 +516,7 @@ func resolveVertexaiEndpointRef(runtime *plugin.Runtime, field *plugin.TValue[*m
 
 	ep, err := client.GetEndpoint(ctx, &aiplatformpb.GetEndpointRequest{Name: endpointName})
 	if err != nil {
-		if isVertexAIRegionSkippable(err) {
+		if isInapplicable(err) {
 			field.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
@@ -624,7 +604,7 @@ func resolveVertexaiModelRef(runtime *plugin.Runtime, field *plugin.TValue[*mqlG
 
 	m, err := client.GetModel(ctx, &aiplatformpb.GetModelRequest{Name: modelName})
 	if err != nil {
-		if isVertexAIRegionSkippable(err) {
+		if isInapplicable(err) {
 			field.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
@@ -690,7 +670,7 @@ func (g *mqlGcpProjectVertexaiService) pipelineJobs() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -856,7 +836,7 @@ func (g *mqlGcpProjectVertexaiService) datasets() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -935,7 +915,7 @@ func (g *mqlGcpProjectVertexaiService) featureOnlineStores() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -1030,7 +1010,7 @@ func (g *mqlGcpProjectVertexaiService) tensorboards() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -1442,7 +1422,7 @@ func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -1502,7 +1482,7 @@ func (g *mqlGcpProjectVertexaiService) indexes() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -1598,7 +1578,7 @@ func (g *mqlGcpProjectVertexaiService) indexEndpoints() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -1685,7 +1665,7 @@ func (g *mqlGcpProjectVertexaiService) metadataStores() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -1759,7 +1739,7 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimes() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -1877,7 +1857,7 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimeTemplates() ([]any, error)
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2002,7 +1982,7 @@ func (g *mqlGcpProjectVertexaiService) notebookExecutionJobs() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2085,7 +2065,7 @@ func (g *mqlGcpProjectVertexaiService) reasoningEngines() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2185,7 +2165,7 @@ func (g *mqlGcpProjectVertexaiService) ragCorpora() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2259,7 +2239,7 @@ func (g *mqlGcpProjectVertexaiService) featureGroups() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2328,7 +2308,7 @@ func (g *mqlGcpProjectVertexaiService) persistentResources() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2416,7 +2396,7 @@ func (g *mqlGcpProjectVertexaiService) schedules() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2552,7 +2532,7 @@ func (g *mqlGcpProjectVertexaiService) deploymentResourcePools() ([]any, error) 
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2627,7 +2607,7 @@ func (g *mqlGcpProjectVertexaiService) cachedContents() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2702,7 +2682,7 @@ func (g *mqlGcpProjectVertexaiService) batchPredictionJobs() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2791,7 +2771,7 @@ func (g *mqlGcpProjectVertexaiService) tuningJobs() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2880,7 +2860,7 @@ func (g *mqlGcpProjectVertexaiService) trainingPipelines() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -2963,7 +2943,7 @@ func (g *mqlGcpProjectVertexaiService) hyperparameterTuningJobs() ([]any, error)
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.
@@ -3054,7 +3034,7 @@ func (g *mqlGcpProjectVertexaiService) modelDeploymentMonitoringJobs() ([]any, e
 				break
 			}
 			if err != nil {
-				if isVertexAIRegionSkippable(err) {
+				if isInapplicable(err) {
 					// Keep what this region already yielded: the iterator
 					// paginates lazily, so a skippable error on a later page
 					// must not discard the pages that succeeded.

--- a/providers/gcp/resources/vertexai_regions_test.go
+++ b/providers/gcp/resources/vertexai_regions_test.go
@@ -9,7 +9,7 @@ import "testing"
 //
 // Vertex AI sub-services have very different regional footprints: the RAG data
 // service is available in a handful of regions and reports the rest as
-// FailedPrecondition, which isVertexAIRegionSkippable treats as skippable.
+// FailedPrecondition, which isInapplicable treats as skippable.
 // While the skip set was shared across all 26 accessors, running ragCorpora()
 // first shrank the candidate region list for models(), endpoints() and every
 // job accessor -- silently returning a fraction of the real inventory, with

--- a/providers/gcp/resources/workbench.go
+++ b/providers/gcp/resources/workbench.go
@@ -6,32 +6,16 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
-	"google.golang.org/api/googleapi"
 	notebooksv1 "google.golang.org/api/notebooks/v1"
 	notebooksv2 "google.golang.org/api/notebooks/v2"
 	"google.golang.org/api/option"
 )
-
-// isNotebooksSkippable returns true for REST errors that indicate the Notebooks
-// API is not enabled or the caller lacks permission.
-func isNotebooksSkippable(err error) bool {
-	gerr, ok := err.(*googleapi.Error)
-	if !ok {
-		return false
-	}
-	if gerr.Code == 403 || gerr.Code == 404 {
-		return true
-	}
-	msg := strings.ToLower(gerr.Message)
-	return strings.Contains(msg, "not enabled") || strings.Contains(msg, "has not been used")
-}
 
 func newWorkbenchService(conn *connection.GcpConnection) (*notebooksv2.Service, error) {
 	client, err := conn.Client(notebooksv2.CloudPlatformScope)
@@ -149,7 +133,7 @@ func (g *mqlGcpProjectWorkbenchService) instances() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isNotebooksSkippable(err) {
+		if isSkippable(err) {
 			log.Debug().Str("project", projectId).Msg("vertex ai workbench api is not enabled, skipping")
 			return []any{}, nil
 		}
@@ -200,7 +184,7 @@ func (g *mqlGcpProjectNotebooksService) instances() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isNotebooksSkippable(err) {
+		if isSkippable(err) {
 			log.Debug().Str("project", projectId).Msg("notebooks api is not enabled, skipping")
 			return []any{}, nil
 		}

--- a/providers/gcp/resources/workstations.go
+++ b/providers/gcp/resources/workstations.go
@@ -6,13 +6,11 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	"google.golang.org/api/workstations/v1"
 )
@@ -23,22 +21,6 @@ func newWorkstationsService(conn *connection.GcpConnection) (*workstations.Servi
 		return nil, err
 	}
 	return workstations.NewService(context.Background(), option.WithHTTPClient(client))
-}
-
-// isWorkstationsServiceDisabled returns true for errors indicating the Cloud
-// Workstations API is not enabled or accessible for this project.
-func isWorkstationsServiceDisabled(err error) bool {
-	gerr, ok := err.(*googleapi.Error)
-	if !ok {
-		return false
-	}
-	if gerr.Code == 403 || gerr.Code == 404 {
-		return true
-	}
-	if strings.Contains(gerr.Message, "not enabled") || strings.Contains(gerr.Message, "has not been used") {
-		return true
-	}
-	return false
 }
 
 func (g *mqlGcpProject) workstations() (*mqlGcpProjectWorkstationsService, error) {
@@ -107,7 +89,7 @@ func (g *mqlGcpProjectWorkstationsService) clusters() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
-		if isWorkstationsServiceDisabled(err) {
+		if isSkippable(err) {
 			return []any{}, nil
 		}
 		return nil, err


### PR DESCRIPTION
Second of five stacked PRs from a refactoring review of the GCP provider. **Based on #9755** — review that one first; this diff is against it.

## What

Twenty-eight service resources each carried their own copy of the "is this API enabled" resolver. **Twenty-six were byte-identical** apart from the receiver type and the service constant — 25 lines, comment included, duplicated 26 times. The other two had drifted.

They are now one embeddable `serviceGate`:

```go
type mqlGcpProjectBatchServiceInternal struct {
	serviceGate
}

func (g *mqlGcpProjectBatchService) isEnabled() (bool, error) {
	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_batch)
}
```

## Why the duplication mattered

A `gcp.project.<service>` resource is reachable three ways — the `gcp.project.<service>()` accessor, its own type name (`gcp.project.cloudRunService.services`), or another resource's init calling `CreateResource` — and **only the first knows whether the API is enabled.** A resource holding that answer in a plain bool reads the zero value `false` on the other two paths, so every collection returns an empty list with no error.

That is an authoritative "this project has nothing", so a posture check over it **passes vacuously** instead of failing. With the resolution embedded in the type, a new service can't reintroduce it by forgetting to copy the block.

## Three races and a drift, fixed on the way through

- **`container_analysis.go`** resolved lazily but with a plain bool pair instead of a `sync.Once` — two concurrent field accessors could both enter the resolve and race on the write.
- **`dns.go`** guarded with `if g.serviceChecked && !g.serviceEnabled`, which on the direct-query path is false-and-so-never-fires. Not a wrong answer (it called the API instead of skipping), but the only service behaving differently from the other 27.
- **`recordEnabled` claims the same `sync.Once` as `resolveEnabled`** rather than writing the field directly, removing the race between the parent accessor's write and a concurrent resolve.
- The old check couldn't tell "checked, disabled" from "never checked", so a recorded `false` re-resolved. Now it short-circuits.

## Not in scope

`compute.go` is deliberately untouched — it gates through an `.lr`-declared `enabled` field rather than an Internal flag. Different mechanism, own guard in `enabled_gate_test.go`.

## Tests

`service_gate_test.go` is rewritten. Its two AST tests existed to police a convention copy-paste could break; the type makes both moot. What replaces them:

- No second mechanism grows alongside the gate — no file re-declares the old fields, and every `isEnabled()` is a forwarder rather than a hand-written body.
- Real unit tests of the gate: record wins the once in **both** directions, a resolution error propagates instead of folding into `false`, a later `record` can't paper over an earlier failure, repeated reads don't re-resolve. The nil runtime in those tests is the assertion — if the memoization didn't hold, they'd panic.
- All pass under `-race`.

## Net

30 files, +336 / −887. `go build`, `go vet`, `go test ./...` and `go test -race` clean. No schema change, no `.lr` change, no version bump.
