### PR TITLE
🐛 cloudformation: a float constraint must not erase every parameter

### DIFF
--- a/providers/cloudformation/resources/cloudformation.go
+++ b/providers/cloudformation/resources/cloudformation.go
@@ -6,7 +6,10 @@ package resources
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
+
+	"github.com/rs/zerolog/log"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/ranger-rpc/codes"
@@ -87,11 +90,41 @@ func nodeToInt(parent *yaml.Node, key string) (*int64, error) {
 	if val.Kind != yaml.ScalarNode {
 		return nil, fmt.Errorf("expected scalar for %s, got kind %v", key, val.Kind)
 	}
-	n, err := strconv.ParseInt(val.Value, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("invalid integer for %s: %w", key, err)
+	if n, err := strconv.ParseInt(val.Value, 10, 64); err == nil {
+		return &n, nil
 	}
+	// CloudFormation `Number` parameters may be integers or floats, so
+	// `MinValue: 1.0` and `MinValue: 1e3` are legal. An integral float is
+	// exactly representable by the int-typed field, so accept it; a genuinely
+	// fractional bound is not, and reporting a truncated value would be worse
+	// than reporting none, so it stays an error for the caller to degrade on.
+	f, err := strconv.ParseFloat(val.Value, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid number for %s: %w", key, err)
+	}
+	if f != math.Trunc(f) || f > math.MaxInt64 || f < math.MinInt64 {
+		return nil, fmt.Errorf("%s is not representable as an integer: %s", key, val.Value)
+	}
+	n := int64(f)
 	return &n, nil
+}
+
+// optionalIntConstraint reads an integer parameter constraint, degrading to nil
+// (an absent constraint) when the value can't be represented rather than
+// failing. `param` names the owning parameter so the warning is actionable.
+//
+// The alternative — propagating the error — takes down the whole parameter
+// list: one `MinValue: 0.5` on one parameter would erase every other
+// parameter in the template, so a policy looking for an unrelated NoEcho
+// credential parameter would find nothing at all.
+func optionalIntConstraint(parent *yaml.Node, key, param string) *int64 {
+	n, err := nodeToInt(parent, key)
+	if err != nil {
+		log.Warn().Err(err).Str("parameter", param).Str("constraint", key).
+			Msg("cloudformation: unrepresentable parameter constraint; reporting it as absent")
+		return nil
+	}
+	return n
 }
 
 // nodeToDictList walks the sequence at `key` and returns each entry as a

--- a/providers/cloudformation/resources/paramconstraints_test.go
+++ b/providers/cloudformation/resources/paramconstraints_test.go
@@ -1,0 +1,99 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws-cloudformation/rain/cft/parse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// CloudFormation `Number` parameters may be integers or floats, so
+// `MinValue: 0.5` is legal template content. Parsing it as an int failed, and
+// that error propagated out of parameterList() — erasing EVERY parameter in the
+// template, including unrelated NoEcho credential parameters that policies care
+// about.
+func TestParameterListSurvivesFloatConstraints(t *testing.T) {
+	tmpl := loadTemplateFromString(t, `
+Parameters:
+  Ratio:
+    Type: Number
+    MinValue: 0.5
+    MaxValue: 1.5
+  Secret:
+    Type: String
+    NoEcho: true
+  Sized:
+    Type: String
+    MinLength: 8
+`)
+
+	params, err := tmpl.parameterList()
+	require.NoError(t, err, "one float constraint must not fail the whole list")
+	require.Len(t, params, 3, "every parameter must survive")
+
+	byName := map[string]*mqlCloudformationParameter{}
+	for _, p := range params {
+		mp := p.(*mqlCloudformationParameter)
+		byName[mp.Name.Data] = mp
+	}
+
+	require.Contains(t, byName, "Secret")
+	assert.True(t, byName["Secret"].NoEcho.Data, "the NoEcho parameter must still be reported")
+
+	require.Contains(t, byName, "Sized")
+	require.NotNil(t, byName["Sized"].MinLength.Data)
+	assert.Equal(t, int64(8), byName["Sized"].MinLength.Data)
+
+	// The fractional bound cannot be represented by the int-typed field, so it
+	// reads as absent rather than as a wrong number.
+	require.Contains(t, byName, "Ratio")
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, byName["Ratio"].MinValue.State&(plugin.StateIsSet|plugin.StateIsNull))
+}
+
+// An integral float (`MinValue: 1.0`) is exactly representable and must be
+// reported, not dropped.
+func TestNodeToIntAcceptsIntegralFloat(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		yaml    string
+		want    *int64
+		wantErr bool
+	}{
+		{name: "integer", yaml: "MinValue: 5", want: int64Ptr(5)},
+		{name: "negative integer", yaml: "MinValue: -3", want: int64Ptr(-3)},
+		{name: "integral float", yaml: "MinValue: 1.0", want: int64Ptr(1)},
+		{name: "integral float with exponent", yaml: "MinValue: 1e3", want: int64Ptr(1000)},
+		{name: "fractional float is not an int", yaml: "MinValue: 0.5", wantErr: true},
+		{name: "not a number", yaml: "MinValue: abc", wantErr: true},
+		{name: "absent key", yaml: "Other: 1", want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parse.String("Parameters:\n  P:\n    " + tc.yaml + "\n")
+			require.NoError(t, err)
+			_, params, err := gatherMapValue(parsed.Node.Content[0], "Parameters")
+			require.NoError(t, err)
+			_, p, err := gatherMapValue(params, "P")
+			require.NoError(t, err)
+
+			got, err := nodeToInt(p, "MinValue")
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tc.want, *got)
+		})
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -497,22 +497,14 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 			noEcho = parseCfnBool(n.Value)
 		}
 
-		minLength, err := nodeToInt(valueNode, "MinLength")
-		if err != nil {
-			return nil, err
-		}
-		maxLength, err := nodeToInt(valueNode, "MaxLength")
-		if err != nil {
-			return nil, err
-		}
-		minValue, err := nodeToInt(valueNode, "MinValue")
-		if err != nil {
-			return nil, err
-		}
-		maxValue, err := nodeToInt(valueNode, "MaxValue")
-		if err != nil {
-			return nil, err
-		}
+		// A constraint we can't represent degrades that single field to null.
+		// Propagating the error would erase EVERY parameter in the template —
+		// including the unrelated NoEcho credential parameters a policy is
+		// looking for — over one bound on one parameter.
+		minLength := optionalIntConstraint(valueNode, "MinLength", keyNode.Value)
+		maxLength := optionalIntConstraint(valueNode, "MaxLength", keyNode.Value)
+		minValue := optionalIntConstraint(valueNode, "MinValue", keyNode.Value)
+		maxValue := optionalIntConstraint(valueNode, "MaxValue", keyNode.Value)
 
 		defaultDict, err := nodeToDict(valueNode, "Default")
 		if err != nil {


### PR DESCRIPTION
## Problem

CloudFormation `Number` parameters may be integers **or floats**, so `MinValue: 0.5` / `MaxValue: 1e6` is legal template content. `nodeToInt` parsed strictly:

```go
n, err := strconv.ParseInt(val.Value, 10, 64)
if err != nil {
    return nil, fmt.Errorf("invalid integer for %s: %w", key, err)
}
```

and `parameterList()` propagated the error:

```go
minValue, err := nodeToInt(valueNode, "MinValue")
if err != nil {
    return nil, err     // kills every parameter in the template
}
```

**Trigger:**

```yaml
Parameters:
  Ratio:
    Type: Number
    MinValue: 0.5
    MaxValue: 1.5
  Secret:
    Type: String
    NoEcho: true
```

Observed:

```
parameterList: err=invalid integer for MinValue: strconv.ParseInt: parsing "0.5": invalid syntax  n=0
```

One bound on one parameter erases **all** parameters — including the unrelated `NoEcho: true` credential parameter a policy is actually looking for. `cloudformation.template.parameterList` returns an *error* rather than a list, so every parameter-level check on that template reports an error instead of evaluating.

## Fix

**`nodeToInt` accepts an integral float.** `MinValue: 1.0` and `MinValue: 1e3` are exactly representable by the `int`-typed field, so they now parse to `1` and `1000`. A genuinely fractional bound stays an error — reporting a truncated `0` for `0.5` would be worse than reporting nothing, and the `.lr` field type is shipped so it can't change.

**The four constraint reads degrade instead of failing.** `optionalIntConstraint` turns an unrepresentable bound into a null field plus a warning naming the parameter and the constraint, so the rest of the parameter — and every other parameter — still reports.

## Test plan

New `resources/paramconstraints_test.go`:

- a template mixing a float-bounded `Number`, a `NoEcho` string and a `MinLength` string: all three parameters survive, `NoEcho` still reads `true`, `MinLength` still reads `8`, and the fractional `MinValue` reads as set-and-null
- a `nodeToInt` table: integer, negative integer, integral float, integral float with exponent, fractional float (error), non-numeric (error), absent key (nil)

Verified as a regression fence by reverting the two source files and re-running — `TestParameterListSurvivesFloatConstraints` and both integral-float cases fail.

`go test ./...` passes across the whole cloudformation provider.

## Note

This is the error-propagation half of a broader pattern in this file — a malformed or YAML-aliased entry in `resources()` / `outputs()` aborts those lists the same way. Left alone here to keep the change reviewable; happy to follow up.
