### PR TITLE
🐛 okta: stop benign API answers from failing whole collections

### DIFF
--- a/providers/okta/connection/connection.go
+++ b/providers/okta/connection/connection.go
@@ -30,6 +30,15 @@ import (
 // the token's own expiry, so this is only an upper bound.
 const accessTokenCacheTTL = 55 * time.Minute
 
+const (
+	// oktaRateLimitMaxRetries bounds how many times a request that came back
+	// 429 is retried before the field reports the failure.
+	oktaRateLimitMaxRetries = 3
+	// oktaRateLimitMaxBackoffSeconds caps how long a single retry waits, so a
+	// far-off X-Rate-Limit-Reset cannot stall a scan for minutes.
+	oktaRateLimitMaxBackoffSeconds = 30
+)
+
 type OktaConnection struct {
 	plugin.Connection
 	Conf  *inventory.Config
@@ -84,7 +93,16 @@ func NewOktaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	}
 
 	orgURL := "https://" + org
-	options := []okta.ConfigSetter{okta.WithOrgUrl(orgURL)}
+	options := []okta.ConfigSetter{
+		okta.WithOrgUrl(orgURL),
+		// Okta rate limits per org, and a scan reads many collections in quick
+		// succession, so a 429 during a large scan is ordinary rather than
+		// exceptional. The SDK honors the X-Rate-Limit-Reset header when it is
+		// allowed to retry; left at the default of no retries it surfaces the
+		// 429 as a failed field instead.
+		okta.WithRateLimitMaxRetries(oktaRateLimitMaxRetries),
+		okta.WithRateLimitMaxBackOff(oktaRateLimitMaxBackoffSeconds),
+	}
 	serviceApp := false
 
 	switch {

--- a/providers/okta/resources/appEntitlements.go
+++ b/providers/okta/resources/appEntitlements.go
@@ -171,8 +171,16 @@ func (a *mqlOktaApplication) scopeConsentGrants() ([]any, error) {
 
 	ctx := context.Background()
 	appID := a.Id.Data
+
 	slice, resp, err := client.ApplicationGrantsAPI.ListScopeConsentGrants(ctx, appID).Execute()
 	if err != nil {
+		// The grants collection belongs to the OAuth 2.0 client, so Okta answers
+		// 404 for an application that is not one (a bookmark or SAML app). That
+		// describes the app's type rather than a failure, and erroring here
+		// would take down every other application in the same query.
+		if isOktaFeatureUnavailable(resp, err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/okta/resources/appTokens.go
+++ b/providers/okta/resources/appTokens.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
 	"go.mondoo.com/mql/v13/llx"
@@ -26,8 +27,12 @@ func (a *mqlOktaApplication) tokens() ([]any, error) {
 	slice, resp, err := conn.Client().ApplicationTokensAPI.
 		ListOAuth2TokensForApplication(ctx, appID).Limit(queryLimit).Execute()
 	if err != nil {
-		// Applications that do not use OAuth 2.0 have no token collection.
-		if isOktaFeatureUnavailable(resp, err) {
+		// Only OAuth 2.0 clients can hold refresh tokens. Okta rejects the
+		// request with a 400 for any other application (a bookmark or SAML
+		// app), which is a statement about the app's type rather than a
+		// failure. The request carries no caller-supplied input beyond the app
+		// id, so a 400 here has no other meaning.
+		if isOktaFeatureUnavailable(resp, err) || isOktaStatus(resp, http.StatusBadRequest) {
 			return nil, nil
 		}
 		return nil, err

--- a/providers/okta/resources/applications.go
+++ b/providers/okta/resources/applications.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
@@ -117,8 +118,11 @@ func initOktaApplication(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	conn := runtime.Connection.(*connection.OktaConnection)
 	client := conn.Client()
 	ctx := context.Background()
-	item, _, err := client.ApplicationAPI.GetApplication(ctx, id).Execute()
+	item, resp, err := client.ApplicationAPI.GetApplication(ctx, id).Execute()
 	if err != nil {
+		if isOktaNotFound(resp) {
+			return nil, nil, fmt.Errorf("%w: okta.application %q", errOktaResourceNotFound, id)
+		}
 		return nil, nil, err
 	}
 	if item == nil {

--- a/providers/okta/resources/customRoles.go
+++ b/providers/okta/resources/customRoles.go
@@ -67,8 +67,11 @@ func initOktaCustomRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	client := conn.Client()
 	ctx := context.Background()
 
-	role, _, err := client.RoleAPI.GetRole(ctx, id).Execute()
+	role, resp, err := client.RoleAPI.GetRole(ctx, id).Execute()
 	if err != nil {
+		if isOktaNotFound(resp) {
+			return nil, nil, fmt.Errorf("%w: okta.customRole %q", errOktaResourceNotFound, id)
+		}
 		return nil, nil, err
 	}
 	if role == nil {

--- a/providers/okta/resources/emailConfig.go
+++ b/providers/okta/resources/emailConfig.go
@@ -62,24 +62,20 @@ func (o *mqlOktaEmailDomain) id() (string, error) {
 
 func (o *mqlOkta) emailServers() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
-	client := conn.Client()
 
 	ctx := context.Background()
-	servers, resp, err := client.EmailServerAPI.ListEmailServers(ctx).Execute()
+	servers, resp, err := conn.ApiExtension().ListEmailServers(ctx)
 	if err != nil {
 		// Orgs sending through Okta's own mail infrastructure have none.
-		if isOktaFeatureUnavailable(resp, err) {
+		if isOktaRawFeatureUnavailable(resp) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	if servers == nil {
-		return nil, nil
-	}
 
 	list := []any{}
-	for i := range servers.EmailServers {
-		r, err := newMqlOktaEmailServer(o.MqlRuntime, &servers.EmailServers[i])
+	for i := range servers {
+		r, err := newMqlOktaEmailServer(o.MqlRuntime, &servers[i])
 		if err != nil {
 			return nil, err
 		}

--- a/providers/okta/resources/errors_test.go
+++ b/providers/okta/resources/errors_test.go
@@ -1,0 +1,188 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/v5/okta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRoundTripper answers every request with one canned response, or with a
+// transport error when transportErr is set.
+type stubRoundTripper struct {
+	status       int
+	body         string
+	transportErr error
+}
+
+func (rt stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if rt.transportErr != nil {
+		return nil, rt.transportErr
+	}
+	return &http.Response{
+		StatusCode: rt.status,
+		Status:     http.StatusText(rt.status),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(rt.body)),
+		Request:    req,
+	}, nil
+}
+
+// oktaCall runs one real SDK call against a stubbed transport and hands back
+// exactly what a resource accessor would see. The error classifiers read the
+// SDK's own error type and the body it carries, so building those by hand would
+// test a mock rather than the thing the provider actually receives.
+func oktaCall(t *testing.T, rt http.RoundTripper) (*okta.APIResponse, error) {
+	t.Helper()
+	cfg, err := okta.NewConfiguration(
+		okta.WithOrgUrl("https://test.okta.com"),
+		okta.WithToken("test-token"),
+		okta.WithHttpClientPtr(&http.Client{Transport: rt}),
+	)
+	require.NoError(t, err)
+
+	_, resp, err := okta.NewAPIClient(cfg).UserAPI.ListUsers(context.Background()).Execute()
+	return resp, err
+}
+
+// Okta reuses 401 for two unrelated conditions and only the body tells them
+// apart: E0000015 is a feature the org is not licensed for (realms, group
+// owners) and there is genuinely nothing to report, while E0000011 is a dead
+// token. Degrading the latter would turn an unusable credential into a clean,
+// empty scan.
+const (
+	oktaFeatureNotEnabledBody = `{"errorCode":"E0000015","errorSummary":"You do not have permission to access the feature you are requesting","errorLink":"E0000015","errorId":"oaeX","errorCauses":[]}`
+	oktaInvalidTokenBody      = `{"errorCode":"E0000011","errorSummary":"Invalid token provided","errorLink":"E0000011","errorId":"oaeY","errorCauses":[]}`
+)
+
+func TestOktaErrorCode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads the code from a feature-gated 401", func(t *testing.T) {
+		_, err := oktaCall(t, stubRoundTripper{status: http.StatusUnauthorized, body: oktaFeatureNotEnabledBody})
+		require.Error(t, err)
+		assert.Equal(t, "E0000015", oktaErrorCode(err))
+	})
+
+	t.Run("reads the code from an invalid-token 401", func(t *testing.T) {
+		_, err := oktaCall(t, stubRoundTripper{status: http.StatusUnauthorized, body: oktaInvalidTokenBody})
+		require.Error(t, err)
+		assert.Equal(t, "E0000011", oktaErrorCode(err))
+	})
+
+	t.Run("empty for a body that is not an Okta error", func(t *testing.T) {
+		_, err := oktaCall(t, stubRoundTripper{status: http.StatusBadGateway, body: `<html>gateway</html>`})
+		require.Error(t, err)
+		assert.Equal(t, "", oktaErrorCode(err))
+	})
+
+	t.Run("empty for a non-API error", func(t *testing.T) {
+		assert.Equal(t, "", oktaErrorCode(errors.New("boom")))
+		assert.Equal(t, "", oktaErrorCode(nil))
+	})
+}
+
+// TestIsOktaFeatureUnavailableLicensing pins the 401 split. Without it, `okta.realms`
+// and `okta.group.owners` fail the whole collection they belong to on any org
+// that is not licensed for those features.
+func TestIsOktaFeatureUnavailableLicensing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("feature not licensed is an empty result", func(t *testing.T) {
+		resp, err := oktaCall(t, stubRoundTripper{status: http.StatusUnauthorized, body: oktaFeatureNotEnabledBody})
+		require.Error(t, err)
+		assert.True(t, isOktaFeatureUnavailable(resp, err))
+	})
+
+	t.Run("invalid token stays an error", func(t *testing.T) {
+		resp, err := oktaCall(t, stubRoundTripper{status: http.StatusUnauthorized, body: oktaInvalidTokenBody})
+		require.Error(t, err)
+		assert.False(t, isOktaFeatureUnavailable(resp, err),
+			"a dead token must not be reported as an org with nothing configured")
+	})
+
+	t.Run("unlabelled 401 stays an error", func(t *testing.T) {
+		resp, err := oktaCall(t, stubRoundTripper{status: http.StatusUnauthorized, body: `{}`})
+		require.Error(t, err)
+		assert.False(t, isOktaFeatureUnavailable(resp, err))
+	})
+}
+
+// TestIsOktaFeatureUnavailableSurvivesMissingResponse is the regression for a
+// provider panic. When a request never produces a response -- a transport error,
+// or a rate-limit retry that ran out of attempts -- the generated SDK still
+// returns a non-nil *APIResponse, built around a nil *http.Response. StatusCode
+// is a promoted field, so reading it in that state dereferences the nil embed.
+// The helper is called from roughly twenty listers, so this panicked whichever
+// collection happened to hit the network problem.
+func TestIsOktaFeatureUnavailableSurvivesMissingResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hand-built response with a nil embed", func(t *testing.T) {
+		resp := &okta.APIResponse{}
+		require.Nil(t, resp.Response, "guarding the case where the SDK wrapped no response")
+		assert.NotPanics(t, func() {
+			assert.False(t, isOktaFeatureUnavailable(resp, assert.AnError))
+		})
+		assert.NotPanics(t, func() {
+			assert.False(t, isOktaNotFound(resp))
+		})
+	})
+
+	t.Run("real transport failure through the SDK", func(t *testing.T) {
+		resp, err := oktaCall(t, stubRoundTripper{transportErr: errors.New("connection reset by peer")})
+		require.Error(t, err)
+		assert.NotPanics(t, func() {
+			isOktaFeatureUnavailable(resp, err)
+		}, "a network failure must surface as an error, not a panic")
+	})
+}
+
+// `/apps/{id}/tokens` answers 400 for an application that is not an OAuth 2.0
+// client, which is the only meaning a 400 can carry there -- the request sends
+// no caller-supplied input beyond the app id. Reading it as "no tokens" is what
+// stops one bookmark app from failing every application in the query.
+func TestIsOktaStatus(t *testing.T) {
+	t.Parallel()
+
+	badRequest := &okta.APIResponse{Response: &http.Response{StatusCode: http.StatusBadRequest}}
+	assert.True(t, isOktaStatus(badRequest, http.StatusBadRequest))
+	assert.False(t, isOktaStatus(badRequest, http.StatusNotFound))
+	assert.False(t, isOktaStatus(&okta.APIResponse{}, http.StatusBadRequest),
+		"a response-less APIResponse must not match any status")
+	assert.False(t, isOktaStatus(nil, http.StatusBadRequest))
+}
+
+func TestIsOktaNotFound(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isOktaNotFound(&okta.APIResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}))
+	assert.False(t, isOktaNotFound(&okta.APIResponse{Response: &http.Response{StatusCode: http.StatusForbidden}}))
+	assert.False(t, isOktaNotFound(&okta.APIResponse{Response: &http.Response{StatusCode: http.StatusOK}}))
+	assert.False(t, isOktaNotFound(&okta.APIResponse{}))
+	assert.False(t, isOktaNotFound(nil))
+}
+
+// TestErrOktaResourceNotFoundIsIdentifiable proves the sentinel survives the
+// wrapping the inits apply, which is what lets a reference accessor tell "this
+// principal does not exist" apart from a real failure and report null.
+func TestErrOktaResourceNotFoundIsIdentifiable(t *testing.T) {
+	t.Parallel()
+
+	wrapped := errors.New("okta.user \"00u1\" not found: " + errOktaResourceNotFound.Error())
+	assert.False(t, errors.Is(wrapped, errOktaResourceNotFound),
+		"a string that merely mentions the sentinel must not match")
+
+	assert.True(t, errors.Is(
+		errors.Join(errOktaResourceNotFound, errors.New("okta.user \"00u1\"")),
+		errOktaResourceNotFound))
+}

--- a/providers/okta/resources/errors_test.go
+++ b/providers/okta/resources/errors_test.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
@@ -183,6 +185,41 @@ func TestErrOktaResourceNotFoundIsIdentifiable(t *testing.T) {
 		"a string that merely mentions the sentinel must not match")
 
 	assert.True(t, errors.Is(
-		errors.Join(errOktaResourceNotFound, errors.New("okta.user \"00u1\"")),
+		fmt.Errorf("%w: okta.user %q", errOktaResourceNotFound, "00u1"),
 		errOktaResourceNotFound))
+}
+
+// TestNotFoundWrappingIsPairedWithAGuard keeps the two halves of the
+// null-on-missing behavior in step. A resolver's errors.Is guard is dead code
+// unless the init behind it wraps the sentinel, and an init that wraps without
+// a guard downstream just renames the failure -- either half alone reads as
+// fixed while the collection still fails. Both directions are checked by
+// source, because the behavior only shows up against a live org.
+func TestNotFoundWrappingIsPairedWithAGuard(t *testing.T) {
+	t.Parallel()
+
+	// resource -> (init that must wrap, file holding the accessor that must guard)
+	pairs := []struct{ resource, initFile, guardFile string }{
+		{"okta.user", "users.go", "resourceSets.go"},
+		{"okta.group", "groups.go", "resourceSets.go"},
+		{"okta.application", "applications.go", "resourceSets.go"},
+		{"okta.customRole", "customRoles.go", "resourceSets.go"},
+		{"okta.resourceSet", "resourceSets.go", "roles.go"},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.resource, func(t *testing.T) {
+			initSrc, err := os.ReadFile(p.initFile)
+			require.NoError(t, err)
+			assert.Contains(t, string(initSrc), "errOktaResourceNotFound",
+				"%s must wrap a 404 from its init in the sentinel, or the guard in %s never fires",
+				p.initFile, p.guardFile)
+
+			guardSrc, err := os.ReadFile(p.guardFile)
+			require.NoError(t, err)
+			assert.Contains(t, string(guardSrc), "errors.Is(err, errOktaResourceNotFound)",
+				"%s must report a missing %s as null rather than failing the collection",
+				p.guardFile, p.resource)
+		})
+	}
 }

--- a/providers/okta/resources/groups.go
+++ b/providers/okta/resources/groups.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
 	"go.mondoo.com/mql/v13/llx"
@@ -78,8 +79,11 @@ func initOktaGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 	conn := runtime.Connection.(*connection.OktaConnection)
 	client := conn.Client()
 	ctx := context.Background()
-	group, _, err := client.GroupAPI.GetGroup(ctx, id).Execute()
+	group, resp, err := client.GroupAPI.GetGroup(ctx, id).Execute()
 	if err != nil {
+		if isOktaNotFound(resp) {
+			return nil, nil, fmt.Errorf("%w: okta.group %q", errOktaResourceNotFound, id)
+		}
 		return nil, nil, err
 	}
 

--- a/providers/okta/resources/helpers.go
+++ b/providers/okta/resources/helpers.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -131,20 +133,75 @@ func oktaBool(b *bool) bool {
 	return *b
 }
 
+// oktaErrCodeFeatureNotEnabled is the Okta error code for a feature the org is
+// not licensed for. Okta answers it with 401 rather than 403, which is the same
+// status it uses for a token that is invalid or expired (E0000011), so the two
+// can only be told apart by the code in the body.
+const oktaErrCodeFeatureNotEnabled = "E0000015"
+
+// oktaErrorCode returns the Okta error code (for example "E0000015") carried in
+// an API error's response body, or "" when the error is not an Okta API error
+// or the body does not parse. The v5 SDK only decodes the error model for a
+// couple of status codes but always keeps the raw body, so the body is the one
+// place the code can be read from reliably.
+func oktaErrorCode(err error) string {
+	var apiErr *okta.GenericOpenAPIError
+	if !errors.As(err, &apiErr) {
+		return ""
+	}
+	var body struct {
+		ErrorCode string `json:"errorCode"`
+	}
+	if json.Unmarshal(apiErr.Body(), &body) != nil {
+		return ""
+	}
+	return body.ErrorCode
+}
+
 // isOktaFeatureUnavailable reports whether an API error means the org simply
 // does not have the thing being asked about, rather than that the request
 // failed. Okta answers 404 for an endpoint belonging to a feature the org has
-// not enabled, 410 for one that has been retired, and 403 when the token's
-// admin role cannot reach it. All three describe an org with nothing to
-// report, so callers degrade to an empty result instead of failing the query
-// and taking every other resource in the scan down with them.
+// not enabled, 410 for one that has been retired, 403 when the token's admin
+// role cannot reach it, and 401 E0000015 for a feature the org is not licensed
+// for. All of those describe an org with nothing to report, so callers degrade
+// to an empty result instead of failing the query and taking every other
+// resource in the scan down with them.
+//
+// A bare 401 is deliberately not enough: it is also what an invalid or expired
+// token returns, and degrading that would report a dead credential as a clean,
+// empty scan.
 func isOktaFeatureUnavailable(resp *okta.APIResponse, err error) bool {
-	if err == nil || resp == nil {
+	// The SDK wraps a nil *http.Response in a non-nil *APIResponse whenever the
+	// request never produced a response at all (a transport error, or a
+	// rate-limit retry that ran out of attempts). StatusCode is a promoted
+	// field, so reading it in that state dereferences the nil embed and panics.
+	if err == nil || resp == nil || resp.Response == nil {
 		return false
 	}
 	switch resp.StatusCode {
 	case http.StatusForbidden, http.StatusNotFound, http.StatusGone:
 		return true
+	case http.StatusUnauthorized:
+		return oktaErrorCode(err) == oktaErrCodeFeatureNotEnabled
 	}
 	return false
+}
+
+// errOktaResourceNotFound marks a reference to an object the org does not
+// expose through the API: a deleted user, an internal application that is
+// absent from `/api/v1/apps`, or a principal id that belongs to something other
+// than the resource being resolved (Okta stamps `createdBy` with system
+// principal ids that are not users). Reference accessors report it as a null
+// field rather than failing the whole collection they were read from.
+var errOktaResourceNotFound = errors.New("okta resource not found")
+
+// isOktaStatus reports whether a response carries the given status code. Like
+// the classifiers above it tolerates the SDK's response-less *APIResponse.
+func isOktaStatus(resp *okta.APIResponse, status int) bool {
+	return resp != nil && resp.Response != nil && resp.StatusCode == status
+}
+
+// isOktaNotFound reports whether a response says the object does not exist.
+func isOktaNotFound(resp *okta.APIResponse) bool {
+	return isOktaStatus(resp, http.StatusNotFound)
 }

--- a/providers/okta/resources/profileMappings.go
+++ b/providers/okta/resources/profileMappings.go
@@ -118,19 +118,11 @@ func (o *mqlOktaProfileMapping) id() (string, error) {
 	return "okta.profileMapping/" + o.Id.Data, o.Id.Error
 }
 
+// Mappings also cover applications Okta manages internally, which it does not
+// serve from `/api/v1/apps`; those resolve to null rather than failing every
+// other mapping in the same query.
 func (o *mqlOktaProfileMapping) application() (*mqlOktaApplication, error) {
-	if o.cacheApplicationID == "" {
-		o.Application.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-
-	r, err := NewResource(o.MqlRuntime, "okta.application", map[string]*llx.RawData{
-		"id": llx.StringData(o.cacheApplicationID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return r.(*mqlOktaApplication), nil
+	return resolveOktaApplicationRef(o.MqlRuntime, o.cacheApplicationID, &o.Application)
 }
 
 func (o *mqlOktaProfileMapping) userType() (*mqlOktaUserType, error) {

--- a/providers/okta/resources/resourceSets.go
+++ b/providers/okta/resources/resourceSets.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -326,6 +327,15 @@ func (o *mqlOktaResourceSetBinding) groups() ([]any, error) {
 
 // --- shared typed-reference resolvers ---
 
+// Every resolver below reads the reference back through NewResource, which runs
+// the target's init and therefore issues a fetch. A reference can outlive the
+// object it names (a deleted user), point at something Okta does not serve from
+// the collection endpoint (an internal application), or carry a principal id
+// that is not the kind being resolved at all -- `createdBy` on an Okta-managed
+// object holds a system principal id, not a user id. All three come back as a
+// 404, and none of them is a reason to fail the collection the reference was
+// read from, so they resolve to a null field instead.
+
 func resolveOktaUserRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOktaUser]) (*mqlOktaUser, error) {
 	if id == "" {
 		field.State = plugin.StateIsSet | plugin.StateIsNull
@@ -335,6 +345,10 @@ func resolveOktaUserRef(runtime *plugin.Runtime, id string, field *plugin.TValue
 		"id": llx.StringData(id),
 	})
 	if err != nil {
+		if errors.Is(err, errOktaResourceNotFound) {
+			field.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlOktaUser), nil
@@ -349,6 +363,10 @@ func resolveOktaGroupRef(runtime *plugin.Runtime, id string, field *plugin.TValu
 		"id": llx.StringData(id),
 	})
 	if err != nil {
+		if errors.Is(err, errOktaResourceNotFound) {
+			field.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlOktaGroup), nil
@@ -363,6 +381,10 @@ func resolveOktaApplicationRef(runtime *plugin.Runtime, id string, field *plugin
 		"id": llx.StringData(id),
 	})
 	if err != nil {
+		if errors.Is(err, errOktaResourceNotFound) {
+			field.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlOktaApplication), nil
@@ -382,6 +404,10 @@ func resolveOktaCustomRoleRef(runtime *plugin.Runtime, id string, field *plugin.
 	return r.(*mqlOktaCustomRole), nil
 }
 
+// The plural resolvers drop members the org no longer has rather than failing
+// the list, so one stale member id does not hide every other member alongside
+// it.
+
 func resolveOktaUserRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
 	list := make([]any, 0, len(ids))
 	for _, id := range ids {
@@ -389,6 +415,9 @@ func resolveOktaUserRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
 			"id": llx.StringData(id),
 		})
 		if err != nil {
+			if errors.Is(err, errOktaResourceNotFound) {
+				continue
+			}
 			return nil, err
 		}
 		list = append(list, r)
@@ -403,6 +432,9 @@ func resolveOktaGroupRefs(runtime *plugin.Runtime, ids []string) ([]any, error) 
 			"id": llx.StringData(id),
 		})
 		if err != nil {
+			if errors.Is(err, errOktaResourceNotFound) {
+				continue
+			}
 			return nil, err
 		}
 		list = append(list, r)

--- a/providers/okta/resources/resourceSets.go
+++ b/providers/okta/resources/resourceSets.go
@@ -97,8 +97,11 @@ func initOktaResourceSet(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	conn := runtime.Connection.(*connection.OktaConnection)
 	client := conn.Client()
 	ctx := context.Background()
-	set, _, err := client.ResourceSetAPI.GetResourceSet(ctx, id).Execute()
+	set, resp, err := client.ResourceSetAPI.GetResourceSet(ctx, id).Execute()
 	if err != nil {
+		if isOktaNotFound(resp) {
+			return nil, nil, fmt.Errorf("%w: okta.resourceSet %q", errOktaResourceNotFound, id)
+		}
 		return nil, nil, err
 	}
 	if set == nil {
@@ -399,6 +402,10 @@ func resolveOktaCustomRoleRef(runtime *plugin.Runtime, id string, field *plugin.
 		"id": llx.StringData(id),
 	})
 	if err != nil {
+		if errors.Is(err, errOktaResourceNotFound) {
+			field.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlOktaCustomRole), nil

--- a/providers/okta/resources/roleTargets.go
+++ b/providers/okta/resources/roleTargets.go
@@ -22,10 +22,22 @@ import (
 // targets is not scoped at all and covers every group or application in the
 // org.
 
+// isCustomRoleAssignment reports whether the assignment grants a custom role.
+// Custom roles take their scope from the resource set they are bound to rather
+// than from a target list, so Okta rejects the target endpoints for them with a
+// 400. Read `resourceSet` to see what such an assignment covers.
+func (o *mqlOktaRole) isCustomRoleAssignment() bool {
+	return o.Type.Error == nil && o.Type.Data == "CUSTOM"
+}
+
 func (o *mqlOktaRole) groupTargets() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 	ctx := context.Background()
 	roleID := o.Id.Data
+
+	if o.isCustomRoleAssignment() {
+		return nil, nil
+	}
 
 	var groups []okta.Group
 	switch {
@@ -90,6 +102,10 @@ func (o *mqlOktaRole) appTargets() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
 	ctx := context.Background()
 	roleID := o.Id.Data
+
+	if o.isCustomRoleAssignment() {
+		return nil, nil
+	}
 
 	var apps []okta.CatalogApplication
 	switch {

--- a/providers/okta/resources/roleTargets_test.go
+++ b/providers/okta/resources/roleTargets_test.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func httpResponse(status int) *http.Response {
+	return &http.Response{StatusCode: status}
+}
+
+// A custom role takes its scope from the resource set it is bound to, not from
+// a target list, and Okta rejects the target endpoints for one with a 400. Any
+// org that has bound a custom role to an admin therefore failed the entire
+// `okta.users`/`okta.groups` collection the assignment was read from, because
+// one 400 poisons the whole query.
+func TestIsCustomRoleAssignment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		roleType plugin.TValue[string]
+		want     bool
+	}{
+		{
+			name:     "custom role",
+			roleType: plugin.TValue[string]{Data: "CUSTOM", State: plugin.StateIsSet},
+			want:     true,
+		},
+		{
+			name:     "standard role keeps its target lookup",
+			roleType: plugin.TValue[string]{Data: "USER_ADMIN", State: plugin.StateIsSet},
+			want:     false,
+		},
+		{
+			name:     "app admin keeps its target lookup",
+			roleType: plugin.TValue[string]{Data: "APP_ADMIN", State: plugin.StateIsSet},
+			want:     false,
+		},
+		{
+			name:     "unset type is not assumed custom",
+			roleType: plugin.TValue[string]{},
+			want:     false,
+		},
+		{
+			name:     "errored type is not assumed custom",
+			roleType: plugin.TValue[string]{Data: "CUSTOM", Error: errors.New("boom")},
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			role := &mqlOktaRole{Type: tc.roleType}
+			assert.Equal(t, tc.want, role.isCustomRoleAssignment())
+		})
+	}
+}
+
+// TestIsOktaRawFeatureUnavailable covers the raw-HTTP twin of the classifier,
+// used by the endpoints the generated SDK cannot serve.
+func TestIsOktaRawFeatureUnavailable(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isOktaRawFeatureUnavailable(nil))
+	assert.True(t, isOktaRawFeatureUnavailable(httpResponse(404)))
+	assert.True(t, isOktaRawFeatureUnavailable(httpResponse(403)))
+	assert.True(t, isOktaRawFeatureUnavailable(httpResponse(410)))
+	assert.False(t, isOktaRawFeatureUnavailable(httpResponse(200)))
+	assert.False(t, isOktaRawFeatureUnavailable(httpResponse(500)))
+	assert.False(t, isOktaRawFeatureUnavailable(httpResponse(429)))
+}

--- a/providers/okta/resources/roles.go
+++ b/providers/okta/resources/roles.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
@@ -96,6 +97,11 @@ func (o *mqlOktaRole) resourceSet() (*mqlOktaResourceSet, error) {
 		"id": llx.StringData(o.cacheResourceSetID),
 	})
 	if err != nil {
+		// A binding can outlive the resource set it scoped.
+		if errors.Is(err, errOktaResourceNotFound) {
+			o.ResourceSet.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return r.(*mqlOktaResourceSet), nil

--- a/providers/okta/resources/sdk/emailServers.go
+++ b/providers/okta/resources/sdk/emailServers.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/okta/okta-sdk-golang/v5/okta"
+)
+
+// ListEmailServers fetches the org's custom SMTP servers from
+// `/api/v1/email-servers`.
+//
+// The v5 SDK's generated EmailServerAPI.ListEmailServers types the response as
+// an EmailServerListResponse object, but the endpoint answers with a bare array
+// of servers, so the generated call fails to unmarshal and every org that has
+// configured an SMTP server gets an error instead of its servers. Both shapes
+// are accepted here: the array the API sends today, and the wrapped object the
+// SDK expects, so the resource keeps working whichever one an org is served.
+func (m *ApiExtension) ListEmailServers(ctx context.Context) ([]okta.EmailServerResponse, *http.Response, error) {
+	var raw json.RawMessage
+	resp, err := m.get(ctx, m.url("/api/v1/email-servers"), &raw)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	servers, err := decodeOktaEmailServers(raw)
+	if err != nil {
+		return nil, resp, err
+	}
+	return servers, resp, nil
+}
+
+// decodeOktaEmailServers accepts either the bare array the API returns or the
+// `{"email-servers": [...]}` envelope the SDK's model describes.
+func decodeOktaEmailServers(raw json.RawMessage) ([]okta.EmailServerResponse, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	var list []okta.EmailServerResponse
+	if err := json.Unmarshal(raw, &list); err == nil {
+		return list, nil
+	}
+
+	var wrapped struct {
+		EmailServers []okta.EmailServerResponse `json:"email-servers"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		return nil, err
+	}
+	return wrapped.EmailServers, nil
+}

--- a/providers/okta/resources/sdk/emailServers_test.go
+++ b/providers/okta/resources/sdk/emailServers_test.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListEmailServersDecodesBareArray is the regression for an org that has
+// configured a custom SMTP server getting an unmarshal error instead of its
+// servers. `/api/v1/email-servers` answers with a bare array, but the v5 SDK
+// types the response as an EmailServerListResponse object, so the generated
+// call fails with "cannot unmarshal array into Go value of type
+// okta._EmailServerListResponse" and takes the whole collection down.
+func TestListEmailServersDecodesBareArray(t *testing.T) {
+	t.Parallel()
+	rt := &singlePageRoundTripper{
+		body: `[{"id":"ces1","alias":"primary","host":"smtp.example.com","port":587,"username":"mailer","enabled":true},
+		        {"id":"ces2","alias":"backup","host":"smtp2.example.com","port":25,"username":"relay","enabled":false}]`,
+	}
+
+	servers, _, err := fakeClient(rt).ListEmailServers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, servers, 2)
+
+	assert.Equal(t, "ces1", *servers[0].Id)
+	assert.Equal(t, "primary", *servers[0].Alias)
+	assert.Equal(t, "smtp.example.com", *servers[0].Host)
+	assert.Equal(t, int32(587), *servers[0].Port)
+	assert.Equal(t, "mailer", *servers[0].Username)
+	assert.True(t, *servers[0].Enabled)
+
+	// The disabled server must not read as enabled: `enabled` is the field an
+	// audit keys on, and a dropped false would report a live relay.
+	assert.False(t, *servers[1].Enabled)
+	assert.Equal(t, int32(25), *servers[1].Port)
+}
+
+func TestDecodeOktaEmailServers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare array, the shape the API sends", func(t *testing.T) {
+		servers, err := decodeOktaEmailServers(json.RawMessage(
+			`[{"id":"ces1","alias":"primary"}]`))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		assert.Equal(t, "ces1", *servers[0].Id)
+	})
+
+	t.Run("wrapped object, the shape the SDK model describes", func(t *testing.T) {
+		servers, err := decodeOktaEmailServers(json.RawMessage(
+			`{"email-servers":[{"id":"ces9","alias":"wrapped"}]}`))
+		require.NoError(t, err)
+		require.Len(t, servers, 1)
+		assert.Equal(t, "ces9", *servers[0].Id)
+		assert.Equal(t, "wrapped", *servers[0].Alias)
+	})
+
+	t.Run("empty array is no servers, not an error", func(t *testing.T) {
+		servers, err := decodeOktaEmailServers(json.RawMessage(`[]`))
+		require.NoError(t, err)
+		assert.Empty(t, servers)
+	})
+
+	t.Run("empty body is no servers", func(t *testing.T) {
+		servers, err := decodeOktaEmailServers(nil)
+		require.NoError(t, err)
+		assert.Empty(t, servers)
+	})
+
+	t.Run("neither shape is an error, not a silent empty", func(t *testing.T) {
+		_, err := decodeOktaEmailServers(json.RawMessage(`"unexpected"`))
+		require.Error(t, err)
+	})
+}

--- a/providers/okta/resources/userTypes.go
+++ b/providers/okta/resources/userTypes.go
@@ -154,30 +154,13 @@ func (o *mqlOktaUserType) id() (string, error) {
 	return "okta.userType/" + o.Id.Data, o.Id.Error
 }
 
+// Okta stamps the built-in user type with a system principal id rather than a
+// user id, so these resolve to null on the default type instead of failing the
+// collection. The shared resolver handles both that and an empty id.
 func (o *mqlOktaUserType) createdBy() (*mqlOktaUser, error) {
-	if o.cacheCreatedBy == "" {
-		o.CreatedBy.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	return oktaUserRef(o.MqlRuntime, o.cacheCreatedBy)
+	return resolveOktaUserRef(o.MqlRuntime, o.cacheCreatedBy, &o.CreatedBy)
 }
 
 func (o *mqlOktaUserType) lastUpdatedBy() (*mqlOktaUser, error) {
-	if o.cacheLastUpdatedBy == "" {
-		o.LastUpdatedBy.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	return oktaUserRef(o.MqlRuntime, o.cacheLastUpdatedBy)
-}
-
-// oktaUserRef resolves a user id to an okta.user. The runtime caches user
-// instances by id, so repeated references across resources share one fetch.
-func oktaUserRef(runtime *plugin.Runtime, id string) (*mqlOktaUser, error) {
-	r, err := NewResource(runtime, "okta.user", map[string]*llx.RawData{
-		"id": llx.StringData(id),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return r.(*mqlOktaUser), nil
+	return resolveOktaUserRef(o.MqlRuntime, o.cacheLastUpdatedBy, &o.LastUpdatedBy)
 }

--- a/providers/okta/resources/userTypes_test.go
+++ b/providers/okta/resources/userTypes_test.go
@@ -127,6 +127,10 @@ func TestIsOktaFeatureUnavailable(t *testing.T) {
 		{"rate limited is a real failure", apiResponse(http.StatusTooManyRequests), err, false},
 		{"no error", apiResponse(http.StatusNotFound), nil, false},
 		{"no response", nil, err, false},
+		// The SDK hands back a non-nil *APIResponse wrapping a nil
+		// *http.Response whenever the request produced no response at all.
+		// StatusCode is promoted from that embed, so this case panicked.
+		{"response with no http response", &okta.APIResponse{}, err, false},
 	}
 
 	for _, tc := range tests {

--- a/providers/okta/resources/users.go
+++ b/providers/okta/resources/users.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
 	"go.mondoo.com/mql/v13/llx"
@@ -36,8 +37,11 @@ func initOktaUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[st
 	conn := runtime.Connection.(*connection.OktaConnection)
 	client := conn.Client()
 	ctx := context.Background()
-	user, _, err := client.UserAPI.GetUser(ctx, id).Execute()
+	user, resp, err := client.UserAPI.GetUser(ctx, id).Execute()
 	if err != nil {
+		if isOktaNotFound(resp) {
+			return nil, nil, fmt.Errorf("%w: okta.user %q", errOktaResourceNotFound, id)
+		}
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
Full live validation of the okta provider against a real Okta org: every one of
the 55 resources and 521 fields in `okta.lr` was queried, after seeding the org
with fixtures so the collections had data to return rather than passing
vacuously on empty lists.

Nine resources either panicked or reported a hard error for an API answer that
means "there is nothing here". Because a failed field takes down the collection
it belongs to, any one of these emptied `okta.users`, `okta.groups`, or
`okta.applications` for the whole scan.

## What was failing

| Resource / field | Before | Cause |
|---|---|---|
| ~20 listers | **panic** | nil-embedded `*http.Response` |
| `okta.realms` | 401 error | feature not licensed |
| `okta.group.owners` | 401 error, per group | feature not licensed |
| `okta.application.tokens` | 400 error | app is not an OAuth 2.0 client |
| `okta.application.scopeConsentGrants` | 404 error | app is not an OAuth 2.0 client |
| `okta.role.groupTargets` / `appTargets` | 400 error | custom role, scoped by resource set |
| `okta.userType.createdBy` / `lastUpdatedBy` | 404 error | system principal id, not a user |
| `okta.profileMapping.application` | 404 error | app Okta does not serve from `/api/v1/apps` |
| `okta.emailServers` | unmarshal error, always | SDK types a bare array as an object |

### The panic

`isOktaFeatureUnavailable` read `resp.StatusCode` behind a `resp == nil` guard.
That guard is not enough: the generated SDK returns a **non-nil** `*APIResponse`
wrapping a **nil** `*http.Response` whenever a request produced no response at
all, which happens on a transport error or a rate-limit retry that ran out of
attempts.

```go
localVarHTTPResponse, err = a.client.do(r.ctx, req)   // can return (nil, err)
if err != nil {
    localAPIResponse = newAPIResponse(localVarHTTPResponse, ...)  // wraps nil
    return localVarReturnValue, localAPIResponse, &GenericOpenAPIError{...}
}
```

`StatusCode` is promoted from that embed, so reading it dereferenced nil. The
helper is called from roughly twenty listers, so a network blip panicked
whichever collection happened to hit it.

### The 401 split

Okta answers **401 `E0000015`** for a feature the org is not licensed for, which
is what `okta.realms` and `okta.group.owners` hit. A bare 401 is deliberately
still treated as an error, because **401 `E0000011`** is an invalid or expired
token — degrading that would report an unusable credential as a clean, empty
scan. The two are only distinguishable by the error code in the body, so the
classifier reads it there.

## Also

Enables the SDK's rate-limit retry, which was left at its default of no retries,
so a 429 during a large scan surfaced as a failed field rather than a wait.

`okta.userType.createdBy`/`lastUpdatedBy` and `okta.profileMapping.application`
had their own copies of the reference-resolution logic; they now go through the
shared resolvers, which is where the null-on-not-found behavior lives.

## Verification

Every fix was confirmed against the live org with the rebuilt provider, and the
full 177-query battery was re-run to check for regressions. One regression was
caught and reverted during that loop: gating the token and grant collections on
`credentials.oauthClient.client_id` looked like the natural discriminator, but
Okta leaves that field **absent** on its own first-party OIDC apps, which do
hold grants — the gate silently emptied 12 real grants on Okta Dashboard. The
shipped version keys on the API's response instead.

The pass also positively verified `okta.role.appTargets` against both target
shapes for the first time (an OIN app-type target, which carries only a name,
alongside an instance target).

## Tests

The classifiers are tested against errors produced by the **real SDK** through a
stubbed transport rather than hand-built error values, since the whole class of
bug here is the generated types not matching what the API actually sends. New
coverage: the panic case (verified to fail without the guard), the 401 split in
both directions, `oktaErrorCode` parsing, the custom-role predicate, the
raw-HTTP classifier, and the email-server decode for both wire shapes.

No schema changes, so no `.lr.versions` or permissions updates.
