### PR TITLE
🎉 vercel-13.2.0, mongodbatlas-13.2.0

### DIFF
--- a/providers/mongodbatlas/config/config.go
+++ b/providers/mongodbatlas/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "mongodbatlas",
 	ID:        "go.mondoo.com/mql/providers/mongodbatlas",
-	Version:   "13.1.3",
+	Version:   "13.2.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/vercel/config/config.go
+++ b/providers/vercel/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vercel",
 	ID:              "go.mondoo.com/mql/providers/vercel",
-	Version:         "13.1.4",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for `vercel` and `mongodbatlas`. Both picked up additive schema changes since the last release (`a94aa193e`), so minor rather than patch.

## vercel 13.1.4 → 13.2.0

- 5457d4adb 🐛 vercel: read automation bypass from the project, not the alias (#9742)
- e75db4def 🐛 vercel: stop reporting denied reads as empty lists (#9741)
- 8c81c61f3 ✨ vercel: expose deployment-protection bypass surfaces and aliases (#9648)
- b95864b65 ✨ vercel: expose team governance, project security settings, WAF bypass, and shared env vars (#9592)
- 189d6fe7f 📄 providers: standardize developer READMEs + scaffold template (#9614)
- Dependency refreshes: #9651, #9619, #9601, #9580

## mongodbatlas 13.1.3 → 13.2.0

- 539a806ea 🐛 mongodbatlas: stop reporting denied reads as empty lists (#9737)
- 13da69718 ✨ mongodbatlas: expose project role grants, Flex clusters, and backup schedules (#9589)
- 189d6fe7f 📄 providers: standardize developer READMEs + scaffold template (#9614)
- Dependency refreshes: #9651, #9619, #9601, #9580

🤖 Generated with [Claude Code](https://claude.com/claude-code)