### PR TITLE
✨ k8s: attribute network exposures to the workloads backing exposed pods

### DIFF
--- a/providers/k8s/resources/exposure_targets.go
+++ b/providers/k8s/resources/exposure_targets.go
@@ -110,6 +110,94 @@ func (k *mqlK8sPod) exposures() ([]any, error) {
 	return out, nil
 }
 
+// exposuresForPods returns the network exposures that route to any of the
+// given pods, in the cluster's stable exposure order, deduplicated by
+// exposure. It is the shared fold behind the workload-level exposures
+// accessors: a workload is exposed exactly when one of its pods is.
+func exposuresForPods(runtime *plugin.Runtime, pods []any) ([]any, error) {
+	if len(pods) == 0 {
+		return []any{}, nil
+	}
+	want := make(map[string]struct{}, len(pods))
+	for _, p := range pods {
+		if mp, ok := p.(*mqlK8sPod); ok {
+			want[mp.MqlID()] = struct{}{}
+		}
+	}
+
+	cluster, err := k8sCluster(runtime)
+	if err != nil {
+		return nil, err
+	}
+	exps := cluster.GetNetworkExposures()
+	if exps.Error != nil {
+		return nil, exps.Error
+	}
+
+	out := []any{}
+	for i := range exps.Data {
+		exp, ok := exps.Data[i].(*mqlK8sNetworkExposure)
+		if !ok {
+			continue
+		}
+		expPods, err := exp.pods()
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range expPods {
+			if mp, ok := p.(*mqlK8sPod); ok {
+				if _, hit := want[mp.MqlID()]; hit {
+					out = append(out, exp)
+					break
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+// exposures returns the network exposures that route to any pod backing this
+// deployment. This is what lets a controller-managed workload be attributed
+// the internet exposure its pods serve: the pods themselves are represented
+// by their controller, so the exposure has to surface here.
+func (k *mqlK8sDeployment) exposures() ([]any, error) {
+	pods := k.GetPods()
+	if pods.Error != nil {
+		return nil, pods.Error
+	}
+	return exposuresForPods(k.MqlRuntime, pods.Data)
+}
+
+// exposures returns the network exposures that route to any pod backing this
+// DaemonSet.
+func (k *mqlK8sDaemonset) exposures() ([]any, error) {
+	pods := k.GetPods()
+	if pods.Error != nil {
+		return nil, pods.Error
+	}
+	return exposuresForPods(k.MqlRuntime, pods.Data)
+}
+
+// exposures returns the network exposures that route to any pod backing this
+// StatefulSet.
+func (k *mqlK8sStatefulset) exposures() ([]any, error) {
+	pods := k.GetPods()
+	if pods.Error != nil {
+		return nil, pods.Error
+	}
+	return exposuresForPods(k.MqlRuntime, pods.Data)
+}
+
+// exposures returns the network exposures that route to any pod backing this
+// ReplicaSet.
+func (k *mqlK8sReplicaset) exposures() ([]any, error) {
+	pods := k.GetPods()
+	if pods.Error != nil {
+		return nil, pods.Error
+	}
+	return exposuresForPods(k.MqlRuntime, pods.Data)
+}
+
 // pods returns the pods behind the ingress, resolved through the services its
 // rules and default backend route to.
 func (k *mqlK8sIngress) pods() ([]any, error) {

--- a/providers/k8s/resources/exposure_targets_test.go
+++ b/providers/k8s/resources/exposure_targets_test.go
@@ -214,6 +214,73 @@ func TestPodExposures(t *testing.T) {
 	assert.Empty(t, otherExps.Data)
 }
 
+// requireServiceExposure asserts that the exposure list contains the
+// internet-exposed Service exposure for web-svc.
+func requireServiceExposure(t *testing.T, exps []any) {
+	t.Helper()
+	for i := range exps {
+		e, ok := exps[i].(*mqlK8sNetworkExposure)
+		if !ok {
+			continue
+		}
+		if e.SourceKind.Data == "Service" && e.Name.Data == "web-svc" {
+			internet := e.GetInternetExposed()
+			require.NoError(t, internet.Error)
+			assert.True(t, internet.Data, "web-svc exposure must classify as internet exposed")
+			return
+		}
+	}
+	t.Fatalf("expected the web-svc Service exposure, got %d other exposures", len(exps))
+}
+
+func TestWorkloadExposures(t *testing.T) {
+	runtime := exposureRuntime(t)
+
+	// The deployment backing web-1/web-2 inherits the exposures that route to
+	// its pods. This is the edge that lets controller-managed workloads carry
+	// the internet exposure their pods serve, since owned pods are not
+	// discovered as assets of their own.
+	dep, err := NewResource(runtime, "k8s.deployment", map[string]*llx.RawData{
+		"name":      llx.StringData("web"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	depExps := dep.(*mqlK8sDeployment).GetExposures()
+	require.NoError(t, depExps.Error)
+	requireServiceExposure(t, depExps.Data)
+
+	// A bare ReplicaSet with the same selector resolves the same exposure.
+	rs, err := NewResource(runtime, "k8s.replicaset", map[string]*llx.RawData{
+		"name":      llx.StringData("web-rs"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	rsExps := rs.(*mqlK8sReplicaset).GetExposures()
+	require.NoError(t, rsExps.Error)
+	requireServiceExposure(t, rsExps.Data)
+
+	// A workload whose pods no service selects reports no exposures.
+	ds, err := NewResource(runtime, "k8s.daemonset", map[string]*llx.RawData{
+		"name":      llx.StringData("other-ds"),
+		"namespace": llx.StringData("prod"),
+	})
+	require.NoError(t, err)
+	dsExps := ds.(*mqlK8sDaemonset).GetExposures()
+	require.NoError(t, dsExps.Error)
+	assert.Empty(t, dsExps.Data)
+
+	// Same pod labels in another namespace must not inherit the prod service's
+	// exposure: service selection is namespace scoped.
+	sts, err := NewResource(runtime, "k8s.statefulset", map[string]*llx.RawData{
+		"name":      llx.StringData("web-staging-sts"),
+		"namespace": llx.StringData("staging"),
+	})
+	require.NoError(t, err)
+	stsExps := sts.(*mqlK8sStatefulset).GetExposures()
+	require.NoError(t, stsExps.Error)
+	assert.Empty(t, stsExps.Data)
+}
+
 // testCertPEM generates a self-signed certificate that expires at notAfter.
 func testCertPEM(t *testing.T, notAfter time.Time) []byte {
 	t.Helper()

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -821,6 +821,8 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   containers() []k8s.container
   // Pods backing this deployment (label-selector match; technically owned by the deployment's ReplicaSets)
   pods() []k8s.pod
+  // Network exposures that route to the pods backing this deployment
+  exposures() []k8s.networkExposure
   // Number of pods requested by the deployment
   desiredReplicas() int
   // Label selector that identifies pods owned by this deployment
@@ -998,6 +1000,8 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   containers() []k8s.container
   // Pods backing this DaemonSet (label-selector match)
   pods() []k8s.pod
+  // Network exposures that route to the pods backing this DaemonSet
+  exposures() []k8s.networkExposure
   // Label selector that identifies pods owned by this DaemonSet
   selector() dict
   // Update strategy (OnDelete or RollingUpdate with maxUnavailable/maxSurge)
@@ -1165,6 +1169,8 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   containers() []k8s.container
   // Pods backing this StatefulSet (label-selector match)
   pods() []k8s.pod
+  // Network exposures that route to the pods backing this StatefulSet
+  exposures() []k8s.networkExposure
   // Number of pods requested by the StatefulSet
   desiredReplicas() int
   // Label selector that identifies pods owned by this StatefulSet
@@ -1354,6 +1360,8 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   containers() []k8s.container
   // Pods backing this ReplicaSet (label-selector match)
   pods() []k8s.pod
+  // Network exposures that route to the pods backing this ReplicaSet
+  exposures() []k8s.networkExposure
   // Number of pods requested by the ReplicaSet
   desiredReplicas() int
   // Label selector that identifies pods owned by this ReplicaSet

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -1356,6 +1356,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.pods": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
 	},
+	"k8s.deployment.exposures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
+	},
 	"k8s.deployment.desiredReplicas": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetDesiredReplicas()).ToDataRes(types.Int)
 	},
@@ -1557,6 +1560,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.pods": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
 	},
+	"k8s.daemonset.exposures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
+	},
 	"k8s.daemonset.selector": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetSelector()).ToDataRes(types.Dict)
 	},
@@ -1754,6 +1760,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.pods": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
+	},
+	"k8s.statefulset.exposures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
 	},
 	"k8s.statefulset.desiredReplicas": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetDesiredReplicas()).ToDataRes(types.Int)
@@ -1967,6 +1976,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.replicaset.pods": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
+	},
+	"k8s.replicaset.exposures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetExposures()).ToDataRes(types.Array(types.Resource("k8s.networkExposure")))
 	},
 	"k8s.replicaset.desiredReplicas": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetDesiredReplicas()).ToDataRes(types.Int)
@@ -6500,6 +6512,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.exposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).Exposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.desiredReplicas": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).DesiredReplicas, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -6772,6 +6788,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.exposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).Exposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.selector": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).Selector, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -7038,6 +7058,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.pods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.exposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).Exposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.desiredReplicas": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7326,6 +7350,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.replicaset.pods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.exposures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).Exposures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.replicaset.desiredReplicas": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15027,6 +15055,7 @@ type mqlK8sDeployment struct {
 	InitContainers               plugin.TValue[[]any]
 	Containers                   plugin.TValue[[]any]
 	Pods                         plugin.TValue[[]any]
+	Exposures                    plugin.TValue[[]any]
 	DesiredReplicas              plugin.TValue[int64]
 	Selector                     plugin.TValue[any]
 	Strategy                     plugin.TValue[any]
@@ -15424,6 +15453,22 @@ func (c *mqlK8sDeployment) GetPods() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sDeployment) GetExposures() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Exposures, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.deployment", c.__id, "exposures")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.exposures()
+	})
+}
+
 func (c *mqlK8sDeployment) GetDesiredReplicas() *plugin.TValue[int64] {
 	return plugin.GetOrCompute[int64](&c.DesiredReplicas, func() (int64, error) {
 		return c.desiredReplicas()
@@ -15586,6 +15631,7 @@ type mqlK8sDaemonset struct {
 	InitContainers               plugin.TValue[[]any]
 	Containers                   plugin.TValue[[]any]
 	Pods                         plugin.TValue[[]any]
+	Exposures                    plugin.TValue[[]any]
 	Selector                     plugin.TValue[any]
 	UpdateStrategy               plugin.TValue[any]
 	RevisionHistoryLimit         plugin.TValue[int64]
@@ -15982,6 +16028,22 @@ func (c *mqlK8sDaemonset) GetPods() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sDaemonset) GetExposures() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Exposures, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.daemonset", c.__id, "exposures")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.exposures()
+	})
+}
+
 func (c *mqlK8sDaemonset) GetSelector() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.Selector, func() (any, error) {
 		return c.selector()
@@ -16138,6 +16200,7 @@ type mqlK8sStatefulset struct {
 	InitContainers                       plugin.TValue[[]any]
 	Containers                           plugin.TValue[[]any]
 	Pods                                 plugin.TValue[[]any]
+	Exposures                            plugin.TValue[[]any]
 	DesiredReplicas                      plugin.TValue[int64]
 	Selector                             plugin.TValue[any]
 	ServiceName                          plugin.TValue[string]
@@ -16539,6 +16602,22 @@ func (c *mqlK8sStatefulset) GetPods() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sStatefulset) GetExposures() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Exposures, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.statefulset", c.__id, "exposures")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.exposures()
+	})
+}
+
 func (c *mqlK8sStatefulset) GetDesiredReplicas() *plugin.TValue[int64] {
 	return plugin.GetOrCompute[int64](&c.DesiredReplicas, func() (int64, error) {
 		return c.desiredReplicas()
@@ -16725,6 +16804,7 @@ type mqlK8sReplicaset struct {
 	InitContainers               plugin.TValue[[]any]
 	Containers                   plugin.TValue[[]any]
 	Pods                         plugin.TValue[[]any]
+	Exposures                    plugin.TValue[[]any]
 	DesiredReplicas              plugin.TValue[int64]
 	Selector                     plugin.TValue[any]
 	MinReadySeconds              plugin.TValue[int64]
@@ -17113,6 +17193,22 @@ func (c *mqlK8sReplicaset) GetPods() *plugin.TValue[[]any] {
 		}
 
 		return c.pods()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetExposures() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Exposures, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.replicaset", c.__id, "exposures")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.exposures()
 	})
 }
 

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -320,6 +320,7 @@ k8s.daemonset.created 9.0.0
 k8s.daemonset.currentNumberScheduled 13.0.16
 k8s.daemonset.desiredNumberScheduled 13.0.16
 k8s.daemonset.dropsAllCapabilities 13.2.2
+k8s.daemonset.exposures 13.8.6
 k8s.daemonset.hasCpuLimit 13.3.1
 k8s.daemonset.hasMemoryLimit 13.3.1
 k8s.daemonset.hasResourceLimits 13.3.1
@@ -388,6 +389,7 @@ k8s.deployment.context 13.6.1
 k8s.deployment.created 9.0.0
 k8s.deployment.desiredReplicas 13.0.16
 k8s.deployment.dropsAllCapabilities 13.2.2
+k8s.deployment.exposures 13.8.6
 k8s.deployment.hasCpuLimit 13.3.1
 k8s.deployment.hasMemoryLimit 13.3.1
 k8s.deployment.hasResourceLimits 13.3.1
@@ -1362,6 +1364,7 @@ k8s.replicaset.context 13.6.1
 k8s.replicaset.created 9.0.0
 k8s.replicaset.desiredReplicas 13.0.16
 k8s.replicaset.dropsAllCapabilities 13.2.2
+k8s.replicaset.exposures 13.8.6
 k8s.replicaset.fullyLabeledReplicas 13.0.16
 k8s.replicaset.hasCpuLimit 13.3.1
 k8s.replicaset.hasMemoryLimit 13.3.1
@@ -1540,6 +1543,7 @@ k8s.statefulset.currentReplicas 13.0.16
 k8s.statefulset.currentRevision 13.0.16
 k8s.statefulset.desiredReplicas 13.0.16
 k8s.statefulset.dropsAllCapabilities 13.2.2
+k8s.statefulset.exposures 13.8.6
 k8s.statefulset.hasCpuLimit 13.3.1
 k8s.statefulset.hasMemoryLimit 13.3.1
 k8s.statefulset.hasResourceLimits 13.3.1

--- a/providers/k8s/resources/testdata/exposure_targets.yaml
+++ b/providers/k8s/resources/testdata/exposure_targets.yaml
@@ -100,7 +100,10 @@ spec:
 status:
   loadBalancer:
     ingress:
-      - ip: 203.0.113.10
+      # A genuinely public address: the classifier treats the TEST-NET
+      # documentation ranges as non-public, so exposure fixtures must use a
+      # real global-unicast IP to produce internetExposed=true.
+      - ip: 8.8.4.4
 ---
 # Selectorless service — selects no pods.
 apiVersion: v1
@@ -185,6 +188,90 @@ spec:
     - backendRefs:
         - name: web-svc
           port: 80
+---
+# Deployment backing web-1/web-2 — must inherit the exposures that route to
+# its pods (the public web-svc, the ingress, and the gateway).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: prod
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27
+---
+# Bare ReplicaSet with the same selector — the exposure fold must work at the
+# ReplicaSet level too.
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: web-rs
+  namespace: prod
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27
+---
+# DaemonSet backing other-1, which no service selects — must report no
+# exposures.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: other-ds
+  namespace: prod
+spec:
+  selector:
+    matchLabels:
+      app: other
+  template:
+    metadata:
+      labels:
+        app: other
+    spec:
+      containers:
+        - name: other
+          image: busybox
+---
+# StatefulSet in staging with the same labels as the exposed prod pods — the
+# prod service must not leak exposure across namespaces.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web-staging-sts
+  namespace: staging
+spec:
+  replicas: 1
+  serviceName: headless
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27
 ---
 # Secret mounted by web-1 — used, not orphaned.
 apiVersion: v1


### PR DESCRIPTION
## Problem

The internet-exposed risk factor gained `k8s-pod`/`-service`/`-ingress` checks, but pod discovery skips every pod with a controller owner (`PodOwnerReferencesFilter`, `discovery.go:1682`). The pods actually serving traffic behind an internet-facing load balancer therefore never become assets — they are represented by their Deployment/StatefulSet/DaemonSet/ReplicaSet — and no workload platform had any way to answer "does internet traffic reach you?". In a real fleet that is nearly every pod, so the "tie the load balancer to the workload serving it" story could not fire (found while debugging why a customer's internet-facing ALBs were flagged but nothing behind them).

## Changes

- Add `exposures()` to `k8s.deployment`, `k8s.statefulset`, `k8s.daemonset`, and `k8s.replicaset`: the union of the network exposures (Service, Ingress, Gateway, or the pod's own host-network bindings) that route to any pod the workload backs, folded through the existing pod-mediated exposure model via the workload's label selector. A workload is exposed exactly when one of its pods is.
- Shared fold helper `exposuresForPods` in `exposure_targets.go`, mirroring `k8s.pod.exposures`.
- `.lr.versions` entries at 13.8.6.

## Verification

Manifest fixtures (`exposure_targets.yaml`): a Deployment and a bare ReplicaSet backing pods behind a public LoadBalancer Service report the Service exposure with `internetExposed=true`; a DaemonSet whose pods no service selects reports none; a StatefulSet with identical pod labels in another namespace reports none (service selection is namespace-scoped). The fixture's LB address moves off the TEST-NET documentation range, which the address classifier correctly treats as non-public. Full `providers/k8s/resources` test package passes.

## Consumers

mondoohq/server adds `k8s-{deployment,statefulset,daemonset,replicaset}-public` checks to the internet-exposed risk factor on top of these fields (mondoohq/server#18347; the container-image CVE prioritization on top rides mondoohq/cnspec#3223). That server PR must not deploy before this ships in a k8s provider release (bundle compile against baked provider schemas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)