### PR TITLE
🎉 bicep-13.4.10, ansible-13.2.14, kustomize-13.1.14, cloudformation-13.2.9, helm-13.3.12

### DIFF
--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.2.13",
+	Version:         "13.2.14",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.4.9",
+	Version:         "13.4.10",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudformation",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
-	Version:         "13.2.8",
+	Version:         "13.2.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.3.11",
+	Version:         "13.3.12",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "kustomize",
 	ID:              "go.mondoo.com/mql/v13/providers/kustomize",
-	Version:         "13.1.13",
+	Version:         "13.1.14",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,


### PR DESCRIPTION
Patch release for the five IaC providers, covering the bug fixes from a static audit of their parsing and error handling.

| Provider | Version |
|---|---|
| bicep | 13.4.9 → **13.4.10** |
| ansible | 13.2.13 → **13.2.14** |
| kustomize | 13.1.13 → **13.1.14** |
| cloudformation | 13.2.8 → **13.2.9** |
| helm | 13.3.11 → **13.3.12** |

## What's included

**bicep**
- #9772 — `/* */` block comments are now lexed. A commented-out resource was parsed as live source and reported as deployed; separately, an unbalanced `{`, `(`, `[` or quote *inside* a comment consumed the rest of the file, so `bicep.file.resources` returned `[]` with no error.
- #9773 — `@sys.`-qualified decorators are recognized, and a `#disable-next-line` directive no longer detaches a declaration's decorators. Both made `@secure()` read back as `false`.
- #9775 — resource field extraction is scoped to the body's top level. A VNet whose `name:` followed its `properties:` block reported the *subnet's* name; a nested `properties.template` supplied its own `tags`/`dependsOn`.
- #9776 — malformed declarations are skipped instead of appended as empty husks. Union-typed (`'a' | 'b'`) and array-typed (`string[]`) params and outputs were lost entirely, and the husks aliased on an identical `__id`.

**ansible**
- #9774 — a null list entry (a bare `-` left behind when a play is commented out) decoded to a nil `*Play` that the resource layer dereferenced, panicking and killing the whole scan.

**kustomize**
- #9777 — an inline `patchesStrategicMerge` entry is read as a patch body rather than a file path. `content` read `""`, so `patches.where(content.contains("privileged"))` returned `[]`.
- #9779 — `kustomize.image(name:)`, a selector the schema documents, resolves instead of returning a husk with an empty `__id` that every other bare lookup aliased onto.

**cloudformation**
- #9778 — a legal float constraint (`MinValue: 0.5` on a `Number` parameter) no longer erases every parameter in the template.

**helm**
- #9780 — `helm.file(path:)` and `helm.template(name:)` resolve instead of returning husks with fabricated-empty `content` and unset `size`.
- #9781 — both inits require their selector argument and reject an unexpected connection, closing the remaining paths that rebuilt the husk.

## Notes

No schema changes beyond the `private` markers in #9779/#9780, which affect only top-level instantiation and not traversal — `.lr.versions` is unchanged for all five providers. Every fix ships with regression tests; `go test ./...` passes in each provider.
