### PR TITLE
🐛 github: stop reporting pull requests as issues

### DIFF
--- a/providers/github/resources/github_issues_test.go
+++ b/providers/github/resources/github_issues_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GitHub's issues endpoint returns pull requests alongside issues: every pull
+// request is an issue, and only the `pull_request` member distinguishes them.
+// Leaving them in makes `openIssues` a mix of both, double counting work that
+// `openMergeRequests` already reports.
+func TestListIssuesRawExcludesPullRequests(t *testing.T) {
+	body := `[
+		{"number": 1, "title": "a real issue", "state": "open"},
+		{"number": 2, "title": "a pull request", "state": "open",
+		 "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/2"}},
+		{"number": 3, "title": "another issue", "state": "open"},
+		{"number": 4, "title": "another pull request", "state": "open",
+		 "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/4"}}
+	]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v3/repos/o/r/issues", r.URL.Path)
+		assert.Equal(t, "open", r.URL.Query().Get("state"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	defer server.Close()
+
+	issues, err := listIssuesRaw(context.Background(), newTestGithubClient(t, server), "o", "r", "open")
+	require.NoError(t, err)
+
+	numbers := []int{}
+	for _, i := range issues {
+		numbers = append(numbers, i.GetNumber())
+	}
+	assert.Equal(t, []int{1, 3}, numbers, "pull requests must not be reported as issues")
+}
+
+// The state filter is passed through and pagination still collects every page.
+func TestListIssuesRawPaginatesClosedIssues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "closed", r.URL.Query().Get("state"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			w.Header().Set("Link", fmt.Sprintf(
+				`<http://%s/api/v3/repos/o/r/issues?state=closed&page=2>; rel="next"`, r.Host))
+			fmt.Fprint(w, `[{"number": 10, "state": "closed"},
+			                {"number": 11, "state": "closed",
+			                 "pull_request": {"url": "https://api.github.com/repos/o/r/pulls/11"}}]`)
+		case "2":
+			fmt.Fprint(w, `[{"number": 12, "state": "closed"}]`)
+		default:
+			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+		}
+	}))
+	defer server.Close()
+
+	issues, err := listIssuesRaw(context.Background(), newTestGithubClient(t, server), "o", "r", "closed")
+	require.NoError(t, err)
+
+	numbers := []int{}
+	for _, i := range issues {
+		numbers = append(numbers, i.GetNumber())
+	}
+	assert.Equal(t, []int{10, 12}, numbers)
+}
+
+// A repository whose issues endpoint returns only pull requests reports no
+// issues rather than reporting the pull requests.
+func TestListIssuesRawAllPullRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"number": 5, "pull_request": {"url": "u"}}]`)
+	}))
+	defer server.Close()
+
+	issues, err := listIssuesRaw(context.Background(), newTestGithubClient(t, server), "o", "r", "open")
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -1773,13 +1774,7 @@ func (g *mqlGithubRepository) closedIssues() ([]any, error) {
 	return g.getIssues("closed")
 }
 
-func (g *mqlGithubRepository) getIssues(state string) ([]any, error) {
-	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	ownerLogin, repoName, err := repoOwnerAndName(g)
-	if err != nil {
-		return nil, err
-	}
-
+func listIssuesRaw(ctx context.Context, client *github.Client, ownerLogin, repoName, state string) ([]*github.Issue, error) {
 	listOpts := &github.IssueListByRepoOptions{
 		State: state,
 		ListOptions: github.ListOptions{
@@ -1788,19 +1783,42 @@ func (g *mqlGithubRepository) getIssues(state string) ([]any, error) {
 	}
 	var allIssues []*github.Issue
 	for {
-		issues, resp, err := conn.Client().Issues.ListByRepo(conn.Context(), ownerLogin, repoName, listOpts)
+		issues, resp, err := client.Issues.ListByRepo(ctx, ownerLogin, repoName, listOpts)
 		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				return nil, nil
-			}
-			log.Error().Err(err).Msg("unable to get issues")
 			return nil, err
 		}
-		allIssues = append(allIssues, issues...)
+		for _, issue := range issues {
+			// Every pull request is also an issue, and this endpoint returns
+			// both. Only the `pull_request` member tells them apart. Pull
+			// requests are reported by openMergeRequests/closedMergeRequests,
+			// so keeping them here would count the same work twice.
+			if issue.IsPullRequest() {
+				continue
+			}
+			allIssues = append(allIssues, issue)
+		}
 		if resp.NextPage == 0 {
 			break
 		}
 		listOpts.ListOptions.Page = resp.NextPage
+	}
+	return allIssues, nil
+}
+
+func (g *mqlGithubRepository) getIssues(state string) ([]any, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
+	}
+
+	allIssues, err := listIssuesRaw(conn.Context(), conn.Client(), ownerLogin, repoName, state)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil, nil
+		}
+		log.Error().Err(err).Msg("unable to get issues")
+		return nil, err
 	}
 
 	res := []any{}


### PR DESCRIPTION
## Problem

`github.repository.openIssues` counts pull requests as issues.

On `mondoohq/cnspec`:

```
github.repository.openIssues.length         ->  88
github.repository.openMergeRequests.length  ->  43
```

The repository actually has **45** open issues. The extra 43 are the open pull requests — already reported by `openMergeRequests`. 45 + 43 = 88.

Confirmed against the search API:

```
repo:mondoohq/cnspec is:issue is:open  ->  45
repo:mondoohq/cnspec is:pr    is:open  ->  43
```

Any policy that counts or filters issues counts the same work twice, and each pull request also materialises as a `github.issue` resource with pull-request-shaped data.

## Cause

GitHub's `GET /repos/{owner}/{repo}/issues` returns pull requests alongside issues — every pull request *is* an issue in the API's data model, and only the `pull_request` member distinguishes them. `getIssues` appended the whole response without checking, so both `openIssues` and `closedIssues` were a mix.

## Fix

Skip entries where `issue.IsPullRequest()` is true. The listing is extracted as `listIssuesRaw` so the filtering and pagination are testable without a live connection.

## Tests

New `github_issues_test.go`, driven by `httptest`:

- **`...ExcludesPullRequests`** — a page mixing 2 issues and 2 pull requests returns only the issues (`[1, 3]`).
- **`...PaginatesClosedIssues`** — the `state` filter is passed through, both pages are collected, and the pull request on page 1 is dropped while the issue on page 2 is kept (`[10, 12]`) — so filtering does not break the pagination walk.
- **`...AllPullRequests`** — a repository whose issues endpoint returns only pull requests reports no issues at all, rather than reporting the pull requests.

All three fail on `main`.

## Verification

Against live GitHub with the patched provider:

| query | before | after |
|---|---|---|
| `mondoohq/cnspec` `openIssues.length` | 88 | **45** (matches `is:issue is:open`) |
| `mondoohq/cnspec` `openMergeRequests.length` | 43 | 43 (unchanged) |

`go test ./...` passes for the whole provider.
