### PR TITLE
🐛 databricks: report an unreadable serving endpoint ACL as null

### DIFF
--- a/providers/databricks/resources/databricks.lr
+++ b/providers/databricks/resources/databricks.lr
@@ -1034,6 +1034,10 @@ databricks.servingEndpoint @defaults("name state task") {
   // AI Gateway governance configured on the endpoint
   aiGateway() databricks.servingEndpoint.gatewayConfig
   // Workspace access control list of the endpoint
+  //
+  // Null on a foundation model endpoint, which carries no identifier the
+  // permissions API can be keyed on. A null here means the access control list
+  // could not be read, not that no principal holds access to the endpoint.
   permissions() []databricks.permission
 }
 

--- a/providers/databricks/resources/permissions.go
+++ b/providers/databricks/resources/permissions.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"strconv"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -109,10 +110,22 @@ func flattenObjectPermissions(objectType string, objectId string, perms *iam.Obj
 	return out
 }
 
+// errNoObjectId reports that the object carries no identifier the permissions
+// API can be keyed on. Callers degrade the field to null rather than reporting
+// an empty access control list, which would read as "nobody holds access".
+var errNoObjectId = errors.New("object carries no id the permissions API can be keyed on")
+
 // mqlDatabricksPermissions fetches the workspace access control list of a single
 // object and maps it to one databricks.permission per principal and permission
 // level.
 func mqlDatabricksPermissions(runtime *plugin.Runtime, objectType string, objectId string) ([]any, error) {
+	// The object id is interpolated into the request path, so an empty one asks
+	// the API for /permissions/<type>/ and gets a 404 whose message names no
+	// object. Report what is actually wrong instead.
+	if objectId == "" {
+		return nil, errNoObjectId
+	}
+
 	ws, err := workspaceClient(runtime)
 	if err != nil {
 		return nil, err
@@ -167,6 +180,17 @@ func (r *mqlDatabricksPipeline) permissions() ([]any, error) {
 // permissions reads the endpoint access control list. The permissions API keys
 // serving endpoints on the endpoint id rather than its name, unlike the serving
 // endpoints API itself.
+//
+// A foundation model endpoint carries no id: the serving endpoints API omits it
+// from both the list and the detail response, and the permissions API rejects
+// the endpoint name in its place. Its access control list is therefore
+// unreadable, and the field reports null rather than an empty list so it cannot
+// be mistaken for an endpoint nobody holds access to.
 func (r *mqlDatabricksServingEndpoint) permissions() ([]any, error) {
-	return mqlDatabricksPermissions(r.MqlRuntime, permissionObjectServingEndpoint, r.Id.Data)
+	perms, err := mqlDatabricksPermissions(r.MqlRuntime, permissionObjectServingEndpoint, r.Id.Data)
+	if errors.Is(err, errNoObjectId) {
+		r.Permissions = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+		return nil, nil
+	}
+	return perms, err
 }

--- a/providers/databricks/resources/permissions_test.go
+++ b/providers/databricks/resources/permissions_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -167,5 +168,16 @@ func TestPermissionObjectTypesAreDistinct(t *testing.T) {
 			t.Fatalf("%s and %s share the object type %q", name, other, segment)
 		}
 		seen[segment] = name
+	}
+}
+
+// An object with no id must be reported as unreadable rather than sent to the
+// API, where the empty id makes the request path end in a bare slash and the
+// 404 that comes back names no object. Foundation model serving endpoints are
+// the real case: they carry no id at all.
+func TestPermissionsRejectsEmptyObjectId(t *testing.T) {
+	_, err := mqlDatabricksPermissions(nil, permissionObjectServingEndpoint, "")
+	if !errors.Is(err, errNoObjectId) {
+		t.Fatalf("expected errNoObjectId, got %v", err)
 	}
 }


### PR DESCRIPTION
Found by running the provider against a live workspace. The Aug 6-9 expansion stack (#9590, #9698, #9711, #9715) had never been exercised live; this is what that surfaced.

## The bug

`databricks.servingEndpoint.permissions` errored on **every foundation model endpoint** — 44 of 44 in the workspace I tested:

```
permissions: No API found for 'GET /permissions/serving-endpoints/'
```

Note the trailing slash with nothing after it. The permissions API keys serving endpoints on the endpoint **id**, and a foundation model endpoint has none — I confirmed against the raw API that `id` is absent from both the list and the detail response:

```
GET /api/2.0/serving-endpoints        -> keys: [capabilities, config, creation_timestamp,
                                                endpoint_type, last_updated_timestamp, name,
                                                permission_level, state, task]     # no id
GET /api/2.0/serving-endpoints/{name} -> same, still no id
```

Passing the name instead does not work either — the API rejects it explicitly:

```
GET /api/2.0/permissions/serving-endpoints/databricks-gpt-oss-120b
400 'databricks-gpt-oss-120b' is not a valid Inference Endpoint ID.
```

So the ACL genuinely cannot be read for this endpoint type.

## The fix

`mqlDatabricksPermissions` now rejects an empty object id up front rather than issuing a request that cannot succeed, and the serving endpoint accessor degrades to **null**.

Null rather than an empty list is the point: an empty list reads as "no principal holds access to this endpoint", which is the opposite of true for endpoints anyone in the workspace can query. The `.lr` doc now says so, so a policy author knows a null means unread rather than unrestricted.

The guard is central, so any other object type that ever arrives without an id gets a clear error instead of an unattributable 404.

## Verified live

Before: `No API found for 'GET /permissions/serving-endpoints/'`
After: `permissions: null`

Warehouse, cluster policy, pipeline, and repo ACLs all still resolve correctly, including inheritance:

```
databricks.warehouses { name permissions { principal principalType permissionLevel inherited inheritedFromObject } }
  principal: "users",  GROUP, CAN_USE,    inherited: false
  principal: "admins", GROUP, CAN_MANAGE, inherited: true, inheritedFromObject: ["/sql/warehouses/"]
```

That last row is also the validation for modeling one resource per *(principal, level)* pair — the two levels on the same object differ in `inherited`, which a grouped shape would have lost.

## Test

Unit test pins the empty-id guard, which is the pure-logic half of the fix.

## Also verified in the same sweep (no changes needed)

Pipelines (all 15 computed spec fields via the memoized detail fetch, with the hand-flattened `libraries` shape matching its doc), repos, registered models and their typed `catalog`/`schema` refs, external locations and the typed `credential` ref, UC catalogs/schemas/grants/volumes, credentials, system schemas, tokens, serving endpoint `aiGateway` and `servedEntities`, and workspace settings.

I checked the empty-looking results against the raw API rather than assuming: pipeline `health`/`channel`/`edition`/`storage` and permission `displayName` are genuinely absent from the payloads, so those are faithful, not dropped data.