### PR TITLE
🐛 github: collect every Dependabot alert, not just the first page

### DIFF
--- a/providers/github/resources/github_dependabot_test.go
+++ b/providers/github/resources/github_dependabot_test.go
@@ -1,0 +1,116 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// alertPage renders a JSON array of dependabot alerts with the given numbers.
+func alertPage(numbers ...int) string {
+	entries := make([]string, 0, len(numbers))
+	for _, n := range numbers {
+		entries = append(entries, fmt.Sprintf(`{"number": %d, "state": "open"}`, n))
+	}
+	return "[" + strings.Join(entries, ",") + "]"
+}
+
+func seq(from, to int) []int {
+	out := []int{}
+	for i := from; i <= to; i++ {
+		out = append(out, i)
+	}
+	return out
+}
+
+// The dependabot alerts endpoint is cursor paginated: its Link header advertises
+// the next page as `after=<cursor>`, never `page=N`. A walk driven by the
+// page-based NextPage therefore stops after the first page and silently drops
+// every alert beyond it.
+func TestListDependabotAlertsRawFollowsCursorPagination(t *testing.T) {
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v3/repos/o/r/dependabot/alerts", r.URL.Path)
+		after := r.URL.Query().Get("after")
+		seen = append(seen, after)
+		w.Header().Set("Content-Type", "application/json")
+		switch after {
+		case "":
+			w.Header().Set("Link", fmt.Sprintf(
+				`<%s/api/v3/repos/o/r/dependabot/alerts?per_page=100&after=CUR2>; rel="next"`, serverURL(r)))
+			fmt.Fprint(w, alertPage(seq(1, 100)...))
+		case "CUR2":
+			w.Header().Set("Link", fmt.Sprintf(
+				`<%s/api/v3/repos/o/r/dependabot/alerts?per_page=100&after=CUR3>; rel="next"`, serverURL(r)))
+			fmt.Fprint(w, alertPage(seq(101, 200)...))
+		case "CUR3":
+			fmt.Fprint(w, alertPage(seq(201, 231)...))
+		default:
+			t.Fatalf("unexpected cursor %q", after)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGithubClient(t, server)
+	alerts, err := listDependabotAlertsRaw(context.Background(), client, "o", "r")
+	require.NoError(t, err)
+
+	require.Len(t, alerts, 231, "every page must be collected, not just the first")
+	assert.Equal(t, 1, alerts[0].GetNumber())
+	assert.Equal(t, 231, alerts[230].GetNumber())
+	assert.Equal(t, []string{"", "CUR2", "CUR3"}, seen)
+}
+
+// A server that keeps handing back the same cursor must not spin forever.
+func TestListDependabotAlertsRawStopsOnRepeatedCursor(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", fmt.Sprintf(
+			`<%s/api/v3/repos/o/r/dependabot/alerts?per_page=100&after=STUCK>; rel="next"`, serverURL(r)))
+		fmt.Fprint(w, alertPage(1))
+	}))
+	defer server.Close()
+
+	client := newTestGithubClient(t, server)
+	alerts, err := listDependabotAlertsRaw(context.Background(), client, "o", "r")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, calls, "a repeated cursor must end the walk instead of looping")
+	assert.Len(t, alerts, 2)
+}
+
+// A repository with fewer alerts than one page still returns them all, and does
+// not issue a second request.
+func TestListDependabotAlertsRawSinglePage(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, alertPage(seq(1, 41)...))
+	}))
+	defer server.Close()
+
+	client := newTestGithubClient(t, server)
+	alerts, err := listDependabotAlertsRaw(context.Background(), client, "o", "r")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls)
+	assert.Len(t, alerts, 41)
+}
+
+func serverURL(r *http.Request) string {
+	u := url.URL{Scheme: "http", Host: r.Host}
+	return u.String()
+}

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -2091,6 +2092,39 @@ func (g *mqlGithubDependabotAlert) id() (string, error) {
 	return "github.dependabotAlert/" + strconv.FormatInt(g.Number.Data, 10), nil
 }
 
+// listDependabotAlertsRaw collects every Dependabot alert for a repository.
+//
+// The endpoint paginates by cursor, not by page: its Link header advertises the
+// next page as `after=<cursor>`, so the page-based NextPage stays zero and a
+// walk driven by it stops after the first page, silently reporting at most
+// paginationPerPage alerts for a repository that has more.
+func listDependabotAlertsRaw(ctx context.Context, client *github.Client, ownerLogin, repoName string) ([]*github.DependabotAlert, error) {
+	listOpts := &github.ListAlertsOptions{
+		ListCursorOptions: github.ListCursorOptions{PerPage: paginationPerPage},
+	}
+
+	var allAlerts []*github.DependabotAlert
+	seenCursors := map[string]struct{}{}
+	for {
+		alerts, resp, err := client.Dependabot.ListRepoAlerts(ctx, ownerLogin, repoName, listOpts)
+		if err != nil {
+			return nil, err
+		}
+		allAlerts = append(allAlerts, alerts...)
+		if resp.After == "" {
+			break
+		}
+		// A server that keeps handing back a cursor we already followed would
+		// otherwise loop forever, re-collecting the same page.
+		if _, ok := seenCursors[resp.After]; ok {
+			break
+		}
+		seenCursors[resp.After] = struct{}{}
+		listOpts.ListCursorOptions.After = resp.After
+	}
+	return allAlerts, nil
+}
+
 func (g *mqlGithubRepository) dependabotAlerts() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 	ownerLogin, repoName, err := repoOwnerAndName(g)
@@ -2098,29 +2132,17 @@ func (g *mqlGithubRepository) dependabotAlerts() ([]any, error) {
 		return nil, err
 	}
 
-	listOpts := &github.ListAlertsOptions{
-		ListOptions: github.ListOptions{PerPage: paginationPerPage},
-	}
-
-	var allAlerts []*github.DependabotAlert
-	for {
-		alerts, resp, err := conn.Client().Dependabot.ListRepoAlerts(conn.Context(), ownerLogin, repoName, listOpts)
-		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				return nil, nil
-			}
-			// Dependabot alerts may not be enabled or accessible
-			if strings.Contains(err.Error(), "403") {
-				log.Debug().Msg("Dependabot alerts are not accessible for this repository")
-				return nil, nil
-			}
-			return nil, err
+	allAlerts, err := listDependabotAlertsRaw(conn.Context(), conn.Client(), ownerLogin, repoName)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil, nil
 		}
-		allAlerts = append(allAlerts, alerts...)
-		if resp.NextPage == 0 {
-			break
+		// Dependabot alerts may not be enabled or accessible
+		if strings.Contains(err.Error(), "403") {
+			log.Debug().Msg("Dependabot alerts are not accessible for this repository")
+			return nil, nil
 		}
-		listOpts.ListOptions.Page = resp.NextPage
+		return nil, err
 	}
 
 	res := []any{}


### PR DESCRIPTION
## Problem

`github.repository.dependabotAlerts` returns at most **100** alerts for any repository. On `mondoohq/server` it reported **100 of 331** — silently dropping 231 (70%) of the alerts.

A control asserting "no critical Dependabot alerts" therefore **passes** on a repository that has them, as long as they sit past the first page.

```
github.repository(name: "server") { dependabotAlerts.length }           ->  100
manual cursor walk of the API                                           ->  331
github.repository(name: "server").dependabotAlerts.where(number == 47)  ->  []
GET /repos/mondoohq/server/dependabot/alerts/47                         ->  200, state "fixed"
```

## Cause

The Dependabot alerts endpoint paginates by **cursor**, not by page. Its `Link` header advertises the next page as `after=<cursor>`:

```
Link: <.../dependabot/alerts?per_page=100&after=Y3Vyc29yOnYyOpPP...>; rel="next"
```

go-github only populates `Response.NextPage` from a `page=` link, so it stayed `0` and the `if resp.NextPage == 0 { break }` loop exited after a single request.

The bug is invisible below 100 alerts (`mondoohq/cnspec` has 41 and was always correct), which is why it survived.

## Fix

Drive the walk with `ListCursorOptions` + `Response.After` — the pattern the organization audit log lister already uses (`github_audit.go`). `ListAlertsOptions` embeds both option structs, so this needs no SDK change. A repeated cursor ends the walk so a misbehaving response cannot loop forever.

The lister is extracted as `listDependabotAlertsRaw` to make the pagination walk testable on its own, matching the existing `listRunnersRaw` pattern.

## Tests

New `github_dependabot_test.go`, driven by `httptest`:

- **`...FollowsCursorPagination`** — three cursor-linked pages (100 + 100 + 31); asserts all 231 alerts are collected and the cursors are followed in order. This test **fails on `main`** with `should have 231 item(s), but has 100` — the same signature as the production bug.
- **`...StopsOnRepeatedCursor`** — a server that always returns the same cursor terminates after 2 requests instead of looping.
- **`...SinglePage`** — a 41-alert repository returns all 41 in exactly one request (no regression, no extra call).

## Verification

Against live GitHub with the patched provider:

| query | before | after |
|---|---|---|
| `mondoohq/server` `dependabotAlerts.length` | 100 | **331** (matches API) |
| `mondoohq/server` alert #47 | `[]` | resolves, correct repo + state `fixed` |
| `mondoohq/cnspec` `dependabotAlerts.length` | 41 | 41 (unchanged) |

`go test ./...` passes for the whole provider.

## Notes

`codeScanningAlerts` is genuinely page-based and was verified correct against live data (463 alerts) — it is not affected. `secretScanningAlerts` uses the same page-based shape; I could not exercise it against a repository with secret-scanning alerts enabled, so it is left alone here.
