### PR TITLE
🐛 cloudflare: bind the account for bare r2 and workers resources

### DIFF
--- a/providers/cloudflare/resources/cloudflare.lr.go
+++ b/providers/cloudflare/resources/cloudflare.lr.go
@@ -158,7 +158,7 @@ func init() {
 			Create: createCloudflareStreamsVideo,
 		},
 		"cloudflare.r2": {
-			// to override args, implement: initCloudflareR2(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initCloudflareR2,
 			Create: createCloudflareR2,
 		},
 		"cloudflare.r2.bucket": {
@@ -166,7 +166,7 @@ func init() {
 			Create: createCloudflareR2Bucket,
 		},
 		"cloudflare.workers": {
-			// to override args, implement: initCloudflareWorkers(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initCloudflareWorkers,
 			Create: createCloudflareWorkers,
 		},
 		"cloudflare.workers.worker": {

--- a/providers/cloudflare/resources/helpers.go
+++ b/providers/cloudflare/resources/helpers.go
@@ -12,8 +12,37 @@ import (
 
 	cloudflare "github.com/cloudflare/cloudflare-go/v6"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 )
+
+// errNoAccountBound guards the account-scoped accessors. An empty account id
+// interpolates into a request against /accounts//… , which the API answers 404;
+// isUnavailable then degrades that to an empty list, so a malformed request
+// reads as "nothing configured" and any all()/none() check over it passes. Fail
+// instead, so the query reports why it could not run.
+var errNoAccountBound = errors.New("no Cloudflare account bound to this resource")
+
+// connectionAccountID returns the account this connection is scoped to, read
+// from the asset's platform id — the same source initCloudflareAccount uses to
+// resolve the singular cloudflare.account.
+//
+// Account-scoped resources reached bare (cloudflare.r2, cloudflare.workers) have
+// no parent to inherit an account from, so they resolve it through this.
+func connectionAccountID(runtime *plugin.Runtime) (string, error) {
+	conn, ok := runtime.Connection.(*connection.CloudflareConnection)
+	if !ok || conn.Asset() == nil {
+		return "", errors.New("no asset found")
+	}
+
+	for _, platformID := range conn.Asset().PlatformIds {
+		if accID := strings.TrimPrefix(platformID, connection.PlatformIdCloudflareAccount); accID != platformID {
+			return accID, nil
+		}
+	}
+	return "", errors.New("cannot determine the Cloudflare account for this asset; " +
+		"scan an account, or reach this resource through cloudflare.account")
+}
 
 // timeOrNil converts a cloudflare-go v6 time.Time value into MQL time data,
 // returning a null value when the timestamp is the zero value. The v6 SDK

--- a/providers/cloudflare/resources/r2.go
+++ b/providers/cloudflare/resources/r2.go
@@ -51,6 +51,27 @@ func newR2(runtime *plugin.Runtime, accountID string) (*mqlCloudflareR2, error) 
 	return r2, nil
 }
 
+// initCloudflareR2 binds the connection's account when `cloudflare.r2` is
+// reached bare, i.e. not through cloudflare.account.r2. R2 is account-scoped, so
+// without this the resource is built with an empty AccountID and every request
+// goes to /accounts//r2/buckets.
+func initCloudflareR2(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	accountID, err := connectionAccountID(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := newR2(runtime, accountID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
+}
+
 func (c *mqlCloudflareAccount) r2() (*mqlCloudflareR2, error) {
 	return newR2(c.MqlRuntime, c.Id.Data)
 }
@@ -90,6 +111,9 @@ func (c *mqlCloudflareR2) buckets() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
 	accountID := c.mqlCloudflareR2Internal.AccountID
+	if accountID == "" {
+		return nil, errNoAccountBound
+	}
 
 	var (
 		result  []any

--- a/providers/cloudflare/resources/r2_test.go
+++ b/providers/cloudflare/resources/r2_test.go
@@ -133,3 +133,22 @@ func TestR2BucketPublicAccess_forbidden(t *testing.T) {
 	assert.Equal(t, "", domain)
 	assert.Equal(t, plugin.StateIsNull|plugin.StateIsSet, bucket.PublicAccessDomain.State)
 }
+
+// TestR2BucketsUnboundAccountIssuesNoRequest is the regression guard for the
+// empty account id. `cloudflare.r2` reached bare (not via cloudflare.account.r2)
+// was built with no AccountID, so buckets() requested /accounts//r2/buckets. The
+// API answers that 404, isUnavailable degrades a 404 to an empty list, and the
+// malformed request read as "no buckets" — so r2-buckets-not-public passed on an
+// account whose buckets were never listed. Fail before issuing the request.
+func TestR2BucketsUnboundAccountIssuesNoRequest(t *testing.T) {
+	env := setupTestEnv(t)
+	env.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no request may be issued without an account: %s", r.URL.Path)
+	})
+
+	r2 := &mqlCloudflareR2{MqlRuntime: env.Runtime} // no AccountID bound
+
+	res, err := r2.buckets()
+	require.ErrorIs(t, err, errNoAccountBound)
+	assert.Nil(t, res, "must not degrade to an empty list, which would pass vacuously")
+}

--- a/providers/cloudflare/resources/workers.go
+++ b/providers/cloudflare/resources/workers.go
@@ -29,6 +29,27 @@ func newWorkers(runtime *plugin.Runtime, accountID string) (*mqlCloudflareWorker
 	return workers, nil
 }
 
+// initCloudflareWorkers binds the connection's account when `cloudflare.workers`
+// is reached bare, i.e. not through cloudflare.account.workers. Workers are
+// account-scoped, so without this the resource is built with an empty AccountID
+// and every request goes to /accounts//workers/scripts.
+func initCloudflareWorkers(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	accountID, err := connectionAccountID(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := newWorkers(runtime, accountID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
+}
+
 func (c *mqlCloudflareAccount) workers() (*mqlCloudflareWorkers, error) {
 	return newWorkers(c.MqlRuntime, c.Id.Data)
 }
@@ -97,6 +118,10 @@ func (c *mqlCloudflareWorkers) fetchWorkerList() ([]workerScript, error) {
 }
 
 func (c *mqlCloudflareWorkers) workers() ([]any, error) {
+	if c.mqlCloudflareWorkersInternal.AccountID == "" {
+		return nil, errNoAccountBound
+	}
+
 	workerList, err := c.fetchWorkerList()
 	if err != nil {
 		return nil, err
@@ -136,6 +161,10 @@ func (c *mqlCloudflareWorkers) workers() ([]any, error) {
 // single paged call covers it; preview/historical deployments are out of scope
 // here. Degrades to empty when Pages isn't available to the token.
 func (c *mqlCloudflareWorkers) pages() ([]any, error) {
+	if c.mqlCloudflareWorkersInternal.AccountID == "" {
+		return nil, errNoAccountBound
+	}
+
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
 	projects, err := cfGetPaged[pagesProject](conn, fmt.Sprintf("accounts/%s/pages/projects", c.AccountID))
@@ -185,6 +214,10 @@ func (c *mqlCloudflarePagesEnvVar) id() (string, error) {
 // account. We only surface name + type — Cloudflare's API never returns the
 // secret value, and we explicitly avoid fields that could expose plaintext.
 func (c *mqlCloudflareWorkers) secrets() ([]any, error) {
+	if c.mqlCloudflareWorkersInternal.AccountID == "" {
+		return nil, errNoAccountBound
+	}
+
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
 	workerList, err := c.fetchWorkerList()
@@ -263,6 +296,10 @@ type pagesProject struct {
 // project. We expose only `{name, type, environment}` and never `value` so
 // secret bindings cannot leak even if the API were to return one.
 func (c *mqlCloudflareWorkers) pageEnvVars() ([]any, error) {
+	if c.mqlCloudflareWorkersInternal.AccountID == "" {
+		return nil, errNoAccountBound
+	}
+
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
 	projects, err := cfGetPaged[pagesProject](conn, fmt.Sprintf("accounts/%s/pages/projects", c.mqlCloudflareWorkersInternal.AccountID))

--- a/providers/cloudflare/resources/workers_test.go
+++ b/providers/cloudflare/resources/workers_test.go
@@ -91,3 +91,32 @@ func TestWorkersPages(t *testing.T) {
 	assert.Equal(t, "https://marketing.pages.dev", p.Url.Data)
 	assert.Equal(t, "main", p.ProductionBranch.Data)
 }
+
+// TestWorkersUnboundAccountIssuesNoRequest is the regression guard for the empty
+// account id. `cloudflare.workers` reached bare (not via
+// cloudflare.account.workers) was built with no AccountID, so every accessor
+// requested /accounts//workers/scripts and friends. Those 404, and a 404
+// degrades to an empty list, so a malformed request read as "nothing deployed".
+// Fail before issuing the request.
+func TestWorkersUnboundAccountIssuesNoRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*mqlCloudflareWorkers) ([]any, error)
+	}{
+		{"workers", (*mqlCloudflareWorkers).workers},
+		{"pages", (*mqlCloudflareWorkers).pages},
+		{"secrets", (*mqlCloudflareWorkers).secrets},
+		{"pageEnvVars", (*mqlCloudflareWorkers).pageEnvVars},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTestEnv(t)
+			env.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("no request may be issued without an account: %s", r.URL.Path)
+			})
+
+			res, err := tc.call(&mqlCloudflareWorkers{MqlRuntime: env.Runtime})
+			require.ErrorIs(t, err, errNoAccountBound)
+			assert.Nil(t, res, "must not degrade to an empty list, which would pass vacuously")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`cloudflare.r2` and `cloudflare.workers` are `private`, account-scoped resources. Being private, they are also reachable **bare** — `cloudflare.r2.buckets` — not only through `cloudflare.account.r2`. Nothing bound an account on that path, so the resource was constructed with an empty `AccountID` and every accessor requested a URL with a hole in it:

```
cloudflare.r2.buckets          -> /client/v4/accounts//r2/buckets            404 code 7003
cloudflare.account.r2.buckets  -> /client/v4/accounts/681fdcbf.../r2/buckets 403 code 10042
```

The API answers the malformed path 404 ("Could not route to …, perhaps your object identifier is invalid?"), and `isUnavailable` degrades a 404 to an empty list. So a broken request read as **"nothing configured"**.

The consequence is a silently passing security check. `mondoo-cloudflare-security-r2-buckets-not-public` is:

```coffee
cloudflare.r2.buckets.all(publicAccessEnabled == false)
```

`[].all(...)` is vacuously true, so that check passed on every account without ever listing a bucket. `cloudflare.workers` has the same shape across `workers()`, `pages()`, `secrets()` and `pageEnvVars()` (`/accounts//workers/scripts`, `/accounts//pages/projects`).

This is not the unidentified root asset — it reproduces when the account asset is targeted directly with `--platform-id`.

## Fix

Two layers:

1. **Bind the account.** `initCloudflareR2` / `initCloudflareWorkers` resolve the account from the asset's platform id — the same source `initCloudflareAccount` already uses for the singular `cloudflare.account`. The LR init hooks were already generated for both resources; they just had no implementation.
2. **Refuse to build a request without one.** The account-scoped accessors now fail with `errNoAccountBound` rather than interpolating `""`. Degrading a malformed request to an empty list is what turned this into a silent pass, so the guard fails loudly instead.

An asset that genuinely is not an account now says so:

```
cannot determine the Cloudflare account for this asset;
scan an account, or reach this resource through cloudflare.account
```

## Verification

Regression tests register a catch-all handler that fails if *any* request is issued, then call each accessor on an unbound resource and assert `errNoAccountBound` with a nil result. Confirmed they fail without the guards:

```
--- FAIL: TestR2BucketsUnboundAccountIssuesNoRequest
    r2_test.go:146: no request may be issued without an account: /accounts/r2/buckets
```

Against a live account, `cloudflare.r2.buckets` now reaches `/accounts/681fdcbf.../r2/buckets` and gets the genuine `403 10042 "Please enable R2 through the Cloudflare Dashboard"`, and `cloudflare.workers.workers` returns the real (empty) script list rather than a degraded 404. `go test ./...` green for the cloudflare provider module.

## Related

Found while verifying mondoohq/mql#9790, whose degrade-logging is what exposed the malformed URL. The two are independent and can merge in either order; both touch `helpers.go`, so the second to land may need a trivial import merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)