### PR TITLE
🐛 bicep: skip malformed declarations instead of emitting empty husks

### DIFF
--- a/providers/bicep/resources/declmiss_test.go
+++ b/providers/bicep/resources/declmiss_test.go
@@ -1,0 +1,159 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A literal-union type has no bare word after the parameter name, so the old
+// `(\w+)` type capture missed and `parseParameter` returned a zero-value
+// struct that the caller appended anyway. The real declaration disappeared and
+// the husk took its place.
+func TestParseParameterUnionType(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		src      string
+		wantName string
+		typ      string
+		def      string
+	}{
+		{
+			name:     "single-quoted union with default",
+			src:      "param sku 'Standard_LRS' | 'Premium_LRS' = 'Standard_LRS'\n",
+			wantName: "sku",
+			typ:      "'Standard_LRS' | 'Premium_LRS'",
+			def:      "Standard_LRS",
+		},
+		{
+			name:     "parenthesized union",
+			src:      "param tier ('a'|'b') = 'a'\n",
+			wantName: "tier",
+			typ:      "('a'|'b')",
+			def:      "a",
+		},
+		{
+			name:     "union with no default",
+			src:      "param sku 'Standard_LRS' | 'Premium_LRS'\n",
+			wantName: "sku",
+			typ:      "'Standard_LRS' | 'Premium_LRS'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := parseBicep(tc.src)
+			require.Len(t, parsed.parameters, 1, "the declaration must not be dropped")
+			p := parsed.parameters[0]
+			assert.Equal(t, tc.wantName, p.name)
+			assert.Equal(t, tc.typ, p.typ)
+			assert.Equal(t, tc.def, p.defaultValue)
+		})
+	}
+}
+
+// An array type dropped its `[]` suffix, and because the remainder then started
+// with `[]` rather than `=`, the default was silently discarded too.
+func TestParseParameterArrayType(t *testing.T) {
+	parsed := parseBicep("param names string[] = ['a', 'b']\n")
+
+	require.Len(t, parsed.parameters, 1)
+	p := parsed.parameters[0]
+	assert.Equal(t, "names", p.name)
+	assert.Equal(t, "string[]", p.typ, "the array suffix belongs to the type")
+	assert.Equal(t, "['a', 'b']", p.defaultValue, "the default must not be dropped")
+}
+
+func TestParseParameterNullableAndCustomTypes(t *testing.T) {
+	parsed := parseBicep(`param a myType
+param b myType?
+param c int[]
+`)
+	require.Len(t, parsed.parameters, 3)
+	assert.Equal(t, "myType", parsed.parameters[0].typ)
+	assert.Equal(t, "myType?", parsed.parameters[1].typ)
+	assert.Equal(t, "int[]", parsed.parameters[2].typ)
+}
+
+// A `param` with no type at all is malformed. It must be skipped rather than
+// appended as an all-empty entry — two such husks share the __id
+// `bicep.parameter:<path>:` and alias onto one cached resource.
+func TestParseParameterMalformedIsSkipped(t *testing.T) {
+	parsed := parseBicep(`param p
+param q
+param good string
+`)
+
+	require.Len(t, parsed.parameters, 1, "only the well-formed declaration survives")
+	assert.Equal(t, "good", parsed.parameters[0].name)
+	for _, p := range parsed.parameters {
+		assert.NotEmpty(t, p.name, "no husk may be emitted")
+	}
+}
+
+func TestParseOutputArrayType(t *testing.T) {
+	parsed := parseBicep("output ids string[] = names\n")
+
+	require.Len(t, parsed.outputs, 1, "the declaration must not be dropped")
+	o := parsed.outputs[0]
+	assert.Equal(t, "ids", o.name)
+	assert.Equal(t, "string[]", o.typ)
+	assert.Equal(t, "names", o.expression)
+}
+
+func TestParseOutputMalformedIsSkipped(t *testing.T) {
+	parsed := parseBicep(`output broken
+output alsoBroken string
+output good string = 'x'
+`)
+
+	require.Len(t, parsed.outputs, 1, "an output with no assignment is malformed")
+	assert.Equal(t, "good", parsed.outputs[0].name)
+}
+
+// The regression this guards: two husks carry identical (empty) names, and the
+// __id is built as `bicep.parameter:<file>:<name>`, so they collapse onto one
+// cached instance and the list silently contains duplicates of one entry.
+func TestParseBicepNoDuplicateEmptyDeclarations(t *testing.T) {
+	parsed := parseBicep(`param a 'x' | 'y' = 'x'
+param b 'p' | 'q' = 'p'
+output o1 string[] = a
+output o2 string[] = b
+`)
+
+	require.Len(t, parsed.parameters, 2)
+	assert.Equal(t, "a", parsed.parameters[0].name)
+	assert.Equal(t, "b", parsed.parameters[1].name)
+	assert.NotEqual(t, parsed.parameters[0].name, parsed.parameters[1].name)
+
+	require.Len(t, parsed.outputs, 2)
+	assert.Equal(t, "o1", parsed.outputs[0].name)
+	assert.Equal(t, "o2", parsed.outputs[1].name)
+}
+
+func TestSplitDeclAtEquals(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		in            string
+		before, after string
+		ok            bool
+	}{
+		{"simple", "string = 'x'", "string", "'x'", true},
+		{"no assignment", "string", "", "", false},
+		{"equals inside a string literal", "string = 'a=b'", "string", "'a=b'", true},
+		{"union type before the assignment", "'a' | 'b' = 'a'", "'a' | 'b'", "'a'", true},
+		{"array type", "string[] = ['a']", "string[]", "['a']", true},
+		{"comparison in the value", "bool = a == b", "bool", "a == b", true},
+		{"lambda arrow in the value", "object = map(xs, x => x)", "object", "map(xs, x => x)", true},
+		{"equals inside parens is not top level", "('a=b') = 'x'", "('a=b')", "'x'", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before, after, ok := splitDeclAtEquals(tc.in)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.before, before)
+			assert.Equal(t, tc.after, after)
+		})
+	}
+}

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -158,11 +158,19 @@ const decNS = `@(?:sys\.)?`
 
 var (
 	targetScopeRe = regexp.MustCompile(`(?m)^targetScope\s*=\s*'([^']+)'`)
-	paramRe       = regexp.MustCompile(`(?m)^param\s+(\w+)\s+(\w+)(.*)$`)
-	varRe         = regexp.MustCompile(`(?m)^var\s+(\w+)\s*=\s*(.+)$`)
-	resourceRe    = regexp.MustCompile(`(?m)^(resource)\s+(\w+)\s+'([^']+)'(\s+existing)?\s*=`)
-	moduleRe      = regexp.MustCompile(`(?m)^module\s+(\w+)\s+'([^']+)'\s*=`)
-	outputRe      = regexp.MustCompile(`(?m)^output\s+(\w+)\s+(\w+)\s*=\s*(.+)$`)
+	// paramRe captures only the parameter NAME and the remainder of the
+	// header. The type cannot be a bare `(\w+)` — Bicep types include literal
+	// unions (`'a' | 'b'`), arrays (`string[]`), nullables (`myType?`) and
+	// parenthesized forms — so the type and default are separated afterwards
+	// with the delimiter-aware splitDeclAtEquals.
+	paramRe    = regexp.MustCompile(`(?m)^param\s+(\w+)\s+(\S.*)$`)
+	varRe      = regexp.MustCompile(`(?m)^var\s+(\w+)\s*=\s*(.+)$`)
+	resourceRe = regexp.MustCompile(`(?m)^(resource)\s+(\w+)\s+'([^']+)'(\s+existing)?\s*=`)
+	moduleRe   = regexp.MustCompile(`(?m)^module\s+(\w+)\s+'([^']+)'\s*=`)
+	// outputRe captures the output NAME and the remainder of the header, for
+	// the same reason as paramRe — `output ids string[] = names` has no bare
+	// word before the `=`.
+	outputRe = regexp.MustCompile(`(?m)^output\s+(\w+)\s+(\S.*)$`)
 	// Every built-in decorator may also be written through the `sys`
 	// namespace (`@sys.secure()`), which is what Bicep requires when a
 	// user-defined symbol shadows the bare name. `decNS` makes that prefix
@@ -290,9 +298,10 @@ func parseBicep(content string) *parsedBicepFile {
 			// whole default instead of just the opening `{`/`[`. Inline
 			// comments are stripped string-aware so a trailing `// ...` doesn't
 			// leak into the default value.
-			p := parseParameter(reassembleParamStatement(stmtLines), stmt.decorators)
-			p.startLine, p.endLine = startLine, endLine
-			result.parameters = append(result.parameters, p)
+			if p, ok := parseParameter(reassembleParamStatement(stmtLines), stmt.decorators); ok {
+				p.startLine, p.endLine = startLine, endLine
+				result.parameters = append(result.parameters, p)
+			}
 		case "var":
 			v, _ := parseVariableDecl(stmtLines, 0, stmt.decorators)
 			v.startLine, v.endLine = startLine, endLine
@@ -315,9 +324,10 @@ func parseBicep(content string) *parsedBicepFile {
 			if len(stmtLines) > 1 {
 				outLine = strings.Join(strings.Fields(strings.Join(stmtLines, " ")), " ")
 			}
-			o := parseOutput(outLine, stmt.decorators)
-			o.startLine, o.endLine = startLine, endLine
-			result.outputs = append(result.outputs, o)
+			if o, ok := parseOutput(outLine, stmt.decorators); ok {
+				o.startLine, o.endLine = startLine, endLine
+				result.outputs = append(result.outputs, o)
+			}
 		case "type":
 			if t, ok := parseTypeDecl(stmt.text, stmt.decorators); ok {
 				result.types = append(result.types, t)
@@ -378,24 +388,33 @@ func stripInlineComment(s string, st *scanState) string {
 	return s
 }
 
-func parseParameter(line string, decorators []string) parsedParameter {
+// parseParameter parses a `param` declaration. ok is false when the line is not
+// a well-formed parameter declaration, in which case the caller must skip it:
+// appending a zero-value entry both loses the real declaration and gives every
+// husk the same `bicep.parameter:<file>:` cache key, so they alias onto one
+// instance.
+func parseParameter(line string, decorators []string) (parsedParameter, bool) {
 	p := parsedParameter{decorators: decorators}
 
 	m := paramRe.FindStringSubmatch(line)
-	if len(m) >= 3 {
-		p.name = m[1]
-		p.typ = m[2]
-		if len(m) > 3 {
-			rest := strings.TrimSpace(m[3])
-			if strings.HasPrefix(rest, "=") {
-				val := strings.TrimSpace(rest[1:])
-				// Strip Bicep single-quote string delimiters
-				if len(val) >= 2 && val[0] == '\'' && val[len(val)-1] == '\'' {
-					val = val[1 : len(val)-1]
-				}
-				p.defaultValue = val
-			}
+	if len(m) < 3 {
+		return parsedParameter{}, false
+	}
+
+	p.name = m[1]
+	rest := strings.TrimSpace(m[2])
+	if typ, def, hasDefault := splitDeclAtEquals(rest); hasDefault {
+		p.typ = typ
+		// Strip Bicep single-quote string delimiters
+		if len(def) >= 2 && def[0] == '\'' && def[len(def)-1] == '\'' {
+			def = def[1 : len(def)-1]
 		}
+		p.defaultValue = def
+	} else {
+		p.typ = rest
+	}
+	if p.typ == "" {
+		return parsedParameter{}, false
 	}
 
 	decText := strings.Join(decorators, "\n")
@@ -411,7 +430,7 @@ func parseParameter(line string, decorators []string) parsedParameter {
 	p.minValue = parseIntDecorator(decText, minValueDecRe)
 	p.maxValue = parseIntDecorator(decText, maxValueDecRe)
 
-	return p
+	return p, true
 }
 
 // parseIntDecorator matches a decorator like `@minLength(8)` and returns the
@@ -512,23 +531,36 @@ func parseVariableDecl(lines []string, startIdx int, decorators []string) (parse
 // `=` inside the resource type string or a condition expression is ignored).
 // Returns "" when no top-level `=` is found.
 func declValueAfterEquals(lines []string, startIdx int) string {
-	full := strings.Join(lines[startIdx:], "\n")
+	_, after, _ := splitDeclAtEquals(strings.Join(lines[startIdx:], "\n"))
+	return after
+}
+
+// splitDeclAtEquals splits a declaration at its assignment `=` — the first one
+// that sits outside any string, comment, and bracket, and is not part of a
+// `==`/`=>` operator. Returns ok=false when there is no assignment.
+//
+// The left side is what precedes the assignment, which for a `param` or
+// `output` header is the declared type. That type cannot be captured with a
+// bare `\w+`: Bicep types include literal unions (`'a' | 'b'`), arrays
+// (`string[]`), nullables (`myType?`) and parenthesized forms, so the split has
+// to be delimiter-aware rather than lexical.
+func splitDeclAtEquals(s string) (before, after string, ok bool) {
 	st := scanState{}
-	for i := 0; i < len(full); {
-		if st.inStr == 0 && !st.inMulti && full[i] == '=' &&
+	for i := 0; i < len(s); {
+		if st.inStr == 0 && !st.inMulti && s[i] == '=' &&
 			st.paren == 0 && st.bracket == 0 && st.brace == 0 {
-			// Guard against `==`/`=>` which can appear in conditions; a real
-			// assignment `=` is followed by whitespace or a value char, not
-			// another `=` or `>`.
-			if i+1 < len(full) && (full[i+1] == '=' || full[i+1] == '>') {
-				i = st.stepAt(full, i)
+			// Guard against `==`/`=>` which can appear in conditions and
+			// lambdas; a real assignment `=` is followed by whitespace or a
+			// value char, not another `=` or `>`.
+			if i+1 < len(s) && (s[i+1] == '=' || s[i+1] == '>') {
+				i = st.stepAt(s, i)
 				continue
 			}
-			return strings.TrimSpace(full[i+1:])
+			return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+1:]), true
 		}
-		i = st.stepAt(full, i)
+		i = st.stepAt(s, i)
 	}
-	return ""
+	return "", "", false
 }
 
 func parseResourceDecl(lines []string, startIdx int, decorators []string) (*parsedResource, int) {
@@ -739,30 +771,40 @@ func parseModuleDecl(lines []string, startIdx int, decorators []string) (*parsed
 	return mod, endIdx
 }
 
-func parseOutput(line string, decorators []string) parsedOutput {
+// parseOutput parses an `output` declaration. ok is false when the line is not
+// a well-formed output declaration — including one with no assignment, which
+// Bicep requires — so the caller can skip it rather than append a husk.
+func parseOutput(line string, decorators []string) (parsedOutput, bool) {
 	o := parsedOutput{}
 	m := outputRe.FindStringSubmatch(line)
-	if len(m) >= 4 {
-		o.name = m[1]
-		o.typ = m[2]
-		expr := strings.TrimSpace(m[3])
-		// A looped output (`output ids array = [for sa in sas: sa.id]`)
-		// produces an array. Intentionally store the per-iteration value
-		// expression in `expression` (here `sa.id`), not the raw `[for ...]`
-		// text, and record the loop header separately. This keeps `expression`
-		// describing the value each iteration produces.
-		if loop := detectLoop(expr); loop.isLoop {
-			o.loop = loop
-			o.expression = loop.body
-		} else {
-			o.expression = expr
-		}
+	if len(m) < 3 {
+		return parsedOutput{}, false
 	}
+
+	typ, expr, hasValue := splitDeclAtEquals(strings.TrimSpace(m[2]))
+	if !hasValue || typ == "" {
+		return parsedOutput{}, false
+	}
+
+	o.name = m[1]
+	o.typ = typ
+	// A looped output (`output ids array = [for sa in sas: sa.id]`)
+	// produces an array. Intentionally store the per-iteration value
+	// expression in `expression` (here `sa.id`), not the raw `[for ...]`
+	// text, and record the loop header separately. This keeps `expression`
+	// describing the value each iteration produces.
+	if loop := detectLoop(expr); loop.isLoop {
+		o.loop = loop
+		o.expression = loop.body
+	} else {
+		o.expression = expr
+	}
+
 	decText := strings.Join(decorators, "\n")
 	if m := descDecRe.FindStringSubmatch(decText); len(m) > 1 {
 		o.description = m[1]
 	}
-	return o
+	return o, true
 }
 
 // parseTypeDecl handles a `type Name = <definition>` statement. The whole

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -107,7 +107,8 @@ func TestParseParameterDefaultValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := parseParameter(tt.input, nil)
+			p, ok := parseParameter(tt.input, nil)
+			require.True(t, ok, "well-formed declaration must parse")
 			assert.Equal(t, tt.wantName, p.name)
 			assert.Equal(t, tt.wantType, p.typ)
 			assert.Equal(t, tt.wantDef, p.defaultValue)
@@ -557,7 +558,8 @@ func TestParseModuleDecl(t *testing.T) {
 
 func TestParseOutput(t *testing.T) {
 	t.Run("simple output", func(t *testing.T) {
-		o := parseOutput("output rgId string = rg.id", nil)
+		o, ok := parseOutput("output rgId string = rg.id", nil)
+		require.True(t, ok)
 		assert.Equal(t, "rgId", o.name)
 		assert.Equal(t, "string", o.typ)
 		assert.Equal(t, "rg.id", o.expression)
@@ -572,7 +574,8 @@ output rgId string = rg.id`
 	})
 
 	t.Run("int output", func(t *testing.T) {
-		o := parseOutput("output count int = length(items)", nil)
+		o, ok := parseOutput("output count int = length(items)", nil)
+		require.True(t, ok)
 		assert.Equal(t, "count", o.name)
 		assert.Equal(t, "int", o.typ)
 		assert.Equal(t, "length(items)", o.expression)


### PR DESCRIPTION
## Problem

`parseParameter` and `parseOutput` returned a **zero-value struct** when their regex missed, and the caller appended it unconditionally:

```go
case "param":
    p := parseParameter(reassembleParamStatement(stmtLines), stmt.decorators)
    p.startLine, p.endLine = startLine, endLine
    result.parameters = append(result.parameters, p)   // appended even on a miss
```

Two things go wrong at once:

1. **The real declaration disappears.** `bicep.file.parameters.where(name == "sku")` is empty, so a "this parameter must be constrained" audit passes vacuously.
2. **The husks alias.** Every one gets the identical `__id` `bicep.parameter:<file>:`, so several collapse onto one cached instance and the list silently contains duplicates of a single blank entry.

The regexes missed on **valid** Bicep because both captured the type as a bare `(\w+)`:

```go
paramRe  = regexp.MustCompile(`(?m)^param\s+(\w+)\s+(\w+)(.*)$`)
outputRe = regexp.MustCompile(`(?m)^output\s+(\w+)\s+(\w+)\s*=\s*(.+)$`)
```

Observed before the fix:

```
param sku 'Standard_LRS' | 'Premium_LRS' = 'Standard_LRS'
   -> name="" typ="" def=""          declaration lost
param names string[] = ['a']
   -> typ="string" def=""            array suffix and default both dropped
output ids string[] = names
   -> name="" typ=""                 declaration lost
```

A literal union has no bare word after the parameter name. And for `string[]`, the remainder began with `[]` rather than `=`, so the `HasPrefix(rest, "=")` test failed and the default was silently discarded.

## Fix

Both regexes now capture the **name** plus the remainder of the header, and the type/value split happens afterwards with a new `splitDeclAtEquals` — factored out of the existing `declValueAfterEquals` so the string-, bracket-, `==`- and `=>`-aware logic has a single implementation.

That makes every Bicep type shape parse: literal unions (`'a' | 'b'`), parenthesized unions, arrays (`string[]`), nullables (`myType?`) and custom type references.

Both parsers now return an `ok` flag and the caller skips on a miss — matching how `parseResourceDecl` / `parseModuleDecl` / `parseTypeDecl` already gate on `nil`/`ok`.

## Test plan

New `resources/declmiss_test.go`:

- union-typed params (quoted, parenthesized, and with no default) keep their name, full type text and default
- `param names string[] = ['a', 'b']` reports type `string[]` **and** keeps the default
- nullable (`myType?`), custom-type and `int[]` params
- `param p` with no type is skipped rather than appended as a husk
- `output ids string[] = names` parses; `output broken` and `output alsoBroken string` (no assignment) are skipped
- the aliasing regression directly: two union params and two array outputs in one file must yield two distinct entries each, not duplicates of one blank
- a `splitDeclAtEquals` table: simple, no-assignment, `=` inside a string literal, union before the assignment, array type, `==` in the value, a `=>` lambda in the value, and `=` inside parens

Three existing call sites in `parser_test.go` were updated to the new two-value signature; since all their inputs are well-formed I assert `ok` is true rather than discarding it.

`go test ./...` passes across the whole bicep provider.

## Note

Touches `resources/parser.go` alongside #9772, #9773 and #9775. This one edits the `paramRe`/`outputRe` lines, which sit near the decorator block #9773 touches — expect a small conflict if those two merge apart; the resolution is to keep both edits.
