### PR TITLE
🎉 ansible-13.2.13, atlassian-13.4.6, bicep-13.4.9, claude-13.1.0, cloudformation-13.2.8, databricks-13.2.0, depsdev-13.1.8, google-workspace-13.3.2, grafana-13.1.20, hcp-13.0.4, helm-13.3.11, huggingface-13.1.13, ipinfo-13.0.27, ipmi-13.0.27, iru-13.0.5, jamf-13.1.14, kustomize-13.1.13, mikrotik-13.0.9, mistral-13.0.13, mondoo-13.1.16, nextdns-13.0.12, nmap-13.0.25, nutanix-13.3.2, ollama-13.1.0, opcua-13.0.24, openai-13.1.0

### DIFF
--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.2.12",
+	Version:         "13.2.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "atlassian",
 	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version:   "13.4.5",
+	Version:   "13.4.6",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.4.8",
+	Version:         "13.4.9",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/claude/config/config.go
+++ b/providers/claude/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "claude",
 	ID:              "go.mondoo.com/mql/providers/claude",
-	Version:         "13.0.12",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudformation",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
-	Version:         "13.2.7",
+	Version:         "13.2.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/databricks/config/config.go
+++ b/providers/databricks/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "databricks",
 	ID:        "go.mondoo.com/mql/providers/databricks",
-	Version:   "13.1.3",
+	Version:   "13.2.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/depsdev/config/config.go
+++ b/providers/depsdev/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "depsdev",
 	ID:              "go.mondoo.com/mql/v13/providers/depsdev",
-	Version:         "13.1.7",
+	Version:         "13.1.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.3.1",
+	Version:         "13.3.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "grafana",
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
-	Version:         "13.1.19",
+	Version:         "13.1.20",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/hcp/config/config.go
+++ b/providers/hcp/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "hcp",
 	ID:        "go.mondoo.com/mql/providers/hcp",
-	Version:   "13.0.3",
+	Version:   "13.0.4",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.3.10",
+	Version:         "13.3.11",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "huggingface",
 	ID:              "go.mondoo.com/mql/providers/huggingface",
-	Version:         "13.1.12",
+	Version:         "13.1.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ipinfo/config/config.go
+++ b/providers/ipinfo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipinfo",
 	ID:              "go.mondoo.com/cnquery/providers/ipinfo",
-	Version:         "13.0.26",
+	Version:         "13.0.27",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipmi",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
-	Version:         "13.0.26",
+	Version:         "13.0.27",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/iru/config/config.go
+++ b/providers/iru/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "iru",
 	ID:              "go.mondoo.com/mql/providers/iru",
-	Version:         "13.0.4",
+	Version:         "13.0.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "jamf",
 	ID:              "go.mondoo.com/mql/v13/providers/jamf",
-	Version:         "13.1.13",
+	Version:         "13.1.14",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "kustomize",
 	ID:              "go.mondoo.com/mql/v13/providers/kustomize",
-	Version:         "13.1.12",
+	Version:         "13.1.13",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mikrotik",
 	ID:              "go.mondoo.com/mql/providers/mikrotik",
-	Version:         "13.0.8",
+	Version:         "13.0.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mistral/config/config.go
+++ b/providers/mistral/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mistral",
 	ID:              "go.mondoo.com/mql/providers/mistral",
-	Version:         "13.0.12",
+	Version:         "13.0.13",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mondoo",
 	ID:              "go.mondoo.com/mql/v13/providers/mondoo",
-	Version:         "13.1.15",
+	Version:         "13.1.16",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nextdns/config/config.go
+++ b/providers/nextdns/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nextdns",
 	ID:              "go.mondoo.com/mql/providers/nextdns",
-	Version:         "13.0.11",
+	Version:         "13.0.12",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nmap/config/config.go
+++ b/providers/nmap/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nmap",
 	ID:              "go.mondoo.com/mql/v13/providers/nmap",
-	Version:         "13.0.24",
+	Version:         "13.0.25",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nutanix",
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
-	Version:         "13.3.1",
+	Version:         "13.3.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ollama/config/config.go
+++ b/providers/ollama/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ollama",
 	ID:              "go.mondoo.com/mql/providers/ollama",
-	Version:         "13.0.12",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "opcua",
 	ID:              "go.mondoo.com/cnquery/v9/providers/opcua",
-	Version:         "13.0.23",
+	Version:         "13.0.24",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openai/config/config.go
+++ b/providers/openai/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openai",
 	ID:              "go.mondoo.com/mql/providers/openai",
-	Version:         "13.0.11",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Version bumps for 26 providers. Changes are listed since the last release commit (a94aa193e).

Four providers take a **minor** bump because they shipped new schema; the remaining 22 take a **patch** bump to pick up dependency updates.

## Minor

**databricks 13.1.3 -> 13.2.0**
* 🐛 databricks: report an unreadable serving endpoint ACL as null (#9770)
* 🌟 databricks: expose Git folders, artifact allowlists, and instance pools (#9711)
* 🌟 databricks: expose Unity Catalog connections, credentials, and workspace bindings (#9698)
* 🌟 databricks: expose jobs, pipelines, and the workspace ACL plane (#9590)
* 📄 providers: standardize developer READMEs + scaffold template (#9614)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

**claude 13.0.12 -> 13.1.0**
* 🐛 claude: derive model family from the id instead of a fixed list (#9738)
* ✨ claude: typed resource references instead of raw ID strings (#9678)
* 📄 providers: standardize developer READMEs + scaffold template (#9614)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

**ollama 13.0.12 -> 13.1.0**
* ✨ ollama: server posture and model provenance (#9685)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

**openai 13.0.11 -> 13.1.0**
* ⭐ openai: model admin keys, roles, groups, and project membership (#9697)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

## Patch

These four also pick up the developer README standardization (#9614) alongside the dependency updates:

**ansible 13.2.12 -> 13.2.13**
* 📄 providers: standardize developer READMEs + scaffold template (#9614)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

**ipinfo 13.0.26 -> 13.0.27**
* 📄 providers: standardize developer READMEs + scaffold template (#9614)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

**mistral 13.0.12 -> 13.0.13**
* 📄 providers: standardize developer READMEs + scaffold template (#9614)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

**nmap 13.0.24 -> 13.0.25**
* 📄 providers: standardize developer READMEs + scaffold template (#9614)
* 🧹 dependency updates (#9651, #9619, #9601, #9580)

The remaining 18 carry the dependency updates in #9651, #9619, #9601, and #9580 and no other change:

| provider | version |
| --- | --- |
| atlassian | 13.4.5 -> 13.4.6 |
| bicep | 13.4.8 -> 13.4.9 |
| cloudformation | 13.2.7 -> 13.2.8 |
| depsdev | 13.1.7 -> 13.1.8 |
| google-workspace | 13.3.1 -> 13.3.2 |
| grafana | 13.1.19 -> 13.1.20 |
| hcp | 13.0.3 -> 13.0.4 |
| helm | 13.3.10 -> 13.3.11 |
| huggingface | 13.1.12 -> 13.1.13 |
| ipmi | 13.0.26 -> 13.0.27 |
| iru | 13.0.4 -> 13.0.5 |
| jamf | 13.1.13 -> 13.1.14 |
| kustomize | 13.1.12 -> 13.1.13 |
| mikrotik | 13.0.8 -> 13.0.9 |
| mondoo | 13.1.15 -> 13.1.16 |
| nextdns | 13.0.11 -> 13.0.12 |
| nutanix | 13.3.1 -> 13.3.2 |
| opcua | 13.0.23 -> 13.0.24 |
