### PR TITLE
🎉 activedirectory-13.1.12, cassandra-13.0.1, digitalocean-13.15.1, elasticsearch-13.0.1, equinix-13.0.27, ms365-13.10.2, opensearch-13.0.1, portainer-13.1.7, redfish-13.0.5, redisdb-13.0.1, shodan-13.2.11, slack-13.1.20, terraform-13.3.12, together-13.0.12, vcd-13.0.25, vllm-13.0.20, vsphere-13.7.6, weaviate-13.0.1

### DIFF
--- a/providers/activedirectory/config/config.go
+++ b/providers/activedirectory/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "activedirectory",
 	ID:              "go.mondoo.com/mql/v13/providers/activedirectory",
-	Version:         "13.1.11",
+	Version:         "13.1.12",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{{

--- a/providers/cassandra/config/config.go
+++ b/providers/cassandra/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cassandra",
 	ID:              "go.mondoo.com/mql/v13/providers/cassandra",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.15.0",
+	Version:         "13.15.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/elasticsearch/config/config.go
+++ b/providers/elasticsearch/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "elasticsearch",
 	ID:              "go.mondoo.com/mql/v13/providers/elasticsearch",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
-	Version:         "13.0.26",
+	Version:         "13.0.27",
 	Maturity:        resources.MaturityDeprecated,
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.10.1",
+	Version:         "13.10.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/opensearch/config/config.go
+++ b/providers/opensearch/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "opensearch",
 	ID:              "go.mondoo.com/mql/v13/providers/opensearch",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "portainer",
 	ID:              "go.mondoo.com/mql/providers/portainer",
-	Version:         "13.1.6",
+	Version:         "13.1.7",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,

--- a/providers/redfish/config/config.go
+++ b/providers/redfish/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "redfish",
 	ID:              "go.mondoo.com/mql/providers/redfish",
-	Version:         "13.0.4",
+	Version:         "13.0.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/redisdb/config/config.go
+++ b/providers/redisdb/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "redisdb",
 	ID:              "go.mondoo.com/mql/v13/providers/redisdb",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "shodan",
 	ID:              "go.mondoo.com/mql/v13/providers/shodan",
-	Version:         "13.2.10",
+	Version:         "13.2.11",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
-	Version:         "13.1.19",
+	Version:         "13.1.20",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "terraform",
 	ID:        "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version:   "13.3.11",
+	Version:   "13.3.12",
 	Platforms: provider.Platforms,
 	ConnectionTypes: []string{
 		provider.StateConnectionType,

--- a/providers/together/config/config.go
+++ b/providers/together/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "together",
 	ID:              "go.mondoo.com/mql/providers/together",
-	Version:         "13.0.11",
+	Version:         "13.0.12",
 	Platforms:       provider.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vcd",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vcd",
-	Version:         "13.0.24",
+	Version:         "13.0.25",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vllm/config/config.go
+++ b/providers/vllm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vllm",
 	ID:              "go.mondoo.com/mql/providers/vllm",
-	Version:         "13.0.19",
+	Version:         "13.0.20",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.7.5",
+	Version:         "13.7.6",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/weaviate/config/config.go
+++ b/providers/weaviate/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "weaviate",
 	ID:              "go.mondoo.com/mql/v13/providers/weaviate",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.
