### PR TITLE
🐛 github: stop an archived repository from failing the whole repo listing

### DIFF
--- a/providers/github/resources/github_private_reporting_test.go
+++ b/providers/github/resources/github_private_reporting_test.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GitHub answers the private-vulnerability-reporting endpoint with 422 for any
+// repository that is private or archived, which is a normal state rather than a
+// failure. Letting that error escape fails the whole repository listing the
+// field was read from, so a single archived repository takes out every other
+// repository in the query.
+func TestPrivateVulnerabilityReportingEnabledRaw(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		status    int
+		body      string
+		want      bool
+		wantError bool
+	}{
+		{name: "enabled", status: http.StatusOK, body: `{"enabled": true}`, want: true},
+		{name: "disabled", status: http.StatusOK, body: `{"enabled": false}`, want: false},
+		{
+			name:   "private or archived repository",
+			status: http.StatusUnprocessableEntity,
+			body:   `{"message": "Repository must be public and not archived"}`,
+			want:   false,
+		},
+		{
+			name:   "not found",
+			status: http.StatusNotFound,
+			body:   `{"message": "Not Found"}`,
+			want:   false,
+		},
+		{
+			name:   "permission denied",
+			status: http.StatusForbidden,
+			body:   `{"message": "Resource not accessible by personal access token"}`,
+			want:   false,
+		},
+		{
+			name:      "server error propagates",
+			status:    http.StatusInternalServerError,
+			body:      `{"message": "boom"}`,
+			want:      false,
+			wantError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/v3/repos/o/r/private-vulnerability-reporting", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, tc.body)
+			}))
+			defer server.Close()
+
+			got, err := privateVulnerabilityReportingEnabledRaw(
+				context.Background(), newTestGithubClient(t, server), "o", "r")
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -2618,16 +2619,20 @@ func (g *mqlGithubRepository) vulnerabilityAlertsEnabled() (bool, error) {
 	return enabled, nil
 }
 
-func (g *mqlGithubRepository) privateVulnerabilityReportingEnabled() (bool, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	ownerLogin, repoName, err := repoOwnerAndName(g)
-	if err != nil {
-		return false, err
-	}
-	enabled, _, err := conn.Client().Repositories.IsPrivateReportingEnabled(conn.Context(), ownerLogin, repoName)
+func privateVulnerabilityReportingEnabledRaw(ctx context.Context, client *github.Client, ownerLogin, repoName string) (bool, error) {
+	enabled, _, err := client.Repositories.IsPrivateReportingEnabled(ctx, ownerLogin, repoName)
 	if err != nil {
 		switch githubResponseStatus(err) {
 		case http.StatusNotFound:
+			return false, nil
+		case http.StatusUnprocessableEntity:
+			// GitHub answers 422 "Repository must be public and not archived"
+			// for every private or archived repository. The setting genuinely
+			// cannot be on for those, so this is a normal answer, not a
+			// failure: letting it escape fails the entire repository listing
+			// this field was read from.
+			log.Debug().Str("owner", ownerLogin).Str("repo", repoName).
+				Msg("private vulnerability reporting is unavailable for this repository (private or archived)")
 			return false, nil
 		case http.StatusForbidden:
 			log.Warn().Err(err).Str("owner", ownerLogin).Str("repo", repoName).
@@ -2637,4 +2642,13 @@ func (g *mqlGithubRepository) privateVulnerabilityReportingEnabled() (bool, erro
 		return false, err
 	}
 	return enabled, nil
+}
+
+func (g *mqlGithubRepository) privateVulnerabilityReportingEnabled() (bool, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return false, err
+	}
+	return privateVulnerabilityReportingEnabledRaw(conn.Context(), conn.Client(), ownerLogin, repoName)
 }


### PR DESCRIPTION
## Problem

Reading `privateVulnerabilityReportingEnabled` on a **private or archived** repository fails the entire query it belongs to:

```
github.user.repositories { name privateVulnerabilityReportingEnabled }

1 error occurred:
  * GET /repos/tas50/bad_k8s_test/private-vulnerability-reporting:
    422 Repository must be public and not archived
```

One archived repository was enough to lose **all 233 repositories** in that listing. The same happened on `mondoohq`, where 6 archived repositories took out `github.organization.teams.repositories` entirely.

## Cause

GitHub answers `GET /repos/{owner}/{repo}/private-vulnerability-reporting` with **422** for every private or archived repository — the setting cannot be enabled for those, so it is a normal answer rather than a failure.

`privateVulnerabilityReportingEnabled()` handled only 404 and 403:

```go
switch githubResponseStatus(err) {
case http.StatusNotFound:
    return false, nil
case http.StatusForbidden:
    ...
    return false, nil
}
return false, err   // <- 422 lands here
```

So the error escaped and propagated up through the enclosing repository list.

## Fix

Handle `http.StatusUnprocessableEntity` alongside the other two and report the setting as disabled, which is accurate for a repository that cannot have it enabled.

The API call is extracted as `privateVulnerabilityReportingEnabledRaw` so the status handling is testable without a live connection.

## Tests

New `github_private_reporting_test.go` — a table test over the endpoint's real answers, driven by `httptest`:

| case | status | expected |
|---|---|---|
| enabled | 200 `{"enabled": true}` | `true`, no error |
| disabled | 200 `{"enabled": false}` | `false`, no error |
| **private or archived** | **422** | **`false`, no error** |
| not found | 404 | `false`, no error |
| permission denied | 403 | `false`, no error |
| server error | 500 | error propagates |

Only the 422 row fails on `main`, with the exact production message — the other five pass, so the test isolates precisely this change and still pins the surrounding behavior (including that a 500 must *not* be swallowed).

## Verification

Against live GitHub with the patched provider:

- `github.user.repositories { name archived private privateVulnerabilityReportingEnabled }` over all **233** repositories: completes with **zero errors** (previously: no data at all, just the 422). 2 repositories report the setting enabled, 464 report disabled.
- `tas50/bad_k8s_test` (archived) now returns `privateVulnerabilityReportingEnabled: false` instead of erroring.

`go test ./...` passes for the whole provider.
