### PR TITLE
🐛 snowflake: read SHOW GRANTS directly so a table-argument function does not panic

### DIFF
--- a/providers/snowflake/resources/file_formats_options_test.go
+++ b/providers/snowflake/resources/file_formats_options_test.go
@@ -1,0 +1,112 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nullString stands in for the single-field wrapper the SDK uses for the
+// entries of NULL_IF.
+type nullString struct {
+	S string
+}
+
+// jsonNativeValue feeds a dict field, and llx requires dict values to be
+// JSON-native. A value that slips through as some other Go type is not rejected
+// at compile time, so each accepted kind is pinned here.
+func TestJSONNativeValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want any
+		ok   bool
+	}{
+		{"string", "|", "|", true},
+		{"empty string", "", "", true},
+		{"bool true", true, true, true},
+		{"bool false", false, false, true},
+		{"int", 3, int64(3), true},
+		{"int64", int64(97), int64(97), true},
+		{"int32", int32(-1), int64(-1), true},
+		{"zero int", 0, int64(0), true},
+
+		// Floats are not among the accepted kinds; the caller must see that
+		// rather than receive a silently dropped option.
+		{"float is rejected", 1.5, nil, false},
+		{"struct is rejected", struct{ A int }{1}, nil, false},
+		{"map is rejected", map[string]string{"a": "b"}, nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := jsonNativeValue(reflect.ValueOf(tc.in))
+			assert.Equal(t, tc.ok, ok)
+			if tc.ok {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestJSONNativeValuePointer(t *testing.T) {
+	s := "HEX"
+	n := 3
+	b := true
+
+	t.Run("a pointer is dereferenced", func(t *testing.T) {
+		got, ok := jsonNativeValue(reflect.ValueOf(&s))
+		require.True(t, ok)
+		assert.Equal(t, "HEX", got)
+
+		got, ok = jsonNativeValue(reflect.ValueOf(&n))
+		require.True(t, ok)
+		assert.Equal(t, int64(3), got)
+
+		got, ok = jsonNativeValue(reflect.ValueOf(&b))
+		require.True(t, ok)
+		assert.Equal(t, true, got)
+	})
+
+	// An unset option is absent, not an option whose value is the zero value.
+	t.Run("a nil pointer is not a value", func(t *testing.T) {
+		var p *string
+		_, ok := jsonNativeValue(reflect.ValueOf(p))
+		assert.False(t, ok)
+	})
+}
+
+func TestJSONNativeValueSlice(t *testing.T) {
+	t.Run("single-field string structs are flattened", func(t *testing.T) {
+		// NULL_IF arrives as a list of wrappers; the dict should carry the
+		// strings they wrap, not the wrappers.
+		in := []nullString{{S: `\N`}, {S: "NULL"}}
+		got, ok := jsonNativeValue(reflect.ValueOf(in))
+		require.True(t, ok)
+		assert.Equal(t, []any{`\N`, "NULL"}, got)
+	})
+
+	t.Run("a plain string slice passes through", func(t *testing.T) {
+		got, ok := jsonNativeValue(reflect.ValueOf([]string{"a", "b"}))
+		require.True(t, ok)
+		assert.Equal(t, []any{"a", "b"}, got)
+	})
+
+	t.Run("an empty slice is an empty list", func(t *testing.T) {
+		got, ok := jsonNativeValue(reflect.ValueOf([]string{}))
+		require.True(t, ok)
+		assert.Equal(t, []any{}, got)
+	})
+
+	// One unrepresentable element fails the whole slice rather than yielding a
+	// list that silently omits it.
+	t.Run("an unrepresentable element rejects the slice", func(t *testing.T) {
+		_, ok := jsonNativeValue(reflect.ValueOf([]float64{1.5}))
+		assert.False(t, ok)
+	})
+}

--- a/providers/snowflake/resources/grant_filters_test.go
+++ b/providers/snowflake/resources/grant_filters_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestGrantedRoleNames(t *testing.T) {
+	grants := []snowflakeGrant{
+		{grantedOn: "ROLE", name: `"ANALYST"`},
+		// Privileges on other object types are not steps in the hierarchy.
+		{grantedOn: "TABLE", name: `"DB"."SCH"."T"`},
+		{grantedOn: "DATABASE", name: `"DB"`},
+		{grantedOn: "ROLE", name: `"REPORTER"`},
+		// A repeat is one edge, not two.
+		{grantedOn: "ROLE", name: `"ANALYST"`},
+		// A role grant with no name cannot be followed.
+		{grantedOn: "ROLE", name: ""},
+	}
+
+	assert.Equal(t, []string{"ANALYST", "REPORTER"}, grantedRoleNames(grants))
+}
+
+func TestGrantedRoleNamesQuotedName(t *testing.T) {
+	// The name arrives qualified and quoted; the hierarchy walk needs the bare
+	// role name to look it up.
+	grants := []snowflakeGrant{{grantedOn: "ROLE", name: `"my role"`}}
+	assert.Equal(t, []string{"my role"}, grantedRoleNames(grants))
+}
+
+func TestGrantedRoleNamesEmpty(t *testing.T) {
+	assert.Empty(t, grantedRoleNames(nil))
+}
+
+func TestGranteeNames(t *testing.T) {
+	// SHOW GRANTS OF ROLE reports users and roles in one result set, so the
+	// grantee kind is the only thing separating them.
+	grants := []snowflakeGrant{
+		{grantedTo: "USER", granteeName: "TAS50"},
+		{grantedTo: "ROLE", granteeName: "SYSADMIN"},
+		{grantedTo: "USER", granteeName: "SVC_ETL"},
+		{grantedTo: "USER", granteeName: "TAS50"},
+	}
+
+	assert.Equal(t, []string{"TAS50", "SVC_ETL"}, granteeNames(grants, sdk.ObjectTypeUser))
+	assert.Equal(t, []string{"SYSADMIN"}, granteeNames(grants, sdk.ObjectTypeRole))
+}
+
+func TestGranteeNamesNoMatch(t *testing.T) {
+	grants := []snowflakeGrant{{grantedTo: "ROLE", granteeName: "SYSADMIN"}}
+	assert.Empty(t, granteeNames(grants, sdk.ObjectTypeUser))
+}
+
+func TestUnsafeTime(t *testing.T) {
+	stamp := time.Date(2026, 8, 11, 12, 14, 31, 0, time.UTC)
+
+	t.Run("a timestamp column arrives as a time", func(t *testing.T) {
+		var v any = stamp
+		assert.Equal(t, llx.TimeData(stamp), unsafeTime(&v))
+	})
+
+	t.Run("a string form is parsed", func(t *testing.T) {
+		var v any = "2026-08-11 12:14:31.000 -0700"
+		got := unsafeTime(&v)
+		assert.NotEqual(t, llx.NilData, got, "a parsable timestamp is not null")
+	})
+
+	// An absent value must stay null. Coercing it to the zero time would report
+	// the year 1 as a real moment.
+	t.Run("a missing cell is null", func(t *testing.T) {
+		assert.Equal(t, llx.NilData, unsafeTime(nil))
+	})
+
+	t.Run("a nil cell is null", func(t *testing.T) {
+		var v any
+		assert.Equal(t, llx.NilData, unsafeTime(&v))
+	})
+}

--- a/providers/snowflake/resources/grants.go
+++ b/providers/snowflake/resources/grants.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"context"
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -16,13 +15,8 @@ import (
 // account-level grants: SHOW GRANTS ON ACCOUNT
 func (r *mqlSnowflakeAccount) grants() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
-	client := conn.Client()
-	ctx := context.Background()
 
-	on := true
-	grants, err := client.Grants.Show(ctx, &sdk.ShowGrantOptions{
-		On: &sdk.ShowGrantsOn{Account: &on},
-	})
+	grants, err := showGrantsRaw(conn, "SHOW GRANTS ON ACCOUNT")
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +288,7 @@ func (r *mqlSnowflakeDatabase) grants() ([]any, error) {
 // database later (SHOW FUTURE GRANTS IN DATABASE).
 func (r *mqlSnowflakeDatabase) futureGrants() ([]any, error) {
 	id := sdk.NewAccountObjectIdentifier(r.Name.Data)
-	return showFutureGrants(r.MqlRuntime, &sdk.ShowGrantsIn{Database: &id})
+	return showFutureGrants(r.MqlRuntime, sdk.ObjectTypeDatabase, id)
 }
 
 // grants returns the privileges granted on the schema (SHOW GRANTS ON SCHEMA).
@@ -307,7 +301,7 @@ func (r *mqlSnowflakeSchema) grants() ([]any, error) {
 // schema later (SHOW FUTURE GRANTS IN SCHEMA).
 func (r *mqlSnowflakeSchema) futureGrants() ([]any, error) {
 	id := sdk.NewDatabaseObjectIdentifier(r.DatabaseName.Data, r.Name.Data)
-	return showFutureGrants(r.MqlRuntime, &sdk.ShowGrantsIn{Schema: &id})
+	return showFutureGrants(r.MqlRuntime, sdk.ObjectTypeSchema, id)
 }
 
 // grants returns the objects an outbound share exposes (SHOW GRANTS TO SHARE).
@@ -320,11 +314,8 @@ func (r *mqlSnowflakeShare) grants() ([]any, error) {
 	}
 
 	conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
-	grants, err := conn.Client().Grants.Show(context.Background(), &sdk.ShowGrantOptions{
-		To: &sdk.ShowGrantsTo{
-			Share: &sdk.ShowGrantsToShare{Name: sdk.NewAccountObjectIdentifier(r.Name.Data)},
-		},
-	})
+	id := sdk.NewAccountObjectIdentifier(r.Name.Data)
+	grants, err := showGrantsRaw(conn, "SHOW GRANTS TO SHARE "+id.FullyQualifiedName())
 	if err != nil {
 		return nil, err
 	}
@@ -334,11 +325,8 @@ func (r *mqlSnowflakeShare) grants() ([]any, error) {
 // grants returns the privileges granted to the database role.
 func (r *mqlSnowflakeDatabaseRole) grants() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
-	grants, err := conn.Client().Grants.Show(context.Background(), &sdk.ShowGrantOptions{
-		To: &sdk.ShowGrantsTo{
-			DatabaseRole: sdk.NewDatabaseObjectIdentifier(r.DatabaseName.Data, r.Name.Data),
-		},
-	})
+	id := sdk.NewDatabaseObjectIdentifier(r.DatabaseName.Data, r.Name.Data)
+	grants, err := showGrantsRaw(conn, "SHOW GRANTS TO DATABASE ROLE "+id.FullyQualifiedName())
 	if err != nil {
 		return nil, err
 	}
@@ -348,11 +336,8 @@ func (r *mqlSnowflakeDatabaseRole) grants() ([]any, error) {
 // grantees returns the roles and database roles this database role is granted to.
 func (r *mqlSnowflakeDatabaseRole) grantees() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
-	grants, err := conn.Client().Grants.Show(context.Background(), &sdk.ShowGrantOptions{
-		Of: &sdk.ShowGrantsOf{
-			DatabaseRole: sdk.NewDatabaseObjectIdentifier(r.DatabaseName.Data, r.Name.Data),
-		},
-	})
+	id := sdk.NewDatabaseObjectIdentifier(r.DatabaseName.Data, r.Name.Data)
+	grants, err := showGrantsRaw(conn, "SHOW GRANTS OF DATABASE ROLE "+id.FullyQualifiedName())
 	if err != nil {
 		return nil, err
 	}
@@ -361,29 +346,27 @@ func (r *mqlSnowflakeDatabaseRole) grantees() ([]any, error) {
 
 func showObjectGrants(runtime *plugin.Runtime, objectType sdk.ObjectType, id sdk.ObjectIdentifier) ([]any, error) {
 	conn := runtime.Connection.(*connection.SnowflakeConnection)
-	grants, err := conn.Client().Grants.Show(context.Background(), &sdk.ShowGrantOptions{
-		On: &sdk.ShowGrantsOn{Object: &sdk.Object{ObjectType: objectType, Name: id}},
-	})
+	grants, err := showGrantsRaw(conn,
+		"SHOW GRANTS ON "+string(objectType)+" "+id.FullyQualifiedName())
 	if err != nil {
 		return nil, err
 	}
 	return convertGrants(runtime, grants)
 }
 
-func showFutureGrants(runtime *plugin.Runtime, in *sdk.ShowGrantsIn) ([]any, error) {
+// showFutureGrants reads SHOW FUTURE GRANTS IN <scope> <name>, the grants that
+// will apply to objects created in that scope later.
+func showFutureGrants(runtime *plugin.Runtime, scope sdk.ObjectType, id sdk.ObjectIdentifier) ([]any, error) {
 	conn := runtime.Connection.(*connection.SnowflakeConnection)
-	future := true
-	grants, err := conn.Client().Grants.Show(context.Background(), &sdk.ShowGrantOptions{
-		Future: &future,
-		In:     in,
-	})
+	grants, err := showGrantsRaw(conn,
+		"SHOW FUTURE GRANTS IN "+string(scope)+" "+id.FullyQualifiedName())
 	if err != nil {
 		return nil, err
 	}
 	return convertGrants(runtime, grants)
 }
 
-func convertGrants(runtime *plugin.Runtime, grants []sdk.Grant) ([]any, error) {
+func convertGrants(runtime *plugin.Runtime, grants []snowflakeGrant) ([]any, error) {
 	list := make([]any, 0, len(grants))
 	for i := range grants {
 		mqlGrant, err := newMqlSnowflakeGrant(runtime, grants[i])
@@ -399,42 +382,22 @@ func convertGrants(runtime *plugin.Runtime, grants []sdk.Grant) ([]any, error) {
 // privilege, and the object the privilege is on. Callers that merge grants from
 // several statements deduplicate on this so a privilege reached twice through
 // the role hierarchy yields one resource.
-func snowflakeGrantID(grant sdk.Grant) string {
-	objectName := ""
-	if grant.Name != nil {
-		objectName = grant.Name.FullyQualifiedName()
-	}
-	return grant.GranteeName.Name() + "/" + string(grant.GrantedTo) + "/" +
-		grant.Privilege + "/" + string(grant.GrantedOn) + "/" + objectName
+func snowflakeGrantID(grant snowflakeGrant) string {
+	return grant.granteeName + "/" + grant.grantedTo + "/" +
+		grant.privilege + "/" + grant.grantedOn + "/" + grant.name
 }
 
-func newMqlSnowflakeGrant(runtime *plugin.Runtime, grant sdk.Grant) (*mqlSnowflakeGrant, error) {
-	objectName := ""
-	if grant.Name != nil {
-		objectName = grant.Name.FullyQualifiedName()
-	}
-
-	// A future grant reports the object type it will apply to in grant_on
-	// rather than granted_on, which is empty until the object exists.
-	grantedOn := grant.GrantedOn
-	if grantedOn == "" {
-		grantedOn = grant.GrantOn
-	}
-	grantedTo := grant.GrantedTo
-	if grantedTo == "" {
-		grantedTo = grant.GrantTo
-	}
-
+func newMqlSnowflakeGrant(runtime *plugin.Runtime, grant snowflakeGrant) (*mqlSnowflakeGrant, error) {
 	r, err := CreateResource(runtime, "snowflake.grant", map[string]*llx.RawData{
 		"__id":        llx.StringData(snowflakeGrantID(grant)),
-		"privilege":   llx.StringData(grant.Privilege),
-		"grantedOn":   llx.StringData(string(grantedOn)),
-		"name":        llx.StringData(objectName),
-		"grantedTo":   llx.StringData(string(grantedTo)),
-		"granteeName": llx.StringData(grant.GranteeName.Name()),
-		"grantOption": llx.BoolData(grant.GrantOption),
-		"grantedBy":   llx.StringData(grant.GrantedBy.Name()),
-		"createdAt":   llx.TimeData(grant.CreatedOn),
+		"privilege":   llx.StringData(grant.privilege),
+		"grantedOn":   llx.StringData(grant.grantedOn),
+		"name":        llx.StringData(grant.name),
+		"grantedTo":   llx.StringData(grant.grantedTo),
+		"granteeName": llx.StringData(grant.granteeName),
+		"grantOption": llx.BoolData(grant.grantOption),
+		"grantedBy":   llx.StringData(grant.grantedBy),
+		"createdAt":   grant.createdOn,
 	})
 	if err != nil {
 		return nil, err

--- a/providers/snowflake/resources/grants_raw.go
+++ b/providers/snowflake/resources/grants_raw.go
@@ -1,0 +1,145 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers/snowflake/connection"
+)
+
+// snowflakeGrant is one row of any SHOW GRANTS variant, read straight from the
+// result set.
+//
+// The SDK's typed reader cannot be used for this statement. Its row converter
+// parses the name column into an object identifier, and for a grant on a
+// function whose argument is a table it reaches
+// datatypes.(*TableDataType).ToLegacyDataTypeSql on a nil receiver and panics.
+// Snowflake ships built-in data metric functions with exactly that shape
+// (SNOWFLAKE.CORE.ACCEPTED_VALUES(TABLE(DATE)) and its siblings) and grants them
+// to ACCOUNTADMIN on every account, so any SHOW GRANTS whose result reaches
+// those rows takes the whole field down.
+//
+// Recovering from the panic would not do: it fires part way through converting
+// the result set, so what survives is an empty grant list, and a field that
+// reports no privileges where privileges exist is worse than one that errors.
+// MQL's three-valued logic makes that failure silent, since an assertion over an
+// empty list passes.
+type snowflakeGrant struct {
+	createdOn   *llx.RawData
+	privilege   string
+	grantedOn   string
+	grantedTo   string
+	name        string
+	granteeName string
+	grantedBy   string
+	grantOption bool
+}
+
+// showGrantsRaw runs a SHOW GRANTS statement and reads its rows directly.
+// Callers build the statement with identifiers rendered by the SDK, so names
+// reach it already quoted rather than interpolated raw.
+func showGrantsRaw(conn *connection.SnowflakeConnection, statement string) ([]snowflakeGrant, error) {
+	rows, err := conn.Client().QueryUnsafe(context.Background(), statement)
+	if err != nil {
+		return nil, err
+	}
+	return parseGrantRows(rows), nil
+}
+
+// parseGrantRows reads the rows of a SHOW GRANTS result.
+//
+// A future grant names the object type it will apply to in grant_on/grant_to;
+// granted_on/granted_to stay empty until the object exists, so each pair falls
+// back to the future form.
+func parseGrantRows(rows []map[string]*any) []snowflakeGrant {
+	grants := make([]snowflakeGrant, 0, len(rows))
+	for _, row := range rows {
+		grantedOn := unsafeString(row["granted_on"])
+		if grantedOn == "" {
+			grantedOn = unsafeString(row["grant_on"])
+		}
+		grantedTo := unsafeString(row["granted_to"])
+		if grantedTo == "" {
+			grantedTo = unsafeString(row["grant_to"])
+		}
+
+		grants = append(grants, snowflakeGrant{
+			createdOn:   unsafeTime(row["created_on"]),
+			privilege:   unsafeString(row["privilege"]),
+			grantedOn:   grantedOn,
+			grantedTo:   grantedTo,
+			name:        quoteQualifiedName(unsafeString(row["name"])),
+			granteeName: identifierName(unsafeString(row["grantee_name"])),
+			grantedBy:   identifierName(unsafeString(row["granted_by"])),
+			grantOption: unsafeBool(row["grant_option"]),
+		})
+	}
+	return grants
+}
+
+// splitQualifiedName splits a qualified object name on its part separators.
+// A dot inside double quotes belongs to the name, and a dot inside parentheses
+// belongs to an argument list (a function's arguments arrive as part of its
+// name), so neither separates parts.
+func splitQualifiedName(name string) []string {
+	parts := []string{}
+	var current strings.Builder
+	inQuotes := false
+	depth := 0
+
+	for _, r := range name {
+		switch {
+		case r == '"':
+			inQuotes = !inQuotes
+			current.WriteRune(r)
+		case r == '(' && !inQuotes:
+			depth++
+			current.WriteRune(r)
+		case r == ')' && !inQuotes:
+			if depth > 0 {
+				depth--
+			}
+			current.WriteRune(r)
+		case r == '.' && !inQuotes && depth == 0:
+			parts = append(parts, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	parts = append(parts, current.String())
+	return parts
+}
+
+// quoteQualifiedName renders a name the way the SDK's FullyQualifiedName does,
+// with every part double quoted. The value is what the name field of a grant
+// reports, so it is kept in that shape rather than normalized.
+func quoteQualifiedName(name string) string {
+	if name == "" {
+		return ""
+	}
+	parts := splitQualifiedName(name)
+	for i, part := range parts {
+		if strings.HasPrefix(part, `"`) && strings.HasSuffix(part, `"`) && len(part) > 1 {
+			continue
+		}
+		parts[i] = `"` + part + `"`
+	}
+	return strings.Join(parts, ".")
+}
+
+// identifierName returns the bare last part of a qualified name, without the
+// quoting an identifier carries when it needs it.
+func identifierName(name string) string {
+	parts := splitQualifiedName(name)
+	last := parts[len(parts)-1]
+	if len(last) > 1 && strings.HasPrefix(last, `"`) && strings.HasSuffix(last, `"`) {
+		last = last[1 : len(last)-1]
+		last = strings.ReplaceAll(last, `""`, `"`)
+	}
+	return last
+}

--- a/providers/snowflake/resources/grants_raw_test.go
+++ b/providers/snowflake/resources/grants_raw_test.go
@@ -1,0 +1,194 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// grantRowCells builds the cell map a QueryUnsafe result hands back, where every value is
+// a pointer to an any.
+func grantRowCells(pairs map[string]any) map[string]*any {
+	out := make(map[string]*any, len(pairs))
+	for k, v := range pairs {
+		v := v
+		out[k] = &v
+	}
+	return out
+}
+
+func TestSplitQualifiedName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"unqualified", "ANALYST", []string{"ANALYST"}},
+		{"two parts", "DB.SCH", []string{"DB", "SCH"}},
+		{"three parts", "DB.SCH.T", []string{"DB", "SCH", "T"}},
+		{
+			// A dot inside quotes is part of the name, not a separator.
+			"quoted part containing a dot",
+			`DB."my.schema".T`,
+			[]string{"DB", `"my.schema"`, "T"},
+		},
+		{
+			// A function carries its argument list in its name, and an argument
+			// type can itself contain a dot.
+			"function arguments are one part",
+			"SNOWFLAKE.CORE.ACCEPTED_VALUES(TABLE(DATE))",
+			[]string{"SNOWFLAKE", "CORE", "ACCEPTED_VALUES(TABLE(DATE))"},
+		},
+		{"empty", "", []string{""}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitQualifiedName(tc.in))
+		})
+	}
+}
+
+func TestQuoteQualifiedName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// This is the shape the SDK's FullyQualifiedName produced, and what the
+		// name field of a grant has always reported.
+		{"three parts", "DB.SCH.T", `"DB"."SCH"."T"`},
+		{"account object", "UKB48668", `"UKB48668"`},
+		{"already quoted parts are left alone", `"DB"."SCH"`, `"DB"."SCH"`},
+		{"mixed quoting", `DB."my.schema"`, `"DB"."my.schema"`},
+		{
+			"function with table argument",
+			"SNOWFLAKE.CORE.ACCEPTED_VALUES(TABLE(DATE))",
+			`"SNOWFLAKE"."CORE"."ACCEPTED_VALUES(TABLE(DATE))"`,
+		},
+		// An account-level privilege carries no object name; it must stay empty
+		// rather than become a pair of quotes around nothing.
+		{"empty stays empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, quoteQualifiedName(tc.in))
+		})
+	}
+}
+
+func TestIdentifierName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"unqualified", "ANALYST", "ANALYST"},
+		{"qualified takes the last part", "DB.SCH.T", "T"},
+		{"quoting is removed", `"ANALYST"`, "ANALYST"},
+		{"quoted last part", `"DB"."SCH"."my table"`, "my table"},
+		{"embedded quotes are unescaped", `"say ""hi"""`, `say "hi"`},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, identifierName(tc.in))
+		})
+	}
+}
+
+func TestParseGrantRows(t *testing.T) {
+	created := time.Date(2026, 8, 11, 12, 14, 31, 0, time.UTC)
+
+	rows := []map[string]*any{
+		grantRowCells(map[string]any{
+			"created_on":   created,
+			"privilege":    "SELECT",
+			"granted_on":   "TABLE",
+			"name":         "DB.SCH.T",
+			"granted_to":   "ROLE",
+			"grantee_name": "ANALYST",
+			"grant_option": "false",
+			"granted_by":   "ACCOUNTADMIN",
+		}),
+	}
+
+	grants := parseGrantRows(rows)
+	require.Len(t, grants, 1)
+
+	g := grants[0]
+	assert.Equal(t, "SELECT", g.privilege)
+	assert.Equal(t, "TABLE", g.grantedOn)
+	assert.Equal(t, "ROLE", g.grantedTo)
+	assert.Equal(t, `"DB"."SCH"."T"`, g.name)
+	assert.Equal(t, "ANALYST", g.granteeName)
+	assert.Equal(t, "ACCOUNTADMIN", g.grantedBy)
+	assert.False(t, g.grantOption)
+	assert.Equal(t, llx.TimeData(created), g.createdOn)
+}
+
+// A grant on a function whose argument is a table is the row that made the
+// SDK's typed reader panic, so it has to survive parsing intact.
+func TestParseGrantRowsFunctionWithTableArgument(t *testing.T) {
+	rows := []map[string]*any{
+		grantRowCells(map[string]any{
+			"privilege":    "USAGE",
+			"granted_on":   "FUNCTION",
+			"name":         "SNOWFLAKE.CORE.ACCEPTED_VALUES(TABLE(DATE))",
+			"granted_to":   "ROLE",
+			"grantee_name": "ACCOUNTADMIN",
+			"grant_option": "true",
+		}),
+	}
+
+	grants := parseGrantRows(rows)
+	require.Len(t, grants, 1)
+	assert.Equal(t, `"SNOWFLAKE"."CORE"."ACCEPTED_VALUES(TABLE(DATE))"`, grants[0].name)
+	assert.Equal(t, "FUNCTION", grants[0].grantedOn)
+	assert.True(t, grants[0].grantOption)
+}
+
+// A future grant names the object type it will apply to in grant_on/grant_to;
+// granted_on/granted_to are empty until the object exists.
+func TestParseGrantRowsFutureGrant(t *testing.T) {
+	rows := []map[string]*any{
+		grantRowCells(map[string]any{
+			"privilege":    "SELECT",
+			"granted_on":   "",
+			"grant_on":     "TABLE",
+			"name":         "DB.SCH.<TABLE>",
+			"granted_to":   "",
+			"grant_to":     "ROLE",
+			"grantee_name": "ANALYST",
+			"grant_option": "false",
+		}),
+	}
+
+	grants := parseGrantRows(rows)
+	require.Len(t, grants, 1)
+	assert.Equal(t, "TABLE", grants[0].grantedOn, "grant_on stands in for granted_on")
+	assert.Equal(t, "ROLE", grants[0].grantedTo, "grant_to stands in for granted_to")
+}
+
+// An absent timestamp must stay null rather than become the zero time, which
+// would report the year 1 as the moment the grant was made.
+func TestParseGrantRowsMissingCreatedOn(t *testing.T) {
+	grants := parseGrantRows([]map[string]*any{
+		grantRowCells(map[string]any{"privilege": "USAGE", "granted_on": "DATABASE"}),
+	})
+	require.Len(t, grants, 1)
+	assert.Equal(t, llx.NilData, grants[0].createdOn)
+}
+
+func TestParseGrantRowsEmpty(t *testing.T) {
+	assert.Empty(t, parseGrantRows(nil))
+	assert.Empty(t, parseGrantRows([]map[string]*any{}))
+}

--- a/providers/snowflake/resources/policies_authentication.go
+++ b/providers/snowflake/resources/policies_authentication.go
@@ -9,10 +9,15 @@ import (
 	"sync"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/snowflake/connection"
 )
+
+// allSecurityIntegrations is the keyword an authentication policy reports in
+// place of a list when it permits every security integration in the account.
+const allSecurityIntegrations = "ALL"
 
 type mqlSnowflakeAuthenticationPolicyInternal struct {
 	descLock          sync.Mutex
@@ -167,19 +172,61 @@ func (r *mqlSnowflakeAuthenticationPolicy) securityIntegrations() ([]any, error)
 	return r.descSecIntegs, nil
 }
 
+// securityIntegrationRefs resolves the policy's security integrations.
+//
+// The property is not always a list of names. A policy that does not restrict
+// which integrations may be used reports the single value ALL, which is a
+// keyword standing for every integration in the account rather than the name of
+// one, and is the value every policy carries until it is narrowed. Resolving it
+// as a name finds nothing, so ALL expands to the account's integrations instead.
 func (r *mqlSnowflakeAuthenticationPolicy) securityIntegrationRefs() ([]any, error) {
 	if err := r.gatherDescribe(); err != nil {
 		return nil, err
 	}
-	out := []any{}
+
+	names := []string{}
 	for _, s := range r.descSecIntegs {
 		name, ok := s.(string)
 		if !ok || name == "" {
 			continue
 		}
+		if strings.EqualFold(name, allSecurityIntegrations) {
+			return r.allSecurityIntegrationRefs()
+		}
+		names = append(names, name)
+	}
+
+	out := []any{}
+	for _, name := range names {
 		res, err := NewResource(r.MqlRuntime, "snowflake.securityIntegration", map[string]*llx.RawData{
 			"name": llx.StringData(name),
 		})
+		if err != nil {
+			// An integration named by the policy but no longer present in the
+			// account is reported by dropping it, not by discarding every other
+			// integration the policy does resolve.
+			log.Warn().Err(err).Str("integration", name).
+				Msg("could not resolve security integration referenced by authentication policy")
+			continue
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// allSecurityIntegrationRefs returns every security integration in the account,
+// which is what a policy means when it reports ALL.
+func (r *mqlSnowflakeAuthenticationPolicy) allSecurityIntegrationRefs() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
+	integrations, err := conn.Client().SecurityIntegrations.Show(context.Background(),
+		sdk.NewShowSecurityIntegrationRequest())
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, 0, len(integrations))
+	for i := range integrations {
+		res, err := newMqlSnowflakeSecurityIntegration(r.MqlRuntime, integrations[i])
 		if err != nil {
 			return nil, err
 		}

--- a/providers/snowflake/resources/role_graph.go
+++ b/providers/snowflake/resources/role_graph.go
@@ -28,8 +28,8 @@ import (
 // round trips, which is the better deal against an API this chatty.
 type snowflakeGrantCache struct {
 	mu     sync.Mutex
-	toRole map[string]grantResult[sdk.Grant]
-	ofRole map[string]grantResult[sdk.Grant]
+	toRole map[string]grantResult[snowflakeGrant]
+	ofRole map[string]grantResult[snowflakeGrant]
 	toUser map[string]grantResult[userRoleGrant]
 }
 
@@ -89,8 +89,8 @@ func snowflakeAccount(runtime *plugin.Runtime) (*mqlSnowflakeAccount, error) {
 func (r *mqlSnowflakeAccount) grantCache() *snowflakeGrantCache {
 	r.grantCacheOnce.Do(func() {
 		r.cachedGrants = &snowflakeGrantCache{
-			toRole: map[string]grantResult[sdk.Grant]{},
-			ofRole: map[string]grantResult[sdk.Grant]{},
+			toRole: map[string]grantResult[snowflakeGrant]{},
+			ofRole: map[string]grantResult[snowflakeGrant]{},
 			toUser: map[string]grantResult[userRoleGrant]{},
 		}
 	})
@@ -100,27 +100,27 @@ func (r *mqlSnowflakeAccount) grantCache() *snowflakeGrantCache {
 // showGrants runs one memoized SHOW GRANTS statement. The caller picks the
 // bucket to memoize into, since the same name means different things in each
 // direction.
-func (r *mqlSnowflakeAccount) showGrants(bucket map[string]grantResult[sdk.Grant], name string, opts *sdk.ShowGrantOptions) ([]sdk.Grant, error) {
-	return memoGrants(r.grantCache(), bucket, name, func() ([]sdk.Grant, error) {
+func (r *mqlSnowflakeAccount) showGrants(bucket map[string]grantResult[snowflakeGrant], name string, statement string) ([]snowflakeGrant, error) {
+	return memoGrants(r.grantCache(), bucket, name, func() ([]snowflakeGrant, error) {
 		conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
-		return conn.Client().Grants.Show(context.Background(), opts)
+		return showGrantsRaw(conn, statement)
 	})
 }
 
 // grantsToRole returns SHOW GRANTS TO ROLE <name>: the privileges the role holds
 // directly, including the roles granted to it.
-func (r *mqlSnowflakeAccount) grantsToRole(name string) ([]sdk.Grant, error) {
-	return r.showGrants(r.grantCache().toRole, name, &sdk.ShowGrantOptions{
-		To: &sdk.ShowGrantsTo{Role: sdk.NewAccountObjectIdentifier(name)},
-	})
+func (r *mqlSnowflakeAccount) grantsToRole(name string) ([]snowflakeGrant, error) {
+	id := sdk.NewAccountObjectIdentifier(name)
+	return r.showGrants(r.grantCache().toRole, name,
+		"SHOW GRANTS TO ROLE "+id.FullyQualifiedName())
 }
 
 // grantsOfRole returns SHOW GRANTS OF ROLE <name>: the users and roles the role
 // has been granted to.
-func (r *mqlSnowflakeAccount) grantsOfRole(name string) ([]sdk.Grant, error) {
-	return r.showGrants(r.grantCache().ofRole, name, &sdk.ShowGrantOptions{
-		Of: &sdk.ShowGrantsOf{Role: sdk.NewAccountObjectIdentifier(name)},
-	})
+func (r *mqlSnowflakeAccount) grantsOfRole(name string) ([]snowflakeGrant, error) {
+	id := sdk.NewAccountObjectIdentifier(name)
+	return r.showGrants(r.grantCache().ofRole, name,
+		"SHOW GRANTS OF ROLE "+id.FullyQualifiedName())
 }
 
 // grantsToUser returns SHOW GRANTS TO USER <name>, the roles granted to the
@@ -245,14 +245,21 @@ func directChildRoles(account *mqlSnowflakeAccount, roleName string) ([]string, 
 	if err != nil {
 		return nil, err
 	}
+	return grantedRoleNames(grants), nil
+}
+
+// grantedRoleNames returns the roles named by grants of a role to something
+// else, in the order first seen. A grant on any other object type is not a step
+// in the hierarchy, and a role grant with no name cannot be followed.
+func grantedRoleNames(grants []snowflakeGrant) []string {
 	names := newNameSet()
 	for i := range grants {
-		if grants[i].GrantedOn != sdk.ObjectTypeRole || grants[i].Name == nil {
+		if grants[i].grantedOn != string(sdk.ObjectTypeRole) || grants[i].name == "" {
 			continue
 		}
-		names.add(grants[i].Name.Name())
+		names.add(identifierName(grants[i].name))
 	}
-	return names.order, nil
+	return names.order
 }
 
 // directParentRoles returns the roles that roleName has been granted to, which
@@ -262,14 +269,21 @@ func directParentRoles(account *mqlSnowflakeAccount, roleName string) ([]string,
 	if err != nil {
 		return nil, err
 	}
+	return granteeNames(grants, sdk.ObjectTypeRole), nil
+}
+
+// granteeNames returns the grantees of one kind named by a SHOW GRANTS OF
+// result, in the order first seen. The same statement reports both the users and
+// the roles holding a role, so the kind is what separates them.
+func granteeNames(grants []snowflakeGrant, grantedTo sdk.ObjectType) []string {
 	names := newNameSet()
 	for i := range grants {
-		if grants[i].GrantedTo != sdk.ObjectTypeRole {
+		if grants[i].grantedTo != string(grantedTo) {
 			continue
 		}
-		names.add(grants[i].GranteeName.Name())
+		names.add(grants[i].granteeName)
 	}
-	return names.order, nil
+	return names.order
 }
 
 // directRoleUsers returns the users roleName has been granted to directly.
@@ -278,14 +292,7 @@ func directRoleUsers(account *mqlSnowflakeAccount, roleName string) ([]string, e
 	if err != nil {
 		return nil, err
 	}
-	names := newNameSet()
-	for i := range grants {
-		if grants[i].GrantedTo != sdk.ObjectTypeUser {
-			continue
-		}
-		names.add(grants[i].GranteeName.Name())
-	}
-	return names.order, nil
+	return granteeNames(grants, sdk.ObjectTypeUser), nil
 }
 
 // directUserRoles returns the roles granted to userName directly.

--- a/providers/snowflake/resources/role_graph_test.go
+++ b/providers/snowflake/resources/role_graph_test.go
@@ -130,15 +130,15 @@ func TestCollectRoleHoldersWithNoHolders(t *testing.T) {
 
 func TestMemoGrants(t *testing.T) {
 	newCache := func() *snowflakeGrantCache {
-		return &snowflakeGrantCache{toRole: map[string]grantResult[sdk.Grant]{}}
+		return &snowflakeGrantCache{toRole: map[string]grantResult[snowflakeGrant]{}}
 	}
 
 	t.Run("a success is fetched once", func(t *testing.T) {
 		cache := newCache()
 		calls := 0
-		fetch := func() ([]sdk.Grant, error) {
+		fetch := func() ([]snowflakeGrant, error) {
 			calls++
-			return []sdk.Grant{{Privilege: "SELECT"}}, nil
+			return []snowflakeGrant{{privilege: "SELECT"}}, nil
 		}
 
 		for range 3 {
@@ -156,7 +156,7 @@ func TestMemoGrants(t *testing.T) {
 		cache := newCache()
 		boom := errors.New("insufficient privileges")
 		calls := 0
-		fetch := func() ([]sdk.Grant, error) {
+		fetch := func() ([]snowflakeGrant, error) {
 			calls++
 			return nil, boom
 		}
@@ -171,7 +171,7 @@ func TestMemoGrants(t *testing.T) {
 	t.Run("names are memoized independently", func(t *testing.T) {
 		cache := newCache()
 		calls := 0
-		fetch := func() ([]sdk.Grant, error) {
+		fetch := func() ([]snowflakeGrant, error) {
 			calls++
 			return nil, nil
 		}
@@ -229,34 +229,34 @@ func TestParseUserRoleGrants(t *testing.T) {
 }
 
 func TestSnowflakeGrantID(t *testing.T) {
-	grant := sdk.Grant{
-		Privilege:   "SELECT",
-		GrantedOn:   sdk.ObjectTypeTable,
-		Name:        sdk.NewSchemaObjectIdentifier("DB", "SCH", "T"),
-		GrantedTo:   sdk.ObjectTypeRole,
-		GranteeName: sdk.NewAccountObjectIdentifier("ANALYST"),
+	grant := snowflakeGrant{
+		privilege:   "SELECT",
+		grantedOn:   string(sdk.ObjectTypeTable),
+		name:        `"DB"."SCH"."T"`,
+		grantedTo:   string(sdk.ObjectTypeRole),
+		granteeName: "ANALYST",
 	}
 
 	assert.Equal(t, `ANALYST/ROLE/SELECT/TABLE/"DB"."SCH"."T"`, snowflakeGrantID(grant))
 
 	// The same privilege on a different object is a different grant.
 	other := grant
-	other.Name = sdk.NewSchemaObjectIdentifier("DB", "SCH", "OTHER")
+	other.name = `"DB"."SCH"."OTHER"`
 	assert.NotEqual(t, snowflakeGrantID(grant), snowflakeGrantID(other))
 
 	// The same object granted to a different role is a different grant.
 	otherGrantee := grant
-	otherGrantee.GranteeName = sdk.NewAccountObjectIdentifier("REPORTER")
+	otherGrantee.granteeName = "REPORTER"
 	assert.NotEqual(t, snowflakeGrantID(grant), snowflakeGrantID(otherGrantee))
 }
 
 func TestSnowflakeGrantIDWithoutName(t *testing.T) {
 	// Account-level privileges carry no object name.
-	grant := sdk.Grant{
-		Privilege:   "CREATE INTEGRATION",
-		GrantedOn:   sdk.ObjectTypeAccount,
-		GrantedTo:   sdk.ObjectTypeRole,
-		GranteeName: sdk.NewAccountObjectIdentifier("ANALYST"),
+	grant := snowflakeGrant{
+		privilege:   "CREATE INTEGRATION",
+		grantedOn:   string(sdk.ObjectTypeAccount),
+		grantedTo:   string(sdk.ObjectTypeRole),
+		granteeName: "ANALYST",
 	}
 
 	assert.Equal(t, "ANALYST/ROLE/CREATE INTEGRATION/ACCOUNT/", snowflakeGrantID(grant))


### PR DESCRIPTION
Two bugs found while validating the provider against a live Enterprise account,
both of which fire on every real Snowflake account.

## 1. `SHOW GRANTS` panics on a function with a table argument

`snowflake.user.effectiveRoles`, `snowflake.user.effectiveGrants` and the
`snowflake.role` equivalents returned a nil pointer dereference rather than data:

```
resource=snowflake.user, field=effectiveGrants
panic in provider GetData: runtime error: invalid memory address or nil pointer dereference
```

The SDK's row converter parses the `name` column into an object identifier, and
for a grant on a function whose argument is a table it reaches
`datatypes.(*TableDataType).ToLegacyDataTypeSql` on a nil receiver:

```
sdk.grantRow.convert                                        grants.go:260
  -> ParseSchemaObjectIdentifierWithArgumentsAndReturnType   identifier_parsers.go:194
    -> LegacyDataTypeFrom                                    data_types_deprecated.go:54
      -> (*TableDataType).ToLegacyDataTypeSql                table.go:43
```

Snowflake ships built-in data metric functions with exactly that shape
(`SNOWFLAKE.CORE.ACCEPTED_VALUES(TABLE(DATE))` and its siblings) and grants them
to `ACCOUNTADMIN` on every account, so any `SHOW GRANTS` whose result reaches
those rows takes the field down. A fresh trial account already carries 132 of
them.

`SHOW GRANTS` is now read directly with `QueryUnsafe`, the way this file already
read `SHOW GRANTS TO USER` for a sibling defect in the same SDK struct. All seven
call sites move over, not just the two that surfaced the panic, since a grant on
a function can appear in any of them.

Recovering from the panic would not have been a fix. It fires part way through
converting the result set, so what survives is an empty grant list, and a field
reporting no privileges where privileges exist is worse than one that errors:
MQL's three-valued logic passes an assertion over an empty list, so a
who-can-do-what policy would go green against a result that was never read.

The `name` field keeps the quoted form the SDK produced (`"DB"."SCH"."T"`), so
existing queries are unaffected.

## 2. An authentication policy's `ALL` is a keyword, not a name

```
securityIntegrationRefs: snowflake.securityIntegration "ALL" not found
```

`SECURITY_INTEGRATIONS` reports the single value `ALL` when a policy does not
restrict which integrations may be used, which is every policy until it is
narrowed. Resolving that as an integration name finds nothing, and the accessor
returned the error, discarding the whole list. `ALL` now expands to the account's
integrations, and an integration named by a policy but no longer present is
dropped with a warning rather than taking the other entries with it.

`securityIntegrations` still reports the raw `["ALL"]` unchanged.

## Tests

Unit tests cover the new parsing (`parseGrantRows`, including the
table-argument row, future grants whose type is in `grant_on`/`grant_to`, and an
absent timestamp staying null rather than becoming year 1) and the qualified-name
helpers. The grant filtering behind the hierarchy walk is extracted into
`grantedRoleNames`/`granteeNames` and tested directly. `jsonNativeValue` had ten
branches and no coverage; its accepted kinds are now pinned, since a dict value
that is not JSON-native is not caught at compile time. 28 test functions -> 45.

## Verification

Verified live against an Enterprise account: `effectiveRoles` returns the full
`ACCOUNTADMIN` closure, `effectiveGrants` returns 738 grants including the
`ACCEPTED_VALUES(TABLE(...))` rows that previously panicked, and
`securityIntegrationRefs` resolves the account's integrations from a policy
reporting `ALL`.
