### PR TITLE
🎉 okta-13.5.0

### DIFF
--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "okta",
 	ID:              "go.mondoo.com/cnquery/v9/providers/okta",
-	Version:         "13.4.3",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Bumps the okta provider from `13.4.3` to `13.5.0`.

A minor rather than a patch bump: this release adds new resources and a new
authentication mechanism, not just fixes.

## Features

- **#9686** — service app authentication with a private key JWT, alongside the
  existing SSWS API token. A service app holds only the scopes it was granted,
  so it can be limited to read-only access. New flags: `--client-id`,
  `--private-key`, `--private-key-id`, `--scopes`.
- **#9679** — admin role scope targets and group owners: `okta.role.groupTargets`
  and `okta.role.appTargets` per principal kind (user, group, client), the new
  `okta.role.appTarget`, and `okta.group.owners`.
- **#9681** — `okta.application.tokens`, the OAuth 2.0 refresh tokens an
  application already holds (as opposed to the scopes it may ask for).
- **#9596** — `okta.userType`, `okta.profileMapping`, `okta.agentPool` +
  `.agent`, `okta.emailDomain`, `okta.emailServer`, `okta.realm`, and
  `okta.rateLimitSettings`.

## Fixes

- **#9785** — nine resources stopped failing whole collections on benign API
  answers, including a provider panic reachable from roughly twenty listers on
  any transport failure. Found by a full live validation of all 55 resources.
- **#9732** — build fix after `ApiExtension.Token` was removed.
- **#9595** — deferred audit papercuts; consolidated the raw HTTP paths.

## Note

Release PR #9784 is still open and bumps okta to `13.4.4`. It was cut before
#9785 merged, so it does not carry that fix. These two cannot both land — drop
okta from #9784 in favour of this one, or close this and re-cut after #9784
merges.
