### PR TITLE
🐛 embed a VERSIONINFO resource in Windows provider builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ data/
 # primarily used to ignore all dist files built for providers
 providers/*.resources.json
 providers/*/dist
+# generated Windows version resource (see scripts/provider_bundler.sh)
+providers/*/rsrc_windows_*.syso
 providers/*/resources/*.resources.json
 providers/mock_coordinator.go
 providers/mock_plugin_interface.go

--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -55,6 +55,24 @@ ${REPOROOT}/lr go ${PROVIDER_PATH}/resources/${PROVIDER_NAME}.lr --dist ${PROVID
 echo "  - Generate the resource versions..."
 ${REPOROOT}/lr versions ${PROVIDER_PATH}/resources/${PROVIDER_NAME}.lr
 
+# Windows binaries carry a VERSIONINFO resource and an application manifest.
+# Without them the provider .exe reports no CompanyName/ProductName/
+# FileDescription, which contributes to heuristic AV/EDR misclassification.
+#
+# This has to happen before the build loop below: both windows targets share
+# these files, so generating them inside build_bundle would race whenever
+# MAX_PARALLEL > 1.
+echo "  - Generate the Windows version resource..."
+WINRES_JSON="${PROVIDER_DIST}/winres.json"
+sed "s/__PROVIDER_NAME__/${PROVIDER_NAME}/g" \
+  "${REPOROOT}/scripts/winres/provider.json.tmpl" > "${WINRES_JSON}"
+go run github.com/tc-hib/go-winres@v0.3.3 make \
+  --in "${WINRES_JSON}" \
+  --out "${PROVIDER_PATH}/rsrc" \
+  --arch amd64,arm64 \
+  --file-version "${PROVIDER_VERSION}" \
+  --product-version "${PROVIDER_VERSION}"
+
 build_bundle(){
   set -eo pipefail
   local GOOS=$1
@@ -76,8 +94,12 @@ build_bundle(){
     PROVIDER_EXECUTABLE="${PROVIDER_EXECUTABLE}.exe"
   fi
 
-  # Build the binary into the arch-specific directory
-  cd ${PROVIDER_PATH} && CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM} go build -tags production -ldflags "-s -w" -o ${ARCH_DIST}/${PROVIDER_EXECUTABLE} main.go
+  # Build the binary into the arch-specific directory.
+  #
+  # NOTE: the build target must stay the package ("."), not main.go. Go only
+  # links rsrc_windows_*.syso when building a package directory; passing an
+  # explicit .go file silently drops the version resource and manifest.
+  cd ${PROVIDER_PATH} && CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} GOARM=${GOARM} go build -tags production -ldflags "-s -w" -o ${ARCH_DIST}/${PROVIDER_EXECUTABLE} .
 
   if [[ "${GOOS}" == "windows" ]]; then
     ### SIGN THE BINARY
@@ -150,6 +172,12 @@ fi
 
 echo "  - Building ${#BUILDS[@]} architecture targets (max parallel: ${MAX_PARALLEL})..."
 
+# The generated resource objects live in the provider source directory, so drop
+# them once every target has been linked rather than leaving them in the tree.
+remove_winres() {
+  rm -f "${PROVIDER_PATH}"/rsrc_windows_*.syso
+}
+
 # Kill all background build processes on interrupt/termination
 cleanup() {
   echo ""
@@ -158,6 +186,7 @@ cleanup() {
     kill "$pid" 2>/dev/null || true
   done
   wait 2>/dev/null
+  remove_winres
   exit 130
 }
 trap cleanup INT TERM
@@ -185,6 +214,8 @@ done
 for pid in "${PIDS[@]}"; do
   wait "$pid" || FAILED=1
 done
+
+remove_winres
 
 if [ $FAILED -ne 0 ]; then
   echo "One or more architecture builds failed."

--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -64,7 +64,7 @@ ${REPOROOT}/lr versions ${PROVIDER_PATH}/resources/${PROVIDER_NAME}.lr
 # MAX_PARALLEL > 1.
 echo "  - Generate the Windows version resource..."
 WINRES_JSON="${PROVIDER_DIST}/winres.json"
-sed "s/__PROVIDER_NAME__/${PROVIDER_NAME}/g" \
+sed "s|__PROVIDER_NAME__|${PROVIDER_NAME}|g" \
   "${REPOROOT}/scripts/winres/provider.json.tmpl" > "${WINRES_JSON}"
 go run github.com/tc-hib/go-winres@v0.3.3 make \
   --in "${WINRES_JSON}" \

--- a/scripts/provider_bundler.sh
+++ b/scripts/provider_bundler.sh
@@ -55,24 +55,6 @@ ${REPOROOT}/lr go ${PROVIDER_PATH}/resources/${PROVIDER_NAME}.lr --dist ${PROVID
 echo "  - Generate the resource versions..."
 ${REPOROOT}/lr versions ${PROVIDER_PATH}/resources/${PROVIDER_NAME}.lr
 
-# Windows binaries carry a VERSIONINFO resource and an application manifest.
-# Without them the provider .exe reports no CompanyName/ProductName/
-# FileDescription, which contributes to heuristic AV/EDR misclassification.
-#
-# This has to happen before the build loop below: both windows targets share
-# these files, so generating them inside build_bundle would race whenever
-# MAX_PARALLEL > 1.
-echo "  - Generate the Windows version resource..."
-WINRES_JSON="${PROVIDER_DIST}/winres.json"
-sed "s|__PROVIDER_NAME__|${PROVIDER_NAME}|g" \
-  "${REPOROOT}/scripts/winres/provider.json.tmpl" > "${WINRES_JSON}"
-go run github.com/tc-hib/go-winres@v0.3.3 make \
-  --in "${WINRES_JSON}" \
-  --out "${PROVIDER_PATH}/rsrc" \
-  --arch amd64,arm64 \
-  --file-version "${PROVIDER_VERSION}" \
-  --product-version "${PROVIDER_VERSION}"
-
 build_bundle(){
   set -eo pipefail
   local GOOS=$1
@@ -178,6 +160,40 @@ remove_winres() {
   rm -f "${PROVIDER_PATH}"/rsrc_windows_*.syso
 }
 
+# On every exit path, not just the expected ones: nothing clears these objects
+# at the start of a run, so a leaked one would be linked into the next windows
+# build of this provider carrying a stale version. A background build does not
+# inherit an EXIT trap, so this cannot fire while another target is linking.
+trap remove_winres EXIT
+
+# Windows binaries carry a VERSIONINFO resource and an application manifest.
+# Without them the provider .exe reports no CompanyName/ProductName/
+# FileDescription, which contributes to heuristic AV/EDR misclassification.
+#
+# This has to happen before the build loop below rather than inside
+# build_bundle: both windows targets share these files, so generating them per
+# target would race whenever MAX_PARALLEL > 1.
+#
+# The template carries only what go-winres does not already default to. Of the
+# manifest settings, `dpi-awareness` is the one that is not a default: left out,
+# a binary is marked DPI-aware, which is a claim a headless plugin has no
+# business making.
+for build in "${BUILDS[@]}"; do
+  if [[ "${build}" == windows* ]]; then
+    echo "  - Generate the Windows version resource..."
+    WINRES_JSON="${PROVIDER_DIST}/winres.json"
+    sed "s|__PROVIDER_NAME__|${PROVIDER_NAME}|g" \
+      "${REPOROOT}/scripts/winres/provider.json.tmpl" > "${WINRES_JSON}"
+    go run github.com/tc-hib/go-winres@v0.3.3 make \
+      --in "${WINRES_JSON}" \
+      --out "${PROVIDER_PATH}/rsrc" \
+      --arch amd64,arm64 \
+      --file-version "${PROVIDER_VERSION}" \
+      --product-version "${PROVIDER_VERSION}"
+    break
+  fi
+done
+
 # Kill all background build processes on interrupt/termination
 cleanup() {
   echo ""
@@ -186,7 +202,6 @@ cleanup() {
     kill "$pid" 2>/dev/null || true
   done
   wait 2>/dev/null
-  remove_winres
   exit 130
 }
 trap cleanup INT TERM
@@ -214,8 +229,6 @@ done
 for pid in "${PIDS[@]}"; do
   wait "$pid" || FAILED=1
 done
-
-remove_winres
 
 if [ $FAILED -ne 0 ]; then
   echo "One or more architecture builds failed."

--- a/scripts/winres/provider.json.tmpl
+++ b/scripts/winres/provider.json.tmpl
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "mql __PROVIDER_NAME__ provider plugin",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "unaware",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": true,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "https://mondoo.com/docs/mql/resources",
+            "CompanyName": "Mondoo, Inc.",
+            "FileDescription": "mql __PROVIDER_NAME__ provider plugin",
+            "FileVersion": "",
+            "InternalName": "__PROVIDER_NAME__",
+            "LegalCopyright": "Copyright Mondoo, Inc. All rights reserved.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "__PROVIDER_NAME__.exe",
+            "PrivateBuild": "",
+            "ProductName": "mql",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/winres/provider.json.tmpl
+++ b/scripts/winres/provider.json.tmpl
@@ -2,25 +2,11 @@
   "RT_MANIFEST": {
     "#1": {
       "0409": {
-        "identity": {
-          "name": "",
-          "version": ""
-        },
         "description": "mql __PROVIDER_NAME__ provider plugin",
         "minimum-os": "win7",
         "execution-level": "as invoker",
-        "ui-access": false,
-        "auto-elevate": false,
         "dpi-awareness": "unaware",
-        "disable-theming": false,
-        "disable-window-filtering": false,
-        "high-resolution-scrolling-aware": false,
-        "ultra-high-resolution-scrolling-aware": false,
-        "long-path-aware": true,
-        "printer-driver-isolation": false,
-        "gdi-scaling": false,
-        "segment-heap": false,
-        "use-common-controls-v6": false
+        "long-path-aware": true
       }
     }
   },
@@ -36,15 +22,10 @@
             "Comments": "https://mondoo.com/docs/mql/resources",
             "CompanyName": "Mondoo, Inc.",
             "FileDescription": "mql __PROVIDER_NAME__ provider plugin",
-            "FileVersion": "",
             "InternalName": "__PROVIDER_NAME__",
             "LegalCopyright": "Copyright Mondoo, Inc. All rights reserved.",
-            "LegalTrademarks": "",
             "OriginalFilename": "__PROVIDER_NAME__.exe",
-            "PrivateBuild": "",
-            "ProductName": "mql",
-            "ProductVersion": "",
-            "SpecialBuild": ""
+            "ProductName": "mql"
           }
         }
       }


### PR DESCRIPTION
Companion to mondoohq/cnspec#3233, which does the same for `cnspec.exe`.

Provider `.exe` plugins shipped with no PE file metadata — empty `CompanyName`, `ProductName`, `FileDescription`, `FileVersion` and `OriginalFilename`. Go does not emit a version resource on its own; it has to be linked in as a `.syso`, and the bundler never supplied one.

Providers are the more exposed half of the pair. They are downloaded and executed at runtime by `cnspec serve`, from under `ProgramData`, as children of a SYSTEM service — a shape endpoint products already score heavily. They are Authenticode-signed via jsign, so the publisher identity was there; only the descriptive metadata was missing.

## Changes

- **`scripts/winres/provider.json.tmpl`** — shared [go-winres](https://github.com/tc-hib/go-winres) template holding the version resource and application manifest. `__PROVIDER_NAME__` is substituted per provider, so each plugin identifies itself rather than sharing one generic identity.
- **`scripts/provider_bundler.sh`** — renders the template and generates `rsrc_windows_{amd64,arm64}.syso` into the provider directory. Version comes from the same `config/config.go` value the bundle filenames already use. Pinned to `go-winres@v0.3.3` and invoked via `go run`, so no provider `go.mod` is touched and no CI install step is needed.
- **`.gitignore`** — ignores the generated `.syso` files.

Only the bundler is changed. It is the release path (`.github/workflows/providers.yaml` calls it directly); `make providers/dist` is a local-dev target not used by CI, and is left alone.

## Two things worth reviewing

**Generation is hoisted out of `build_bundle`.** Both windows targets share the same `.syso` files, so generating them per-target would race whenever `MAX_PARALLEL > 1` — one build could be linking a file the other is rewriting. It runs once, alongside the other pre-build steps. A matching `remove_winres` drops the objects from the provider source directory once all targets are linked, and on the interrupt path too.

**The build target moved from `main.go` to `.`.** Go only links `rsrc_windows_*.syso` when building a **package directory** — passing an explicit `.go` file makes it ignore the resource with no warning. I hit this while testing: the first binary I built had the `.syso` sitting right next to it and came out with no resource directory at all. Verified every provider has exactly one top-level `.go` file (`main.go`), so the switch is otherwise a no-op:

```
$ for d in providers/*/; do ls $d*.go | wc -l; done   # all 1
```

There is a comment on the build line so it does not get "tidied" back.

## Verification

Replayed the script's generation step for `providers/ansible`, built `windows/arm64`, and read the resource back out of the linked binary with `go-winres extract`:

```
"file_version":     "13.2.14.0"     <- from providers/ansible/config/config.go
"product_version":  "13.2.14.0"
"CompanyName":      "Mondoo, Inc."
"ProductName":      "mql"
"FileDescription":  "mql ansible provider plugin"
"InternalName":     "ansible"
"OriginalFilename": "ansible.exe"
"LegalCopyright":   "Copyright Mondoo, Inc. All rights reserved."
```

Extracted manifest confirms the execution level — providers must never request elevation:

```xml
<requestedExecutionLevel level="asInvoker"/>
```

Also confirmed:

- The rendered template is valid JSON.
- `linux/amd64` builds are unaffected with the `.syso` files present — the `_windows_<arch>` filename suffix keeps the Go toolchain from linking them.
- `go run` works with the provider directory as cwd, including providers with their own `go.mod` (that is the cwd at that point in the script), and leaves `go.mod` / `go.sum` untouched.
- `bash -n` passes; the working tree is clean after a run.

Signing is unaffected. It still runs after the build inside `build_bundle`, so the Authenticode signature covers the new resource.

## Why bother

A stripped (`-s -w`), statically linked, `CGO_ENABLED=0` Go binary with no file metadata is a well-documented contributor to heuristic and ML-based AV/EDR misclassification — endpoint products weight PE metadata completeness as a feature. Every provider release also lands as a previously unseen hash with no cloud prevalence.

This does not make the problem go away on its own, but it is the cheapest available mitigation and removes an easy strike against the binaries.
