### PR TITLE
🐛 bicep: lex `/* */` block comments

### DIFF
--- a/providers/bicep/resources/blockcomment_test.go
+++ b/providers/bicep/resources/blockcomment_test.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A resource inside a `/* ... */` comment is not deployed, so it must not be
+// reported. Before block comments were lexed, the tokenizer saw the commented
+// body as ordinary source and emitted a phantom resource, which made a policy
+// fail on infrastructure that does not exist.
+func TestParseBicepIgnoresCommentedOutResource(t *testing.T) {
+	src := `param a string
+
+/*
+resource commented 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'ghost'
+  properties: {
+    supportsHttpsTrafficOnly: false
+  }
+}
+*/
+
+resource real 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'real'
+}
+`
+	parsed := parseBicep(src)
+
+	require.Len(t, parsed.resources, 1, "only the uncommented resource should be reported")
+	assert.Equal(t, "real", parsed.resources[0].symbolicName)
+	assert.Equal(t, "'real'", parsed.resources[0].name)
+	require.Len(t, parsed.parameters, 1)
+	assert.Equal(t, "a", parsed.parameters[0].name)
+}
+
+// An unbalanced delimiter inside a block comment must not consume the rest of
+// the file. The depth counter is only fooled when the comment body is treated
+// as source, so this pins the string-aware blanking.
+func TestParseBicepUnbalancedDelimiterInBlockComment(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{"open brace", "/* TODO: reinstate the { block below */\n"},
+		{"open paren", "/* see foo( for details */\n"},
+		{"open bracket", "/* the [ here is prose */\n"},
+		{"odd quote", "/* don't let this quote leak */\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := tc.src + `resource real 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'real'
+}
+param p string
+`
+			parsed := parseBicep(src)
+
+			require.Len(t, parsed.resources, 1, "the comment must not swallow the file")
+			assert.Equal(t, "real", parsed.resources[0].symbolicName)
+			require.Len(t, parsed.parameters, 1)
+			assert.Equal(t, "p", parsed.parameters[0].name)
+		})
+	}
+}
+
+// A `/*` sequence inside a string literal is not a comment opener. Blanking it
+// would corrupt the value, so the stripper has to share the lexer's string
+// rules rather than doing a plain text scan.
+func TestStripBlockCommentsIgnoresCommentMarkersInStrings(t *testing.T) {
+	src := `param glob string = '/*.json'
+
+resource real 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'a/*b'
+}
+`
+	parsed := parseBicep(src)
+
+	require.Len(t, parsed.parameters, 1)
+	assert.Equal(t, "/*.json", parsed.parameters[0].defaultValue, "the `/*` inside the literal must survive")
+	require.Len(t, parsed.resources, 1)
+	assert.Equal(t, "'a/*b'", parsed.resources[0].name)
+}
+
+// Blanking preserves byte offsets and newlines so every line number the
+// tokenizer reports (and the source excerpts built from them) stays accurate.
+func TestStripBlockCommentsPreservesLineNumbers(t *testing.T) {
+	src := `/*
+a multi-line comment
+spanning three lines
+*/
+param p string
+`
+	stripped := stripBlockComments(src)
+
+	assert.Equal(t, len(src), len(stripped), "byte offsets must be preserved")
+	assert.Equal(t, strings.Count(src, "\n"), strings.Count(stripped, "\n"), "newlines must be preserved")
+
+	parsed := parseBicep(src)
+	require.Len(t, parsed.parameters, 1)
+	assert.Equal(t, 5, parsed.parameters[0].startLine, "the param is on source line 5")
+}
+
+// blanks returns as many spaces as s has bytes, so a table expectation reads
+// as "this span is blanked" instead of a hand-counted run of spaces.
+func blanks(s string) string { return strings.Repeat(" ", len(s)) }
+
+func TestStripBlockComments(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no comment is returned untouched", "param p string", "param p string"},
+		{"inline comment is blanked", "param p string /* note */", "param p string " + blanks("/* note */")},
+		{"line comment hides a block opener", "// see /* here\nparam p string", "// see /* here\nparam p string"},
+		{"block comment inside a string is kept", "var v = '/* not a comment */'", "var v = '/* not a comment */'"},
+		{"unterminated comment runs to EOF", "param p string\n/* unterminated", "param p string\n" + blanks("/* unterminated")},
+		{"nested-looking markers close at the first */", "/* a /* b */ param p string", blanks("/* a /* b */") + " param p string"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripBlockComments(tc.in))
+		})
+	}
+}
+
+// scanState is the shared lexer for every bracket-balancing helper in the
+// package, so it must not count delimiters inside a block comment.
+func TestScanStateSkipsBlockComments(t *testing.T) {
+	st := scanState{}
+	st.feed("resource r 'T@v' = { /* } } } */")
+	assert.Equal(t, 1, st.totalDepth(), "braces inside the comment must not count")
+
+	multi := scanState{}
+	multi.feed("var v = { /* opening { here")
+	multi.feed("   still inside the comment }")
+	multi.feed("*/ }")
+	assert.Equal(t, 0, multi.totalDepth(), "a comment spanning lines keeps its state")
+}

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -214,6 +214,9 @@ var (
 // `.bicep` constructs; multi-line object/array values are reassembled into a
 // single collapsed-whitespace value.
 func parseBicepParam(content string) (string, map[string]string) {
+	// `.bicepparam` files take the same comment syntax as `.bicep`.
+	content = stripBlockComments(content)
+
 	var using string
 	if m := usingRe.FindStringSubmatch(content); len(m) > 1 {
 		using = m[1]
@@ -240,6 +243,11 @@ func parseBicepParam(content string) (string, map[string]string) {
 
 func parseBicep(content string) *parsedBicepFile {
 	result := &parsedBicepFile{}
+
+	// Blank out `/*…*/` comments before anything reads the source. Offsets and
+	// line numbers are preserved, so this is invisible to every consumer other
+	// than removing content that isn't part of the deployment.
+	content = stripBlockComments(content)
 
 	// Target scope
 	if m := targetScopeRe.FindStringSubmatch(content); len(m) > 1 {
@@ -1300,6 +1308,7 @@ type scanState struct {
 	brace   int
 	inStr   byte // 0, '\'', or '"' — single-line string
 	inMulti bool // true while inside a `'''…'''` multi-line string
+	inCmt   bool // true while inside a `/*…*/` block comment
 }
 
 func (s *scanState) totalDepth() int { return s.paren + s.bracket + s.brace }
@@ -1311,6 +1320,16 @@ func (s *scanState) totalDepth() int { return s.paren + s.bracket + s.brace }
 // every walker in this file can share the same lexer rules without
 // duplicating them.
 func (s *scanState) stepAt(body string, i int) int {
+	// A `/*…*/` block comment runs across lines and suppresses everything
+	// inside it, including delimiters. Checked before the multi-line string
+	// case because a comment opened first wins until it closes.
+	if s.inCmt {
+		if i+1 < len(body) && body[i] == '*' && body[i+1] == '/' {
+			s.inCmt = false
+			return i + 2
+		}
+		return i + 1
+	}
 	if s.inMulti {
 		if i+2 < len(body) && body[i] == '\'' && body[i+1] == '\'' && body[i+2] == '\'' {
 			s.inMulti = false
@@ -1337,6 +1356,12 @@ func (s *scanState) stepAt(body string, i int) int {
 			j++
 		}
 		return j
+	}
+	// `/*` block comment opener. Checked after the `//` case so a block
+	// opener that appears inside a line comment is left alone.
+	if ch == '/' && i+1 < len(body) && body[i+1] == '*' {
+		s.inCmt = true
+		return i + 2
 	}
 	// Triple-quoted multi-line string opener: enter `inMulti` and
 	// hand back the index just past the `'''`.
@@ -1370,6 +1395,49 @@ func (s *scanState) feed(line string) {
 	for i := 0; i < len(line); {
 		i = s.stepAt(line, i)
 	}
+}
+
+// stripBlockComments replaces the contents of every `/*…*/` comment with
+// spaces, leaving newlines and every other byte in place.
+//
+// Blanking rather than deleting keeps byte offsets and line numbers identical
+// to the original source, so statement start lines, source excerpts, and the
+// regex helpers that index into a resource body all stay accurate. Because the
+// walk shares scanState, a `/*` inside a string literal (`'/*.json'`) is not
+// treated as a comment opener, and a `//` line comment hides a `/*` that
+// follows it on the same line.
+//
+// Doing this once up front is what keeps the ~15 bracket-balancing and
+// field-extraction helpers in this file correct without each one having to
+// know about comments: by the time they run, a commented-out resource is
+// whitespace, and an unbalanced delimiter inside a comment can no longer fool
+// the depth counter into consuming the rest of the file.
+func stripBlockComments(content string) string {
+	if !strings.Contains(content, "/*") {
+		return content
+	}
+
+	out := []byte(content)
+	st := scanState{}
+	for i := 0; i < len(content); {
+		openBefore := st.inCmt
+		next := st.stepAt(content, i)
+		if next <= i {
+			// Defensive: stepAt always advances, but a non-advancing step
+			// here would hang the scan on user-supplied input.
+			next = i + 1
+		}
+		// Blank the span when it opened, continued, or closed a comment.
+		if openBefore || st.inCmt {
+			for j := i; j < next && j < len(out); j++ {
+				if out[j] != '\n' {
+					out[j] = ' '
+				}
+			}
+		}
+		i = next
+	}
+	return string(out)
 }
 
 // scanForBodyBrace advances the state through one line and returns the


### PR DESCRIPTION
## Problem

`scanState` — the lexer shared by every bracket-balancing and field-extraction helper in the bicep parser — understood `//` line comments, single- and double-quoted strings and `'''` multi-line strings, but **not** `/* */` block comments. Two distinct user-visible failures fell out of that one gap.

**1. Commented-out resources were reported as deployed.**

```bicep
/*
resource commented 'Microsoft.Storage/storageAccounts@2023-01-01' = {
  name: 'ghost'
  properties: {
    supportsHttpsTrafficOnly: false
  }
}
*/
```

The tokenizer saw the comment body as ordinary source, so `bicep.file.resources` reported a phantom `ghost` storage account. A policy could fail on infrastructure that does not exist.

**2. An unbalanced delimiter inside a comment ate the rest of the file.**

```bicep
/* TODO: reinstate the { block below */
resource real 'Microsoft.Storage/storageAccounts@2023-01-01' = {
  name: 'real'
}
param p string
```

Because brace counting was not comment-aware, the `{` in the comment kept the statement open to EOF. The whole file collapsed into one empty-keyword statement: `resources=0 params=0`, returned with **no error**, so every audit over the file passed vacuously. A stray `(`, `[` or an odd quote in any comment does the same.

## Fix

`scanState` now tracks a `/*…*/` state, and a new `stripBlockComments` blanks comment bodies before parsing.

Blanking rather than deleting preserves newlines and byte offsets, so statement start lines, source excerpts and the regex helpers that index into a resource body are all unaffected. Doing this once at the top of `parseBicep` / `parseBicepParam` is what keeps the bracket-balancing and field-extraction helpers correct without teaching each of them about comments — by the time they run, a commented-out resource is whitespace.

The walk shares `scanState`, so the string rules come along for free:

- `param glob string = '/*.json'` — the `/*` is inside a literal and is left alone.
- `// see /* here` — a line comment still hides a block opener on the same line.
- An unterminated `/*` correctly runs to EOF, which is what Bicep does.

## Test plan

New `resources/blockcomment_test.go`:

- a commented-out resource is not reported, and the real one still is
- an unbalanced `{`, `(`, `[` or quote inside a comment does not swallow the file (table over all four)
- `/*` inside a string literal survives, in both a param default and a resource name
- byte offsets and newline count are preserved, and a param after a 4-line comment still reports `startLine: 5`
- a `stripBlockComments` table covering inline, line-comment-hidden, in-string, unterminated, and nested-looking `/* a /* b */` cases
- `scanState` does not count braces inside a comment, including one spanning three `feed` calls

`go test ./...` passes across the whole bicep provider.