### PR TITLE
🐛 cloudflare: surface credential-scope failures, and log every degrade

### DIFF
--- a/providers/cloudflare/resources/helpers.go
+++ b/providers/cloudflare/resources/helpers.go
@@ -125,20 +125,63 @@ func cfTimeString(s string) *llx.RawData {
 	return llx.TimeDataPtr(&t)
 }
 
-// isUnavailable reports whether err is a 401, 403, or 404 from the Cloudflare
-// API. These statuses mean the resource isn't available to the calling token —
-// an unsupported plan, a missing permission, or an absent resource — which
-// callers treat as a null/empty result rather than a hard failure. v6 collapses
-// the v0 typed *AuthenticationError/*AuthorizationError/*NotFoundError into a
-// single *cloudflare.Error with a StatusCode.
+// credentialScopeCodes are the Cloudflare error codes that blame the caller's
+// credentials rather than the resource: the token is the wrong kind, or lacks the
+// permission outright. The API still answers 403, so status alone cannot tell
+// them apart from a plan-gated or unprovisioned product.
+//
+// They must not degrade to an empty result. cnspec scores on what the provider
+// returns, so an empty list makes `list.all(...)`/`none(...)` pass vacuously and
+// the account is reported compliant on data that was never read. An account with
+// five API tokens scanned by an account-scoped token hits exactly this: the
+// user-scoped token endpoint answers 9109, and all three api-token checks pass.
+// Surfacing the error makes those checks report as errored, which is visible.
+//
+// The deny-list stays deliberately narrow. Cloudflare overloads 403 for
+// plan-gated features too (bot management, leaked-credential checks, security.txt
+// on a free zone), and those carry the generic code 10000. A zone whose plan does
+// not include a feature genuinely has nothing to assess, so those keep degrading.
+var credentialScopeCodes = map[int64]struct{}{
+	// "Valid user-level authentication not found" — an account-scoped token used
+	// against a user-scoped endpoint such as /user/tokens.
+	9109: {},
+	// "Authorization Failure: The authentication credentials are not authorized
+	// to perform the request. Verify the credentials and try again."
+	10002: {},
+}
+
+// isUnavailable reports whether err may be degraded to a null/empty result
+// instead of failing the query.
+//
+// 401, 403, and 404 mean the resource isn't available to the calling token — an
+// unsupported plan, an unprovisioned product, or an absent resource — and empty
+// is the honest answer for those. The exception is a failure the API attributes
+// to the credentials themselves, which says nothing about whether the resource
+// exists and so must surface. See credentialScopeCodes.
+//
+// v6 collapses the v0 typed *AuthenticationError/*AuthorizationError/
+// *NotFoundError into a single *cloudflare.Error with a StatusCode.
 func isUnavailable(err error) bool {
 	var apiErr *cloudflare.Error
 	if !errors.As(err, &apiErr) {
 		return false
 	}
 	switch apiErr.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return !isCredentialScope(apiErr)
+	case http.StatusNotFound:
 		return true
+	}
+	return false
+}
+
+// isCredentialScope reports whether the API blamed the caller's credentials, as
+// opposed to the resource being absent or not enabled.
+func isCredentialScope(apiErr *cloudflare.Error) bool {
+	for _, e := range apiErr.Errors {
+		if _, ok := credentialScopeCodes[e.Code]; ok {
+			return true
+		}
 	}
 	return false
 }

--- a/providers/cloudflare/resources/helpers.go
+++ b/providers/cloudflare/resources/helpers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 )
@@ -168,11 +169,31 @@ func isUnavailable(err error) bool {
 	}
 	switch apiErr.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return !isCredentialScope(apiErr)
+		if isCredentialScope(apiErr) {
+			return false
+		}
 	case http.StatusNotFound:
-		return true
+	default:
+		return false
 	}
-	return false
+	logDegraded(apiErr)
+	return true
+}
+
+// logDegraded records that a response was turned into an empty/null result. The
+// scan still succeeds, so without this the difference between "nothing is
+// configured" and "nothing was readable" leaves no trace at all. Mirrors the
+// warning the AWS provider emits when it degrades an AccessDenied region
+// (providers/aws/resources/aws_acm.go).
+func logDegraded(apiErr *cloudflare.Error) {
+	ev := log.Warn().Int("status", apiErr.StatusCode)
+	if apiErr.Request != nil && apiErr.Request.URL != nil {
+		ev = ev.Str("path", apiErr.Request.URL.Path)
+	}
+	if len(apiErr.Errors) > 0 {
+		ev = ev.Int64("code", apiErr.Errors[0].Code).Str("error", apiErr.Errors[0].Message)
+	}
+	ev.Msg("cloudflare> no data returned; reporting an empty result for this resource")
 }
 
 // isCredentialScope reports whether the API blamed the caller's credentials, as

--- a/providers/cloudflare/resources/helpers_unit_test.go
+++ b/providers/cloudflare/resources/helpers_unit_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	cloudflarev6 "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/llx"
@@ -41,10 +42,43 @@ func TestParseRFC3339(t *testing.T) {
 	assert.Equal(t, time.July, got.Month())
 }
 
-func TestIsUnavailable(t *testing.T) {
-	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
-		assert.Truef(t, isUnavailable(&cloudflarev6.Error{StatusCode: code}), "status %d should be treated as unavailable", code)
+// apiErr builds a *cloudflare.Error carrying the per-error code/message the API
+// actually returns, which is what separates "product not enabled" from "this
+// token may not read it".
+func apiErr(status int, code int64, msg string) *cloudflarev6.Error {
+	return &cloudflarev6.Error{
+		StatusCode: status,
+		Errors:     []shared.ErrorData{{Code: code, Message: msg}},
 	}
+}
+
+func TestIsUnavailable(t *testing.T) {
+	// 401/403/404 still degrade by default: an absent resource, an unprovisioned
+	// product, or a plan-gated feature genuinely has nothing to assess. Codes and
+	// messages below are copied from live API responses.
+	unavailable := []*cloudflarev6.Error{
+		{StatusCode: http.StatusNotFound},
+		{StatusCode: http.StatusForbidden},
+		apiErr(http.StatusForbidden, 10042, "Please enable R2 through the Cloudflare Dashboard."),
+		apiErr(http.StatusForbidden, 9999, "access.api.error.not_enabled: Access is not enabled."),
+		apiErr(http.StatusUnauthorized, 1001, "Account ID is invalid or has not been initialized."),
+		// Plan-gated zone features answer with the generic code.
+		apiErr(http.StatusForbidden, 10000, "Forbidden"),
+	}
+	for _, e := range unavailable {
+		assert.Truef(t, isUnavailable(e), "should degrade: %+v", e.Errors)
+	}
+
+	// A failure the API blames on the credentials must NOT degrade. Swallowing
+	// these is what let an under-scoped token produce vacuous passes.
+	credentialScope := []*cloudflarev6.Error{
+		apiErr(http.StatusForbidden, 9109, "Valid user-level authentication not found"),
+		apiErr(http.StatusForbidden, 10002, "Authorization Failure: The authentication credentials are not authorized to perform the request."),
+	}
+	for _, e := range credentialScope {
+		assert.Falsef(t, isUnavailable(e), "credential-scope failure must surface: %+v", e.Errors)
+	}
+
 	for _, code := range []int{http.StatusInternalServerError, http.StatusTooManyRequests, http.StatusBadRequest} {
 		assert.Falsef(t, isUnavailable(&cloudflarev6.Error{StatusCode: code}), "status %d should NOT be unavailable", code)
 	}
@@ -62,6 +96,12 @@ func TestDegradedList(t *testing.T) {
 	got, err = degradedList(&cloudflarev6.Error{StatusCode: http.StatusNotFound})
 	require.NoError(t, err)
 	assert.Empty(t, got)
+
+	// A credential-scope failure propagates, so the check reports errored rather
+	// than passing vacuously over an empty list.
+	got, err = degradedList(apiErr(http.StatusForbidden, 9109, "Valid user-level authentication not found"))
+	assert.Nil(t, got)
+	require.Error(t, err)
 
 	// Any other error propagates unchanged (not swallowed).
 	sentinel := errors.New("rate limited")

--- a/providers/cloudflare/resources/helpers_unit_test.go
+++ b/providers/cloudflare/resources/helpers_unit_test.go
@@ -61,6 +61,8 @@ func TestIsUnavailable(t *testing.T) {
 		{StatusCode: http.StatusForbidden},
 		apiErr(http.StatusForbidden, 10042, "Please enable R2 through the Cloudflare Dashboard."),
 		apiErr(http.StatusForbidden, 9999, "access.api.error.not_enabled: Access is not enabled."),
+		// A 401 carrying a not-provisioned code: Zero Trust/Gateway on an account
+		// that never initialized it. This is why 401 is not blanket-surfaced.
 		apiErr(http.StatusUnauthorized, 1001, "Account ID is invalid or has not been initialized."),
 		// Plan-gated zone features answer with the generic code.
 		apiErr(http.StatusForbidden, 10000, "Forbidden"),
@@ -74,6 +76,12 @@ func TestIsUnavailable(t *testing.T) {
 	credentialScope := []*cloudflarev6.Error{
 		apiErr(http.StatusForbidden, 9109, "Valid user-level authentication not found"),
 		apiErr(http.StatusForbidden, 10002, "Authorization Failure: The authentication credentials are not authorized to perform the request."),
+		// The deny-list is keyed on the error code, not the status, so it applies
+		// to a 401 too. Cloudflare does populate Errors on 401 responses — the
+		// 1001 case above is an observed one — so this branch is live, not a
+		// no-op that happens to reproduce the old behavior.
+		apiErr(http.StatusUnauthorized, 9109, "Valid user-level authentication not found"),
+		apiErr(http.StatusUnauthorized, 10002, "Authorization Failure: The authentication credentials are not authorized to perform the request."),
 	}
 	for _, e := range credentialScope {
 		assert.Falsef(t, isUnavailable(e), "credential-scope failure must surface: %+v", e.Errors)


### PR DESCRIPTION
## Problem

`isUnavailable()` mapped every 401/403/404 to an empty result — 27 call sites across 14 files degrade through it. Two consequences:

1. **"This token may not read the resource" was indistinguishable from "the resource isn't there."** cnspec scores on what the provider returns, so an empty list makes `list.all(...)` / `list.none(...)` pass **vacuously**: the account is reported compliant on data that was never read. For a security scanner that is the worst failure mode, because it is invisible.
2. **Degrading left no trace.** The scan still succeeds, so after the fact there was no way to tell "nothing is configured" from "nothing was readable".

The first is not theoretical. Scanning a live account that owns **five API tokens** with an account-scoped token:

```
GET /user/tokens -> 403 {"code":9109,"message":"Valid user-level authentication not found"}
cloudflare.apiTokens -> []
```

…and all three api-token checks pass. In that scan **7 of 7 passing checks were vacuous passes** on unreadable data.

## Why not just stop swallowing 401/403

I tried that first and backed it out. Cloudflare overloads these statuses for cases that genuinely have nothing to assess:

- plan-gated zone features — bot management, leaked-credential checks, security.txt on a free zone — which answer with the generic code `10000`
- unprovisioned products — R2 `10042` "Please enable R2 through the Cloudflare Dashboard", Access `9999` `not_enabled`, Zero Trust `1001` "Account ID is invalid or has not been initialized"

Flipping the default turned 11 existing tests red and would flood legitimate free/pro-plan scans with errors. A zone whose plan lacks a feature really does have no config to evaluate, so empty is the honest answer there.

## Changes

**1. Exempt credential-scope failures from the degrade.** Only the codes where the API blames the *caller's credentials*, which say nothing about whether the resource exists:

| Code | Meaning |
|---|---|
| `9109` | "Valid user-level authentication not found" — account-scoped token against a user-scoped endpoint |
| `10002` | "Authorization Failure: The authentication credentials are not authorized to perform the request." |

Those propagate, so the check reports **errored** — visible and actionable — instead of passing. Every other 401/403/404 behaves exactly as before, and all 11 existing degrade tests pass unchanged.

The deny-list is keyed on the error code rather than the status, so it applies to 401 as well as 403. Cloudflare does populate `errors[]` on 401 responses (an account that never initialized Zero Trust answers `/gateway/locations` with 401 + code `1001`), so that branch is live rather than a no-op that reproduces the old behavior. Both sides of it are covered by tests.

**2. Warn whenever a response is degraded.** The AWS provider already warns when it drops an AccessDenied region (`providers/aws/resources/aws_acm.go`); do the same here. Logging from `isUnavailable` covers every call site at once, and the `*cloudflare.Error` carries the request, so the warning can name the path, status and API error code rather than just the resource:

```
! cloudflare> no data returned; reporting an empty result for this resource
    error="Please enable R2 through the Cloudflare Dashboard." code=10042
    path=/client/v4/accounts/681fdcbf.../r2/buckets status=403
```

No verdict changes from this part — it only makes a silent degrade traceable.

Codes and messages in the tests are copied from live API responses, not synthesized.

## Verification

Built and installed the provider, then scanned a live account with `mondoo-cloudflare-security`:

| | before | after |
|---|---|---|
| pass | 7 (all vacuous) | 2 |
| fail | 4 | 4 |
| error | 0 | **5** |

The five api-token checks moved from vacuous pass to error. `go test ./...` green for the cloudflare provider module.

## A bug the new logging exposed (not fixed here)

The two remaining passes are `r2-buckets-not-public`. An earlier draft of this description claimed they pass "correctly, because R2 is genuinely not enabled" — that reasoning was wrong, and the warning is what showed it:

```
cloudflare.r2.buckets          -> path=/client/v4/accounts//r2/buckets           status=404 code=7003
cloudflare.account.r2.buckets  -> path=/client/v4/accounts/681fdcbf.../r2/buckets status=403 code=10042
```

The top-level `cloudflare.r2` accessor interpolates an **empty account id**, so it 404s and degrades — the check passes because of a malformed URL, not because R2 is disabled. It reproduces when the account asset is targeted directly with `--platform-id`, so it is not merely the unidentified root asset. `cloudflare.workers` has the same shape (`/accounts//workers/scripts`).

That is a separate defect and is left alone here.

## Related

Pairs with mondoohq/cnspec#3236, which fixes a separate null-reading bug in the Cloudflare policy found in the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)