### PR TITLE
🌟 gcp: expose labels on six resources

### DIFF
--- a/providers/gcp/resources/bigquery_reservation.go
+++ b/providers/gcp/resources/bigquery_reservation.go
@@ -11,7 +11,9 @@ import (
 	"cloud.google.com/go/bigquery/reservation/apiv1/reservationpb"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
+	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -97,6 +99,7 @@ func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
 				"primaryLocation":         llx.StringData(r.PrimaryLocation),
 				"secondaryLocation":       llx.StringData(r.SecondaryLocation),
 				"originalPrimaryLocation": llx.StringData(r.OriginalPrimaryLocation),
+				"labels":                  llx.MapData(convert.MapToInterfaceMap(r.GetLabels()), types.String),
 				"created":                 created,
 				"updated":                 updated,
 			})

--- a/providers/gcp/resources/compute_networking.go
+++ b/providers/gcp/resources/compute_networking.go
@@ -851,6 +851,7 @@ func (g *mqlGcpProjectComputeService) interconnectAttachments() ([]any, error) {
 					"regionUrl":                 llx.StringData(ia.Region),
 					"selfLink":                  llx.StringData(ia.SelfLink),
 					"dataplaneVersion":          llx.IntData(ia.DataplaneVersion),
+					"labels":                    llx.MapData(convert.MapToInterfaceMap(ia.Labels), types.String),
 					"created":                   llx.TimeDataPtr(parseTime(ia.CreationTimestamp)),
 				})
 				if err != nil {

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -1386,6 +1386,7 @@ func (g *mqlGcpProjectDataprocService) autoscalingPolicies() ([]any, error) {
 						"workerConfig":          llx.DictData(workerConfig),
 						"secondaryWorkerConfig": llx.DictData(secondaryWorkerConfig),
 						"basicAlgorithm":        llx.DictData(basicAlgorithm),
+						"labels":                llx.MapData(convert.MapToInterfaceMap(policy.Labels), types.String),
 					})
 					if err != nil {
 						log.Error().Err(err).Send()

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -494,6 +494,7 @@ func (g *mqlGcpProjectDnsService) responsePolicies() ([]any, error) {
 				"description":        llx.StringData(responsePolicy.Description),
 				"networkUrls":        llx.ArrayData(networkUrls, types.String),
 				"gkeClusters":        llx.ArrayData(gkeClusters, types.String),
+				"labels":             llx.MapData(convert.MapToInterfaceMap(responsePolicy.Labels), types.String),
 			})
 			if err != nil {
 				return err

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -289,6 +289,7 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 			"pubsubTopic":   llx.StringData(channel.GetPubsubTopic()),
 			"state":         llx.StringData(channel.State.String()),
 			"cryptoKeyName": llx.StringData(channel.GetCryptoKeyName()),
+			"labels":        llx.MapData(convert.MapToInterfaceMap(channel.GetLabels()), types.String),
 			"created":       llx.TimeDataPtr(timestampAsTimePtr(channel.CreateTime)),
 			"updated":       llx.TimeDataPtr(timestampAsTimePtr(channel.UpdateTime)),
 		})

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -4211,6 +4211,8 @@ private gcp.project.bigqueryService.reservation @defaults("name slotCapacity edi
   secondaryLocation string
   // Location where the reservation was originally created
   originalPrimaryLocation string
+  // User-provided labels for the reservation
+  labels map[string]string
   // Creation timestamp
   created time
   // Last update timestamp
@@ -4475,6 +4477,8 @@ private gcp.project.dnsService.responsePolicy @defaults("responsePolicyName") {
   networks() []gcp.project.computeService.network
   // Resource names of the GKE clusters this response policy is applied to
   gkeClusters []string
+  // User-provided labels for the response policy
+  labels map[string]string
 }
 
 // Google Kubernetes Engine (GKE)
@@ -7776,6 +7780,8 @@ private gcp.project.dataprocService.autoscalingPolicy @defaults("name") {
   // clusters add and remove workers. `sparkStandaloneConfig` carries the
   // equivalent settings for Spark Standalone clusters.
   basicAlgorithm dict
+  // User-provided labels for the policy
+  labels map[string]string
 }
 
 // Google Cloud (GCP) Cloud Run
@@ -8451,6 +8457,8 @@ private gcp.project.monitoringService.dashboard @defaults("name displayName") {
   // `rowLayout`, or `columnLayout`) describing how charts and widgets are
   // arranged.
   layout dict
+  // User-provided labels for the dashboard
+  labels map[string]string
 }
 
 // Google Cloud (GCP) Cloud Monitoring service (for SLO tracking)
@@ -12435,6 +12443,8 @@ private gcp.project.computeService.interconnectAttachment @defaults("name type s
   selfLink string
   // Dataplane version
   dataplaneVersion int
+  // User-provided labels for the attachment
+  labels map[string]string
   // Creation timestamp
   created time
 }
@@ -15390,6 +15400,8 @@ private gcp.project.eventarcService.channel @defaults("name state") {
   cryptoKeyName @maturity("deprecated") string
   // Customer-managed Cloud KMS key used to encrypt events flowing through the channel at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
+  // User-provided labels for the channel
+  labels map[string]string
   // Creation time
   created time
   // Last update time

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -6501,6 +6501,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.bigqueryService.reservation.originalPrimaryLocation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceReservation).GetOriginalPrimaryLocation()).ToDataRes(types.String)
 	},
+	"gcp.project.bigqueryService.reservation.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceReservation).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"gcp.project.bigqueryService.reservation.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceReservation).GetCreated()).ToDataRes(types.Time)
 	},
@@ -6722,6 +6725,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dnsService.responsePolicy.gkeClusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceResponsePolicy).GetGkeClusters()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.dnsService.responsePolicy.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDnsServiceResponsePolicy).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"gcp.project.gkeService.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeService).GetProjectId()).ToDataRes(types.String)
@@ -9558,6 +9564,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dataprocService.autoscalingPolicy.basicAlgorithm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceAutoscalingPolicy).GetBasicAlgorithm()).ToDataRes(types.Dict)
 	},
+	"gcp.project.dataprocService.autoscalingPolicy.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDataprocServiceAutoscalingPolicy).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"gcp.project.cloudRunService.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunService).GetProjectId()).ToDataRes(types.String)
 	},
@@ -10169,6 +10178,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.monitoringService.dashboard.layout": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMonitoringServiceDashboard).GetLayout()).ToDataRes(types.Dict)
+	},
+	"gcp.project.monitoringService.dashboard.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectMonitoringServiceDashboard).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"gcp.project.monitoringService.service.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectMonitoringServiceService).GetProjectId()).ToDataRes(types.String)
@@ -13683,6 +13695,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.interconnectAttachment.dataplaneVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetDataplaneVersion()).ToDataRes(types.Int)
 	},
+	"gcp.project.computeService.interconnectAttachment.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"gcp.project.computeService.interconnectAttachment.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInterconnectAttachment).GetCreated()).ToDataRes(types.Time)
 	},
@@ -16439,6 +16454,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.eventarcService.channel.kmsKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectEventarcServiceChannel).GetKmsKey()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey"))
+	},
+	"gcp.project.eventarcService.channel.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectEventarcServiceChannel).GetLabels()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"gcp.project.eventarcService.channel.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectEventarcServiceChannel).GetCreated()).ToDataRes(types.Time)
@@ -24411,6 +24429,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBigqueryServiceReservation).OriginalPrimaryLocation, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.bigqueryService.reservation.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceReservation).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.bigqueryService.reservation.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceReservation).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -24733,6 +24755,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dnsService.responsePolicy.gkeClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceResponsePolicy).GkeClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dnsService.responsePolicy.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDnsServiceResponsePolicy).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28883,6 +28909,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectDataprocServiceAutoscalingPolicy).BasicAlgorithm, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.dataprocService.autoscalingPolicy.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDataprocServiceAutoscalingPolicy).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudRunService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunService).__id, ok = v.Value.(string)
 		return
@@ -29769,6 +29799,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.monitoringService.dashboard.layout": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectMonitoringServiceDashboard).Layout, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.monitoringService.dashboard.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectMonitoringServiceDashboard).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.monitoringService.service.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34875,6 +34909,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).DataplaneVersion, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.interconnectAttachment.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.interconnectAttachment.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInterconnectAttachment).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -38885,6 +38923,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.eventarcService.channel.kmsKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectEventarcServiceChannel).KmsKey, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokey](v.Value, v.Error)
+		return
+	},
+	"gcp.project.eventarcService.channel.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectEventarcServiceChannel).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.eventarcService.channel.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -56025,6 +56067,7 @@ type mqlGcpProjectBigqueryServiceReservation struct {
 	PrimaryLocation         plugin.TValue[string]
 	SecondaryLocation       plugin.TValue[string]
 	OriginalPrimaryLocation plugin.TValue[string]
+	Labels                  plugin.TValue[map[string]any]
 	Created                 plugin.TValue[*time.Time]
 	Updated                 plugin.TValue[*time.Time]
 }
@@ -56108,6 +56151,10 @@ func (c *mqlGcpProjectBigqueryServiceReservation) GetSecondaryLocation() *plugin
 
 func (c *mqlGcpProjectBigqueryServiceReservation) GetOriginalPrimaryLocation() *plugin.TValue[string] {
 	return &c.OriginalPrimaryLocation
+}
+
+func (c *mqlGcpProjectBigqueryServiceReservation) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 func (c *mqlGcpProjectBigqueryServiceReservation) GetCreated() *plugin.TValue[*time.Time] {
@@ -56826,6 +56873,7 @@ type mqlGcpProjectDnsServiceResponsePolicy struct {
 	NetworkUrls        plugin.TValue[[]any]
 	Networks           plugin.TValue[[]any]
 	GkeClusters        plugin.TValue[[]any]
+	Labels             plugin.TValue[map[string]any]
 }
 
 // createGcpProjectDnsServiceResponsePolicy creates a new instance of this resource
@@ -56903,6 +56951,10 @@ func (c *mqlGcpProjectDnsServiceResponsePolicy) GetNetworks() *plugin.TValue[[]a
 
 func (c *mqlGcpProjectDnsServiceResponsePolicy) GetGkeClusters() *plugin.TValue[[]any] {
 	return &c.GkeClusters
+}
+
+func (c *mqlGcpProjectDnsServiceResponsePolicy) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 // mqlGcpProjectGkeService for the gcp.project.gkeService resource
@@ -66736,6 +66788,7 @@ type mqlGcpProjectDataprocServiceAutoscalingPolicy struct {
 	WorkerConfig          plugin.TValue[any]
 	SecondaryWorkerConfig plugin.TValue[any]
 	BasicAlgorithm        plugin.TValue[any]
+	Labels                plugin.TValue[map[string]any]
 }
 
 // createGcpProjectDataprocServiceAutoscalingPolicy creates a new instance of this resource
@@ -66793,6 +66846,10 @@ func (c *mqlGcpProjectDataprocServiceAutoscalingPolicy) GetSecondaryWorkerConfig
 
 func (c *mqlGcpProjectDataprocServiceAutoscalingPolicy) GetBasicAlgorithm() *plugin.TValue[any] {
 	return &c.BasicAlgorithm
+}
+
+func (c *mqlGcpProjectDataprocServiceAutoscalingPolicy) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 // mqlGcpProjectCloudRunService for the gcp.project.cloudRunService resource
@@ -68755,6 +68812,7 @@ type mqlGcpProjectMonitoringServiceDashboard struct {
 	DisplayName plugin.TValue[string]
 	Etag        plugin.TValue[string]
 	Layout      plugin.TValue[any]
+	Labels      plugin.TValue[map[string]any]
 }
 
 // createGcpProjectMonitoringServiceDashboard creates a new instance of this resource
@@ -68812,6 +68870,10 @@ func (c *mqlGcpProjectMonitoringServiceDashboard) GetEtag() *plugin.TValue[strin
 
 func (c *mqlGcpProjectMonitoringServiceDashboard) GetLayout() *plugin.TValue[any] {
 	return &c.Layout
+}
+
+func (c *mqlGcpProjectMonitoringServiceDashboard) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 // mqlGcpProjectMonitoringServiceService for the gcp.project.monitoringService.service resource
@@ -80650,6 +80712,7 @@ type mqlGcpProjectComputeServiceInterconnectAttachment struct {
 	Region                    plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	SelfLink                  plugin.TValue[string]
 	DataplaneVersion          plugin.TValue[int64]
+	Labels                    plugin.TValue[map[string]any]
 	Created                   plugin.TValue[*time.Time]
 }
 
@@ -80824,6 +80887,10 @@ func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetSelfLink() *plugi
 
 func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetDataplaneVersion() *plugin.TValue[int64] {
 	return &c.DataplaneVersion
+}
+
+func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 func (c *mqlGcpProjectComputeServiceInterconnectAttachment) GetCreated() *plugin.TValue[*time.Time] {
@@ -90621,6 +90688,7 @@ type mqlGcpProjectEventarcServiceChannel struct {
 	State         plugin.TValue[string]
 	CryptoKeyName plugin.TValue[string]
 	KmsKey        plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokey]
+	Labels        plugin.TValue[map[string]any]
 	Created       plugin.TValue[*time.Time]
 	Updated       plugin.TValue[*time.Time]
 }
@@ -90700,6 +90768,10 @@ func (c *mqlGcpProjectEventarcServiceChannel) GetKmsKey() *plugin.TValue[*mqlGcp
 
 		return c.kmsKey()
 	})
+}
+
+func (c *mqlGcpProjectEventarcServiceChannel) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 func (c *mqlGcpProjectEventarcServiceChannel) GetCreated() *plugin.TValue[*time.Time] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -797,6 +797,7 @@ gcp.project.bigqueryService.reservation.concurrency 13.11.2
 gcp.project.bigqueryService.reservation.created 13.11.2
 gcp.project.bigqueryService.reservation.edition 13.11.2
 gcp.project.bigqueryService.reservation.ignoreIdleSlots 13.11.2
+gcp.project.bigqueryService.reservation.labels 13.35.1
 gcp.project.bigqueryService.reservation.location 13.11.2
 gcp.project.bigqueryService.reservation.name 13.11.2
 gcp.project.bigqueryService.reservation.originalPrimaryLocation 13.11.2
@@ -2141,6 +2142,7 @@ gcp.project.computeService.interconnectAttachment.encryption 13.6.1
 gcp.project.computeService.interconnectAttachment.id 13.6.1
 gcp.project.computeService.interconnectAttachment.interconnect 13.6.1
 gcp.project.computeService.interconnectAttachment.interconnectUrl 13.6.1
+gcp.project.computeService.interconnectAttachment.labels 13.35.1
 gcp.project.computeService.interconnectAttachment.name 13.6.1
 gcp.project.computeService.interconnectAttachment.partnerMetadata 13.6.1
 gcp.project.computeService.interconnectAttachment.privateInterconnectInfo 13.6.1
@@ -2787,6 +2789,7 @@ gcp.project.dataprocService 9.0.0
 gcp.project.dataprocService.autoscalingPolicies 13.7.2
 gcp.project.dataprocService.autoscalingPolicy 13.7.2
 gcp.project.dataprocService.autoscalingPolicy.basicAlgorithm 13.7.2
+gcp.project.dataprocService.autoscalingPolicy.labels 13.35.1
 gcp.project.dataprocService.autoscalingPolicy.name 13.7.2
 gcp.project.dataprocService.autoscalingPolicy.projectId 13.7.2
 gcp.project.dataprocService.autoscalingPolicy.secondaryWorkerConfig 13.7.2
@@ -3200,6 +3203,7 @@ gcp.project.dnsService.responsePolicy 13.18.1
 gcp.project.dnsService.responsePolicy.description 13.18.1
 gcp.project.dnsService.responsePolicy.gkeClusters 13.18.1
 gcp.project.dnsService.responsePolicy.id 13.18.1
+gcp.project.dnsService.responsePolicy.labels 13.35.1
 gcp.project.dnsService.responsePolicy.networkUrls 13.18.1
 gcp.project.dnsService.responsePolicy.networks 13.18.1
 gcp.project.dnsService.responsePolicy.projectId 13.18.1
@@ -3247,6 +3251,7 @@ gcp.project.eventarcService.channel 13.6.1
 gcp.project.eventarcService.channel.created 13.6.1
 gcp.project.eventarcService.channel.cryptoKeyName 13.6.1
 gcp.project.eventarcService.channel.kmsKey 13.19.2
+gcp.project.eventarcService.channel.labels 13.35.1
 gcp.project.eventarcService.channel.name 13.6.1
 gcp.project.eventarcService.channel.provider 13.6.1
 gcp.project.eventarcService.channel.pubsubTopic 13.6.1
@@ -4220,6 +4225,7 @@ gcp.project.monitoringService.alertPolicy.validity 9.0.0
 gcp.project.monitoringService.dashboard 13.7.2
 gcp.project.monitoringService.dashboard.displayName 13.7.2
 gcp.project.monitoringService.dashboard.etag 13.7.2
+gcp.project.monitoringService.dashboard.labels 13.35.1
 gcp.project.monitoringService.dashboard.layout 13.7.2
 gcp.project.monitoringService.dashboard.name 13.7.2
 gcp.project.monitoringService.dashboard.projectId 13.7.2

--- a/providers/gcp/resources/monitoring.go
+++ b/providers/gcp/resources/monitoring.go
@@ -535,6 +535,7 @@ func (g *mqlGcpProjectMonitoringService) dashboards() ([]any, error) {
 			"displayName": llx.StringData(db.DisplayName),
 			"etag":        llx.StringData(db.Etag),
 			"layout":      llx.DictData(layout),
+			"labels":      llx.MapData(convert.MapToInterfaceMap(db.GetLabels()), types.String),
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What

Adds `labels` to six GCP resources whose backing API already returns the field but whose schema never surfaced it.

| Resource | SDK source |
| --- | --- |
| `gcp.project.bigqueryService.reservation` | `reservationpb.Reservation.Labels` |
| `gcp.project.computeService.interconnectAttachment` | `compute/v1.InterconnectAttachment.Labels` |
| `gcp.project.dataprocService.autoscalingPolicy` | `dataproc/v1.AutoscalingPolicy.Labels` |
| `gcp.project.dnsService.responsePolicy` | `dns/v1.ResponsePolicy.Labels` |
| `gcp.project.eventarcService.channel` | `eventarcpb.Channel.Labels` |
| `gcp.project.monitoringService.dashboard` | `dashboardpb.Dashboard.Labels` |

## Why

Labels are how most users scope a fleet query to an environment or owner (`.where(labels['env'] == 'prod')`). These six were the only gaps left: a sweep of all 222 top-level GCP resources found 116 already expose labels somewhere, and of the remaining 106 these six are the only ones where the upstream API actually has the data.

## Notes

- **No new API calls.** Every value comes from the struct the lister already iterates, so this is purely additive mapping. `gcp.permissions.json` regenerates unchanged (287 permissions).
- **No new tests.** These are the excluded case in the pure-Go test gate — one SDK field into one `CreateResource`, no parsing, no derived predicate, no branch to assert.
- New `.lr.versions` entries are at `13.35.1`, the next patch after the shipped `13.35.0`.

## Not included

Three resources expose labels only on a nested child rather than at the top level: `pubsubService.topic` (`topic.config.labels`), `pubsubService.subscription` (`subscription.config.labels`), and `sqlService.instance` (`instance.settings.userLabels`). A fleet query can't reach those without traversing. That's an ergonomics change with its own trade-offs (the Pub/Sub ones would each cost a lazy config fetch), so it's deliberately left out of this PR.

Separately, Resource Manager **tags** remain largely uncovered — only `gcp.storage.bucket.tags()` resolves effective (inherited) tags today, while `computeService.vpnGateway`/`vpnTunnel` expose a `resourceManagerTags` field that only carries tags attached at create time. Worth its own PR.

## Verification

- `make providers/build/gcp` — clean; permissions manifest unchanged
- `go build ./...` and `go test ./resources/...` in `providers/gcp` — pass
- `gofmt -l` — clean; generated files regenerated via `mqlr generate`

**Live verification is owed.** I did not have GCP credentials in this session, so the six fields have not been queried against real infrastructure. The mapping is confirmed against the vendored SDK struct definitions, but if any of these APIs returns labels only on a `GET` and not the `LIST`/aggregated call the listers use, the field would render as an empty map rather than null. Worth a pass against a live project before release.
