### PR TITLE
🎉 cloudflare-13.7.0

### DIFF
--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.6.7",
+	Version:         "13.7.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor release of the cloudflare provider: `13.6.7` → `13.7.0`.

Minor rather than patch because #9627 adds new schema surface (new resources and fields), not just fixes.

### Changes since 13.6.7

- ✨ #9627 — add client certs, origin mTLS, Turnstile, and zone security toggles
- 🐛 #9790 — surface credential-scope failures, and log every degrade
- 🐛 #9791 — bind the account for bare r2 and workers resources
- 🧹 #9580, #9601, #9619, #9651 — dependency updates
