### PR TITLE
🐛 skip login-gated consoles in the markdown link check

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -3,6 +3,12 @@
   "ignorePatterns": [
     {
       "pattern": "^https:\\/\\/wiki\\.jenkins\\.io\\/display\\/JENKINS\\/Building\\+a\\+software\\+project"
+    },
+    {
+      "pattern": "^https:\\/\\/platform\\.openai\\.com\\/"
+    },
+    {
+      "pattern": "^https:\\/\\/console\\.mistral\\.ai"
     }
   ]
 }


### PR DESCRIPTION
`main` has been red since #9798 bumped `tcort/github-action-markdown-link-check` from v1.1.2 to v1.1.3 this morning. The two runs on main since that merge have both failed; the ones before it passed. Every PR opened since inherits the failure.

The newer release reports four links as dead:

| File | Link | Reported as |
|---|---|---|
| `providers/openai/README.md` | `platform.openai.com/api-keys` | 403 |
| `providers/openai/README.md` | `platform.openai.com/organization/admin-keys` | 403 |
| `providers/mistral/README.md` | `console.mistral.ai` | Max redirects reached |
| `providers/mistral/README.md` | `console.mistral.ai/api-keys` | Max redirects reached |

## None of these are actually broken

Both hosts are dashboards behind a login, and neither can be resolved by an unauthenticated HTTP client:

- `console.mistral.ai` immediately bounces into `auth.mistral.ai/self-service/login/browser?flow=…`, which the checker follows until it gives up.
- `platform.openai.com` answers 403 to requests from GitHub-hosted runner ranges. It resolves fine from a normal network — which is exactly why this reproduces in CI but not locally.

## Fix

Adds both hosts to `ignorePatterns` rather than touching the READMEs. The links are correct and genuinely useful to readers (they are where you go to get the API key the provider needs), so the right place to record that an automated checker cannot verify them is the checker config.

Host-level patterns rather than per-URL, since every path on both hosts is behind the same login wall.

The alternative was widening `aliveStatusCodes` to include 403, but that would mask genuinely dead links across the whole repo.

## Verification

Ran the checker locally against both files with the new config — all four are now skipped (`[/]`) and the run exits clean:

```
FILE: providers/openai/README.md
  [/] https://platform.openai.com/api-keys
  [/] https://platform.openai.com/organization/admin-keys
  2 links checked.

FILE: providers/mistral/README.md
  [/] https://console.mistral.ai
  [/] https://console.mistral.ai/api-keys
  2 links checked.
```

Negative control with `origin/main`'s config reproduces the Mistral failure locally (`ERROR: 2 dead links found!`), confirming the config change is what fixes it rather than the sites having recovered. The OpenAI pair passes locally, per the runner-IP note above.
