### PR TITLE
🐛 github: honor --discover none for repository and user connections

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -199,15 +199,17 @@ func repo(runtime *plugin.Runtime, repoName string, owner string, conn *connecti
 	if err != nil {
 		return nil, err
 	}
-	cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
-	cfg.Options["repository"] = repo.Name.Data
-	assetList = append(assetList, &inventory.Asset{
-		PlatformIds: []string{connection.NewGitHubRepoIdentifier(owner, repo.Name.Data)},
-		Name:        owner + "/" + repo.Name.Data,
-		Platform:    connection.NewGitHubRepoPlatform(owner, repo.Name.Data),
-		Labels:      convert.DictToTypedMap[string](repo.CustomProperties.Data),
-		Connections: []*inventory.Config{cfg},
-	})
+	if discoverRepoAsset(targets) {
+		cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
+		cfg.Options["repository"] = repo.Name.Data
+		assetList = append(assetList, &inventory.Asset{
+			PlatformIds: []string{connection.NewGitHubRepoIdentifier(owner, repo.Name.Data)},
+			Name:        owner + "/" + repo.Name.Data,
+			Platform:    connection.NewGitHubRepoPlatform(owner, repo.Name.Data),
+			Labels:      convert.DictToTypedMap[string](repo.CustomProperties.Data),
+			Connections: []*inventory.Config{cfg},
+		})
+	}
 
 	iacAssets, err := discoverRepoIac(conn, repo, targets)
 	if err != nil {
@@ -236,15 +238,17 @@ func user(runtime *plugin.Runtime, userName string, conn *connection.GithubConne
 	if err != nil {
 		return nil, err
 	}
-	cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
-	cfg.Options["user"] = user.Login.Data
-	assetList = append(assetList, &inventory.Asset{
-		PlatformIds: []string{connection.NewGithubUserIdentifier(user.Login.Data)},
-		Name:        user.Name.Data,
-		Platform:    connection.NewGithubUserPlatform(user.Login.Data),
-		Labels:      make(map[string]string),
-		Connections: []*inventory.Config{cfg},
-	})
+	if discoverUserAsset(targets) {
+		cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
+		cfg.Options["user"] = user.Login.Data
+		assetList = append(assetList, &inventory.Asset{
+			PlatformIds: []string{connection.NewGithubUserIdentifier(user.Login.Data)},
+			Name:        user.Name.Data,
+			Platform:    connection.NewGithubUserPlatform(user.Login.Data),
+			Labels:      make(map[string]string),
+			Connections: []*inventory.Config{cfg},
+		})
+	}
 
 	if discoverUserRepos(conf, targets) {
 		repos, err := userScopeRepos(runtime, conn, user)
@@ -338,6 +342,20 @@ func userScopeRepos(runtime *plugin.Runtime, conn *connection.GithubConnection, 
 // explicit repository is configured: discover() also reaches the user path
 // through the owner fallback of single-repo scans, which must not fan out to
 // every repository the owner has.
+// discoverRepoAsset reports whether the repository itself should be emitted as
+// an asset, mirroring the target check the organization asset already makes.
+func discoverRepoAsset(targets []string) bool {
+	return stringx.ContainsAnyOf(targets,
+		connection.DiscoveryRepos, connection.DiscoveryAll, connection.DiscoveryAuto)
+}
+
+// discoverUserAsset reports whether the account being scanned should be emitted
+// as an asset.
+func discoverUserAsset(targets []string) bool {
+	return stringx.ContainsAnyOf(targets,
+		connection.DiscoveryUsers, connection.DiscoveryAll, connection.DiscoveryAuto)
+}
+
 func discoverUserRepos(conf *inventory.Config, targets []string) bool {
 	return conf.Options["repository"] == "" &&
 		stringx.ContainsAnyOf(targets, connection.DiscoveryRepos, connection.DiscoveryAll, connection.DiscoveryAuto)

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -135,3 +135,47 @@ func TestDiscoverUserRepos(t *testing.T) {
 		))
 	})
 }
+
+// `--discover none` must mean none. The repository and user assets were
+// appended unconditionally, so a single-repo scan produced three assets (the
+// connection's own asset, the repository again, and the owner account) and ran
+// every query three times.
+func TestDiscoverRepoAsset(t *testing.T) {
+	t.Run("the default auto target emits the repository asset", func(t *testing.T) {
+		assert.True(t, discoverRepoAsset([]string{connection.DiscoveryAuto}))
+	})
+
+	t.Run("repos and all emit it too", func(t *testing.T) {
+		assert.True(t, discoverRepoAsset([]string{connection.DiscoveryRepos}))
+		assert.True(t, discoverRepoAsset(handleTargets([]string{connection.DiscoveryAll})))
+	})
+
+	t.Run("none emits nothing", func(t *testing.T) {
+		assert.False(t, discoverRepoAsset([]string{"none"}))
+		assert.False(t, discoverRepoAsset(nil))
+	})
+
+	t.Run("an unrelated target does not emit it", func(t *testing.T) {
+		assert.False(t, discoverRepoAsset([]string{connection.DiscoveryUsers}))
+	})
+}
+
+func TestDiscoverUserAsset(t *testing.T) {
+	t.Run("the default auto target emits the user asset", func(t *testing.T) {
+		assert.True(t, discoverUserAsset([]string{connection.DiscoveryAuto}))
+	})
+
+	t.Run("users and all emit it too", func(t *testing.T) {
+		assert.True(t, discoverUserAsset([]string{connection.DiscoveryUsers}))
+		assert.True(t, discoverUserAsset(handleTargets([]string{connection.DiscoveryAll})))
+	})
+
+	t.Run("none emits nothing", func(t *testing.T) {
+		assert.False(t, discoverUserAsset([]string{"none"}))
+		assert.False(t, discoverUserAsset(nil))
+	})
+
+	t.Run("an unrelated target does not emit it", func(t *testing.T) {
+		assert.False(t, discoverUserAsset([]string{connection.DiscoveryOrganization}))
+	})
+}


### PR DESCRIPTION
## Problem

`--discover none` is ignored in repo and user mode. A single-repo scan produces **three** assets:

```
mql run github repo mondoohq/cnspec --discover none -c "asset.name"
asset.name: ""                 <- the connection's own asset
asset.name: "mondoohq/cnspec"  <- the same repository, discovered again
asset.name: "Mondoo Inc"       <- the owner account
```

Every query runs three times. That triples API calls against a rate-limited service and reports each finding three times. (It also made a 233-repository listing render 466 rows in testing.)

## Cause

`org()` already gates its asset on the discovery targets:

```go
if stringx.ContainsAnyOf(targets, connection.DiscoveryOrganization, connection.DiscoveryAll, connection.DiscoveryAuto) && reposFilter.empty() {
```

but `repo()` and `user()` append theirs **unconditionally**. `targets` is passed into both functions and consulted only for the nested fan-out (`discoverRepoIac`, `discoverUserRepos`) — never for the asset itself. So no value of `--discover` could suppress them.

## Fix

Gate both on the same kind of target check, via two predicates that mirror the existing `discoverUserRepos`:

```go
func discoverRepoAsset(targets []string) bool {
	return stringx.ContainsAnyOf(targets,
		connection.DiscoveryRepos, connection.DiscoveryAll, connection.DiscoveryAuto)
}
```

The default `auto` target still emits both, so ordinary scans are unchanged. `none` matches nothing and now emits neither — the connection's own asset carries the scan, exactly as it already does in org mode.

## Tests

Added to `discovery_test.go`, following the style of the existing `TestDiscoverUserRepos`:

- `auto` emits the asset (the default path, and what the server sends for GitHub integrations)
- `repos` / `users` / the expansion of `all` emit it
- **`none` and an empty target list emit nothing**
- an unrelated target (e.g. `users` for the repo asset) does not emit it

The `none` and unrelated-target cases fail on `main`; the rest pass, pinning the behavior that must not change.

## Verification

Against live GitHub with the patched provider:

| connection | flag | before | after |
|---|---|---|---|
| `repo Lunalectric/frontend` | `--discover none` | 3 assets | **1** |
| `repo Lunalectric/frontend` | default (`auto`) | 3 assets | 3 (unchanged) |
| `user tas50` | `--discover none` | 2 assets | **1** |
| `org Lunalectric` | `--discover none` | 1 asset | 1 (unchanged) |
| `org Lunalectric` | `--discover organization` | 2 assets | 2 (unchanged) |

`go test ./...` passes for the whole provider.

## Not addressed here

Two related things this PR deliberately leaves alone, both found in the same sweep:

- Under the default `auto` target, a repo connection still emits its **owner organization as a `github-user` asset** (platform id `.../runtime/github/user/mondoohq`). Whether the owner should be discovered at all, and as which platform, is a separate semantic question from the flag being ignored.
- The connection's own asset has an empty name (`asset.Name = conf.Host`, but the github `ParseCLI` never sets `Host`).
