### PR TITLE
🐛 hetzner: do not report a truncated list as the complete one

### DIFF
--- a/providers/hetzner/connection/connection.go
+++ b/providers/hetzner/connection/connection.go
@@ -9,12 +9,33 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// requestTimeout bounds a single Hetzner API request. hcloud.NewClient
+// defaults to &http.Client{}, which has no timeout at all, and the plugin
+// runtime hands resources no context to carry a deadline instead: GetData
+// takes none, so every call site uses context.Background(). Without this a
+// request that never answers hangs the scan indefinitely.
+//
+// hcloud issues each retry as its own request, so this bounds an attempt
+// rather than the whole retried operation.
+// They are vars so tests can shrink them.
+var (
+	requestTimeout = 30 * time.Second
+
+	// maxRetries matches hcloud's own default. It is set explicitly because
+	// it multiplies requestTimeout: a completely unresponsive endpoint costs
+	// roughly maxRetries attempts plus hcloud's exponential backoff before
+	// the call gives up, so the two numbers only make sense together.
+	maxRetries = 5
 )
 
 var PlatformIdHetznerProject = "//platformid.api.mondoo.app/runtime/hetzner/project/"
@@ -42,7 +63,11 @@ func NewHetznerConnection(id uint32, asset *inventory.Asset, conf *inventory.Con
 			OPTION_TOKEN, HCLOUD_TOKEN_VAR)
 	}
 
-	opts := []hcloud.ClientOption{hcloud.WithToken(token)}
+	opts := []hcloud.ClientOption{
+		hcloud.WithToken(token),
+		hcloud.WithHTTPClient(&http.Client{Timeout: requestTimeout}),
+		hcloud.WithRetryOpts(hcloud.RetryOpts{MaxRetries: maxRetries}),
+	}
 	if endpoint, ok := GetEndpoint(conf); ok {
 		opts = append(opts, hcloud.WithEndpoint(endpoint))
 	}

--- a/providers/hetzner/connection/timeout_test.go
+++ b/providers/hetzner/connection/timeout_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// TestRequestTimeoutApplies proves a Hetzner API call cannot hang forever.
+//
+// hcloud.NewClient defaults to &http.Client{}, which has no timeout, and the
+// plugin runtime gives resources no context to carry a deadline instead, so
+// without an explicit client timeout an unanswered request blocks the scan
+// indefinitely. This points the connection at a server that never replies and
+// requires the call to come back.
+func TestRequestTimeoutApplies(t *testing.T) {
+	blocked := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked // hold the request open until the test finishes
+	}))
+	// Order matters: srv.Close waits for in-flight handlers, so the handler
+	// has to be released first. Defers run last-registered-first, so this
+	// pair must be registered in this order.
+	defer srv.Close()
+	defer close(blocked)
+
+	origTimeout, origRetries := requestTimeout, maxRetries
+	requestTimeout, maxRetries = 150*time.Millisecond, 1
+	defer func() { requestTimeout, maxRetries = origTimeout, origRetries }()
+
+	conn, err := NewHetznerConnection(0, &inventory.Asset{}, &inventory.Config{
+		Options: map[string]string{
+			OPTION_TOKEN:    "test-token",
+			OPTION_ENDPOINT: srv.URL,
+		},
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- conn.Verify() }()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "a request that never answers must fail, not succeed")
+		elapsed := time.Since(start)
+		t.Logf("bounded after %s", elapsed)
+		assert.Less(t, elapsed, 10*time.Second,
+			"the call must be bounded rather than hanging")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the request hung: no timeout is being applied")
+	}
+}

--- a/providers/hetzner/resources/helpers.go
+++ b/providers/hetzner/resources/helpers.go
@@ -60,14 +60,21 @@ func paginate[T any](
 ) ([]T, error) {
 	var out []T
 	opts := hcloud.ListOpts{Page: 1, PerPage: 50}
+	read := false
 	for {
 		page, resp, err := list(opts)
 		if err != nil {
-			if translateHcloudError(err) == nil {
+			// A collection that is absent from the start is genuinely empty:
+			// the product is not provisioned for this project. One that
+			// disappears part way through is not. Returning the pages read so
+			// far would present a truncated list as the whole of it, which is
+			// the same silent-undercount this helper exists to prevent.
+			if translateHcloudError(err) == nil && !read {
 				return out, nil
 			}
 			return nil, err
 		}
+		read = true
 		out = append(out, page...)
 		if resp == nil || resp.Meta.Pagination == nil || resp.Meta.Pagination.NextPage == 0 {
 			break

--- a/providers/hetzner/resources/helpers_test.go
+++ b/providers/hetzner/resources/helpers_test.go
@@ -137,8 +137,19 @@ func TestPaginate(t *testing.T) {
 		assert.Nil(t, out)
 	})
 
-	t.Run("a missing collection mid-stream ends the walk", func(t *testing.T) {
-		// 404 means the product is not provisioned, so what was read stands.
+	t.Run("a collection absent from the start is empty", func(t *testing.T) {
+		// The product is not provisioned for this project, which is a real
+		// answer. Storage Boxes behave this way on a plain cloud project.
+		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
+			return nil, nil, hcloud.Error{Code: hcloud.ErrorCodeNotFound}
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("a collection that vanishes mid-walk is not a short list", func(t *testing.T) {
+		// Pages were read, so the collection existed. Returning only those
+		// would present a truncated list as the complete one.
 		calls := 0
 		out, err := paginate(func(opts hcloud.ListOpts) ([]int, *hcloud.Response, error) {
 			calls++
@@ -149,8 +160,8 @@ func TestPaginate(t *testing.T) {
 			}
 			return nil, nil, hcloud.Error{Code: hcloud.ErrorCodeNotFound}
 		})
-		require.NoError(t, err)
-		assert.Equal(t, []int{1, 2}, out)
+		assert.Error(t, err)
+		assert.Nil(t, out)
 	})
 
 	t.Run("nil response terminates loop", func(t *testing.T) {


### PR DESCRIPTION
Third of the Hetzner fixes, **based on #9763**.

## The problem

`paginate` treated a not-found **at any point in the walk** as "the collection is empty" and returned the pages gathered so far:

```go
if translateHcloudError(err) == nil {
    return out, nil        // out may already hold pages 1..n
}
```

Those are two different situations:

- **Absent from the first request** — genuinely none. The product is not provisioned for the project; Storage Boxes answer exactly this way on a plain cloud project, and `storageBoxes: 0` being correct depends on it.
- **Disappears part way through** — not none. It had pages, they were read, and returning only those presents a **truncated list as the whole of it**. That is the same silent undercount the helper exists to prevent, arriving through its own error path.

## The change

Track whether any page was read, and only take the empty-collection path before the first one succeeds. Four lines.

## Tests

The previous test asserted the old behaviour (`a missing collection mid-stream ends the walk`, returning `[]int{1,2}` with no error). It is replaced by the two cases that are actually distinct:

| Case | Result |
|---|---|
| not-found on the first request | empty, no error |
| not-found after pages were read | error, no partial |

## Verification

Build and the full provider suite pass. Not live-verified — the Hetzner token was rotated earlier today and now returns 401.