### PR TITLE
✨ Give print drivers a pkg:windows-driver purl

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -10686,6 +10686,14 @@ windows.printerDrivers {
 windows.printerDriver @defaults("name version manufacturer") {
   // Driver name as the spooler reports it
   name string
+  // Package URL identifying this driver
+  //
+  // A pkg:windows-driver purl whose namespace is the vendor, for example
+  // pkg:windows-driver/ricoh/pcl-6-driver@4.40.0.0. Empty when the spooler
+  // reports no manufacturer or no name, because a driver name alone does not
+  // identify a driver: "PCL 6 Driver" and "PostScript3 Driver" name page
+  // description languages that every printer vendor ships a driver for.
+  purl string
   // Vendor driver version in dotted form, for example "3.0.0.0"
   //
   // Windows stores this packed into a single 64-bit integer holding four

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -11133,6 +11133,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.printerDriver.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsPrinterDriver).GetName()).ToDataRes(types.String)
 	},
+	"windows.printerDriver.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsPrinterDriver).GetPurl()).ToDataRes(types.String)
+	},
 	"windows.printerDriver.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsPrinterDriver).GetVersion()).ToDataRes(types.String)
 	},
@@ -26685,6 +26688,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.printerDriver.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsPrinterDriver).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.printerDriver.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsPrinterDriver).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"windows.printerDriver.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -70571,6 +70578,7 @@ type mqlWindowsPrinterDriver struct {
 	__id       string
 	// optional: if you define mqlWindowsPrinterDriverInternal it will be used here
 	Name           plugin.TValue[string]
+	Purl           plugin.TValue[string]
 	Version        plugin.TValue[string]
 	ModelVersion   plugin.TValue[int64]
 	Manufacturer   plugin.TValue[string]
@@ -70621,6 +70629,10 @@ func (c *mqlWindowsPrinterDriver) MqlID() string {
 
 func (c *mqlWindowsPrinterDriver) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlWindowsPrinterDriver) GetPurl() *plugin.TValue[string] {
+	return &c.Purl
 }
 
 func (c *mqlWindowsPrinterDriver) GetVersion() *plugin.TValue[string] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -3794,6 +3794,7 @@ windows.printerDriver.manufacturer 13.40.6
 windows.printerDriver.modelVersion 13.40.6
 windows.printerDriver.name 13.40.6
 windows.printerDriver.printProcessor 13.40.6
+windows.printerDriver.purl 13.40.6
 windows.printerDriver.version 13.40.6
 windows.printerDrivers 13.40.6
 windows.printerDrivers.list 13.40.6

--- a/providers/os/resources/purl/purl_types.go
+++ b/providers/os/resources/purl/purl_types.go
@@ -17,6 +17,17 @@ var (
 	TypeAppx Type = "appx"
 	// TypeMacos is a pkg:macos purl.
 	TypeMacos Type = "macos"
+	// TypeWindowsDriver is a pkg:windows-driver purl.
+	//
+	// Drivers are not ordinary Windows software and must not share pkg:windows
+	// with it. A vendor bundle that shipped an installer registers in
+	// Add/Remove Programs as well as with the spooler, so the same driver can
+	// be reported twice; the type keeps those apart. The namespace is the
+	// VENDOR, because driver names are not unique across vendors: "PCL 6
+	// Driver" and "PostScript3 Driver" name page description languages every
+	// printer vendor ships a driver for, so keying on the name alone would
+	// match one vendor's advisory against another's driver.
+	TypeWindowsDriver Type = "windows-driver"
 	// Type_X_Platform is a pkg:platform purl.
 	Type_X_Platform Type = "platform"
 	// TypeSnap is a pkg:snap purl.
@@ -36,18 +47,19 @@ var (
 	TypeRPM     = Type(packageurl.TypeRPM)
 
 	KnownTypes = map[Type]struct{}{
-		TypeAppx:        {},
-		TypeWindows:     {},
-		TypeMacos:       {},
-		Type_X_Platform: {},
-		TypeGeneric:     {},
-		TypeApk:         {},
-		TypeDebian:      {},
-		TypeAlpm:        {},
-		TypeEbuild:      {},
-		TypeNix:         {},
-		TypeRPM:         {},
-		TypeCos:         {},
+		TypeAppx:          {},
+		TypeWindows:       {},
+		TypeWindowsDriver: {},
+		TypeMacos:         {},
+		Type_X_Platform:   {},
+		TypeGeneric:       {},
+		TypeApk:           {},
+		TypeDebian:        {},
+		TypeAlpm:          {},
+		TypeEbuild:        {},
+		TypeNix:           {},
+		TypeRPM:           {},
+		TypeCos:           {},
 	}
 )
 

--- a/providers/os/resources/windows/printerdriver.go
+++ b/providers/os/resources/windows/printerdriver.go
@@ -115,3 +115,71 @@ func ParsePrinterDrivers(r io.Reader) ([]PrinterDriver, error) {
 	}
 	return out, nil
 }
+
+// purlToken reduces a driver or vendor string to a PURL token: lowercase, with
+// anything outside [a-z0-9.+] folded to a single "-".
+//
+// The same normalisation both sides of a match must agree on, so it is written
+// once here rather than at each call site.
+func purlToken(s string) string {
+	var b strings.Builder
+	dash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '+':
+			b.WriteRune(r)
+			dash = false
+		default:
+			if b.Len() > 0 && !dash {
+				b.WriteByte('-')
+				dash = true
+			}
+		}
+	}
+	// Trailing punctuation is never part of a name. A "." survives the loop
+	// because it is a legal token character mid-string ("Ver.3.0"), but
+	// "Ricoh Company, Ltd." would otherwise end "-ltd." and miss the suffix
+	// list below.
+	return strings.Trim(b.String(), "-.")
+}
+
+// vendorSuffixes are the corporate suffixes a driver's Manufacturer carries
+// that its advisories do not: "Ricoh Company, Ltd." and "RICOH" have to reach
+// the same token.
+var vendorSuffixes = []string{
+	"-company-ltd", "-company-limited", "-co-ltd", "-corporation", "-corp",
+	"-industries-ltd", "-industries", "-inc", "-ltd", "-gmbh", "-kk",
+}
+
+// VendorToken reduces a driver's Manufacturer to the vendor namespace.
+func VendorToken(manufacturer string) string {
+	token := purlToken(manufacturer)
+	for _, suffix := range vendorSuffixes {
+		if strings.HasSuffix(token, suffix) {
+			token = strings.TrimSuffix(token, suffix)
+			break
+		}
+	}
+	return strings.Trim(token, "-")
+}
+
+// Purl is the package URL identifying this driver, empty when it cannot be
+// identified.
+//
+// Returns nothing rather than a partial identity when the manufacturer or name
+// is missing. A vendor-less driver PURL would match whatever advisory happened
+// to carry the same driver name, and driver names are emphatically not unique
+// across vendors, so guessing here attaches one vendor's vulnerability to
+// another vendor's driver.
+func (d PrinterDriver) Purl() string {
+	vendor := VendorToken(d.Manufacturer)
+	name := purlToken(d.Name)
+	if vendor == "" || name == "" {
+		return ""
+	}
+	p := "pkg:windows-driver/" + vendor + "/" + name
+	if v := d.DottedVersion(); v != "" {
+		p += "@" + v
+	}
+	return p
+}

--- a/providers/os/resources/windows/printerdriver_test.go
+++ b/providers/os/resources/windows/printerdriver_test.go
@@ -90,3 +90,62 @@ func TestParsePrinterDriversAcceptsAStringVersion(t *testing.T) {
 	assert.Equal(t, uint64(844433520133734400), drivers[0].DriverVersion)
 	assert.Equal(t, int64(3), drivers[0].MajorVersion)
 }
+
+// TestPurlKeepsVendorsApart is the reason the vendor is the namespace.
+//
+// Driver names are NOT unique across vendors: "PCL 6 Driver" and
+// "PostScript3 Driver" name page description languages that every printer
+// vendor ships a driver for. Keying on the name alone would match one vendor's
+// advisory against another vendor's driver.
+func TestPurlKeepsVendorsApart(t *testing.T) {
+	ricoh := PrinterDriver{Name: "PCL 6 Driver", Manufacturer: "RICOH", DriverVersion: 3 << 48}
+	brother := PrinterDriver{Name: "PCL 6 Driver", Manufacturer: "Brother", DriverVersion: 3 << 48}
+
+	assert.Equal(t, "pkg:windows-driver/ricoh/pcl-6-driver@3.0.0.0", ricoh.Purl())
+	assert.Equal(t, "pkg:windows-driver/brother/pcl-6-driver@3.0.0.0", brother.Purl())
+	assert.NotEqual(t, ricoh.Purl(), brother.Purl(), "same driver name, different vendors")
+}
+
+// TestVendorTokenNormalisesCorporateSuffixes: the spooler reports the
+// manufacturer as the INF spells it, which carries corporate suffixes the
+// vendor's advisories do not.
+func TestVendorTokenNormalisesCorporateSuffixes(t *testing.T) {
+	for _, in := range []string{"RICOH", "Ricoh", "Ricoh Company, Ltd.", "RICOH COMPANY, LTD."} {
+		assert.Equal(t, "ricoh", VendorToken(in), "input %q", in)
+	}
+	for _, in := range []string{"Brother", "Brother Industries, Ltd", "brother industries"} {
+		assert.Equal(t, "brother", VendorToken(in), "input %q", in)
+	}
+	assert.Equal(t, "konica-minolta", VendorToken("Konica Minolta, Inc."))
+}
+
+// TestPurlRefusesAPartialIdentity: a vendor-less driver PURL would match
+// whatever advisory carried the same driver name, so an unidentifiable driver
+// yields nothing at all.
+func TestPurlRefusesAPartialIdentity(t *testing.T) {
+	assert.Empty(t, PrinterDriver{Name: "PCL 6 Driver"}.Purl(), "no manufacturer")
+	assert.Empty(t, PrinterDriver{Manufacturer: "RICOH"}.Purl(), "no name")
+	assert.Empty(t, PrinterDriver{Name: "  ", Manufacturer: "  "}.Purl())
+
+	// A driver with no version is still identifiable; the PURL simply carries
+	// no version, and an unversioned package cannot match a bounded advisory.
+	assert.Equal(t, "pkg:windows-driver/ricoh/lan-fax-driver",
+		PrinterDriver{Name: "LAN Fax Driver", Manufacturer: "RICOH"}.Purl())
+}
+
+// TestPurlOnRealVendorDriverNames uses the names Ricoh publishes in its own
+// advisories, which are what the catalog rows have to line up with.
+func TestPurlOnRealVendorDriverNames(t *testing.T) {
+	for name, want := range map[string]string{
+		"PostScript3 Driver":                 "pkg:windows-driver/ricoh/postscript3-driver",
+		"PCL 6 Driver":                       "pkg:windows-driver/ricoh/pcl-6-driver",
+		"PS Driver for Universal Print":      "pkg:windows-driver/ricoh/ps-driver-for-universal-print",
+		"PCL6 Driver for Universal Print":    "pkg:windows-driver/ricoh/pcl6-driver-for-universal-print",
+		"PCL6 V4 Driver for Universal Print": "pkg:windows-driver/ricoh/pcl6-v4-driver-for-universal-print",
+		"LAN Fax Driver":                     "pkg:windows-driver/ricoh/lan-fax-driver",
+		"Generic PCL5 Driver":                "pkg:windows-driver/ricoh/generic-pcl5-driver",
+	} {
+		got := PrinterDriver{Name: name, Manufacturer: "RICOH"}.Purl()
+		assert.Equal(t, want, got, "name %q", name)
+	}
+}

--- a/providers/os/resources/windows_printerdriver.go
+++ b/providers/os/resources/windows_printerdriver.go
@@ -44,6 +44,7 @@ func (r *mqlWindowsPrinterDrivers) list() ([]any, error) {
 	for _, d := range drivers {
 		res, err := CreateResource(r.MqlRuntime, "windows.printerDriver", map[string]*llx.RawData{
 			"name":           llx.StringData(d.Name),
+			"purl":           llx.StringData(d.Purl()),
 			"version":        llx.StringData(d.DottedVersion()),
 			"modelVersion":   llx.IntData(d.MajorVersion),
 			"manufacturer":   llx.StringData(d.Manufacturer),


### PR DESCRIPTION
Follow-on to #9804. Adds the `purl` field to `windows.printerDriver` and registers the `pkg:windows-driver` type, so a driver can be **identified** rather than only listed.

```
pkg:windows-driver/ricoh/pcl-6-driver@4.40.0.0
```

## Why a separate type from `pkg:windows`

A vendor bundle that shipped an installer registers in Add/Remove Programs **as well as** with the spooler, so the same driver can be reported by two enumerations. Sharing a type would collapse those into one identity and count it twice.

## Why the vendor is the namespace — the part worth reviewing

Driver names are **not unique across vendors**. `PCL 6 Driver`, `PostScript3 Driver` and `Generic PCL5 Driver` name page description languages that *every* printer vendor ships a driver for, so a name-keyed identity would match one vendor's advisory against another vendor's driver:

```go
ricoh:   pkg:windows-driver/ricoh/pcl-6-driver@3.0.0.0
brother: pkg:windows-driver/brother/pcl-6-driver@3.0.0.0
```

`TestPurlKeepsVendorsApart` pins that those don't collide. It also matches the shape already used for discovered hardware — `pkg:hardware/ricoh/im-c3000` — where the type says what the thing is and the namespace says whose it is.

## Vendor normalisation

The spooler reports the manufacturer as the INF spells it, carrying corporate suffixes the vendor's own advisories don't. `RICOH`, `Ricoh` and `Ricoh Company, Ltd.` all have to reach `ricoh`.

One subtlety: a trailing `.` needed trimming for that to work. `.` is a legal token character mid-string (`Ver.3.0`), so `Ricoh Company, Ltd.` normalised to `ricoh-company-ltd.` and missed the suffix list entirely. Caught by the test, not by inspection.

## Refuses a partial identity

`Purl()` returns empty when the manufacturer or the name is missing, rather than emitting a vendor-less PURL. That would match whatever advisory carried the same driver name — the exact failure the vendor namespace exists to prevent — so an unidentifiable driver yields nothing.

A driver with **no version** is still identifiable and keeps its PURL, simply without a version; an unversioned package can't match a bounded advisory anyway.

## Checks run

Beyond build/vet/test: the `os.lr` diff is additions-only (0 removed, 8 added), and the undocumented-resource check is clean (0 on main, 0 now, none newly introduced) — the two verifications that came out of the review rounds on #9804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
