### PR TITLE
🎉 hetzner-13.7.6, stackit-13.6.0

### DIFF
--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "hetzner",
 	ID:              "go.mondoo.com/mql/providers/hetzner",
-	Version:         "13.7.5",
+	Version:         "13.7.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -16,7 +16,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.5.1",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Release bump for two providers.

### hetzner `13.7.5` → `13.7.6` (patch)

* 🐛 hetzner: do not report a truncated list as the complete one (#9764)
* 🐛 hetzner: bound how long an API call can take (#9763)
* 🐛 hetzner: stop reporting denied reads as empty lists (#9753)
* ✨ hetzner: expose egress restriction, vSwitch bridging, TSIG auth, and typed parent refs (#9585)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

### stackit `13.5.1` → `13.6.0` (minor)

* ✨ stackit: expose SKE end-of-support, DB users, federated identity, and KMS versions (#9587)
* 🧹 stackit: migrate off SDK packages slated for removal (#9569)
* 🧹 dependency updates (#9651, #9619, #9601, #9580, #9560)