### PR TITLE
✨ oci: add freeform and defined tags to 25 more resources

### DIFF
--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -68,6 +68,8 @@ func (o *mqlOciBastion) bastions() ([]any, error) {
 					"dnsProxyStatus": llx.StringData(string(b.DnsProxyStatus)),
 					"created":        llx.TimeDataPtr(created),
 					"timeUpdated":    llx.TimeDataPtr(timeUpdated),
+					"freeformTags":   llx.MapData(strMapToAny(b.FreeformTags), types.String),
+					"definedTags":    llx.MapData(definedTagsToAny(b.DefinedTags), types.Any),
 					"systemTags":     llx.MapData(definedTagsToAny(b.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -238,6 +238,8 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 			"state":              llx.StringData(string(target.LifecycleState)),
 			"recipeCount":        llx.IntDataPtr(target.RecipeCount),
 			"created":            llx.TimeDataPtr(created),
+			"freeformTags":       llx.MapData(strMapToAny(target.FreeformTags), types.String),
+			"definedTags":        llx.MapData(definedTagsToAny(target.DefinedTags), types.Any),
 			"systemTags":         llx.MapData(definedTagsToAny(target.SystemTags), types.Dict),
 		})
 		if err != nil {
@@ -554,6 +556,8 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 			"detectorType":  llx.StringData(string(recipe.Detector)),
 			"state":         llx.StringData(string(recipe.LifecycleState)),
 			"created":       llx.TimeDataPtr(created),
+			"freeformTags":  llx.MapData(strMapToAny(recipe.FreeformTags), types.String),
+			"definedTags":   llx.MapData(definedTagsToAny(recipe.DefinedTags), types.Any),
 			"systemTags":    llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
 		})
 		if err != nil {
@@ -620,6 +624,8 @@ func (o *mqlOciCloudGuard) securityZones() ([]any, error) {
 			"isInheritanceAfterDeleteEnabled": llx.BoolDataPtr(zone.IsInheritanceAfterDeleteEnabled),
 			"state":                           llx.StringData(string(zone.LifecycleState)),
 			"created":                         llx.TimeDataPtr(created),
+			"freeformTags":                    llx.MapData(strMapToAny(zone.FreeformTags), types.String),
+			"definedTags":                     llx.MapData(definedTagsToAny(zone.DefinedTags), types.Any),
 			"systemTags":                      llx.MapData(definedTagsToAny(zone.SystemTags), types.Dict),
 		})
 		if err != nil {
@@ -678,6 +684,8 @@ func (o *mqlOciCloudGuard) securityZoneRecipes() ([]any, error) {
 			"owner":         llx.StringData(string(recipe.Owner)),
 			"state":         llx.StringData(string(recipe.LifecycleState)),
 			"created":       llx.TimeDataPtr(created),
+			"freeformTags":  llx.MapData(strMapToAny(recipe.FreeformTags), types.String),
+			"definedTags":   llx.MapData(definedTagsToAny(recipe.DefinedTags), types.Any),
 			"systemTags":    llx.MapData(definedTagsToAny(recipe.SystemTags), types.Dict),
 		})
 		if err != nil {
@@ -744,6 +752,8 @@ func (o *mqlOciCloudGuard) securityPolicies() ([]any, error) {
 			"services":      llx.ArrayData(services, types.String),
 			"state":         llx.StringData(string(policy.LifecycleState)),
 			"created":       llx.TimeDataPtr(created),
+			"freeformTags":  llx.MapData(strMapToAny(policy.FreeformTags), types.String),
+			"definedTags":   llx.MapData(definedTagsToAny(policy.DefinedTags), types.Any),
 			"systemTags":    llx.MapData(definedTagsToAny(policy.SystemTags), types.Dict),
 		})
 		if err != nil {

--- a/providers/oci/resources/compartment_args_test.go
+++ b/providers/oci/resources/compartment_args_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestOciCompartmentArgs(t *testing.T) {
+	created := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	compartment := identity.Compartment{
+		Id:             common.String("ocid1.compartment.oc1..a"),
+		Name:           common.String("platform"),
+		Description:    common.String("shared infrastructure"),
+		TimeCreated:    &common.SDKTime{Time: created},
+		LifecycleState: identity.CompartmentLifecycleStateActive,
+		FreeformTags:   map[string]string{"env": "prod"},
+		DefinedTags: map[string]map[string]interface{}{
+			"Operations": {"CostCenter": "42"},
+		},
+	}
+
+	args := ociCompartmentArgs(compartment)
+
+	assert.Equal(t, "ocid1.compartment.oc1..a", args["id"].Value)
+	assert.Equal(t, "platform", args["name"].Value)
+	assert.Equal(t, "shared infrastructure", args["description"].Value)
+	assert.Equal(t, "ACTIVE", args["state"].Value)
+	assert.Equal(t, map[string]any{"env": "prod"}, args["freeformTags"].Value)
+	assert.Equal(t, map[string]any{"Operations": map[string]any{"CostCenter": "42"}}, args["definedTags"].Value)
+
+	ts, ok := args["created"].Value.(*time.Time)
+	require.True(t, ok, "created should carry a *time.Time")
+	assert.Equal(t, created, ts.UTC())
+}
+
+// A compartment with nothing set must still produce every field. An absent
+// timestamp in particular has to stay null rather than becoming the zero time,
+// which would report 1 January year 1 as a real creation date.
+func TestOciCompartmentArgsEmpty(t *testing.T) {
+	args := ociCompartmentArgs(identity.Compartment{})
+
+	for _, name := range []string{"id", "name", "description", "created", "state", "freeformTags", "definedTags"} {
+		_, ok := args[name]
+		assert.True(t, ok, "field %q missing for an empty compartment", name)
+	}
+	assert.Nil(t, args["created"].Value, "an absent TimeCreated must stay null, not become the zero time")
+	assert.Empty(t, args["freeformTags"].Value)
+	assert.Empty(t, args["definedTags"].Value)
+}
+
+// initOciCompartment hand-populates args on the access-denied path. Any field
+// it leaves out ships unset rather than null, and an unset field crosses the
+// plugin boundary as a primitive with no type information - which surfaces to
+// the user as an unattributed coercion warning instead of a readable null.
+//
+// This pins that the denied path covers exactly the fields the readable path
+// produces, minus the id the caller already supplied.
+func TestOciCompartmentUnreadableCoversEveryField(t *testing.T) {
+	args := map[string]*llx.RawData{"id": llx.StringData("ocid1.compartment.oc1..a")}
+	ociCompartmentUnreadable(args)
+
+	for name := range ociCompartmentArgs(identity.Compartment{}) {
+		raw, ok := args[name]
+		require.True(t, ok, "field %q is unset on the access-denied path", name)
+		if name == "id" {
+			assert.Equal(t, "ocid1.compartment.oc1..a", raw.Value, "id must survive; it is how the caller found the compartment")
+			continue
+		}
+		assert.Nil(t, raw.Value, "field %q must be explicitly null when the compartment cannot be read", name)
+	}
+
+	assert.Len(t, args, len(ociCompartmentArgs(identity.Compartment{})),
+		"the denied path should set the same field set as the readable one, no more and no less")
+}

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -469,6 +469,8 @@ func (o *mqlOciCompute) blockVolumes() ([]any, error) {
 					"isAutoTuneEnabled":    llx.BoolDataPtr(vol.IsAutoTuneEnabled),
 					"sourceVolumeBackupId": llx.StringData(sourceVolumeBackupID),
 					"created":              llx.TimeDataPtr(created),
+					"freeformTags":         llx.MapData(strMapToAny(vol.FreeformTags), types.String),
+					"definedTags":          llx.MapData(definedTagsToAny(vol.DefinedTags), types.Any),
 					"systemTags":           llx.MapData(definedTagsToAny(vol.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -571,6 +573,8 @@ func (o *mqlOciCompute) bootVolumes() ([]any, error) {
 					"state":                    llx.StringData(string(bv.LifecycleState)),
 					"sourceBootVolumeBackupId": llx.StringData(sourceBootVolumeBackupID),
 					"created":                  llx.TimeDataPtr(created),
+					"freeformTags":             llx.MapData(strMapToAny(bv.FreeformTags), types.String),
+					"definedTags":              llx.MapData(definedTagsToAny(bv.DefinedTags), types.Any),
 					"systemTags":               llx.MapData(definedTagsToAny(bv.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/events.go
+++ b/providers/oci/resources/events.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOciEvents) id() (string, error) {
@@ -53,6 +54,8 @@ func (o *mqlOciEvents) rules() ([]any, error) {
 					"isEnabled":     llx.BoolDataPtr(rule.IsEnabled),
 					"state":         llx.StringData(string(rule.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
+					"freeformTags":  llx.MapData(strMapToAny(rule.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(rule.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -79,6 +79,8 @@ func (o *mqlOciFileStorage) fileSystems() ([]any, error) {
 						"meteredBytes":       llx.IntDataPtr(fs.MeteredBytes),
 						"isCloneParent":      llx.BoolDataPtr(fs.IsCloneParent),
 						"created":            llx.TimeDataPtr(created),
+						"freeformTags":       llx.MapData(strMapToAny(fs.FreeformTags), types.String),
+						"definedTags":        llx.MapData(definedTagsToAny(fs.DefinedTags), types.Any),
 						"systemTags":         llx.MapData(definedTagsToAny(fs.SystemTags), types.Dict),
 					})
 					if err != nil {

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -15,6 +15,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOciKms) id() (string, error) {
@@ -60,6 +61,8 @@ func (o *mqlOciKms) vaults() ([]any, error) {
 					"state":              llx.StringData(string(vault.LifecycleState)),
 					"managementEndpoint": llx.StringDataPtr(vault.ManagementEndpoint),
 					"created":            llx.TimeDataPtr(created),
+					"freeformTags":       llx.MapData(strMapToAny(vault.FreeformTags), types.String),
+					"definedTags":        llx.MapData(definedTagsToAny(vault.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -171,6 +174,8 @@ func (o *mqlOciKmsVault) keys() ([]any, error) {
 			"state":                 llx.StringData(string(key.LifecycleState)),
 			"isAutoRotationEnabled": llx.BoolDataPtr(key.IsAutoRotationEnabled),
 			"created":               llx.TimeDataPtr(created),
+			"freeformTags":          llx.MapData(strMapToAny(key.FreeformTags), types.String),
+			"definedTags":           llx.MapData(definedTagsToAny(key.DefinedTags), types.Any),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -55,6 +55,8 @@ func (o *mqlOciLogging) logGroups() ([]any, error) {
 					"compartmentID": llx.StringDataPtr(lg.CompartmentId),
 					"state":         llx.StringData(string(lg.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
+					"freeformTags":  llx.MapData(strMapToAny(lg.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(lg.DefinedTags), types.Any),
 					"systemTags":    llx.MapData(definedTagsToAny(lg.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -177,6 +179,8 @@ func (o *mqlOciLoggingLogGroup) logs() ([]any, error) {
 			"sourceResource":    llx.StringData(sourceResource),
 			"created":           llx.TimeDataPtr(logCreated),
 			"timeLastModified":  llx.TimeDataPtr(logLastModified),
+			"freeformTags":      llx.MapData(strMapToAny(l.FreeformTags), types.String),
+			"definedTags":       llx.MapData(definedTagsToAny(l.DefinedTags), types.Any),
 			"systemTags":        llx.MapData(definedTagsToAny(l.SystemTags), types.Dict),
 		})
 		if err != nil {

--- a/providers/oci/resources/monitoring.go
+++ b/providers/oci/resources/monitoring.go
@@ -67,6 +67,8 @@ func (o *mqlOciMonitoring) alarms() ([]any, error) {
 					"destinations":        llx.ArrayData(destinations, types.String),
 					"isEnabled":           llx.BoolDataPtr(alarm.IsEnabled),
 					"state":               llx.StringData(string(alarm.LifecycleState)),
+					"freeformTags":        llx.MapData(strMapToAny(alarm.FreeformTags), types.String),
+					"definedTags":         llx.MapData(definedTagsToAny(alarm.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -1308,6 +1308,8 @@ func (o *mqlOciNetwork) publicIps() ([]any, error) {
 					"availabilityDomain": llx.StringDataPtr(publicIp.AvailabilityDomain),
 					"state":              llx.StringData(string(publicIp.LifecycleState)),
 					"created":            llx.TimeDataPtr(created),
+					"freeformTags":       llx.MapData(strMapToAny(publicIp.FreeformTags), types.String),
+					"definedTags":        llx.MapData(definedTagsToAny(publicIp.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -71,6 +71,8 @@ func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 					"created":            llx.TimeDataPtr(created),
 					"timeUpdated":        llx.TimeDataPtr(timeUpdated),
 					"securityAttributes": llx.MapData(definedTagsToAny(fw.SecurityAttributes), types.Dict),
+					"freeformTags":       llx.MapData(strMapToAny(fw.FreeformTags), types.String),
+					"definedTags":        llx.MapData(definedTagsToAny(fw.DefinedTags), types.Any),
 					"systemTags":         llx.MapData(definedTagsToAny(fw.SystemTags), types.Dict),
 				})
 				if err != nil {
@@ -181,6 +183,8 @@ func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 					"compartmentID": llx.StringDataPtr(p.CompartmentId),
 					"state":         llx.StringData(string(p.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
+					"freeformTags":  llx.MapData(strMapToAny(p.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(p.DefinedTags), types.Any),
 					"systemTags":    llx.MapData(definedTagsToAny(p.SystemTags), types.Dict),
 				})
 				if err != nil {

--- a/providers/oci/resources/oci.go
+++ b/providers/oci/resources/oci.go
@@ -14,6 +14,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOci) id() (string, error) {
@@ -66,20 +67,7 @@ func (o *mqlOci) compartments() ([]any, error) {
 
 	res := []any{}
 	for i := range compartments {
-		compartment := compartments[i]
-
-		var created *time.Time
-		if compartment.TimeCreated != nil {
-			created = &compartment.TimeCreated.Time
-		}
-
-		mqlCompartment, err := CreateResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
-			"id":          llx.StringDataPtr(compartment.Id),
-			"name":        llx.StringDataPtr(compartment.Name),
-			"description": llx.StringDataPtr(compartment.Description),
-			"created":     llx.TimeDataPtr(created),
-			"state":       llx.StringData(string(compartment.LifecycleState)),
-		})
+		mqlCompartment, err := CreateResource(o.MqlRuntime, "oci.compartment", ociCompartmentArgs(compartments[i]))
 		if err != nil {
 			return nil, err
 		}
@@ -87,6 +75,43 @@ func (o *mqlOci) compartments() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// ociCompartmentArgs builds the MQL fields for a compartment.
+//
+// Both the lister and initOciCompartment create oci.compartment, so a field
+// added to one and forgotten in the other ships unset rather than null, which
+// crosses the plugin boundary as a primitive with no type information. Building
+// both from here makes the two impossible to drift apart.
+func ociCompartmentArgs(compartment identity.Compartment) map[string]*llx.RawData {
+	var created *time.Time
+	if compartment.TimeCreated != nil {
+		created = &compartment.TimeCreated.Time
+	}
+
+	return map[string]*llx.RawData{
+		"id":           llx.StringDataPtr(compartment.Id),
+		"name":         llx.StringDataPtr(compartment.Name),
+		"description":  llx.StringDataPtr(compartment.Description),
+		"created":      llx.TimeDataPtr(created),
+		"state":        llx.StringData(string(compartment.LifecycleState)),
+		"freeformTags": llx.MapData(strMapToAny(compartment.FreeformTags), types.String),
+		"definedTags":  llx.MapData(definedTagsToAny(compartment.DefinedTags), types.Any),
+	}
+}
+
+// ociCompartmentUnreadable marks every field except id explicitly null, for a
+// compartment the caller may see by OCID but not read.
+//
+// The field list is derived from ociCompartmentArgs rather than written out, so
+// a field added there is nulled here without a second edit.
+func ociCompartmentUnreadable(args map[string]*llx.RawData) {
+	for name := range ociCompartmentArgs(identity.Compartment{}) {
+		if name == "id" {
+			continue
+		}
+		args[name] = llx.NilData
+	}
 }
 
 func (o *mqlOciCompartment) id() (string, error) {
@@ -119,24 +144,13 @@ func initOciCompartment(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		// explicitly null. Leaving them unset sends a primitive with no type
 		// information across the plugin boundary, which surfaces client-side as
 		// an unattributed coercion warning rather than a readable null.
-		args["name"] = llx.NilData
-		args["description"] = llx.NilData
-		args["created"] = llx.NilData
-		args["state"] = llx.NilData
+		ociCompartmentUnreadable(args)
 		return args, nil, nil
 	}
-	compartment := resp.Compartment
 
-	var created *time.Time
-	if compartment.TimeCreated != nil {
-		created = &compartment.TimeCreated.Time
+	for name, value := range ociCompartmentArgs(resp.Compartment) {
+		args[name] = value
 	}
-
-	args["id"] = llx.StringDataPtr(compartment.Id)
-	args["name"] = llx.StringDataPtr(compartment.Name)
-	args["description"] = llx.StringDataPtr(compartment.Description)
-	args["created"] = llx.TimeDataPtr(created)
-	args["state"] = llx.StringData(string(compartment.LifecycleState))
 	return args, nil, nil
 }
 
@@ -155,6 +169,8 @@ func initOciTenancy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	args["id"] = llx.StringDataPtr(tenancy.Id)
 	args["name"] = llx.StringDataPtr(tenancy.Name)
 	args["description"] = llx.StringDataPtr(tenancy.Description)
+	args["freeformTags"] = llx.MapData(strMapToAny(tenancy.FreeformTags), types.String)
+	args["definedTags"] = llx.MapData(definedTagsToAny(tenancy.DefinedTags), types.Any)
 
 	return args, nil, nil
 }

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -36,6 +36,10 @@ oci.tenancy @defaults("name") {
   description string
   // Event retention period duration
   retentionPeriod() time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) region
@@ -76,6 +80,10 @@ private oci.compartment @defaults("id name") {
   created time
   // Compartment lifecycle state (CREATING, ACTIVE, INACTIVE, DELETING, DELETED)
   state string
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) Identity and Access Management
@@ -1142,6 +1150,10 @@ private oci.compute.blockVolume @defaults("name") {
   sourceVolumeBackupId string
   // Block volume creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -1187,6 +1199,10 @@ private oci.compute.bootVolume @defaults("name") {
   kmsKey() oci.kms.key
   // Boot volume creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -1279,6 +1295,10 @@ private oci.network.publicIp @defaults("ipAddress lifetime assignedEntityType") 
   state string
   // Creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) Virtual Cloud Network (VCN)
@@ -1779,6 +1799,10 @@ private oci.network.drgAttachment @defaults("name networkType state") {
   state string
   // Creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) local peering gateway (LPG)
@@ -2212,6 +2236,10 @@ private oci.logging.logGroup @defaults("name") {
   logs() []oci.logging.log
   // Creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2256,6 +2284,10 @@ private oci.logging.log @defaults("name") {
   created time
   // Last modification time
   timeLastModified time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2302,6 +2334,10 @@ private oci.kms.vault @defaults("name") {
   keys() []oci.kms.key
   // Creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) KMS key
@@ -2347,6 +2383,10 @@ private oci.kms.key @defaults("name") {
   keyVersions() []oci.kms.keyVersion
   // Creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) KMS key version (represents a specific version of a master encryption key)
@@ -2554,6 +2594,10 @@ private oci.fileStorage.fileSystem @defaults("name") {
   isCloneParent bool
   // File system creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2611,6 +2655,10 @@ private oci.events.rule @defaults("name") {
   actions() []dict
   // Rule creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) Cloud Guard
@@ -2669,6 +2717,10 @@ private oci.cloudGuard.target @defaults("name") {
   recipeCount int
   // Target creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2703,6 +2755,10 @@ private oci.cloudGuard.detectorRecipe @defaults("name") {
   created time
   // Detector rules in the recipe, each with its enabled state and risk level
   rules() []oci.cloudGuard.detectorRule
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2844,6 +2900,10 @@ private oci.cloudGuard.securityZone @defaults("name") {
   state string
   // Security zone creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2874,6 +2934,10 @@ private oci.cloudGuard.securityZoneRecipe @defaults("name") {
   state string
   // Recipe creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2908,6 +2972,10 @@ private oci.cloudGuard.securityPolicy @defaults("name category") {
   state string
   // Policy creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -2950,6 +3018,10 @@ private oci.ons.topic @defaults("name") {
   created time
   // Topic subscriptions
   subscriptions() []oci.ons.subscription
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) notification subscription
@@ -2966,6 +3038,10 @@ private oci.ons.subscription @defaults("id") {
   state string
   // Subscription creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) Audit
@@ -3260,6 +3336,10 @@ private oci.bastion.instance @defaults("name") {
   created time
   // Last update time
   timeUpdated time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -3320,6 +3400,10 @@ private oci.monitoring.alarm @defaults("name") {
   isEnabled bool
   // Lifecycle state (e.g., ACTIVE, DELETING, DELETED)
   state string
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) Vault
@@ -3818,6 +3902,10 @@ private oci.resourceManager.job @defaults("name operation state") {
   created time
   // Job completion time
   finished time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
 }
 
 // Oracle Cloud Infrastructure (OCI) Streaming
@@ -4665,6 +4753,10 @@ private oci.networkFirewall.firewall @defaults("name") {
   //
   // One of OK, WARNING, CRITICAL, or UNKNOWN.
   healthStatus() string
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -4693,6 +4785,10 @@ private oci.networkFirewall.policy @defaults("name") {
   state string
   // Creation time
   created time
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The
@@ -4955,6 +5051,10 @@ private oci.oke.nodePool @defaults("name") {
   networkSecurityGroups() []oci.network.networkSecurityGroup
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED, NEEDS_ATTENTION)
   state string
+  // Free-form tags for resource management
+  freeformTags map[string]string
+  // Defined tags for governance and cost tracking
+  definedTags map[string]map[string]string
   // System tags
   //
   // Tags applied automatically by Oracle, keyed by namespace. The

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -1166,6 +1166,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.tenancy.retentionPeriod": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciTenancy).GetRetentionPeriod()).ToDataRes(types.Time)
 	},
+	"oci.tenancy.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciTenancy).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.tenancy.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciTenancy).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.region.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciRegion).GetId()).ToDataRes(types.String)
 	},
@@ -1192,6 +1198,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compartment.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCompartment).GetState()).ToDataRes(types.String)
+	},
+	"oci.compartment.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCompartment).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.compartment.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCompartment).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.identity.users": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciIdentity).GetUsers()).ToDataRes(types.Array(types.Resource("oci.identity.user")))
@@ -2204,6 +2216,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.blockVolume.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.compute.blockVolume.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBlockVolume).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.compute.blockVolume.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBlockVolume).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.compute.blockVolume.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBlockVolume).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -2245,6 +2263,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.compute.bootVolume.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.compute.bootVolume.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBootVolume).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.compute.bootVolume.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeBootVolume).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.compute.bootVolume.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeBootVolume).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
@@ -2329,6 +2353,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.network.publicIp.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkPublicIp).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.network.publicIp.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkPublicIp).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.network.publicIp.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkPublicIp).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.network.vcn.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkVcn).GetId()).ToDataRes(types.String)
@@ -2786,6 +2816,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.network.drgAttachment.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkDrgAttachment).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.network.drgAttachment.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkDrgAttachment).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.network.drgAttachment.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkDrgAttachment).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.network.localPeeringGateway.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkLocalPeeringGateway).GetId()).ToDataRes(types.String)
 	},
@@ -3212,6 +3248,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.logging.logGroup.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLogGroup).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.logging.logGroup.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoggingLogGroup).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.logging.logGroup.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoggingLogGroup).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.logging.logGroup.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLogGroup).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -3254,6 +3296,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.logging.log.timeLastModified": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLog).GetTimeLastModified()).ToDataRes(types.Time)
 	},
+	"oci.logging.log.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoggingLog).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.logging.log.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoggingLog).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.logging.log.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoggingLog).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -3286,6 +3334,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.kms.vault.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsVault).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.kms.vault.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsVault).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.kms.vault.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsVault).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.kms.key.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetId()).ToDataRes(types.String)
@@ -3328,6 +3382,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.kms.key.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKey).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.kms.key.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsKey).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.kms.key.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciKmsKey).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.kms.keyVersion.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciKmsKeyVersion).GetId()).ToDataRes(types.String)
@@ -3524,6 +3584,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.fileStorage.fileSystem.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.fileStorage.fileSystem.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFileStorageFileSystem).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.fileStorage.fileSystem.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciFileStorageFileSystem).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.fileStorage.fileSystem.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciFileStorageFileSystem).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -3559,6 +3625,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.events.rule.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciEventsRule).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.events.rule.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciEventsRule).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.events.rule.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciEventsRule).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.cloudGuard.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuard).GetStatus()).ToDataRes(types.Bool)
@@ -3614,6 +3686,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.target.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardTarget).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.cloudGuard.target.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardTarget).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.cloudGuard.target.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardTarget).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.cloudGuard.target.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardTarget).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -3646,6 +3724,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.detectorRecipe.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetRules()).ToDataRes(types.Array(types.Resource("oci.cloudGuard.detectorRule")))
+	},
+	"oci.cloudGuard.detectorRecipe.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardDetectorRecipe).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.cloudGuard.detectorRecipe.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardDetectorRecipe).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.cloudGuard.detectorRecipe.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardDetectorRecipe).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
@@ -3782,6 +3866,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.securityZone.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.cloudGuard.securityZone.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZone).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.cloudGuard.securityZone.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZone).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.cloudGuard.securityZone.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZone).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -3811,6 +3901,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.cloudGuard.securityZoneRecipe.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.cloudGuard.securityZoneRecipe.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.cloudGuard.securityZoneRecipe.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.cloudGuard.securityZoneRecipe.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityZoneRecipe).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
@@ -3848,6 +3944,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.cloudGuard.securityPolicy.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetCreated()).ToDataRes(types.Time)
 	},
+	"oci.cloudGuard.securityPolicy.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityPolicy).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.cloudGuard.securityPolicy.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciCloudGuardSecurityPolicy).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.cloudGuard.securityPolicy.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciCloudGuardSecurityPolicy).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -3878,6 +3980,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.ons.topic.subscriptions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOnsTopic).GetSubscriptions()).ToDataRes(types.Array(types.Resource("oci.ons.subscription")))
 	},
+	"oci.ons.topic.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOnsTopic).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.ons.topic.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOnsTopic).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.ons.subscription.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOnsSubscription).GetId()).ToDataRes(types.String)
 	},
@@ -3895,6 +4003,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.ons.subscription.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOnsSubscription).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.ons.subscription.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOnsSubscription).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.ons.subscription.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOnsSubscription).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.audit.retentionPeriodDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciAudit).GetRetentionPeriodDays()).ToDataRes(types.Int)
@@ -4109,6 +4223,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.bastion.instance.timeUpdated": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciBastionInstance).GetTimeUpdated()).ToDataRes(types.Time)
 	},
+	"oci.bastion.instance.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciBastionInstance).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.bastion.instance.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciBastionInstance).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.bastion.instance.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciBastionInstance).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -4150,6 +4270,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.monitoring.alarm.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciMonitoringAlarm).GetState()).ToDataRes(types.String)
+	},
+	"oci.monitoring.alarm.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciMonitoringAlarm).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.monitoring.alarm.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciMonitoringAlarm).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.vault.secrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciVault).GetSecrets()).ToDataRes(types.Array(types.Resource("oci.vault.secret")))
@@ -4561,6 +4687,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.resourceManager.job.finished": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciResourceManagerJob).GetFinished()).ToDataRes(types.Time)
+	},
+	"oci.resourceManager.job.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciResourceManagerJob).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.resourceManager.job.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciResourceManagerJob).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.streaming.streams": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciStreaming).GetStreams()).ToDataRes(types.Array(types.Resource("oci.streaming.stream")))
@@ -5291,6 +5423,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.networkFirewall.firewall.healthStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetHealthStatus()).ToDataRes(types.String)
 	},
+	"oci.networkFirewall.firewall.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallFirewall).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.networkFirewall.firewall.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallFirewall).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
+	},
 	"oci.networkFirewall.firewall.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallFirewall).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
 	},
@@ -5317,6 +5455,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.networkFirewall.policy.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetCreated()).ToDataRes(types.Time)
+	},
+	"oci.networkFirewall.policy.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallPolicy).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.networkFirewall.policy.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciNetworkFirewallPolicy).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.networkFirewall.policy.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciNetworkFirewallPolicy).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
@@ -5509,6 +5653,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.oke.nodePool.state": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetState()).ToDataRes(types.String)
+	},
+	"oci.oke.nodePool.freeformTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeNodePool).GetFreeformTags()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"oci.oke.nodePool.definedTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciOkeNodePool).GetDefinedTags()).ToDataRes(types.Map(types.String, types.Map(types.String, types.String)))
 	},
 	"oci.oke.nodePool.systemTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciOkeNodePool).GetSystemTags()).ToDataRes(types.Map(types.String, types.Dict))
@@ -8488,6 +8638,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciTenancy).RetentionPeriod, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.tenancy.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciTenancy).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.tenancy.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciTenancy).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.region.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciRegion).__id, ok = v.Value.(string)
 		return
@@ -8530,6 +8688,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compartment.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCompartment).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.compartment.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCompartment).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.compartment.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCompartment).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.identity.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9992,6 +10158,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciComputeBlockVolume).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.compute.blockVolume.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBlockVolume).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.compute.blockVolume.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBlockVolume).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.compute.blockVolume.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBlockVolume).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -10050,6 +10224,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.bootVolume.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeBootVolume).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.compute.bootVolume.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBootVolume).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.compute.bootVolume.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeBootVolume).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.compute.bootVolume.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10170,6 +10352,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.network.publicIp.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkPublicIp).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.network.publicIp.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkPublicIp).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.network.publicIp.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkPublicIp).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.network.vcn.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10824,6 +11014,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkDrgAttachment).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.network.drgAttachment.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkDrgAttachment).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.network.drgAttachment.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkDrgAttachment).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.network.localPeeringGateway.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkLocalPeeringGateway).__id, ok = v.Value.(string)
 		return
@@ -11436,6 +11634,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoggingLogGroup).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.logging.logGroup.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoggingLogGroup).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.logging.logGroup.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoggingLogGroup).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.logging.logGroup.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoggingLogGroup).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -11496,6 +11702,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoggingLog).TimeLastModified, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.logging.log.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoggingLog).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.logging.log.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoggingLog).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.logging.log.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoggingLog).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -11546,6 +11760,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.kms.vault.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsVault).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.kms.vault.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsVault).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.kms.vault.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsVault).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.kms.key.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11606,6 +11828,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.kms.key.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciKmsKey).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.kms.key.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsKey).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.kms.key.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciKmsKey).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.kms.keyVersion.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11896,6 +12126,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciFileStorageFileSystem).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.fileStorage.fileSystem.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFileStorageFileSystem).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.fileStorage.fileSystem.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciFileStorageFileSystem).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.fileStorage.fileSystem.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciFileStorageFileSystem).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -11950,6 +12188,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.events.rule.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciEventsRule).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.events.rule.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciEventsRule).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.events.rule.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciEventsRule).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12032,6 +12278,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardTarget).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.target.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardTarget).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.target.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardTarget).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.target.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardTarget).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -12078,6 +12332,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.detectorRecipe.rules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardDetectorRecipe).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.detectorRecipe.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardDetectorRecipe).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.detectorRecipe.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardDetectorRecipe).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.detectorRecipe.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12272,6 +12534,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardSecurityZone).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.securityZone.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZone).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.securityZone.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZone).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.securityZone.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZone).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -12314,6 +12584,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.cloudGuard.securityZoneRecipe.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityZoneRecipe).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.securityZoneRecipe.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZoneRecipe).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.securityZoneRecipe.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityZoneRecipe).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.cloudGuard.securityZoneRecipe.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12368,6 +12646,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciCloudGuardSecurityPolicy).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.cloudGuard.securityPolicy.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityPolicy).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.cloudGuard.securityPolicy.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciCloudGuardSecurityPolicy).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.cloudGuard.securityPolicy.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciCloudGuardSecurityPolicy).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -12416,6 +12702,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciOnsTopic).Subscriptions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"oci.ons.topic.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOnsTopic).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.ons.topic.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOnsTopic).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.ons.subscription.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOnsSubscription).__id, ok = v.Value.(string)
 		return
@@ -12442,6 +12736,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.ons.subscription.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOnsSubscription).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.ons.subscription.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOnsSubscription).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.ons.subscription.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOnsSubscription).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.audit.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12752,6 +13054,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciBastionInstance).TimeUpdated, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"oci.bastion.instance.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciBastionInstance).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.bastion.instance.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciBastionInstance).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.bastion.instance.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciBastionInstance).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -12814,6 +13124,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.monitoring.alarm.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciMonitoringAlarm).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.monitoring.alarm.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciMonitoringAlarm).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.monitoring.alarm.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciMonitoringAlarm).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.vault.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13422,6 +13740,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.resourceManager.job.finished": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciResourceManagerJob).Finished, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.resourceManager.job.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciResourceManagerJob).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.resourceManager.job.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciResourceManagerJob).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.streaming.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14488,6 +14814,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciNetworkFirewallFirewall).HealthStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.networkFirewall.firewall.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallFirewall).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.networkFirewall.firewall.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallFirewall).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"oci.networkFirewall.firewall.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallFirewall).SystemTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -14526,6 +14860,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.networkFirewall.policy.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciNetworkFirewallPolicy).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.networkFirewall.policy.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallPolicy).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.networkFirewall.policy.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciNetworkFirewallPolicy).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.networkFirewall.policy.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14806,6 +15148,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.oke.nodePool.state": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciOkeNodePool).State, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.oke.nodePool.freeformTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeNodePool).FreeformTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"oci.oke.nodePool.definedTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciOkeNodePool).DefinedTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"oci.oke.nodePool.systemTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19139,6 +19489,8 @@ type mqlOciTenancy struct {
 	Name            plugin.TValue[string]
 	Description     plugin.TValue[string]
 	RetentionPeriod plugin.TValue[*time.Time]
+	FreeformTags    plugin.TValue[map[string]any]
+	DefinedTags     plugin.TValue[map[string]any]
 }
 
 // createOciTenancy creates a new instance of this resource
@@ -19194,6 +19546,14 @@ func (c *mqlOciTenancy) GetRetentionPeriod() *plugin.TValue[*time.Time] {
 	return plugin.GetOrCompute[*time.Time](&c.RetentionPeriod, func() (*time.Time, error) {
 		return c.retentionPeriod()
 	})
+}
+
+func (c *mqlOciTenancy) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciTenancy) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciRegion for the oci.region resource
@@ -19265,11 +19625,13 @@ type mqlOciCompartment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOciCompartmentInternal it will be used here
-	Id          plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Description plugin.TValue[string]
-	Created     plugin.TValue[*time.Time]
-	State       plugin.TValue[string]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	State        plugin.TValue[string]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciCompartment creates a new instance of this resource
@@ -19327,6 +19689,14 @@ func (c *mqlOciCompartment) GetCreated() *plugin.TValue[*time.Time] {
 
 func (c *mqlOciCompartment) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlOciCompartment) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciCompartment) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciIdentity for the oci.identity resource
@@ -22730,6 +23100,8 @@ type mqlOciComputeBlockVolume struct {
 	SourceVolume         plugin.TValue[*mqlOciComputeBlockVolume]
 	SourceVolumeBackupId plugin.TValue[string]
 	Created              plugin.TValue[*time.Time]
+	FreeformTags         plugin.TValue[map[string]any]
+	DefinedTags          plugin.TValue[map[string]any]
 	SystemTags           plugin.TValue[map[string]any]
 }
 
@@ -22862,6 +23234,14 @@ func (c *mqlOciComputeBlockVolume) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciComputeBlockVolume) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciComputeBlockVolume) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciComputeBlockVolume) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -22884,6 +23264,8 @@ type mqlOciComputeBootVolume struct {
 	State                    plugin.TValue[string]
 	KmsKey                   plugin.TValue[*mqlOciKmsKey]
 	Created                  plugin.TValue[*time.Time]
+	FreeformTags             plugin.TValue[map[string]any]
+	DefinedTags              plugin.TValue[map[string]any]
 	SystemTags               plugin.TValue[map[string]any]
 }
 
@@ -23022,6 +23404,14 @@ func (c *mqlOciComputeBootVolume) GetKmsKey() *plugin.TValue[*mqlOciKmsKey] {
 
 func (c *mqlOciComputeBootVolume) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciComputeBootVolume) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciComputeBootVolume) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 func (c *mqlOciComputeBootVolume) GetSystemTags() *plugin.TValue[map[string]any] {
@@ -23344,6 +23734,8 @@ type mqlOciNetworkPublicIp struct {
 	AvailabilityDomain plugin.TValue[string]
 	State              plugin.TValue[string]
 	Created            plugin.TValue[*time.Time]
+	FreeformTags       plugin.TValue[map[string]any]
+	DefinedTags        plugin.TValue[map[string]any]
 }
 
 // createOciNetworkPublicIp creates a new instance of this resource
@@ -23441,6 +23833,14 @@ func (c *mqlOciNetworkPublicIp) GetState() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkPublicIp) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciNetworkPublicIp) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciNetworkPublicIp) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciNetworkVcn for the oci.network.vcn resource
@@ -25038,6 +25438,8 @@ type mqlOciNetworkDrgAttachment struct {
 	IsCrossTenancy  plugin.TValue[bool]
 	State           plugin.TValue[string]
 	Created         plugin.TValue[*time.Time]
+	FreeformTags    plugin.TValue[map[string]any]
+	DefinedTags     plugin.TValue[map[string]any]
 }
 
 // createOciNetworkDrgAttachment creates a new instance of this resource
@@ -25187,6 +25589,14 @@ func (c *mqlOciNetworkDrgAttachment) GetState() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkDrgAttachment) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciNetworkDrgAttachment) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciNetworkDrgAttachment) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciNetworkLocalPeeringGateway for the oci.network.localPeeringGateway resource
@@ -26590,6 +27000,8 @@ type mqlOciLoggingLogGroup struct {
 	State         plugin.TValue[string]
 	Logs          plugin.TValue[[]any]
 	Created       plugin.TValue[*time.Time]
+	FreeformTags  plugin.TValue[map[string]any]
+	DefinedTags   plugin.TValue[map[string]any]
 	SystemTags    plugin.TValue[map[string]any]
 }
 
@@ -26686,6 +27098,14 @@ func (c *mqlOciLoggingLogGroup) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciLoggingLogGroup) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciLoggingLogGroup) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciLoggingLogGroup) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -26708,6 +27128,8 @@ type mqlOciLoggingLog struct {
 	SourceResource    plugin.TValue[string]
 	Created           plugin.TValue[*time.Time]
 	TimeLastModified  plugin.TValue[*time.Time]
+	FreeformTags      plugin.TValue[map[string]any]
+	DefinedTags       plugin.TValue[map[string]any]
 	SystemTags        plugin.TValue[map[string]any]
 }
 
@@ -26812,6 +27234,14 @@ func (c *mqlOciLoggingLog) GetTimeLastModified() *plugin.TValue[*time.Time] {
 	return &c.TimeLastModified
 }
 
+func (c *mqlOciLoggingLog) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciLoggingLog) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciLoggingLog) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -26891,6 +27321,8 @@ type mqlOciKmsVault struct {
 	ManagementEndpoint plugin.TValue[string]
 	Keys               plugin.TValue[[]any]
 	Created            plugin.TValue[*time.Time]
+	FreeformTags       plugin.TValue[map[string]any]
+	DefinedTags        plugin.TValue[map[string]any]
 }
 
 // createOciKmsVault creates a new instance of this resource
@@ -26990,6 +27422,14 @@ func (c *mqlOciKmsVault) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciKmsVault) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciKmsVault) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 // mqlOciKmsKey for the oci.kms.key resource
 type mqlOciKmsKey struct {
 	MqlRuntime *plugin.Runtime
@@ -27009,6 +27449,8 @@ type mqlOciKmsKey struct {
 	IsAutoRotationEnabled plugin.TValue[bool]
 	KeyVersions           plugin.TValue[[]any]
 	Created               plugin.TValue[*time.Time]
+	FreeformTags          plugin.TValue[map[string]any]
+	DefinedTags           plugin.TValue[map[string]any]
 }
 
 // createOciKmsKey creates a new instance of this resource
@@ -27142,6 +27584,14 @@ func (c *mqlOciKmsKey) GetKeyVersions() *plugin.TValue[[]any] {
 
 func (c *mqlOciKmsKey) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciKmsKey) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciKmsKey) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciKmsKeyVersion for the oci.kms.keyVersion resource
@@ -27819,6 +28269,8 @@ type mqlOciFileStorageFileSystem struct {
 	ParentFileSystem   plugin.TValue[*mqlOciFileStorageFileSystem]
 	IsCloneParent      plugin.TValue[bool]
 	Created            plugin.TValue[*time.Time]
+	FreeformTags       plugin.TValue[map[string]any]
+	DefinedTags        plugin.TValue[map[string]any]
 	SystemTags         plugin.TValue[map[string]any]
 }
 
@@ -27939,6 +28391,14 @@ func (c *mqlOciFileStorageFileSystem) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciFileStorageFileSystem) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciFileStorageFileSystem) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciFileStorageFileSystem) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -28019,6 +28479,8 @@ type mqlOciEventsRule struct {
 	State         plugin.TValue[string]
 	Actions       plugin.TValue[[]any]
 	Created       plugin.TValue[*time.Time]
+	FreeformTags  plugin.TValue[map[string]any]
+	DefinedTags   plugin.TValue[map[string]any]
 }
 
 // createOciEventsRule creates a new instance of this resource
@@ -28110,6 +28572,14 @@ func (c *mqlOciEventsRule) GetActions() *plugin.TValue[[]any] {
 
 func (c *mqlOciEventsRule) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciEventsRule) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciEventsRule) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciCloudGuard for the oci.cloudGuard resource
@@ -28293,6 +28763,8 @@ type mqlOciCloudGuardTarget struct {
 	State              plugin.TValue[string]
 	RecipeCount        plugin.TValue[int64]
 	Created            plugin.TValue[*time.Time]
+	FreeformTags       plugin.TValue[map[string]any]
+	DefinedTags        plugin.TValue[map[string]any]
 	SystemTags         plugin.TValue[map[string]any]
 }
 
@@ -28381,6 +28853,14 @@ func (c *mqlOciCloudGuardTarget) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardTarget) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciCloudGuardTarget) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciCloudGuardTarget) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -28400,6 +28880,8 @@ type mqlOciCloudGuardDetectorRecipe struct {
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
 	Rules         plugin.TValue[[]any]
+	FreeformTags  plugin.TValue[map[string]any]
+	DefinedTags   plugin.TValue[map[string]any]
 	SystemTags    plugin.TValue[map[string]any]
 }
 
@@ -28502,6 +28984,14 @@ func (c *mqlOciCloudGuardDetectorRecipe) GetRules() *plugin.TValue[[]any] {
 
 		return c.rules()
 	})
+}
+
+func (c *mqlOciCloudGuardDetectorRecipe) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciCloudGuardDetectorRecipe) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 func (c *mqlOciCloudGuardDetectorRecipe) GetSystemTags() *plugin.TValue[map[string]any] {
@@ -28804,6 +29294,8 @@ type mqlOciCloudGuardSecurityZone struct {
 	IsInheritanceAfterDeleteEnabled plugin.TValue[bool]
 	State                           plugin.TValue[string]
 	Created                         plugin.TValue[*time.Time]
+	FreeformTags                    plugin.TValue[map[string]any]
+	DefinedTags                     plugin.TValue[map[string]any]
 	SystemTags                      plugin.TValue[map[string]any]
 }
 
@@ -28904,6 +29396,14 @@ func (c *mqlOciCloudGuardSecurityZone) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardSecurityZone) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciCloudGuardSecurityZone) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciCloudGuardSecurityZone) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -28922,6 +29422,8 @@ type mqlOciCloudGuardSecurityZoneRecipe struct {
 	SecurityPolicies plugin.TValue[[]any]
 	State            plugin.TValue[string]
 	Created          plugin.TValue[*time.Time]
+	FreeformTags     plugin.TValue[map[string]any]
+	DefinedTags      plugin.TValue[map[string]any]
 	SystemTags       plugin.TValue[map[string]any]
 }
 
@@ -29022,6 +29524,14 @@ func (c *mqlOciCloudGuardSecurityZoneRecipe) GetCreated() *plugin.TValue[*time.T
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardSecurityZoneRecipe) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciCloudGuardSecurityZoneRecipe) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciCloudGuardSecurityZoneRecipe) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -29042,6 +29552,8 @@ type mqlOciCloudGuardSecurityPolicy struct {
 	Services      plugin.TValue[[]any]
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
+	FreeformTags  plugin.TValue[map[string]any]
+	DefinedTags   plugin.TValue[map[string]any]
 	SystemTags    plugin.TValue[map[string]any]
 }
 
@@ -29138,6 +29650,14 @@ func (c *mqlOciCloudGuardSecurityPolicy) GetCreated() *plugin.TValue[*time.Time]
 	return &c.Created
 }
 
+func (c *mqlOciCloudGuardSecurityPolicy) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciCloudGuardSecurityPolicy) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciCloudGuardSecurityPolicy) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -29216,6 +29736,8 @@ type mqlOciOnsTopic struct {
 	State         plugin.TValue[string]
 	Created       plugin.TValue[*time.Time]
 	Subscriptions plugin.TValue[[]any]
+	FreeformTags  plugin.TValue[map[string]any]
+	DefinedTags   plugin.TValue[map[string]any]
 }
 
 // createOciOnsTopic creates a new instance of this resource
@@ -29311,17 +29833,27 @@ func (c *mqlOciOnsTopic) GetSubscriptions() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlOciOnsTopic) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciOnsTopic) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 // mqlOciOnsSubscription for the oci.ons.subscription resource
 type mqlOciOnsSubscription struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciOnsSubscriptionInternal
-	Id       plugin.TValue[string]
-	Topic    plugin.TValue[*mqlOciOnsTopic]
-	Protocol plugin.TValue[string]
-	Endpoint plugin.TValue[string]
-	State    plugin.TValue[string]
-	Created  plugin.TValue[*time.Time]
+	Id           plugin.TValue[string]
+	Topic        plugin.TValue[*mqlOciOnsTopic]
+	Protocol     plugin.TValue[string]
+	Endpoint     plugin.TValue[string]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciOnsSubscription creates a new instance of this resource
@@ -29395,6 +29927,14 @@ func (c *mqlOciOnsSubscription) GetState() *plugin.TValue[string] {
 
 func (c *mqlOciOnsSubscription) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciOnsSubscription) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciOnsSubscription) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciAudit for the oci.audit resource
@@ -30047,6 +30587,8 @@ type mqlOciBastionInstance struct {
 	DnsProxyStatus            plugin.TValue[string]
 	Created                   plugin.TValue[*time.Time]
 	TimeUpdated               plugin.TValue[*time.Time]
+	FreeformTags              plugin.TValue[map[string]any]
+	DefinedTags               plugin.TValue[map[string]any]
 	SystemTags                plugin.TValue[map[string]any]
 }
 
@@ -30197,6 +30739,14 @@ func (c *mqlOciBastionInstance) GetTimeUpdated() *plugin.TValue[*time.Time] {
 	return &c.TimeUpdated
 }
 
+func (c *mqlOciBastionInstance) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciBastionInstance) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciBastionInstance) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -30279,6 +30829,8 @@ type mqlOciMonitoringAlarm struct {
 	Topics              plugin.TValue[[]any]
 	IsEnabled           plugin.TValue[bool]
 	State               plugin.TValue[string]
+	FreeformTags        plugin.TValue[map[string]any]
+	DefinedTags         plugin.TValue[map[string]any]
 }
 
 // createOciMonitoringAlarm creates a new instance of this resource
@@ -30388,6 +30940,14 @@ func (c *mqlOciMonitoringAlarm) GetIsEnabled() *plugin.TValue[bool] {
 
 func (c *mqlOciMonitoringAlarm) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlOciMonitoringAlarm) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciMonitoringAlarm) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciVault for the oci.vault resource
@@ -31945,14 +32505,16 @@ type mqlOciResourceManagerJob struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciResourceManagerJobInternal
-	Id          plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Compartment plugin.TValue[*mqlOciCompartment]
-	Stack       plugin.TValue[*mqlOciResourceManagerStack]
-	Operation   plugin.TValue[string]
-	State       plugin.TValue[string]
-	Created     plugin.TValue[*time.Time]
-	Finished    plugin.TValue[*time.Time]
+	Id           plugin.TValue[string]
+	Name         plugin.TValue[string]
+	Compartment  plugin.TValue[*mqlOciCompartment]
+	Stack        plugin.TValue[*mqlOciResourceManagerStack]
+	Operation    plugin.TValue[string]
+	State        plugin.TValue[string]
+	Created      plugin.TValue[*time.Time]
+	Finished     plugin.TValue[*time.Time]
+	FreeformTags plugin.TValue[map[string]any]
+	DefinedTags  plugin.TValue[map[string]any]
 }
 
 // createOciResourceManagerJob creates a new instance of this resource
@@ -32046,6 +32608,14 @@ func (c *mqlOciResourceManagerJob) GetCreated() *plugin.TValue[*time.Time] {
 
 func (c *mqlOciResourceManagerJob) GetFinished() *plugin.TValue[*time.Time] {
 	return &c.Finished
+}
+
+func (c *mqlOciResourceManagerJob) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciResourceManagerJob) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 // mqlOciStreaming for the oci.streaming resource
@@ -34737,6 +35307,8 @@ type mqlOciNetworkFirewallFirewall struct {
 	TimeUpdated        plugin.TValue[*time.Time]
 	SecurityAttributes plugin.TValue[map[string]any]
 	HealthStatus       plugin.TValue[string]
+	FreeformTags       plugin.TValue[map[string]any]
+	DefinedTags        plugin.TValue[map[string]any]
 	SystemTags         plugin.TValue[map[string]any]
 }
 
@@ -34871,6 +35443,14 @@ func (c *mqlOciNetworkFirewallFirewall) GetHealthStatus() *plugin.TValue[string]
 	})
 }
 
+func (c *mqlOciNetworkFirewallFirewall) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciNetworkFirewallFirewall) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
+}
+
 func (c *mqlOciNetworkFirewallFirewall) GetSystemTags() *plugin.TValue[map[string]any] {
 	return &c.SystemTags
 }
@@ -34888,6 +35468,8 @@ type mqlOciNetworkFirewallPolicy struct {
 	AttachedFirewallCount plugin.TValue[int64]
 	State                 plugin.TValue[string]
 	Created               plugin.TValue[*time.Time]
+	FreeformTags          plugin.TValue[map[string]any]
+	DefinedTags           plugin.TValue[map[string]any]
 	SystemTags            plugin.TValue[map[string]any]
 	DecryptionProfiles    plugin.TValue[[]any]
 	SecurityRules         plugin.TValue[[]any]
@@ -34977,6 +35559,14 @@ func (c *mqlOciNetworkFirewallPolicy) GetState() *plugin.TValue[string] {
 
 func (c *mqlOciNetworkFirewallPolicy) GetCreated() *plugin.TValue[*time.Time] {
 	return &c.Created
+}
+
+func (c *mqlOciNetworkFirewallPolicy) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciNetworkFirewallPolicy) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 func (c *mqlOciNetworkFirewallPolicy) GetSystemTags() *plugin.TValue[map[string]any] {
@@ -35541,6 +36131,8 @@ type mqlOciOkeNodePool struct {
 	Subnets               plugin.TValue[[]any]
 	NetworkSecurityGroups plugin.TValue[[]any]
 	State                 plugin.TValue[string]
+	FreeformTags          plugin.TValue[map[string]any]
+	DefinedTags           plugin.TValue[map[string]any]
 	SystemTags            plugin.TValue[map[string]any]
 }
 
@@ -35699,6 +36291,14 @@ func (c *mqlOciOkeNodePool) GetNetworkSecurityGroups() *plugin.TValue[[]any] {
 
 func (c *mqlOciOkeNodePool) GetState() *plugin.TValue[string] {
 	return &c.State
+}
+
+func (c *mqlOciOkeNodePool) GetFreeformTags() *plugin.TValue[map[string]any] {
+	return &c.FreeformTags
+}
+
+func (c *mqlOciOkeNodePool) GetDefinedTags() *plugin.TValue[map[string]any] {
+	return &c.DefinedTags
 }
 
 func (c *mqlOciOkeNodePool) GetSystemTags() *plugin.TValue[map[string]any] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -488,7 +488,9 @@ oci.bastion.instance.clientCidrBlockAllowList 13.16.4
 oci.bastion.instance.compartment 13.6.2
 oci.bastion.instance.compartmentID 13.0.6
 oci.bastion.instance.created 13.0.6
+oci.bastion.instance.definedTags 13.18.1
 oci.bastion.instance.dnsProxyStatus 13.0.6
+oci.bastion.instance.freeformTags 13.18.1
 oci.bastion.instance.id 13.0.6
 oci.bastion.instance.maxSessionTtlInSeconds 13.16.4
 oci.bastion.instance.maxSessionsAllowed 13.16.4
@@ -559,8 +561,10 @@ oci.cloudGuard.detectorRecipe 13.0.6
 oci.cloudGuard.detectorRecipe.compartment 13.12.2
 oci.cloudGuard.detectorRecipe.compartmentID 13.12.2
 oci.cloudGuard.detectorRecipe.created 13.0.6
+oci.cloudGuard.detectorRecipe.definedTags 13.18.1
 oci.cloudGuard.detectorRecipe.description 13.0.6
 oci.cloudGuard.detectorRecipe.detectorType 13.0.6
+oci.cloudGuard.detectorRecipe.freeformTags 13.18.1
 oci.cloudGuard.detectorRecipe.id 13.0.6
 oci.cloudGuard.detectorRecipe.name 13.0.6
 oci.cloudGuard.detectorRecipe.owner 13.0.6
@@ -613,7 +617,9 @@ oci.cloudGuard.securityPolicy.category 13.5.1
 oci.cloudGuard.securityPolicy.compartment 13.12.2
 oci.cloudGuard.securityPolicy.compartmentID 13.5.1
 oci.cloudGuard.securityPolicy.created 13.5.1
+oci.cloudGuard.securityPolicy.definedTags 13.18.1
 oci.cloudGuard.securityPolicy.description 13.5.1
+oci.cloudGuard.securityPolicy.freeformTags 13.18.1
 oci.cloudGuard.securityPolicy.friendlyName 13.5.1
 oci.cloudGuard.securityPolicy.id 13.5.1
 oci.cloudGuard.securityPolicy.name 13.5.1
@@ -625,7 +631,9 @@ oci.cloudGuard.securityZone 13.5.1
 oci.cloudGuard.securityZone.compartment 13.12.2
 oci.cloudGuard.securityZone.compartmentID 13.5.1
 oci.cloudGuard.securityZone.created 13.5.1
+oci.cloudGuard.securityZone.definedTags 13.18.1
 oci.cloudGuard.securityZone.description 13.5.1
+oci.cloudGuard.securityZone.freeformTags 13.18.1
 oci.cloudGuard.securityZone.id 13.5.1
 oci.cloudGuard.securityZone.isInheritanceAfterDeleteEnabled 13.5.1
 oci.cloudGuard.securityZone.name 13.5.1
@@ -636,7 +644,9 @@ oci.cloudGuard.securityZoneRecipe 13.5.1
 oci.cloudGuard.securityZoneRecipe.compartment 13.12.2
 oci.cloudGuard.securityZoneRecipe.compartmentID 13.5.1
 oci.cloudGuard.securityZoneRecipe.created 13.5.1
+oci.cloudGuard.securityZoneRecipe.definedTags 13.18.1
 oci.cloudGuard.securityZoneRecipe.description 13.5.1
+oci.cloudGuard.securityZoneRecipe.freeformTags 13.18.1
 oci.cloudGuard.securityZoneRecipe.id 13.5.1
 oci.cloudGuard.securityZoneRecipe.name 13.5.1
 oci.cloudGuard.securityZoneRecipe.owner 13.5.1
@@ -651,6 +661,8 @@ oci.cloudGuard.target 13.0.6
 oci.cloudGuard.target.compartment 13.12.2
 oci.cloudGuard.target.compartmentID 13.0.6
 oci.cloudGuard.target.created 13.0.6
+oci.cloudGuard.target.definedTags 13.18.1
+oci.cloudGuard.target.freeformTags 13.18.1
 oci.cloudGuard.target.id 13.0.6
 oci.cloudGuard.target.name 13.0.6
 oci.cloudGuard.target.recipeCount 13.0.6
@@ -661,7 +673,9 @@ oci.cloudGuard.target.targetResourceType 13.0.6
 oci.cloudGuard.targets 13.0.6
 oci.compartment 9.0.0
 oci.compartment.created 9.0.0
+oci.compartment.definedTags 13.18.1
 oci.compartment.description 9.0.0
+oci.compartment.freeformTags 13.18.1
 oci.compartment.id 9.0.0
 oci.compartment.name 9.0.0
 oci.compartment.state 9.0.0
@@ -672,6 +686,8 @@ oci.compute.blockVolume.availabilityDomain 13.0.6
 oci.compute.blockVolume.compartment 13.6.2
 oci.compute.blockVolume.compartmentID 13.0.6
 oci.compute.blockVolume.created 13.0.6
+oci.compute.blockVolume.definedTags 13.18.1
+oci.compute.blockVolume.freeformTags 13.18.1
 oci.compute.blockVolume.id 13.0.6
 oci.compute.blockVolume.isAutoTuneEnabled 13.0.6
 oci.compute.blockVolume.isHydrated 13.0.6
@@ -689,6 +705,8 @@ oci.compute.bootVolume.availabilityDomain 13.0.6
 oci.compute.bootVolume.compartment 13.6.2
 oci.compute.bootVolume.compartmentID 13.0.6
 oci.compute.bootVolume.created 13.0.6
+oci.compute.bootVolume.definedTags 13.18.1
+oci.compute.bootVolume.freeformTags 13.18.1
 oci.compute.bootVolume.id 13.0.6
 oci.compute.bootVolume.image 13.6.2
 oci.compute.bootVolume.imageId 13.0.6
@@ -1088,7 +1106,9 @@ oci.events.rule.compartment 13.6.2
 oci.events.rule.compartmentID 13.0.6
 oci.events.rule.condition 13.0.6
 oci.events.rule.created 13.0.6
+oci.events.rule.definedTags 13.18.1
 oci.events.rule.description 13.0.6
+oci.events.rule.freeformTags 13.18.1
 oci.events.rule.id 13.0.6
 oci.events.rule.isEnabled 13.0.6
 oci.events.rule.name 13.0.6
@@ -1100,6 +1120,8 @@ oci.fileStorage.fileSystem.availabilityDomain 13.0.6
 oci.fileStorage.fileSystem.compartment 13.12.2
 oci.fileStorage.fileSystem.compartmentID 13.0.6
 oci.fileStorage.fileSystem.created 13.0.6
+oci.fileStorage.fileSystem.definedTags 13.18.1
+oci.fileStorage.fileSystem.freeformTags 13.18.1
 oci.fileStorage.fileSystem.id 13.0.6
 oci.fileStorage.fileSystem.isCloneParent 13.12.2
 oci.fileStorage.fileSystem.kmsKey 13.0.6
@@ -1476,6 +1498,8 @@ oci.kms.key.compartment 13.6.2
 oci.kms.key.compartmentID 13.0.6
 oci.kms.key.created 13.0.6
 oci.kms.key.curveId 13.15.1
+oci.kms.key.definedTags 13.18.1
+oci.kms.key.freeformTags 13.18.1
 oci.kms.key.id 13.0.6
 oci.kms.key.isAutoRotationEnabled 13.0.6
 oci.kms.key.keyVersions 13.1.1
@@ -1501,6 +1525,8 @@ oci.kms.vault 13.0.6
 oci.kms.vault.compartment 13.6.2
 oci.kms.vault.compartmentID 13.0.6
 oci.kms.vault.created 13.0.6
+oci.kms.vault.definedTags 13.18.1
+oci.kms.vault.freeformTags 13.18.1
 oci.kms.vault.id 13.0.6
 oci.kms.vault.keys 13.0.6
 oci.kms.vault.managementEndpoint 13.0.6
@@ -1553,6 +1579,8 @@ oci.logging.log 13.0.6
 oci.logging.log.category 13.4.1
 oci.logging.log.configuration 13.0.6
 oci.logging.log.created 13.0.6
+oci.logging.log.definedTags 13.18.1
+oci.logging.log.freeformTags 13.18.1
 oci.logging.log.id 13.0.6
 oci.logging.log.isEnabled 13.0.6
 oci.logging.log.logGroup 13.0.6
@@ -1568,7 +1596,9 @@ oci.logging.logGroup 13.0.6
 oci.logging.logGroup.compartment 13.12.2
 oci.logging.logGroup.compartmentID 13.0.6
 oci.logging.logGroup.created 13.0.6
+oci.logging.logGroup.definedTags 13.18.1
 oci.logging.logGroup.description 13.0.6
+oci.logging.logGroup.freeformTags 13.18.1
 oci.logging.logGroup.id 13.0.6
 oci.logging.logGroup.logs 13.0.6
 oci.logging.logGroup.name 13.0.6
@@ -1579,7 +1609,9 @@ oci.monitoring 13.0.6
 oci.monitoring.alarm 13.0.6
 oci.monitoring.alarm.compartment 13.6.2
 oci.monitoring.alarm.compartmentID 13.0.6
+oci.monitoring.alarm.definedTags 13.18.1
 oci.monitoring.alarm.destinations 13.0.6
+oci.monitoring.alarm.freeformTags 13.18.1
 oci.monitoring.alarm.id 13.0.6
 oci.monitoring.alarm.isEnabled 13.0.6
 oci.monitoring.alarm.metricCompartmentId 13.0.6
@@ -1664,7 +1696,9 @@ oci.network.drgAttachment 13.13.1
 oci.network.drgAttachment.compartment 13.13.1
 oci.network.drgAttachment.compartmentID 13.13.1
 oci.network.drgAttachment.created 13.13.1
+oci.network.drgAttachment.definedTags 13.18.1
 oci.network.drgAttachment.drg 13.13.1
+oci.network.drgAttachment.freeformTags 13.18.1
 oci.network.drgAttachment.id 13.13.1
 oci.network.drgAttachment.ipsecConnection 13.13.1
 oci.network.drgAttachment.isCrossTenancy 13.13.1
@@ -1799,6 +1833,8 @@ oci.network.publicIp.availabilityDomain 13.8.2
 oci.network.publicIp.compartment 13.12.2
 oci.network.publicIp.compartmentID 13.8.2
 oci.network.publicIp.created 13.8.2
+oci.network.publicIp.definedTags 13.18.1
+oci.network.publicIp.freeformTags 13.18.1
 oci.network.publicIp.id 13.8.2
 oci.network.publicIp.ipAddress 13.8.2
 oci.network.publicIp.lifetime 13.8.2
@@ -1968,6 +2004,8 @@ oci.networkFirewall.firewall 13.0.6
 oci.networkFirewall.firewall.compartment 13.12.2
 oci.networkFirewall.firewall.compartmentID 13.0.6
 oci.networkFirewall.firewall.created 13.0.6
+oci.networkFirewall.firewall.definedTags 13.18.1
+oci.networkFirewall.firewall.freeformTags 13.18.1
 oci.networkFirewall.firewall.healthStatus 13.8.2
 oci.networkFirewall.firewall.id 13.0.6
 oci.networkFirewall.firewall.ipv4Address 13.0.6
@@ -2009,7 +2047,9 @@ oci.networkFirewall.policy.decryptionRule.name 13.16.4
 oci.networkFirewall.policy.decryptionRule.priorityOrder 13.16.4
 oci.networkFirewall.policy.decryptionRule.secret 13.16.4
 oci.networkFirewall.policy.decryptionRules 13.16.4
+oci.networkFirewall.policy.definedTags 13.18.1
 oci.networkFirewall.policy.description 13.0.6
+oci.networkFirewall.policy.freeformTags 13.18.1
 oci.networkFirewall.policy.id 13.0.6
 oci.networkFirewall.policy.name 13.0.6
 oci.networkFirewall.policy.securityRule 13.16.4
@@ -2164,6 +2204,8 @@ oci.oke.nodePool.bootVolumeSizeInGBs 13.16.4
 oci.oke.nodePool.cluster 13.12.2
 oci.oke.nodePool.compartment 13.12.2
 oci.oke.nodePool.compartmentID 13.0.6
+oci.oke.nodePool.definedTags 13.18.1
+oci.oke.nodePool.freeformTags 13.18.1
 oci.oke.nodePool.id 13.0.6
 oci.oke.nodePool.kubernetesVersion 13.0.6
 oci.oke.nodePool.name 13.0.6
@@ -2179,7 +2221,9 @@ oci.oke.nodePool.systemTags 13.12.2
 oci.ons 13.0.6
 oci.ons.subscription 13.0.6
 oci.ons.subscription.created 13.0.6
+oci.ons.subscription.definedTags 13.18.1
 oci.ons.subscription.endpoint 13.0.6
+oci.ons.subscription.freeformTags 13.18.1
 oci.ons.subscription.id 13.0.6
 oci.ons.subscription.protocol 13.0.6
 oci.ons.subscription.state 13.0.6
@@ -2188,7 +2232,9 @@ oci.ons.topic 13.0.6
 oci.ons.topic.compartment 13.6.2
 oci.ons.topic.compartmentID 13.0.6
 oci.ons.topic.created 13.0.6
+oci.ons.topic.definedTags 13.18.1
 oci.ons.topic.description 13.0.6
+oci.ons.topic.freeformTags 13.18.1
 oci.ons.topic.id 13.0.6
 oci.ons.topic.name 13.0.6
 oci.ons.topic.state 13.0.6
@@ -2306,7 +2352,9 @@ oci.resourceManager 13.17.2
 oci.resourceManager.job 13.17.2
 oci.resourceManager.job.compartment 13.17.2
 oci.resourceManager.job.created 13.17.2
+oci.resourceManager.job.definedTags 13.18.1
 oci.resourceManager.job.finished 13.17.2
+oci.resourceManager.job.freeformTags 13.18.1
 oci.resourceManager.job.id 13.17.2
 oci.resourceManager.job.name 13.17.2
 oci.resourceManager.job.operation 13.17.2
@@ -2386,7 +2434,9 @@ oci.streaming.streamPool.subnet 13.17.2
 oci.streaming.streamPools 13.17.2
 oci.streaming.streams 13.17.2
 oci.tenancy 9.0.0
+oci.tenancy.definedTags 13.18.1
 oci.tenancy.description 9.0.0
+oci.tenancy.freeformTags 13.18.1
 oci.tenancy.id 9.0.0
 oci.tenancy.name 9.0.0
 oci.tenancy.retentionPeriod 9.0.0

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -307,6 +307,8 @@ func (o *mqlOciOkeCluster) nodePools() ([]any, error) {
 			"bootVolumeSizeInGBs": llx.IntDataPtr(bootVolumeSizeInGBs),
 			"sshPublicKey":        llx.StringDataPtr(np.SshPublicKey),
 			"state":               llx.StringData(string(np.LifecycleState)),
+			"freeformTags":        llx.MapData(strMapToAny(np.FreeformTags), types.String),
+			"definedTags":         llx.MapData(definedTagsToAny(np.DefinedTags), types.Any),
 			"systemTags":          llx.MapData(definedTagsToAny(np.SystemTags), types.Dict),
 		})
 		if err != nil {

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -15,6 +15,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/oci/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOciOns) id() (string, error) {
@@ -58,6 +59,8 @@ func (o *mqlOciOns) topics() ([]any, error) {
 					"compartmentID": llx.StringDataPtr(topic.CompartmentId),
 					"state":         llx.StringData(string(topic.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
+					"freeformTags":  llx.MapData(strMapToAny(topic.FreeformTags), types.String),
+					"definedTags":   llx.MapData(definedTagsToAny(topic.DefinedTags), types.Any),
 				})
 				if err != nil {
 					return nil, err
@@ -180,11 +183,13 @@ func (o *mqlOciOnsTopic) subscriptions() ([]any, error) {
 		}
 
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.ons.subscription", map[string]*llx.RawData{
-			"id":       llx.StringDataPtr(sub.Id),
-			"protocol": llx.StringDataPtr(sub.Protocol),
-			"endpoint": llx.StringDataPtr(sub.Endpoint),
-			"state":    llx.StringData(string(sub.LifecycleState)),
-			"created":  llx.TimeDataPtr(created),
+			"id":           llx.StringDataPtr(sub.Id),
+			"protocol":     llx.StringDataPtr(sub.Protocol),
+			"endpoint":     llx.StringDataPtr(sub.Endpoint),
+			"state":        llx.StringData(string(sub.LifecycleState)),
+			"created":      llx.TimeDataPtr(created),
+			"freeformTags": llx.MapData(strMapToAny(sub.FreeformTags), types.String),
+			"definedTags":  llx.MapData(definedTagsToAny(sub.DefinedTags), types.Any),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/resourcemanager.go
+++ b/providers/oci/resources/resourcemanager.go
@@ -205,12 +205,14 @@ func (o *mqlOciResourceManagerStack) jobs() ([]any, error) {
 		job := jobs[i]
 
 		mqlJob, err := CreateResource(o.MqlRuntime, "oci.resourceManager.job", map[string]*llx.RawData{
-			"id":        llx.StringDataPtr(job.Id),
-			"name":      llx.StringDataPtr(job.DisplayName),
-			"operation": llx.StringData(string(job.Operation)),
-			"state":     llx.StringData(string(job.LifecycleState)),
-			"created":   sdkTimeData(job.TimeCreated),
-			"finished":  sdkTimeData(job.TimeFinished),
+			"id":           llx.StringDataPtr(job.Id),
+			"name":         llx.StringDataPtr(job.DisplayName),
+			"operation":    llx.StringData(string(job.Operation)),
+			"state":        llx.StringData(string(job.LifecycleState)),
+			"created":      sdkTimeData(job.TimeCreated),
+			"finished":     sdkTimeData(job.TimeFinished),
+			"freeformTags": llx.MapData(strMapToAny(job.FreeformTags), types.String),
+			"definedTags":  llx.MapData(definedTagsToAny(job.DefinedTags), types.Any),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -206,6 +206,8 @@ func (o *mqlOciNetworkDrg) newDrgAttachment(att core.DrgAttachment) (*mqlOciNetw
 		"isCrossTenancy": llx.BoolDataPtr(att.IsCrossTenancy),
 		"state":          llx.StringData(string(att.LifecycleState)),
 		"created":        llx.TimeDataPtr(created),
+		"freeformTags":   llx.MapData(strMapToAny(att.FreeformTags), types.String),
+		"definedTags":    llx.MapData(definedTagsToAny(att.DefinedTags), types.Any),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

Adds `freeformTags` and `definedTags` to 25 OCI resources that were missing them. 92 resources already carried both, so tag-based querying worked almost everywhere — these were the gaps.

Tags are how OCI carries ownership, environment and cost-centre metadata, so a resource without them drops out of any fleet-wide query that filters on one:

```
oci.compute.blockVolumes.where(freeformTags["env"] == "prod")
oci.kms.keys.where(definedTags["Operations"]["CostCenter"] == "42")
```

Before this change those returned nothing on the resources below, whether or not the tags were set in OCI.

## Which resources

Every one was checked against the pinned SDK (`oci-go-sdk/v65@v65.123.1`) — the struct each lister maps from really does carry `FreeformTags` and `DefinedTags`.

| Area | Resources |
|---|---|
| Identity | `oci.tenancy`, `oci.compartment` |
| Compute | `compute.blockVolume`, `compute.bootVolume` |
| Storage | `fileStorage.fileSystem` |
| Network | `network.publicIp`, `network.drgAttachment`, `networkFirewall.firewall`, `networkFirewall.policy` |
| KMS | `kms.vault`, `kms.key` |
| Logging | `logging.logGroup`, `logging.log` |
| Cloud Guard | `target`, `detectorRecipe`, `securityZone`, `securityZoneRecipe`, `securityPolicy` |
| Messaging | `ons.topic`, `ons.subscription`, `events.rule` |
| Other | `bastion.instance`, `monitoring.alarm`, `oke.nodePool`, `resourceManager.job` |

`blockVolume` and `bootVolume` were inverted from every other resource in the provider — they modelled `systemTags` but neither of the two user-facing tag maps.

**Deliberately untouched**, because the API genuinely has no tags on them: `database.backup`, `database.autonomousDatabaseBackup`, `objectStorage.preauthenticatedRequest`, `objectStorage.retentionRule`, `vault.secretVersion`, `network.ipsecConnectionTunnel`.

## The compartment fix

`oci.compartment` is created in two places — the lister and `initOciCompartment` — and each populated the field set by hand. Adding the tag fields to only the lister would have left them **unset** (not null) on any compartment reached through `NewResource`, which `compute.go` and `policy_statement.go` both do. An unset field crosses the plugin boundary as a primitive with no type information and surfaces client-side as an unattributed coercion warning, so `oci.compute.instances { compartment.freeformTags }` is the query that would have hit it.

Both paths now build from one `ociCompartmentArgs` helper, and the access-denied branch derives its null field list from that same helper — so a field added later cannot be set in one place and forgotten in the other. The denied path keeps setting fields explicitly null rather than omitting them, since "we could not read this compartment" has to stay distinguishable from "this compartment has no tags".

## Notes

- `.lr.versions` entries are at `13.18.1`, the next patch after the shipped `13.18.0`. No version bump in `config.go`.
- No new API calls. Every value comes from a response the provider already fetches; `oci.tenancy` reuses the `identity.Tenancy` its init already has in hand.
- This does **not** add tag-based discovery filtering — the OCI provider has no `conn.Filters` support at all today, which is a separate piece of work.

## Testing

- `go build ./...`, `go test ./...` and `golangci-lint run ./resources/...` all clean in `providers/oci/`.
- New `compartment_args_test.go` pins the invariant behind the bug above: the access-denied path must cover exactly the field set the readable path produces, and an absent `TimeCreated` must stay null rather than becoming the zero time.
- The existing `strMapToAny` / `definedTagsToAny` tests already cover the converters this leans on (nil, empty, non-string passthrough, and the non-aliasing property).

**Live verification is owed and will be partial.** Our OCI test tenancy is Always-Free-only, so Cloud Guard, Network Firewall, Bastion and OKE node pools have no instances to read tags from. I have not run this against live infrastructure yet.
