### PR TITLE
🐛 ansible: drop null list entries so a stray `-` cannot panic the scan

### DIFF
--- a/providers/ansible/play/nilentry_test.go
+++ b/providers/ansible/play/nilentry_test.go
@@ -1,0 +1,131 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package play
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A YAML sequence entry that is null decodes to a nil element. It happens for
+// real whenever a play or task is commented out and the leading `-` is left
+// behind. The decoders are the single choke point every consumer goes through,
+// so they must never hand back a nil the resource layer would dereference.
+func TestDecodePlaybookDropsNilPlays(t *testing.T) {
+	pb, err := DecodePlaybook([]byte(`
+- hosts: web
+  tasks:
+    - ping:
+
+# temporarily disabled
+-
+- ~
+- null
+`))
+	require.NoError(t, err)
+	require.Len(t, pb, 1, "the three null entries must be dropped")
+	for i, p := range pb {
+		require.NotNil(t, p, "play[%d] must not be nil", i)
+	}
+	assert.Equal(t, "web", pb[0].Hosts)
+}
+
+func TestDecodeTaskListDropsNilTasks(t *testing.T) {
+	tasks, err := DecodeTaskList([]byte(`
+- name: real
+  ping:
+-
+- ~
+`))
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	require.NotNil(t, tasks[0])
+	assert.Equal(t, "real", tasks[0].Name)
+}
+
+func TestDecodeHandlerListDropsNilHandlers(t *testing.T) {
+	handlers, err := DecodeHandlerList([]byte(`
+- name: restart nginx
+  service:
+    name: nginx
+    state: restarted
+-
+`))
+	require.NoError(t, err)
+	require.Len(t, handlers, 1)
+	require.NotNil(t, handlers[0])
+	assert.Equal(t, "restart nginx", handlers[0].Name)
+}
+
+// A null entry can also sit inside a play's task lists or inside a block, and
+// those are reached through the same accessors, so they need the same guard.
+func TestDecodePlaybookDropsNilNestedEntries(t *testing.T) {
+	pb, err := DecodePlaybook([]byte(`
+- hosts: web
+  pre_tasks:
+    - name: pre
+      ping:
+    -
+  tasks:
+    - name: outer
+      block:
+        - name: inner
+          ping:
+        -
+      rescue:
+        -
+        - name: recover
+          ping:
+      always:
+        -
+    -
+  post_tasks:
+    -
+    - name: post
+      ping:
+  handlers:
+    -
+    - name: h
+      ping:
+`))
+	require.NoError(t, err)
+	require.Len(t, pb, 1)
+	p := pb[0]
+
+	require.Len(t, p.PreTasks, 1)
+	require.NotNil(t, p.PreTasks[0])
+	assert.Equal(t, "pre", p.PreTasks[0].Name)
+
+	require.Len(t, p.Tasks, 1)
+	outer := p.Tasks[0]
+	require.NotNil(t, outer)
+
+	require.Len(t, outer.Block, 1)
+	require.NotNil(t, outer.Block[0])
+	assert.Equal(t, "inner", outer.Block[0].Name)
+
+	require.Len(t, outer.Rescue, 1)
+	require.NotNil(t, outer.Rescue[0])
+	assert.Equal(t, "recover", outer.Rescue[0].Name)
+
+	assert.Empty(t, outer.Always, "a block of only null entries collapses to empty")
+
+	require.Len(t, p.PostTasks, 1)
+	require.NotNil(t, p.PostTasks[0])
+	assert.Equal(t, "post", p.PostTasks[0].Name)
+
+	require.Len(t, p.Handlers, 1)
+	require.NotNil(t, p.Handlers[0])
+	assert.Equal(t, "h", p.Handlers[0].Name)
+}
+
+// A file that is entirely null entries is a valid (if useless) playbook and
+// must decode to an empty list rather than a list of nils.
+func TestDecodePlaybookAllNullEntries(t *testing.T) {
+	pb, err := DecodePlaybook([]byte("-\n-\n"))
+	require.NoError(t, err)
+	assert.Empty(t, pb)
+}

--- a/providers/ansible/play/playbook.go
+++ b/providers/ansible/play/playbook.go
@@ -281,11 +281,50 @@ func DecodeTasks(data []byte) (Tasks, error) {
 	return tasks, nil
 }
 
+// compact returns xs without its nil elements, reusing the backing array when
+// there is nothing to drop.
+//
+// A YAML sequence entry that is null — a bare `-`, `- ~`, or `- null` — decodes
+// to a nil pointer. That happens for real whenever a play or task is commented
+// out and its leading dash is left behind. Nothing downstream nil-checks these
+// elements, so a single stray dash would otherwise panic the resource layer and
+// take the whole scan with it (blocks run in executor goroutines, so the panic
+// is not recoverable per-query).
+func compact[T any](xs []*T) []*T {
+	keep := xs[:0]
+	for _, x := range xs {
+		if x != nil {
+			keep = append(keep, x)
+		}
+	}
+	return keep
+}
+
+// compactTasks drops nil entries from a task list and from every nested
+// block/rescue/always list, which are reached through the same accessors.
+func compactTasks(tasks []*Task) []*Task {
+	tasks = compact(tasks)
+	for _, t := range tasks {
+		t.Block = compactTasks(t.Block)
+		t.Rescue = compactTasks(t.Rescue)
+		t.Always = compactTasks(t.Always)
+	}
+	return tasks
+}
+
 func DecodePlaybook(data []byte) (Playbook, error) {
 	var playbook Playbook
 	err := yaml.Unmarshal(data, &playbook)
 	if err != nil {
 		return nil, err
+	}
+
+	playbook = compact(playbook)
+	for _, p := range playbook {
+		p.PreTasks = compactTasks(p.PreTasks)
+		p.Tasks = compactTasks(p.Tasks)
+		p.PostTasks = compactTasks(p.PostTasks)
+		p.Handlers = compact(p.Handlers)
 	}
 	return playbook, nil
 }
@@ -297,7 +336,7 @@ func DecodeTaskList(data []byte) ([]*Task, error) {
 	if err := yaml.Unmarshal(data, &tasks); err != nil {
 		return nil, err
 	}
-	return tasks, nil
+	return compactTasks(tasks), nil
 }
 
 // DecodeHandlerList decodes a bare YAML list of handlers, the shape used by a
@@ -307,7 +346,7 @@ func DecodeHandlerList(data []byte) ([]*Handler, error) {
 	if err := yaml.Unmarshal(data, &handlers); err != nil {
 		return nil, err
 	}
-	return handlers, nil
+	return compact(handlers), nil
 }
 
 // RoleApplication is a single role applied by a play, including the directives

--- a/providers/ansible/resources/nullentry_test.go
+++ b/providers/ansible/resources/nullentry_test.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// A playbook whose leading `-` is left behind after a play is commented out
+// decodes to a nil *Play. Nothing downstream nil-checked it, so reading any
+// field panicked — and because the executor runs blocks in goroutines, that
+// killed the entire scan rather than failing one query.
+func TestPlaysSkipNullPlaybookEntries(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- name: real
+  hosts: web
+  tasks:
+    - name: do-thing
+      ping:
+
+# temporarily disabled
+-
+`)
+	a, err := CreateResource(rt, "ansible", map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	plays, err := a.(*mqlAnsible).plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 1, "the null entry must not become a play")
+
+	assert.Equal(t, "real", plays[0].(*mqlAnsiblePlay).Name.Data)
+}
+
+// The same hazard inside a play's task list, reached through the tasks
+// accessor rather than the plays accessor.
+func TestTasksSkipNullEntries(t *testing.T) {
+	rt := newTestRuntime(t, `---
+- name: real
+  hosts: web
+  tasks:
+    - name: do-thing
+      ping:
+    -
+    - name: other-thing
+      ping:
+`)
+	a, err := CreateResource(rt, "ansible", map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	plays, err := a.(*mqlAnsible).plays()
+	require.NoError(t, err)
+	require.Len(t, plays, 1)
+
+	tasks, err := plays[0].(*mqlAnsiblePlay).tasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 2, "the null entry must not become a task")
+
+	assert.Equal(t, "do-thing", tasks[0].(*mqlAnsibleTask).Name.Data)
+	assert.Equal(t, "other-thing", tasks[1].(*mqlAnsibleTask).Name.Data)
+}


### PR DESCRIPTION
## Problem

A YAML sequence entry that is null — a bare `-`, `- ~`, or `- null` — decodes to a **nil pointer**. This is not an exotic input: it is what a playbook looks like when a play or task is commented out and the leading dash is left behind.

```yaml
- hosts: web
  tasks:
    - ping:

# temporarily disabled
-
```

`looksLikePlaybook` accepts the file, and the resource layer dereferences the element with no guard:

```go
// resources/ansible.go
for i, p := range playbook {
    mqlPlay, err := newMqlAnsiblePlay(runtime, id, baseDir, p)   // p == nil
    ...
    "name": llx.StringData(p.Name),                              // panic
```

Because the executor runs blocks in goroutines, the panic is **not** recoverable per-query — it kills the whole scan. Reproduced against the real decoder:

```
len=2   play[0] isNil=false   play[1] isNil=true
PANIC on p.Name deref: runtime error: invalid memory address or nil pointer dereference
```

The same shape reaches `newMqlAnsibleTask` (`task.Name`) and `newMqlAnsibleHandler` (`handler.Name`).

## Fix

Filtered at the three decoders — `DecodePlaybook`, `DecodeTaskList`, `DecodeHandlerList` — which are the single choke point every consumer goes through.

The filter recurses, because a null entry can also sit inside a play's `pre_tasks` / `tasks` / `post_tasks` / `handlers` or inside a task's `block` / `rescue` / `always`, and those are reached through the same accessors.

Indices are assigned after filtering, so `__id`s stay dense and stable (`play[0]`, `play[1]`, …) rather than gaining holes.

## Test plan

New `play/nilentry_test.go` — decoder contract:

- `DecodePlaybook` drops `-`, `- ~` and `- null` entries and keeps the real play
- `DecodeTaskList` and `DecodeHandlerList` likewise
- nested coverage: null entries in `pre_tasks`, `tasks`, `post_tasks`, `handlers`, and inside `block` / `rescue` / `always` — including a block that is *only* null entries, which must collapse to empty
- a file that is entirely null entries decodes to an empty playbook, not a list of nils

New `resources/nullentry_test.go` — the user-visible behavior, through the real runtime:

- `ansible.plays` on a playbook with a trailing bare `-` returns 1 play instead of panicking
- `ansible.play.tasks` with a null entry mid-list returns the 2 real tasks in order

Verified these are a genuine regression fence by reverting the fix and re-running: all five decoder tests fail, and the resource-layer test reproduces the original `invalid memory address or nil pointer dereference`.

`go test ./...` passes across the whole ansible provider.
