### PR TITLE
🧹 azure: a shared lister for the ARM pager walk

### DIFF
--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -175,213 +175,222 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup) id()
 }
 
 func (a *mqlAzureSubscriptionEventHubService) namespaces() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	subId := a.SubscriptionId.Data
+	conn, err := azureConn(a.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
 
-	client, err := armeventhub.NewNamespacesClient(subId, token, &arm.ClientOptions{
+	client, err := armeventhub.NewNamespacesClient(a.SubscriptionId.Data, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	pager := client.NewListPager(nil)
-	var res []any
+	return listPaged(a.MqlRuntime, &a.Namespaces, "event hub namespaces",
+		client.NewListPager(nil),
+		func(page armeventhub.NamespacesClientListResponse) []*armeventhub.EHNamespace {
+			return page.Value
+		},
+		createEventHubNamespace,
+	)
+}
 
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, err
+// createEventHubNamespace builds the MQL resource for one Event Hub namespace.
+func createEventHubNamespace(runtime *plugin.Runtime, ns *armeventhub.EHNamespace) (plugin.Resource, error) {
+	rawData, err := createEventHubNamespaceRawData(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	mqlNs, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace", rawData)
+	if err != nil {
+		return nil, err
+	}
+	sysData, err := convert.JsonToDict(ns.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlNsRes := mqlNs.(*mqlAzureSubscriptionEventHubServiceNamespace)
+	mqlNsRes.cacheSystemData = sysData
+	if ns.Properties != nil {
+		mqlNsRes.cachePrivateEndpointConnections = ns.Properties.PrivateEndpointConnections
+	}
+	return mqlNs, nil
+}
+
+// createEventHubNamespaceRawData maps one namespace onto its MQL fields.
+//
+// Pure by construction -- no client, no context, no runtime -- so it can be
+// exercised against the shapes ARM actually returns, including a row with no
+// Properties block and a KeyVaultProperties list with a nil entry in it. Both of
+// those panic if dereferenced, and a panic in an accessor ends the scan rather
+// than the query.
+func createEventHubNamespaceRawData(ns *armeventhub.EHNamespace) (map[string]*llx.RawData, error) {
+	sku, err := convert.JsonToDict(ns.SKU)
+	if err != nil {
+		return nil, err
+	}
+
+	var status, cmkKeySource string
+	var isAutoInflateEnabled, kafkaEnabled, disableLocalAuth, zoneRedundant bool
+	var requireInfraEnc *bool
+	var maximumThroughputUnits int64
+	var minimumTlsVersion, publicNetworkAccess string
+	var cmkKeys []any
+	var creationTime, updatedAt *time.Time
+	var alternateName, metricId, clusterArmId, serviceBusEndpoint *string
+	if ns.Properties != nil {
+		creationTime = ns.Properties.CreatedAt
+		updatedAt = ns.Properties.UpdatedAt
+		alternateName = ns.Properties.AlternateName
+		metricId = ns.Properties.MetricID
+		clusterArmId = ns.Properties.ClusterArmID
+		serviceBusEndpoint = ns.Properties.ServiceBusEndpoint
+		if ns.Properties.Status != nil {
+			status = *ns.Properties.Status
 		}
-		for _, ns := range page.Value {
-			if ns == nil {
-				continue
+		if ns.Properties.IsAutoInflateEnabled != nil {
+			isAutoInflateEnabled = *ns.Properties.IsAutoInflateEnabled
+		}
+		if ns.Properties.MaximumThroughputUnits != nil {
+			maximumThroughputUnits = int64(*ns.Properties.MaximumThroughputUnits)
+		}
+		if ns.Properties.KafkaEnabled != nil {
+			kafkaEnabled = *ns.Properties.KafkaEnabled
+		}
+		if ns.Properties.DisableLocalAuth != nil {
+			disableLocalAuth = *ns.Properties.DisableLocalAuth
+		}
+		if ns.Properties.MinimumTLSVersion != nil {
+			minimumTlsVersion = string(*ns.Properties.MinimumTLSVersion)
+		}
+		if ns.Properties.PublicNetworkAccess != nil {
+			publicNetworkAccess = string(*ns.Properties.PublicNetworkAccess)
+		}
+		if ns.Properties.ZoneRedundant != nil {
+			zoneRedundant = *ns.Properties.ZoneRedundant
+		}
+		if enc := ns.Properties.Encryption; enc != nil {
+			if enc.KeySource != nil {
+				cmkKeySource = string(*enc.KeySource)
 			}
-
-			sku, err := convert.JsonToDict(ns.SKU)
-			if err != nil {
-				return nil, err
-			}
-
-			var status, cmkKeySource string
-			var isAutoInflateEnabled, kafkaEnabled, disableLocalAuth, zoneRedundant bool
-			var requireInfraEnc *bool
-			var maximumThroughputUnits int64
-			var minimumTlsVersion, publicNetworkAccess string
-			var cmkKeys []any
-			var creationTime, updatedAt *time.Time
-			var alternateName, metricId, clusterArmId, serviceBusEndpoint *string
-			if ns.Properties != nil {
-				creationTime = ns.Properties.CreatedAt
-				updatedAt = ns.Properties.UpdatedAt
-				alternateName = ns.Properties.AlternateName
-				metricId = ns.Properties.MetricID
-				clusterArmId = ns.Properties.ClusterArmID
-				serviceBusEndpoint = ns.Properties.ServiceBusEndpoint
-				if ns.Properties.Status != nil {
-					status = *ns.Properties.Status
+			requireInfraEnc = enc.RequireInfrastructureEncryption
+			for _, kvp := range enc.KeyVaultProperties {
+				if kvp == nil {
+					continue
 				}
-				if ns.Properties.IsAutoInflateEnabled != nil {
-					isAutoInflateEnabled = *ns.Properties.IsAutoInflateEnabled
-				}
-				if ns.Properties.MaximumThroughputUnits != nil {
-					maximumThroughputUnits = int64(*ns.Properties.MaximumThroughputUnits)
-				}
-				if ns.Properties.KafkaEnabled != nil {
-					kafkaEnabled = *ns.Properties.KafkaEnabled
-				}
-				if ns.Properties.DisableLocalAuth != nil {
-					disableLocalAuth = *ns.Properties.DisableLocalAuth
-				}
-				if ns.Properties.MinimumTLSVersion != nil {
-					minimumTlsVersion = string(*ns.Properties.MinimumTLSVersion)
-				}
-				if ns.Properties.PublicNetworkAccess != nil {
-					publicNetworkAccess = string(*ns.Properties.PublicNetworkAccess)
-				}
-				if ns.Properties.ZoneRedundant != nil {
-					zoneRedundant = *ns.Properties.ZoneRedundant
-				}
-				if enc := ns.Properties.Encryption; enc != nil {
-					if enc.KeySource != nil {
-						cmkKeySource = string(*enc.KeySource)
-					}
-					requireInfraEnc = enc.RequireInfrastructureEncryption
-					for _, kvp := range enc.KeyVaultProperties {
-						if kvp == nil {
-							continue
-						}
-						if d, err := convert.JsonToDict(kvp); err == nil {
-							cmkKeys = append(cmkKeys, d)
-						}
-					}
+				if d, err := convert.JsonToDict(kvp); err == nil {
+					cmkKeys = append(cmkKeys, d)
 				}
 			}
-
-			mqlNs, err := CreateResource(a.MqlRuntime, "azure.subscription.eventHubService.namespace", map[string]*llx.RawData{
-				"id":                              llx.StringDataPtr(ns.ID),
-				"name":                            llx.StringDataPtr(ns.Name),
-				"location":                        llx.StringDataPtr(ns.Location),
-				"tags":                            llx.MapData(convert.PtrMapStrToInterface(ns.Tags), types.String),
-				"sku":                             llx.DictData(sku),
-				"status":                          llx.StringData(status),
-				"isAutoInflateEnabled":            llx.BoolData(isAutoInflateEnabled),
-				"maximumThroughputUnits":          llx.IntData(maximumThroughputUnits),
-				"kafkaEnabled":                    llx.BoolData(kafkaEnabled),
-				"disableLocalAuth":                llx.BoolData(disableLocalAuth),
-				"minimumTlsVersion":               llx.StringData(minimumTlsVersion),
-				"publicNetworkAccess":             llx.StringData(publicNetworkAccess),
-				"zoneRedundant":                   llx.BoolData(zoneRedundant),
-				"cmkKeySource":                    llx.StringData(cmkKeySource),
-				"requireInfrastructureEncryption": llx.BoolDataPtr(requireInfraEnc),
-				"cmkKeys":                         llx.ArrayData(cmkKeys, types.Dict),
-				"creationTime":                    llx.TimeDataPtr(creationTime),
-				"alternateName":                   llx.StringDataPtr(alternateName),
-				"metricId":                        llx.StringDataPtr(metricId),
-				"clusterArmId":                    llx.StringDataPtr(clusterArmId),
-				"serviceBusEndpoint":              llx.StringDataPtr(serviceBusEndpoint),
-				"updatedAt":                       llx.TimeDataPtr(updatedAt),
-			})
-			if err != nil {
-				return nil, err
-			}
-			sysData, err := convert.JsonToDict(ns.SystemData)
-			if err != nil {
-				return nil, err
-			}
-			mqlNsRes := mqlNs.(*mqlAzureSubscriptionEventHubServiceNamespace)
-			mqlNsRes.cacheSystemData = sysData
-			if ns.Properties != nil {
-				mqlNsRes.cachePrivateEndpointConnections = ns.Properties.PrivateEndpointConnections
-			}
-			res = append(res, mqlNs)
 		}
 	}
 
-	return res, nil
+	return map[string]*llx.RawData{
+		"id":                              llx.StringDataPtr(ns.ID),
+		"name":                            llx.StringDataPtr(ns.Name),
+		"location":                        llx.StringDataPtr(ns.Location),
+		"tags":                            llx.MapData(convert.PtrMapStrToInterface(ns.Tags), types.String),
+		"sku":                             llx.DictData(sku),
+		"status":                          llx.StringData(status),
+		"isAutoInflateEnabled":            llx.BoolData(isAutoInflateEnabled),
+		"maximumThroughputUnits":          llx.IntData(maximumThroughputUnits),
+		"kafkaEnabled":                    llx.BoolData(kafkaEnabled),
+		"disableLocalAuth":                llx.BoolData(disableLocalAuth),
+		"minimumTlsVersion":               llx.StringData(minimumTlsVersion),
+		"publicNetworkAccess":             llx.StringData(publicNetworkAccess),
+		"zoneRedundant":                   llx.BoolData(zoneRedundant),
+		"cmkKeySource":                    llx.StringData(cmkKeySource),
+		"requireInfrastructureEncryption": llx.BoolDataPtr(requireInfraEnc),
+		"cmkKeys":                         llx.ArrayData(cmkKeys, types.Dict),
+		"creationTime":                    llx.TimeDataPtr(creationTime),
+		"alternateName":                   llx.StringDataPtr(alternateName),
+		"metricId":                        llx.StringDataPtr(metricId),
+		"clusterArmId":                    llx.StringDataPtr(clusterArmId),
+		"serviceBusEndpoint":              llx.StringDataPtr(serviceBusEndpoint),
+		"updatedAt":                       llx.TimeDataPtr(updatedAt),
+	}, nil
 }
 
 func (a *mqlAzureSubscriptionEventHubServiceNamespace) eventHubs() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-
-	resourceID, err := ParseResourceID(id)
+	conn, err := azureConn(a.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
 
-	nsName := a.Name.Data
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
 
-	client, err := armeventhub.NewEventHubsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+	client, err := armeventhub.NewEventHubsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	pager := client.NewListByNamespacePager(resourceID.ResourceGroup, nsName, nil)
-	var res []any
+	return listPaged(a.MqlRuntime, &a.EventHubs, "event hubs",
+		client.NewListByNamespacePager(resourceID.ResourceGroup, a.Name.Data, nil),
+		func(page armeventhub.EventHubsClientListByNamespaceResponse) []*armeventhub.Eventhub {
+			return page.Value
+		},
+		createEventHub,
+	)
+}
 
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, err
+// createEventHub builds the MQL resource for one event hub within a namespace.
+func createEventHub(runtime *plugin.Runtime, eh *armeventhub.Eventhub) (plugin.Resource, error) {
+	mqlEh, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace.eventHub",
+		createEventHubRawData(eh))
+	if err != nil {
+		return nil, err
+	}
+	sysData, err := convert.JsonToDict(eh.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlEh.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).cacheSystemData = sysData
+	return mqlEh, nil
+}
+
+// createEventHubRawData maps one event hub onto its MQL fields. Pure, so the
+// nil-Properties and nil-partition-id cases are testable without a namespace.
+func createEventHubRawData(eh *armeventhub.Eventhub) map[string]*llx.RawData {
+	var partitionCount, messageRetentionInDays int64
+	var status string
+	var partitionIds []any
+	var creationTime *time.Time
+	if eh.Properties != nil {
+		creationTime = eh.Properties.CreatedAt
+		if eh.Properties.PartitionCount != nil {
+			partitionCount = *eh.Properties.PartitionCount
 		}
-		for _, eh := range page.Value {
-			if eh == nil {
-				continue
-			}
-
-			var partitionCount, messageRetentionInDays int64
-			var status string
-			var partitionIds []any
-			var creationTime *time.Time
-			if eh.Properties != nil {
-				creationTime = eh.Properties.CreatedAt
-				if eh.Properties.PartitionCount != nil {
-					partitionCount = *eh.Properties.PartitionCount
-				}
-				if eh.Properties.MessageRetentionInDays != nil {
-					messageRetentionInDays = *eh.Properties.MessageRetentionInDays
-				}
-				if eh.Properties.Status != nil {
-					status = string(*eh.Properties.Status)
-				}
-				if eh.Properties.PartitionIDs != nil {
-					for _, pid := range eh.Properties.PartitionIDs {
-						if pid != nil {
-							partitionIds = append(partitionIds, *pid)
-						}
-					}
+		if eh.Properties.MessageRetentionInDays != nil {
+			messageRetentionInDays = *eh.Properties.MessageRetentionInDays
+		}
+		if eh.Properties.Status != nil {
+			status = string(*eh.Properties.Status)
+		}
+		if eh.Properties.PartitionIDs != nil {
+			for _, pid := range eh.Properties.PartitionIDs {
+				if pid != nil {
+					partitionIds = append(partitionIds, *pid)
 				}
 			}
-
-			mqlEh, err := CreateResource(a.MqlRuntime, "azure.subscription.eventHubService.namespace.eventHub", map[string]*llx.RawData{
-				"id":                     llx.StringDataPtr(eh.ID),
-				"name":                   llx.StringDataPtr(eh.Name),
-				"partitionCount":         llx.IntData(partitionCount),
-				"messageRetentionInDays": llx.IntData(messageRetentionInDays),
-				"status":                 llx.StringData(status),
-				"partitionIds":           llx.ArrayData(partitionIds, types.String),
-				"creationTime":           llx.TimeDataPtr(creationTime),
-			})
-			if err != nil {
-				return nil, err
-			}
-			sysData, err := convert.JsonToDict(eh.SystemData)
-			if err != nil {
-				return nil, err
-			}
-			mqlEh.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHub).cacheSystemData = sysData
-			res = append(res, mqlEh)
 		}
 	}
 
-	return res, nil
+	return map[string]*llx.RawData{
+		"id":                     llx.StringDataPtr(eh.ID),
+		"name":                   llx.StringDataPtr(eh.Name),
+		"partitionCount":         llx.IntData(partitionCount),
+		"messageRetentionInDays": llx.IntData(messageRetentionInDays),
+		"status":                 llx.StringData(status),
+		"partitionIds":           llx.ArrayData(partitionIds, types.String),
+		"creationTime":           llx.TimeDataPtr(creationTime),
+	}
 }
 
 func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() ([]any, error) {
@@ -450,6 +459,18 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() 
 	}
 
 	return res, nil
+}
+
+// networkRuleSet fetches the namespace-level network rule set.
+func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRuleSet() (any, error) {
+	props, err := a.fetchNetworkRuleSetProperties()
+	if err != nil {
+		return nil, err
+	}
+	if props == nil {
+		return nil, nil
+	}
+	return convert.JsonToDict(props)
 }
 
 func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRules() (*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules, error) {

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -421,27 +421,15 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() 
 		func(page armeventhub.ConsumerGroupsClientListByEventHubResponse) []*armeventhub.ConsumerGroup {
 			return page.Value
 		},
-		createConsumerGroup,
+		createEventHubConsumerGroup,
 	)
 }
 
-// createConsumerGroup builds the MQL resource for one consumer group of an event hub.
-func createConsumerGroup(runtime *plugin.Runtime, cg *armeventhub.ConsumerGroup) (plugin.Resource, error) {
-	var userMetadata string
-	var creationTime *time.Time
-	if cg.Properties != nil {
-		creationTime = cg.Properties.CreatedAt
-		if cg.Properties.UserMetadata != nil {
-			userMetadata = *cg.Properties.UserMetadata
-		}
-	}
-
-	mqlCg, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace.eventHub.consumerGroup", map[string]*llx.RawData{
-		"id":           llx.StringDataPtr(cg.ID),
-		"name":         llx.StringDataPtr(cg.Name),
-		"userMetadata": llx.StringData(userMetadata),
-		"creationTime": llx.TimeDataPtr(creationTime),
-	})
+// createEventHubConsumerGroup builds the MQL resource for one consumer group of
+// an event hub.
+func createEventHubConsumerGroup(runtime *plugin.Runtime, cg *armeventhub.ConsumerGroup) (plugin.Resource, error) {
+	mqlCg, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace.eventHub.consumerGroup",
+		createEventHubConsumerGroupRawData(cg))
 	if err != nil {
 		return nil, err
 	}
@@ -453,6 +441,27 @@ func createConsumerGroup(runtime *plugin.Runtime, cg *armeventhub.ConsumerGroup)
 	mqlCg.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).cacheSystemData = sysData
 
 	return mqlCg, nil
+}
+
+// createEventHubConsumerGroupRawData maps one consumer group onto its MQL
+// fields. Pure, so the nil-Properties case is reachable without an event hub
+// behind it -- the $Default group comes back that way.
+func createEventHubConsumerGroupRawData(cg *armeventhub.ConsumerGroup) map[string]*llx.RawData {
+	var userMetadata string
+	var creationTime *time.Time
+	if cg.Properties != nil {
+		creationTime = cg.Properties.CreatedAt
+		if cg.Properties.UserMetadata != nil {
+			userMetadata = *cg.Properties.UserMetadata
+		}
+	}
+
+	return map[string]*llx.RawData{
+		"id":           llx.StringDataPtr(cg.ID),
+		"name":         llx.StringDataPtr(cg.Name),
+		"userMetadata": llx.StringData(userMetadata),
+		"creationTime": llx.TimeDataPtr(creationTime),
+	}
 }
 
 func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRules() (*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules, error) {

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -74,7 +74,7 @@ func eventHubAuthorizationRulesToMql(runtime *plugin.Runtime, rules []*armeventh
 				rights = append(rights, string(*right))
 			}
 		}
-		mqlRule, err := CreateResource(runtime, "azure.subscription.eventHubService.authorizationRule", map[string]*llx.RawData{
+		mqlRule, err := CreateResource(runtime, ResourceAzureSubscriptionEventHubServiceAuthorizationRule, map[string]*llx.RawData{
 			"id":     llx.StringDataPtr(r.ID),
 			"name":   llx.StringDataPtr(r.Name),
 			"rights": llx.ArrayData(rights, types.String),
@@ -203,7 +203,7 @@ func createEventHubNamespace(runtime *plugin.Runtime, ns *armeventhub.EHNamespac
 		return nil, err
 	}
 
-	mqlNs, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace", rawData)
+	mqlNs, err := CreateResource(runtime, ResourceAzureSubscriptionEventHubServiceNamespace, rawData)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespace) eventHubs() ([]any, error
 
 // createEventHub builds the MQL resource for one event hub within a namespace.
 func createEventHub(runtime *plugin.Runtime, eh *armeventhub.Eventhub) (plugin.Resource, error) {
-	mqlEh, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace.eventHub",
+	mqlEh, err := CreateResource(runtime, ResourceAzureSubscriptionEventHubServiceNamespaceEventHub,
 		createEventHubRawData(eh))
 	if err != nil {
 		return nil, err
@@ -428,7 +428,7 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() 
 // createEventHubConsumerGroup builds the MQL resource for one consumer group of
 // an event hub.
 func createEventHubConsumerGroup(runtime *plugin.Runtime, cg *armeventhub.ConsumerGroup) (plugin.Resource, error) {
-	mqlCg, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace.eventHub.consumerGroup",
+	mqlCg, err := CreateResource(runtime, ResourceAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup,
 		createEventHubConsumerGroupRawData(cg))
 	if err != nil {
 		return nil, err
@@ -516,7 +516,7 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRules() (*mqlAzure
 			subnetID = *r.Subnet.ID
 		}
 		id := fmt.Sprintf("%s/networkRules/virtualNetworkRules/%d", a.Id.Data, i)
-		mqlRule, err := CreateResource(a.MqlRuntime, "azure.subscription.eventHubService.namespace.networkRules.virtualNetworkRule",
+		mqlRule, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionEventHubServiceNamespaceNetworkRulesVirtualNetworkRule,
 			map[string]*llx.RawData{
 				"__id":                             llx.StringData(id),
 				"ignoreMissingVnetServiceEndpoint": llx.BoolData(ignore),
@@ -528,13 +528,13 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRules() (*mqlAzure
 		vnetRules = append(vnetRules, mqlRule)
 	}
 
-	res, err := CreateResource(a.MqlRuntime, "azure.subscription.eventHubService.namespace.networkRules", map[string]*llx.RawData{
+	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionEventHubServiceNamespaceNetworkRules, map[string]*llx.RawData{
 		"__id":                        llx.StringData(a.Id.Data + "/networkRules"),
 		"defaultAction":               llx.StringData(defaultAction),
 		"publicNetworkAccess":         llx.StringData(publicNetworkAccess),
 		"trustedServiceAccessEnabled": llx.BoolData(trustedServiceAccess),
 		"ipRules":                     llx.ArrayData(ipRules, types.Dict),
-		"virtualNetworkRules":         llx.ArrayData(vnetRules, types.Resource("azure.subscription.eventHubService.namespace.networkRules.virtualNetworkRule")),
+		"virtualNetworkRules":         llx.ArrayData(vnetRules, types.Resource(ResourceAzureSubscriptionEventHubServiceNamespaceNetworkRulesVirtualNetworkRule)),
 	})
 	if err != nil {
 		return nil, err
@@ -586,7 +586,7 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceNetworkRulesVirtualNetworkR
 		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.subnet",
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceSubnet,
 		map[string]*llx.RawData{"id": llx.StringData(a.cacheSubnetID)})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/eventhub.go
+++ b/providers/azure/resources/eventhub.go
@@ -394,12 +394,12 @@ func createEventHubRawData(eh *armeventhub.Eventhub) map[string]*llx.RawData {
 }
 
 func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
+	conn, err := azureConn(a.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
 
-	resourceID, err := ParseResourceID(id)
+	resourceID, err := ParseResourceID(a.Id.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -409,68 +409,50 @@ func (a *mqlAzureSubscriptionEventHubServiceNamespaceEventHub) consumerGroups() 
 		return nil, err
 	}
 
-	ehName := a.Name.Data
-
-	client, err := armeventhub.NewConsumerGroupsClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
+	client, err := armeventhub.NewConsumerGroupsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	pager := client.NewListByEventHubPager(resourceID.ResourceGroup, nsName, ehName, nil)
-	var res []any
+	return listPaged(a.MqlRuntime, &a.ConsumerGroups, "event hub consumer groups",
+		client.NewListByEventHubPager(resourceID.ResourceGroup, nsName, a.Name.Data, nil),
+		func(page armeventhub.ConsumerGroupsClientListByEventHubResponse) []*armeventhub.ConsumerGroup {
+			return page.Value
+		},
+		createConsumerGroup,
+	)
+}
 
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, cg := range page.Value {
-			if cg == nil {
-				continue
-			}
-
-			var userMetadata string
-			var creationTime *time.Time
-			if cg.Properties != nil {
-				creationTime = cg.Properties.CreatedAt
-				if cg.Properties.UserMetadata != nil {
-					userMetadata = *cg.Properties.UserMetadata
-				}
-			}
-
-			mqlCg, err := CreateResource(a.MqlRuntime, "azure.subscription.eventHubService.namespace.eventHub.consumerGroup", map[string]*llx.RawData{
-				"id":           llx.StringDataPtr(cg.ID),
-				"name":         llx.StringDataPtr(cg.Name),
-				"userMetadata": llx.StringData(userMetadata),
-				"creationTime": llx.TimeDataPtr(creationTime),
-			})
-			if err != nil {
-				return nil, err
-			}
-			sysData, err := convert.JsonToDict(cg.SystemData)
-			if err != nil {
-				return nil, err
-			}
-			mqlCg.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).cacheSystemData = sysData
-			res = append(res, mqlCg)
+// createConsumerGroup builds the MQL resource for one consumer group of an event hub.
+func createConsumerGroup(runtime *plugin.Runtime, cg *armeventhub.ConsumerGroup) (plugin.Resource, error) {
+	var userMetadata string
+	var creationTime *time.Time
+	if cg.Properties != nil {
+		creationTime = cg.Properties.CreatedAt
+		if cg.Properties.UserMetadata != nil {
+			userMetadata = *cg.Properties.UserMetadata
 		}
 	}
 
-	return res, nil
-}
-
-// networkRuleSet fetches the namespace-level network rule set.
-func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRuleSet() (any, error) {
-	props, err := a.fetchNetworkRuleSetProperties()
+	mqlCg, err := CreateResource(runtime, "azure.subscription.eventHubService.namespace.eventHub.consumerGroup", map[string]*llx.RawData{
+		"id":           llx.StringDataPtr(cg.ID),
+		"name":         llx.StringDataPtr(cg.Name),
+		"userMetadata": llx.StringData(userMetadata),
+		"creationTime": llx.TimeDataPtr(creationTime),
+	})
 	if err != nil {
 		return nil, err
 	}
-	if props == nil {
-		return nil, nil
+
+	sysData, err := convert.JsonToDict(cg.SystemData)
+	if err != nil {
+		return nil, err
 	}
-	return convert.JsonToDict(props)
+	mqlCg.(*mqlAzureSubscriptionEventHubServiceNamespaceEventHubConsumerGroup).cacheSystemData = sysData
+
+	return mqlCg, nil
 }
 
 func (a *mqlAzureSubscriptionEventHubServiceNamespace) networkRules() (*mqlAzureSubscriptionEventHubServiceNamespaceNetworkRules, error) {

--- a/providers/azure/resources/eventhub_test.go
+++ b/providers/azure/resources/eventhub_test.go
@@ -1,0 +1,139 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These exercise the mapping half of the two listers migrated onto listPaged.
+// Splitting the map out of the pager walk is what makes them possible: before
+// the split the only way to reach this code was through an ARM client and a
+// live subscription.
+
+func TestCreateEventHubNamespaceRawData(t *testing.T) {
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	keySource := "Microsoft.KeyVault"
+	tlsVersion := armeventhub.TLSVersionOne2
+	publicAccess := armeventhub.PublicNetworkAccessDisabled
+
+	ns := &armeventhub.EHNamespace{
+		ID:       ptr("/subscriptions/s/resourceGroups/rg/providers/Microsoft.EventHub/namespaces/ns1"),
+		Name:     ptr("ns1"),
+		Location: ptr("westeurope"),
+		Tags:     map[string]*string{"env": ptr("prod")},
+		Properties: &armeventhub.EHNamespaceProperties{
+			CreatedAt:              &created,
+			Status:                 ptr("Active"),
+			IsAutoInflateEnabled:   ptr(true),
+			MaximumThroughputUnits: ptr(int32(12)),
+			KafkaEnabled:           ptr(true),
+			DisableLocalAuth:       ptr(true),
+			MinimumTLSVersion:      &tlsVersion,
+			PublicNetworkAccess:    &publicAccess,
+			ZoneRedundant:          ptr(true),
+			Encryption: &armeventhub.Encryption{
+				KeySource:                       &keySource,
+				RequireInfrastructureEncryption: ptr(true),
+				KeyVaultProperties: []*armeventhub.KeyVaultProperties{
+					{KeyName: ptr("cmk1")},
+				},
+			},
+		},
+	}
+
+	raw, err := createEventHubNamespaceRawData(ns)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/subscriptions/s/resourceGroups/rg/providers/Microsoft.EventHub/namespaces/ns1", raw["id"].Value)
+	assert.Equal(t, "ns1", raw["name"].Value)
+	assert.Equal(t, "westeurope", raw["location"].Value)
+	assert.Equal(t, "Active", raw["status"].Value)
+	assert.Equal(t, true, raw["isAutoInflateEnabled"].Value)
+	assert.Equal(t, int64(12), raw["maximumThroughputUnits"].Value)
+	assert.Equal(t, true, raw["kafkaEnabled"].Value)
+	assert.Equal(t, true, raw["disableLocalAuth"].Value)
+	assert.Equal(t, "1.2", raw["minimumTlsVersion"].Value)
+	assert.Equal(t, "Disabled", raw["publicNetworkAccess"].Value)
+	assert.Equal(t, true, raw["zoneRedundant"].Value)
+	assert.Equal(t, "Microsoft.KeyVault", raw["cmkKeySource"].Value)
+	assert.Equal(t, true, raw["requireInfrastructureEncryption"].Value)
+	assert.Len(t, raw["cmkKeys"].Value, 1)
+	assert.Equal(t, &created, raw["creationTime"].Value)
+}
+
+// ARM omits the whole properties block on some rows. Dereferencing it panics,
+// and a panic in an accessor ends the scan rather than the query.
+func TestCreateEventHubNamespaceRawDataWithoutProperties(t *testing.T) {
+	ns := &armeventhub.EHNamespace{ID: ptr("/subscriptions/s/x/ns1"), Name: ptr("ns1")}
+
+	raw, err := createEventHubNamespaceRawData(ns)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ns1", raw["name"].Value)
+	assert.Equal(t, "", raw["status"].Value)
+	assert.Equal(t, false, raw["kafkaEnabled"].Value)
+	assert.Nil(t, raw["creationTime"].Value)
+	assert.Nil(t, raw["requireInfrastructureEncryption"].Value)
+}
+
+// A nil entry inside KeyVaultProperties must be skipped, not dereferenced.
+func TestCreateEventHubNamespaceRawDataSkipsNilKeyVaultProperties(t *testing.T) {
+	ns := &armeventhub.EHNamespace{
+		Name: ptr("ns1"),
+		Properties: &armeventhub.EHNamespaceProperties{
+			Encryption: &armeventhub.Encryption{
+				KeyVaultProperties: []*armeventhub.KeyVaultProperties{
+					nil,
+					{KeyName: ptr("cmk1")},
+					nil,
+				},
+			},
+		},
+	}
+
+	raw, err := createEventHubNamespaceRawData(ns)
+
+	require.NoError(t, err)
+	assert.Len(t, raw["cmkKeys"].Value, 1)
+}
+
+func TestCreateEventHubRawData(t *testing.T) {
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	status := armeventhub.EntityStatusActive
+
+	raw := createEventHubRawData(&armeventhub.Eventhub{
+		ID:   ptr("/subscriptions/s/resourceGroups/rg/providers/Microsoft.EventHub/namespaces/ns1/eventhubs/eh1"),
+		Name: ptr("eh1"),
+		Properties: &armeventhub.Properties{
+			CreatedAt:              &created,
+			PartitionCount:         ptr(int64(4)),
+			MessageRetentionInDays: ptr(int64(7)),
+			Status:                 &status,
+			PartitionIDs:           []*string{ptr("0"), nil, ptr("1")},
+		},
+	})
+
+	assert.Equal(t, "eh1", raw["name"].Value)
+	assert.Equal(t, int64(4), raw["partitionCount"].Value)
+	assert.Equal(t, int64(7), raw["messageRetentionInDays"].Value)
+	assert.Equal(t, "Active", raw["status"].Value)
+	// the nil partition id is skipped rather than dereferenced
+	assert.Equal(t, []any{"0", "1"}, raw["partitionIds"].Value)
+	assert.Equal(t, &created, raw["creationTime"].Value)
+}
+
+func TestCreateEventHubRawDataWithoutProperties(t *testing.T) {
+	raw := createEventHubRawData(&armeventhub.Eventhub{Name: ptr("eh1")})
+
+	assert.Equal(t, "eh1", raw["name"].Value)
+	assert.Equal(t, int64(0), raw["partitionCount"].Value)
+	assert.Equal(t, "", raw["status"].Value)
+	assert.Nil(t, raw["creationTime"].Value)
+}

--- a/providers/azure/resources/eventhub_test.go
+++ b/providers/azure/resources/eventhub_test.go
@@ -137,3 +137,33 @@ func TestCreateEventHubRawDataWithoutProperties(t *testing.T) {
 	assert.Equal(t, "", raw["status"].Value)
 	assert.Nil(t, raw["creationTime"].Value)
 }
+
+func TestCreateEventHubConsumerGroupRawData(t *testing.T) {
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	raw := createEventHubConsumerGroupRawData(&armeventhub.ConsumerGroup{
+		ID:   ptr("/subscriptions/s/resourceGroups/rg/providers/Microsoft.EventHub/namespaces/ns1/eventhubs/eh1/consumergroups/cg1"),
+		Name: ptr("cg1"),
+		Properties: &armeventhub.ConsumerGroupProperties{
+			CreatedAt:    &created,
+			UserMetadata: ptr("owner=platform"),
+		},
+	})
+
+	assert.Equal(t, "/subscriptions/s/resourceGroups/rg/providers/Microsoft.EventHub/namespaces/ns1/eventhubs/eh1/consumergroups/cg1", raw["id"].Value)
+	assert.Equal(t, "cg1", raw["name"].Value)
+	assert.Equal(t, "owner=platform", raw["userMetadata"].Value)
+	assert.Equal(t, &created, raw["creationTime"].Value)
+}
+
+// The $Default consumer group comes back with no properties block at all.
+// Dereferencing it panics, and a panic in an accessor ends the scan rather than
+// the query.
+func TestCreateEventHubConsumerGroupRawDataWithoutProperties(t *testing.T) {
+	raw := createEventHubConsumerGroupRawData(&armeventhub.ConsumerGroup{Name: ptr("$Default")})
+
+	assert.Equal(t, "$Default", raw["name"].Value)
+	assert.Equal(t, "", raw["userMetadata"].Value)
+	// an absent creation time stays null rather than becoming the zero time
+	assert.Nil(t, raw["creationTime"].Value)
+}

--- a/providers/azure/resources/lister.go
+++ b/providers/azure/resources/lister.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers/azure/connection"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/azure/connection"
 )
 
 // Nearly every list accessor in this provider walks an ARM pager and turns each

--- a/providers/azure/resources/lister.go
+++ b/providers/azure/resources/lister.go
@@ -1,0 +1,184 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// Nearly every list accessor in this provider walks an ARM pager and turns each
+// row into an MQL resource. Written out per call site, that loop is about
+// fifteen lines of scaffolding around two lines of service-specific logic -- and
+// four of the things it does are decisions rather than mechanism: how long a
+// call may take, what a denied read reports, what a truncated walk reports, and
+// whether a nil row is dropped or dereferenced. Made independently a few hundred
+// times, those decisions drift, and the drift is invisible because nothing
+// fails: the list still has a length, the rows are just wrong or absent.
+//
+// listPaged makes them once. What is left at each call site is the pager and a
+// mapping function, which is the part that actually differs between services --
+// and, being pure, the part that can be tested without a subscription.
+
+// listPagerTimeout bounds a single page fetch.
+//
+// The plugin API gives an accessor no context to inherit, so there is nothing to
+// propagate a cancelled scan from; the best available is to make sure no single
+// call can hang forever. The bound is per page rather than per walk so that a
+// large collection is not cut off partway through merely for being large.
+//
+// Matches armHTTPTimeout in arm_paging.go, which bounds the hand-rolled requests
+// for the same reason.
+const listPagerTimeout = 60 * time.Second
+
+// pager is the part of *azruntime.Pager[P] that listPaged uses. Depending on the
+// interface rather than the concrete SDK type is what lets the walk be tested
+// against a fake that returns pages and errors on demand, with no HTTP and no
+// credential.
+type pager[P any] interface {
+	More() bool
+	NextPage(context.Context) (P, error)
+}
+
+// azureFaultKind classifies an ARM error by what the caller should report,
+// rather than by what went wrong.
+type azureFaultKind int
+
+const (
+	// faultFatal is anything that proves nothing about the resource: a
+	// throttle, a 5xx, a transport failure, an expired credential. It must
+	// surface as an error. Reporting it as "nothing here" would state as fact
+	// something the call never established.
+	faultFatal azureFaultKind = iota
+
+	// faultDenied is a 403: the collection exists, and this identity may not
+	// see it. The honest answer is null -- unknown -- not an empty list.
+	//
+	// This distinction is the whole reason the type exists. An empty list is a
+	// claim that there is nothing there, and a policy written as
+	// `things.none(insecure)` passes on it. Reported for a read that was
+	// refused, that is a silent pass on an unexamined subscription.
+	faultDenied
+
+	// faultAbsent is a 404: the resource provider is not registered in this
+	// subscription, or the service is not available here. Unlike a denial this
+	// is an answer -- there are genuinely zero resources of this kind -- so an
+	// empty list is correct and a null would understate what is known.
+	faultAbsent
+)
+
+// azureFault classifies err.
+//
+// It deliberately does not treat 429 or 5xx as anything but fatal: a throttled
+// or failing call says nothing about whether the collection is empty, and
+// degrading it would report an authoritative answer derived from no data.
+//
+// note: the provider still carries about ten hand-written variants of this
+// predicate (isAzureForbidden, isCosmosForbiddenError, isFunctionAppForbiddenError
+// and so on) plus a further ~99 inline status checks. Folding those onto this
+// function is follow-up work; this is the classifier the shared lister uses.
+func azureFault(err error) azureFaultKind {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return faultFatal
+	}
+	switch respErr.StatusCode {
+	case http.StatusForbidden:
+		return faultDenied
+	case http.StatusNotFound:
+		return faultAbsent
+	default:
+		return faultFatal
+	}
+}
+
+// listPaged walks every page of an ARM pager and builds one MQL resource per
+// row.
+//
+// field is the resource field being computed. listPaged writes null into it
+// directly when the read was denied; returning (nil, nil) would not do it,
+// because GetOrCompute renders an unset nil slice as an empty list -- which is
+// exactly the silent pass faultDenied exists to prevent. GetOrCompute checks
+// whether the field was set proactively and keeps that value, so setting it here
+// is the supported way to report null from an accessor.
+//
+// what names the collection for log messages, e.g. "event hub namespaces".
+func listPaged[P, I any](
+	runtime *plugin.Runtime,
+	field *plugin.TValue[[]any],
+	what string,
+	p pager[P],
+	pageItems func(P) []*I,
+	create func(*plugin.Runtime, *I) (plugin.Resource, error),
+) ([]any, error) {
+	var res []any
+
+	for p.More() {
+		ctx, cancel := context.WithTimeout(context.Background(), listPagerTimeout)
+		page, err := p.NextPage(ctx)
+		cancel()
+
+		if err != nil {
+			// A fault partway through a walk is not the same as a fault on the
+			// first page. Returning what was collected so far would present a
+			// truncated collection as a complete one, and a policy cannot tell
+			// the difference -- so once any row has been read, only a complete
+			// walk may be reported.
+			if len(res) > 0 {
+				return nil, errors.New("could not read all " + what + ": " + err.Error())
+			}
+
+			switch azureFault(err) {
+			case faultDenied:
+				log.Warn().Err(err).Str("collection", what).
+					Msg("azure> not permitted to list, reporting null")
+				field.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
+			case faultAbsent:
+				log.Debug().Err(err).Str("collection", what).
+					Msg("azure> not available in this subscription, reporting an empty list")
+				return []any{}, nil
+			default:
+				return nil, err
+			}
+		}
+
+		for _, item := range pageItems(page) {
+			// ARM omits rows on occasion; dereferencing one would panic, and a
+			// panic in an accessor takes down the whole scan rather than the
+			// one query, because the executor runs blocks in goroutines.
+			if item == nil {
+				continue
+			}
+			resource, err := create(runtime, item)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, resource)
+		}
+	}
+
+	return res, nil
+}
+
+// azureConn returns the Azure connection behind a runtime.
+//
+// The unchecked form of this assertion appears at ~394 sites in this package.
+// Each is a panic waiting on a connection of the wrong type, and a panic in an
+// accessor is unrecoverable -- the executor runs blocks in goroutines, so it
+// ends the scan rather than the query.
+func azureConn(runtime *plugin.Runtime) (*connection.AzureConnection, error) {
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	return conn, nil
+}

--- a/providers/azure/resources/lister_test.go
+++ b/providers/azure/resources/lister_test.go
@@ -1,0 +1,262 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// --- fixtures ---------------------------------------------------------------
+
+// fakeItem stands in for an ARM row.
+type fakeItem struct{ name string }
+
+// fakePage stands in for an ARM list response.
+type fakePage struct{ values []*fakeItem }
+
+// fakePager replays a fixed script of pages and errors. Each entry is either a
+// page or an error; the pager reports More until the script is exhausted.
+type fakePager struct {
+	pages []fakePage
+	errs  []error // errs[i], when non-nil, is returned instead of pages[i]
+	at    int
+	// deadlines records whether each NextPage call arrived with a deadline set,
+	// so a test can assert the timeout is actually applied.
+	deadlines []bool
+}
+
+func (p *fakePager) More() bool { return p.at < len(p.pages) }
+
+func (p *fakePager) NextPage(ctx context.Context) (fakePage, error) {
+	_, ok := ctx.Deadline()
+	p.deadlines = append(p.deadlines, ok)
+
+	i := p.at
+	p.at++
+	if i < len(p.errs) && p.errs[i] != nil {
+		return fakePage{}, p.errs[i]
+	}
+	return p.pages[i], nil
+}
+
+func fakePageItems(p fakePage) []*fakeItem { return p.values }
+
+// stubResource is the minimum that satisfies plugin.Resource, so listPaged can
+// be exercised without a runtime or a schema.
+type stubResource struct{ id string }
+
+func (r *stubResource) MqlID() string   { return r.id }
+func (r *stubResource) MqlName() string { return "stub" }
+
+func stubCreate(_ *plugin.Runtime, item *fakeItem) (plugin.Resource, error) {
+	return &stubResource{id: item.name}, nil
+}
+
+func items(names ...string) []*fakeItem {
+	res := make([]*fakeItem, 0, len(names))
+	for _, n := range names {
+		res = append(res, &fakeItem{name: n})
+	}
+	return res
+}
+
+func ids(t *testing.T, res []any) []string {
+	t.Helper()
+	out := make([]string, 0, len(res))
+	for _, r := range res {
+		s, ok := r.(*stubResource)
+		require.True(t, ok, "unexpected element type %T", r)
+		out = append(out, s.id)
+	}
+	return out
+}
+
+// --- azureFault -------------------------------------------------------------
+
+func TestAzureFault(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want azureFaultKind
+	}{
+		{"403 is denied", armError(http.StatusForbidden, ""), faultDenied},
+		{"404 is absent", armError(http.StatusNotFound, ""), faultAbsent},
+		// A throttle or a server error proves nothing about the collection.
+		// Degrading either one would report an authoritative answer derived
+		// from a call that never returned data.
+		{"429 is fatal", armError(http.StatusTooManyRequests, ""), faultFatal},
+		{"500 is fatal", armError(http.StatusInternalServerError, ""), faultFatal},
+		{"401 is fatal", armError(http.StatusUnauthorized, ""), faultFatal},
+		{"a plain error is fatal", errors.New("dial tcp: i/o timeout"), faultFatal},
+		{"nil is fatal", nil, faultFatal},
+		{
+			"a wrapped response error is still classified",
+			fmt.Errorf("listing namespaces: %w", armError(http.StatusForbidden, "")),
+			faultDenied,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, azureFault(tt.err))
+		})
+	}
+}
+
+// --- listPaged --------------------------------------------------------------
+
+func TestListPagedWalksEveryPage(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{pages: []fakePage{
+		{values: items("a", "b")},
+		{values: items("c")},
+	}}
+
+	res, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, ids(t, res))
+	assert.False(t, field.IsSet(), "a successful walk must leave the field to GetOrCompute")
+}
+
+func TestListPagedSkipsNilItems(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{pages: []fakePage{
+		{values: []*fakeItem{{name: "a"}, nil, {name: "b"}}},
+	}}
+
+	res, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, ids(t, res))
+}
+
+func TestListPagedEmptyCollection(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{pages: []fakePage{{values: nil}}}
+
+	res, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+	require.NoError(t, err)
+	assert.Empty(t, res)
+	assert.False(t, field.IsSet())
+}
+
+// A denied read must report null, not an empty list. An empty list is a claim
+// that there is nothing there, and `things.none(insecure)` passes on it -- so
+// reporting one for a read that was refused is a silent pass on a collection
+// nobody was able to look at.
+func TestListPagedDeniedReportsNullNotEmpty(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{
+		pages: []fakePage{{}},
+		errs:  []error{armError(http.StatusForbidden, "")},
+	}
+
+	res, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	require.True(t, field.IsSet(), "the field must be set proactively, or GetOrCompute renders nil as []")
+	assert.True(t, field.IsNull())
+}
+
+// A 404 means the resource provider is not registered here, which is an answer:
+// there are genuinely zero resources. An empty list is correct and a null would
+// understate what the call established.
+func TestListPagedAbsentReportsEmptyList(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{
+		pages: []fakePage{{}},
+		errs:  []error{armError(http.StatusNotFound, "")},
+	}
+
+	res, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Empty(t, res)
+	assert.False(t, field.IsSet(), "an absent collection is a normal empty result")
+}
+
+func TestListPagedFatalErrorSurfaces(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{
+		pages: []fakePage{{}},
+		errs:  []error{armError(http.StatusTooManyRequests, "")},
+	}
+
+	res, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.False(t, field.IsSet())
+}
+
+// Once any row has been read, a later fault must not degrade: returning the rows
+// collected so far would present a truncated collection as a complete one, and
+// no policy can tell the difference. This is the case the per-call-site loops
+// got wrong in both directions -- some returned partial results, some returned
+// the error.
+func TestListPagedDoesNotDegradeAfterPartialRead(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var field plugin.TValue[[]any]
+			pager := &fakePager{
+				pages: []fakePage{{values: items("a")}, {}},
+				errs:  []error{nil, armError(status, "")},
+			}
+
+			res, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "could not read all things")
+			assert.Nil(t, res, "a truncated collection must not be returned as complete")
+			assert.False(t, field.IsSet())
+		})
+	}
+}
+
+func TestListPagedPropagatesCreateErrors(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{pages: []fakePage{{values: items("a", "b")}}}
+	boom := errors.New("schema mismatch")
+
+	res, err := listPaged(nil, &field, "things", pager, fakePageItems,
+		func(_ *plugin.Runtime, item *fakeItem) (plugin.Resource, error) {
+			if item.name == "b" {
+				return nil, boom
+			}
+			return &stubResource{id: item.name}, nil
+		})
+
+	require.ErrorIs(t, err, boom)
+	assert.Nil(t, res)
+}
+
+// The plugin API hands an accessor no context to inherit, so listPaged builds
+// one. If it ever stops doing so, a hung ARM call stalls the field forever with
+// nothing to time it out.
+func TestListPagedBoundsEachPage(t *testing.T) {
+	var field plugin.TValue[[]any]
+	pager := &fakePager{pages: []fakePage{
+		{values: items("a")},
+		{values: items("b")},
+	}}
+
+	_, err := listPaged(nil, &field, "things", pager, fakePageItems, stubCreate)
+
+	require.NoError(t, err)
+	require.Len(t, pager.deadlines, 2)
+	for i, hasDeadline := range pager.deadlines {
+		assert.True(t, hasDeadline, "page %d was fetched with no deadline", i)
+	}
+}

--- a/providers/azure/resources/lister_test.go
+++ b/providers/azure/resources/lister_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
 // --- fixtures ---------------------------------------------------------------


### PR DESCRIPTION
## What

344 list accessors in this provider walk an ARM pager and turn each row into an MQL resource. Written out per call site that is ~15 lines of scaffolding around two lines of service-specific logic — and **four of the things it does are decisions, not mechanism**:

| Decision | Today |
|---|---|
| How long a single call may take | no bound at all — 490 bare `context.Background()` |
| What a denied read reports | three different answers: partial results, the error, or an explicit `[]any{}` |
| What a truncated walk reports | whatever the call site happened to do |
| Whether a nil row is dropped or dereferenced | mostly dropped; a deref panics, and a panic in an accessor ends the **scan**, not the query |

Made independently a few hundred times, those decisions drift. The drift is silent: the list still has a length, the rows are just wrong or absent.

`listPaged` makes them once.

## The policy it encodes

- **403 → null, not an empty list.** An empty list is a claim that there is nothing there, and `things.none(insecure)` passes on it. Reported for a read that was *refused*, that is a silent pass on an unexamined subscription. `GetOrCompute` renders an unset nil slice as `[]`, so the field has to be set proactively for a null to survive — that's why the helper takes the field.
- **404 → empty list.** The resource provider isn't registered in this subscription, which is an answer: there are genuinely zero resources. A null would understate what the call established.
- **429 / 5xx → fatal.** A throttled or failing call proves nothing about the collection. Degrading it would report an authoritative answer derived from no data.
- **Any fault after a row has been read → fatal, regardless of status.** Returning what was collected presents a truncated collection as a complete one, and no policy can tell the difference.

## Before / after

```go
// before — repeated 344 times
conn := a.MqlRuntime.Connection.(*connection.AzureConnection)   // panics → kills the scan
ctx := context.Background()                                     // no deadline
pager := client.NewListPager(nil)
for pager.More() {
    page, err := pager.NextPage(ctx)
    if err != nil { return nil, err }                           // 403 → error here, [] elsewhere
    for _, ns := range page.Value { ... }
}

// after
return listPaged(a.MqlRuntime, &a.Namespaces, "event hub namespaces",
    client.NewListPager(nil),
    func(page armeventhub.NamespacesClientListResponse) []*armeventhub.EHNamespace { return page.Value },
    createEventHubNamespace,
)
```

## Testability

`listPaged` takes the pager through a two-method interface rather than the concrete `*azruntime.Pager`, so the walk runs against a fake that replays pages and errors on demand — no HTTP, no credential, no subscription. **13 tests** cover the walk (multi-page, nil rows, empty, denied, absent, fatal, mid-walk fault, create errors, per-page deadline) and the classifier (403/404/429/500/401/plain/wrapped).

The two migrated Event Hub listers also get their mapping split into `create*RawData` functions, following the convention `batch.go` and `cosmosdb_extras.go` already use. That split is what makes the mapping reachable at all — before it, the only route to this code was an ARM client and a live subscription. **5 tests** cover the row shapes ARM actually returns, including a nil `Properties` block and a nil entry inside `KeyVaultProperties`.

## Scope

Two listers migrated, deliberately: one subscription-scoped, one parent-scoped, to prove the shape generalises. The remaining 342 are follow-up, service by service.

**Field semantics are unchanged in this pass** — the error policy above is the only behaviour change. The pointer sweep (535 sites where an absent `*bool` is published as `false`) is separate work with its own discussion, since it flips values policies may depend on.

`azureConn` is included because `listPaged`'s call sites need it; folding the other ~394 unchecked assertions onto it is not in this PR. Likewise `azureFault` is the classifier the shared lister uses — consolidating the ten hand-written `isXxxForbidden` predicates and ~99 inline status checks onto it is called out in a comment as follow-up.

## Context

Second of two PRs from an azure provider audit; #9754 (discovery tag filters) is the other. They are independent and can merge in any order.
