### PR TITLE
⭐ azure: expose tags on the remaining taggable resources

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -2621,6 +2621,8 @@ private azure.subscription.networkService.virtualNetworkGateway.connection @defa
   etag string
   // VNet gateway Connection location
   location string
+  // VNet gateway Connection tags
+  tags map[string]string
   // VNet gateway Connection properties
   properties dict
   // Connection type (one of: "IPsec", "Vnet2Vnet", "ExpressRoute", "VPNClient")
@@ -7004,6 +7006,10 @@ private azure.subscription.sqlService.database @defaults("name edition zoneRedun
   id string
   // SQL database name
   name string
+  // SQL database location
+  location string
+  // SQL database tags
+  tags map[string]string
   // SQL database type
   type string
   // SQL database collation
@@ -8972,6 +8978,10 @@ private azure.subscription.monitorService.metricAlert @defaults("name enabled se
   id string
   // Rule name
   name string
+  // Location
+  location string
+  // Rule tags
+  tags map[string]string
   // Description
   description string
   // Whether the rule is enabled
@@ -9015,6 +9025,10 @@ private azure.subscription.monitorService.scheduledQueryRule @defaults("name dis
   id string
   // Rule name
   name string
+  // Location
+  location string
+  // Rule tags
+  tags map[string]string
   // Display name
   displayName string
   // Description
@@ -9060,6 +9074,8 @@ private azure.subscription.monitorService.actionGroup @defaults("name groupShort
   name string
   // Location
   location string
+  // Action group tags
+  tags map[string]string
   // Whether the action group is enabled; a disabled group receives no notifications
   enabled bool
   // Short name shown as the source of SMS and other length-limited notifications
@@ -12755,6 +12771,10 @@ private azure.subscription.recoveryServicesService.vault.backupPolicy @defaults(
   id string
   // Backup policy name
   name string
+  // Backup policy location
+  location string
+  // Backup policy tags
+  tags map[string]string
   // Resource type
   type string
   // Backup policy properties
@@ -12773,6 +12793,10 @@ private azure.subscription.recoveryServicesService.vault.protectedItem @defaults
   id string
   // Protected item name
   name string
+  // Protected item location
+  location string
+  // Protected item tags
+  tags map[string]string
   // Resource type
   type string
   // Protected item properties
@@ -14073,6 +14097,8 @@ private azure.subscription.frontDoorService.profile.endpoint @defaults("id name 
   name string
   // Endpoint location
   location string
+  // Endpoint tags
+  tags map[string]string
   // Endpoint hostname
   hostName string
   // Enabled state (Enabled, Disabled)

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -5301,6 +5301,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.virtualNetworkGateway.connection.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).GetLocation()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.virtualNetworkGateway.connection.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"azure.subscription.networkService.virtualNetworkGateway.connection.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).GetProperties()).ToDataRes(types.Dict)
 	},
@@ -9822,6 +9825,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.sqlService.database.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetName()).ToDataRes(types.String)
 	},
+	"azure.subscription.sqlService.database.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.sqlService.database.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"azure.subscription.sqlService.database.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabase).GetType()).ToDataRes(types.String)
 	},
@@ -12027,6 +12036,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.monitorService.metricAlert.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).GetName()).ToDataRes(types.String)
 	},
+	"azure.subscription.monitorService.metricAlert.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.monitorService.metricAlert.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"azure.subscription.monitorService.metricAlert.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).GetDescription()).ToDataRes(types.String)
 	},
@@ -12071,6 +12086,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.monitorService.scheduledQueryRule.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceScheduledQueryRule).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.monitorService.scheduledQueryRule.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceScheduledQueryRule).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.monitorService.scheduledQueryRule.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceScheduledQueryRule).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"azure.subscription.monitorService.scheduledQueryRule.displayName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceScheduledQueryRule).GetDisplayName()).ToDataRes(types.String)
@@ -12119,6 +12140,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.monitorService.actionGroup.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceActionGroup).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.monitorService.actionGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceActionGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"azure.subscription.monitorService.actionGroup.enabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceActionGroup).GetEnabled()).ToDataRes(types.Bool)
@@ -15909,6 +15933,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.recoveryServicesService.vault.backupPolicy.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).GetName()).ToDataRes(types.String)
 	},
+	"azure.subscription.recoveryServicesService.vault.backupPolicy.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.vault.backupPolicy.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"azure.subscription.recoveryServicesService.vault.backupPolicy.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).GetType()).ToDataRes(types.String)
 	},
@@ -15920,6 +15950,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.recoveryServicesService.vault.protectedItem.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.vault.protectedItem.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.vault.protectedItem.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"azure.subscription.recoveryServicesService.vault.protectedItem.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem).GetType()).ToDataRes(types.String)
@@ -17006,6 +17042,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.frontDoorService.profile.endpoint.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.hostName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).GetHostName()).ToDataRes(types.String)
@@ -24245,6 +24284,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.virtualNetworkGateway.connection.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.virtualNetworkGateway.connection.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -30801,6 +30844,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSqlServiceDatabase).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.sqlService.database.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceDatabase).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.sqlService.database.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceDatabase).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.sqlService.database.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceDatabase).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -34013,6 +34064,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.monitorService.metricAlert.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.monitorService.metricAlert.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.monitorService.metricAlert.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceMetricAlert).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -34075,6 +34134,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.monitorService.scheduledQueryRule.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceScheduledQueryRule).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.monitorService.scheduledQueryRule.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceScheduledQueryRule).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.monitorService.scheduledQueryRule.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceScheduledQueryRule).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.monitorService.scheduledQueryRule.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34143,6 +34210,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.monitorService.actionGroup.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceActionGroup).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.monitorService.actionGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceActionGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.monitorService.actionGroup.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39661,6 +39732,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.recoveryServicesService.vault.backupPolicy.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.vault.backupPolicy.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.recoveryServicesService.vault.backupPolicy.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -39679,6 +39758,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.recoveryServicesService.vault.protectedItem.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.vault.protectedItem.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.vault.protectedItem.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.recoveryServicesService.vault.protectedItem.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -41287,6 +41374,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.frontDoorService.profile.endpoint.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionFrontDoorServiceProfileEndpoint).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.frontDoorService.profile.endpoint.hostName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -55580,6 +55671,7 @@ type mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection struct {
 	Type                           plugin.TValue[string]
 	Etag                           plugin.TValue[string]
 	Location                       plugin.TValue[string]
+	Tags                           plugin.TValue[map[string]any]
 	Properties                     plugin.TValue[any]
 	ConnectionType                 plugin.TValue[string]
 	ConnectionStatus               plugin.TValue[string]
@@ -55654,6 +55746,10 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetE
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetLocation() *plugin.TValue[string] {
 	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayConnection) GetProperties() *plugin.TValue[any] {
@@ -71191,6 +71287,8 @@ type mqlAzureSubscriptionSqlServiceDatabase struct {
 	// optional: if you define mqlAzureSubscriptionSqlServiceDatabaseInternal it will be used here
 	Id                                      plugin.TValue[string]
 	Name                                    plugin.TValue[string]
+	Location                                plugin.TValue[string]
+	Tags                                    plugin.TValue[map[string]any]
 	Type                                    plugin.TValue[string]
 	Collation                               plugin.TValue[string]
 	CreationDate                            plugin.TValue[*time.Time]
@@ -71273,6 +71371,14 @@ func (c *mqlAzureSubscriptionSqlServiceDatabase) GetId() *plugin.TValue[string] 
 
 func (c *mqlAzureSubscriptionSqlServiceDatabase) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionSqlServiceDatabase) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionSqlServiceDatabase) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlAzureSubscriptionSqlServiceDatabase) GetType() *plugin.TValue[string] {
@@ -79282,6 +79388,8 @@ type mqlAzureSubscriptionMonitorServiceMetricAlert struct {
 	mqlAzureSubscriptionMonitorServiceMetricAlertInternal
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
+	Location             plugin.TValue[string]
+	Tags                 plugin.TValue[map[string]any]
 	Description          plugin.TValue[string]
 	Enabled              plugin.TValue[bool]
 	Severity             plugin.TValue[int64]
@@ -79340,6 +79448,14 @@ func (c *mqlAzureSubscriptionMonitorServiceMetricAlert) GetId() *plugin.TValue[s
 
 func (c *mqlAzureSubscriptionMonitorServiceMetricAlert) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceMetricAlert) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceMetricAlert) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlAzureSubscriptionMonitorServiceMetricAlert) GetDescription() *plugin.TValue[string] {
@@ -79425,6 +79541,8 @@ type mqlAzureSubscriptionMonitorServiceScheduledQueryRule struct {
 	mqlAzureSubscriptionMonitorServiceScheduledQueryRuleInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
+	Location            plugin.TValue[string]
+	Tags                plugin.TValue[map[string]any]
 	DisplayName         plugin.TValue[string]
 	Description         plugin.TValue[string]
 	Enabled             plugin.TValue[bool]
@@ -79483,6 +79601,14 @@ func (c *mqlAzureSubscriptionMonitorServiceScheduledQueryRule) GetId() *plugin.T
 
 func (c *mqlAzureSubscriptionMonitorServiceScheduledQueryRule) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceScheduledQueryRule) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceScheduledQueryRule) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlAzureSubscriptionMonitorServiceScheduledQueryRule) GetDisplayName() *plugin.TValue[string] {
@@ -79569,6 +79695,7 @@ type mqlAzureSubscriptionMonitorServiceActionGroup struct {
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Location                   plugin.TValue[string]
+	Tags                       plugin.TValue[map[string]any]
 	Enabled                    plugin.TValue[bool]
 	GroupShortName             plugin.TValue[string]
 	EmailReceivers             plugin.TValue[[]any]
@@ -79629,6 +79756,10 @@ func (c *mqlAzureSubscriptionMonitorServiceActionGroup) GetName() *plugin.TValue
 
 func (c *mqlAzureSubscriptionMonitorServiceActionGroup) GetLocation() *plugin.TValue[string] {
 	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceActionGroup) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlAzureSubscriptionMonitorServiceActionGroup) GetEnabled() *plugin.TValue[bool] {
@@ -93186,6 +93317,8 @@ type mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy struct {
 	// optional: if you define mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicyInternal it will be used here
 	Id         plugin.TValue[string]
 	Name       plugin.TValue[string]
+	Location   plugin.TValue[string]
+	Tags       plugin.TValue[map[string]any]
 	Type       plugin.TValue[string]
 	Properties plugin.TValue[any]
 }
@@ -93235,6 +93368,14 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy) GetName()
 	return &c.Name
 }
 
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
+}
+
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy) GetType() *plugin.TValue[string] {
 	return &c.Type
 }
@@ -93250,6 +93391,8 @@ type mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem struct {
 	// optional: if you define mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItemInternal it will be used here
 	Id         plugin.TValue[string]
 	Name       plugin.TValue[string]
+	Location   plugin.TValue[string]
+	Tags       plugin.TValue[map[string]any]
 	Type       plugin.TValue[string]
 	Properties plugin.TValue[any]
 }
@@ -93297,6 +93440,14 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem) GetId() 
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVaultProtectedItem) GetType() *plugin.TValue[string] {
@@ -97566,6 +97717,7 @@ type mqlAzureSubscriptionFrontDoorServiceProfileEndpoint struct {
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
+	Tags              plugin.TValue[map[string]any]
 	HostName          plugin.TValue[string]
 	EnabledState      plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
@@ -97620,6 +97772,10 @@ func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) GetName() *plugin.
 
 func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) GetLocation() *plugin.TValue[string] {
 	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
 }
 
 func (c *mqlAzureSubscriptionFrontDoorServiceProfileEndpoint) GetHostName() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2552,6 +2552,7 @@ azure.subscription.frontDoorService.profile.endpoint.route.systemMetadata 13.22.
 azure.subscription.frontDoorService.profile.endpoint.route.type 13.5.1
 azure.subscription.frontDoorService.profile.endpoint.routes 13.5.1
 azure.subscription.frontDoorService.profile.endpoint.systemMetadata 13.22.1
+azure.subscription.frontDoorService.profile.endpoint.tags 13.34.1
 azure.subscription.frontDoorService.profile.endpoints 13.3.3
 azure.subscription.frontDoorService.profile.frontDoorId 13.3.3
 azure.subscription.frontDoorService.profile.id 13.3.3
@@ -3275,6 +3276,7 @@ azure.subscription.monitorService.actionGroup.logicAppReceivers 13.32.1
 azure.subscription.monitorService.actionGroup.name 13.32.1
 azure.subscription.monitorService.actionGroup.smsReceivers 13.32.1
 azure.subscription.monitorService.actionGroup.systemMetadata 13.32.1
+azure.subscription.monitorService.actionGroup.tags 13.34.1
 azure.subscription.monitorService.actionGroup.voiceReceivers 13.32.1
 azure.subscription.monitorService.actionGroup.webhookReceivers 13.32.1
 azure.subscription.monitorService.actionGroups 13.32.1
@@ -3369,10 +3371,12 @@ azure.subscription.monitorService.metricAlert.enabled 13.32.1
 azure.subscription.monitorService.metricAlert.evaluationFrequency 13.32.1
 azure.subscription.monitorService.metricAlert.id 13.32.1
 azure.subscription.monitorService.metricAlert.lastUpdatedTime 13.32.1
+azure.subscription.monitorService.metricAlert.location 13.34.1
 azure.subscription.monitorService.metricAlert.name 13.32.1
 azure.subscription.monitorService.metricAlert.scopes 13.32.1
 azure.subscription.monitorService.metricAlert.severity 13.32.1
 azure.subscription.monitorService.metricAlert.systemMetadata 13.32.1
+azure.subscription.monitorService.metricAlert.tags 13.34.1
 azure.subscription.monitorService.metricAlert.targetResourceRegion 13.32.1
 azure.subscription.monitorService.metricAlert.targetResourceType 13.32.1
 azure.subscription.monitorService.metricAlert.windowSize 13.32.1
@@ -3411,11 +3415,13 @@ azure.subscription.monitorService.scheduledQueryRule.displayName 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.enabled 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.evaluationFrequency 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.id 13.32.1
+azure.subscription.monitorService.scheduledQueryRule.location 13.34.1
 azure.subscription.monitorService.scheduledQueryRule.muteActionsDuration 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.name 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.scopes 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.severity 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.systemMetadata 13.32.1
+azure.subscription.monitorService.scheduledQueryRule.tags 13.34.1
 azure.subscription.monitorService.scheduledQueryRule.targetResourceTypes 13.32.1
 azure.subscription.monitorService.scheduledQueryRule.windowSize 13.32.1
 azure.subscription.monitorService.scheduledQueryRules 13.32.1
@@ -4718,6 +4724,7 @@ azure.subscription.networkService.virtualNetworkGateway.connection.properties 9.
 azure.subscription.networkService.virtualNetworkGateway.connection.provisioningState 13.10.2
 azure.subscription.networkService.virtualNetworkGateway.connection.routingConfiguration 13.25.1
 azure.subscription.networkService.virtualNetworkGateway.connection.routingWeight 13.10.2
+azure.subscription.networkService.virtualNetworkGateway.connection.tags 13.34.1
 azure.subscription.networkService.virtualNetworkGateway.connection.type 9.0.8
 azure.subscription.networkService.virtualNetworkGateway.connection.useLocalAzureIpAddress 13.10.2
 azure.subscription.networkService.virtualNetworkGateway.connection.usePolicyBasedTrafficSelectors 13.10.2
@@ -5142,8 +5149,10 @@ azure.subscription.recoveryServicesService.vault.backupConfig.storageTypeState 1
 azure.subscription.recoveryServicesService.vault.backupPolicies 13.3.3
 azure.subscription.recoveryServicesService.vault.backupPolicy 13.3.3
 azure.subscription.recoveryServicesService.vault.backupPolicy.id 13.3.3
+azure.subscription.recoveryServicesService.vault.backupPolicy.location 13.34.1
 azure.subscription.recoveryServicesService.vault.backupPolicy.name 13.3.3
 azure.subscription.recoveryServicesService.vault.backupPolicy.properties 13.3.3
+azure.subscription.recoveryServicesService.vault.backupPolicy.tags 13.34.1
 azure.subscription.recoveryServicesService.vault.backupPolicy.type 13.3.3
 azure.subscription.recoveryServicesService.vault.backupStorageVersion 13.3.3
 azure.subscription.recoveryServicesService.vault.costManagementGranularityLevel 13.30.1
@@ -5168,8 +5177,10 @@ azure.subscription.recoveryServicesService.vault.privateEndpointStateForBackup 1
 azure.subscription.recoveryServicesService.vault.privateEndpointStateForSiteRecovery 13.3.3
 azure.subscription.recoveryServicesService.vault.protectedItem 13.3.3
 azure.subscription.recoveryServicesService.vault.protectedItem.id 13.3.3
+azure.subscription.recoveryServicesService.vault.protectedItem.location 13.34.1
 azure.subscription.recoveryServicesService.vault.protectedItem.name 13.3.3
 azure.subscription.recoveryServicesService.vault.protectedItem.properties 13.3.3
+azure.subscription.recoveryServicesService.vault.protectedItem.tags 13.34.1
 azure.subscription.recoveryServicesService.vault.protectedItem.type 13.3.3
 azure.subscription.recoveryServicesService.vault.protectedItems 13.3.3
 azure.subscription.recoveryServicesService.vault.provisioningState 13.3.3
@@ -5515,6 +5526,7 @@ azure.subscription.sqlService.database.ledgerDigestUpload.digestStorageEndpoint 
 azure.subscription.sqlService.database.ledgerDigestUpload.id 13.8.2
 azure.subscription.sqlService.database.ledgerDigestUpload.name 13.8.2
 azure.subscription.sqlService.database.ledgerDigestUpload.state 13.8.2
+azure.subscription.sqlService.database.location 13.34.1
 azure.subscription.sqlService.database.longTermRetentionPolicy 11.4.28
 azure.subscription.sqlService.database.longtermretentionpolicy 11.4.28
 azure.subscription.sqlService.database.longtermretentionpolicy.id 11.4.28
@@ -5543,6 +5555,7 @@ azure.subscription.sqlService.database.serviceLevelObjective 9.0.1
 azure.subscription.sqlService.database.sourceDatabaseDeletionDate 9.0.1
 azure.subscription.sqlService.database.sourceDatabaseId 9.0.1
 azure.subscription.sqlService.database.status 9.0.1
+azure.subscription.sqlService.database.tags 13.34.1
 azure.subscription.sqlService.database.threatDetectionPolicy 9.0.1
 azure.subscription.sqlService.database.transparentDataEncryption 9.0.1
 azure.subscription.sqlService.database.transparentDataEncryptionEnabled 13.8.2

--- a/providers/azure/resources/frontdoor.go
+++ b/providers/azure/resources/frontdoor.go
@@ -266,6 +266,7 @@ func (a *mqlAzureSubscriptionFrontDoorServiceProfile) endpoints() ([]any, error)
 				"id":                llx.StringDataPtr(ep.ID),
 				"name":              llx.StringDataPtr(ep.Name),
 				"location":          llx.StringDataPtr(ep.Location),
+				"tags":              llx.MapData(convert.PtrMapStrToInterface(ep.Tags), types.String),
 				"hostName":          llx.StringData(hostName),
 				"enabledState":      llx.StringData(enabledState),
 				"provisioningState": llx.StringData(provisioningState),

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -475,6 +475,7 @@ func (a *mqlAzureSubscriptionMonitorService) actionGroups() ([]any, error) {
 					"id":                         llx.StringDataPtr(ag.ID),
 					"name":                       llx.StringDataPtr(ag.Name),
 					"location":                   llx.StringDataPtr(ag.Location),
+					"tags":                       llx.MapData(convert.PtrMapStrToInterface(ag.Tags), types.String),
 					"enabled":                    llx.BoolDataPtr(enabled),
 					"groupShortName":             llx.StringData(groupShortName),
 					"emailReceivers":             llx.ArrayData(emailReceivers, types.Dict),
@@ -625,6 +626,8 @@ func (a *mqlAzureSubscriptionMonitorService) metricAlerts() ([]any, error) {
 			mqlMa, err := CreateResource(a.MqlRuntime, "azure.subscription.monitorService.metricAlert", map[string]*llx.RawData{
 				"id":                   llx.StringDataPtr(ma.ID),
 				"name":                 llx.StringDataPtr(ma.Name),
+				"location":             llx.StringDataPtr(ma.Location),
+				"tags":                 llx.MapData(convert.PtrMapStrToInterface(ma.Tags), types.String),
 				"description":          llx.StringData(description),
 				"enabled":              llx.BoolDataPtr(enabled),
 				"severity":             llx.IntData(severity),
@@ -740,6 +743,8 @@ func (a *mqlAzureSubscriptionMonitorService) scheduledQueryRules() ([]any, error
 			mqlSqr, err := CreateResource(a.MqlRuntime, "azure.subscription.monitorService.scheduledQueryRule", map[string]*llx.RawData{
 				"id":                  llx.StringDataPtr(sqr.ID),
 				"name":                llx.StringDataPtr(sqr.Name),
+				"location":            llx.StringDataPtr(sqr.Location),
+				"tags":                llx.MapData(convert.PtrMapStrToInterface(sqr.Tags), types.String),
 				"displayName":         llx.StringData(displayName),
 				"description":         llx.StringData(description),
 				"enabled":             llx.BoolDataPtr(enabled),

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2997,6 +2997,7 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkGateway) connections() 
 				"name":       llx.StringDataPtr(cn.Name),
 				"etag":       llx.StringDataPtr(cn.Etag),
 				"location":   llx.StringDataPtr(cn.Location),
+				"tags":       llx.MapData(convert.PtrMapStrToInterface(cn.Tags), types.String),
 				"properties": llx.DictData(props),
 			}
 			if cn.Properties != nil {

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -773,6 +773,8 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) backupPolicies() ([]a
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(policy.ID),
 					"name":       llx.StringDataPtr(policy.Name),
+					"location":   llx.StringDataPtr(policy.Location),
+					"tags":       llx.MapData(convert.PtrMapStrToInterface(policy.Tags), types.String),
 					"type":       llx.StringDataPtr(policy.Type),
 					"properties": llx.DictData(properties),
 				})
@@ -833,6 +835,8 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) protectedItems() ([]a
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(item.ID),
 					"name":       llx.StringDataPtr(item.Name),
+					"location":   llx.StringDataPtr(item.Location),
+					"tags":       llx.MapData(convert.PtrMapStrToInterface(item.Tags), types.String),
 					"type":       llx.StringDataPtr(item.Type),
 					"properties": llx.DictData(properties),
 				})

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -309,6 +309,8 @@ func (a *mqlAzureSubscriptionSqlServiceServer) databases() ([]any, error) {
 			args := map[string]*llx.RawData{
 				"id":               llx.StringDataPtr(entry.ID),
 				"name":             llx.StringDataPtr(entry.Name),
+				"location":         llx.StringDataPtr(entry.Location),
+				"tags":             llx.MapData(convert.PtrMapStrToInterface(entry.Tags), types.String),
 				"type":             llx.StringDataPtr(entry.Type),
 				"collation":        llx.StringDataPtr(entry.Properties.Collation),
 				"creationDate":     llx.TimeDataPtr(entry.Properties.CreationDate),

--- a/providers/azure/resources/tags_coverage_test.go
+++ b/providers/azure/resources/tags_coverage_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Azure splits resources into two kinds. A *tracked* resource has its own
+// location and carries tags; a *proxy* resource is a child of a tracked parent
+// (a subnet, a firewall rule, a role assignment) and ARM rejects tags on it.
+// Modeling `location` is the schema's own statement that a resource is
+// tracked, which makes "declares location but not tags" a reliable signal that
+// a taggable resource shipped without its tags -- and a tag field that is
+// missing is invisible at query time: a governance policy filtering on
+// `tags["env"]` just skips the resource instead of failing.
+//
+// Every entry below was checked against the pinned SDK struct and has no Tags
+// field, so the absence is correct rather than an oversight.
+var untaggableWithLocation = map[string]string{
+	"azure.subscription.cacheService.redisInstance.patchSchedule":     "armredis.PatchSchedule is a proxy child of the cache",
+	"azure.subscription.cloudDefenderService.jitNetworkAccessPolicy":  "armsecurity.JitNetworkAccessPolicy has no Tags",
+	"azure.subscription.kustoService.cluster.database":                "armkusto.Database/ReadWriteDatabase have no Tags",
+	"azure.subscription.kustoService.cluster.database.dataConnection": "armkusto data connections have no Tags",
+	"azure.subscription.monitorService.workspace.replication":         "replication config is a proxy child of the workspace",
+	"azure.subscription.networkService.routeFilter.rule":              "armnetwork.RouteFilterRule is a proxy child of the filter",
+	"azure.subscription.recoveryServicesService.deletedVault":         "armrecoveryservices.DeletedVault has neither Location nor Tags; location is derived from the per-region listing",
+	"azure.subscription.sqlService.database.dataMaskingPolicy":        "armsql.DataMaskingPolicy is a proxy child of the database",
+}
+
+// TestTrackedResourcesDeclareTags fails when a resource models `location`
+// without `tags`. If the resource really is untaggable, add it to
+// untaggableWithLocation with the SDK type you checked; otherwise add the tags
+// field and populate it from the SDK struct.
+//
+// This catches half-modeled tracked resources, not unmodeled ones: a taggable
+// resource that declares neither field looks the same as a proxy resource from
+// here, so adding a tracked resource still means checking the SDK struct for
+// Location and Tags by hand.
+func TestTrackedResourcesDeclareTags(t *testing.T) {
+	raw, err := os.ReadFile("azure.resources.json")
+	require.NoError(t, err)
+
+	var schema struct {
+		Resources map[string]struct {
+			Fields map[string]json.RawMessage `json:"fields"`
+		} `json:"resources"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &schema))
+	require.NotEmpty(t, schema.Resources, "schema failed to load")
+
+	for name, res := range schema.Resources {
+		if _, tracked := res.Fields["location"]; !tracked {
+			continue
+		}
+		if _, ok := res.Fields["tags"]; ok {
+			continue
+		}
+		require.Containsf(t, untaggableWithLocation, name,
+			"%s declares location but not tags -- add the tags field, or record here why the SDK type has none", name)
+	}
+
+	// Keep the allowlist honest: an entry that has since gained tags is stale
+	// and would otherwise mask the next real gap on that resource.
+	for name := range untaggableWithLocation {
+		res, ok := schema.Resources[name]
+		require.Truef(t, ok, "%s is allowlisted but no longer exists in the schema", name)
+		require.NotContainsf(t, res.Fields, "tags",
+			"%s now declares tags -- drop it from untaggableWithLocation", name)
+	}
+}


### PR DESCRIPTION
## What

Azure splits resources into **tracked** (has its own `location`, carries tags) and **proxy** (a child of a tracked parent — a subnet, a firewall rule, a role assignment — where ARM rejects tags). 145 resources already modeled `tags`. These eight are tracked resources whose SDK struct has a `Tags` field the schema never exposed:

| Resource | SDK type | Also gained `location` |
|---|---|---|
| `sqlService.database` | `armsql.Database` | ✅ |
| `monitorService.metricAlert` | `armmonitor.MetricAlertResource` | ✅ |
| `monitorService.scheduledQueryRule` | `armmonitor.ScheduledQueryRuleResource` | ✅ |
| `monitorService.actionGroup` | `armmonitor.ActionGroupResource` | — |
| `networkService.virtualNetworkGateway.connection` | `armnetwork.VirtualNetworkGatewayConnection` | — |
| `frontDoorService.profile.endpoint` | `armcdn.AFDEndpoint` | — |
| `recoveryServicesService.vault.backupPolicy` | `armrecoveryservicesbackup.ProtectionPolicyResource` | ✅ |
| `recoveryServicesService.vault.protectedItem` | `armrecoveryservicesbackup.ProtectedItemResource` | ✅ |

## Why

A missing tag field is invisible at query time. A policy filtering on `tags["cost-center"]` doesn't fail on these resources — it just skips them, so a tag-governance audit reports clean coverage it never actually checked.

`sqlService.database` is the one that matters most: SQL databases are among the most commonly tagged resources in an Azure estate, and until now `azure.subscription.sqlService.servers { databases { tags } }` wasn't expressible at all.

Five of the eight didn't model `location` either. It comes off the same SDK struct, and a tag query without location is half a governance answer, so it's added alongside.

## Regression guard

`TestTrackedResourcesDeclareTags` reads the generated `azure.resources.json` and fails when a resource declares `location` without `tags`. The eight resources where ARM genuinely has no tags (Kusto databases, JIT network access policies, route filter rules, …) are allowlisted with the SDK type each was checked against, and the test also fails on a *stale* allowlist entry — one that has since gained tags — so the list can't quietly mask the next real gap.

It catches half-modeled tracked resources, not unmodeled ones: a taggable resource declaring neither field is indistinguishable from a proxy resource, so adding a tracked resource still means checking the SDK struct by hand. Noted in the test.

## Verification

- `go test ./...` in `providers/azure/` — green
- Guard negative-checked: removing an allowlist entry fails the test with an actionable message
- `azure.permissions.json` unchanged at 330 permissions — no new API calls
- `.lr.versions`: 13 entries at `13.34.1` (provider is at `13.34.0`; no version bump in this PR)

**Not live-verified** — this is static plus unit verification. The tag values come straight off the same SDK structs the surrounding fields already use, but a run against a subscription with a tagged SQL DB and a tagged action group would confirm end to end.
