### PR TITLE
🐛 bicep: detect @sys.-qualified decorators and survive #disable-next-line

### DIFF
--- a/providers/bicep/resources/decorators_test.go
+++ b/providers/bicep/resources/decorators_test.go
@@ -1,0 +1,142 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bicep lets every built-in decorator be written through the `sys` namespace,
+// which is required when a user-defined symbol shadows the bare name. Reading
+// `@sys.secure()` as "not secure" is the dangerous direction: a "secrets must
+// be @secure()" policy reports a false violation, and its inverse a false pass.
+func TestParseParameterSysQualifiedDecorators(t *testing.T) {
+	for _, prefix := range []string{"@", "@sys."} {
+		t.Run(prefix, func(t *testing.T) {
+			src := prefix + "secure()\n" +
+				prefix + "description('the admin password')\n" +
+				prefix + "minLength(8)\n" +
+				prefix + "maxLength(64)\n" +
+				"param pw string\n"
+
+			parsed := parseBicep(src)
+			require.Len(t, parsed.parameters, 1)
+			p := parsed.parameters[0]
+
+			assert.Equal(t, "pw", p.name)
+			assert.True(t, p.secure, "%ssecure() must set secure", prefix)
+			assert.Equal(t, "the admin password", p.description)
+			require.NotNil(t, p.minLength)
+			assert.Equal(t, int64(8), *p.minLength)
+			require.NotNil(t, p.maxLength)
+			assert.Equal(t, int64(64), *p.maxLength)
+		})
+	}
+}
+
+func TestParseParameterSysQualifiedAllowedAndValueBounds(t *testing.T) {
+	src := `@sys.allowed([
+  'Standard_LRS'
+  'Premium_LRS'
+])
+@sys.minValue(1)
+@sys.maxValue(10)
+param sku string
+`
+	parsed := parseBicep(src)
+	require.Len(t, parsed.parameters, 1)
+	p := parsed.parameters[0]
+
+	assert.Equal(t, []string{"Standard_LRS", "Premium_LRS"}, p.allowed)
+	require.NotNil(t, p.minValue)
+	assert.Equal(t, int64(1), *p.minValue)
+	require.NotNil(t, p.maxValue)
+	assert.Equal(t, int64(10), *p.maxValue)
+}
+
+func TestParseTypeSysQualifiedExportAndDiscriminator(t *testing.T) {
+	src := `@sys.export()
+@sys.discriminator('kind')
+type shape = { kind: string }
+`
+	parsed := parseBicep(src)
+	require.Len(t, parsed.types, 1)
+
+	assert.True(t, parsed.types[0].exported, "@sys.export() must mark the type exported")
+	assert.Equal(t, "kind", parsed.types[0].discriminator)
+}
+
+// `#disable-next-line` is a first-class Bicep construct and idiomatically sits
+// immediately above the declaration, below its decorators. The tokenizer only
+// skipped blank and `//` lines between a decorator and its statement, so the
+// directive detached every decorator onto a phantom empty statement — taking
+// `secure`, `description` and the bounds with it.
+func TestTokenizeDecoratorsSurviveDisableNextLine(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "directive between the decorators and the declaration",
+			src: `@secure()
+@description('pw')
+#disable-next-line secure-parameter-default
+param pw string = ''
+`,
+		},
+		{
+			name: "directive between two decorators",
+			src: `@secure()
+#disable-next-line BCP081
+@description('pw')
+param pw string = ''
+`,
+		},
+		{
+			name: "directive above the decorators",
+			src: `#disable-next-line secure-parameter-default
+@secure()
+@description('pw')
+param pw string = ''
+`,
+		},
+		{
+			name: "directive with a trailing comment",
+			src: `@secure()
+@description('pw')
+#disable-next-line secure-parameter-default // intentional
+param pw string = ''
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := parseBicep(tc.src)
+
+			require.Len(t, parsed.parameters, 1, "the param must still be parsed")
+			p := parsed.parameters[0]
+			assert.Equal(t, "pw", p.name)
+			assert.Equal(t, "string", p.typ)
+			assert.True(t, p.secure, "@secure() must stay attached across the directive")
+			assert.Equal(t, "pw", p.description, "@description() must stay attached too")
+		})
+	}
+}
+
+// A `#` directive on its own must not become an empty-keyword statement — that
+// is what dropped the decorators onto a phantom declaration.
+func TestTokenizeBicepSkipsDirectiveLines(t *testing.T) {
+	stmts := tokenizeBicep(`#disable-next-line no-unused-params
+
+@secure()
+#disable-next-line secure-parameter-default
+param pw string = ''
+`)
+
+	require.Len(t, stmts, 1, "only the param statement should be emitted")
+	assert.Equal(t, "param", stmts[0].keyword)
+	assert.Equal(t, []string{"@secure()"}, stmts[0].decorators)
+}

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -163,7 +163,6 @@ var (
 	resourceRe    = regexp.MustCompile(`(?m)^(resource)\s+(\w+)\s+'([^']+)'(\s+existing)?\s*=`)
 	moduleRe      = regexp.MustCompile(`(?m)^module\s+(\w+)\s+'([^']+)'\s*=`)
 	outputRe      = regexp.MustCompile(`(?m)^output\s+(\w+)\s+(\w+)\s*=\s*(.+)$`)
-	decoratorRe   = regexp.MustCompile(`(?m)^@(\w+)\(([^)]*)\)`)
 	// Every built-in decorator may also be written through the `sys`
 	// namespace (`@sys.secure()`), which is what Bicep requires when a
 	// user-defined symbol shadows the bare name. `decNS` makes that prefix

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -150,26 +150,37 @@ type parsedImport struct {
 	wildcard  bool
 }
 
+// decNS is the leading `@` of a decorator plus an optional `sys.` namespace
+// qualifier. Bicep exposes every built-in decorator on the `sys` namespace as
+// well as bare, and a file must use the qualified form when a user-defined
+// symbol shadows the bare name — so both spellings have to match.
+const decNS = `@(?:sys\.)?`
+
 var (
-	targetScopeRe  = regexp.MustCompile(`(?m)^targetScope\s*=\s*'([^']+)'`)
-	paramRe        = regexp.MustCompile(`(?m)^param\s+(\w+)\s+(\w+)(.*)$`)
-	varRe          = regexp.MustCompile(`(?m)^var\s+(\w+)\s*=\s*(.+)$`)
-	resourceRe     = regexp.MustCompile(`(?m)^(resource)\s+(\w+)\s+'([^']+)'(\s+existing)?\s*=`)
-	moduleRe       = regexp.MustCompile(`(?m)^module\s+(\w+)\s+'([^']+)'\s*=`)
-	outputRe       = regexp.MustCompile(`(?m)^output\s+(\w+)\s+(\w+)\s*=\s*(.+)$`)
-	decoratorRe    = regexp.MustCompile(`(?m)^@(\w+)\(([^)]*)\)`)
-	descDecRe      = regexp.MustCompile(`@description\('([^']*)'\)`)
-	secureDecRe    = regexp.MustCompile(`@secure\(\)`)
-	allowedDecRe   = regexp.MustCompile(`@allowed\(\[([^\]]*)\]\)`)
-	minLengthDecRe = regexp.MustCompile(`@minLength\(\s*(-?\d+)\s*\)`)
-	maxLengthDecRe = regexp.MustCompile(`@maxLength\(\s*(-?\d+)\s*\)`)
-	minValueDecRe  = regexp.MustCompile(`@minValue\(\s*(-?\d+)\s*\)`)
-	maxValueDecRe  = regexp.MustCompile(`@maxValue\(\s*(-?\d+)\s*\)`)
-	exportDecRe    = regexp.MustCompile(`@export\(\)`)
+	targetScopeRe = regexp.MustCompile(`(?m)^targetScope\s*=\s*'([^']+)'`)
+	paramRe       = regexp.MustCompile(`(?m)^param\s+(\w+)\s+(\w+)(.*)$`)
+	varRe         = regexp.MustCompile(`(?m)^var\s+(\w+)\s*=\s*(.+)$`)
+	resourceRe    = regexp.MustCompile(`(?m)^(resource)\s+(\w+)\s+'([^']+)'(\s+existing)?\s*=`)
+	moduleRe      = regexp.MustCompile(`(?m)^module\s+(\w+)\s+'([^']+)'\s*=`)
+	outputRe      = regexp.MustCompile(`(?m)^output\s+(\w+)\s+(\w+)\s*=\s*(.+)$`)
+	decoratorRe   = regexp.MustCompile(`(?m)^@(\w+)\(([^)]*)\)`)
+	// Every built-in decorator may also be written through the `sys`
+	// namespace (`@sys.secure()`), which is what Bicep requires when a
+	// user-defined symbol shadows the bare name. `decNS` makes that prefix
+	// optional everywhere so a namespace-qualified `@sys.secure()` is not
+	// silently read as "not secure".
+	descDecRe      = regexp.MustCompile(decNS + `description\('([^']*)'\)`)
+	secureDecRe    = regexp.MustCompile(decNS + `secure\(\)`)
+	allowedDecRe   = regexp.MustCompile(decNS + `allowed\(\[([^\]]*)\]\)`)
+	minLengthDecRe = regexp.MustCompile(decNS + `minLength\(\s*(-?\d+)\s*\)`)
+	maxLengthDecRe = regexp.MustCompile(decNS + `maxLength\(\s*(-?\d+)\s*\)`)
+	minValueDecRe  = regexp.MustCompile(decNS + `minValue\(\s*(-?\d+)\s*\)`)
+	maxValueDecRe  = regexp.MustCompile(decNS + `maxValue\(\s*(-?\d+)\s*\)`)
+	exportDecRe    = regexp.MustCompile(decNS + `export\(\)`)
 
 	// discriminatorDecRe captures the key argument of an
 	// `@discriminator('<key>')` decorator on a tagged-union type.
-	discriminatorDecRe = regexp.MustCompile(`@discriminator\(\s*'([^']*)'\s*\)`)
+	discriminatorDecRe = regexp.MustCompile(decNS + `discriminator\(\s*'([^']*)'\s*\)`)
 
 	// typeRe matches the header of a `type Name = <definition>` statement.
 	// The definition (everything after the first `=`) is captured raw;

--- a/providers/bicep/resources/tokenizer.go
+++ b/providers/bicep/resources/tokenizer.go
@@ -57,10 +57,10 @@ func tokenizeBicep(content string) []bicepStatement {
 	for i < len(lines) {
 		trimmed := strings.TrimSpace(lines[i])
 
-		// Skip blank lines and comment-only lines that sit between
-		// statements (decorators are handled below, so we only land here
-		// for separators).
-		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+		// Skip blank lines, comment-only lines, and `#` directives that sit
+		// between statements (decorators are handled below, so we only land
+		// here for separators).
+		if isSeparatorLine(trimmed) {
 			i++
 			continue
 		}
@@ -83,15 +83,15 @@ func tokenizeBicep(content string) []bicepStatement {
 			}
 			decorators = append(decorators, decLine)
 
-			// Advance past any blank/comment lines between a decorator and
-			// the statement (or the next decorator) it attaches to.
+			// Advance past any blank, comment, or directive lines between a
+			// decorator and the statement (or the next decorator) it attaches
+			// to. `#disable-next-line` idiomatically sits right here, below
+			// the decorators and above the declaration.
 			for i < len(lines) {
-				t := strings.TrimSpace(lines[i])
-				if t == "" || strings.HasPrefix(t, "//") {
-					i++
-					continue
+				if !isSeparatorLine(strings.TrimSpace(lines[i])) {
+					break
 				}
-				break
+				i++
 			}
 			if i >= len(lines) {
 				break
@@ -140,6 +140,20 @@ func tokenizeBicep(content string) []bicepStatement {
 	}
 
 	return statements
+}
+
+// isSeparatorLine reports whether a trimmed line carries no statement content
+// and may be skipped between (or inside) statements.
+//
+// Besides blank and `// …` comment lines, this covers Bicep's `#` directives —
+// `#disable-next-line <rule>` is a first-class construct that idiomatically
+// sits between a declaration's decorators and the declaration itself. Treating
+// it as content there detached every decorator onto a phantom empty statement,
+// so an `@secure()` parameter read back as not secure.
+func isSeparatorLine(trimmed string) bool {
+	return trimmed == "" ||
+		strings.HasPrefix(trimmed, "//") ||
+		strings.HasPrefix(trimmed, "#")
 }
 
 // classifyKeyword returns the canonical statement keyword for the leading


### PR DESCRIPTION
## Problem

`bicep.parameter.secure` read back as `false` in two shapes that are both ordinary, valid Bicep. A "secrets must be `@secure()`" policy reports a **false violation**; the inverse ("`@secure()` params must not have a default") reports a **false pass**. `description`, `allowed` and the length/value bounds are lost alongside it.

Observed before the fix:

```
"@secure()\nparam pw string"                                 -> secure=true
"@sys.secure()\nparam pw string"                             -> secure=false
"@secure()\n#disable-next-line ...\nparam pw string = ''"    -> secure=false
```

**1. Namespace-qualified decorators were invisible.**

Bicep exposes every built-in decorator on the `sys` namespace as well as bare, and the qualified form is *required* when a user-defined symbol shadows the bare name. The regexes hard-required a bare `@`:

```go
secureDecRe = regexp.MustCompile(`@secure\(\)`)
```

so `@sys.secure()` matched nothing — and likewise `@sys.description`, `@sys.allowed`, `@sys.minLength` / `maxLength` / `minValue` / `maxValue`, `@sys.export` and `@sys.discriminator`.

**2. A `#disable-next-line` directive detached every decorator.**

The directive is a first-class Bicep construct and idiomatically sits immediately above the declaration, below its decorators:

```bicep
@secure()
#disable-next-line secure-parameter-default
param pw string = ''
```

The tokenizer's decorator-attachment loop skipped only blank and `//` lines, so the directive was treated as statement content. The decorators attached to a phantom empty-keyword statement and the real `param` was left with `decorators: []`:

```
stmt kw=""      decs=[@secure() @description('d')]  text="#disable-next-line ..."
stmt kw="param" decs=[]                             text="param pw string = ''"
```

## Fix

- A new `decNS` prefix (`@(?:sys\.)?`) makes the namespace optional on all nine decorator patterns.
- Both skip loops in the tokenizer now share `isSeparatorLine`, which treats a leading `#` as a separator alongside blank and `//` lines.

## Test plan

New `resources/decorators_test.go`:

- every decorator parsed through both `@` and `@sys.` (table over the prefix, so the bare form is pinned as a control): `secure`, `description`, `minLength`, `maxLength`
- `@sys.allowed([...])` multi-line, `@sys.minValue`/`maxValue`
- `@sys.export()` and `@sys.discriminator('kind')` on a `type`
- `#disable-next-line` in all four positions — between decorators and declaration, between two decorators, above the decorators, and with a trailing `//` comment — each asserting `secure` and `description` survive
- `tokenizeBicep` emits **one** statement for a directive-laden param, not a phantom empty-keyword one

`go test ./...` passes across the whole bicep provider.

## Note

Touches `resources/parser.go` alongside #9772 (block comments), but in a different region of the file — they should merge independently in either order.
