### PR TITLE
🧹 aws: centralize region fan-out and AWS error classification

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -45,6 +45,9 @@ type AwsConnection struct {
 	awsConfigOptions []func(*config.LoadOptions) error
 	PlatformOverride string
 	Filters          DiscoveryFilters
+	// gaps records service/region pairs this scan could not read. See
+	// coverage.go for why an unreadable region must not look like an empty one.
+	gaps coverageGaps
 
 	opts awsConnectionOptions
 }

--- a/providers/aws/connection/coverage.go
+++ b/providers/aws/connection/coverage.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+)
+
+// GapReason explains why a service/region pair produced no data.
+type GapReason string
+
+const (
+	// GapDenied means the caller lacked permission to make the read. The
+	// resource list is empty, but empty is not the truth: there may well be
+	// resources there that the scan could not see.
+	GapDenied GapReason = "access denied"
+	// GapFailed means the read was attempted and errored for a reason that is
+	// neither a permission gap nor an absent service (a throttle, a 5xx, a
+	// malformed response).
+	GapFailed GapReason = "read failed"
+)
+
+// Gap is a single service/region pair the scan could not read.
+type Gap struct {
+	Service string
+	Region  string
+	Reason  GapReason
+}
+
+// coverageGaps records the reads a scan was not able to make.
+//
+// AWS gives a denied read and an empty account the same observable shape: a
+// list accessor that returns no rows. Left at that, a policy asserting over an
+// empty list passes vacuously, and a permission gap reads as a clean bill of
+// health. Recording the gaps lets the scan say which answers it does not
+// actually have.
+type coverageGaps struct {
+	mu   sync.Mutex
+	gaps map[Gap]struct{}
+}
+
+func (c *coverageGaps) record(g Gap) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.gaps == nil {
+		c.gaps = map[Gap]struct{}{}
+	}
+	if _, seen := c.gaps[g]; seen {
+		return
+	}
+	c.gaps[g] = struct{}{}
+	// Warn once per unique gap. A denied read fans out across every region of
+	// every service the caller cannot see, so logging per occurrence would bury
+	// the signal in its own repetition.
+	log.Warn().
+		Str("service", g.Service).
+		Str("region", g.Region).
+		Str("reason", string(g.Reason)).
+		Msg("no data collected; results for this service and region are incomplete")
+}
+
+func (c *coverageGaps) list() []Gap {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Gap, 0, len(c.gaps))
+	for g := range c.gaps {
+		out = append(out, g)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Service != out[j].Service {
+			return out[i].Service < out[j].Service
+		}
+		return out[i].Region < out[j].Region
+	})
+	return out
+}
+
+// RecordGap notes that the scan could not read service in region, and why. It
+// is safe for concurrent use and deduplicates, so callers may report the same
+// gap from every lister that hits it.
+func (c *AwsConnection) RecordGap(service, region string, reason GapReason) {
+	c.gaps.record(Gap{Service: service, Region: region, Reason: reason})
+}
+
+// CoverageGaps returns every service/region pair this connection failed to
+// read, sorted by service then region. It is the set of answers the scan does
+// not have, as distinct from the answers that are genuinely empty.
+func (c *AwsConnection) CoverageGaps() []Gap {
+	return c.gaps.list()
+}

--- a/providers/aws/resources/aws_disposition.go
+++ b/providers/aws/resources/aws_disposition.go
@@ -1,0 +1,191 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"github.com/aws/smithy-go"
+	"github.com/cockroachdb/errors"
+)
+
+// disposition is what a lister should do about an AWS error.
+//
+// The same error text can mean three very different things, and conflating them
+// is how a scan reports a clean result it never actually collected. Deciding
+// this once, centrally, keeps every lister out of the business of guessing.
+type disposition int
+
+const (
+	// dispositionFail means the answer is unknown because the call went wrong:
+	// a throttle, a 5xx, a malformed request. The caller must surface it.
+	dispositionFail disposition = iota
+	// dispositionEmpty means there is genuinely nothing to report: the service
+	// is not deployed in this region, or the account never opted in. Zero rows
+	// is the truthful answer.
+	dispositionEmpty
+	// dispositionUnreadable means the read was refused. Zero rows is NOT the
+	// truthful answer, so the caller records a coverage gap rather than letting
+	// the absence pass for an all-clear.
+	dispositionUnreadable
+)
+
+// accessDeniedCodes are the API error codes AWS returns when the caller is not
+// permitted to make the call.
+//
+// These are matched on smithy's ErrorCode rather than on the rendered message.
+// Codes are part of the API contract; messages are prose AWS rewrites at will,
+// and a guard keyed on prose stops firing the day a wording changes.
+var accessDeniedCodes = map[string]bool{
+	"AccessDenied":                true,
+	"AccessDeniedException":       true,
+	"AuthorizationError":          true,
+	"AuthFailure":                 true,
+	"UnauthorizedOperation":       true,
+	"UnauthorizedException":       true,
+	"MissingAuthenticationToken":  true,
+	"InvalidClientTokenId":        true,
+	"UnrecognizedClientException": true,
+	"InvalidAccessKeyId":          true,
+	"SignatureDoesNotMatch":       true,
+}
+
+// serviceAbsentCodes are the API error codes meaning the service or operation
+// does not exist here, as opposed to existing and being refused.
+var serviceAbsentCodes = map[string]bool{
+	// The region exists but the account has not opted into it.
+	"OptInRequired": true,
+	// The endpoint resolved but does not implement this operation, which is how
+	// several services answer in regions they have not been deployed to yet.
+	"UnknownOperationException": true,
+	"InvalidAction":             true,
+	"NotImplemented":            true,
+	"MethodNotAllowed":          true,
+	// The service exists but has never been turned on for this account.
+	"SubscriptionRequiredException": true,
+}
+
+// dispositionRule matches errors whose meaning cannot be read off the code
+// alone. Every field left at its zero value is a wildcard.
+type dispositionRule struct {
+	// code, when set, must equal the smithy API error code.
+	code string
+	// messageAny, when set, requires the error text to contain at least one of
+	// these substrings, compared after apostrophe normalization.
+	messageAny []string
+	// disposition is the answer when the rule matches.
+	disposition disposition
+}
+
+func (r dispositionRule) matches(err error, msg string) bool {
+	if r.code != "" {
+		var ae smithy.APIError
+		if !errors.As(err, &ae) || ae.ErrorCode() != r.code {
+			return false
+		}
+	}
+	if len(r.messageAny) == 0 {
+		return true
+	}
+	for _, want := range r.messageAny {
+		if strings.Contains(msg, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// serviceRules carries per-service overrides, consulted before the generic code
+// tables.
+//
+// A handful of services have no distinct code for "this was never enabled for
+// your account" and reuse AccessDeniedException or ResourceNotFoundException,
+// putting the distinguishing fact in the message. Those are the only cases that
+// legitimately need message matching, and confining them here keeps the rest of
+// the provider off prose entirely.
+var serviceRules = map[string][]dispositionRule{
+	"macie2": {
+		{
+			code:        "AccessDeniedException",
+			messageAny:  []string{"Macie is not enabled", "Macie isn't enabled"},
+			disposition: dispositionEmpty,
+		},
+		// Macie answers a not-found on its list and get endpoints when the
+		// account has nothing configured in the region, so a bare not-found
+		// here is an empty result rather than a miss worth reporting.
+		{
+			code:        "ResourceNotFoundException",
+			disposition: dispositionEmpty,
+		},
+	},
+	"securitylake": {
+		{
+			code:        "ResourceNotFoundException",
+			messageAny:  []string{"Security Lake is not enabled", "Security Lake isn't enabled"},
+			disposition: dispositionEmpty,
+		},
+	},
+	"guardduty": {
+		{
+			code:        "BadRequestException",
+			messageAny:  []string{"is not enabled", "isn't enabled"},
+			disposition: dispositionEmpty,
+		},
+	},
+}
+
+// transportRegionMisses are the failures that happen below the API layer, where
+// there is no code to match because no request ever completed: the endpoint does
+// not resolve, or every attempt failed to leave the client.
+//
+// This is the one place raw text matching is unavoidable. The strings are the
+// SDK's and Go's own, not AWS service prose, so they are far more stable than
+// the service messages this table exists to avoid.
+var transportRegionMisses = []string{
+	"no such host",
+	"UnknownEndpoint",
+	"could not resolve endpoint",
+}
+
+// classifyError decides what a lister should do about err from the named
+// service. service is the AWS service id, matching the key used to build the
+// client (for example "ecr", "macie2", "rds").
+func classifyError(service string, err error) disposition {
+	if err == nil {
+		return dispositionFail
+	}
+	msg := awsNormalizeApostrophes(err.Error())
+
+	for _, rule := range serviceRules[service] {
+		if rule.matches(err, msg) {
+			return rule.disposition
+		}
+	}
+
+	for _, miss := range transportRegionMisses {
+		if strings.Contains(msg, miss) {
+			return dispositionEmpty
+		}
+	}
+	// An endpoint that resolves but fails every single attempt to send is a
+	// service that is not really deployed in this region. Both halves are
+	// required: a throttle or a 5xx also exhausts retries, and the caller must
+	// see those.
+	if strings.Contains(msg, "exceeded maximum number of attempts") &&
+		strings.Contains(msg, "request send failed") {
+		return dispositionEmpty
+	}
+
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		switch {
+		case accessDeniedCodes[ae.ErrorCode()]:
+			return dispositionUnreadable
+		case serviceAbsentCodes[ae.ErrorCode()]:
+			return dispositionEmpty
+		}
+	}
+
+	return dispositionFail
+}

--- a/providers/aws/resources/aws_disposition.go
+++ b/providers/aws/resources/aws_disposition.go
@@ -133,6 +133,16 @@ var serviceRules = map[string][]dispositionRule{
 			code:        "ResourceNotFoundException",
 			disposition: dispositionEmpty,
 		},
+		// The automated-discovery read has a shape of its own that never names
+		// Macie: AccessDeniedException "Account Id: [...] has not been
+		// onboarded". Onboarding state is not a permission gap, and no IAM
+		// denial is phrased this way, so matching it does not reintroduce the
+		// swallowing this table exists to prevent.
+		{
+			code:        "AccessDeniedException",
+			messageAny:  []string{"has not been onboarded"},
+			disposition: dispositionEmpty,
+		},
 	},
 	"securitylake": {
 		{

--- a/providers/aws/resources/aws_disposition.go
+++ b/providers/aws/resources/aws_disposition.go
@@ -104,6 +104,11 @@ func (r dispositionRule) matches(err error, msg string) bool {
 // putting the distinguishing fact in the message. Those are the only cases that
 // legitimately need message matching, and confining them here keeps the rest of
 // the provider off prose entirely.
+//
+// A key may be narrowed to a group of endpoints as "<service>/<scope>", for
+// when one service's endpoints disagree about what an error code means.
+// Classification tries the narrow key first and then falls back to the bare
+// service, so a scope only has to state where it differs.
 var serviceRules = map[string][]dispositionRule{
 	"macie2": {
 		{
@@ -111,9 +116,19 @@ var serviceRules = map[string][]dispositionRule{
 			messageAny:  []string{"Macie is not enabled", "Macie isn't enabled"},
 			disposition: dispositionEmpty,
 		},
-		// Macie answers a not-found on its list and get endpoints when the
-		// account has nothing configured in the region, so a bare not-found
-		// here is an empty result rather than a miss worth reporting.
+		{
+			code:        "ResourceNotFoundException",
+			messageAny:  []string{"Macie is not enabled", "Macie isn't enabled", "not enabled for your account"},
+			disposition: dispositionEmpty,
+		},
+	},
+	// The single-record configuration reads (GetMacieSession,
+	// GetAdministratorAccount, GetAutomatedDiscoveryConfiguration) answer
+	// not-found when the feature has never been configured in the region, so
+	// for these a bare not-found is an empty result. The list endpoints get no
+	// such licence: a not-found there is a resource that vanished mid-read,
+	// which the caller must see.
+	"macie2/config": {
 		{
 			code:        "ResourceNotFoundException",
 			disposition: dispositionEmpty,
@@ -148,18 +163,43 @@ var transportRegionMisses = []string{
 	"could not resolve endpoint",
 }
 
+// classificationKeys expands a classification scope into the keys to consult,
+// narrowest first: "macie2/config" yields "macie2/config" then "macie2".
+func classificationKeys(service string) []string {
+	if base, _, found := strings.Cut(service, "/"); found {
+		return []string{service, base}
+	}
+	return []string{service}
+}
+
+// serviceName strips any endpoint scope, giving the name to report a coverage
+// gap under. Users think in services, not in the groupings we classify by.
+func serviceName(service string) string {
+	base, _, _ := strings.Cut(service, "/")
+	return base
+}
+
 // classifyError decides what a lister should do about err from the named
 // service. service is the AWS service id, matching the key used to build the
-// client (for example "ecr", "macie2", "rds").
+// client (for example "ecr", "macie2", "rds"), optionally narrowed to a group
+// of endpoints as "<service>/<scope>" - see serviceRules.
+//
+// Callers must not pass a nil error: there is nothing to classify, and the
+// question only arises on an error path. A nil is answered with
+// dispositionFail because that is the one answer that cannot silently drop a
+// region's real results.
 func classifyError(service string, err error) disposition {
 	if err == nil {
 		return dispositionFail
 	}
 	msg := awsNormalizeApostrophes(err.Error())
 
-	for _, rule := range serviceRules[service] {
-		if rule.matches(err, msg) {
-			return rule.disposition
+	// The narrow key wins where it speaks; the bare service covers the rest.
+	for _, key := range classificationKeys(service) {
+		for _, rule := range serviceRules[key] {
+			if rule.matches(err, msg) {
+				return rule.disposition
+			}
 		}
 	}
 

--- a/providers/aws/resources/aws_disposition_test.go
+++ b/providers/aws/resources/aws_disposition_test.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/require"
+)
+
+// apiErr builds an error shaped like the one a real SDK call returns: the API
+// error wrapped in an OperationError, which is what callers actually get.
+func apiErr(code, message string) error {
+	return &smithy.OperationError{
+		ServiceID:     "test",
+		OperationName: "TestOp",
+		Err:           &smithy.GenericAPIError{Code: code, Message: message},
+	}
+}
+
+func TestClassifyAccessDeniedIsUnreadable(t *testing.T) {
+	for _, code := range []string{
+		"AccessDenied", "AccessDeniedException", "UnauthorizedOperation",
+		"AuthorizationError", "AuthFailure", "InvalidClientTokenId",
+	} {
+		t.Run(code, func(t *testing.T) {
+			require.Equal(t, dispositionUnreadable, classifyError("ecr", apiErr(code, "nope")))
+		})
+	}
+}
+
+func TestClassifyAbsentServiceIsEmpty(t *testing.T) {
+	for _, code := range []string{
+		"OptInRequired", "UnknownOperationException", "InvalidAction",
+		"SubscriptionRequiredException",
+	} {
+		t.Run(code, func(t *testing.T) {
+			require.Equal(t, dispositionEmpty, classifyError("bedrock", apiErr(code, "not here")))
+		})
+	}
+}
+
+func TestClassifyRealFailuresAreFailures(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"throttling", apiErr("ThrottlingException", "Rate exceeded")},
+		{"internal error", apiErr("InternalServerError", "boom")},
+		{"validation", apiErr("ValidationException", "bad parameter")},
+		{"plain error", errors.New("something went wrong")},
+		// Retry exhaustion on its own is a throttle or a 5xx, and the caller has
+		// to see it. Only exhaustion *plus* a send failure means the endpoint is
+		// not really there.
+		{"retries exhausted alone", errors.New("exceeded maximum number of attempts")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, dispositionFail, classifyError("ecr", tc.err))
+		})
+	}
+}
+
+func TestClassifyTransportRegionMissIsEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"dns miss", errors.New(`dial tcp: lookup bedrock.us-west-1.amazonaws.com: no such host`)},
+		{"unknown endpoint", errors.New("UnknownEndpoint: endpoint not found")},
+		{"unresolvable", errors.New("could not resolve endpoint")},
+		{"send failure exhaustion", errors.New("exceeded maximum number of attempts, request send failed")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, dispositionEmpty, classifyError("bedrock", tc.err))
+		})
+	}
+}
+
+// A service-not-enabled message must read as empty, while a genuine permission
+// gap on the same service and the same error code must not. Collapsing the two
+// is what makes a data-classification policy pass on an account nobody can read.
+func TestClassifyMacieDistinguishesNotEnabledFromDenied(t *testing.T) {
+	notEnabled := apiErr("AccessDeniedException", "Macie is not enabled")
+	require.Equal(t, dispositionEmpty, classifyError("macie2", notEnabled))
+
+	denied := apiErr("AccessDeniedException", "User is not authorized to perform macie2:ListFindings")
+	require.Equal(t, dispositionUnreadable, classifyError("macie2", denied))
+}
+
+// The same message with a curly apostrophe must classify identically. AWS
+// serves both forms, and a guard that only knows the ASCII spelling silently
+// stops firing the day the service switches.
+func TestClassifyToleratesCurlyApostrophe(t *testing.T) {
+	ascii := apiErr("ResourceNotFoundException", "Amazon Macie isn't enabled for your account")
+	curly := apiErr("ResourceNotFoundException", "Amazon Macie isn’t enabled for your account")
+
+	require.Equal(t, dispositionEmpty, classifyError("macie2", ascii))
+	require.Equal(t, dispositionEmpty, classifyError("macie2", curly),
+		"curly apostrophe must classify the same as the ASCII spelling")
+}
+
+// A service rule must not leak into other services: Macie's not-enabled
+// wording carries no meaning for, say, RDS.
+func TestClassifyServiceRulesAreScoped(t *testing.T) {
+	err := apiErr("AccessDeniedException", "Macie is not enabled")
+	require.Equal(t, dispositionEmpty, classifyError("macie2", err))
+	require.Equal(t, dispositionUnreadable, classifyError("rds", err),
+		"another service's not-enabled wording must not be honoured here")
+}
+
+func TestClassifySecurityLakeNotEnabled(t *testing.T) {
+	err := apiErr("ResourceNotFoundException", "Security Lake isn't enabled for your account in any Regions")
+	require.Equal(t, dispositionEmpty, classifyError("securitylake", err))
+
+	// A plain not-found from the same service is a real miss, not an absent
+	// service, so it must still surface.
+	other := apiErr("ResourceNotFoundException", "The subscriber could not be found")
+	require.Equal(t, dispositionFail, classifyError("securitylake", other))
+}
+
+// Classification must survive arbitrary wrapping, since callers wrap freely.
+func TestClassifyUnwrapsWrappedErrors(t *testing.T) {
+	wrapped := fmt.Errorf("listing repositories: %w", apiErr("AccessDenied", "denied"))
+	require.Equal(t, dispositionUnreadable, classifyError("ecr", wrapped))
+}
+
+func TestClassifyNilErrorDoesNotReportEmpty(t *testing.T) {
+	// Nothing should be calling this with a nil error, but if it does it must
+	// not answer "empty" and quietly drop a region's real results.
+	require.Equal(t, dispositionFail, classifyError("ecr", nil))
+}

--- a/providers/aws/resources/aws_disposition_test.go
+++ b/providers/aws/resources/aws_disposition_test.go
@@ -120,6 +120,18 @@ func TestClassifyMacieListDoesNotSwallowBareNotFound(t *testing.T) {
 	require.Equal(t, dispositionFail, classifyError("macie2", err))
 }
 
+// An account that never onboarded to Macie answers the automated-discovery
+// read with an access denial that never names Macie. That is an absent feature,
+// not a permission gap, so it reads as empty rather than as a coverage gap.
+func TestClassifyMacieConfigScopeTreatsNotOnboardedAsEmpty(t *testing.T) {
+	err := apiErr("AccessDeniedException", "Account Id: [123456789012] has not been onboarded")
+	require.Equal(t, dispositionEmpty, classifyError("macie2/config", err))
+
+	// The list endpoints never see this wording, and must keep reporting a
+	// denial as unreadable.
+	require.Equal(t, dispositionUnreadable, classifyError("macie2", err))
+}
+
 // A scope still inherits the not-enabled rules from its bare service, so the
 // narrow key only has to state where it differs.
 func TestClassifyScopeInheritsServiceRules(t *testing.T) {

--- a/providers/aws/resources/aws_disposition_test.go
+++ b/providers/aws/resources/aws_disposition_test.go
@@ -105,6 +105,44 @@ func TestClassifyToleratesCurlyApostrophe(t *testing.T) {
 		"curly apostrophe must classify the same as the ASCII spelling")
 }
 
+// The single-record config reads tolerate a bare not-found, because Macie
+// answers that way when the feature was never configured in the region.
+func TestClassifyMacieConfigScopeToleratesBareNotFound(t *testing.T) {
+	err := apiErr("ResourceNotFoundException", "The request failed because the resource was not found")
+	require.Equal(t, dispositionEmpty, classifyError("macie2/config", err))
+}
+
+// ...but a list endpoint gets no such licence. A not-found from ListFindings
+// is a resource that vanished mid-read, and swallowing it would report a
+// partial listing as a complete one.
+func TestClassifyMacieListDoesNotSwallowBareNotFound(t *testing.T) {
+	err := apiErr("ResourceNotFoundException", "The request failed because the resource was not found")
+	require.Equal(t, dispositionFail, classifyError("macie2", err))
+}
+
+// A scope still inherits the not-enabled rules from its bare service, so the
+// narrow key only has to state where it differs.
+func TestClassifyScopeInheritsServiceRules(t *testing.T) {
+	notEnabled := apiErr("AccessDeniedException", "Macie is not enabled")
+	require.Equal(t, dispositionEmpty, classifyError("macie2/config", notEnabled))
+
+	denied := apiErr("AccessDeniedException", "User is not authorized to perform macie2:GetMacieSession")
+	require.Equal(t, dispositionUnreadable, classifyError("macie2/config", denied))
+}
+
+// The not-enabled wording still reads as empty on the list endpoints, which is
+// the whole point of keeping that rule on the bare service.
+func TestClassifyMacieListStillHonoursNotEnabled(t *testing.T) {
+	err := apiErr("ResourceNotFoundException", "Amazon Macie isn't enabled for your account")
+	require.Equal(t, dispositionEmpty, classifyError("macie2", err))
+}
+
+// Coverage gaps are reported per service, not per endpoint scope.
+func TestServiceNameStripsScope(t *testing.T) {
+	require.Equal(t, "macie2", serviceName("macie2/config"))
+	require.Equal(t, "ecr", serviceName("ecr"))
+}
+
 // A service rule must not leak into other services: Macie's not-enabled
 // wording carries no meaning for, say, RDS.
 func TestClassifyServiceRulesAreScoped(t *testing.T) {

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -21,7 +21,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 
 	"go.mondoo.com/mql/v13/types"
@@ -144,75 +143,42 @@ func (a *mqlAwsEcr) privateRepositories() ([]any, error) {
 		return []any{}, nil
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getPrivateRepositories(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "ecr", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Ecr(region)
+		res := []any{}
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
+		// AWS caps repositoryNames at ECRDescribeRepositoriesNameLimit per request, so
+		// a larger filter is split into batches and each batch is described separately.
+		// 0 batches means all repositories should be described.
+		batches := conn.Filters.Ecr.PrivateRepositoryNameBatches()
+		if len(batches) == 0 {
+			batches = [][]string{{}}
+		}
 
-	return res, nil
-}
-
-func (a *mqlAwsEcr) getPrivateRepositories(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	ctx := context.Background()
-
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
-	}
-	for ri := range regions {
-		region := regions[ri]
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Ecr(region)
-			res := []any{}
-
-			// AWS caps repositoryNames at ECRDescribeRepositoriesNameLimit per request, so
-			// a larger filter is split into batches and each batch is described separately.
-			// 0 batches means all repositories should be described.
-			batches := conn.Filters.Ecr.PrivateRepositoryNameBatches()
-			if len(batches) == 0 {
-				batches = [][]string{{}}
+		for _, batch := range batches {
+			req := &ecr.DescribeRepositoriesInput{}
+			if len(batch) > 0 {
+				req.RepositoryNames = batch
 			}
 
-			for _, batch := range batches {
-				req := &ecr.DescribeRepositoriesInput{}
-				if len(batch) > 0 {
-					req.RepositoryNames = batch
+			paginator := ecr.NewDescribeRepositoriesPaginator(svc, req)
+			for paginator.HasMorePages() {
+				repoResp, err := paginator.NextPage(ctx, withEcrDescribeRetries)
+				if err != nil {
+					return nil, err
 				}
-
-				paginator := ecr.NewDescribeRepositoriesPaginator(svc, req)
-				for paginator.HasMorePages() {
-					repoResp, err := paginator.NextPage(ctx, withEcrDescribeRetries)
+				for _, r := range repoResp.Repositories {
+					mqlRepoResource, err := buildEcrPrivateRepositoryResource(a.MqlRuntime, region, r)
 					if err != nil {
-						if Is400AccessDeniedError(err) {
-							log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-							return res, nil
-						}
 						return nil, err
 					}
-					for _, r := range repoResp.Repositories {
-						mqlRepoResource, err := buildEcrPrivateRepositoryResource(a.MqlRuntime, region, r)
-						if err != nil {
-							return nil, err
-						}
-						res = append(res, mqlRepoResource)
-					}
+					res = append(res, mqlRepoResource)
 				}
 			}
-
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+
+		return res, nil
+	})
 }
 
 func (a *mqlAwsEcrRepository) scanningFrequency() (string, error) {

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -18,7 +18,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 
 	"go.mondoo.com/mql/v13/types"
@@ -31,67 +30,36 @@ func (a *mqlAwsEfsFilesystem) id() (string, error) {
 func (a *mqlAwsEfs) filesystems() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getFilesystems(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "elasticfilesystem", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("efs>getFilesystems>calling aws with region %s", region)
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
+		svc := conn.Efs(region)
+		res := []any{}
 
-	return res, nil
-}
+		params := &efs.DescribeFileSystemsInput{}
+		paginator := efs.NewDescribeFileSystemsPaginator(svc, params)
+		for paginator.HasMorePages() {
+			describeFileSystemsRes, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
 
-func (a *mqlAwsEfs) getFilesystems(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("efs>getFilesystems>calling aws with region %s", region)
+			for _, fs := range describeFileSystemsRes.FileSystems {
+				if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(efsTagsToMap(fs.Tags))) {
+					log.Debug().Interface("filesystem", fs.FileSystemArn).Msg("skipping efs filesystem due to filters")
+					continue
+				}
 
-			svc := conn.Efs(region)
-			ctx := context.Background()
-			res := []any{}
-
-			params := &efs.DescribeFileSystemsInput{}
-			paginator := efs.NewDescribeFileSystemsPaginator(svc, params)
-			for paginator.HasMorePages() {
-				describeFileSystemsRes, err := paginator.NextPage(ctx)
+				mqlFilesystem, err := buildEfsFilesystemResource(a.MqlRuntime, region, fs)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
 					return nil, err
 				}
 
-				for _, fs := range describeFileSystemsRes.FileSystems {
-					if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(efsTagsToMap(fs.Tags))) {
-						log.Debug().Interface("filesystem", fs.FileSystemArn).Msg("skipping efs filesystem due to filters")
-						continue
-					}
-
-					mqlFilesystem, err := buildEfsFilesystemResource(a.MqlRuntime, region, fs)
-					if err != nil {
-						return nil, err
-					}
-
-					res = append(res, mqlFilesystem)
-				}
+				res = append(res, mqlFilesystem)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 type mqlAwsEfsFilesystemInternal struct {

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -129,70 +129,40 @@ func (a *mqlAwsKms) id() (string, error) {
 func (a *mqlAwsKms) keys() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getKeys(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "kms", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("kms>getKeys>calling aws with region %s", region)
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
-}
+		svc := conn.Kms(region)
+		res := []any{}
 
-func (a *mqlAwsKms) getKeys(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("kms>getKeys>calling aws with region %s", region)
-
-			svc := conn.Kms(region)
-			res := []any{}
-
-			keys := make([]types.KeyListEntry, 0)
-			params := &kms.ListKeysInput{}
-			paginator := kms.NewListKeysPaginator(svc, params, func(o *kms.ListKeysPaginatorOptions) {
-				o.Limit = 100
-			})
-			for paginator.HasMorePages() {
-				output, err := paginator.NextPage(context.TODO())
-				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
-					return nil, err
-				}
-				keys = append(keys, output.Keys...)
+		keys := make([]types.KeyListEntry, 0)
+		params := &kms.ListKeysInput{}
+		paginator := kms.NewListKeysPaginator(svc, params, func(o *kms.ListKeysPaginatorOptions) {
+			o.Limit = 100
+		})
+		for paginator.HasMorePages() {
+			output, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
 			}
-
-			for _, key := range keys {
-				mqlKey, err := CreateResource(a.MqlRuntime, "aws.kms.key",
-					map[string]*llx.RawData{
-						"id":     llx.StringDataPtr(key.KeyId),
-						"arn":    llx.StringDataPtr(key.KeyArn),
-						"region": llx.StringData(region),
-					})
-				if err != nil {
-					return nil, err
-				}
-				res = append(res, mqlKey)
-			}
-
-			return jobpool.JobResult(res), nil
+			keys = append(keys, output.Keys...)
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+
+		for _, key := range keys {
+			mqlKey, err := CreateResource(a.MqlRuntime, "aws.kms.key",
+				map[string]*llx.RawData{
+					"id":     llx.StringDataPtr(key.KeyId),
+					"arn":    llx.StringDataPtr(key.KeyArn),
+					"region": llx.StringData(region),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlKey)
+		}
+
+		return res, nil
+	})
 }
 
 func (a *mqlAwsKms) grants() ([]any, error) {
@@ -241,60 +211,27 @@ func (a *mqlAwsKms) grants() ([]any, error) {
 func (a *mqlAwsKms) customKeyStores() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getCustomKeyStoreTasks(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "kms", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Str("region", region).Msg("kms>getCustomKeyStores>describe")
 
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		entries, ok := poolOfJobs.Jobs[i].Result.([]any)
-		if !ok {
-			continue
-		}
-		res = append(res, entries...)
-	}
-	return res, nil
-}
-
-func (a *mqlAwsKms) getCustomKeyStoreTasks(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		region := region
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Str("region", region).Msg("kms>getCustomKeyStores>describe")
-
-			svc := conn.Kms(region)
-			res := []any{}
-			paginator := kms.NewDescribeCustomKeyStoresPaginator(svc, &kms.DescribeCustomKeyStoresInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(context.TODO())
+		svc := conn.Kms(region)
+		res := []any{}
+		paginator := kms.NewDescribeCustomKeyStoresPaginator(svc, &kms.DescribeCustomKeyStoresInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, entry := range page.CustomKeyStores {
+				mqlStore, err := newMqlAwsKmsCustomKeyStore(a.MqlRuntime, region, entry)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("access denied describing KMS custom key stores")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, entry := range page.CustomKeyStores {
-					mqlStore, err := newMqlAwsKmsCustomKeyStore(a.MqlRuntime, region, entry)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlStore)
-				}
+				res = append(res, mqlStore)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 // kmsCustomKeyStoreID returns the `__id` shape used by every aws.kms.customKeyStore

--- a/providers/aws/resources/aws_macie.go
+++ b/providers/aws/resources/aws_macie.go
@@ -27,7 +27,7 @@ func (a *mqlAwsMacie) id() (string, error) {
 func (a *mqlAwsMacie) sessions() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+	return perRegion(conn, "macie2/config", func(ctx context.Context, region string) ([]any, error) {
 		svc := conn.Macie2(region)
 		res := []any{}
 
@@ -1116,7 +1116,7 @@ func (a *mqlAwsMacieInvitation) id() (string, error) {
 func (a *mqlAwsMacie) administrators() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+	return perRegion(conn, "macie2/config", func(ctx context.Context, region string) ([]any, error) {
 		svc := conn.Macie2(region)
 		res := []any{}
 		resp, err := svc.GetAdministratorAccount(ctx, &macie2.GetAdministratorAccountInput{})
@@ -1155,7 +1155,7 @@ func (a *mqlAwsMacieAdministrator) id() (string, error) {
 func (a *mqlAwsMacie) automatedDiscoveryConfigurations() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+	return perRegion(conn, "macie2/config", func(ctx context.Context, region string) ([]any, error) {
 		svc := conn.Macie2(region)
 		res := []any{}
 		resp, err := svc.GetAutomatedDiscoveryConfiguration(ctx, &macie2.GetAutomatedDiscoveryConfigurationInput{})

--- a/providers/aws/resources/aws_macie.go
+++ b/providers/aws/resources/aws_macie.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"slices"
 	"strings"
 	"sync"
@@ -17,7 +16,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	mqlTypes "go.mondoo.com/mql/v13/types"
 )
@@ -29,280 +27,144 @@ func (a *mqlAwsMacie) id() (string, error) {
 func (a *mqlAwsMacie) sessions() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getSessions(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
+		session, err := svc.GetMacieSession(ctx, &macie2.GetMacieSessionInput{})
+		if err != nil {
+			return nil, err
 		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getSessions(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-
-			session, err := svc.GetMacieSession(ctx, &macie2.GetMacieSessionInput{})
-			if err != nil {
-				if IsMacieNotEnabledError(err) {
-					log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-					return res, nil
-				}
-				var notFoundErr *types.ResourceNotFoundException
-				if errors.As(err, &notFoundErr) {
-					return res, nil
-				}
-				return nil, err
-			}
-
-			// Get bucket statistics for S3 bucket count
-			bucketStats, err := svc.GetBucketStatistics(ctx, &macie2.GetBucketStatisticsInput{})
-			var s3BucketCount int
-			if err == nil && bucketStats.BucketCount != nil {
-				s3BucketCount = int(*bucketStats.BucketCount)
-			}
-
-			mqlSession, err := CreateResource(a.MqlRuntime, ResourceAwsMacieSession,
-				map[string]*llx.RawData{
-					"arn":                        llx.StringData(generateMacieSessionArn(conn.AccountId(), region)),
-					"region":                     llx.StringData(region),
-					"status":                     llx.StringData(string(session.Status)),
-					"createdAt":                  llx.TimeDataPtr(session.CreatedAt),
-					"updatedAt":                  llx.TimeDataPtr(session.UpdatedAt),
-					"findingPublishingFrequency": llx.StringData(string(session.FindingPublishingFrequency)),
-					"serviceRole":                llx.StringDataPtr(session.ServiceRole),
-					"s3BucketCount":              llx.IntData(int64(s3BucketCount)),
-				})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlSession)
-			return jobpool.JobResult(res), nil
+		// Get bucket statistics for S3 bucket count
+		bucketStats, err := svc.GetBucketStatistics(ctx, &macie2.GetBucketStatisticsInput{})
+		var s3BucketCount int
+		if err == nil && bucketStats.BucketCount != nil {
+			s3BucketCount = int(*bucketStats.BucketCount)
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+
+		mqlSession, err := CreateResource(a.MqlRuntime, ResourceAwsMacieSession,
+			map[string]*llx.RawData{
+				"arn":                        llx.StringData(generateMacieSessionArn(conn.AccountId(), region)),
+				"region":                     llx.StringData(region),
+				"status":                     llx.StringData(string(session.Status)),
+				"createdAt":                  llx.TimeDataPtr(session.CreatedAt),
+				"updatedAt":                  llx.TimeDataPtr(session.UpdatedAt),
+				"findingPublishingFrequency": llx.StringData(string(session.FindingPublishingFrequency)),
+				"serviceRole":                llx.StringDataPtr(session.ServiceRole),
+				"s3BucketCount":              llx.IntData(int64(s3BucketCount)),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlSession)
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacie) classificationJobs() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getClassificationJobs(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
+		params := &macie2.ListClassificationJobsInput{}
+		paginator := macie2.NewListClassificationJobsPaginator(svc, params)
+		for paginator.HasMorePages() {
+			jobs, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
 
-func (a *mqlAwsMacie) getClassificationJobs(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-
-			params := &macie2.ListClassificationJobsInput{}
-			paginator := macie2.NewListClassificationJobsPaginator(svc, params)
-			for paginator.HasMorePages() {
-				jobs, err := paginator.NextPage(ctx)
+			for _, job := range jobs.Items {
+				jobId := ""
+				if job.JobId != nil {
+					jobId = *job.JobId
+				}
+				jobArn := generateClassificationJobArn(conn.AccountId(), region, jobId)
+				mqlJob, err := CreateResource(a.MqlRuntime, ResourceAwsMacieClassificationJob,
+					map[string]*llx.RawData{
+						"arn":       llx.StringData(jobArn),
+						"jobId":     llx.StringDataPtr(job.JobId),
+						"name":      llx.StringDataPtr(job.Name),
+						"region":    llx.StringData(region),
+						"status":    llx.StringData(string(job.JobStatus)),
+						"jobType":   llx.StringData(string(job.JobType)),
+						"createdAt": llx.TimeDataPtr(job.CreatedAt),
+					})
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-
-				for _, job := range jobs.Items {
-					jobId := ""
-					if job.JobId != nil {
-						jobId = *job.JobId
-					}
-					jobArn := generateClassificationJobArn(conn.AccountId(), region, jobId)
-					mqlJob, err := CreateResource(a.MqlRuntime, ResourceAwsMacieClassificationJob,
-						map[string]*llx.RawData{
-							"arn":       llx.StringData(jobArn),
-							"jobId":     llx.StringDataPtr(job.JobId),
-							"name":      llx.StringDataPtr(job.Name),
-							"region":    llx.StringData(region),
-							"status":    llx.StringData(string(job.JobStatus)),
-							"jobType":   llx.StringData(string(job.JobType)),
-							"createdAt": llx.TimeDataPtr(job.CreatedAt),
-						})
-					if err != nil {
-						return nil, err
-					}
-					mqlJob.(*mqlAwsMacieClassificationJob).cacheJob = &job
-					res = append(res, mqlJob)
-				}
+				mqlJob.(*mqlAwsMacieClassificationJob).cacheJob = &job
+				res = append(res, mqlJob)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacie) findings() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getFindings(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
+		params := &macie2.ListFindingsInput{}
+		paginator := macie2.NewListFindingsPaginator(svc, params)
+		for paginator.HasMorePages() {
+			findings, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
 
-func (a *mqlAwsMacie) getFindings(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-
-			params := &macie2.ListFindingsInput{}
-			paginator := macie2.NewListFindingsPaginator(svc, params)
-			for paginator.HasMorePages() {
-				findings, err := paginator.NextPage(ctx)
+			// Get finding details for all finding IDs
+			if len(findings.FindingIds) > 0 {
+				detailsRes, err := fetchMacieFindings(svc, region, findings.FindingIds, a.MqlRuntime)
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-
-				// Get finding details for all finding IDs
-				if len(findings.FindingIds) > 0 {
-					detailsRes, err := fetchMacieFindings(svc, region, findings.FindingIds, a.MqlRuntime)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, detailsRes...)
-				}
+				res = append(res, detailsRes...)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacie) customDataIdentifiers() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getCustomDataIdentifiers(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
+		params := &macie2.ListCustomDataIdentifiersInput{}
+		paginator := macie2.NewListCustomDataIdentifiersPaginator(svc, params)
+		for paginator.HasMorePages() {
+			identifiers, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
 
-func (a *mqlAwsMacie) getCustomDataIdentifiers(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-
-			params := &macie2.ListCustomDataIdentifiersInput{}
-			paginator := macie2.NewListCustomDataIdentifiersPaginator(svc, params)
-			for paginator.HasMorePages() {
-				identifiers, err := paginator.NextPage(ctx)
+			for _, identifier := range identifiers.Items {
+				mqlIdentifier, err := CreateResource(a.MqlRuntime, ResourceAwsMacieCustomDataIdentifier,
+					map[string]*llx.RawData{
+						"id":        llx.StringDataPtr(identifier.Id),
+						"arn":       llx.StringDataPtr(identifier.Arn),
+						"name":      llx.StringDataPtr(identifier.Name),
+						"createdAt": llx.TimeDataPtr(identifier.CreatedAt),
+					})
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-
-				for _, identifier := range identifiers.Items {
-					mqlIdentifier, err := CreateResource(a.MqlRuntime, ResourceAwsMacieCustomDataIdentifier,
-						map[string]*llx.RawData{
-							"id":        llx.StringDataPtr(identifier.Id),
-							"arn":       llx.StringDataPtr(identifier.Arn),
-							"name":      llx.StringDataPtr(identifier.Name),
-							"createdAt": llx.TimeDataPtr(identifier.CreatedAt),
-						})
-					if err != nil {
-						return nil, err
-					}
-					mqlIdentifier.(*mqlAwsMacieCustomDataIdentifier).cacheIdentifier = &identifier
-					mqlIdentifier.(*mqlAwsMacieCustomDataIdentifier).cacheRegion = region
-					res = append(res, mqlIdentifier)
-				}
+				mqlIdentifier.(*mqlAwsMacieCustomDataIdentifier).cacheIdentifier = &identifier
+				mqlIdentifier.(*mqlAwsMacieCustomDataIdentifier).cacheRegion = region
+				res = append(res, mqlIdentifier)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 // Resource ID implementations
@@ -765,54 +627,26 @@ func describeMacieBucket(runtime *plugin.Runtime, conn *connection.AwsConnection
 
 func (a *mqlAwsMacie) buckets() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getBuckets(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getBuckets(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			paginator := macie2.NewDescribeBucketsPaginator(svc, &macie2.DescribeBucketsInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		paginator := macie2.NewDescribeBucketsPaginator(svc, &macie2.DescribeBucketsInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, bm := range page.Buckets {
+				mqlBucket, err := newMqlMacieBucket(a.MqlRuntime, bm, region)
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, bm := range page.Buckets {
-					mqlBucket, err := newMqlMacieBucket(a.MqlRuntime, bm, region)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlBucket)
-				}
+				res = append(res, mqlBucket)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func newMqlMacieBucket(runtime *plugin.Runtime, bm types.BucketMetadata, region string) (*mqlAwsMacieBucket, error) {
@@ -970,63 +804,35 @@ type mqlAwsMacieAllowListInternal struct {
 
 func (a *mqlAwsMacie) allowLists() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getAllowLists(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getAllowLists(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			paginator := macie2.NewListAllowListsPaginator(svc, &macie2.ListAllowListsInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		paginator := macie2.NewListAllowListsPaginator(svc, &macie2.ListAllowListsInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range page.AllowLists {
+				mqlList, err := CreateResource(a.MqlRuntime, ResourceAwsMacieAllowList,
+					map[string]*llx.RawData{
+						"id":        llx.StringDataPtr(item.Id),
+						"arn":       llx.StringDataPtr(item.Arn),
+						"region":    llx.StringData(region),
+						"name":      llx.StringDataPtr(item.Name),
+						"createdAt": llx.TimeDataPtr(item.CreatedAt),
+						"updatedAt": llx.TimeDataPtr(item.UpdatedAt),
+					})
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, item := range page.AllowLists {
-					mqlList, err := CreateResource(a.MqlRuntime, ResourceAwsMacieAllowList,
-						map[string]*llx.RawData{
-							"id":        llx.StringDataPtr(item.Id),
-							"arn":       llx.StringDataPtr(item.Arn),
-							"region":    llx.StringData(region),
-							"name":      llx.StringDataPtr(item.Name),
-							"createdAt": llx.TimeDataPtr(item.CreatedAt),
-							"updatedAt": llx.TimeDataPtr(item.UpdatedAt),
-						})
-					if err != nil {
-						return nil, err
-					}
-					mqlList.(*mqlAwsMacieAllowList).cacheRegion = region
-					res = append(res, mqlList)
-				}
+				mqlList.(*mqlAwsMacieAllowList).cacheRegion = region
+				res = append(res, mqlList)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacieAllowList) id() (string, error) {
@@ -1114,67 +920,39 @@ type mqlAwsMacieFindingsFilterInternal struct {
 
 func (a *mqlAwsMacie) findingsFilters() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getFindingsFilters(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getFindingsFilters(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			paginator := macie2.NewListFindingsFiltersPaginator(svc, &macie2.ListFindingsFiltersInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		paginator := macie2.NewListFindingsFiltersPaginator(svc, &macie2.ListFindingsFiltersInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range page.FindingsFilterListItems {
+				var itemTags map[string]any
+				if item.Tags != nil {
+					itemTags = convert.MapToInterfaceMap(item.Tags)
+				}
+				mqlFilter, err := CreateResource(a.MqlRuntime, ResourceAwsMacieFindingsFilter,
+					map[string]*llx.RawData{
+						"id":     llx.StringDataPtr(item.Id),
+						"arn":    llx.StringDataPtr(item.Arn),
+						"region": llx.StringData(region),
+						"name":   llx.StringDataPtr(item.Name),
+						"action": llx.StringData(string(item.Action)),
+						"tags":   llx.MapData(itemTags, mqlTypes.String),
+					})
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, item := range page.FindingsFilterListItems {
-					var itemTags map[string]any
-					if item.Tags != nil {
-						itemTags = convert.MapToInterfaceMap(item.Tags)
-					}
-					mqlFilter, err := CreateResource(a.MqlRuntime, ResourceAwsMacieFindingsFilter,
-						map[string]*llx.RawData{
-							"id":     llx.StringDataPtr(item.Id),
-							"arn":    llx.StringDataPtr(item.Arn),
-							"region": llx.StringData(region),
-							"name":   llx.StringDataPtr(item.Name),
-							"action": llx.StringData(string(item.Action)),
-							"tags":   llx.MapData(itemTags, mqlTypes.String),
-						})
-					if err != nil {
-						return nil, err
-					}
-					mqlFilter.(*mqlAwsMacieFindingsFilter).cacheRegion = region
-					res = append(res, mqlFilter)
-				}
+				mqlFilter.(*mqlAwsMacieFindingsFilter).cacheRegion = region
+				res = append(res, mqlFilter)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacieFindingsFilter) id() (string, error) {
@@ -1237,82 +1015,54 @@ func (a *mqlAwsMacieFindingsFilter) findingCriteria() (any, error) {
 
 func (a *mqlAwsMacie) members() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getMembers(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getMembers(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	onlyAssociated := "false"
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			paginator := macie2.NewListMembersPaginator(svc, &macie2.ListMembersInput{
-				OnlyAssociated: &onlyAssociated,
-			})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		onlyAssociated := "false"
+		paginator := macie2.NewListMembersPaginator(svc, &macie2.ListMembersInput{
+			OnlyAssociated: &onlyAssociated,
+		})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, m := range page.Members {
+				memberAccountId := ""
+				if m.AccountId != nil {
+					memberAccountId = *m.AccountId
+				}
+				arn := ""
+				if m.Arn != nil {
+					arn = *m.Arn
+				} else {
+					arn = generateMacieMemberArn(conn.AccountId(), region, memberAccountId)
+				}
+				var memberTags map[string]any
+				if m.Tags != nil {
+					memberTags = convert.MapToInterfaceMap(m.Tags)
+				}
+				mqlMember, err := CreateResource(a.MqlRuntime, ResourceAwsMacieMember,
+					map[string]*llx.RawData{
+						"accountId":              llx.StringData(memberAccountId),
+						"arn":                    llx.StringData(arn),
+						"region":                 llx.StringData(region),
+						"administratorAccountId": llx.StringDataPtr(m.AdministratorAccountId),
+						"email":                  llx.StringDataPtr(m.Email),
+						"relationshipStatus":     llx.StringData(string(m.RelationshipStatus)),
+						"invitedAt":              llx.TimeDataPtr(m.InvitedAt),
+						"updatedAt":              llx.TimeDataPtr(m.UpdatedAt),
+						"tags":                   llx.MapData(memberTags, mqlTypes.String),
+					})
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, m := range page.Members {
-					memberAccountId := ""
-					if m.AccountId != nil {
-						memberAccountId = *m.AccountId
-					}
-					arn := ""
-					if m.Arn != nil {
-						arn = *m.Arn
-					} else {
-						arn = generateMacieMemberArn(conn.AccountId(), region, memberAccountId)
-					}
-					var memberTags map[string]any
-					if m.Tags != nil {
-						memberTags = convert.MapToInterfaceMap(m.Tags)
-					}
-					mqlMember, err := CreateResource(a.MqlRuntime, ResourceAwsMacieMember,
-						map[string]*llx.RawData{
-							"accountId":              llx.StringData(memberAccountId),
-							"arn":                    llx.StringData(arn),
-							"region":                 llx.StringData(region),
-							"administratorAccountId": llx.StringDataPtr(m.AdministratorAccountId),
-							"email":                  llx.StringDataPtr(m.Email),
-							"relationshipStatus":     llx.StringData(string(m.RelationshipStatus)),
-							"invitedAt":              llx.TimeDataPtr(m.InvitedAt),
-							"updatedAt":              llx.TimeDataPtr(m.UpdatedAt),
-							"tags":                   llx.MapData(memberTags, mqlTypes.String),
-						})
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlMember)
-				}
+				res = append(res, mqlMember)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacieMember) id() (string, error) {
@@ -1325,61 +1075,33 @@ func (a *mqlAwsMacieMember) id() (string, error) {
 
 func (a *mqlAwsMacie) invitations() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getInvitations(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getInvitations(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			paginator := macie2.NewListInvitationsPaginator(svc, &macie2.ListInvitationsInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		paginator := macie2.NewListInvitationsPaginator(svc, &macie2.ListInvitationsInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, inv := range page.Invitations {
+				mqlInv, err := CreateResource(a.MqlRuntime, ResourceAwsMacieInvitation,
+					map[string]*llx.RawData{
+						"invitationId":       llx.StringDataPtr(inv.InvitationId),
+						"accountId":          llx.StringDataPtr(inv.AccountId),
+						"region":             llx.StringData(region),
+						"relationshipStatus": llx.StringData(string(inv.RelationshipStatus)),
+						"invitedAt":          llx.TimeDataPtr(inv.InvitedAt),
+					})
 				if err != nil {
-					if IsMacieNotEnabledError(err) {
-						log.Debug().Str("region", region).Msg("Macie is not enabled in region")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, inv := range page.Invitations {
-					mqlInv, err := CreateResource(a.MqlRuntime, ResourceAwsMacieInvitation,
-						map[string]*llx.RawData{
-							"invitationId":       llx.StringDataPtr(inv.InvitationId),
-							"accountId":          llx.StringDataPtr(inv.AccountId),
-							"region":             llx.StringData(region),
-							"relationshipStatus": llx.StringData(string(inv.RelationshipStatus)),
-							"invitedAt":          llx.TimeDataPtr(inv.InvitedAt),
-						})
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlInv)
-				}
+				res = append(res, mqlInv)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacieInvitation) id() (string, error) {
@@ -1393,63 +1115,32 @@ func (a *mqlAwsMacieInvitation) id() (string, error) {
 
 func (a *mqlAwsMacie) administrators() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getAdministrators(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getAdministrators(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			resp, err := svc.GetAdministratorAccount(ctx, &macie2.GetAdministratorAccountInput{})
-			if err != nil {
-				if IsMacieNotEnabledError(err) {
-					return res, nil
-				}
-				var notFoundErr *types.ResourceNotFoundException
-				if errors.As(err, &notFoundErr) {
-					return res, nil
-				}
-				return nil, err
-			}
-			if resp.Administrator == nil || resp.Administrator.AccountId == nil {
-				return res, nil
-			}
-			adm := resp.Administrator
-			mqlAdmin, err := CreateResource(a.MqlRuntime, ResourceAwsMacieAdministrator,
-				map[string]*llx.RawData{
-					"accountId":          llx.StringDataPtr(adm.AccountId),
-					"region":             llx.StringData(region),
-					"invitationId":       llx.StringDataPtr(adm.InvitationId),
-					"invitedAt":          llx.TimeDataPtr(adm.InvitedAt),
-					"relationshipStatus": llx.StringData(string(adm.RelationshipStatus)),
-				})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlAdmin)
-			return jobpool.JobResult(res), nil
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		resp, err := svc.GetAdministratorAccount(ctx, &macie2.GetAdministratorAccountInput{})
+		if err != nil {
+			return nil, err
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		if resp.Administrator == nil || resp.Administrator.AccountId == nil {
+			return res, nil
+		}
+		adm := resp.Administrator
+		mqlAdmin, err := CreateResource(a.MqlRuntime, ResourceAwsMacieAdministrator,
+			map[string]*llx.RawData{
+				"accountId":          llx.StringDataPtr(adm.AccountId),
+				"region":             llx.StringData(region),
+				"invitationId":       llx.StringDataPtr(adm.InvitationId),
+				"invitedAt":          llx.TimeDataPtr(adm.InvitedAt),
+				"relationshipStatus": llx.StringData(string(adm.RelationshipStatus)),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlAdmin)
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacieAdministrator) id() (string, error) {
@@ -1463,70 +1154,39 @@ func (a *mqlAwsMacieAdministrator) id() (string, error) {
 
 func (a *mqlAwsMacie) automatedDiscoveryConfigurations() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getAutomatedDiscoveryConfigurations(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getAutomatedDiscoveryConfigurations(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			resp, err := svc.GetAutomatedDiscoveryConfiguration(ctx, &macie2.GetAutomatedDiscoveryConfigurationInput{})
-			if err != nil {
-				if IsMacieNotEnabledError(err) {
-					return res, nil
-				}
-				var notFoundErr *types.ResourceNotFoundException
-				if errors.As(err, &notFoundErr) {
-					return res, nil
-				}
-				return nil, err
-			}
-			classificationScopeId := ""
-			if resp.ClassificationScopeId != nil {
-				classificationScopeId = *resp.ClassificationScopeId
-			}
-			sensitivityTemplateId := ""
-			if resp.SensitivityInspectionTemplateId != nil {
-				sensitivityTemplateId = *resp.SensitivityInspectionTemplateId
-			}
-			mqlConfig, err := CreateResource(a.MqlRuntime, ResourceAwsMacieAutomatedDiscoveryConfiguration,
-				map[string]*llx.RawData{
-					"region":                          llx.StringData(region),
-					"status":                          llx.StringData(string(resp.Status)),
-					"autoEnableOrganizationMembers":   llx.StringData(string(resp.AutoEnableOrganizationMembers)),
-					"classificationScopeId":           llx.StringData(classificationScopeId),
-					"sensitivityInspectionTemplateId": llx.StringData(sensitivityTemplateId),
-					"firstEnabledAt":                  llx.TimeDataPtr(resp.FirstEnabledAt),
-					"disabledAt":                      llx.TimeDataPtr(resp.DisabledAt),
-					"lastUpdatedAt":                   llx.TimeDataPtr(resp.LastUpdatedAt),
-				})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlConfig)
-			return jobpool.JobResult(res), nil
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		resp, err := svc.GetAutomatedDiscoveryConfiguration(ctx, &macie2.GetAutomatedDiscoveryConfigurationInput{})
+		if err != nil {
+			return nil, err
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		classificationScopeId := ""
+		if resp.ClassificationScopeId != nil {
+			classificationScopeId = *resp.ClassificationScopeId
+		}
+		sensitivityTemplateId := ""
+		if resp.SensitivityInspectionTemplateId != nil {
+			sensitivityTemplateId = *resp.SensitivityInspectionTemplateId
+		}
+		mqlConfig, err := CreateResource(a.MqlRuntime, ResourceAwsMacieAutomatedDiscoveryConfiguration,
+			map[string]*llx.RawData{
+				"region":                          llx.StringData(region),
+				"status":                          llx.StringData(string(resp.Status)),
+				"autoEnableOrganizationMembers":   llx.StringData(string(resp.AutoEnableOrganizationMembers)),
+				"classificationScopeId":           llx.StringData(classificationScopeId),
+				"sensitivityInspectionTemplateId": llx.StringData(sensitivityTemplateId),
+				"firstEnabledAt":                  llx.TimeDataPtr(resp.FirstEnabledAt),
+				"disabledAt":                      llx.TimeDataPtr(resp.DisabledAt),
+				"lastUpdatedAt":                   llx.TimeDataPtr(resp.LastUpdatedAt),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlConfig)
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacieAutomatedDiscoveryConfiguration) id() (string, error) {
@@ -1540,75 +1200,48 @@ func (a *mqlAwsMacieAutomatedDiscoveryConfiguration) id() (string, error) {
 
 func (a *mqlAwsMacie) classificationExportConfigurations() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getClassificationExportConfigurations(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
 
-func (a *mqlAwsMacie) getClassificationExportConfigurations(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.Macie2(region)
-			ctx := context.Background()
-			res := []any{}
-			resp, err := svc.GetClassificationExportConfiguration(ctx, &macie2.GetClassificationExportConfigurationInput{})
-			if err != nil {
-				if IsMacieNotEnabledError(err) {
-					return res, nil
-				}
-				return nil, err
-			}
-			if resp.Configuration == nil || resp.Configuration.S3Destination == nil {
-				return res, nil
-			}
-			dest := resp.Configuration.S3Destination
-			bucketName := ""
-			if dest.BucketName != nil {
-				bucketName = *dest.BucketName
-			}
-			keyPrefix := ""
-			if dest.KeyPrefix != nil {
-				keyPrefix = *dest.KeyPrefix
-			}
-			expectedBucketOwner := ""
-			if dest.ExpectedBucketOwner != nil {
-				expectedBucketOwner = *dest.ExpectedBucketOwner
-			}
-			kmsKeyArn := ""
-			if dest.KmsKeyArn != nil {
-				kmsKeyArn = *dest.KmsKeyArn
-			}
-			mqlConfig, err := CreateResource(a.MqlRuntime, ResourceAwsMacieClassificationExportConfiguration,
-				map[string]*llx.RawData{
-					"region":              llx.StringData(region),
-					"s3BucketName":        llx.StringData(bucketName),
-					"s3KeyPrefix":         llx.StringData(keyPrefix),
-					"expectedBucketOwner": llx.StringData(expectedBucketOwner),
-					"kmsKeyArn":           llx.StringData(kmsKeyArn),
-				})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, mqlConfig)
-			return jobpool.JobResult(res), nil
+	return perRegion(conn, "macie2", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.Macie2(region)
+		res := []any{}
+		resp, err := svc.GetClassificationExportConfiguration(ctx, &macie2.GetClassificationExportConfigurationInput{})
+		if err != nil {
+			return nil, err
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		if resp.Configuration == nil || resp.Configuration.S3Destination == nil {
+			return res, nil
+		}
+		dest := resp.Configuration.S3Destination
+		bucketName := ""
+		if dest.BucketName != nil {
+			bucketName = *dest.BucketName
+		}
+		keyPrefix := ""
+		if dest.KeyPrefix != nil {
+			keyPrefix = *dest.KeyPrefix
+		}
+		expectedBucketOwner := ""
+		if dest.ExpectedBucketOwner != nil {
+			expectedBucketOwner = *dest.ExpectedBucketOwner
+		}
+		kmsKeyArn := ""
+		if dest.KmsKeyArn != nil {
+			kmsKeyArn = *dest.KmsKeyArn
+		}
+		mqlConfig, err := CreateResource(a.MqlRuntime, ResourceAwsMacieClassificationExportConfiguration,
+			map[string]*llx.RawData{
+				"region":              llx.StringData(region),
+				"s3BucketName":        llx.StringData(bucketName),
+				"s3KeyPrefix":         llx.StringData(keyPrefix),
+				"expectedBucketOwner": llx.StringData(expectedBucketOwner),
+				"kmsKeyArn":           llx.StringData(kmsKeyArn),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlConfig)
+		return res, nil
+	})
 }
 
 func (a *mqlAwsMacieClassificationExportConfiguration) id() (string, error) {

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -18,7 +18,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -34,115 +33,117 @@ func (a *mqlAwsRds) id() (string, error) {
 // instances returns all RDS instances
 func (a *mqlAwsRds) instances() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getDbInstances(conn), 5)
-	poolOfJobs.Run()
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", region)
 
-	return res, nil
+		res := []any{}
+		svc := conn.Rds(region)
+
+		params := &rds.DescribeDBInstancesInput{}
+		paginator := rds.NewDescribeDBInstancesPaginator(svc, params)
+		for paginator.HasMorePages() {
+			dbInstances, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, dbInstance := range dbInstances.DBInstances {
+				// we cannot filter it in the api call since the api does not support it negative filters
+				if dbInstance.Engine != nil && slices.Contains(nonRdsEngines, *dbInstance.Engine) {
+					log.Debug().Str("engine", *dbInstance.Engine).Msg("skipping non-RDS engine")
+					continue
+				}
+
+				if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(rdsTagsToMap(dbInstance.TagList))) {
+					log.Debug().Interface("dbInstance", dbInstance.DBInstanceArn).Msg("skipping rds db instance due to filters")
+					continue
+				}
+
+				mqlDBInstance, err := newMqlAwsRdsInstance(a.MqlRuntime, region, conn.AccountId(), dbInstance)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, mqlDBInstance)
+			}
+		}
+		return res, nil
+	})
 }
 
 func (a *mqlAwsRds) clusterParameterGroups() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getClusterParameterGroups(conn), 5)
-	poolOfJobs.Run()
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("rds>getClusterParameterGroup>calling aws with region %s", region)
+		res := []any{}
+		svc := conn.Rds(region)
+
+		params := &rds.DescribeDBClusterParameterGroupsInput{}
+		paginator := rds.NewDescribeDBClusterParameterGroupsPaginator(svc, params)
+		for paginator.HasMorePages() {
+			DBClusterParameterGroups, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, dbClusterParameterGroup := range DBClusterParameterGroups.DBClusterParameterGroups {
+				mqlParameterGroup, err := newMqlAwsRdsClusterParameterGroup(a.MqlRuntime, region, dbClusterParameterGroup)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, mqlParameterGroup)
+			}
+		}
+		return res, nil
+	})
 }
 
 func (a *mqlAwsRds) eventSubscriptions() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getEventSubscriptions(conn), 5)
-	poolOfJobs.Run()
 
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
-}
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("rds>getEventSubscriptions>calling aws with region %s", region)
+		res := []any{}
+		svc := conn.Rds(region)
 
-func (a *mqlAwsRds) getEventSubscriptions(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getEventSubscriptions>calling aws with region %s", region)
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
+		paginator := rds.NewDescribeEventSubscriptionsPaginator(svc, &rds.DescribeEventSubscriptionsInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, sub := range page.EventSubscriptionsList {
+				sourceIds := make([]any, 0, len(sub.SourceIdsList))
+				for _, id := range sub.SourceIdsList {
+					sourceIds = append(sourceIds, id)
+				}
+				eventCategories := make([]any, 0, len(sub.EventCategoriesList))
+				for _, cat := range sub.EventCategoriesList {
+					eventCategories = append(eventCategories, cat)
+				}
 
-			paginator := rds.NewDescribeEventSubscriptionsPaginator(svc, &rds.DescribeEventSubscriptionsInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+				mqlSub, err := CreateResource(a.MqlRuntime, "aws.rds.eventSubscription",
+					map[string]*llx.RawData{
+						"__id":                     llx.StringDataPtr(sub.EventSubscriptionArn),
+						"arn":                      llx.StringDataPtr(sub.EventSubscriptionArn),
+						"name":                     llx.StringDataPtr(sub.CustSubscriptionId),
+						"region":                   llx.StringData(region),
+						"status":                   llx.StringDataPtr(sub.Status),
+						"snsTopicArn":              llx.StringDataPtr(sub.SnsTopicArn),
+						"sourceType":               llx.StringDataPtr(sub.SourceType),
+						"sourceIds":                llx.ArrayData(sourceIds, types.String),
+						"enabled":                  llx.BoolData(convert.ToValue(sub.Enabled)),
+						"eventCategories":          llx.ArrayData(eventCategories, types.String),
+						"customerAwsId":            llx.StringDataPtr(sub.CustomerAwsId),
+						"subscriptionCreationTime": llx.StringDataPtr(sub.SubscriptionCreationTime),
+					})
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, sub := range page.EventSubscriptionsList {
-					sourceIds := make([]any, 0, len(sub.SourceIdsList))
-					for _, id := range sub.SourceIdsList {
-						sourceIds = append(sourceIds, id)
-					}
-					eventCategories := make([]any, 0, len(sub.EventCategoriesList))
-					for _, cat := range sub.EventCategoriesList {
-						eventCategories = append(eventCategories, cat)
-					}
-
-					mqlSub, err := CreateResource(a.MqlRuntime, "aws.rds.eventSubscription",
-						map[string]*llx.RawData{
-							"__id":                     llx.StringDataPtr(sub.EventSubscriptionArn),
-							"arn":                      llx.StringDataPtr(sub.EventSubscriptionArn),
-							"name":                     llx.StringDataPtr(sub.CustSubscriptionId),
-							"region":                   llx.StringData(region),
-							"status":                   llx.StringDataPtr(sub.Status),
-							"snsTopicArn":              llx.StringDataPtr(sub.SnsTopicArn),
-							"sourceType":               llx.StringDataPtr(sub.SourceType),
-							"sourceIds":                llx.ArrayData(sourceIds, types.String),
-							"enabled":                  llx.BoolData(convert.ToValue(sub.Enabled)),
-							"eventCategories":          llx.ArrayData(eventCategories, types.String),
-							"customerAwsId":            llx.StringDataPtr(sub.CustomerAwsId),
-							"subscriptionCreationTime": llx.StringDataPtr(sub.SubscriptionCreationTime),
-						})
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlSub)
-				}
+				res = append(res, mqlSub)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 type mqlAwsRdsEventSubscriptionInternal struct {
@@ -175,58 +176,29 @@ func (a *mqlAwsRdsEventSubscription) snsTopic() (*mqlAwsSnsTopic, error) {
 
 func (a *mqlAwsRds) parameterGroups() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getParameterGroups(conn), 5)
-	poolOfJobs.Run()
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
-}
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("rds>getParameterGroup>calling aws with region %s", region)
+		res := []any{}
+		svc := conn.Rds(region)
 
-func (a *mqlAwsRds) getClusterParameterGroups(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getClusterParameterGroup>calling aws with region %s", region)
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
-
-			params := &rds.DescribeDBClusterParameterGroupsInput{}
-			paginator := rds.NewDescribeDBClusterParameterGroupsPaginator(svc, params)
-			for paginator.HasMorePages() {
-				DBClusterParameterGroups, err := paginator.NextPage(ctx)
+		params := &rds.DescribeDBParameterGroupsInput{}
+		paginator := rds.NewDescribeDBParameterGroupsPaginator(svc, params)
+		for paginator.HasMorePages() {
+			dbParameterGroups, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, dbParameterGroup := range dbParameterGroups.DBParameterGroups {
+				mqlParameterGroup, err := newMqlAwsParameterGroup(a.MqlRuntime, region, dbParameterGroup)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, dbClusterParameterGroup := range DBClusterParameterGroups.DBClusterParameterGroups {
-					mqlParameterGroup, err := newMqlAwsRdsClusterParameterGroup(a.MqlRuntime, region, dbClusterParameterGroup)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlParameterGroup)
-				}
+				res = append(res, mqlParameterGroup)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func newMqlAwsRdsClusterParameterGroup(runtime *plugin.Runtime, region string, parameterGroup rds_types.DBClusterParameterGroup) (*mqlAwsRdsClusterParameterGroup, error) {
@@ -266,161 +238,39 @@ func (a *mqlAwsRdsParameterGroup) tags() (map[string]any, error) {
 	})
 }
 
-func (a *mqlAwsRds) getParameterGroups(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getParameterGroup>calling aws with region %s", region)
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
-
-			params := &rds.DescribeDBParameterGroupsInput{}
-			paginator := rds.NewDescribeDBParameterGroupsPaginator(svc, params)
-			for paginator.HasMorePages() {
-				dbParameterGroups, err := paginator.NextPage(ctx)
-				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
-					return nil, err
-				}
-				for _, dbParameterGroup := range dbParameterGroups.DBParameterGroups {
-					mqlParameterGroup, err := newMqlAwsParameterGroup(a.MqlRuntime, region, dbParameterGroup)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlParameterGroup)
-				}
-			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
-}
-
-func (a *mqlAwsRds) getDbInstances(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", region)
-
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
-
-			params := &rds.DescribeDBInstancesInput{}
-			paginator := rds.NewDescribeDBInstancesPaginator(svc, params)
-			for paginator.HasMorePages() {
-				dbInstances, err := paginator.NextPage(ctx)
-				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
-					return nil, err
-				}
-				for _, dbInstance := range dbInstances.DBInstances {
-					// we cannot filter it in the api call since the api does not support it negative filters
-					if dbInstance.Engine != nil && slices.Contains(nonRdsEngines, *dbInstance.Engine) {
-						log.Debug().Str("engine", *dbInstance.Engine).Msg("skipping non-RDS engine")
-						continue
-					}
-
-					if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(rdsTagsToMap(dbInstance.TagList))) {
-						log.Debug().Interface("dbInstance", dbInstance.DBInstanceArn).Msg("skipping rds db instance due to filters")
-						continue
-					}
-
-					mqlDBInstance, err := newMqlAwsRdsInstance(a.MqlRuntime, region, conn.AccountId(), dbInstance)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlDBInstance)
-				}
-			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
-}
-
 // pendingMaintenanceActions returns all pending maintenance actions for all RDS instances
 func (a *mqlAwsRds) allPendingMaintenanceActions() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getPendingMaintenanceActions(conn), 5)
-	poolOfJobs.Run()
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", region)
 
-	return res, nil
-}
+		res := []any{}
+		svc := conn.Rds(region)
 
-func (a *mqlAwsRds) getPendingMaintenanceActions(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getDbInstances>calling aws with region %s", region)
-
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
-
-			params := &rds.DescribePendingMaintenanceActionsInput{}
-			paginator := rds.NewDescribePendingMaintenanceActionsPaginator(svc, params)
-			for paginator.HasMorePages() {
-				pendingMaintenanceList, err := paginator.NextPage(ctx)
-				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
-					return nil, err
+		params := &rds.DescribePendingMaintenanceActionsInput{}
+		paginator := rds.NewDescribePendingMaintenanceActionsPaginator(svc, params)
+		for paginator.HasMorePages() {
+			pendingMaintenanceList, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, resp := range pendingMaintenanceList.PendingMaintenanceActions {
+				if resp.ResourceIdentifier == nil {
+					continue
 				}
-				for _, resp := range pendingMaintenanceList.PendingMaintenanceActions {
-					if resp.ResourceIdentifier == nil {
-						continue
+				for _, action := range resp.PendingMaintenanceActionDetails {
+					resourceArn := *resp.ResourceIdentifier
+					mqlPendingAction, err := newMqlAwsPendingMaintenanceAction(a.MqlRuntime, resourceArn, action)
+					if err != nil {
+						return nil, err
 					}
-					for _, action := range resp.PendingMaintenanceActionDetails {
-						resourceArn := *resp.ResourceIdentifier
-						mqlPendingAction, err := newMqlAwsPendingMaintenanceAction(a.MqlRuntime, resourceArn, action)
-						if err != nil {
-							return nil, err
-						}
-						res = append(res, mqlPendingAction)
-					}
+					res = append(res, mqlPendingAction)
 				}
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func (a *mqlAwsRdsDbinstance) id() (string, error) {
@@ -1224,72 +1074,42 @@ func rdsTagsToMap(tags []rds_types.Tag) map[string]any {
 // clusters returns all RDS clusters
 func (a *mqlAwsRds) clusters() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getDbClusters(conn), 5)
-	poolOfJobs.Run()
 
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("rds>getDbClusters>calling aws with region %s", region)
 
-	return res, nil
-}
+		res := []any{}
+		svc := conn.Rds(region)
 
-func (a *mqlAwsRds) getDbClusters(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getDbClusters>calling aws with region %s", region)
+		params := &rds.DescribeDBClustersInput{}
+		paginator := rds.NewDescribeDBClustersPaginator(svc, params)
+		for paginator.HasMorePages() {
+			dbClusters, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
 
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
+			for _, cluster := range dbClusters.DBClusters {
+				// we cannot filter it in the api call since the api does not support it negative filters
+				if cluster.Engine != nil && slices.Contains(nonRdsEngines, *cluster.Engine) {
+					log.Debug().Str("engine", *cluster.Engine).Msg("skipping non-RDS engine")
+					continue
+				}
 
-			params := &rds.DescribeDBClustersInput{}
-			paginator := rds.NewDescribeDBClustersPaginator(svc, params)
-			for paginator.HasMorePages() {
-				dbClusters, err := paginator.NextPage(ctx)
+				if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(rdsTagsToMap(cluster.TagList))) {
+					log.Debug().Interface("cluster", cluster.DBClusterArn).Msg("skipping rds cluster due to filters")
+					continue
+				}
+
+				mqlDbCluster, err := newMqlAwsRdsCluster(a.MqlRuntime, region, conn.AccountId(), cluster)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
 					return nil, err
 				}
-
-				for _, cluster := range dbClusters.DBClusters {
-					// we cannot filter it in the api call since the api does not support it negative filters
-					if cluster.Engine != nil && slices.Contains(nonRdsEngines, *cluster.Engine) {
-						log.Debug().Str("engine", *cluster.Engine).Msg("skipping non-RDS engine")
-						continue
-					}
-
-					if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(rdsTagsToMap(cluster.TagList))) {
-						log.Debug().Interface("cluster", cluster.DBClusterArn).Msg("skipping rds cluster due to filters")
-						continue
-					}
-
-					mqlDbCluster, err := newMqlAwsRdsCluster(a.MqlRuntime, region, conn.AccountId(), cluster)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlDbCluster)
-				}
+				res = append(res, mqlDbCluster)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 type mqlAwsRdsDbclusterInternal struct {
@@ -1833,64 +1653,33 @@ func (a *mqlAwsRdsSnapshot) isPublic() (bool, error) {
 
 func (a *mqlAwsRds) proxies() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getProxies(conn), 5)
-	poolOfJobs.Run()
 
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		if poolOfJobs.Jobs[i].Result != nil {
-			res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-		}
-	}
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		log.Debug().Msgf("rds>getProxies>calling aws with region %s", region)
 
-	return res, nil
-}
+		res := []any{}
+		svc := conn.Rds(region)
 
-func (a *mqlAwsRds) getProxies(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("rds>getProxies>calling aws with region %s", region)
-
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
-
-			paginator := rds.NewDescribeDBProxiesPaginator(svc, &rds.DescribeDBProxiesInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+		paginator := rds.NewDescribeDBProxiesPaginator(svc, &rds.DescribeDBProxiesInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				if IsServiceNotAvailableInRegionError(err) {
+					log.Debug().Str("region", region).Msg("rds proxy service not available in region")
+					return res, nil
+				}
+				return nil, err
+			}
+			for _, proxy := range page.DBProxies {
+				mqlProxy, err := newMqlAwsRdsProxy(a.MqlRuntime, region, conn.AccountId(), proxy)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
-					if IsServiceNotAvailableInRegionError(err) {
-						log.Debug().Str("region", region).Msg("rds proxy service not available in region")
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, proxy := range page.DBProxies {
-					mqlProxy, err := newMqlAwsRdsProxy(a.MqlRuntime, region, conn.AccountId(), proxy)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlProxy)
-				}
+				res = append(res, mqlProxy)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 func newMqlAwsRdsProxy(runtime *plugin.Runtime, region string, accountID string, proxy rds_types.DBProxy) (*mqlAwsRdsProxy, error) {
@@ -2023,52 +1812,26 @@ func rdsTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[str
 
 func (a *mqlAwsRds) optionGroups() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getOptionGroups(conn), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
-}
 
-func (a *mqlAwsRds) getOptionGroups(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		region := region
-		f := func() (jobpool.JobResult, error) {
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
-			paginator := rds.NewDescribeOptionGroupsPaginator(svc, &rds.DescribeOptionGroupsInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+	return perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		res := []any{}
+		svc := conn.Rds(region)
+		paginator := rds.NewDescribeOptionGroupsPaginator(svc, &rds.DescribeOptionGroupsInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, og := range page.OptionGroupsList {
+				mqlOG, err := newMqlAwsRdsOptionGroup(a.MqlRuntime, region, og)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						return res, nil
-					}
 					return nil, err
 				}
-				for _, og := range page.OptionGroupsList {
-					mqlOG, err := newMqlAwsRdsOptionGroup(a.MqlRuntime, region, og)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlOG)
-				}
+				res = append(res, mqlOG)
 			}
-			return jobpool.JobResult(res), nil
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+		return res, nil
+	})
 }
 
 type mqlAwsRdsOptionGroupInternal struct {
@@ -2171,65 +1934,47 @@ func (a *mqlAwsRdsDbinstance) optionGroups() ([]any, error) {
 
 func (a *mqlAwsRds) globalClusters() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	pool := jobpool.CreatePool(a.getGlobalClusters(conn), 5)
-	pool.Run()
-	if pool.HasErrors() {
-		return nil, pool.GetErrors()
+
+	all, err := perRegion(conn, "rds", func(ctx context.Context, region string) ([]any, error) {
+		res := []any{}
+		svc := conn.Rds(region)
+		paginator := rds.NewDescribeGlobalClustersPaginator(svc, &rds.DescribeGlobalClustersInput{})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, gc := range page.GlobalClusters {
+				mqlGc, err := newMqlAwsRdsGlobalCluster(a.MqlRuntime, region, gc)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, mqlGc)
+			}
+		}
+		return res, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	// Aurora global clusters surface from any member region's regional
-	// endpoint, so deduplicate by ARN across the parallel region jobs.
+	// endpoint, so deduplicate by ARN across the parallel region reads.
 	seen := map[string]bool{}
 	res := []any{}
-	for i := range pool.Jobs {
-		for _, r := range pool.Jobs[i].Result.([]any) {
-			gc := r.(*mqlAwsRdsGlobalCluster)
-			arn := gc.Arn.Data
-			if arn == "" || seen[arn] {
-				continue
-			}
-			seen[arn] = true
-			res = append(res, gc)
+	for _, r := range all {
+		gc, ok := r.(*mqlAwsRdsGlobalCluster)
+		if !ok {
+			continue
 		}
+		arn := gc.Arn.Data
+		if arn == "" || seen[arn] {
+			continue
+		}
+		seen[arn] = true
+		res = append(res, gc)
 	}
 	return res, nil
-}
-
-func (a *mqlAwsRds) getGlobalClusters(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range regions {
-		region := region
-		f := func() (jobpool.JobResult, error) {
-			res := []any{}
-			svc := conn.Rds(region)
-			ctx := context.Background()
-			paginator := rds.NewDescribeGlobalClustersPaginator(svc, &rds.DescribeGlobalClustersInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
-				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("access denied describing RDS global clusters")
-						return res, nil
-					}
-					return nil, err
-				}
-				for _, gc := range page.GlobalClusters {
-					mqlGc, err := newMqlAwsRdsGlobalCluster(a.MqlRuntime, region, gc)
-					if err != nil {
-						return nil, err
-					}
-					res = append(res, mqlGc)
-				}
-			}
-			return jobpool.JobResult(res), nil
-		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
 }
 
 // mqlAwsRdsGlobalClusterInternal carries the region the global cluster was

--- a/providers/aws/resources/aws_regional.go
+++ b/providers/aws/resources/aws_regional.go
@@ -1,0 +1,138 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+// regionalConcurrency bounds how many regions one lister queries at a time.
+const regionalConcurrency = 5
+
+// perRegion runs fn once for every region in scope and returns the results
+// concatenated.
+//
+// It owns the decisions that a hand-rolled region fan-out otherwise makes over
+// and over, differently each time:
+//
+//   - Errors are classified centrally. A region where the service is absent or
+//     was never enabled contributes nothing and is not an error; a region the
+//     caller may not read contributes nothing and is recorded as a coverage gap;
+//     anything else is a real failure.
+//   - Partial results survive. One unreachable region no longer discards the
+//     data collected from every other region, though a run where every region
+//     failed still returns the error rather than an empty list.
+//   - A panic inside fn fails that one region instead of taking down the scan.
+//
+// service is the AWS service id used for error classification and gap
+// reporting, for example "ecr" or "macie2".
+func perRegion[T any](conn *connection.AwsConnection, service string,
+	fn func(ctx context.Context, region string) ([]T, error),
+) ([]T, error) {
+	regions, err := conn.Regions()
+	if err != nil {
+		return nil, err
+	}
+	return forRegions(conn, service, regions, fn)
+}
+
+// forRegions is perRegion over an explicit region list, for the few listers
+// that scope themselves more narrowly than the connection does.
+func forRegions[T any](conn *connection.AwsConnection, service string, regions []string,
+	fn func(ctx context.Context, region string) ([]T, error),
+) ([]T, error) {
+	type outcome struct {
+		items []T
+		err   error
+	}
+	outcomes := make([]outcome, len(regions))
+
+	// TODO: thread the caller's context through here once the plugin runtime
+	// hands one to resource accessors, so a cancelled scan stops in flight.
+	ctx := context.Background()
+
+	sem := make(chan struct{}, regionalConcurrency)
+	var wg sync.WaitGroup
+	for i := range regions {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			outcomes[i].items, outcomes[i].err = callRegion(ctx, regions[i], fn)
+		}(i)
+	}
+	wg.Wait()
+
+	res := []T{}
+	var (
+		firstErr error
+		failed   int
+	)
+	for i := range outcomes {
+		region := regions[i]
+		if err := outcomes[i].err; err != nil {
+			switch classifyError(service, err) {
+			case dispositionEmpty:
+				// Nothing here to report, and that is the honest answer.
+			case dispositionUnreadable:
+				conn.RecordGap(service, region, connection.GapDenied)
+			default:
+				conn.RecordGap(service, region, connection.GapFailed)
+				failed++
+				if firstErr == nil {
+					firstErr = errors.Wrapf(err, "%s in %s", service, region)
+				}
+			}
+			continue
+		}
+		res = append(res, outcomes[i].items...)
+	}
+
+	// Every region failing means the caller learned nothing, so report it.
+	// Otherwise keep what was collected: discarding twenty good regions because
+	// one was throttled loses far more than it protects.
+	if failed > 0 && failed == len(regions) {
+		return nil, firstErr
+	}
+	if failed > 0 {
+		log.Warn().
+			Str("service", service).
+			Int("failedRegions", failed).
+			Int("totalRegions", len(regions)).
+			Err(firstErr).
+			Msg("some regions could not be read; returning partial results")
+	}
+	return res, nil
+}
+
+// callRegion invokes fn, converting a panic into an error for that region.
+//
+// Resource accessors run in the executor's goroutines, where an unrecovered
+// panic takes down the whole scan rather than the one query that caused it. A
+// bad type assertion in one region's mapping code should cost that region, not
+// every other result the run had already collected.
+func callRegion[T any](ctx context.Context, region string,
+	fn func(ctx context.Context, region string) ([]T, error),
+) (items []T, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().
+				Str("region", region).
+				Interface("panic", r).
+				Str("stack", string(debug.Stack())).
+				Msg("recovered panic while collecting region")
+			items = nil
+			err = fmt.Errorf("panic while collecting region %s: %v", region, r)
+		}
+	}()
+	return fn(ctx, region)
+}

--- a/providers/aws/resources/aws_regional.go
+++ b/providers/aws/resources/aws_regional.go
@@ -84,9 +84,9 @@ func forRegions[T any](conn *connection.AwsConnection, service string, regions [
 			case dispositionEmpty:
 				// Nothing here to report, and that is the honest answer.
 			case dispositionUnreadable:
-				conn.RecordGap(service, region, connection.GapDenied)
+				conn.RecordGap(serviceName(service), region, connection.GapDenied)
 			default:
-				conn.RecordGap(service, region, connection.GapFailed)
+				conn.RecordGap(serviceName(service), region, connection.GapFailed)
 				failed++
 				if firstErr == nil {
 					firstErr = errors.Wrapf(err, "%s in %s", service, region)

--- a/providers/aws/resources/aws_regional_test.go
+++ b/providers/aws/resources/aws_regional_test.go
@@ -1,0 +1,208 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+// testConn builds a connection pinned to an explicit region list. Regions()
+// short-circuits on the region filter, so nothing here touches the network.
+func testConn(regions ...string) *connection.AwsConnection {
+	return &connection.AwsConnection{
+		Filters: connection.DiscoveryFilters{
+			General: connection.GeneralDiscoveryFilters{Regions: regions},
+		},
+	}
+}
+
+func TestPerRegionCollectsEveryRegion(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1", "ap-south-1")
+
+	got, err := perRegion(conn, "ecr", func(_ context.Context, region string) ([]any, error) {
+		return []any{region}, nil
+	})
+
+	require.NoError(t, err)
+	strs := toStrings(got)
+	sort.Strings(strs)
+	require.Equal(t, []string{"ap-south-1", "eu-west-1", "us-east-1"}, strs)
+	require.Empty(t, conn.CoverageGaps())
+}
+
+// An empty account must produce an empty list, never a nil one: a nil slice
+// renders differently to MQL than the empty result it is meant to represent.
+func TestPerRegionReturnsEmptySliceNotNil(t *testing.T) {
+	conn := testConn("us-east-1")
+
+	got, err := perRegion(conn, "ecr", func(_ context.Context, _ string) ([]any, error) {
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Empty(t, got)
+}
+
+// A region where the service simply is not deployed contributes nothing and is
+// not a failure, and it is not a coverage gap either: empty is the truth there.
+func TestPerRegionAbsentServiceIsSilent(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1")
+
+	got, err := perRegion(conn, "bedrock", func(_ context.Context, region string) ([]any, error) {
+		if region == "eu-west-1" {
+			return nil, errors.New("could not resolve endpoint")
+		}
+		return []any{region}, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"us-east-1"}, toStrings(got))
+	require.Empty(t, conn.CoverageGaps(), "an absent service is not a coverage gap")
+}
+
+// The case this whole change exists for: a denied read still yields an empty
+// list, but it is recorded so the run can say the answer is incomplete.
+func TestPerRegionDeniedReadIsRecordedAsGap(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1")
+
+	got, err := perRegion(conn, "macie2", func(_ context.Context, region string) ([]any, error) {
+		if region == "eu-west-1" {
+			return nil, apiErr("AccessDeniedException", "not authorized to perform macie2:ListFindings")
+		}
+		return []any{region}, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"us-east-1"}, toStrings(got))
+
+	gaps := conn.CoverageGaps()
+	require.Len(t, gaps, 1)
+	require.Equal(t, connection.Gap{Service: "macie2", Region: "eu-west-1", Reason: connection.GapDenied}, gaps[0])
+}
+
+// One bad region must not discard the regions that answered. This is the
+// behaviour change from the old fan-out, which returned the error and dropped
+// every collected result.
+func TestPerRegionKeepsPartialResults(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1", "ap-south-1")
+
+	got, err := perRegion(conn, "rds", func(_ context.Context, region string) ([]any, error) {
+		if region == "eu-west-1" {
+			return nil, apiErr("ThrottlingException", "Rate exceeded")
+		}
+		return []any{region}, nil
+	})
+
+	require.NoError(t, err, "a single failed region must not fail the whole listing")
+	strs := toStrings(got)
+	sort.Strings(strs)
+	require.Equal(t, []string{"ap-south-1", "us-east-1"}, strs)
+
+	gaps := conn.CoverageGaps()
+	require.Len(t, gaps, 1)
+	require.Equal(t, connection.GapFailed, gaps[0].Reason)
+}
+
+// If nothing worked anywhere, the caller learned nothing and must be told,
+// rather than handed an empty list that reads as "no resources".
+func TestPerRegionAllRegionsFailedReturnsError(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1")
+
+	got, err := perRegion(conn, "rds", func(_ context.Context, _ string) ([]any, error) {
+		return nil, apiErr("ThrottlingException", "Rate exceeded")
+	})
+
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Contains(t, err.Error(), "rds")
+}
+
+// Every region being denied is still an empty list, not an error: the account
+// may genuinely have nothing, and we cannot tell. The gaps are what carry the
+// warning.
+func TestPerRegionAllRegionsDeniedIsEmptyWithGaps(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1")
+
+	got, err := perRegion(conn, "ecr", func(_ context.Context, _ string) ([]any, error) {
+		return nil, apiErr("AccessDenied", "denied")
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, got)
+	require.Len(t, conn.CoverageGaps(), 2)
+}
+
+// A panic in one region's mapping code must cost that region, not the scan.
+func TestPerRegionRecoversPanic(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1")
+
+	got, err := perRegion(conn, "ecr", func(_ context.Context, region string) ([]any, error) {
+		if region == "eu-west-1" {
+			var typed []any
+			_ = typed[3] // index out of range
+		}
+		return []any{region}, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"us-east-1"}, toStrings(got))
+	require.Len(t, conn.CoverageGaps(), 1)
+}
+
+func TestPerRegionRespectsConcurrencyLimit(t *testing.T) {
+	regions := make([]string, 40)
+	for i := range regions {
+		regions[i] = string(rune('a' + i%26))
+	}
+	conn := testConn(regions...)
+
+	var inFlight, peak int64
+	var mu sync.Mutex
+
+	_, err := perRegion(conn, "ecr", func(_ context.Context, region string) ([]any, error) {
+		cur := atomic.AddInt64(&inFlight, 1)
+		mu.Lock()
+		if cur > peak {
+			peak = cur
+		}
+		mu.Unlock()
+		defer atomic.AddInt64(&inFlight, -1)
+		return []any{region}, nil
+	})
+
+	require.NoError(t, err)
+	require.LessOrEqual(t, peak, int64(regionalConcurrency))
+}
+
+// Gaps are recorded from concurrent goroutines and deduplicated.
+func TestCoverageGapsDeduplicate(t *testing.T) {
+	conn := testConn("us-east-1")
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn.RecordGap("ecr", "us-east-1", connection.GapDenied)
+		}()
+	}
+	wg.Wait()
+	require.Len(t, conn.CoverageGaps(), 1)
+}
+
+func toStrings(in []any) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		out = append(out, v.(string))
+	}
+	return out
+}

--- a/providers/aws/resources/aws_regional_test.go
+++ b/providers/aws/resources/aws_regional_test.go
@@ -90,6 +90,20 @@ func TestPerRegionDeniedReadIsRecordedAsGap(t *testing.T) {
 	require.Equal(t, connection.Gap{Service: "macie2", Region: "eu-west-1", Reason: connection.GapDenied}, gaps[0])
 }
 
+// A gap from a scoped classification key is reported under the bare service.
+func TestPerRegionGapUsesBareServiceName(t *testing.T) {
+	conn := testConn("us-east-1")
+
+	_, err := perRegion(conn, "macie2/config", func(_ context.Context, _ string) ([]any, error) {
+		return nil, apiErr("AccessDeniedException", "not authorized to perform macie2:GetMacieSession")
+	})
+
+	require.NoError(t, err)
+	gaps := conn.CoverageGaps()
+	require.Len(t, gaps, 1)
+	require.Equal(t, "macie2", gaps[0].Service, "gaps are reported per service, not per endpoint scope")
+}
+
 // One bad region must not discard the regions that answered. This is the
 // behaviour change from the old fan-out, which returned the error and dropped
 // every collected result.

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -24,7 +24,6 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/providers/aws/resources/awspolicy"
 	"go.mondoo.com/mql/v13/types"
@@ -61,81 +60,55 @@ func (a *mqlAwsS3) id() (string, error) {
 func (a *mqlAwsS3) buckets() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getBuckets(conn), 5)
-	poolOfJobs.Run()
+	return perRegion(conn, "s3", func(ctx context.Context, region string) ([]any, error) {
+		svc := conn.S3(region)
+		log.Debug().Str("region", region).Msg("listing S3 buckets in region")
+		params := &s3.ListBucketsInput{BucketRegion: aws.String(region)}
+		paginator := s3.NewListBucketsPaginator(svc, params, func(o *s3.ListBucketsPaginatorOptions) {
+			o.Limit = 100
+		})
 
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
-}
-
-func (a *mqlAwsS3) getBuckets(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	configuredRegions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
-	}
-	for _, region := range configuredRegions {
-		f := func() (jobpool.JobResult, error) {
-			svc := conn.S3(region)
-			ctx := context.Background()
-			log.Debug().Str("region", region).Msg("listing S3 buckets in region")
-			params := &s3.ListBucketsInput{BucketRegion: aws.String(region)}
-			paginator := s3.NewListBucketsPaginator(svc, params, func(o *s3.ListBucketsPaginatorOptions) {
-				o.Limit = 100
-			})
-
-			res := []any{}
-			for paginator.HasMorePages() {
-				output, err := paginator.NextPage(ctx)
-				if err != nil {
-					log.Warn().Err(err).Str("region", region).Msg("could not list S3 buckets in region")
-					break
+		res := []any{}
+		for paginator.HasMorePages() {
+			output, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, bucket := range output.Buckets {
+				if conn.Filters.S3.IsFilteredOut(convert.ToValue(bucket.Name)) {
+					continue
 				}
-				for _, bucket := range output.Buckets {
-					if conn.Filters.S3.IsFilteredOut(convert.ToValue(bucket.Name)) {
-						continue
-					}
 
-					mqlS3Bucket, err := CreateResource(a.MqlRuntime, ResourceAwsS3Bucket,
-						map[string]*llx.RawData{
-							"name":      llx.StringDataPtr(bucket.Name),
-							"arn":       llx.StringData(fmt.Sprintf(s3ArnPattern, convert.ToValue(bucket.Name))),
-							"exists":    llx.BoolData(true),
-							"location":  llx.StringData(region),
-							"createdAt": llx.TimeDataPtr(bucket.CreationDate),
-						})
+				mqlS3Bucket, err := CreateResource(a.MqlRuntime, ResourceAwsS3Bucket,
+					map[string]*llx.RawData{
+						"name":      llx.StringDataPtr(bucket.Name),
+						"arn":       llx.StringData(fmt.Sprintf(s3ArnPattern, convert.ToValue(bucket.Name))),
+						"exists":    llx.BoolData(true),
+						"location":  llx.StringData(region),
+						"createdAt": llx.TimeDataPtr(bucket.CreationDate),
+					})
+				if err != nil {
+					return nil, err
+				}
+
+				// keeps the tags lazy unless the filters need to be evaluated
+				if conn.Filters.General.HasTags() {
+					tags, err := mqlS3Bucket.(*mqlAwsS3Bucket).tags()
 					if err != nil {
 						return nil, err
 					}
 
-					// keeps the tags lazy unless the filters need to be evaluated
-					if conn.Filters.General.HasTags() {
-						tags, err := mqlS3Bucket.(*mqlAwsS3Bucket).tags()
-						if err != nil {
-							return nil, err
-						}
-
-						if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(tags)) {
-							continue
-						}
+					if conn.Filters.General.IsFilteredOutByTags(mapStringInterfaceToStringString(tags)) {
+						continue
 					}
-
-					res = append(res, mqlS3Bucket)
 				}
-			}
 
-			return jobpool.JobResult(res), nil
+				res = append(res, mqlS3Bucket)
+			}
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
-	}
-	return tasks
+
+		return res, nil
+	})
 }
 
 func initAwsS3BucketPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {


### PR DESCRIPTION
## Why

Every multi-region lister in the AWS provider hand-rolls the same fan-out: a builder that loops regions wrapping a closure in a `jobpool.Job`, plus a collector that runs the pool and flattens the results. There are **375** of them. The scaffolding isn't the problem — the policy baked into each copy is.

Three decisions are re-made at every site, differently each time:

**1. What a failed region means.** Census of what follows `if Is400AccessDeniedError(err)`:

| Action | Sites |
|---|---|
| `return res, nil` (partial, keep going) | 462 |
| `return nil, err` (fail) | 205 |
| `return nil, nil` (**renders as `[]`**) | 139 |
| `continue` / `break` | 23 |

Those 139 are the expensive ones: a list accessor returning `nil, nil` still renders `[]`, so "I was denied permission to look" and "there is nothing here" become the same observable value, and any policy of the form `aws.x.things.all(secure)` passes vacuously on a permission gap.

**2. Whether one bad region discards the rest.** 351 collectors answer `return nil, poolOfJobs.GetErrors()` — a single throttled region throws away everything the other 20-odd regions collected.

**3. Whether the result can be nil.** 362 collectors do a bare `Result.([]any)` with **zero** nil guards. A job returning `(nil, nil)` yields a nil `Result`, and asserting `[]any` on a nil interface panics — which, per `CLAUDE.md`, takes down the whole scan rather than one query. This holds today only because every one of the 375 closures happens to return an empty slice rather than nil. It's a convention held by 375 independent authors, and `getEbsEncryptionPerRegion`'s collector is the only site that guards for it.

The error predicates themselves match on rendered English:

```go
errorMessageMatches := strings.Contains(respErr.Error(), "AccessDenied") || ...
```

`IsServiceNotAvailableInRegionError` is nine `strings.Contains` on the raw error string. This is the class that produced #9746 — AWS changed an apostrophe to U+2019 and a guard silently stopped firing.

## What this adds

**`perRegion`** (`resources/aws_regional.go`) replaces the builder/collector pair:

```go
func perRegion[T any](conn *connection.AwsConnection, service string,
	fn func(ctx context.Context, region string) ([]T, error)) ([]T, error)
```

- errors classified centrally — the closure contains no error policy at all
- partial results survive a failed region; all-regions-failed still returns the error
- a panic inside the closure costs that region, not the scan
- the `[]T` signature makes the nil type assertion unrepresentable

**`classifyError`** (`resources/aws_disposition.go`) sorts an error into `fail` / `empty` / `unreadable`, matching on smithy's `ErrorCode()` rather than the rendered message. Codes are part of the API contract; messages are prose AWS rewrites at will. Message matching survives only for the handful of services with no distinct code for "never enabled" (Macie, Security Lake, GuardDuty) — and those rules are **scoped per service**, so one service's wording can't excuse another's.

**Coverage gaps** (`connection/coverage.go`) — unreadable regions are recorded on the connection and warned once per unique service/region pair, so a scan can say which answers it does not actually have.

## Behaviour change

Only one, and it's deliberate: a single failed region no longer discards the regions that answered. Denied reads still render as an empty list, so **no existing policy changes result** — the gaps are what carry the warning. A queryable `aws.unreadable` resource is the obvious follow-up if we want policies to assert on coverage directly.

## Before / after

ECR's private-repository lister, 60 lines → 36, with the error policy gone from the closure:

```go
func (a *mqlAwsEcr) privateRepositories() ([]any, error) {
	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
	if conn.Filters.Ecr.Scope == connection.EcrScopePublic {
		return []any{}, nil
	}
	return perRegion(conn, "ecr", func(ctx context.Context, region string) ([]any, error) {
		svc := conn.Ecr(region)
		res := []any{}
		for _, batch := range batches {
			paginator := ecr.NewDescribeRepositoriesPaginator(svc, req)
			for paginator.HasMorePages() {
				repoResp, err := paginator.NextPage(ctx, withEcrDescribeRetries)
				if err != nil {
					return nil, err          // classification is perRegion's job
				}
				...
			}
		}
		return res, nil
	})
}
```

## Scope

Migrated **ecr, efs, s3, kms, macie, rds** — 26 of 375 sites, net **−796 lines**. The remaining 349 keep working unchanged. This establishes the shape on a reviewable diff before the wider sweep.

`aws.kms.grants` is left alone: it fans out per-key, not per-region, and wants a separate `perItem` helper.

## Tests

20 new tests, all passing under `-race`:

- **classifier** — access-denied codes → unreadable; absent-service codes → empty; throttling/5xx/validation → fail; transport region misses → empty; retry-exhaustion *alone* stays a failure; classification survives arbitrary wrapping
- **`TestClassifyToleratesCurlyApostrophe`** — regression test for #9746
- **`TestClassifyMacieDistinguishesNotEnabledFromDenied`** — same service, same error code, different meaning
- **`TestClassifyServiceRulesAreScoped`** — Macie's not-enabled wording gives RDS no excuse
- **`perRegion`** — collects all regions; returns `[]` not nil; absent service is silent and *not* a gap; denied read is recorded as a gap; partial results survive; all-failed returns the error; all-denied is empty-with-gaps; panics are contained; concurrency limit respected; gap recording deduplicates under concurrent writers

## Verification

```
gofmt -l          clean
go build ./...    clean
go vet ./...      clean
go test ./...     all packages ok
go test -race     ok (new tests)
go mod tidy       no change
```

One regression caught and fixed during the migration: the scripted rewrite initially dropped `globalClusters`' cross-region ARN deduplication. All 26 migrated collectors were then audited for non-boilerplate logic in their original bodies — `globalClusters` was the only one, and its dedup is restored on top of `perRegion`. Two access-denied guards in non-migrated helpers (`rdsPendingMaintenanceActions`, `rdsRecommendations`) were also verified intact.

## Not live-verified

Static + unit only. Worth a live run against a real account before the wider sweep, particularly to confirm the Macie not-enabled path still classifies as empty against the real API.
