### PR TITLE
🧹 deps: bump GitHub Actions (codeql-action 4.37.5, markdown-link-check 1.1.3)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,7 +75,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,4 +87,4 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: markdown-link-check
-        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
+        uses: tcort/github-action-markdown-link-check@e047c5b37f24ab722bbef1a27b6fab7f96bc4068 # v1.1.3
         with:
           use-verbose-mode: "yes"
           config-file: ".github/actions/link-check/config.json"


### PR DESCRIPTION
Combines three Dependabot GitHub Actions bumps into a single PR.

Supersedes #9691, #9692, and #9693 — those can be closed once this merges (Dependabot will also close them on its own once it sees the versions match in `main`).

## What changes

| Action | From | To | Workflow |
|---|---|---|---|
| `github/codeql-action/init` | 4.37.3 | 4.37.5 | `.github/workflows/codeql.yml` |
| `github/codeql-action/analyze` | 4.37.3 | 4.37.5 | `.github/workflows/codeql.yml` |
| `tcort/github-action-markdown-link-check` | 1.1.2 | 1.1.3 | `.github/workflows/link-check.yaml` |

Three lines total; the diff is the exact union of the three Dependabot diffs.

## Why one PR

`init` and `analyze` come from the same repository at the same commit. Merging #9691 and #9692 separately opens a window where the two steps run different CodeQL bundle versions — bumping them in one commit avoids that skew entirely.

## Pin verification

Both SHAs were resolved against the upstream tags rather than taken from the Dependabot bodies:

- `d1ba80a13dd99fba24a470575428917156a28b43` → `github/codeql-action` **v4.37.5** (annotated tag, dereferenced through the tag object)
- `e047c5b37f24ab722bbef1a27b6fab7f96bc4068` → `tcort/github-action-markdown-link-check` **v1.1.3**

Both workflow files still parse as valid YAML.

## Upstream changes

**codeql-action 4.37.4** — `tools` input for `init` can now be set via a `github-codeql-tools` repository property; default CodeQL bundle moves to 2.26.2.
**codeql-action 4.37.5** — a network error while streaming the CodeQL bundle download no longer terminates `init`; it falls back to downloading before extracting.
**markdown-link-check 1.1.3** — bundles `markdown-link-check` 3.15.0 and moves the image to `node:24.18.0-alpine3.24`.

## Note for a follow-up

`.github/workflows/xgrep.yaml:32` still pins `github/codeql-action/upload-sarif` at the old `e4fba868…` (v4.37.3), and Dependabot has no open PR for it. Left out of scope here since it wasn't part of the three PRs, but it's worth bumping separately so the whole repo is on one codeql-action commit.
