### PR TITLE
🎉 snowflake-13.5.0

### DIFF
--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.4.4",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

Since snowflake-13.4.4:

- ✨ effective access and future grants (#9688)
- 🐛 read SHOW GRANTS directly so a table-argument function does not panic (#9788)

A minor bump rather than a patch, since #9688 adds the effective-access surface
(`effectiveRoles`, `effectiveGrants`, role hierarchy walks, future grants).
#9788 is what makes that surface return data: without it every one of those
fields panicked on any account carrying Snowflake's built-in data metric
functions, which is all of them.
