### PR TITLE
🎉 github-13.8.0, gitlab-13.6.0, k8s-13.9.0

### DIFF
--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.7.7",
+	Version:         "13.8.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.5.5",
+	Version: "13.6.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.8.5",
+	Version:         "13.9.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for the `github`, `gitlab`, and `k8s` providers. Each has shipped new resources/fields since its last release, so minor (not patch) is the correct increment.

| Provider | From | To |
| --- | --- | --- |
| github | 13.7.7 | 13.8.0 |
| gitlab | 13.5.5 | 13.6.0 |
| k8s | 13.8.5 | 13.9.0 |

## github 13.8.0

- ⭐ github: repository team grants, member 2FA/role, and role assignments (#9699)
- 🐛 github: stop reporting pull requests as issues (#9795)
- 🐛 github: stop an archived repository from failing the whole repo listing (#9794)
- 🐛 github: collect every Dependabot alert, not just the first page (#9793)
- 🧹 Dependency updates (#9651, #9619, #9601, #9580)

## gitlab 13.6.0

- ⭐ gitlab: model CI/CD credentials and repository egress paths (#9700)
- 🧹 Dependency updates (#9651, #9619, #9601, #9580)

## k8s 13.9.0

- ✨ k8s: attribute network exposures to the workloads backing exposed pods (#9762)
- 🧹 Dependency updates (#9651, #9619, #9601, #9580)
