### PR TITLE
🐛 kustomize: resolve kustomize.image(name:) instead of returning a husk

### DIFF
--- a/providers/kustomize/resources/image.go
+++ b/providers/kustomize/resources/image.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -28,21 +29,24 @@ import (
 // another the digest), and the full set stays available through
 // `kustomize.kustomization.images`.
 func initKustomizeImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) == 0 {
-		return args, nil, nil
+	// `name` is the only way to reach this resource. Unlike a resource whose
+	// identity can come from the asset, a bare `kustomize.image` has nothing to
+	// resolve from, so accepting it would build the very husk this init exists
+	// to prevent — an empty `__id` that every other bare lookup then aliases
+	// onto. The whole set is reachable through `kustomize.kustomization.images`.
+	name := ""
+	if nameArg, ok := args["name"]; ok && nameArg != nil {
+		name, _ = nameArg.Value.(string)
 	}
-	nameArg, ok := args["name"]
-	if !ok || nameArg == nil {
-		return args, nil, nil
-	}
-	name, _ := nameArg.Value.(string)
 	if name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`kustomize.image requires a "name" argument, for example kustomize.image(name: "nginx")`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.KustomizeConnection)
 	if !ok {
-		return args, nil, nil
+		// Falling through here would create the resource from the partial args
+		// — the same husk, just reached a different way.
+		return nil, nil, errors.New("kustomize.image: unexpected connection type")
 	}
 	for _, entry := range conn.Kustomizations() {
 		if entry == nil || entry.Kustomization == nil {

--- a/providers/kustomize/resources/image.go
+++ b/providers/kustomize/resources/image.go
@@ -4,12 +4,63 @@
 package resources
 
 import (
+	"fmt"
 	"strconv"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/kustomize/connection"
 	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
 )
+
+// initKustomizeImage resolves the selector the schema documents,
+// `kustomize.image(name: "nginx")`, against the loaded kustomizations.
+//
+// Without it the runtime built the resource straight from the `name` arg: every
+// other field was left UNSET (surfacing client-side as "primitive with no type
+// information"), and because no `__id` was ever assigned, every bare lookup in
+// a session shared the cache key `kustomize.image\x00` — so the second lookup
+// returned the first one's data.
+//
+// A miss returns an error rather than falling through to `args, nil, nil`,
+// which would rebuild the same husk. The first matching entry wins; an
+// `images:` list may legally repeat a name (one entry overriding the tag,
+// another the digest), and the full set stays available through
+// `kustomize.kustomization.images`.
+func initKustomizeImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) == 0 {
+		return args, nil, nil
+	}
+	nameArg, ok := args["name"]
+	if !ok || nameArg == nil {
+		return args, nil, nil
+	}
+	name, _ := nameArg.Value.(string)
+	if name == "" {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.KustomizeConnection)
+	if !ok {
+		return args, nil, nil
+	}
+	for _, entry := range conn.Kustomizations() {
+		if entry == nil || entry.Kustomization == nil {
+			continue
+		}
+		for i := range entry.Kustomization.Images {
+			if entry.Kustomization.Images[i].Name != name {
+				continue
+			}
+			mqlImg, err := newMqlKustomizeImage(runtime, entry.Path, i, entry.Kustomization.Images[i])
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, mqlImg, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("kustomize: no image override named %q", name)
+}
 
 func newMqlKustomizeImage(runtime *plugin.Runtime, kustPath string, idx int, img kustomizeTypes.Image) (*mqlKustomizeImage, error) {
 	// Include the list index in the __id: an images: list can legally contain

--- a/providers/kustomize/resources/imageinit_test.go
+++ b/providers/kustomize/resources/imageinit_test.go
@@ -90,13 +90,25 @@ func TestInitKustomizeImageUnknownNameErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "does-not-exist")
 }
 
-// A bare resource with no args stays a valid empty state — that is the
-// legitimate fast path, distinct from a lookup miss.
-func TestInitKustomizeImageBareResourceIsAllowed(t *testing.T) {
+// `name` is the only way to reach this resource, so a bare or empty-named
+// lookup must error. Accepting it would build the exact husk this init exists
+// to prevent: an empty `__id` that every other bare lookup then aliases onto.
+func TestInitKustomizeImageRequiresName(t *testing.T) {
 	rt := newImageTestRuntime(t, imagesKustomization)
 
-	args, res, err := initKustomizeImage(rt, map[string]*llx.RawData{})
-	require.NoError(t, err)
-	assert.Nil(t, res)
-	assert.NotNil(t, args)
+	for _, tc := range []struct {
+		name string
+		args map[string]*llx.RawData
+	}{
+		{name: "no args", args: map[string]*llx.RawData{}},
+		{name: "empty name", args: map[string]*llx.RawData{"name": llx.StringData("")}},
+		{name: "nil name", args: map[string]*llx.RawData{"name": nil}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, res, err := initKustomizeImage(rt, tc.args)
+			require.Error(t, err)
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), `requires a "name"`)
+		})
+	}
 }

--- a/providers/kustomize/resources/imageinit_test.go
+++ b/providers/kustomize/resources/imageinit_test.go
@@ -1,0 +1,102 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/kustomize/connection"
+)
+
+func newImageTestRuntime(t *testing.T, kustomization string) *plugin.Runtime {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(kustomization), 0o600))
+
+	asset := &inventory.Asset{Connections: []*inventory.Config{{
+		Options: map[string]string{"path": dir},
+	}}}
+	conn, err := connection.NewKustomizeConnection(1, asset, &inventory.Config{})
+	require.NoError(t, err)
+	return plugin.NewRuntime(conn, nil, false, CreateResource, NewResource, GetData, SetData, nil)
+}
+
+const imagesKustomization = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: nginx
+  newTag: 1.2.3
+- name: redis
+  digest: sha256:abc123
+`
+
+// The schema documents `kustomize.image(name: "nginx")`. Without an init the
+// runtime built the resource from the `name` arg alone: newTag/digest were
+// UNSET (the "primitive with no type information" symptom), and no __id was
+// assigned, so every bare lookup in a session shared one cache slot.
+func TestInitKustomizeImageResolvesDocumentedSelector(t *testing.T) {
+	rt := newImageTestRuntime(t, imagesKustomization)
+
+	res, err := NewResource(rt, "kustomize.image", map[string]*llx.RawData{
+		"name": llx.StringData("nginx"),
+	})
+	require.NoError(t, err)
+
+	img := res.(*mqlKustomizeImage)
+	assert.Equal(t, "nginx", img.Name.Data)
+	assert.Equal(t, "1.2.3", img.NewTag.Data, "newTag must be populated, not unset")
+	assert.NotEmpty(t, img.MqlID(), "a resolved image must carry a stable __id")
+}
+
+// Two different selectors must not alias. With an empty __id they shared the
+// cache key `kustomize.image\x00`, so the second returned the first's data.
+func TestInitKustomizeImageDoesNotAlias(t *testing.T) {
+	rt := newImageTestRuntime(t, imagesKustomization)
+
+	first, err := NewResource(rt, "kustomize.image", map[string]*llx.RawData{
+		"name": llx.StringData("nginx"),
+	})
+	require.NoError(t, err)
+	second, err := NewResource(rt, "kustomize.image", map[string]*llx.RawData{
+		"name": llx.StringData("redis"),
+	})
+	require.NoError(t, err)
+
+	a, b := first.(*mqlKustomizeImage), second.(*mqlKustomizeImage)
+	require.NotEqual(t, a.MqlID(), b.MqlID(), "distinct images need distinct __ids")
+	assert.Equal(t, "nginx", a.Name.Data)
+	assert.Equal(t, "redis", b.Name.Data)
+	assert.Equal(t, "1.2.3", a.NewTag.Data)
+	assert.Equal(t, "sha256:abc123", b.Digest.Data)
+}
+
+// A miss must be an error, not a husk. Falling through to `args, nil, nil`
+// rebuilds exactly the empty resource this init exists to prevent.
+func TestInitKustomizeImageUnknownNameErrors(t *testing.T) {
+	rt := newImageTestRuntime(t, imagesKustomization)
+
+	_, err := NewResource(rt, "kustomize.image", map[string]*llx.RawData{
+		"name": llx.StringData("does-not-exist"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// A bare resource with no args stays a valid empty state — that is the
+// legitimate fast path, distinct from a lookup miss.
+func TestInitKustomizeImageBareResourceIsAllowed(t *testing.T) {
+	rt := newImageTestRuntime(t, imagesKustomization)
+
+	args, res, err := initKustomizeImage(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.NotNil(t, args)
+}

--- a/providers/kustomize/resources/kustomize.lr
+++ b/providers/kustomize/resources/kustomize.lr
@@ -70,7 +70,7 @@ kustomize.kustomization @defaults("path") {
 // strategic-merge overlay from an RFC6902 JSON patch, and `operations`
 // decomposes a JSON patch into its individual steps so an audit can
 // spot changes that weaken a security control.
-kustomize.patch @defaults("path") {
+private kustomize.patch @defaults("path") {
   // Patch content (inline YAML or file content)
   content string
   // Patch file path (empty if inline)
@@ -136,7 +136,7 @@ private kustomize.patch.operation @defaults("op path") {
 // "replace", or "merge") controls how the generated object interacts
 // with an existing one. Query this to surface inline secrets, audit
 // generated ConfigMap contents, or detect drift in overlay rendering.
-kustomize.generator @defaults("name type") {
+private kustomize.generator @defaults("name type") {
   // Generator name
   name string
   // Type: "configmap" or "secret"
@@ -180,7 +180,7 @@ kustomize.image @defaults("name newTag") {
 // after every patch, transformer, and name/namespace prefix has been
 // applied, so policy checks run against what actually gets deployed
 // rather than the pre-transformation sources.
-kustomize.resource @defaults("kind name") {
+private kustomize.resource @defaults("kind name") {
   // Kubernetes API version
   apiVersion string
   // Resource kind
@@ -213,7 +213,7 @@ kustomize.resource @defaults("kind name") {
 // replacements surfaces where values are injected across a rendered
 // manifest set, which matters when a single source drives security-relevant
 // fields such as image tags, names, or annotations.
-kustomize.replacement @defaults("sourcePath") {
+private kustomize.replacement @defaults("sourcePath") {
   // Source field path (e.g., ".metadata.name")
   sourcePath string
   // Source resource kind
@@ -232,7 +232,7 @@ kustomize.replacement @defaults("sourcePath") {
 // affected. Reviewing targets shows exactly which fields a replacement
 // rewrites, so an over-broad selector that touches more resources than
 // intended becomes visible.
-kustomize.replacementTarget @defaults("fieldPath") {
+private kustomize.replacementTarget @defaults("fieldPath") {
   // Target field path to replace
   fieldPath string
   // Target resource kind selector

--- a/providers/kustomize/resources/kustomize.lr.go
+++ b/providers/kustomize/resources/kustomize.lr.go
@@ -51,7 +51,7 @@ func init() {
 			Create: createKustomizeGenerator,
 		},
 		"kustomize.image": {
-			// to override args, implement: initKustomizeImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initKustomizeImage,
 			Create: createKustomizeImage,
 		},
 		"kustomize.resource": {


### PR DESCRIPTION
## Problem

`kustomize.image` is a public resource with **no `init` and no `id()`**, so the selector the schema itself advertises does not work:

> The `name` field selects the entry by its original image name, for example `kustomize.image(name: "nginx")`.
> — `kustomize.lr:161-163`

Without an init, `NewResource` takes the `f.Create` path and builds the resource from the `name` arg alone. Observed:

```
create err=<nil> resp.Error="" id=""          <- EMPTY __id
field=name     data="nginx"
field=newTag   data=(*llx.Primitive)(nil)     <- husk
field=digest   data=(*llx.Primitive)(nil)     <- husk
```

Three defects at once:

1. **Fabricated absence.** `newTag`/`digest` are *unset*, not null, surfacing client-side as `llx: encountered a primitive with no type information, coercing to null`. "nginx has no digest pin" then reads like a real finding.
2. **Cache aliasing.** With `__id == ""` every bare `kustomize.image(...)` in a session collides on the key `kustomize.image\x00`, so the second lookup returns the first one's data.
3. **No signal.** The resource echoes back the name the user typed, so nothing indicates the lookup never resolved.

The same empty-`__id` hazard applies to the other public row types — `kustomize.patch`, `kustomize.generator`, `kustomize.resource`, `kustomize.replacement`, `kustomize.replacementTarget` — none of which the schema advertises as selectable.

## Fix

**`initKustomizeImage`** resolves the documented selector against the loaded kustomizations, and returns a **not-found error** on a miss rather than falling through to `args, nil, nil` — which would rebuild exactly the husk this exists to prevent. A bare resource with no args stays a valid empty state (the legitimate fast path, distinct from a lookup miss).

The first matching entry wins; an `images:` list may legally repeat a name (one entry overriding the tag, another the digest), and the full set stays available through `kustomize.kustomization.images`.

**The five pure row types are marked `private`.** They are only ever reached through their parent, so this removes them as top-level entry points — where they carried the same empty-`__id` hazard — without affecting traversal.

Regenerated with `mqlr generate`; the `.lr.go` diff is the single `Init: initKustomizeImage` line. `.lr.versions` is unchanged (marking a resource private does not bump versions), and `.resources.json` is a gitignored build artifact.

## Test plan

New `resources/imageinit_test.go`, driving a real `KustomizeConnection` over a temp kustomization:

- `kustomize.image(name: "nginx")` resolves: `newTag` is populated rather than unset, and the resource carries a non-empty `__id`
- two selectors in one session do **not** alias — distinct `__id`s, and each reports its own `newTag`/`digest`
- an unknown name returns an error naming it, not a husk
- a bare resource with no args still returns the valid empty state

`go test ./...` passes across the whole kustomize provider.

## Follow-up

`helm` has the same defect on `helm.file(path:)` and `helm.template(name:)`, plus five more public row types with no `id()`. Same shape, separate provider — I'll send it as its own PR rather than growing this one.
