### PR TITLE
🐛 hetzner: bound how long an API call can take

### DIFF
--- a/providers/hetzner/connection/connection.go
+++ b/providers/hetzner/connection/connection.go
@@ -9,12 +9,33 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// requestTimeout bounds a single Hetzner API request. hcloud.NewClient
+// defaults to &http.Client{}, which has no timeout at all, and the plugin
+// runtime hands resources no context to carry a deadline instead: GetData
+// takes none, so every call site uses context.Background(). Without this a
+// request that never answers hangs the scan indefinitely.
+//
+// hcloud issues each retry as its own request, so this bounds an attempt
+// rather than the whole retried operation.
+// They are vars so tests can shrink them.
+var (
+	requestTimeout = 30 * time.Second
+
+	// maxRetries matches hcloud's own default. It is set explicitly because
+	// it multiplies requestTimeout: a completely unresponsive endpoint costs
+	// roughly maxRetries attempts plus hcloud's exponential backoff before
+	// the call gives up, so the two numbers only make sense together.
+	maxRetries = 5
 )
 
 var PlatformIdHetznerProject = "//platformid.api.mondoo.app/runtime/hetzner/project/"
@@ -42,7 +63,11 @@ func NewHetznerConnection(id uint32, asset *inventory.Asset, conf *inventory.Con
 			OPTION_TOKEN, HCLOUD_TOKEN_VAR)
 	}
 
-	opts := []hcloud.ClientOption{hcloud.WithToken(token)}
+	opts := []hcloud.ClientOption{
+		hcloud.WithToken(token),
+		hcloud.WithHTTPClient(&http.Client{Timeout: requestTimeout}),
+		hcloud.WithRetryOpts(hcloud.RetryOpts{MaxRetries: maxRetries}),
+	}
 	if endpoint, ok := GetEndpoint(conf); ok {
 		opts = append(opts, hcloud.WithEndpoint(endpoint))
 	}

--- a/providers/hetzner/connection/timeout_test.go
+++ b/providers/hetzner/connection/timeout_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// TestRequestTimeoutApplies proves a Hetzner API call cannot hang forever.
+//
+// hcloud.NewClient defaults to &http.Client{}, which has no timeout, and the
+// plugin runtime gives resources no context to carry a deadline instead, so
+// without an explicit client timeout an unanswered request blocks the scan
+// indefinitely. This points the connection at a server that never replies and
+// requires the call to come back.
+func TestRequestTimeoutApplies(t *testing.T) {
+	blocked := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked // hold the request open until the test finishes
+	}))
+	// Order matters: srv.Close waits for in-flight handlers, so the handler
+	// has to be released first. Defers run last-registered-first, so this
+	// pair must be registered in this order.
+	defer srv.Close()
+	defer close(blocked)
+
+	origTimeout, origRetries := requestTimeout, maxRetries
+	requestTimeout, maxRetries = 150*time.Millisecond, 1
+	defer func() { requestTimeout, maxRetries = origTimeout, origRetries }()
+
+	conn, err := NewHetznerConnection(0, &inventory.Asset{}, &inventory.Config{
+		Options: map[string]string{
+			OPTION_TOKEN:    "test-token",
+			OPTION_ENDPOINT: srv.URL,
+		},
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- conn.Verify() }()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "a request that never answers must fail, not succeed")
+		elapsed := time.Since(start)
+		t.Logf("bounded after %s", elapsed)
+		assert.Less(t, elapsed, 10*time.Second,
+			"the call must be bounded rather than hanging")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the request hung: no timeout is being applied")
+	}
+}


### PR DESCRIPTION
Follows #9753 (merged). Second of the Hetzner fixes from a provider audit.

## The problem

**Nothing in the stack had a deadline.**

- `hcloud.NewClient` defaults to `&http.Client{}` — no timeout — and the provider passed no `WithHTTPClient`.
- Every call site then uses `context.Background()` (44 of them).

Worth being precise about the second half: the plugin runtime exposes **no context to `GetData` at all**, so `context.Background()` is the SDK's shape rather than a missed hand-off. That is also why the fix is a client timeout and not context plumbing through 44 sites.

A request that never answered blocked the scan indefinitely.

## The change

A 30s per-request timeout, plus hcloud's retry limit stated explicitly instead of inherited silently. The two numbers only mean anything together: an unresponsive endpoint costs roughly `maxRetries` attempts **plus exponential backoff** before giving up, so writing `5` down next to the timeout makes that product visible. The value matches hcloud's own default, so retry behaviour is unchanged and rate-limit resilience is not weakened.

## What the test caught

It points a connection at a server that accepts the request and never replies, then requires the call to return. Two things reading the code would not have shown:

1. **A client timeout alone does not bound the call.** hcloud retries. With the timeout at 150ms the call still took **26 seconds**, almost all of it backoff. The fix works, but not for the reason the first draft assumed — which is why the retry count is now explicit rather than inherited.
2. **The first version of the test deadlocked itself.** `httptest.Server.Close` waits for in-flight handlers, and the handler was blocked on a channel closed by a later-registered defer. Defers run last-registered-first, so the ordering was inverted.

With both bounds shrunk, the test runs in **1.3s** and still proves the call cannot hang.

## Verification

Build and the full provider suite pass. Not exercised against the live API — the Hetzner token used earlier today has since been rotated and now returns 401 — but this path is about an endpoint that does not answer, which the test reproduces directly.