### PR TITLE
🐛 kustomize: read an inline patchesStrategicMerge entry as a patch, not a path

### DIFF
--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -191,9 +191,10 @@ func (k *mqlKustomizeKustomization) patches() ([]any, error) {
 		mqlPatches = append(mqlPatches, mqlP)
 		idx++
 	}
-	// Legacy patchesStrategicMerge: each entry is a file path, force strategicMerge.
+	// Legacy patchesStrategicMerge: each entry is EITHER a file path or an
+	// inline patch body, so it has to be disambiguated. Format is unambiguous.
 	for i := range kust.PatchesStrategicMerge {
-		p := kustomizeTypes.Patch{Path: string(kust.PatchesStrategicMerge[i])}
+		p := strategicMergePatchEntry(kustPath, string(kust.PatchesStrategicMerge[i]))
 		mqlP, err := newMqlKustomizePatch(k.MqlRuntime, kustPath, idx, &p, hintStrategicMerge)
 		if err != nil {
 			return nil, err

--- a/providers/kustomize/resources/patch.go
+++ b/providers/kustomize/resources/patch.go
@@ -48,6 +48,35 @@ type mqlKustomizePatchInternal struct {
 	ops    []jsonPatchOp
 }
 
+// strategicMergePatchEntry turns one legacy `patchesStrategicMerge` entry into
+// a Patch, deciding whether it names a file or carries an inline patch body.
+//
+// The field is genuinely polymorphic, and kustomize disambiguates the same way
+// — `types.Kustomization.FixKustomizationPreMarshalling` tries to read the
+// entry as a file and falls back to treating it as an inline patch:
+//
+//	if _, err := fSys.ReadFile(string(patchStrategicMerge)); err == nil {
+//	    k.Patches = append(k.Patches, Patch{Path: string(patchStrategicMerge)})
+//	} else {
+//	    k.Patches = append(k.Patches, Patch{Patch: string(patchStrategicMerge)})
+//	}
+//
+// A nonexistent path stays a path so a genuine typo still reports as a missing
+// patch file (with a warning from newMqlKustomizePatch) rather than dumping the
+// filename into `content` as though it were a patch body.
+func strategicMergePatchEntry(kustPath, entry string) kustomizeTypes.Patch {
+	if fi, err := os.Stat(filepath.Join(kustPath, entry)); err == nil && !fi.IsDir() {
+		return kustomizeTypes.Patch{Path: entry}
+	}
+	// An inline body always contains a `:` (it is YAML), and a path never
+	// spans lines. Anything that can't be a filename is treated as inline;
+	// everything else keeps the path reading.
+	if strings.ContainsAny(entry, "\n:") {
+		return kustomizeTypes.Patch{Patch: entry}
+	}
+	return kustomizeTypes.Patch{Path: entry}
+}
+
 func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p *kustomizeTypes.Patch, hint formatHint) (*mqlKustomizePatch, error) {
 	targetGroup := ""
 	targetVersion := ""

--- a/providers/kustomize/resources/strategicmerge_test.go
+++ b/providers/kustomize/resources/strategicmerge_test.go
@@ -1,0 +1,99 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const inlineSMP = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        securityContext:
+          privileged: true`
+
+// A `patchesStrategicMerge` entry is either a file path or an inline patch
+// body. Kustomize itself disambiguates by trying to read the entry as a file
+// (types.Kustomization.FixKustomizationPreMarshalling), and so must we — the
+// provider used to force the path branch unconditionally, which left `content`
+// empty for an inline patch and put a multi-line YAML blob in `path`.
+func TestStrategicMergePatchEntry(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment-patch.yaml"), []byte(inlineSMP), 0o600))
+
+	t.Run("an existing file is a path", func(t *testing.T) {
+		p := strategicMergePatchEntry(dir, "deployment-patch.yaml")
+		assert.Equal(t, "deployment-patch.yaml", p.Path)
+		assert.Empty(t, p.Patch)
+	})
+
+	t.Run("an inline body is a patch", func(t *testing.T) {
+		p := strategicMergePatchEntry(dir, inlineSMP)
+		assert.Empty(t, p.Path, "a multi-line YAML body is not a path")
+		assert.Equal(t, inlineSMP, p.Patch)
+	})
+
+	t.Run("a nonexistent path stays a path", func(t *testing.T) {
+		// Kustomize would fail the build; reporting it as a path (which then
+		// reads as an empty patch, with a warning) keeps the old behavior for
+		// a genuine typo rather than dumping a filename into `content`.
+		p := strategicMergePatchEntry(dir, "missing-patch.yaml")
+		assert.Equal(t, "missing-patch.yaml", p.Path)
+		assert.Empty(t, p.Patch)
+	})
+
+	t.Run("a directory is not a patch file", func(t *testing.T) {
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o750))
+		p := strategicMergePatchEntry(dir, "subdir")
+		assert.Equal(t, "subdir", p.Path, "a directory is not readable as a patch body")
+		assert.Empty(t, p.Patch)
+	})
+
+	t.Run("a single-line inline patch is still inline", func(t *testing.T) {
+		body := "{apiVersion: apps/v1, kind: Deployment, metadata: {name: nginx}}"
+		p := strategicMergePatchEntry(dir, body)
+		assert.Empty(t, p.Path)
+		assert.Equal(t, body, p.Patch)
+	})
+}
+
+// The user-visible consequence: an inline strategic-merge patch must surface
+// its body through `content`, so `patches.where(content.contains("privileged"))`
+// finds it. It used to return "" and the policy passed vacuously.
+func TestInlineStrategicMergePatchExposesContent(t *testing.T) {
+	dir := t.TempDir()
+	rt := newTestRuntime()
+
+	p := strategicMergePatchEntry(dir, inlineSMP)
+	mqlP, err := newMqlKustomizePatch(rt, dir, 0, &p, hintStrategicMerge)
+	require.NoError(t, err)
+
+	assert.Contains(t, mqlP.Content.Data, "privileged: true")
+	assert.Empty(t, mqlP.Path.Data, "an inline patch has no path")
+	assert.Equal(t, patchFormatStrategicMerge, mqlP.Format.Data)
+}
+
+func TestFileStrategicMergePatchExposesContent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "p.yaml"), []byte(inlineSMP), 0o600))
+	rt := newTestRuntime()
+
+	p := strategicMergePatchEntry(dir, "p.yaml")
+	mqlP, err := newMqlKustomizePatch(rt, dir, 0, &p, hintStrategicMerge)
+	require.NoError(t, err)
+
+	assert.Contains(t, mqlP.Content.Data, "privileged: true")
+	assert.Equal(t, "p.yaml", mqlP.Path.Data)
+}


### PR DESCRIPTION
## Problem

A `patchesStrategicMerge` entry is **either** a relative file path **or** an inline strategic-merge patch body. The provider unconditionally took the path branch:

```go
// Legacy patchesStrategicMerge: each entry is a file path, force strategicMerge.
for i := range kust.PatchesStrategicMerge {
    p := kustomizeTypes.Patch{Path: string(kust.PatchesStrategicMerge[i])}
```

The comment's premise is wrong, and kustomize's own migration code proves it (`types.Kustomization.FixKustomizationPreMarshalling`):

```go
if _, err := fSys.ReadFile(string(patchStrategicMerge)); err == nil {
    k.Patches = append(k.Patches, Patch{Path: string(patchStrategicMerge)})
} else {
    k.Patches = append(k.Patches, Patch{Patch: string(patchStrategicMerge)})   // inline
}
```

**Trigger** — extremely common in pre-v4 kustomizations:

```yaml
patchesStrategicMerge:
- |-
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx
  spec:
    template:
      spec:
        containers:
        - name: nginx
          securityContext:
            privileged: true
```

`kustomize.patch.content` reads `""`, so

```
patches.where(content.contains("privileged"))
```

returns `[]` and the policy **passes vacuously** on a patch that grants privileged. Meanwhile `path` — documented as "Patch file path (empty if inline)" — holds a multi-line YAML blob. That bogus path then fails its containment check and `os.ReadFile`, and the `!os.IsNotExist` guard usually suppresses even the warning.

## Fix

A new `strategicMergePatchEntry` disambiguates the same way kustomize does: stat the entry as a file first, fall back to inline.

Two deliberate refinements over a bare stat:

- **A nonexistent path stays a path.** A genuine typo should still report as a missing patch file (with the existing warning) rather than dumping the filename into `content` as though it were a patch body.
- **A directory is not a patch file**, so it keeps the path reading too.

The fallback also requires the entry to contain a `\n` or `:` before treating it as inline — an inline body is YAML and always has one; a filename has neither.

`newMqlKustomizePatch` already handled `p.Patch` correctly, so setting the right field is the whole fix.

## Test plan

New `resources/strategicmerge_test.go`:

- `strategicMergePatchEntry` table: an existing file → `Path`; a multi-line inline body → `Patch`; a nonexistent path → `Path`; a directory → `Path`; a single-line flow-style inline body → `Patch`
- end-to-end through `newMqlKustomizePatch`: an inline patch exposes `privileged: true` via `content`, has an empty `path`, and classifies as `strategicMerge`
- the file-backed form still exposes the same `content` **and** keeps its `path` (regression guard)

`go test ./...` passes across the whole kustomize provider.
