### PR TITLE
✨ mongodbatlas: expose API access lists for programmatic credentials

### DIFF
--- a/providers/mongodbatlas/resources/access_lists.go
+++ b/providers/mongodbatlas/resources/access_lists.go
@@ -1,0 +1,229 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"time"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+)
+
+// apiAccessListEntry is the normalized form of an access list entry. Atlas
+// returns the same entry under two different shapes, one for API keys and one
+// for service accounts, with the usage fields named differently in each. Both
+// are mapped into this shape so a single resource, and therefore a single
+// query, covers either kind of programmatic credential.
+type apiAccessListEntry struct {
+	cidrBlock       string
+	ipAddress       string
+	created         *time.Time
+	requestCount    int64
+	lastUsed        *time.Time
+	lastUsedAddress string
+}
+
+// apiKeyAccessEntry normalizes an API key access list entry.
+func apiKeyAccessEntry(e admin.UserAccessListResponse) apiAccessListEntry {
+	return apiAccessListEntry{
+		cidrBlock:       e.GetCidrBlock(),
+		ipAddress:       e.GetIpAddress(),
+		created:         timePtr(e.GetCreated()),
+		requestCount:    int64(e.GetCount()),
+		lastUsed:        timePtr(e.GetLastUsed()),
+		lastUsedAddress: e.GetLastUsedAddress(),
+	}
+}
+
+// serviceAccountAccessEntry normalizes a service account access list entry.
+func serviceAccountAccessEntry(e admin.ServiceAccountIPAccessListEntry) apiAccessListEntry {
+	return apiAccessListEntry{
+		cidrBlock:       e.GetCidrBlock(),
+		ipAddress:       e.GetIpAddress(),
+		created:         timePtr(e.GetCreatedAt()),
+		requestCount:    int64(e.GetRequestCount()),
+		lastUsed:        timePtr(e.GetLastUsedAt()),
+		lastUsedAddress: e.GetLastUsedAddress(),
+	}
+}
+
+// accessListEntryID builds the cache key for an access list entry under the
+// credential that grants it. Atlas reports a single address as both an
+// ipAddress and an equivalent /32 CIDR block, so the CIDR is the stable key and
+// the address is only the fallback for an entry that reports no CIDR.
+func accessListEntryID(parent string, e apiAccessListEntry) string {
+	value := e.cidrBlock
+	if value == "" {
+		value = e.ipAddress
+	}
+	return "mongodbatlas.apiAccessListEntry/" + parent + "/" + value
+}
+
+func newMqlMongodbatlasApiAccessListEntry(runtime *plugin.Runtime, parent string, e apiAccessListEntry) (*mqlMongodbatlasApiAccessListEntry, error) {
+	res, err := CreateResource(runtime, "mongodbatlas.apiAccessListEntry", map[string]*llx.RawData{
+		"__id":            llx.StringData(accessListEntryID(parent, e)),
+		"cidrBlock":       llx.StringData(e.cidrBlock),
+		"ipAddress":       llx.StringData(e.ipAddress),
+		"created":         llx.TimeDataPtr(e.created),
+		"requestCount":    llx.IntData(e.requestCount),
+		"lastUsed":        llx.TimeDataPtr(e.lastUsed),
+		"lastUsedAddress": llx.StringData(e.lastUsedAddress),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMongodbatlasApiAccessListEntry), nil
+}
+
+// accessList reports the addresses the API key may authenticate from. An empty
+// list means the key carries no source restriction and works from anywhere the
+// Atlas API is reachable, which is the state the organization setting
+// apiAccessListRequired exists to prevent.
+func (r *mqlMongodbatlasApiKey) accessList() ([]any, error) {
+	oid, err := orgID(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	client := atlasClient(r.MqlRuntime)
+	ctx := context.Background()
+
+	out := []any{}
+	for page := 1; ; page++ {
+		resp, httpResp, err := client.ProgrammaticAPIKeysApi.
+			ListApiKeyAccessListsEntries(ctx, oid, r.cacheApiKeyID).
+			ItemsPerPage(pageSize).PageNum(page).Execute()
+		if err != nil {
+			// An empty access list is precisely the finding this accessor
+			// reports, so a denied read must not render as one. Null instead,
+			// which fails an audit over it rather than passing it vacuously.
+			if isAccessDenied(httpResp) {
+				r.AccessList.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
+			}
+			return nil, err
+		}
+		results := resp.GetResults()
+		for i := range results {
+			entry, err := newMqlMongodbatlasApiAccessListEntry(r.MqlRuntime,
+				"apiKey/"+r.cacheApiKeyID, apiKeyAccessEntry(results[i]))
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, entry)
+		}
+		if len(results) < pageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// accessList reports the addresses the service account may authenticate from.
+// As with an API key, an empty list means the credential is usable from any
+// address.
+func (r *mqlMongodbatlasServiceAccount) accessList() ([]any, error) {
+	oid, err := orgID(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	client := atlasClient(r.MqlRuntime)
+	ctx := context.Background()
+	clientID := r.ClientId.Data
+
+	out := []any{}
+	for page := 1; ; page++ {
+		resp, httpResp, err := client.ServiceAccountsApi.
+			ListServiceAccountAccessList(ctx, oid, clientID).
+			ItemsPerPage(pageSize).PageNum(page).Execute()
+		if err != nil {
+			if isAccessDenied(httpResp) {
+				r.AccessList.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
+			}
+			return nil, err
+		}
+		results := resp.GetResults()
+		for i := range results {
+			entry, err := newMqlMongodbatlasApiAccessListEntry(r.MqlRuntime,
+				"serviceAccount/"+clientID, serviceAccountAccessEntry(results[i]))
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, entry)
+		}
+		if len(results) < pageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// projects resolves the projects the service account is assigned to, which is
+// the reach a leaked client secret would carry. The assignment listing returns
+// project ids only, so each is resolved against the organization's project
+// listing.
+func (r *mqlMongodbatlasServiceAccount) projects() ([]any, error) {
+	oid, err := orgID(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	client := atlasClient(r.MqlRuntime)
+	ctx := context.Background()
+	clientID := r.ClientId.Data
+
+	groupIDs := []string{}
+	for page := 1; ; page++ {
+		resp, httpResp, err := client.ServiceAccountsApi.
+			ListServiceAccountProjects(ctx, oid, clientID).
+			ItemsPerPage(pageSize).PageNum(page).Execute()
+		if err != nil {
+			// A denied read establishes nothing about the account's reach, so
+			// it must not render as "assigned to no project".
+			if isAccessDenied(httpResp) {
+				r.Projects.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
+			}
+			return nil, err
+		}
+		results := resp.GetResults()
+		for i := range results {
+			if id := results[i].GetGroupId(); id != "" {
+				groupIDs = append(groupIDs, id)
+			}
+		}
+		if len(results) < pageSize {
+			break
+		}
+	}
+
+	root, err := rootMongodbatlas(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	projectsByID, err := root.orgProjectsByID()
+	if err != nil {
+		return nil, err
+	}
+
+	out := []any{}
+	for _, id := range groupIDs {
+		if p, ok := projectsByID[id]; ok {
+			out = append(out, p)
+			continue
+		}
+		// The organization listing did not cover this project, so fetch it
+		// directly. A failure here is reported rather than skipped: dropping
+		// the entry would under-report the account's reach.
+		proj, err := NewResource(r.MqlRuntime, "mongodbatlas.project", map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, proj)
+	}
+	return out, nil
+}

--- a/providers/mongodbatlas/resources/access_lists_test.go
+++ b/providers/mongodbatlas/resources/access_lists_test.go
@@ -1,0 +1,145 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+)
+
+func TestApiKeyAccessEntry(t *testing.T) {
+	created := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	lastUsed := time.Date(2026, 8, 10, 14, 30, 0, 0, time.UTC)
+
+	got := apiKeyAccessEntry(admin.UserAccessListResponse{
+		CidrBlock:       admin.PtrString("10.0.0.0/24"),
+		IpAddress:       admin.PtrString("10.0.0.1"),
+		Created:         &created,
+		Count:           admin.PtrInt(42),
+		LastUsed:        &lastUsed,
+		LastUsedAddress: admin.PtrString("10.0.0.7"),
+	})
+
+	assert.Equal(t, "10.0.0.0/24", got.cidrBlock)
+	assert.Equal(t, "10.0.0.1", got.ipAddress)
+	require.NotNil(t, got.created)
+	assert.Equal(t, created, *got.created)
+	// The API key endpoint names the usage counter `count`; mistyping it here
+	// would silently report every entry as never used.
+	assert.Equal(t, int64(42), got.requestCount)
+	require.NotNil(t, got.lastUsed)
+	assert.Equal(t, lastUsed, *got.lastUsed)
+	assert.Equal(t, "10.0.0.7", got.lastUsedAddress)
+}
+
+func TestApiKeyAccessEntryUnused(t *testing.T) {
+	// An entry that has never authenticated reports no last-used time. It must
+	// stay null rather than becoming the zero time, which would render as a
+	// real date in year 1 and read as "used long ago".
+	got := apiKeyAccessEntry(admin.UserAccessListResponse{
+		CidrBlock: admin.PtrString("192.168.1.0/24"),
+	})
+
+	assert.Equal(t, "192.168.1.0/24", got.cidrBlock)
+	assert.Empty(t, got.ipAddress)
+	assert.Nil(t, got.created, "an absent creation time stays null")
+	assert.Zero(t, got.requestCount)
+	assert.Nil(t, got.lastUsed, "an unused entry reports no last-used time")
+	assert.Empty(t, got.lastUsedAddress)
+}
+
+func TestServiceAccountAccessEntry(t *testing.T) {
+	created := time.Date(2026, 1, 15, 8, 0, 0, 0, time.UTC)
+	lastUsed := time.Date(2026, 8, 11, 11, 45, 0, 0, time.UTC)
+
+	got := serviceAccountAccessEntry(admin.ServiceAccountIPAccessListEntry{
+		CidrBlock:       admin.PtrString("172.16.0.0/16"),
+		IpAddress:       admin.PtrString("172.16.4.9"),
+		CreatedAt:       &created,
+		RequestCount:    admin.PtrInt(7),
+		LastUsedAt:      &lastUsed,
+		LastUsedAddress: admin.PtrString("172.16.4.9"),
+	})
+
+	assert.Equal(t, "172.16.0.0/16", got.cidrBlock)
+	assert.Equal(t, "172.16.4.9", got.ipAddress)
+	require.NotNil(t, got.created)
+	assert.Equal(t, created, *got.created)
+	// The service account endpoint names the same counter `requestCount` and
+	// the timestamps `createdAt`/`lastUsedAt`. Both shapes must normalize to
+	// the identical resource fields or a query cannot span both credentials.
+	assert.Equal(t, int64(7), got.requestCount)
+	require.NotNil(t, got.lastUsed)
+	assert.Equal(t, lastUsed, *got.lastUsed)
+	assert.Equal(t, "172.16.4.9", got.lastUsedAddress)
+}
+
+func TestServiceAccountAccessEntryUnused(t *testing.T) {
+	got := serviceAccountAccessEntry(admin.ServiceAccountIPAccessListEntry{
+		IpAddress: admin.PtrString("203.0.113.5"),
+	})
+
+	assert.Empty(t, got.cidrBlock)
+	assert.Equal(t, "203.0.113.5", got.ipAddress)
+	assert.Nil(t, got.created)
+	assert.Zero(t, got.requestCount)
+	assert.Nil(t, got.lastUsed)
+}
+
+func TestAccessListEntryID(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry apiAccessListEntry
+		want  string
+	}{
+		{
+			name:  "cidr block keys the entry",
+			entry: apiAccessListEntry{cidrBlock: "10.0.0.0/24", ipAddress: "10.0.0.1"},
+			want:  "mongodbatlas.apiAccessListEntry/apiKey/abc123/10.0.0.0/24",
+		},
+		{
+			name:  "address is the fallback when no cidr is reported",
+			entry: apiAccessListEntry{ipAddress: "203.0.113.5"},
+			want:  "mongodbatlas.apiAccessListEntry/apiKey/abc123/203.0.113.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, accessListEntryID("apiKey/abc123", tt.entry))
+		})
+	}
+}
+
+func TestAccessListEntryIDIsParentScoped(t *testing.T) {
+	// The same CIDR may be allowed for several credentials. The parent segment
+	// keeps those distinct, so one entry does not alias another in the cache.
+	entry := apiAccessListEntry{cidrBlock: "10.0.0.0/24"}
+
+	key := accessListEntryID("apiKey/abc123", entry)
+	other := accessListEntryID("serviceAccount/mdb_sa_id_xyz", entry)
+
+	assert.NotEqual(t, key, other)
+}
+
+func TestLabelMap(t *testing.T) {
+	assert.Equal(t, map[string]any{}, labelMap(nil))
+	assert.Equal(t, map[string]any{}, labelMap([]admin.ComponentLabel{}))
+
+	assert.Equal(t, map[string]any{"team": "payments", "tier": "prod"}, labelMap([]admin.ComponentLabel{
+		{Key: admin.PtrString("team"), Value: admin.PtrString("payments")},
+		{Key: admin.PtrString("tier"), Value: admin.PtrString("prod")},
+	}))
+
+	assert.Equal(t, map[string]any{"team": "platform"}, labelMap([]admin.ComponentLabel{
+		{Key: admin.PtrString("team"), Value: admin.PtrString("payments")},
+		{Key: admin.PtrString("team"), Value: admin.PtrString("platform")},
+	}), "a later label wins on a duplicate key")
+
+	assert.Equal(t, map[string]any{"": ""}, labelMap([]admin.ComponentLabel{{}}),
+		"labels are pointer fields, so an absent key or value must not panic")
+}

--- a/providers/mongodbatlas/resources/dbusers.go
+++ b/providers/mongodbatlas/resources/dbusers.go
@@ -64,6 +64,7 @@ func (r *mqlMongodbatlas) databaseUsers() ([]any, error) {
 				"oidcAuthType":    llx.StringData(u.GetOidcAuthType()),
 				"roles":           llx.ArrayData(roles, types.Dict),
 				"scopes":          llx.ArrayData(scopes, types.Dict),
+				"labels":          llx.MapData(labelMap(u.GetLabels()), types.String),
 				"deleteAfterDate": llx.TimeDataPtr(timePtr(u.GetDeleteAfterDate())),
 			})
 			if err != nil {

--- a/providers/mongodbatlas/resources/mongodbatlas.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.go
@@ -37,6 +37,10 @@ type mqlMongodbatlasInternal struct {
 	accessRolesOnce sync.Once
 	accessRolesByID map[string]*mqlMongodbatlasCloudProviderAccessRole
 	accessRolesErr  error
+
+	projectsOnce sync.Once
+	projectsByID map[string]*mqlMongodbatlasProject
+	projectsErr  error
 }
 
 // rootMongodbatlas returns the cached root resource singleton so sub-resources
@@ -189,6 +193,18 @@ func (r *mqlMongodbatlas) maxServiceAccountSecretValidityInHours() (int64, error
 	return int64(s.GetMaxServiceAccountSecretValidityInHours()), nil
 }
 
+func (r *mqlMongodbatlas) streamsCrossGroupEnabled() (bool, error) {
+	s, err := r.fetchOrgSettings()
+	if err != nil {
+		return false, err
+	}
+	if s == nil {
+		r.StreamsCrossGroupEnabled.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+	return s.GetStreamsCrossGroupEnabled(), nil
+}
+
 func (r *mqlMongodbatlas) securityContact() (string, error) {
 	s, err := r.fetchOrgSettings()
 	if err != nil {
@@ -224,6 +240,17 @@ func tagMap(tags []admin.ResourceTag) map[string]any {
 	out := make(map[string]any, len(tags))
 	for _, t := range tags {
 		out[t.GetKey()] = t.GetValue()
+	}
+	return out
+}
+
+// labelMap converts the labels Atlas carries on a database user to the map form
+// llx.MapData expects. Labels are a separate type from resource tags, with the
+// same key/value shape.
+func labelMap(labels []admin.ComponentLabel) map[string]any {
+	out := make(map[string]any, len(labels))
+	for _, l := range labels {
+		out[l.GetKey()] = l.GetValue()
 	}
 	return out
 }

--- a/providers/mongodbatlas/resources/mongodbatlas.lr
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr
@@ -33,6 +33,8 @@ mongodbatlas {
   maxServiceAccountSecretValidityInHours() int
   // Email address that receives security notifications for the organization
   securityContact() string
+  // Whether Atlas Stream Processing may connect to clusters in other projects
+  streamsCrossGroupEnabled() bool
   // Projects in the organization
   projects() []mongodbatlas.project
   // Organization members
@@ -182,6 +184,8 @@ mongodbatlas.apiKey @defaults("publicKey description") {
   description string
   // Role assignments granted to the key at the organization or project level
   roleAssignments() []mongodbatlas.apiKey.roleAssignment
+  // API access list entries restricting where the key may be used from, empty when the key is usable from any address
+  accessList() []mongodbatlas.apiAccessListEntry
 }
 
 // MongoDB Atlas API key role assignment
@@ -196,6 +200,33 @@ private mongodbatlas.apiKey.roleAssignment @defaults("roleName") {
   orgLevel bool
   // Project the role applies to, null for an organization-level role
   project() mongodbatlas.project
+}
+
+// MongoDB Atlas API access list entry
+//
+// A single source address that a programmatic credential (an API key or a
+// service account) may authenticate from, keyed by the CIDR block or address it
+// grants. A credential with no entries is usable from anywhere on the internet,
+// so an empty access list is the condition to audit for, and the organization
+// setting apiAccessListRequired reports whether Atlas enforces that an entry
+// exists. Covers the granted CIDR block or single address, when the entry was
+// created, and how it has been used: the number of requests seen from it, the
+// last time it was used, and the address that used it. An entry that has never
+// been used reports a null lastUsed, which identifies stale allowances that can
+// be withdrawn.
+private mongodbatlas.apiAccessListEntry @defaults("cidrBlock ipAddress lastUsed") {
+  // CIDR block the credential may authenticate from
+  cidrBlock string
+  // Single IP address the credential may authenticate from
+  ipAddress string
+  // Time the entry was added to the access list
+  created time
+  // Number of requests Atlas has seen from this entry
+  requestCount int
+  // Time the entry was last used to authenticate, null when it has never been used
+  lastUsed time
+  // Address within the entry that most recently authenticated, empty when it has never been used
+  lastUsedAddress string
 }
 
 // MongoDB Atlas service account
@@ -217,6 +248,10 @@ mongodbatlas.serviceAccount @defaults("name clientId") {
   createdAt time
   // Issued secrets, each with its id, creation, expiry, and last-used times (no secret values)
   secrets []dict
+  // API access list entries restricting where the service account may be used from, empty when it is usable from any address
+  accessList() []mongodbatlas.apiAccessListEntry
+  // Projects the service account is assigned to
+  projects() []mongodbatlas.project
 }
 
 // MongoDB Atlas cluster
@@ -518,6 +553,8 @@ mongodbatlas.databaseUser @defaults("username databaseName") {
   scopes []dict
   // Clusters the user is scoped to, empty when the user may access all clusters in the project
   scopedClusters() []mongodbatlas.cluster
+  // Labels attached to the user, as key/value pairs
+  labels map[string]string
   // Time after which the user is automatically deleted, null when permanent
   deleteAfterDate time
 }

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.go
@@ -23,6 +23,7 @@ const (
 	ResourceMongodbatlasTeam                    string = "mongodbatlas.team"
 	ResourceMongodbatlasApiKey                  string = "mongodbatlas.apiKey"
 	ResourceMongodbatlasApiKeyRoleAssignment    string = "mongodbatlas.apiKey.roleAssignment"
+	ResourceMongodbatlasApiAccessListEntry      string = "mongodbatlas.apiAccessListEntry"
 	ResourceMongodbatlasServiceAccount          string = "mongodbatlas.serviceAccount"
 	ResourceMongodbatlasCluster                 string = "mongodbatlas.cluster"
 	ResourceMongodbatlasBackupScheduleConfig    string = "mongodbatlas.backupScheduleConfig"
@@ -76,6 +77,10 @@ func init() {
 		"mongodbatlas.apiKey.roleAssignment": {
 			// to override args, implement: initMongodbatlasApiKeyRoleAssignment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMongodbatlasApiKeyRoleAssignment,
+		},
+		"mongodbatlas.apiAccessListEntry": {
+			// to override args, implement: initMongodbatlasApiAccessListEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMongodbatlasApiAccessListEntry,
 		},
 		"mongodbatlas.serviceAccount": {
 			// to override args, implement: initMongodbatlasServiceAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -252,6 +257,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.securityContact": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlas).GetSecurityContact()).ToDataRes(types.String)
 	},
+	"mongodbatlas.streamsCrossGroupEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlas).GetStreamsCrossGroupEnabled()).ToDataRes(types.Bool)
+	},
 	"mongodbatlas.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlas).GetProjects()).ToDataRes(types.Array(types.Resource("mongodbatlas.project")))
 	},
@@ -393,6 +401,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.apiKey.roleAssignments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasApiKey).GetRoleAssignments()).ToDataRes(types.Array(types.Resource("mongodbatlas.apiKey.roleAssignment")))
 	},
+	"mongodbatlas.apiKey.accessList": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiKey).GetAccessList()).ToDataRes(types.Array(types.Resource("mongodbatlas.apiAccessListEntry")))
+	},
 	"mongodbatlas.apiKey.roleAssignment.roleName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasApiKeyRoleAssignment).GetRoleName()).ToDataRes(types.String)
 	},
@@ -401,6 +412,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mongodbatlas.apiKey.roleAssignment.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasApiKeyRoleAssignment).GetProject()).ToDataRes(types.Resource("mongodbatlas.project"))
+	},
+	"mongodbatlas.apiAccessListEntry.cidrBlock": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiAccessListEntry).GetCidrBlock()).ToDataRes(types.String)
+	},
+	"mongodbatlas.apiAccessListEntry.ipAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiAccessListEntry).GetIpAddress()).ToDataRes(types.String)
+	},
+	"mongodbatlas.apiAccessListEntry.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiAccessListEntry).GetCreated()).ToDataRes(types.Time)
+	},
+	"mongodbatlas.apiAccessListEntry.requestCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiAccessListEntry).GetRequestCount()).ToDataRes(types.Int)
+	},
+	"mongodbatlas.apiAccessListEntry.lastUsed": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiAccessListEntry).GetLastUsed()).ToDataRes(types.Time)
+	},
+	"mongodbatlas.apiAccessListEntry.lastUsedAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiAccessListEntry).GetLastUsedAddress()).ToDataRes(types.String)
 	},
 	"mongodbatlas.serviceAccount.clientId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasServiceAccount).GetClientId()).ToDataRes(types.String)
@@ -419,6 +448,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mongodbatlas.serviceAccount.secrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasServiceAccount).GetSecrets()).ToDataRes(types.Array(types.Dict))
+	},
+	"mongodbatlas.serviceAccount.accessList": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasServiceAccount).GetAccessList()).ToDataRes(types.Array(types.Resource("mongodbatlas.apiAccessListEntry")))
+	},
+	"mongodbatlas.serviceAccount.projects": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasServiceAccount).GetProjects()).ToDataRes(types.Array(types.Resource("mongodbatlas.project")))
 	},
 	"mongodbatlas.cluster.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasCluster).GetId()).ToDataRes(types.String)
@@ -686,6 +721,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mongodbatlas.databaseUser.scopedClusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasDatabaseUser).GetScopedClusters()).ToDataRes(types.Array(types.Resource("mongodbatlas.cluster")))
+	},
+	"mongodbatlas.databaseUser.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasDatabaseUser).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"mongodbatlas.databaseUser.deleteAfterDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasDatabaseUser).GetDeleteAfterDate()).ToDataRes(types.Time)
@@ -1020,6 +1058,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlas).SecurityContact, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"mongodbatlas.streamsCrossGroupEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlas).StreamsCrossGroupEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"mongodbatlas.projects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlas).Projects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1228,6 +1270,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlasApiKey).RoleAssignments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"mongodbatlas.apiKey.accessList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiKey).AccessList, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"mongodbatlas.apiKey.roleAssignment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasApiKeyRoleAssignment).__id, ok = v.Value.(string)
 		return
@@ -1242,6 +1288,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongodbatlas.apiKey.roleAssignment.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasApiKeyRoleAssignment).Project, ok = plugin.RawToTValue[*mqlMongodbatlasProject](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiAccessListEntry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiAccessListEntry).__id, ok = v.Value.(string)
+		return
+	},
+	"mongodbatlas.apiAccessListEntry.cidrBlock": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiAccessListEntry).CidrBlock, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiAccessListEntry.ipAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiAccessListEntry).IpAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiAccessListEntry.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiAccessListEntry).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiAccessListEntry.requestCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiAccessListEntry).RequestCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiAccessListEntry.lastUsed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiAccessListEntry).LastUsed, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiAccessListEntry.lastUsedAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiAccessListEntry).LastUsedAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.serviceAccount.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1270,6 +1344,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongodbatlas.serviceAccount.secrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasServiceAccount).Secrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.serviceAccount.accessList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasServiceAccount).AccessList, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.serviceAccount.projects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasServiceAccount).Projects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.cluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1650,6 +1732,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongodbatlas.databaseUser.scopedClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasDatabaseUser).ScopedClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.databaseUser.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasDatabaseUser).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.databaseUser.deleteAfterDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2121,6 +2207,7 @@ type mqlMongodbatlas struct {
 	GenAiFeaturesEnabled                   plugin.TValue[bool]
 	MaxServiceAccountSecretValidityInHours plugin.TValue[int64]
 	SecurityContact                        plugin.TValue[string]
+	StreamsCrossGroupEnabled               plugin.TValue[bool]
 	Projects                               plugin.TValue[[]any]
 	OrgUsers                               plugin.TValue[[]any]
 	Teams                                  plugin.TValue[[]any]
@@ -2226,6 +2313,12 @@ func (c *mqlMongodbatlas) GetMaxServiceAccountSecretValidityInHours() *plugin.TV
 func (c *mqlMongodbatlas) GetSecurityContact() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.SecurityContact, func() (string, error) {
 		return c.securityContact()
+	})
+}
+
+func (c *mqlMongodbatlas) GetStreamsCrossGroupEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.StreamsCrossGroupEnabled, func() (bool, error) {
+		return c.streamsCrossGroupEnabled()
 	})
 }
 
@@ -2888,6 +2981,7 @@ type mqlMongodbatlasApiKey struct {
 	PublicKey       plugin.TValue[string]
 	Description     plugin.TValue[string]
 	RoleAssignments plugin.TValue[[]any]
+	AccessList      plugin.TValue[[]any]
 }
 
 // createMongodbatlasApiKey creates a new instance of this resource
@@ -2947,6 +3041,22 @@ func (c *mqlMongodbatlasApiKey) GetRoleAssignments() *plugin.TValue[[]any] {
 		}
 
 		return c.roleAssignments()
+	})
+}
+
+func (c *mqlMongodbatlasApiKey) GetAccessList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AccessList, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.apiKey", c.__id, "accessList")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.accessList()
 	})
 }
 
@@ -3016,6 +3126,75 @@ func (c *mqlMongodbatlasApiKeyRoleAssignment) GetProject() *plugin.TValue[*mqlMo
 	})
 }
 
+// mqlMongodbatlasApiAccessListEntry for the mongodbatlas.apiAccessListEntry resource
+type mqlMongodbatlasApiAccessListEntry struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMongodbatlasApiAccessListEntryInternal it will be used here
+	CidrBlock       plugin.TValue[string]
+	IpAddress       plugin.TValue[string]
+	Created         plugin.TValue[*time.Time]
+	RequestCount    plugin.TValue[int64]
+	LastUsed        plugin.TValue[*time.Time]
+	LastUsedAddress plugin.TValue[string]
+}
+
+// createMongodbatlasApiAccessListEntry creates a new instance of this resource
+func createMongodbatlasApiAccessListEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMongodbatlasApiAccessListEntry{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("mongodbatlas.apiAccessListEntry", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) MqlName() string {
+	return "mongodbatlas.apiAccessListEntry"
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) GetCidrBlock() *plugin.TValue[string] {
+	return &c.CidrBlock
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) GetIpAddress() *plugin.TValue[string] {
+	return &c.IpAddress
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) GetRequestCount() *plugin.TValue[int64] {
+	return &c.RequestCount
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) GetLastUsed() *plugin.TValue[*time.Time] {
+	return &c.LastUsed
+}
+
+func (c *mqlMongodbatlasApiAccessListEntry) GetLastUsedAddress() *plugin.TValue[string] {
+	return &c.LastUsedAddress
+}
+
 // mqlMongodbatlasServiceAccount for the mongodbatlas.serviceAccount resource
 type mqlMongodbatlasServiceAccount struct {
 	MqlRuntime *plugin.Runtime
@@ -3027,6 +3206,8 @@ type mqlMongodbatlasServiceAccount struct {
 	Roles       plugin.TValue[[]any]
 	CreatedAt   plugin.TValue[*time.Time]
 	Secrets     plugin.TValue[[]any]
+	AccessList  plugin.TValue[[]any]
+	Projects    plugin.TValue[[]any]
 }
 
 // createMongodbatlasServiceAccount creates a new instance of this resource
@@ -3083,6 +3264,38 @@ func (c *mqlMongodbatlasServiceAccount) GetCreatedAt() *plugin.TValue[*time.Time
 
 func (c *mqlMongodbatlasServiceAccount) GetSecrets() *plugin.TValue[[]any] {
 	return &c.Secrets
+}
+
+func (c *mqlMongodbatlasServiceAccount) GetAccessList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AccessList, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.serviceAccount", c.__id, "accessList")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.accessList()
+	})
+}
+
+func (c *mqlMongodbatlasServiceAccount) GetProjects() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Projects, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.serviceAccount", c.__id, "projects")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.projects()
+	})
 }
 
 // mqlMongodbatlasCluster for the mongodbatlas.cluster resource
@@ -3734,6 +3947,7 @@ type mqlMongodbatlasDatabaseUser struct {
 	Roles           plugin.TValue[[]any]
 	Scopes          plugin.TValue[[]any]
 	ScopedClusters  plugin.TValue[[]any]
+	Labels          plugin.TValue[map[string]any]
 	DeleteAfterDate plugin.TValue[*time.Time]
 }
 
@@ -3823,6 +4037,10 @@ func (c *mqlMongodbatlasDatabaseUser) GetScopedClusters() *plugin.TValue[[]any] 
 
 		return c.scopedClusters()
 	})
+}
+
+func (c *mqlMongodbatlasDatabaseUser) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 func (c *mqlMongodbatlasDatabaseUser) GetDeleteAfterDate() *plugin.TValue[*time.Time] {

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.versions
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.versions
@@ -2,8 +2,16 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 mongodbatlas 13.0.0
+mongodbatlas.apiAccessListEntry 13.2.1
+mongodbatlas.apiAccessListEntry.cidrBlock 13.2.1
+mongodbatlas.apiAccessListEntry.created 13.2.1
+mongodbatlas.apiAccessListEntry.ipAddress 13.2.1
+mongodbatlas.apiAccessListEntry.lastUsed 13.2.1
+mongodbatlas.apiAccessListEntry.lastUsedAddress 13.2.1
+mongodbatlas.apiAccessListEntry.requestCount 13.2.1
 mongodbatlas.apiAccessListRequired 13.0.0
 mongodbatlas.apiKey 13.0.0
+mongodbatlas.apiKey.accessList 13.2.1
 mongodbatlas.apiKey.description 13.0.0
 mongodbatlas.apiKey.id 13.0.0
 mongodbatlas.apiKey.publicKey 13.0.0
@@ -99,6 +107,7 @@ mongodbatlas.databaseUser.databaseName 13.0.0
 mongodbatlas.databaseUser.deleteAfterDate 13.0.0
 mongodbatlas.databaseUser.description 13.0.0
 mongodbatlas.databaseUser.id 13.0.0
+mongodbatlas.databaseUser.labels 13.2.1
 mongodbatlas.databaseUser.ldapAuthType 13.0.0
 mongodbatlas.databaseUser.oidcAuthType 13.0.0
 mongodbatlas.databaseUser.roles 13.0.0
@@ -255,10 +264,12 @@ mongodbatlas.searchIndex.statusDetail 13.0.1
 mongodbatlas.searchIndex.type 13.0.1
 mongodbatlas.securityContact 13.0.0
 mongodbatlas.serviceAccount 13.0.0
+mongodbatlas.serviceAccount.accessList 13.2.1
 mongodbatlas.serviceAccount.clientId 13.0.0
 mongodbatlas.serviceAccount.createdAt 13.0.0
 mongodbatlas.serviceAccount.description 13.0.0
 mongodbatlas.serviceAccount.name 13.0.0
+mongodbatlas.serviceAccount.projects 13.2.1
 mongodbatlas.serviceAccount.roles 13.0.0
 mongodbatlas.serviceAccount.secrets 13.0.0
 mongodbatlas.serviceAccounts 13.0.0
@@ -271,6 +282,7 @@ mongodbatlas.snapshotExportBucket.region 13.1.4
 mongodbatlas.snapshotExportBucket.serviceUrl 13.1.4
 mongodbatlas.snapshotExportBucket.tenantId 13.1.4
 mongodbatlas.snapshotExportBuckets 13.1.4
+mongodbatlas.streamsCrossGroupEnabled 13.2.1
 mongodbatlas.team 13.0.0
 mongodbatlas.team.id 13.0.0
 mongodbatlas.team.name 13.0.0

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -94,6 +94,30 @@ func (r *mqlMongodbatlas) projects() ([]any, error) {
 	return out, nil
 }
 
+// orgProjectsByID lists the organization's projects once and caches them by id
+// on the root resource. Resolving a project reference through this map keeps a
+// list of references to one API call, where hydrating each one by id would run
+// the project init, and therefore a GetProject call, per reference.
+func (r *mqlMongodbatlas) orgProjectsByID() (map[string]*mqlMongodbatlasProject, error) {
+	r.projectsOnce.Do(func() {
+		projects, err := r.projects()
+		if err != nil {
+			r.projectsErr = err
+			return
+		}
+		m := make(map[string]*mqlMongodbatlasProject, len(projects))
+		for _, p := range projects {
+			proj, ok := p.(*mqlMongodbatlasProject)
+			if !ok {
+				continue
+			}
+			m[proj.Id.Data] = proj
+		}
+		r.projectsByID = m
+	})
+	return r.projectsByID, r.projectsErr
+}
+
 func (r *mqlMongodbatlas) orgUsers() ([]any, error) {
 	oid, err := orgID(r.MqlRuntime)
 	if err != nil {


### PR DESCRIPTION
## What

Atlas lets you require an IP access list on programmatic credentials, and the root resource already reports that policy as `apiAccessListRequired`. Nothing reported **compliance** with it, so an org-owner API key or service account usable from any address on the internet was invisible to a scan.

This adds the access list itself, plus three smaller gaps on payloads we already fetch.

### `accessList` on both credential kinds

New `mongodbatlas.apiAccessListEntry`, reachable from `mongodbatlas.apiKey.accessList` and `mongodbatlas.serviceAccount.accessList`.

Atlas returns the same entry under two shapes, with the usage fields named differently per endpoint (`count` vs `requestCount`, `created`/`lastUsed` vs `createdAt`/`lastUsedAt`). Both normalize into one resource, so a single query spans either credential kind:

```
mongodbatlas.apiKeys.all(accessList != empty)
mongodbatlas.serviceAccounts.all(accessList != empty)
```

The entry carries `requestCount`, `lastUsed`, and `lastUsedAddress` as well, so allowances that have never authenticated are queryable:

```
mongodbatlas.apiKeys { description accessList { cidrBlock lastUsed requestCount } }
```

A denied read renders **null**, not an empty list. An empty access list is exactly the finding here, so reporting one on a read that established nothing would pass an audit vacuously (same reasoning as #9737).

### `serviceAccount.projects`

The reach a leaked client secret would carry. The assignment listing returns project ids only, so they resolve through a new organization-wide project cache on the root resource: a list of references costs one `ListProjects` call rather than a `GetProject` per reference. A project the org listing did not cover falls back to a direct lookup, and a failure there is reported rather than skipped, so the list cannot silently under-report.

### Two field gaps

- `streamsCrossGroupEnabled` on the root, the last organization setting in the payload that was not exposed. Whether Atlas Stream Processing may connect to clusters in other projects.
- `databaseUser.labels`, already present on the user payload.

## Testing

- `go build ./...`, `go vet ./...`, `golangci-lint run ./resources/...` (0 issues), `gofmt` clean.
- `go test ./...` passes. New unit tests cover both endpoint shapes decoding into the shared entry (including the differently-named counters), the unused-entry case where `lastUsed` must stay null rather than becoming the zero time, parent-scoping of the cache key so the same CIDR on two credentials does not alias, and `labelMap` against the pointer-valued label struct.
- `.lr.versions` entries at 13.2.1 over the shipped 13.2.0.

**Live verification is owed** — no Atlas credentials in the current environment. Both new endpoints may require more privilege than a read-only org key, which is the case the null-degrade path exists for; that path needs proving against the real API before this is trusted.
