### PR TITLE
🐛 helm: require the selector argument and reject an unexpected connection

### DIFF
--- a/providers/helm/resources/selectors.go
+++ b/providers/helm/resources/selectors.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -11,19 +12,24 @@ import (
 	"go.mondoo.com/mql/v13/providers/helm/connection"
 )
 
-// stringArg reads a required string selector argument. ok is false when the arg
-// is absent or empty, which is the legitimate "bare resource" fast path rather
-// than a lookup miss.
-func stringArg(args map[string]*llx.RawData, key string) (string, bool) {
-	if len(args) == 0 {
-		return "", false
+// requiredStringArg reads the selector argument a resource can only be reached
+// by, erroring when it is absent or empty.
+//
+// There is no useful bare form of these resources: unlike a resource that can
+// take its identity from the asset, `helm.file` and `helm.template` have
+// nothing to resolve from without their selector. Accepting the empty case
+// would build exactly the husk these inits exist to prevent — an empty `__id`
+// that every other bare lookup then aliases onto. The full sets stay reachable
+// through `helm.chart.files` and `helm.chart.templates`.
+func requiredStringArg(args map[string]*llx.RawData, resource, key, example string) (string, error) {
+	var v string
+	if raw, ok := args[key]; ok && raw != nil {
+		v, _ = raw.Value.(string)
 	}
-	raw, ok := args[key]
-	if !ok || raw == nil {
-		return "", false
+	if v == "" {
+		return "", fmt.Errorf("%s requires a %q argument, for example %s", resource, key, example)
 	}
-	v, _ := raw.Value.(string)
-	return v, v != ""
+	return v, nil
 }
 
 // initHelmFile resolves the selector the schema documents,
@@ -38,13 +44,15 @@ func stringArg(args map[string]*llx.RawData, key string) (string, bool) {
 // A miss returns an error rather than falling through to `args, nil, nil`,
 // which would rebuild the same husk.
 func initHelmFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	path, ok := stringArg(args, "path")
-	if !ok {
-		return args, nil, nil
+	path, err := requiredStringArg(args, "helm.file", "path", `helm.file(path: "README.md")`)
+	if err != nil {
+		return nil, nil, err
 	}
 	conn, ok := runtime.Connection.(*connection.HelmConnection)
 	if !ok {
-		return args, nil, nil
+		// Falling through here would create the resource from the partial args
+		// — the same husk, just reached a different way.
+		return nil, nil, errors.New("helm.file: unexpected connection type")
 	}
 
 	for _, loaded := range conn.Charts() {
@@ -72,13 +80,13 @@ func initHelmFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[st
 // is a chart-wide operation reached through `helm.chart.templates`. That is a
 // visible null rather than a fabricated empty string.
 func initHelmTemplate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	name, ok := stringArg(args, "name")
-	if !ok {
-		return args, nil, nil
+	name, err := requiredStringArg(args, "helm.template", "name", `helm.template(name: "templates/deployment.yaml")`)
+	if err != nil {
+		return nil, nil, err
 	}
 	conn, ok := runtime.Connection.(*connection.HelmConnection)
 	if !ok {
-		return args, nil, nil
+		return nil, nil, errors.New("helm.template: unexpected connection type")
 	}
 
 	for _, loaded := range conn.Charts() {

--- a/providers/helm/resources/selectors_test.go
+++ b/providers/helm/resources/selectors_test.go
@@ -121,18 +121,36 @@ func TestInitHelmFileUnknownPathErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "no/such/file.txt")
 }
 
-// A bare resource with no args stays a valid empty state — the legitimate fast
-// path, distinct from a lookup miss.
-func TestHelmSelectorBareResourcesAllowed(t *testing.T) {
+// The selector is the only way to reach these resources, so a bare or
+// empty-valued lookup must error. Accepting it would build the exact husk these
+// inits exist to prevent: an empty `__id` that every other bare lookup aliases
+// onto. The full sets stay reachable through helm.chart.files / .templates.
+func TestHelmSelectorsRequireTheirArgument(t *testing.T) {
 	rt := newSelectorRuntime(t, "../testdata/mychart")
 
-	args, res, err := initHelmFile(rt, map[string]*llx.RawData{})
-	require.NoError(t, err)
-	assert.Nil(t, res)
-	assert.NotNil(t, args)
-
-	args, res, err = initHelmTemplate(rt, map[string]*llx.RawData{})
-	require.NoError(t, err)
-	assert.Nil(t, res)
-	assert.NotNil(t, args)
+	for _, tc := range []struct {
+		name string
+		init func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+		key  string
+		want string
+	}{
+		{name: "helm.file", init: initHelmFile, key: "path", want: `helm.file requires a "path"`},
+		{name: "helm.template", init: initHelmTemplate, key: "name", want: `helm.template requires a "name"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for argName, args := range map[string]map[string]*llx.RawData{
+				"no args":    {},
+				"empty":      {tc.key: llx.StringData("")},
+				"nil":        {tc.key: nil},
+				"wrong type": {tc.key: llx.IntData(3)},
+			} {
+				t.Run(argName, func(t *testing.T) {
+					_, res, err := tc.init(rt, args)
+					require.Error(t, err)
+					assert.Nil(t, res)
+					assert.Contains(t, err.Error(), tc.want)
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
Follow-up to #9780, applying the review feedback from #9779 to the identical paths in helm.

## Problem

#9780 added `initHelmFile` / `initHelmTemplate` so the documented selectors resolve instead of returning husks. Review on the kustomize twin (#9779) pointed out that two `return args, nil, nil` branches survive in that shape — and both rebuild the very husk the init exists to prevent:

**1. No selector argument.** `helm.file` and `helm.template` have nothing to resolve from without their selector — unlike a resource that can take its identity from the asset. Falling through built an empty resource with no `__id`, which every other bare lookup then aliased onto (`helm.file\x00`).

**2. A failed connection assertion.** Falling through created the resource from the partial args — the same husk, just reached a different way.

## Fix

Both now return an error. `stringArg` becomes `requiredStringArg`, which names the resource, the argument and an example:

```
helm.file requires a "path" argument, for example helm.file(path: "README.md")
helm.template requires a "name" argument, for example helm.template(name: "templates/deployment.yaml")
```

That matches the existing convention in gcp (`gcp.project.apiKey requires an "id" argument`).

It also closes a smaller gap the old helper had: a **non-string** argument (`helm.file(path: 3)`) failed the `v, _ := raw.Value.(string)` assertion and fell into the same silent bare-resource path. It now errors like the other cases.

The full sets remain reachable through `helm.chart.files` and `helm.chart.templates`, which go through `CreateResource` and never run the init.

## Test plan

`TestHelmSelectorBareResourcesAllowed` asserted the old behavior and is replaced by `TestHelmSelectorsRequireTheirArgument`, a table over both resources × {no args, empty value, nil value, wrong type} asserting each errors and names its argument.

The existing positive tests are unchanged and still pass: both selectors resolve, neither aliases, and an unknown path/name errors.

`go test ./...` passes across the whole helm provider.
