### PR TITLE
🐛 bicep: scope resource field extraction to the top level of the body

### DIFF
--- a/providers/bicep/resources/fielddepth_test.go
+++ b/providers/bicep/resources/fielddepth_test.go
@@ -1,0 +1,200 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A nested `name:` must not win over the resource's own. This is the ordinary
+// shape of a VNet — subnets carry names, and Bicep does not require the
+// resource's own `name` to come first — so the wrong value is what a naming
+// convention or "this specific resource" policy would have matched on.
+func TestParseResourceNameIgnoresNestedKeys(t *testing.T) {
+	parsed := parseBicep(`resource vnet 'Microsoft.Network/virtualNetworks@2023-01-01' = {
+  properties: {
+    subnets: [
+      {
+        name: 'subnet-1'
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+        }
+      }
+    ]
+  }
+  name: 'my-vnet'
+  location: 'eastus'
+}
+`)
+
+	require.Len(t, parsed.resources, 1)
+	r := parsed.resources[0]
+	assert.Equal(t, "'my-vnet'", r.name, "the resource's own name, not the subnet's")
+	assert.Equal(t, "'eastus'", r.location)
+}
+
+func TestParseResourceLocationIgnoresNestedKeys(t *testing.T) {
+	parsed := parseBicep(`resource site 'Microsoft.Web/sites@2023-01-01' = {
+  properties: {
+    siteConfig: {
+      location: 'nested-should-lose'
+    }
+  }
+  name: 'my-site'
+  location: 'westeurope'
+}
+`)
+
+	require.Len(t, parsed.resources, 1)
+	assert.Equal(t, "'westeurope'", parsed.resources[0].location)
+}
+
+// `Microsoft.Resources/deployments` embeds a whole template under
+// `properties.template`, which has its own `tags` and `dependsOn`. Those belong
+// to the inner template, not to the deployment resource.
+func TestParseResourceTagsIgnoresNestedTemplate(t *testing.T) {
+	parsed := parseBicep(`resource deploy 'Microsoft.Resources/deployments@2022-09-01' = {
+  name: 'nested-deploy'
+  properties: {
+    template: {
+      tags: {
+        inner: 'yes'
+      }
+      resources: []
+    }
+  }
+  tags: {
+    owner: 'platform'
+    env: 'prod'
+  }
+}
+`)
+
+	require.Len(t, parsed.resources, 1)
+	assert.Equal(t, map[string]string{"owner": "platform", "env": "prod"}, parsed.resources[0].tags)
+}
+
+func TestParseResourceDependsOnIgnoresNestedTemplate(t *testing.T) {
+	parsed := parseBicep(`resource deploy 'Microsoft.Resources/deployments@2022-09-01' = {
+  name: 'nested-deploy'
+  properties: {
+    template: {
+      dependsOn: [
+        innerThing
+      ]
+    }
+  }
+  dependsOn: [
+    outerThing
+    otherThing
+  ]
+}
+`)
+
+	require.Len(t, parsed.resources, 1)
+	assert.Equal(t, []string{"outerThing", "otherThing"}, parsed.resources[0].dependsOn)
+}
+
+// A resource that genuinely has no top-level `tags`/`dependsOn` must report
+// none, rather than borrowing a nested block's.
+func TestParseResourceNoTopLevelTagsOrDependsOn(t *testing.T) {
+	parsed := parseBicep(`resource deploy 'Microsoft.Resources/deployments@2022-09-01' = {
+  name: 'nested-deploy'
+  properties: {
+    template: {
+      tags: {
+        inner: 'yes'
+      }
+      dependsOn: [
+        innerThing
+      ]
+    }
+  }
+}
+`)
+
+	require.Len(t, parsed.resources, 1)
+	assert.Nil(t, parsed.resources[0].tags, "a nested tags block is not the resource's own")
+	assert.Nil(t, parsed.resources[0].dependsOn, "a nested dependsOn is not the resource's own")
+}
+
+// The existing behavior for a plain, correctly-ordered body must be unchanged.
+func TestParseResourceTopLevelFieldsStillResolve(t *testing.T) {
+	parsed := parseBicep(`resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'mysa'
+  location: 'eastus'
+  tags: {
+    env: 'dev'
+  }
+  dependsOn: [
+    rg
+  ]
+  properties: {
+    supportsHttpsTrafficOnly: true
+  }
+}
+`)
+
+	require.Len(t, parsed.resources, 1)
+	r := parsed.resources[0]
+	assert.Equal(t, "'mysa'", r.name)
+	assert.Equal(t, "'eastus'", r.location)
+	assert.Equal(t, map[string]string{"env": "dev"}, r.tags)
+	assert.Equal(t, []string{"rg"}, r.dependsOn)
+}
+
+// A `for`-loop resource's per-iteration object is the body, so depth-1 there is
+// relative to that object.
+func TestParseLoopResourceFieldsIgnoreNestedKeys(t *testing.T) {
+	parsed := parseBicep(`resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = [for n in names: {
+  properties: {
+    subnets: [
+      {
+        name: 'inner'
+      }
+    ]
+  }
+  name: n
+}]
+`)
+
+	require.Len(t, parsed.resources, 1)
+	assert.True(t, parsed.resources[0].loop.isLoop)
+	assert.Equal(t, "n", parsed.resources[0].name)
+}
+
+// A module body goes through the same extractor for `scope`.
+func TestParseModuleScopeIgnoresNestedKeys(t *testing.T) {
+	parsed := parseBicep(`module m 'storage.bicep' = {
+  name: 'deploy-storage'
+  params: {
+    scope: 'inner-should-lose'
+  }
+  scope: resourceGroup('other-rg')
+}
+`)
+
+	require.Len(t, parsed.modules, 1)
+	assert.Equal(t, "resourceGroup('other-rg')", parsed.modules[0].scope)
+}
+
+func TestBodyObjectInner(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"declaration header is skipped", "resource r 'T@v' = {\n  name: 'x'\n}", "\n  name: 'x'\n"},
+		{"conditional header is skipped", "resource r 'T@v' = if (a) {\n  name: 'x'\n}", "\n  name: 'x'\n"},
+		{"brace inside a string is not the opener", "resource r 'T@{v}' = {\n  name: 'x'\n}", "\n  name: 'x'\n"},
+		{"no object yields empty", "param p string", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, bodyObjectInner(tc.in))
+		})
+	}
+}

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -1166,26 +1166,74 @@ func extractBlock(lines []string, startIdx int) (string, int) {
 	return strings.Join(blockLines, "\n"), len(lines)
 }
 
-// fieldValueRegexCache stores pre-compiled regexes for extractFieldValue lookups.
-var fieldValueRegexCache = func() map[string]*regexp.Regexp {
-	fields := []string{"name", "location", "parent", "scope"}
-	m := make(map[string]*regexp.Regexp, len(fields))
-	for _, f := range fields {
-		m[f] = regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(f) + `\s*:\s*(.+)$`)
+// bodyObjectInner returns the contents of the outermost `{ … }` object in body,
+// skipping whatever declaration header precedes it (`resource r 'T@v' = `, or
+// the `if (…)` form). Returns "" when body contains no object.
+//
+// The walk shares scanState, so a brace inside a string literal or a comment is
+// not mistaken for the opener. An unterminated object yields everything from
+// the opener on, which keeps a truncated file readable rather than empty.
+func bodyObjectInner(body string) string {
+	st := scanState{}
+	open := -1
+	for i := 0; i < len(body); {
+		before := st.brace
+		next := st.stepAt(body, i)
+		switch {
+		case open == -1 && st.brace == before+1:
+			open = i
+		case open >= 0 && st.brace == 0:
+			return body[open+1 : i]
+		}
+		if next <= i {
+			next = i + 1
+		}
+		i = next
 	}
-	return m
-}()
-
-func extractFieldValue(body string, fieldName string) string {
-	re, ok := fieldValueRegexCache[fieldName]
-	if !ok {
-		re = regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(fieldName) + `\s*:\s*(.+)$`)
-	}
-	m := re.FindStringSubmatch(body)
-	if len(m) > 1 {
-		return strings.TrimSpace(m[1])
+	if open >= 0 {
+		return body[open+1:]
 	}
 	return ""
+}
+
+// topLevelFieldValue returns the raw value text of `fieldName` from the top
+// level of a resource/module body — the members at brace depth 1 — or "" when
+// the body has no such member.
+//
+// Matching has to be depth-aware. Bicep does not require a resource's own
+// `name`/`location`/`tags`/`dependsOn` to come before its `properties`, and
+// nested objects use the very same keys: subnets have names, an inline
+// `properties.template` on a `Microsoft.Resources/deployments` has its own tags
+// and dependsOn. A scan that took the first match at any indentation returned
+// the nested value, so `bicep.resource.name` could report a subnet's name.
+func topLevelFieldValue(body string, fieldName string) string {
+	inner := bodyObjectInner(body)
+	if inner == "" {
+		// No object in body — a bare `key: value` fragment. There is no
+		// nesting to be confused by, so scan it as-is.
+		inner = body
+	}
+
+	entries := splitTopLevelEntries(inner)
+	for i, entry := range entries {
+		key, value, ok := splitFirstColon(entry)
+		if !ok || strings.TrimSpace(key) != fieldName {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		// Bicep allows the value's opening brace on the following line
+		// (`params:\n{ … }`). The newline after the colon sits at depth 0, so
+		// the entry splitter hands the object back as the next entry.
+		if value == "" && i+1 < len(entries) {
+			value = strings.TrimSpace(entries[i+1])
+		}
+		return value
+	}
+	return ""
+}
+
+func extractFieldValue(body string, fieldName string) string {
+	return topLevelFieldValue(body, fieldName)
 }
 
 // joinDeclHeader reassembles the declaration header — everything from
@@ -1249,41 +1297,19 @@ func extractCondition(line string) string {
 //	{
 //	  foo: 'x'
 //	}
+//
+// extractFieldBlock returns the contents of a `fieldName: { … }` object
+// declared at the top level of body. Like extractFieldValue it matches only at
+// brace depth 1, so an inline `properties.template.tags` is not mistaken for
+// the resource's own tags.
 func extractFieldBlock(body string, fieldName string) string {
-	lines := strings.Split(body, "\n")
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, fieldName+":") {
-			continue
-		}
-		rest := strings.TrimSpace(strings.TrimPrefix(trimmed, fieldName+":"))
-		startIdx := i
-		// When the value is empty on this line, the `{` must be on a
-		// later (non-blank) line; advance to it.
-		if rest == "" {
-			j := i + 1
-			for j < len(lines) && strings.TrimSpace(lines[j]) == "" {
-				j++
-			}
-			if j >= len(lines) || !strings.HasPrefix(strings.TrimSpace(lines[j]), "{") {
-				continue
-			}
-			startIdx = j
-		} else if !strings.HasPrefix(rest, "{") {
-			continue
-		}
-		block, _ := extractBlock(lines, startIdx)
-		// Strip the outer braces
-		if idx := strings.Index(block, "{"); idx >= 0 {
-			inner := block[idx+1:]
-			if last := strings.LastIndex(inner, "}"); last >= 0 {
-				inner = inner[:last]
-			}
-			return strings.TrimSpace(inner)
-		}
-		return block
+	value := topLevelFieldValue(body, fieldName)
+	// Require a balanced object: an unterminated `{` is malformed input and
+	// reports no block rather than half of one.
+	if !strings.HasPrefix(value, "{") || !strings.HasSuffix(value, "}") {
+		return ""
 	}
-	return ""
+	return strings.TrimSpace(stripOuter(value, '{', '}'))
 }
 
 // scanState is a tiny lexer state for tracking paren/bracket/brace
@@ -1597,39 +1623,23 @@ func extractTags(body string) map[string]string {
 	return tags
 }
 
-var dependsOnHeaderRe = regexp.MustCompile(`(?m)dependsOn\s*:\s*\[`)
-
-// extractDependsOn finds a `dependsOn: [ ... ]` block and returns the
-// raw entries. It walks the body via the shared `scanState` lexer so
-// brackets that live inside string literals (`'[indexed]'`) or
-// indexed expressions (`storageAccounts['blobServices']`) don't drop
-// the closing `]` early.
+// extractDependsOn returns the raw entries of a `dependsOn: [ ... ]` declared
+// at the top level of body.
+//
+// The lookup is depth-aware for the same reason as extractFieldValue: an inline
+// `properties.template` carries its own dependsOn, and matching it would report
+// the nested template's dependencies as the resource's. splitTopLevelEntries
+// handles both newline- and comma-separated entries and shares the string-aware
+// lexer, so a `]` inside a string literal (`'[indexed]'`) or an indexed
+// expression (`storageAccounts['blobServices']`) never splits the list early.
 func extractDependsOn(body string) []string {
-	loc := dependsOnHeaderRe.FindStringIndex(body)
-	if loc == nil {
+	value := topLevelFieldValue(body, "dependsOn")
+	// Require a balanced list: an unterminated `[` is malformed input and
+	// reports no dependencies rather than a partial list.
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
 		return nil
 	}
-	// loc[1] points just past the opening `[`. Seed the scanner with
-	// that opener already consumed.
-	start := loc[1]
-	st := scanState{bracket: 1}
-	end := -1
-	i := start
-	for i < len(body) {
-		prev := i
-		i = st.stepAt(body, i)
-		if st.bracket == 0 {
-			end = prev
-			break
-		}
-	}
-	if end < 0 {
-		return nil
-	}
-	// splitTopLevelEntries handles both newline- and comma-separated
-	// entries and shares the string-aware lexer, so a `]` inside a
-	// string literal or an indexed expression never splits the list.
-	deps := splitTopLevelEntries(body[start:end])
+	deps := splitTopLevelEntries(stripOuter(value, '[', ']'))
 	if len(deps) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Problem

`extractFieldValue`, `extractFieldBlock` and `extractDependsOn` matched the first occurrence of a key at **any** nesting depth. The value regex is anchored with `^\s*`, which permits arbitrary indentation, and `FindStringSubmatch` takes the first match — so a nested key wins:

```go
m[f] = regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(f) + `\s*:\s*(.+)$`)
```

Bicep does not require a resource's own `name` / `location` / `tags` / `dependsOn` to appear before its `properties`, and nested objects use the very same keys.

**A perfectly ordinary VNet:**

```bicep
resource vnet 'Microsoft.Network/virtualNetworks@2023-01-01' = {
  properties: {
    subnets: [
      {
        name: 'subnet-1'
      }
    ]
  }
  name: 'my-vnet'
}
```

`bicep.resource.name` returned `'subnet-1'` — the **subnet's** name. A naming-convention check, or any policy scoped to a specific resource, matches on the wrong string.

**A nested deployment:**

```bicep
resource deploy 'Microsoft.Resources/deployments@2022-09-01' = {
  properties: {
    template: {
      tags: { inner: 'yes' }
      dependsOn: [ innerThing ]
    }
  }
  tags: { owner: 'platform' }
  dependsOn: [ outerThing ]
}
```

`tags` returned `{inner: yes}` and `dependsOn` returned `[innerThing]` — the inline template's, not the deployment's. `dependsOnHeaderRe` was not even line-anchored.

## Fix

All three now resolve through a new `topLevelFieldValue`, which walks the body's **depth-1** members using the existing string-aware `splitTopLevelEntries` / `splitFirstColon` helpers rather than regexes over raw text. A new `bodyObjectInner` locates the body object, skipping the declaration header (including the `= if (…) {` form) with the shared `scanState`, so a brace inside a string or comment is not mistaken for the opener.

Three existing behaviors are deliberately preserved, each covered by a pre-existing test that I had to keep passing:

- a brace-less `key: value` fragment still resolves — there is no nesting to be confused by, so it is scanned as-is
- a value whose opening `{` sits on the *following* line (`params:\n{ … }`) still resolves — the newline after the colon sits at depth 0, so the object arrives as the next entry
- an unterminated `{` or `[` still reports nothing rather than a partial value

## Test plan

New `resources/fielddepth_test.go`:

- a VNet whose `name`/`location` follow a `properties` block containing a nested `name`/`location` — asserts the resource's own values win
- a `Microsoft.Resources/deployments` with an inline `properties.template` carrying its own `tags` and `dependsOn` — asserts the outer ones win
- the same shape with **no** top-level `tags`/`dependsOn` — asserts `nil`, i.e. a nested block is not borrowed
- a plain, correctly-ordered body still resolves all four fields (regression guard)
- a `for`-loop resource, where depth-1 is relative to the per-iteration object
- a module `scope` shadowed by a `params.scope`
- a `bodyObjectInner` table: declaration header skipped, `if (…)` header skipped, brace inside a string is not the opener, no-object yields empty

`go test ./...` passes across the whole bicep provider.

## Note

Touches `resources/parser.go` alongside #9772 and #9773, but in a different region of the file.
