### PR TITLE
🐛 helm: resolve helm.file(path:) and helm.template(name:) instead of husks

### DIFF
--- a/providers/helm/resources/helm.lr
+++ b/providers/helm/resources/helm.lr
@@ -23,7 +23,7 @@ helm {
 // files, lint results, and supply-chain provenance. Auditing a chart here
 // catches insecure workloads, unpinned dependencies, and policy violations
 // before the chart is ever installed to a cluster.
-helm.chart @defaults("name version") {
+private helm.chart @defaults("name version") {
   // Chart name from Chart.yaml
   name string
   // Chart version
@@ -162,7 +162,7 @@ helm.chart @defaults("name version") {
 // from Chart.lock and the vendored chart on disk. The `sourceType` field
 // classifies where the dependency comes from (OCI registry, chart
 // repository, or local path) for supply-chain auditing.
-helm.dependency @defaults("name version") {
+private helm.dependency @defaults("name version") {
   // Dependency name
   name string
   // Version constraint
@@ -223,7 +223,7 @@ helm.dependency @defaults("name version") {
 // whether they are pinned by tag or by digest. Parsing is offline: the
 // reference string and the dependency's version constraint are classified
 // and decomposed without ever pulling from the registry.
-helm.ociRef @defaults("reference") {
+private helm.ociRef @defaults("reference") {
   // Full OCI reference (e.g., oci://ghcr.io/acme/charts/redis)
   reference string
   // Registry host (e.g., ghcr.io)
@@ -250,7 +250,7 @@ helm.ociRef @defaults("reference") {
 // Use it for supply-chain ownership and contact audits, verifying that
 // charts declare an accountable maintainer and reaching the right party
 // for security disclosures.
-helm.maintainer @defaults("name email") {
+private helm.maintainer @defaults("name email") {
   // Maintainer name
   name string
   // Maintainer email
@@ -295,7 +295,7 @@ helm.template @defaults("name") {
 // expression, and source line. Useful for flagging dynamic constructs
 // that policy can't reason about statically, such as a `tpl` call over
 // unbounded user input.
-helm.directive @defaults("type expression") {
+private helm.directive @defaults("type expression") {
   // Directive type (if, range, include, tpl, define, with, block)
   type string
   // Full expression (e.g., ".Values.replicaCount", "include \"mychart.labels\" .")
@@ -313,7 +313,7 @@ helm.directive @defaults("type expression") {
 // rather than the unrendered template text. The `isHook` and `isCRD`
 // predicates separate lifecycle hooks and pre-installed CRDs from normally
 // applied resources.
-helm.resource @defaults("kind name") {
+private helm.resource @defaults("kind name") {
   // Kubernetes API version
   apiVersion string
   // Resource kind (Deployment, Service, etc.)

--- a/providers/helm/resources/helm.lr.go
+++ b/providers/helm/resources/helm.lr.go
@@ -56,7 +56,7 @@ func init() {
 			Create: createHelmMaintainer,
 		},
 		"helm.template": {
-			// to override args, implement: initHelmTemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initHelmTemplate,
 			Create: createHelmTemplate,
 		},
 		"helm.directive": {
@@ -68,7 +68,7 @@ func init() {
 			Create: createHelmResource,
 		},
 		"helm.file": {
-			// to override args, implement: initHelmFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initHelmFile,
 			Create: createHelmFile,
 		},
 		"helm.chart.dependencyLock": {

--- a/providers/helm/resources/selectors.go
+++ b/providers/helm/resources/selectors.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/helm/connection"
+)
+
+// stringArg reads a required string selector argument. ok is false when the arg
+// is absent or empty, which is the legitimate "bare resource" fast path rather
+// than a lookup miss.
+func stringArg(args map[string]*llx.RawData, key string) (string, bool) {
+	if len(args) == 0 {
+		return "", false
+	}
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return "", false
+	}
+	v, _ := raw.Value.(string)
+	return v, v != ""
+}
+
+// initHelmFile resolves the selector the schema documents,
+// `helm.file(path: "NOTES.txt")`, against the loaded charts.
+//
+// Without it the runtime built the resource from the `path` arg alone:
+// `content` came back "" because the Internal cache was never populated (a
+// fabricated empty answer), `size`/`isBinary` were left UNSET rather than null,
+// and with no `__id` every bare lookup in a session shared the cache key
+// `helm.file\x00` — so the second returned the first one's path.
+//
+// A miss returns an error rather than falling through to `args, nil, nil`,
+// which would rebuild the same husk.
+func initHelmFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	path, ok := stringArg(args, "path")
+	if !ok {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.HelmConnection)
+	if !ok {
+		return args, nil, nil
+	}
+
+	for _, loaded := range conn.Charts() {
+		if loaded.Chart == nil {
+			continue
+		}
+		for _, f := range loaded.Chart.Files {
+			if f == nil || f.Name != path {
+				continue
+			}
+			mqlFile, err := newMqlHelmFile(runtime, loaded.Chart.Name(), f)
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, mqlFile, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("helm: no chart file at path %q", path)
+}
+
+// initHelmTemplate resolves `helm.template(name: "templates/deployment.yaml")`
+// against the loaded charts, for the same reasons as initHelmFile.
+//
+// The template is returned unrendered (no `renderedContent`), because rendering
+// is a chart-wide operation reached through `helm.chart.templates`. That is a
+// visible null rather than a fabricated empty string.
+func initHelmTemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	name, ok := stringArg(args, "name")
+	if !ok {
+		return args, nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.HelmConnection)
+	if !ok {
+		return args, nil, nil
+	}
+
+	for _, loaded := range conn.Charts() {
+		if loaded.Chart == nil {
+			continue
+		}
+		for _, t := range loaded.Chart.Templates {
+			if t == nil || t.Name != name {
+				continue
+			}
+			mqlTemplate, err := newMqlHelmTemplate(runtime, loaded.Chart.Name(), t, "", nil)
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, mqlTemplate, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("helm: no chart template named %q", name)
+}

--- a/providers/helm/resources/selectors_test.go
+++ b/providers/helm/resources/selectors_test.go
@@ -1,0 +1,138 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/helm/connection"
+)
+
+func newSelectorRuntime(t *testing.T, chartPath string) *plugin.Runtime {
+	t.Helper()
+	asset := &inventory.Asset{Connections: []*inventory.Config{{
+		Options: map[string]string{"path": chartPath},
+	}}}
+	conn, err := connection.NewHelmConnection(1, asset, &inventory.Config{})
+	require.NoError(t, err)
+	return plugin.NewRuntime(conn, nil, false, CreateResource, NewResource, GetData, SetData, nil)
+}
+
+// The schema documents `helm.template(name: ...)`. Without an init the runtime
+// built the resource from the `name` arg alone — `raw` was fabricated empty and
+// no __id was assigned, so every bare lookup shared the key `helm.template\x00`.
+func TestInitHelmTemplateResolvesDocumentedSelector(t *testing.T) {
+	rt := newSelectorRuntime(t, "../testdata/mychart")
+
+	res, err := NewResource(rt, "helm.template", map[string]*llx.RawData{
+		"name": llx.StringData("templates/deployment.yaml"),
+	})
+	require.NoError(t, err)
+
+	tpl := res.(*mqlHelmTemplate)
+	assert.Equal(t, "templates/deployment.yaml", tpl.Name.Data)
+	assert.NotEmpty(t, tpl.Raw.Data, "raw source must be populated, not fabricated empty")
+	assert.NotEmpty(t, tpl.MqlID(), "a resolved template must carry a stable __id")
+}
+
+func TestInitHelmTemplateDoesNotAlias(t *testing.T) {
+	rt := newSelectorRuntime(t, "../testdata/mychart")
+
+	a, err := NewResource(rt, "helm.template", map[string]*llx.RawData{
+		"name": llx.StringData("templates/deployment.yaml"),
+	})
+	require.NoError(t, err)
+	b, err := NewResource(rt, "helm.template", map[string]*llx.RawData{
+		"name": llx.StringData("templates/service.yaml"),
+	})
+	require.NoError(t, err)
+
+	ta, tb := a.(*mqlHelmTemplate), b.(*mqlHelmTemplate)
+	require.NotEqual(t, ta.MqlID(), tb.MqlID(), "distinct templates need distinct __ids")
+	assert.Equal(t, "templates/deployment.yaml", ta.Name.Data)
+	assert.Equal(t, "templates/service.yaml", tb.Name.Data)
+	assert.NotEqual(t, ta.Raw.Data, tb.Raw.Data)
+}
+
+func TestInitHelmTemplateUnknownNameErrors(t *testing.T) {
+	rt := newSelectorRuntime(t, "../testdata/mychart")
+
+	_, err := NewResource(rt, "helm.template", map[string]*llx.RawData{
+		"name": llx.StringData("templates/does-not-exist.yaml"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// helm.file's `content` used to read "" because the Internal cache was never
+// populated on a bare-constructed resource — a fabricated empty answer for a
+// file that plainly has content.
+func TestInitHelmFileResolvesDocumentedSelector(t *testing.T) {
+	rt := newSelectorRuntime(t, "../testdata/featurechart")
+
+	res, err := NewResource(rt, "helm.file", map[string]*llx.RawData{
+		"path": llx.StringData("README.md"),
+	})
+	require.NoError(t, err)
+
+	f := res.(*mqlHelmFile)
+	assert.Equal(t, "README.md", f.Path.Data)
+	assert.NotEmpty(t, f.MqlID(), "a resolved file must carry a stable __id")
+
+	content, err := f.content()
+	require.NoError(t, err)
+	assert.NotEmpty(t, content, "content must come from the real file, not a fabricated empty string")
+
+	assert.Positive(t, f.Size.Data, "size must be populated, not left unset")
+}
+
+// Two selectors must not alias on the empty __id they used to share.
+func TestInitHelmFileDoesNotAlias(t *testing.T) {
+	rt := newSelectorRuntime(t, "../testdata/featurechart")
+
+	a, err := NewResource(rt, "helm.file", map[string]*llx.RawData{
+		"path": llx.StringData("README.md"),
+	})
+	require.NoError(t, err)
+	b, err := NewResource(rt, "helm.file", map[string]*llx.RawData{
+		"path": llx.StringData("crds/crontab.yaml"),
+	})
+	require.NoError(t, err)
+
+	fa, fb := a.(*mqlHelmFile), b.(*mqlHelmFile)
+	require.NotEqual(t, fa.MqlID(), fb.MqlID(), "distinct files need distinct __ids")
+	assert.Equal(t, "README.md", fa.Path.Data)
+	assert.Equal(t, "crds/crontab.yaml", fb.Path.Data)
+}
+
+func TestInitHelmFileUnknownPathErrors(t *testing.T) {
+	rt := newSelectorRuntime(t, "../testdata/mychart")
+
+	_, err := NewResource(rt, "helm.file", map[string]*llx.RawData{
+		"path": llx.StringData("no/such/file.txt"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no/such/file.txt")
+}
+
+// A bare resource with no args stays a valid empty state — the legitimate fast
+// path, distinct from a lookup miss.
+func TestHelmSelectorBareResourcesAllowed(t *testing.T) {
+	rt := newSelectorRuntime(t, "../testdata/mychart")
+
+	args, res, err := initHelmFile(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.NotNil(t, args)
+
+	args, res, err = initHelmTemplate(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.NotNil(t, args)
+}


### PR DESCRIPTION
The helm half of #9779 — same defect, separate provider.

## Problem

`helm.file` and `helm.template` are both public, both documented as selectable, and neither has an `init` or an `id()`:

> …selected by its `path` … for example `helm.file(path: "NOTES.txt")` — `helm.lr:368-375`
> …identified by its `name` — `helm.lr:262-271`

So `NewResource` took the `f.Create` path and built the resource from the selector arg alone. Observed:

```
file A id="" path="NOTES.txt" | file B id="" path="README.md"→reported as "NOTES.txt"
same instance=true   content=""   sizeState=0
```

Three defects at once:

1. **Fabricated absence.** `content` reads `""` because the Internal cache was never populated — an authoritative-looking empty answer for a file that plainly has content.
2. **Unset, not null.** `size` / `isBinary` carry state 0, surfacing client-side as `llx: encountered a primitive with no type information, coercing to null`.
3. **Cache aliasing.** With `__id == ""` every bare `helm.file(...)` in a session shares the key `helm.file\x00`, so the second lookup returns the first one's path.

## Fix

`initHelmFile` and `initHelmTemplate` resolve against the loaded charts and return a **not-found error** on a miss, rather than falling through to `args, nil, nil` and rebuilding exactly the husk they exist to prevent. A bare resource with no args stays a valid empty state.

A selected template is returned **unrendered**. Rendering is a chart-wide operation reached through `helm.chart.templates`, so `renderedContent` is a visible null rather than a fabricated empty string.

**Six row types are marked `private`** — `chart`, `dependency`, `ociRef`, `maintainer`, `directive`, `resource`. They are only ever reached through a parent, so this drops them as top-level entry points (where they carried the same empty-`__id` hazard) without affecting traversal.

That also removes a panic as a side effect: every `mqlHelmChart` accessor dereferences `c.chartObj` unguarded, so a bare `helm.chart { name }` — which the shell's auto-complete offered — raised `invalid memory address or nil pointer dereference`. It was contained by `recoverPanic` at the gRPC boundary, so it surfaced as an ugly error rather than a dead scan, but it should not have been reachable.

Regenerated with `mqlr generate`; `.lr.versions` is unchanged (marking a resource private does not bump versions) and `.resources.json` is a gitignored build artifact.

## Test plan

New `resources/selectors_test.go`, driving a real `HelmConnection` over the existing `testdata` charts:

- `helm.template(name: "templates/deployment.yaml")` resolves with non-empty `raw` and a stable `__id`
- two template selectors do not alias — distinct `__id`s and distinct `raw`
- an unknown template name errors, naming it
- `helm.file(path: "README.md")` resolves with real `content` and a populated `size` (the two fields that used to be fabricated-empty and unset)
- two file selectors do not alias
- an unknown file path errors, naming it
- bare `helm.file` / `helm.template` with no args still return the valid empty state

`go test ./...` passes across the whole helm provider.
