### PR TITLE
🌟 aws: add tags to 26 audit-relevant resources

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2725,6 +2725,9 @@ private aws.iam.policy @defaults("arn name") {
   // principal has used, and totalAuthenticatedEntities counts the principals
   // that did use each service.
   lastAccessedServices() []aws.iam.serviceLastAccessed
+
+  // Tags for the policy
+  tags() map[string]string
 }
 
 // AWS IAM policy version
@@ -6551,6 +6554,9 @@ private aws.elb.truststore @defaults("name arn status") {
   numberOfCaCertificates int
   // Number of revoked certificate entries loaded into the trust store
   totalRevokedEntries int
+
+  // Tags for the trust store
+  tags() map[string]string
 }
 
 // AWS Elastic Load Balancer (ELB) Target Group
@@ -6603,6 +6609,9 @@ private aws.elb.targetgroup @defaults("name port ec2Targets lambdaTargets") {
   ipTargets() []string
   // Region where the target group exists
   region string
+
+  // Tags for the target group
+  tags() map[string]string
 }
 
 // AWS ELB target group attributes
@@ -6842,6 +6851,9 @@ private aws.elb.listener @defaults("arn port protocol") {
   trustStore() aws.elb.truststore
   // Rules that route requests reaching the listener
   rules() []aws.elb.listener.rule
+
+  // Tags for the listener
+  tags() map[string]string
 }
 
 // AWS ELB listener rule
@@ -6870,6 +6882,9 @@ private aws.elb.listener.rule @defaults("arn priority isDefault") {
   // authenticate-cognito, or authenticate-oidc), an `Order`, and the config
   // block for that type.
   actions []dict
+
+  // Tags for the listener rule
+  tags() map[string]string
 }
 
 // AWS ELB load balancer attributes
@@ -8230,6 +8245,9 @@ private aws.securityhub.hub @defaults("arn region") {
   members() []aws.securityhub.member
   // Products enabled for finding import
   enabledProducts() []aws.securityhub.enabledProduct
+
+  // Tags for the hub
+  tags() map[string]string
 }
 
 // AWS Security Hub enabled standard subscription
@@ -10889,6 +10907,9 @@ private aws.cloudwatch.metricsalarm @defaults("arn") {
   alarmConfigurationUpdatedAt time
   // Time the alarm state was last updated
   stateUpdatedAt time
+
+  // Tags for the alarm
+  tags() map[string]string
 }
 
 // Amazon CloudWatch metric
@@ -13074,6 +13095,9 @@ private aws.backup.accessPoint @defaults("name status resourceType region") {
   metadata map[string]string
   // Time the access point was created
   createdAt time
+
+  // Tags for the access point
+  tags() map[string]string
 }
 
 // AWS Backup vault
@@ -13111,6 +13135,9 @@ private aws.backup.vault @defaults("name region") {
   // True when an Allow statement grants a wildcard principal access that is not
   // scoped by a source-restricting condition.
   isPublic() bool
+
+  // Tags for the backup vault
+  tags() map[string]string
 }
 
 // AWS Backup vault recovery point
@@ -13151,6 +13178,14 @@ private aws.backup.vaultRecoveryPoint @defaults("resourceType completionDate sta
   isEncrypted bool
   // Backup access points exposing this recovery point through S3 APIs
   accessPoints() []aws.backup.accessPoint
+
+  // Tags for the recovery point
+  //
+  // Null for recovery points of resources that Backup does not fully
+  // manage. Their ARNs belong to the source service (for example
+  // arn:aws:dynamodb) rather than arn:aws:backup, and Backup cannot
+  // read tags for them.
+  tags() map[string]string
 }
 
 // AWS Backup lifecycle settings
@@ -13194,6 +13229,9 @@ private aws.backup.plan @defaults("name region") {
   selections() @maturity("deprecated") []dict
   // Resource selections that assign resources to this backup plan
   resourceSelections() []aws.backup.plan.selection
+
+  // Tags for the backup plan
+  tags() map[string]string
 }
 
 // AWS Backup plan resource selection
@@ -13748,6 +13786,9 @@ private aws.rds.optionGroup @defaults("optionGroupName engineName majorEngineVer
   // Permanent, Port, OptionSettings (list of Name/Value/AllowedValues),
   // VpcSecurityGroupMemberships, and DBSecurityGroupMemberships.
   options []dict
+
+  // Tags for the option group
+  tags() map[string]string
 }
 
 // Amazon Aurora global cluster
@@ -13794,6 +13835,9 @@ private aws.rds.globalCluster @defaults("globalClusterIdentifier engine status")
   //
   // Each entry contains DBClusterArn, IsWriter, GlobalWriteForwardingStatus, SynchronizationStatus, and Readers (list of secondary cluster ARNs).
   members []dict
+
+  // Tags for the global cluster
+  tags() map[string]string
 }
 
 // Amazon RDS Backup Setting
@@ -14351,6 +14395,9 @@ aws.rds.clusterParameterGroup @defaults("name family region arn") {
   // Region of the parameters
   region string
   parameters() []aws.rds.parameterGroup.parameter
+
+  // Tags for the cluster parameter group
+  tags() map[string]string
 }
 
 // Amazon RDS DB parameter group
@@ -14374,6 +14421,9 @@ aws.rds.parameterGroup @defaults("name family region arn") {
   region string
   // The parameters of the group
   parameters() []aws.rds.parameterGroup.parameter
+
+  // Tags for the parameter group
+  tags() map[string]string
 }
 
 // Amazon RDS parameter
@@ -14529,6 +14579,9 @@ private aws.elasticache.replicationGroup @defaults("replicationGroupId status de
   logDeliveryConfigurations []dict
   // Group settings that are pending application
   pendingModifiedValues dict
+
+  // Tags for the replication group
+  tags() map[string]string
 }
 
 // Amazon ElastiCache cluster
@@ -14684,6 +14737,9 @@ private aws.elasticache.serverlessCache @defaults("name description status engin
   createdAt time
   // Subnets associated with the serverless cache
   subnets() []aws.vpc.subnet
+
+  // Tags for the serverless cache
+  tags() map[string]string
 }
 
 // Amazon ElastiCache parameter group
@@ -14706,6 +14762,9 @@ private aws.elasticache.parameterGroup @defaults("name family") {
   description string
   // Whether the parameter group is associated with a Global datastore
   isGlobal bool
+
+  // Tags for the parameter group
+  tags() map[string]string
 }
 
 // Amazon ElastiCache subnet group
@@ -14734,6 +14793,9 @@ private aws.elasticache.subnetGroup @defaults("name") {
   supportedNetworkTypes []string
   // VPC associated with this subnet group
   vpc() aws.vpc
+
+  // Tags for the subnet group
+  tags() map[string]string
 }
 
 // Amazon ElastiCache RBAC user
@@ -14767,6 +14829,9 @@ private aws.elasticache.user @defaults("userName status engine") {
   // Dict with `Type` (the authentication mode, one of password, no-password,
   // or iam) and `PasswordCount` (number of configured passwords, up to two).
   authentication dict
+
+  // Tags for the user
+  tags() map[string]string
 }
 
 // Amazon ElastiCache service update
@@ -14842,6 +14907,9 @@ private aws.elasticache.snapshot @defaults("name status engine") {
   vpc() aws.vpc
   // When the source cluster was created
   cacheClusterCreatedAt time
+
+  // Tags for the snapshot
+  tags() map[string]string
 }
 
 // Amazon Redshift
@@ -17644,6 +17712,9 @@ private aws.ssm.parameter {
   // `NoChangeNotification`), `policyText` (the JSON policy body), and `policyStatus`
   // (one of `Pending`, `Finished`, `Failed`, `InProgress`).
   policies []dict
+
+  // Tags for the parameter
+  tags() map[string]string
 }
 
 // Amazon SSM instance
@@ -19985,6 +20056,9 @@ private aws.config.rule @defaults("name id region state") {
   complianceDetails() []aws.config.rule.complianceDetail
   // Remediation configuration associated with this rule
   remediation() aws.config.rule.remediation
+
+  // Tags for the rule
+  tags() map[string]string
 }
 
 // AWS Config rule compliance detail for an individual resource
@@ -20103,6 +20177,9 @@ private aws.config.conformancePack @defaults("name region") {
   complianceStatus() string
   // Compliance status of individual rules within the conformance pack
   ruleCompliance() []aws.config.conformancePack.ruleCompliance
+
+  // Tags for the conformance pack
+  tags() map[string]string
 }
 
 // AWS Config conformance pack rule compliance
@@ -20129,6 +20206,9 @@ private aws.config.aggregator @defaults("name region") {
   createdAt time
   // Time the aggregator was last updated
   lastUpdatedAt time
+
+  // Tags for the aggregator
+  tags() map[string]string
 }
 
 // AWS Config aggregator account aggregation source
@@ -24917,6 +24997,9 @@ private aws.rds.eventSubscription @defaults("arn name status") {
   customerAwsId string
   // Time the subscription was created (string format from AWS API)
   subscriptionCreationTime string
+
+  // Tags for the event subscription
+  tags() map[string]string
 }
 
 // AWS Glue workflow

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -7517,6 +7517,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.policy.lastAccessedServices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetLastAccessedServices()).ToDataRes(types.Array(types.Resource("aws.iam.serviceLastAccessed")))
 	},
+	"aws.iam.policy.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicy).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.iam.policyversion.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicyversion).GetArn()).ToDataRes(types.String)
 	},
@@ -11777,6 +11780,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.truststore.totalRevokedEntries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbTruststore).GetTotalRevokedEntries()).ToDataRes(types.Int)
 	},
+	"aws.elb.truststore.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbTruststore).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.elb.targetgroup.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbTargetgroup).GetName()).ToDataRes(types.String)
 	},
@@ -11839,6 +11845,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elb.targetgroup.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbTargetgroup).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.elb.targetgroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbTargetgroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.elb.targetgroup.attributes.targetGroupArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbTargetgroupAttributes).GetTargetGroupArn()).ToDataRes(types.String)
@@ -12047,6 +12056,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.listener.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbListener).GetRules()).ToDataRes(types.Array(types.Resource("aws.elb.listener.rule")))
 	},
+	"aws.elb.listener.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbListener).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.elb.listener.rule.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbListenerRule).GetArn()).ToDataRes(types.String)
 	},
@@ -12061,6 +12073,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elb.listener.rule.actions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbListenerRule).GetActions()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.elb.listener.rule.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbListenerRule).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.elb.loadbalancer.attribute.loadBalancerArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancerAttribute).GetLoadBalancerArn()).ToDataRes(types.String)
@@ -13357,6 +13372,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.securityhub.hub.enabledProducts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecurityhubHub).GetEnabledProducts()).ToDataRes(types.Array(types.Resource("aws.securityhub.enabledProduct")))
+	},
+	"aws.securityhub.hub.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecurityhubHub).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.securityhub.standardSubscription.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecurityhubStandardSubscription).GetArn()).ToDataRes(types.String)
@@ -16088,6 +16106,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudwatch.metricsalarm.stateUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchMetricsalarm).GetStateUpdatedAt()).ToDataRes(types.Time)
 	},
+	"aws.cloudwatch.metricsalarm.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchMetricsalarm).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.cloudwatch.metric.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchMetric).GetName()).ToDataRes(types.String)
 	},
@@ -18065,6 +18086,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.backup.accessPoint.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupAccessPoint).GetCreatedAt()).ToDataRes(types.Time)
 	},
+	"aws.backup.accessPoint.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupAccessPoint).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.backup.vault.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVault).GetArn()).ToDataRes(types.String)
 	},
@@ -18107,6 +18131,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.backup.vault.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVault).GetIsPublic()).ToDataRes(types.Bool)
 	},
+	"aws.backup.vault.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupVault).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.backup.vaultRecoveryPoint.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVaultRecoveryPoint).GetArn()).ToDataRes(types.String)
 	},
@@ -18148,6 +18175,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.backup.vaultRecoveryPoint.accessPoints": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupVaultRecoveryPoint).GetAccessPoints()).ToDataRes(types.Array(types.Resource("aws.backup.accessPoint")))
+	},
+	"aws.backup.vaultRecoveryPoint.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupVaultRecoveryPoint).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.backup.lifecycle.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupLifecycle).GetId()).ToDataRes(types.String)
@@ -18196,6 +18226,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.backup.plan.resourceSelections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupPlan).GetResourceSelections()).ToDataRes(types.Array(types.Resource("aws.backup.plan.selection")))
+	},
+	"aws.backup.plan.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsBackupPlan).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.backup.plan.selection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsBackupPlanSelection).GetId()).ToDataRes(types.String)
@@ -18725,6 +18758,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.optionGroup.options": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsOptionGroup).GetOptions()).ToDataRes(types.Array(types.Dict))
 	},
+	"aws.rds.optionGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsOptionGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.rds.globalCluster.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsGlobalCluster).GetArn()).ToDataRes(types.String)
 	},
@@ -18766,6 +18802,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.globalCluster.members": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsGlobalCluster).GetMembers()).ToDataRes(types.Array(types.Dict))
+	},
+	"aws.rds.globalCluster.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsGlobalCluster).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.rds.backupsetting.target": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsBackupsetting).GetTarget()).ToDataRes(types.String)
@@ -19448,6 +19487,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.rds.clusterParameterGroup.parameters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsClusterParameterGroup).GetParameters()).ToDataRes(types.Array(types.Resource("aws.rds.parameterGroup.parameter")))
 	},
+	"aws.rds.clusterParameterGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsClusterParameterGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.rds.parameterGroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsParameterGroup).GetArn()).ToDataRes(types.String)
 	},
@@ -19465,6 +19507,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.parameterGroup.parameters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsParameterGroup).GetParameters()).ToDataRes(types.Array(types.Resource("aws.rds.parameterGroup.parameter")))
+	},
+	"aws.rds.parameterGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsParameterGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.rds.parameterGroup.parameter.allowedValues": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsParameterGroupParameter).GetAllowedValues()).ToDataRes(types.String)
@@ -19627,6 +19672,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.replicationGroup.pendingModifiedValues": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheReplicationGroup).GetPendingModifiedValues()).ToDataRes(types.Dict)
+	},
+	"aws.elasticache.replicationGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheReplicationGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.elasticache.cluster.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheCluster).GetArn()).ToDataRes(types.String)
@@ -19805,6 +19853,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elasticache.serverlessCache.subnets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheServerlessCache).GetSubnets()).ToDataRes(types.Array(types.Resource("aws.vpc.subnet")))
 	},
+	"aws.elasticache.serverlessCache.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheServerlessCache).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.elasticache.parameterGroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheParameterGroup).GetArn()).ToDataRes(types.String)
 	},
@@ -19822,6 +19873,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.parameterGroup.isGlobal": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheParameterGroup).GetIsGlobal()).ToDataRes(types.Bool)
+	},
+	"aws.elasticache.parameterGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheParameterGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.elasticache.subnetGroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheSubnetGroup).GetArn()).ToDataRes(types.String)
@@ -19843,6 +19897,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.subnetGroup.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheSubnetGroup).GetVpc()).ToDataRes(types.Resource("aws.vpc"))
+	},
+	"aws.elasticache.subnetGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheSubnetGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.elasticache.user.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheUser).GetArn()).ToDataRes(types.String)
@@ -19873,6 +19930,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.user.authentication": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheUser).GetAuthentication()).ToDataRes(types.Dict)
+	},
+	"aws.elasticache.user.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheUser).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.elasticache.serviceUpdate.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheServiceUpdate).GetName()).ToDataRes(types.String)
@@ -19957,6 +20017,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.elasticache.snapshot.cacheClusterCreatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElasticacheSnapshot).GetCacheClusterCreatedAt()).ToDataRes(types.Time)
+	},
+	"aws.elasticache.snapshot.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElasticacheSnapshot).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.redshift.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRedshift).GetClusters()).ToDataRes(types.Array(types.Resource("aws.redshift.cluster")))
@@ -22778,6 +22841,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ssm.parameter.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmParameter).GetPolicies()).ToDataRes(types.Array(types.Dict))
 	},
+	"aws.ssm.parameter.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSsmParameter).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.ssm.instance.instanceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSsmInstance).GetInstanceId()).ToDataRes(types.String)
 	},
@@ -25286,6 +25352,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.config.rule.remediation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigRule).GetRemediation()).ToDataRes(types.Resource("aws.config.rule.remediation"))
 	},
+	"aws.config.rule.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsConfigRule).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.config.rule.complianceDetail.resourceType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigRuleComplianceDetail).GetResourceType()).ToDataRes(types.String)
 	},
@@ -25415,6 +25484,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.config.conformancePack.ruleCompliance": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigConformancePack).GetRuleCompliance()).ToDataRes(types.Array(types.Resource("aws.config.conformancePack.ruleCompliance")))
 	},
+	"aws.config.conformancePack.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsConfigConformancePack).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.config.conformancePack.ruleCompliance.ruleName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigConformancePackRuleCompliance).GetRuleName()).ToDataRes(types.String)
 	},
@@ -25441,6 +25513,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.config.aggregator.lastUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigAggregator).GetLastUpdatedAt()).ToDataRes(types.Time)
+	},
+	"aws.config.aggregator.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsConfigAggregator).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.config.aggregator.accountAggregationSource.accountIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsConfigAggregatorAccountAggregationSource).GetAccountIds()).ToDataRes(types.Array(types.String))
@@ -30373,6 +30448,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.rds.eventSubscription.subscriptionCreationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsRdsEventSubscription).GetSubscriptionCreationTime()).ToDataRes(types.String)
+	},
+	"aws.rds.eventSubscription.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsRdsEventSubscription).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.glue.workflow.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsGlueWorkflow).GetName()).ToDataRes(types.String)
@@ -40634,6 +40712,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamPolicy).LastAccessedServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.iam.policy.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicy).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.policyversion.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamPolicyversion).__id, ok = v.Value.(string)
 		return
@@ -46830,6 +46912,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElbTruststore).TotalRevokedEntries, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"aws.elb.truststore.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbTruststore).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.elb.targetgroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbTargetgroup).__id, ok = v.Value.(string)
 		return
@@ -46916,6 +47002,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.targetgroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbTargetgroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.elb.targetgroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbTargetgroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.elb.targetgroup.attributes.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47214,6 +47304,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElbListener).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.elb.listener.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbListener).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.elb.listener.rule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbListenerRule).__id, ok = v.Value.(string)
 		return
@@ -47236,6 +47330,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.listener.rule.actions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbListenerRule).Actions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.elb.listener.rule.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbListenerRule).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.elb.loadbalancer.attribute.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49128,6 +49226,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.securityhub.hub.enabledProducts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSecurityhubHub).EnabledProducts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.securityhub.hub.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecurityhubHub).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.securityhub.standardSubscription.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -53198,6 +53300,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsCloudwatchMetricsalarm).StateUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.cloudwatch.metricsalarm.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchMetricsalarm).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.cloudwatch.metric.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudwatchMetric).__id, ok = v.Value.(string)
 		return
@@ -56118,6 +56224,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsBackupAccessPoint).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.backup.accessPoint.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupAccessPoint).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.backup.vault.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBackupVault).__id, ok = v.Value.(string)
 		return
@@ -56178,6 +56288,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsBackupVault).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.backup.vault.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupVault).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.backup.vaultRecoveryPoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBackupVaultRecoveryPoint).__id, ok = v.Value.(string)
 		return
@@ -56236,6 +56350,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.backup.vaultRecoveryPoint.accessPoints": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBackupVaultRecoveryPoint).AccessPoints, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.backup.vaultRecoveryPoint.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupVaultRecoveryPoint).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.backup.lifecycle.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -56308,6 +56426,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.backup.plan.resourceSelections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsBackupPlan).ResourceSelections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.backup.plan.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsBackupPlan).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.backup.plan.selection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -57074,6 +57196,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsOptionGroup).Options, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.rds.optionGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsOptionGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.rds.globalCluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsGlobalCluster).__id, ok = v.Value.(string)
 		return
@@ -57132,6 +57258,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.globalCluster.members": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsGlobalCluster).Members, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.globalCluster.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsGlobalCluster).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.rds.backupsetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58078,6 +58208,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsRdsClusterParameterGroup).Parameters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.rds.clusterParameterGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsClusterParameterGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.rds.parameterGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsParameterGroup).__id, ok = v.Value.(string)
 		return
@@ -58104,6 +58238,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.parameterGroup.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsParameterGroup).Parameters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.rds.parameterGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsParameterGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.rds.parameterGroup.parameter.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58332,6 +58470,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.replicationGroup.pendingModifiedValues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheReplicationGroup).PendingModifiedValues, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.replicationGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheReplicationGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.cluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58578,6 +58720,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsElasticacheServerlessCache).Subnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.elasticache.serverlessCache.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheServerlessCache).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.elasticache.parameterGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheParameterGroup).__id, ok = v.Value.(string)
 		return
@@ -58604,6 +58750,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.parameterGroup.isGlobal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheParameterGroup).IsGlobal, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.parameterGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheParameterGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.subnetGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58636,6 +58786,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.subnetGroup.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheSubnetGroup).Vpc, ok = plugin.RawToTValue[*mqlAwsVpc](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.subnetGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheSubnetGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58680,6 +58834,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.user.authentication": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheUser).Authentication, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.user.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheUser).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.elasticache.serviceUpdate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58800,6 +58958,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elasticache.snapshot.cacheClusterCreatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElasticacheSnapshot).CacheClusterCreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.elasticache.snapshot.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElasticacheSnapshot).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.redshift.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -62862,6 +63024,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSsmParameter).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.ssm.parameter.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSsmParameter).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.ssm.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSsmInstance).__id, ok = v.Value.(string)
 		return
@@ -66494,6 +66660,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsConfigRule).Remediation, ok = plugin.RawToTValue[*mqlAwsConfigRuleRemediation](v.Value, v.Error)
 		return
 	},
+	"aws.config.rule.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsConfigRule).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.config.rule.complianceDetail.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsConfigRuleComplianceDetail).__id, ok = v.Value.(string)
 		return
@@ -66686,6 +66856,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsConfigConformancePack).RuleCompliance, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.config.conformancePack.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsConfigConformancePack).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.config.conformancePack.ruleCompliance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsConfigConformancePackRuleCompliance).__id, ok = v.Value.(string)
 		return
@@ -66728,6 +66902,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.config.aggregator.lastUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsConfigAggregator).LastUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.config.aggregator.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsConfigAggregator).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.config.aggregator.accountAggregationSource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -73832,6 +74010,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.rds.eventSubscription.subscriptionCreationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsRdsEventSubscription).SubscriptionCreationTime, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.rds.eventSubscription.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsRdsEventSubscription).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.glue.workflow.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -93309,6 +93491,7 @@ type mqlAwsIamPolicy struct {
 	AttachedRoles        plugin.TValue[[]any]
 	AttachedGroups       plugin.TValue[[]any]
 	LastAccessedServices plugin.TValue[[]any]
+	Tags                 plugin.TValue[map[string]any]
 }
 
 // createAwsIamPolicy creates a new instance of this resource
@@ -93515,6 +93698,12 @@ func (c *mqlAwsIamPolicy) GetLastAccessedServices() *plugin.TValue[[]any] {
 		}
 
 		return c.lastAccessedServices()
+	})
+}
+
+func (c *mqlAwsIamPolicy) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
 	})
 }
 
@@ -110061,13 +110250,14 @@ func (c *mqlAwsElbSslPolicy) GetSupportedLoadBalancerTypes() *plugin.TValue[[]an
 type mqlAwsElbTruststore struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsElbTruststoreInternal it will be used here
+	mqlAwsElbTruststoreInternal
 	Arn                    plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Region                 plugin.TValue[string]
 	Status                 plugin.TValue[string]
 	NumberOfCaCertificates plugin.TValue[int64]
 	TotalRevokedEntries    plugin.TValue[int64]
+	Tags                   plugin.TValue[map[string]any]
 }
 
 // createAwsElbTruststore creates a new instance of this resource
@@ -110131,6 +110321,12 @@ func (c *mqlAwsElbTruststore) GetTotalRevokedEntries() *plugin.TValue[int64] {
 	return &c.TotalRevokedEntries
 }
 
+func (c *mqlAwsElbTruststore) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsElbTargetgroup for the aws.elb.targetgroup resource
 type mqlAwsElbTargetgroup struct {
 	MqlRuntime *plugin.Runtime
@@ -110157,6 +110353,7 @@ type mqlAwsElbTargetgroup struct {
 	LambdaTargets              plugin.TValue[[]any]
 	IpTargets                  plugin.TValue[[]any]
 	Region                     plugin.TValue[string]
+	Tags                       plugin.TValue[map[string]any]
 }
 
 // createAwsElbTargetgroup creates a new instance of this resource
@@ -110328,6 +110525,12 @@ func (c *mqlAwsElbTargetgroup) GetIpTargets() *plugin.TValue[[]any] {
 
 func (c *mqlAwsElbTargetgroup) GetRegion() *plugin.TValue[string] {
 	return &c.Region
+}
+
+func (c *mqlAwsElbTargetgroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsElbTargetgroupAttributes for the aws.elb.targetgroup.attributes resource
@@ -110896,6 +111099,7 @@ type mqlAwsElbListener struct {
 	MutualAuthentication plugin.TValue[any]
 	TrustStore           plugin.TValue[*mqlAwsElbTruststore]
 	Rules                plugin.TValue[[]any]
+	Tags                 plugin.TValue[map[string]any]
 }
 
 // createAwsElbListener creates a new instance of this resource
@@ -111051,16 +111255,23 @@ func (c *mqlAwsElbListener) GetRules() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsElbListener) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsElbListenerRule for the aws.elb.listener.rule resource
 type mqlAwsElbListenerRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsElbListenerRuleInternal it will be used here
+	mqlAwsElbListenerRuleInternal
 	Arn        plugin.TValue[string]
 	Priority   plugin.TValue[string]
 	IsDefault  plugin.TValue[bool]
 	Conditions plugin.TValue[[]any]
 	Actions    plugin.TValue[[]any]
+	Tags       plugin.TValue[map[string]any]
 }
 
 // createAwsElbListenerRule creates a new instance of this resource
@@ -111118,6 +111329,12 @@ func (c *mqlAwsElbListenerRule) GetConditions() *plugin.TValue[[]any] {
 
 func (c *mqlAwsElbListenerRule) GetActions() *plugin.TValue[[]any] {
 	return &c.Actions
+}
+
+func (c *mqlAwsElbListenerRule) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsElbLoadbalancerAttribute for the aws.elb.loadbalancer.attribute resource
@@ -115773,6 +115990,7 @@ type mqlAwsSecurityhubHub struct {
 	Insights              plugin.TValue[[]any]
 	Members               plugin.TValue[[]any]
 	EnabledProducts       plugin.TValue[[]any]
+	Tags                  plugin.TValue[map[string]any]
 }
 
 // createAwsSecurityhubHub creates a new instance of this resource
@@ -115923,6 +116141,12 @@ func (c *mqlAwsSecurityhubHub) GetEnabledProducts() *plugin.TValue[[]any] {
 		}
 
 		return c.enabledProducts()
+	})
+}
+
+func (c *mqlAwsSecurityhubHub) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
 	})
 }
 
@@ -127104,7 +127328,7 @@ func (c *mqlAwsCloudwatch) GetAnomalyDetectors() *plugin.TValue[[]any] {
 type mqlAwsCloudwatchMetricsalarm struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsCloudwatchMetricsalarmInternal it will be used here
+	mqlAwsCloudwatchMetricsalarmInternal
 	Arn                         plugin.TValue[string]
 	MetricName                  plugin.TValue[string]
 	MetricNamespace             plugin.TValue[string]
@@ -127131,6 +127355,7 @@ type mqlAwsCloudwatchMetricsalarm struct {
 	Dimensions                  plugin.TValue[[]any]
 	AlarmConfigurationUpdatedAt plugin.TValue[*time.Time]
 	StateUpdatedAt              plugin.TValue[*time.Time]
+	Tags                        plugin.TValue[map[string]any]
 }
 
 // createAwsCloudwatchMetricsalarm creates a new instance of this resource
@@ -127272,6 +127497,12 @@ func (c *mqlAwsCloudwatchMetricsalarm) GetAlarmConfigurationUpdatedAt() *plugin.
 
 func (c *mqlAwsCloudwatchMetricsalarm) GetStateUpdatedAt() *plugin.TValue[*time.Time] {
 	return &c.StateUpdatedAt
+}
+
+func (c *mqlAwsCloudwatchMetricsalarm) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsCloudwatchMetric for the aws.cloudwatch.metric resource
@@ -134929,6 +135160,7 @@ type mqlAwsBackupAccessPoint struct {
 	RecoveryPoint     plugin.TValue[*mqlAwsBackupVaultRecoveryPoint]
 	Metadata          plugin.TValue[map[string]any]
 	CreatedAt         plugin.TValue[*time.Time]
+	Tags              plugin.TValue[map[string]any]
 }
 
 // createAwsBackupAccessPoint creates a new instance of this resource
@@ -135040,11 +135272,17 @@ func (c *mqlAwsBackupAccessPoint) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
 
+func (c *mqlAwsBackupAccessPoint) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsBackupVault for the aws.backup.vault resource
 type mqlAwsBackupVault struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsBackupVaultInternal it will be used here
+	mqlAwsBackupVaultInternal
 	Arn              plugin.TValue[string]
 	Name             plugin.TValue[string]
 	RecoveryPoints   plugin.TValue[[]any]
@@ -135059,6 +135297,7 @@ type mqlAwsBackupVault struct {
 	AccessPolicy     plugin.TValue[string]
 	PolicyStatements plugin.TValue[[]any]
 	IsPublic         plugin.TValue[bool]
+	Tags             plugin.TValue[map[string]any]
 }
 
 // createAwsBackupVault creates a new instance of this resource
@@ -135194,11 +135433,17 @@ func (c *mqlAwsBackupVault) GetIsPublic() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlAwsBackupVault) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsBackupVaultRecoveryPoint for the aws.backup.vaultRecoveryPoint resource
 type mqlAwsBackupVaultRecoveryPoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsBackupVaultRecoveryPointInternal it will be used here
+	mqlAwsBackupVaultRecoveryPointInternal
 	Arn                  plugin.TValue[string]
 	ResourceType         plugin.TValue[string]
 	SourceResourceArn    plugin.TValue[string]
@@ -135213,6 +135458,7 @@ type mqlAwsBackupVaultRecoveryPoint struct {
 	EncryptionKeyArn     plugin.TValue[string]
 	IsEncrypted          plugin.TValue[bool]
 	AccessPoints         plugin.TValue[[]any]
+	Tags                 plugin.TValue[map[string]any]
 }
 
 // createAwsBackupVaultRecoveryPoint creates a new instance of this resource
@@ -135344,6 +135590,12 @@ func (c *mqlAwsBackupVaultRecoveryPoint) GetAccessPoints() *plugin.TValue[[]any]
 	})
 }
 
+func (c *mqlAwsBackupVaultRecoveryPoint) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsBackupLifecycle for the aws.backup.lifecycle resource
 type mqlAwsBackupLifecycle struct {
 	MqlRuntime *plugin.Runtime
@@ -135412,7 +135664,7 @@ func (c *mqlAwsBackupLifecycle) GetOptInToArchiveForSupportedResources() *plugin
 type mqlAwsBackupPlan struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsBackupPlanInternal it will be used here
+	mqlAwsBackupPlanInternal
 	Arn                    plugin.TValue[string]
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
@@ -135425,6 +135677,7 @@ type mqlAwsBackupPlan struct {
 	AdvancedBackupSettings plugin.TValue[[]any]
 	Selections             plugin.TValue[[]any]
 	ResourceSelections     plugin.TValue[[]any]
+	Tags                   plugin.TValue[map[string]any]
 }
 
 // createAwsBackupPlan creates a new instance of this resource
@@ -135535,6 +135788,12 @@ func (c *mqlAwsBackupPlan) GetResourceSelections() *plugin.TValue[[]any] {
 		}
 
 		return c.resourceSelections()
+	})
+}
+
+func (c *mqlAwsBackupPlan) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
 	})
 }
 
@@ -137488,6 +137747,7 @@ type mqlAwsRdsOptionGroup struct {
 	SourceOptionGroup                     plugin.TValue[string]
 	CopyTimestamp                         plugin.TValue[*time.Time]
 	Options                               plugin.TValue[[]any]
+	Tags                                  plugin.TValue[map[string]any]
 }
 
 // createAwsRdsOptionGroup creates a new instance of this resource
@@ -137582,11 +137842,17 @@ func (c *mqlAwsRdsOptionGroup) GetOptions() *plugin.TValue[[]any] {
 	return &c.Options
 }
 
+func (c *mqlAwsRdsOptionGroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsRdsGlobalCluster for the aws.rds.globalCluster resource
 type mqlAwsRdsGlobalCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsRdsGlobalClusterInternal it will be used here
+	mqlAwsRdsGlobalClusterInternal
 	Arn                     plugin.TValue[string]
 	GlobalClusterIdentifier plugin.TValue[string]
 	GlobalClusterResourceId plugin.TValue[string]
@@ -137601,6 +137867,7 @@ type mqlAwsRdsGlobalCluster struct {
 	StorageEncryptionType   plugin.TValue[string]
 	FailoverState           plugin.TValue[any]
 	Members                 plugin.TValue[[]any]
+	Tags                    plugin.TValue[map[string]any]
 }
 
 // createAwsRdsGlobalCluster creates a new instance of this resource
@@ -137689,6 +137956,12 @@ func (c *mqlAwsRdsGlobalCluster) GetFailoverState() *plugin.TValue[any] {
 
 func (c *mqlAwsRdsGlobalCluster) GetMembers() *plugin.TValue[[]any] {
 	return &c.Members
+}
+
+func (c *mqlAwsRdsGlobalCluster) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsRdsBackupsetting for the aws.rds.backupsetting resource
@@ -139574,13 +139847,14 @@ func (c *mqlAwsRdsRecommendationAction) GetContextAttributes() *plugin.TValue[ma
 type mqlAwsRdsClusterParameterGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsRdsClusterParameterGroupInternal it will be used here
+	mqlAwsRdsClusterParameterGroupInternal
 	Arn         plugin.TValue[string]
 	Family      plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
 	Region      plugin.TValue[string]
 	Parameters  plugin.TValue[[]any]
+	Tags        plugin.TValue[map[string]any]
 }
 
 // createAwsRdsClusterParameterGroup creates a new instance of this resource
@@ -139651,17 +139925,24 @@ func (c *mqlAwsRdsClusterParameterGroup) GetParameters() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsRdsClusterParameterGroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsRdsParameterGroup for the aws.rds.parameterGroup resource
 type mqlAwsRdsParameterGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsRdsParameterGroupInternal it will be used here
+	mqlAwsRdsParameterGroupInternal
 	Arn         plugin.TValue[string]
 	Family      plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
 	Region      plugin.TValue[string]
 	Parameters  plugin.TValue[[]any]
+	Tags        plugin.TValue[map[string]any]
 }
 
 // createAwsRdsParameterGroup creates a new instance of this resource
@@ -139729,6 +140010,12 @@ func (c *mqlAwsRdsParameterGroup) GetParameters() *plugin.TValue[[]any] {
 		}
 
 		return c.parameters()
+	})
+}
+
+func (c *mqlAwsRdsParameterGroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
 	})
 }
 
@@ -140046,6 +140333,7 @@ type mqlAwsElasticacheReplicationGroup struct {
 	NodeGroups                 plugin.TValue[[]any]
 	LogDeliveryConfigurations  plugin.TValue[[]any]
 	PendingModifiedValues      plugin.TValue[any]
+	Tags                       plugin.TValue[map[string]any]
 }
 
 // createAwsElasticacheReplicationGroup creates a new instance of this resource
@@ -140247,6 +140535,12 @@ func (c *mqlAwsElasticacheReplicationGroup) GetLogDeliveryConfigurations() *plug
 
 func (c *mqlAwsElasticacheReplicationGroup) GetPendingModifiedValues() *plugin.TValue[any] {
 	return &c.PendingModifiedValues
+}
+
+func (c *mqlAwsElasticacheReplicationGroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsElasticacheCluster for the aws.elasticache.cluster resource
@@ -140624,6 +140918,7 @@ type mqlAwsElasticacheServerlessCache struct {
 	Region                 plugin.TValue[string]
 	CreatedAt              plugin.TValue[*time.Time]
 	Subnets                plugin.TValue[[]any]
+	Tags                   plugin.TValue[map[string]any]
 }
 
 // createAwsElasticacheServerlessCache creates a new instance of this resource
@@ -140770,17 +141065,24 @@ func (c *mqlAwsElasticacheServerlessCache) GetSubnets() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsElasticacheServerlessCache) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsElasticacheParameterGroup for the aws.elasticache.parameterGroup resource
 type mqlAwsElasticacheParameterGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsElasticacheParameterGroupInternal it will be used here
+	mqlAwsElasticacheParameterGroupInternal
 	Arn         plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Region      plugin.TValue[string]
 	Family      plugin.TValue[string]
 	Description plugin.TValue[string]
 	IsGlobal    plugin.TValue[bool]
+	Tags        plugin.TValue[map[string]any]
 }
 
 // createAwsElasticacheParameterGroup creates a new instance of this resource
@@ -140844,6 +141146,12 @@ func (c *mqlAwsElasticacheParameterGroup) GetIsGlobal() *plugin.TValue[bool] {
 	return &c.IsGlobal
 }
 
+func (c *mqlAwsElasticacheParameterGroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsElasticacheSubnetGroup for the aws.elasticache.subnetGroup resource
 type mqlAwsElasticacheSubnetGroup struct {
 	MqlRuntime *plugin.Runtime
@@ -140856,6 +141164,7 @@ type mqlAwsElasticacheSubnetGroup struct {
 	Subnets               plugin.TValue[[]any]
 	SupportedNetworkTypes plugin.TValue[[]any]
 	Vpc                   plugin.TValue[*mqlAwsVpc]
+	Tags                  plugin.TValue[map[string]any]
 }
 
 // createAwsElasticacheSubnetGroup creates a new instance of this resource
@@ -140935,11 +141244,17 @@ func (c *mqlAwsElasticacheSubnetGroup) GetVpc() *plugin.TValue[*mqlAwsVpc] {
 	})
 }
 
+func (c *mqlAwsElasticacheSubnetGroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsElasticacheUser for the aws.elasticache.user resource
 type mqlAwsElasticacheUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsElasticacheUserInternal it will be used here
+	mqlAwsElasticacheUserInternal
 	Arn                  plugin.TValue[string]
 	UserId               plugin.TValue[string]
 	UserName             plugin.TValue[string]
@@ -140950,6 +141265,7 @@ type mqlAwsElasticacheUser struct {
 	Status               plugin.TValue[string]
 	UserGroupIds         plugin.TValue[[]any]
 	Authentication       plugin.TValue[any]
+	Tags                 plugin.TValue[map[string]any]
 }
 
 // createAwsElasticacheUser creates a new instance of this resource
@@ -141027,6 +141343,12 @@ func (c *mqlAwsElasticacheUser) GetUserGroupIds() *plugin.TValue[[]any] {
 
 func (c *mqlAwsElasticacheUser) GetAuthentication() *plugin.TValue[any] {
 	return &c.Authentication
+}
+
+func (c *mqlAwsElasticacheUser) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsElasticacheServiceUpdate for the aws.elasticache.serviceUpdate resource
@@ -141158,6 +141480,7 @@ type mqlAwsElasticacheSnapshot struct {
 	KmsKey                 plugin.TValue[*mqlAwsKmsKey]
 	Vpc                    plugin.TValue[*mqlAwsVpc]
 	CacheClusterCreatedAt  plugin.TValue[*time.Time]
+	Tags                   plugin.TValue[map[string]any]
 }
 
 // createAwsElasticacheSnapshot creates a new instance of this resource
@@ -141279,6 +141602,12 @@ func (c *mqlAwsElasticacheSnapshot) GetVpc() *plugin.TValue[*mqlAwsVpc] {
 
 func (c *mqlAwsElasticacheSnapshot) GetCacheClusterCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CacheClusterCreatedAt
+}
+
+func (c *mqlAwsElasticacheSnapshot) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsRedshift for the aws.redshift resource
@@ -151088,6 +151417,7 @@ type mqlAwsSsmParameter struct {
 	Version          plugin.TValue[int64]
 	LastModifiedUser plugin.TValue[string]
 	Policies         plugin.TValue[[]any]
+	Tags             plugin.TValue[map[string]any]
 }
 
 // createAwsSsmParameter creates a new instance of this resource
@@ -151189,6 +151519,12 @@ func (c *mqlAwsSsmParameter) GetLastModifiedUser() *plugin.TValue[string] {
 
 func (c *mqlAwsSsmParameter) GetPolicies() *plugin.TValue[[]any] {
 	return &c.Policies
+}
+
+func (c *mqlAwsSsmParameter) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsSsmInstance for the aws.ssm.instance resource
@@ -160007,7 +160343,7 @@ func (c *mqlAwsConfig) GetConformancePacks() *plugin.TValue[[]any] {
 type mqlAwsConfigRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsConfigRuleInternal it will be used here
+	mqlAwsConfigRuleInternal
 	Arn               plugin.TValue[string]
 	State             plugin.TValue[string]
 	Source            plugin.TValue[any]
@@ -160018,6 +160354,7 @@ type mqlAwsConfigRule struct {
 	ComplianceStatus  plugin.TValue[string]
 	ComplianceDetails plugin.TValue[[]any]
 	Remediation       plugin.TValue[*mqlAwsConfigRuleRemediation]
+	Tags              plugin.TValue[map[string]any]
 }
 
 // createAwsConfigRule creates a new instance of this resource
@@ -160120,6 +160457,12 @@ func (c *mqlAwsConfigRule) GetRemediation() *plugin.TValue[*mqlAwsConfigRuleReme
 		}
 
 		return c.remediation()
+	})
+}
+
+func (c *mqlAwsConfigRule) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
 	})
 }
 
@@ -160509,7 +160852,7 @@ func (c *mqlAwsConfigDeliverychannel) GetLastDeliveryStatus() *plugin.TValue[str
 type mqlAwsConfigConformancePack struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsConfigConformancePackInternal it will be used here
+	mqlAwsConfigConformancePackInternal
 	Name                    plugin.TValue[string]
 	Arn                     plugin.TValue[string]
 	Region                  plugin.TValue[string]
@@ -160519,6 +160862,7 @@ type mqlAwsConfigConformancePack struct {
 	LastUpdateRequestedTime plugin.TValue[*time.Time]
 	ComplianceStatus        plugin.TValue[string]
 	RuleCompliance          plugin.TValue[[]any]
+	Tags                    plugin.TValue[map[string]any]
 }
 
 // createAwsConfigConformancePack creates a new instance of this resource
@@ -160608,6 +160952,12 @@ func (c *mqlAwsConfigConformancePack) GetRuleCompliance() *plugin.TValue[[]any] 
 	})
 }
 
+func (c *mqlAwsConfigConformancePack) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsConfigConformancePackRuleCompliance for the aws.config.conformancePack.ruleCompliance resource
 type mqlAwsConfigConformancePackRuleCompliance struct {
 	MqlRuntime *plugin.Runtime
@@ -160674,6 +161024,7 @@ type mqlAwsConfigAggregator struct {
 	OrganizationAggregationSource plugin.TValue[*mqlAwsConfigAggregatorOrganizationAggregationSource]
 	CreatedAt                     plugin.TValue[*time.Time]
 	LastUpdatedAt                 plugin.TValue[*time.Time]
+	Tags                          plugin.TValue[map[string]any]
 }
 
 // createAwsConfigAggregator creates a new instance of this resource
@@ -160751,6 +161102,12 @@ func (c *mqlAwsConfigAggregator) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsConfigAggregator) GetLastUpdatedAt() *plugin.TValue[*time.Time] {
 	return &c.LastUpdatedAt
+}
+
+func (c *mqlAwsConfigAggregator) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsConfigAggregatorAccountAggregationSource for the aws.config.aggregator.accountAggregationSource resource
@@ -178307,7 +178664,7 @@ func (c *mqlAwsRdsProxy) GetTags() *plugin.TValue[map[string]any] {
 type mqlAwsRdsEventSubscription struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsRdsEventSubscriptionInternal it will be used here
+	mqlAwsRdsEventSubscriptionInternal
 	Arn                      plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Region                   plugin.TValue[string]
@@ -178320,6 +178677,7 @@ type mqlAwsRdsEventSubscription struct {
 	EventCategories          plugin.TValue[[]any]
 	CustomerAwsId            plugin.TValue[string]
 	SubscriptionCreationTime plugin.TValue[string]
+	Tags                     plugin.TValue[map[string]any]
 }
 
 // createAwsRdsEventSubscription creates a new instance of this resource
@@ -178417,6 +178775,12 @@ func (c *mqlAwsRdsEventSubscription) GetCustomerAwsId() *plugin.TValue[string] {
 
 func (c *mqlAwsRdsEventSubscription) GetSubscriptionCreationTime() *plugin.TValue[string] {
 	return &c.SubscriptionCreationTime
+}
+
+func (c *mqlAwsRdsEventSubscription) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsGlueWorkflow for the aws.glue.workflow resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -852,6 +852,7 @@ aws.backup.accessPoint.resourceType 13.52.2
 aws.backup.accessPoint.sourceResourceArn 13.52.2
 aws.backup.accessPoint.status 13.52.2
 aws.backup.accessPoint.statusMessage 13.52.2
+aws.backup.accessPoint.tags 13.53.1
 aws.backup.accessPoint.vault 13.52.2
 aws.backup.accessPoints 13.52.2
 aws.backup.lifecycle 11.15.2
@@ -904,6 +905,7 @@ aws.backup.plan.selection.name 13.35.2
 aws.backup.plan.selection.notResources 13.35.2
 aws.backup.plan.selection.resources 13.35.2
 aws.backup.plan.selections 13.6.3
+aws.backup.plan.tags 13.53.1
 aws.backup.plan.versionId 11.15.2
 aws.backup.plans 11.15.2
 aws.backup.scanJob 13.28.1
@@ -947,6 +949,7 @@ aws.backup.vault.name 11.15.2
 aws.backup.vault.policyStatements 13.32.2
 aws.backup.vault.recoveryPoints 11.15.2
 aws.backup.vault.region 11.15.2
+aws.backup.vault.tags 13.53.1
 aws.backup.vaultRecoveryPoint 11.15.2
 aws.backup.vaultRecoveryPoint.accessPoints 13.52.2
 aws.backup.vaultRecoveryPoint.arn 11.15.2
@@ -962,6 +965,7 @@ aws.backup.vaultRecoveryPoint.resourceType 11.15.2
 aws.backup.vaultRecoveryPoint.sourceBackupVaultArn 13.35.2
 aws.backup.vaultRecoveryPoint.sourceResourceArn 13.35.2
 aws.backup.vaultRecoveryPoint.status 11.15.2
+aws.backup.vaultRecoveryPoint.tags 13.53.1
 aws.backup.vaults 11.15.2
 aws.batch 13.1.1
 aws.batch.computeEnvironment 13.1.1
@@ -2198,6 +2202,7 @@ aws.cloudwatch.metricsalarm.stateReason 11.15.2
 aws.cloudwatch.metricsalarm.stateReasonData 13.49.1
 aws.cloudwatch.metricsalarm.stateUpdatedAt 13.49.1
 aws.cloudwatch.metricsalarm.statistic 13.49.1
+aws.cloudwatch.metricsalarm.tags 13.53.1
 aws.cloudwatch.metricsalarm.threshold 13.49.1
 aws.cloudwatch.metricsalarm.thresholdMetricId 13.49.1
 aws.cloudwatch.metricsalarm.treatMissingData 13.49.1
@@ -2536,6 +2541,7 @@ aws.config.aggregator.organizationAggregationSource.allAwsRegions 13.5.0
 aws.config.aggregator.organizationAggregationSource.awsRegions 13.5.0
 aws.config.aggregator.organizationAggregationSource.iamRole 13.5.0
 aws.config.aggregator.region 13.5.0
+aws.config.aggregator.tags 13.53.1
 aws.config.aggregators 13.5.0
 aws.config.conformancePack 13.12.1
 aws.config.conformancePack.arn 13.12.1
@@ -2549,6 +2555,7 @@ aws.config.conformancePack.region 13.12.1
 aws.config.conformancePack.ruleCompliance 13.12.1
 aws.config.conformancePack.ruleCompliance.complianceType 13.12.1
 aws.config.conformancePack.ruleCompliance.ruleName 13.12.1
+aws.config.conformancePack.tags 13.53.1
 aws.config.conformancePacks 13.12.1
 aws.config.deliveryChannels 11.15.2
 aws.config.deliverychannel 11.15.2
@@ -2600,6 +2607,7 @@ aws.config.rule.remediation.targetId 13.12.1
 aws.config.rule.remediation.targetType 13.12.1
 aws.config.rule.source 11.15.2
 aws.config.rule.state 11.15.2
+aws.config.rule.tags 13.53.1
 aws.config.rules 11.15.2
 aws.controltower 13.10.0
 aws.controltower.enabledBaseline 13.10.0
@@ -4736,6 +4744,7 @@ aws.elasticache.parameterGroup.family 13.12.1
 aws.elasticache.parameterGroup.isGlobal 13.12.1
 aws.elasticache.parameterGroup.name 13.12.1
 aws.elasticache.parameterGroup.region 13.12.1
+aws.elasticache.parameterGroup.tags 13.53.1
 aws.elasticache.parameterGroups 13.12.1
 aws.elasticache.replicationGroup 13.49.1
 aws.elasticache.replicationGroup.arn 13.49.1
@@ -4770,6 +4779,7 @@ aws.elasticache.replicationGroup.snapshotWindow 13.49.1
 aws.elasticache.replicationGroup.snapshottingClusterId 13.49.1
 aws.elasticache.replicationGroup.status 13.49.1
 aws.elasticache.replicationGroup.storageEncryptionType 13.49.1
+aws.elasticache.replicationGroup.tags 13.53.1
 aws.elasticache.replicationGroup.transitEncryptionEnabled 13.49.1
 aws.elasticache.replicationGroup.transitEncryptionMode 13.49.1
 aws.elasticache.replicationGroup.userGroupIds 13.49.1
@@ -4791,6 +4801,7 @@ aws.elasticache.serverlessCache.securityGroups 11.15.2
 aws.elasticache.serverlessCache.snapshotRetentionLimit 11.15.2
 aws.elasticache.serverlessCache.status 11.15.2
 aws.elasticache.serverlessCache.subnets 11.15.2
+aws.elasticache.serverlessCache.tags 13.53.1
 aws.elasticache.serverlessCaches 11.15.2
 aws.elasticache.serviceUpdate 13.12.1
 aws.elasticache.serviceUpdate.autoUpdateAfterRecommendedApplyByDate 13.12.1
@@ -4822,6 +4833,7 @@ aws.elasticache.snapshot.replicationGroupId 13.12.1
 aws.elasticache.snapshot.snapshotRetentionLimit 13.12.1
 aws.elasticache.snapshot.snapshotSource 13.12.1
 aws.elasticache.snapshot.status 13.12.1
+aws.elasticache.snapshot.tags 13.53.1
 aws.elasticache.snapshot.vpc 13.12.1
 aws.elasticache.snapshots 13.12.1
 aws.elasticache.subnetGroup 13.12.1
@@ -4831,6 +4843,7 @@ aws.elasticache.subnetGroup.name 13.12.1
 aws.elasticache.subnetGroup.region 13.12.1
 aws.elasticache.subnetGroup.subnets 13.12.1
 aws.elasticache.subnetGroup.supportedNetworkTypes 13.12.1
+aws.elasticache.subnetGroup.tags 13.53.1
 aws.elasticache.subnetGroup.vpc 13.12.1
 aws.elasticache.subnetGroups 13.12.1
 aws.elasticache.user 13.12.1
@@ -4841,6 +4854,7 @@ aws.elasticache.user.engine 13.12.1
 aws.elasticache.user.minimumEngineVersion 13.12.1
 aws.elasticache.user.region 13.12.1
 aws.elasticache.user.status 13.12.1
+aws.elasticache.user.tags 13.53.1
 aws.elasticache.user.userGroupIds 13.12.1
 aws.elasticache.user.userId 13.12.1
 aws.elasticache.user.userName 13.12.1
@@ -4930,9 +4944,11 @@ aws.elb.listener.rule.arn 13.49.1
 aws.elb.listener.rule.conditions 13.49.1
 aws.elb.listener.rule.isDefault 13.49.1
 aws.elb.listener.rule.priority 13.49.1
+aws.elb.listener.rule.tags 13.53.1
 aws.elb.listener.rules 13.49.1
 aws.elb.listener.sslPolicy 11.15.2
 aws.elb.listener.sslPolicyRef 13.49.1
+aws.elb.listener.tags 13.53.1
 aws.elb.listener.trustStore 13.49.1
 aws.elb.loadBalancers 11.15.2
 aws.elb.loadbalancer 11.15.2
@@ -5019,6 +5035,7 @@ aws.elb.targetgroup.port 11.15.2
 aws.elb.targetgroup.protocol 11.15.2
 aws.elb.targetgroup.protocolVersion 11.15.2
 aws.elb.targetgroup.region 11.16.1
+aws.elb.targetgroup.tags 13.53.1
 aws.elb.targetgroup.targetType 11.15.2
 aws.elb.targetgroup.unhealthyThresholdCount 11.15.2
 aws.elb.targetgroup.vpc 11.15.2
@@ -5029,6 +5046,7 @@ aws.elb.truststore.name 13.49.1
 aws.elb.truststore.numberOfCaCertificates 13.49.1
 aws.elb.truststore.region 13.49.1
 aws.elb.truststore.status 13.49.1
+aws.elb.truststore.tags 13.53.1
 aws.elb.truststore.totalRevokedEntries 13.49.1
 aws.emr 11.15.2
 aws.emr.blockPublicAccessConfiguration 13.12.1
@@ -6111,6 +6129,7 @@ aws.iam.policy.name 11.15.2
 aws.iam.policy.policyId 11.15.2
 aws.iam.policy.scope 11.15.2
 aws.iam.policy.statements 13.32.2
+aws.iam.policy.tags 13.53.1
 aws.iam.policy.updatedAt 11.15.2
 aws.iam.policy.versions 11.15.2
 aws.iam.policyStatement 13.32.2
@@ -8090,6 +8109,7 @@ aws.rds.clusterParameterGroup.family 11.15.2
 aws.rds.clusterParameterGroup.name 11.15.2
 aws.rds.clusterParameterGroup.parameters 11.15.2
 aws.rds.clusterParameterGroup.region 11.15.2
+aws.rds.clusterParameterGroup.tags 13.53.1
 aws.rds.clusterParameterGroups 11.15.2
 aws.rds.clusters 11.15.2
 aws.rds.dbcluster 11.15.2
@@ -8260,6 +8280,7 @@ aws.rds.eventSubscription.sourceIds 13.6.3
 aws.rds.eventSubscription.sourceType 13.6.3
 aws.rds.eventSubscription.status 13.6.3
 aws.rds.eventSubscription.subscriptionCreationTime 13.6.3
+aws.rds.eventSubscription.tags 13.53.1
 aws.rds.eventSubscriptions 13.6.3
 aws.rds.globalCluster 13.21.4
 aws.rds.globalCluster.arn 13.21.4
@@ -8276,6 +8297,7 @@ aws.rds.globalCluster.members 13.21.4
 aws.rds.globalCluster.status 13.21.4
 aws.rds.globalCluster.storageEncrypted 13.21.4
 aws.rds.globalCluster.storageEncryptionType 13.21.4
+aws.rds.globalCluster.tags 13.53.1
 aws.rds.globalClusters 13.21.4
 aws.rds.instances 11.15.2
 aws.rds.optionGroup 13.21.4
@@ -8290,6 +8312,7 @@ aws.rds.optionGroup.options 13.21.4
 aws.rds.optionGroup.region 13.21.4
 aws.rds.optionGroup.sourceAccountId 13.21.4
 aws.rds.optionGroup.sourceOptionGroup 13.21.4
+aws.rds.optionGroup.tags 13.53.1
 aws.rds.optionGroup.vpc 13.21.4
 aws.rds.optionGroups 13.21.4
 aws.rds.parameterGroup 11.15.2
@@ -8311,6 +8334,7 @@ aws.rds.parameterGroup.parameter.supportedEngineModes 11.15.2
 aws.rds.parameterGroup.parameter.value 11.15.2
 aws.rds.parameterGroup.parameters 11.15.2
 aws.rds.parameterGroup.region 11.15.2
+aws.rds.parameterGroup.tags 13.53.1
 aws.rds.parameterGroups 11.15.2
 aws.rds.pendingMaintenanceAction 11.15.2
 aws.rds.pendingMaintenanceAction.action 11.15.2
@@ -10091,6 +10115,7 @@ aws.securityhub.hub.members 13.12.1
 aws.securityhub.hub.region 11.15.2
 aws.securityhub.hub.standardSubscriptions 13.12.1
 aws.securityhub.hub.subscribedAt 11.15.2
+aws.securityhub.hub.tags 13.53.1
 aws.securityhub.hubs 11.15.2
 aws.securityhub.insight 13.12.1
 aws.securityhub.insight.arn 13.12.1
@@ -10483,6 +10508,7 @@ aws.ssm.parameter.lastModifiedUser 13.26.3
 aws.ssm.parameter.name 11.15.2
 aws.ssm.parameter.policies 13.26.3
 aws.ssm.parameter.region 11.15.2
+aws.ssm.parameter.tags 13.53.1
 aws.ssm.parameter.tier 11.15.2
 aws.ssm.parameter.type 11.15.2
 aws.ssm.parameter.version 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.53.0",
-  "generated_at": "2026-08-10T18:30:41+02:00",
+  "generated_at": "2026-08-12T08:57:16-07:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -78,6 +78,7 @@
     "backup:ListBackupVaults",
     "backup:ListRecoveryPointsByBackupVault",
     "backup:ListScanJobs",
+    "backup:ListTags",
     "batch:DescribeComputeEnvironments",
     "batch:DescribeJobDefinitions",
     "batch:DescribeJobQueues",
@@ -184,6 +185,7 @@
     "cloudwatch:DescribeAlarmsForMetric",
     "cloudwatch:GetMetricStatistics",
     "cloudwatch:ListMetrics",
+    "cloudwatch:ListTagsForResource",
     "codeartifact:DescribeDomain",
     "codeartifact:DescribeRepository",
     "codeartifact:GetDomainPermissionsPolicy",
@@ -232,6 +234,7 @@
     "config:DescribeRemediationConfigurations",
     "config:GetComplianceDetailsByConfigRule",
     "config:GetConformancePackComplianceSummary",
+    "config:ListTagsForResource",
     "controltower:ListEnabledBaselines",
     "controltower:ListLandingZones",
     "datasync:DescribeAgent",
@@ -907,6 +910,7 @@
     "securityhub:ListEnabledProductsForImport",
     "securityhub:ListMembers",
     "securityhub:ListSecurityControlDefinitions",
+    "securityhub:ListTagsForResource",
     "securitylake:ListSubscribers",
     "ses:GetAccount",
     "ses:GetConfigurationSet",
@@ -1486,6 +1490,12 @@
       "permission": "backup:ListScanJobs",
       "service": "backup",
       "action": "ListScanJobs",
+      "source_file": "aws_backups.go"
+    },
+    {
+      "permission": "backup:ListTags",
+      "service": "backup",
+      "action": "ListTags",
       "source_file": "aws_backups.go"
     },
     {
@@ -2143,6 +2153,12 @@
       "source_file": "aws_cloudwatch.go"
     },
     {
+      "permission": "cloudwatch:ListTagsForResource",
+      "service": "cloudwatch",
+      "action": "ListTagsForResource",
+      "source_file": "aws_cloudwatch.go"
+    },
+    {
       "permission": "codeartifact:DescribeDomain",
       "service": "codeartifact",
       "action": "DescribeDomain",
@@ -2428,6 +2444,12 @@
       "permission": "config:GetConformancePackComplianceSummary",
       "service": "config",
       "action": "GetConformancePackComplianceSummary",
+      "source_file": "aws_config.go"
+    },
+    {
+      "permission": "config:ListTagsForResource",
+      "service": "config",
+      "action": "ListTagsForResource",
       "source_file": "aws_config.go"
     },
     {
@@ -6661,6 +6683,12 @@
       "source_file": "aws_securityhub.go"
     },
     {
+      "permission": "securityhub:ListTagsForResource",
+      "service": "securityhub",
+      "action": "ListTagsForResource",
+      "source_file": "aws_securityhub.go"
+    },
+    {
       "permission": "securitylake:ListSubscribers",
       "service": "securitylake",
       "action": "ListSubscribers",
@@ -6917,6 +6945,12 @@
       "service": "ssm",
       "action": "ListResourceComplianceSummaries",
       "source_file": "aws_ssm_documents.go"
+    },
+    {
+      "permission": "ssm:ListTagsForResource",
+      "service": "ssm",
+      "action": "ListTagsForResource",
+      "source_file": "aws_ssm.go"
     },
     {
       "permission": "ssm:ListTagsForResource",

--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -70,32 +70,19 @@ func backupManagedArn(resourceArn string) (region string, ok bool) {
 
 // backupResolveTags resolves and caches a Backup resource's tags, marking the
 // field null when Backup cannot read them.
-//
-// The null case sets the field's state directly instead of returning a value:
-// GetOrCompute honors a state the accessor set itself, so the field surfaces as
-// null rather than as an empty map that would read as "this resource has no
-// tags". It takes the field pointer because only the caller knows which field
-// to mark.
 func backupResolveTags(runtime *plugin.Runtime, cache *lazyTags, field *plugin.TValue[map[string]any], region, resourceArn string) (map[string]any, error) {
-	return cache.resolveTags(func() (map[string]any, error) {
-		tags, ok, err := backupTagsForArn(runtime, region, resourceArn)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			field.State = plugin.StateIsSet | plugin.StateIsNull
-			return nil, nil
-		}
-		return tags, nil
+	return cache.resolveTags(field, func() (map[string]any, error) {
+		return backupTagsForArn(runtime, region, resourceArn)
 	})
 }
 
-// backupTagsForArn reads the tags of a Backup-managed resource. The bool
-// reports whether the tags could be read at all; see backupManagedArn.
-func backupTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[string]any, bool, error) {
+// backupTagsForArn reads the tags of a Backup-managed resource, reporting
+// errTagsUnreadable for a resource Backup does not manage (see
+// backupManagedArn) or when the call is denied.
+func backupTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[string]any, error) {
 	arnRegion, ok := backupManagedArn(resourceArn)
 	if !ok {
-		return nil, false, nil
+		return nil, errTagsUnreadable
 	}
 	if region == "" {
 		region = arnRegion
@@ -114,9 +101,9 @@ func backupTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[
 		})
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return nil, false, nil
+				return nil, errTagsUnreadable
 			}
-			return nil, false, err
+			return nil, err
 		}
 		for k, v := range resp.Tags {
 			tags[k] = v
@@ -126,7 +113,7 @@ func backupTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[
 		}
 		nextToken = resp.NextToken
 	}
-	return tags, true, nil
+	return tags, nil
 }
 
 func (a *mqlAwsBackup) vaults() ([]any, error) {

--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -25,12 +25,108 @@ func (a *mqlAwsBackup) id() (string, error) {
 	return "aws.backup", nil
 }
 
+type mqlAwsBackupVaultInternal struct {
+	lazyTags
+}
+
 func (a *mqlAwsBackupVault) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+func (a *mqlAwsBackupVault) tags() (map[string]any, error) {
+	return backupResolveTags(a.MqlRuntime, &a.lazyTags, &a.Tags, a.Region.Data, a.Arn.Data)
+}
+
+type mqlAwsBackupVaultRecoveryPointInternal struct {
+	lazyTags
+}
+
 func (a *mqlAwsBackupVaultRecoveryPoint) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+// tags passes no region: a recovery point has no region field, so the region
+// comes from its ARN, which is only parsed when Backup manages the resource.
+func (a *mqlAwsBackupVaultRecoveryPoint) tags() (map[string]any, error) {
+	return backupResolveTags(a.MqlRuntime, &a.lazyTags, &a.Tags, "", a.Arn.Data)
+}
+
+// backupManagedArn reports whether Backup can read tags for resourceArn, and
+// the region to read them from.
+//
+// ListTags only accepts resources Backup fully manages, whose ARNs begin with
+// arn:aws:backup. A recovery point of a resource Backup does not fully manage
+// keeps the source service's ARN (arn:aws:dynamodb, arn:aws:ec2, and so on),
+// and ListTags rejects those. Callers must report unreadable rather than empty
+// tags for them, or an audit filtering on a tag would silently treat every such
+// recovery point as untagged.
+func backupManagedArn(resourceArn string) (region string, ok bool) {
+	parsed, err := arn.Parse(resourceArn)
+	if err != nil || parsed.Service != "backup" {
+		return "", false
+	}
+	return parsed.Region, true
+}
+
+// backupResolveTags resolves and caches a Backup resource's tags, marking the
+// field null when Backup cannot read them.
+//
+// The null case sets the field's state directly instead of returning a value:
+// GetOrCompute honors a state the accessor set itself, so the field surfaces as
+// null rather than as an empty map that would read as "this resource has no
+// tags". It takes the field pointer because only the caller knows which field
+// to mark.
+func backupResolveTags(runtime *plugin.Runtime, cache *lazyTags, field *plugin.TValue[map[string]any], region, resourceArn string) (map[string]any, error) {
+	return cache.resolveTags(func() (map[string]any, error) {
+		tags, ok, err := backupTagsForArn(runtime, region, resourceArn)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			field.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return tags, nil
+	})
+}
+
+// backupTagsForArn reads the tags of a Backup-managed resource. The bool
+// reports whether the tags could be read at all; see backupManagedArn.
+func backupTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[string]any, bool, error) {
+	arnRegion, ok := backupManagedArn(resourceArn)
+	if !ok {
+		return nil, false, nil
+	}
+	if region == "" {
+		region = arnRegion
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Backup(region)
+	ctx := context.Background()
+
+	tags := map[string]any{}
+	var nextToken *string
+	for {
+		resp, err := svc.ListTags(ctx, &backup.ListTagsInput{
+			ResourceArn: &resourceArn,
+			NextToken:   nextToken,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		for k, v := range resp.Tags {
+			tags[k] = v
+		}
+		if resp.NextToken == nil {
+			break
+		}
+		nextToken = resp.NextToken
+	}
+	return tags, true, nil
 }
 
 func (a *mqlAwsBackup) vaults() ([]any, error) {
@@ -244,6 +340,14 @@ func (a *mqlAwsBackupVault) policyStatements() ([]any, error) {
 // ========================
 // aws.backup.plan
 // ========================
+
+type mqlAwsBackupPlanInternal struct {
+	lazyTags
+}
+
+func (a *mqlAwsBackupPlan) tags() (map[string]any, error) {
+	return backupResolveTags(a.MqlRuntime, &a.lazyTags, &a.Tags, a.Region.Data, a.Arn.Data)
+}
 
 func (a *mqlAwsBackupPlan) id() (string, error) {
 	return a.Arn.Data, nil
@@ -929,10 +1033,15 @@ func (a *mqlAwsBackupScanJob) scannerRole() (*mqlAwsIamRole, error) {
 // ========================
 
 type mqlAwsBackupAccessPointInternal struct {
+	lazyTags
 	cacheVaultArn         string
 	cacheVaultName        string
 	cacheRecoveryPointArn string
 	cacheRegion           string
+}
+
+func (a *mqlAwsBackupAccessPoint) tags() (map[string]any, error) {
+	return backupResolveTags(a.MqlRuntime, &a.lazyTags, &a.Tags, a.Region.Data, a.Arn.Data)
 }
 
 func (a *mqlAwsBackupAccessPoint) id() (string, error) {

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -960,7 +960,7 @@ func (a *mqlAwsCloudwatchMetricsalarm) id() (string, error) {
 }
 
 func (a *mqlAwsCloudwatchMetricsalarm) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 		alarmArn := a.Arn.Data
 

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -951,8 +951,33 @@ func (a *mqlAwsCloudwatchLoggroupMetricsfilter) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+type mqlAwsCloudwatchMetricsalarmInternal struct {
+	lazyTags
+}
+
 func (a *mqlAwsCloudwatchMetricsalarm) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsCloudwatchMetricsalarm) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		alarmArn := a.Arn.Data
+
+		svc := conn.Cloudwatch(a.Region.Data)
+		resp, err := svc.ListTagsForResource(context.Background(), &cloudwatch.ListTagsForResourceInput{
+			ResourceARN: &alarmArn,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return tagsToMap(resp.Tags,
+			func(t cloudwatchtypes.Tag) *string { return t.Key },
+			func(t cloudwatchtypes.Tag) *string { return t.Value }), nil
+	})
 }
 
 // cloudwatchMetricID builds the cache key for a CloudWatch metric. ListMetrics

--- a/providers/aws/resources/aws_config.go
+++ b/providers/aws/resources/aws_config.go
@@ -47,7 +47,7 @@ func configTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[
 		})
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return nil, nil
+				return nil, errTagsUnreadable
 			}
 			return nil, err
 		}
@@ -63,19 +63,19 @@ func configTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[
 }
 
 func (a *mqlAwsConfigRule) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return configTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
 
 func (a *mqlAwsConfigConformancePack) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return configTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
 
 func (a *mqlAwsConfigAggregator) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return configTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }

--- a/providers/aws/resources/aws_config.go
+++ b/providers/aws/resources/aws_config.go
@@ -24,6 +24,62 @@ func (a *mqlAwsConfig) id() (string, error) {
 	return "aws.config", nil
 }
 
+func configTagsToMap(tags []cstypes.Tag) map[string]any {
+	return tagsToMap(tags,
+		func(t cstypes.Tag) *string { return t.Key },
+		func(t cstypes.Tag) *string { return t.Value })
+}
+
+// configTagsForArn reads the tags of a Config resource. ListTagsForResource
+// covers config rules, conformance packs, and aggregators, none of which carry
+// tags in their describe responses.
+func configTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[string]any, error) {
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.ConfigService(region)
+	ctx := context.Background()
+
+	tags := map[string]any{}
+	var nextToken *string
+	for {
+		resp, err := svc.ListTagsForResource(ctx, &configservice.ListTagsForResourceInput{
+			ResourceArn: &resourceArn,
+			NextToken:   nextToken,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		for k, v := range configTagsToMap(resp.Tags) {
+			tags[k] = v
+		}
+		if resp.NextToken == nil {
+			break
+		}
+		nextToken = resp.NextToken
+	}
+	return tags, nil
+}
+
+func (a *mqlAwsConfigRule) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return configTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
+}
+
+func (a *mqlAwsConfigConformancePack) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return configTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
+}
+
+func (a *mqlAwsConfigAggregator) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return configTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
+}
+
 func (a *mqlAwsConfig) recorders() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []any{}
@@ -431,9 +487,18 @@ func (a *mqlAwsConfig) getAggregators(conn *connection.AwsConnection) []*jobpool
 }
 
 type mqlAwsConfigAggregatorInternal struct {
+	lazyTags
 	cacheOrgRoleArn       *string
 	cacheOrgAllAwsRegions bool
 	cacheOrgAwsRegions    []string
+}
+
+type mqlAwsConfigRuleInternal struct {
+	lazyTags
+}
+
+type mqlAwsConfigConformancePackInternal struct {
+	lazyTags
 }
 
 func (a *mqlAwsConfigAggregator) id() (string, error) {

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -216,6 +216,32 @@ func (a *mqlAwsElasticacheCluster) tags() (map[string]any, error) {
 	return tags, nil
 }
 
+func elasticacheTagsToMap(tags []elasticache_types.Tag) map[string]any {
+	return tagsToMap(tags,
+		func(t elasticache_types.Tag) *string { return t.Key },
+		func(t elasticache_types.Tag) *string { return t.Value })
+}
+
+// elasticacheTagsForArn reads the tags of any ElastiCache resource. None of the
+// describe responses carry tags, so every resource resolves them here.
+//
+// An access-denied response yields no tags rather than an empty set: a tag set
+// that could not be read must not be published as an authoritative "no tags".
+func elasticacheTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[string]any, error) {
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Elasticache(region)
+	resp, err := svc.ListTagsForResource(context.Background(), &elasticache.ListTagsForResourceInput{
+		ResourceName: &resourceArn,
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return elasticacheTagsToMap(resp.TagList), nil
+}
+
 func (a *mqlAwsElasticacheCluster) kmsKey() (*mqlAwsKmsKey, error) {
 	// The KMS key protecting a cluster's data at rest lives on its replication
 	// group, so delegate through the group rather than fetching replication
@@ -388,8 +414,15 @@ func (a *mqlAwsElasticache) getReplicationGroups(conn *connection.AwsConnection)
 }
 
 type mqlAwsElasticacheReplicationGroupInternal struct {
+	lazyTags
 	cacheKmsKeyId       *string
 	cacheMemberClusters []string
+}
+
+func (a *mqlAwsElasticacheReplicationGroup) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 func newMqlAwsElasticacheReplicationGroup(runtime *plugin.Runtime, region string, rg elasticache_types.ReplicationGroup) (*mqlAwsElasticacheReplicationGroup, error) {
@@ -570,10 +603,17 @@ func (a *mqlAwsElasticache) getServerlessCaches(conn *connection.AwsConnection) 
 
 type mqlAwsElasticacheServerlessCacheInternal struct {
 	securityGroupIdHandler
+	lazyTags
 	region        string
 	accountID     string
 	subnetIds     []string
 	cacheKmsKeyId *string
+}
+
+func (a *mqlAwsElasticacheServerlessCache) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 func newMqlAwsElasticacheServerlessCache(runtime *plugin.Runtime, region string, accountID string, cache elasticache_types.ServerlessCache) (*mqlAwsElasticacheServerlessCache, error) {
@@ -748,8 +788,18 @@ func (a *mqlAwsElasticache) getParameterGroups(conn *connection.AwsConnection) [
 	return tasks
 }
 
+type mqlAwsElasticacheParameterGroupInternal struct {
+	lazyTags
+}
+
 func (a *mqlAwsElasticacheParameterGroup) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsElasticacheParameterGroup) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 // ── Subnet Groups ───────────────────────────────────────────────────────────
@@ -825,7 +875,14 @@ func (a *mqlAwsElasticache) getSubnetGroups(conn *connection.AwsConnection) []*j
 }
 
 type mqlAwsElasticacheSubnetGroupInternal struct {
+	lazyTags
 	cacheVpcId *string
+}
+
+func (a *mqlAwsElasticacheSubnetGroup) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 func (a *mqlAwsElasticacheSubnetGroup) id() (string, error) {
@@ -921,8 +978,18 @@ func (a *mqlAwsElasticache) getUsers(conn *connection.AwsConnection) []*jobpool.
 	return tasks
 }
 
+type mqlAwsElasticacheUserInternal struct {
+	lazyTags
+}
+
 func (a *mqlAwsElasticacheUser) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsElasticacheUser) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 // ── Service Updates ─────────────────────────────────────────────────────────
@@ -1055,8 +1122,15 @@ func (a *mqlAwsElasticache) getSnapshots(conn *connection.AwsConnection) []*jobp
 }
 
 type mqlAwsElasticacheSnapshotInternal struct {
+	lazyTags
 	cacheKmsKeyId *string
 	cacheVpcId    *string
+}
+
+func (a *mqlAwsElasticacheSnapshot) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 func (a *mqlAwsElasticacheSnapshot) id() (string, error) {

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -224,9 +224,6 @@ func elasticacheTagsToMap(tags []elasticache_types.Tag) map[string]any {
 
 // elasticacheTagsForArn reads the tags of any ElastiCache resource. None of the
 // describe responses carry tags, so every resource resolves them here.
-//
-// An access-denied response yields no tags rather than an empty set: a tag set
-// that could not be read must not be published as an authoritative "no tags".
 func elasticacheTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[string]any, error) {
 	conn := runtime.Connection.(*connection.AwsConnection)
 	svc := conn.Elasticache(region)
@@ -235,7 +232,7 @@ func elasticacheTagsForArn(runtime *plugin.Runtime, region, resourceArn string) 
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return nil, errTagsUnreadable
 		}
 		return nil, err
 	}
@@ -420,7 +417,7 @@ type mqlAwsElasticacheReplicationGroupInternal struct {
 }
 
 func (a *mqlAwsElasticacheReplicationGroup) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -611,7 +608,7 @@ type mqlAwsElasticacheServerlessCacheInternal struct {
 }
 
 func (a *mqlAwsElasticacheServerlessCache) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -797,7 +794,7 @@ func (a *mqlAwsElasticacheParameterGroup) id() (string, error) {
 }
 
 func (a *mqlAwsElasticacheParameterGroup) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -880,7 +877,7 @@ type mqlAwsElasticacheSubnetGroupInternal struct {
 }
 
 func (a *mqlAwsElasticacheSubnetGroup) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -987,7 +984,7 @@ func (a *mqlAwsElasticacheUser) id() (string, error) {
 }
 
 func (a *mqlAwsElasticacheUser) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -1128,7 +1125,7 @@ type mqlAwsElasticacheSnapshotInternal struct {
 }
 
 func (a *mqlAwsElasticacheSnapshot) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elasticacheTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -699,8 +699,37 @@ func (a *mqlAwsElbLoadbalancer) listeners() ([]any, error) {
 }
 
 type mqlAwsElbListenerInternal struct {
+	lazyTags
 	defaultActionsCache     []elbtypes.Action
 	mutualAuthTrustStoreArn string
+}
+
+// mqlAwsElbListenerRuleInternal and mqlAwsElbTruststoreInternal exist only to
+// carry the tag cache; neither resource had per-instance state before.
+type mqlAwsElbListenerRuleInternal struct {
+	lazyTags
+}
+
+type mqlAwsElbTruststoreInternal struct {
+	lazyTags
+}
+
+func (a *mqlAwsElbListener) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
+	})
+}
+
+func (a *mqlAwsElbListenerRule) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
+	})
+}
+
+func (a *mqlAwsElbTruststore) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
+	})
 }
 
 func (a *mqlAwsElb) sslPolicies() ([]any, error) {
@@ -1089,8 +1118,45 @@ func (a *mqlAwsElbLoadbalancer) tags() (map[string]any, error) {
 	return tags, nil
 }
 
+// elbv2TagsForArn reads the tags of one ELBv2 resource. DescribeTags accepts up
+// to 20 ARNs per request, but each resource resolves only its own: tags are a
+// computed field, and listing a load balancer's target groups must not pay for
+// tags nobody asked for. Batching would need the ARNs of sibling resources that
+// a single resource cannot see.
+//
+// An ARN the API returns no tag description for yields an empty map rather than
+// an error, since DescribeTags omits resources that carry no tags.
+func elbv2TagsForArn(runtime *plugin.Runtime, resourceArn string) (map[string]any, error) {
+	region, err := GetRegionFromArn(resourceArn)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Elbv2(region)
+	resp, err := svc.DescribeTags(context.Background(), &elasticloadbalancingv2.DescribeTagsInput{
+		ResourceArns: []string{resourceArn},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, desc := range resp.TagDescriptions {
+		if convert.ToValue(desc.ResourceArn) == resourceArn {
+			return elbv2TagsToMap(desc.Tags), nil
+		}
+	}
+	return map[string]any{}, nil
+}
+
 func (a *mqlAwsElbTargetgroup) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsElbTargetgroup) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
+	})
 }
 
 func (a *mqlAwsElbLoadbalancer) targetGroups() ([]any, error) {
@@ -1150,6 +1216,7 @@ func (a *mqlAwsElbLoadbalancer) targetGroups() ([]any, error) {
 }
 
 type mqlAwsElbTargetgroupInternal struct {
+	lazyTags
 	targetGroup elbtypes.TargetGroup
 	region      string
 }

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -715,19 +715,19 @@ type mqlAwsElbTruststoreInternal struct {
 }
 
 func (a *mqlAwsElbListener) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
 	})
 }
 
 func (a *mqlAwsElbListenerRule) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
 	})
 }
 
 func (a *mqlAwsElbTruststore) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
 	})
 }
@@ -1138,6 +1138,9 @@ func elbv2TagsForArn(runtime *plugin.Runtime, resourceArn string) (map[string]an
 		ResourceArns: []string{resourceArn},
 	})
 	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return nil, errTagsUnreadable
+		}
 		return nil, err
 	}
 
@@ -1154,7 +1157,7 @@ func (a *mqlAwsElbTargetgroup) id() (string, error) {
 }
 
 func (a *mqlAwsElbTargetgroup) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return elbv2TagsForArn(a.MqlRuntime, a.Arn.Data)
 	})
 }

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1412,6 +1412,18 @@ func (a *mqlAwsIamPolicy) policyId() (string, error) {
 	return convert.ToValue(policy.PolicyId), nil
 }
 
+// tags reads the policy tags off the cached GetPolicy response. ListPolicies,
+// which is what aws.iam.policies pages through, leaves Tags empty on every
+// Policy it returns even though the field exists, so the tags have to come from
+// the per-policy call that name and description already share.
+func (a *mqlAwsIamPolicy) tags() (map[string]any, error) {
+	policy, err := a.loadPolicy(a.Arn.Data)
+	if err != nil {
+		return nil, err
+	}
+	return iamTagsToMap(policy.Tags), nil
+}
+
 func (a *mqlAwsIamPolicy) isAttachable() (bool, error) {
 	arn := a.Arn.Data
 

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -145,8 +145,18 @@ func (a *mqlAwsRds) getEventSubscriptions(conn *connection.AwsConnection) []*job
 	return tasks
 }
 
+type mqlAwsRdsEventSubscriptionInternal struct {
+	lazyTags
+}
+
 func (a *mqlAwsRdsEventSubscription) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+func (a *mqlAwsRdsEventSubscription) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 func (a *mqlAwsRdsEventSubscription) snsTopic() (*mqlAwsSnsTopic, error) {
@@ -234,6 +244,26 @@ func newMqlAwsRdsClusterParameterGroup(runtime *plugin.Runtime, region string, p
 	}
 	mqlParameterGroup := resource.(*mqlAwsRdsClusterParameterGroup)
 	return mqlParameterGroup, nil
+}
+
+type mqlAwsRdsClusterParameterGroupInternal struct {
+	lazyTags
+}
+
+func (a *mqlAwsRdsClusterParameterGroup) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
+}
+
+type mqlAwsRdsParameterGroupInternal struct {
+	lazyTags
+}
+
+func (a *mqlAwsRdsParameterGroup) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 func (a *mqlAwsRds) getParameterGroups(conn *connection.AwsConnection) []*jobpool.Job {
@@ -425,7 +455,7 @@ func newMqlAwsParameterGroup(runtime *plugin.Runtime, region string, parameterGr
 	return mqlParameterGroup, nil
 }
 
-func (a mqlAwsRdsClusterParameterGroup) parameters() ([]any, error) {
+func (a *mqlAwsRdsClusterParameterGroup) parameters() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []any{}
 	svc := conn.Rds(a.Region.Data)
@@ -1963,13 +1993,17 @@ func (a *mqlAwsRdsProxy) id() (string, error) {
 }
 
 func (a *mqlAwsRdsProxy) tags() (map[string]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Rds(a.Region.Data)
-	ctx := context.Background()
-	arn := a.Arn.Data
+	return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+}
 
-	resp, err := svc.ListTagsForResource(ctx, &rds.ListTagsForResourceInput{
-		ResourceName: &arn,
+// rdsTagsForArn reads the tags of any RDS resource. RDS leaves tags out of most
+// of its describe responses, so every resource that is not a DB instance,
+// cluster, or snapshot (which carry TagList inline) resolves them here.
+func rdsTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[string]any, error) {
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Rds(region)
+	resp, err := svc.ListTagsForResource(context.Background(), &rds.ListTagsForResourceInput{
+		ResourceName: &resourceArn,
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
@@ -2033,7 +2067,14 @@ func (a *mqlAwsRds) getOptionGroups(conn *connection.AwsConnection) []*jobpool.J
 }
 
 type mqlAwsRdsOptionGroupInternal struct {
+	lazyTags
 	cacheVpcId string
+}
+
+func (a *mqlAwsRdsOptionGroup) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	})
 }
 
 func newMqlAwsRdsOptionGroup(runtime *plugin.Runtime, region string, og rds_types.OptionGroup) (*mqlAwsRdsOptionGroup, error) {
@@ -2172,7 +2213,7 @@ func (a *mqlAwsRds) getGlobalClusters(conn *connection.AwsConnection) []*jobpool
 					return nil, err
 				}
 				for _, gc := range page.GlobalClusters {
-					mqlGc, err := newMqlAwsRdsGlobalCluster(a.MqlRuntime, gc)
+					mqlGc, err := newMqlAwsRdsGlobalCluster(a.MqlRuntime, region, gc)
 					if err != nil {
 						return nil, err
 					}
@@ -2186,7 +2227,21 @@ func (a *mqlAwsRds) getGlobalClusters(conn *connection.AwsConnection) []*jobpool
 	return tasks
 }
 
-func newMqlAwsRdsGlobalCluster(runtime *plugin.Runtime, gc rds_types.GlobalCluster) (*mqlAwsRdsGlobalCluster, error) {
+// mqlAwsRdsGlobalClusterInternal carries the region the global cluster was
+// discovered through. A global cluster ARN has no region segment, so the tag
+// lookup has no other way to pick a regional RDS client.
+type mqlAwsRdsGlobalClusterInternal struct {
+	lazyTags
+	region string
+}
+
+func (a *mqlAwsRdsGlobalCluster) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		return rdsTagsForArn(a.MqlRuntime, a.region, a.Arn.Data)
+	})
+}
+
+func newMqlAwsRdsGlobalCluster(runtime *plugin.Runtime, region string, gc rds_types.GlobalCluster) (*mqlAwsRdsGlobalCluster, error) {
 	failoverState, err := convert.JsonToDict(gc.FailoverState)
 	if err != nil {
 		return nil, err
@@ -2215,7 +2270,9 @@ func newMqlAwsRdsGlobalCluster(runtime *plugin.Runtime, gc rds_types.GlobalClust
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAwsRdsGlobalCluster), nil
+	mqlGc := res.(*mqlAwsRdsGlobalCluster)
+	mqlGc.region = region
+	return mqlGc, nil
 }
 
 func (a *mqlAwsRdsDbcluster) globalCluster() (*mqlAwsRdsGlobalCluster, error) {
@@ -2241,5 +2298,5 @@ func (a *mqlAwsRdsDbcluster) globalCluster() (*mqlAwsRdsGlobalCluster, error) {
 		a.GlobalCluster.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return newMqlAwsRdsGlobalCluster(a.MqlRuntime, resp.GlobalClusters[0])
+	return newMqlAwsRdsGlobalCluster(a.MqlRuntime, a.Region.Data, resp.GlobalClusters[0])
 }

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -154,7 +154,7 @@ func (a *mqlAwsRdsEventSubscription) id() (string, error) {
 }
 
 func (a *mqlAwsRdsEventSubscription) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -251,7 +251,7 @@ type mqlAwsRdsClusterParameterGroupInternal struct {
 }
 
 func (a *mqlAwsRdsClusterParameterGroup) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -261,7 +261,7 @@ type mqlAwsRdsParameterGroupInternal struct {
 }
 
 func (a *mqlAwsRdsParameterGroup) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -1993,7 +1993,12 @@ func (a *mqlAwsRdsProxy) id() (string, error) {
 }
 
 func (a *mqlAwsRdsProxy) tags() (map[string]any, error) {
-	return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	tags, err := rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
+	if errors.Is(err, errTagsUnreadable) {
+		a.Tags.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return tags, err
 }
 
 // rdsTagsForArn reads the tags of any RDS resource. RDS leaves tags out of most
@@ -2007,7 +2012,7 @@ func rdsTagsForArn(runtime *plugin.Runtime, region, resourceArn string) (map[str
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return nil, errTagsUnreadable
 		}
 		return nil, err
 	}
@@ -2072,7 +2077,7 @@ type mqlAwsRdsOptionGroupInternal struct {
 }
 
 func (a *mqlAwsRdsOptionGroup) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return rdsTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	})
 }
@@ -2236,7 +2241,7 @@ type mqlAwsRdsGlobalClusterInternal struct {
 }
 
 func (a *mqlAwsRdsGlobalCluster) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		return rdsTagsForArn(a.MqlRuntime, a.region, a.Arn.Data)
 	})
 }

--- a/providers/aws/resources/aws_securityhub.go
+++ b/providers/aws/resources/aws_securityhub.go
@@ -92,9 +92,33 @@ func (a *mqlAwsSecurityhubHub) id() (string, error) {
 }
 
 type mqlAwsSecurityhubHubInternal struct {
+	lazyTags
 	standardsFetched bool
 	standardsLock    sync.Mutex
 	standards        []types.StandardsSubscription
+}
+
+func (a *mqlAwsSecurityhubHub) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		hubArn := a.Arn.Data
+
+		svc := conn.Securityhub(a.Region.Data)
+		resp, err := svc.ListTagsForResource(context.Background(), &securityhub.ListTagsForResourceInput{
+			ResourceArn: &hubArn,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		tags := make(map[string]any, len(resp.Tags))
+		for k, v := range resp.Tags {
+			tags[k] = v
+		}
+		return tags, nil
+	})
 }
 
 func (a *mqlAwsSecurityhubHub) getEnabledStandards() ([]types.StandardsSubscription, error) {

--- a/providers/aws/resources/aws_securityhub.go
+++ b/providers/aws/resources/aws_securityhub.go
@@ -99,7 +99,7 @@ type mqlAwsSecurityhubHubInternal struct {
 }
 
 func (a *mqlAwsSecurityhubHub) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 		hubArn := a.Arn.Data
 
@@ -109,7 +109,7 @@ func (a *mqlAwsSecurityhubHub) tags() (map[string]any, error) {
 		})
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return nil, nil
+				return nil, errTagsUnreadable
 			}
 			return nil, err
 		}

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -124,7 +124,7 @@ type mqlAwsSsmParameterInternal struct {
 // resource id and type rather than an ARN, and for a parameter the id is the
 // parameter name, including its leading path for a hierarchical parameter.
 func (a *mqlAwsSsmParameter) tags() (map[string]any, error) {
-	return a.resolveTags(func() (map[string]any, error) {
+	return a.resolveTags(&a.Tags, func() (map[string]any, error) {
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 		name := a.Name.Data
 
@@ -135,7 +135,7 @@ func (a *mqlAwsSsmParameter) tags() (map[string]any, error) {
 		})
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return nil, nil
+				return nil, errTagsUnreadable
 			}
 			return nil, err
 		}

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -115,8 +115,34 @@ func (a *mqlAwsSsm) getParameters(conn *connection.AwsConnection) []*jobpool.Job
 }
 
 type mqlAwsSsmParameterInternal struct {
+	lazyTags
 	parameterCache types.ParameterMetadata
 	region         string
+}
+
+// tags reads the parameter's tags. SSM's ListTagsForResource is keyed on a
+// resource id and type rather than an ARN, and for a parameter the id is the
+// parameter name, including its leading path for a hierarchical parameter.
+func (a *mqlAwsSsmParameter) tags() (map[string]any, error) {
+	return a.resolveTags(func() (map[string]any, error) {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		name := a.Name.Data
+
+		svc := conn.Ssm(a.region)
+		resp, err := svc.ListTagsForResource(context.Background(), &ssm.ListTagsForResourceInput{
+			ResourceId:   &name,
+			ResourceType: types.ResourceTypeForTaggingParameter,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return tagsToMap(resp.TagList,
+			func(t types.Tag) *string { return t.Key },
+			func(t types.Tag) *string { return t.Value }), nil
+	})
 }
 
 func (a *mqlAwsSsmParameter) kmsKey() (*mqlAwsKmsKey, error) {

--- a/providers/aws/resources/aws_tags.go
+++ b/providers/aws/resources/aws_tags.go
@@ -4,6 +4,9 @@
 package resources
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 )
 
@@ -25,6 +28,57 @@ func tagsToStringMap[T any](tags []T, key func(T) *string, value func(T) *string
 		m[*k] = convert.ToValue(value(tags[i]))
 	}
 	return m
+}
+
+// lazyTags caches a tag lookup that costs its own API call. Most AWS services
+// leave tags out of their list and describe responses, so those resources
+// declare tags as a computed field and resolve it through this handler on first
+// read. Embed it in the resource's Internal struct:
+//
+//	type mqlAwsRdsParameterGroupInternal struct {
+//		lazyTags
+//	}
+//
+//	func (a *mqlAwsRdsParameterGroup) tags() (map[string]any, error) {
+//		return a.resolveTags(func() (map[string]any, error) { ... })
+//	}
+//
+// A resource with no tags caches an empty map, so an untagged resource costs
+// one call rather than one per read. Errors are not cached: a throttled or
+// briefly denied call is worth retrying, and caching the failure would turn it
+// into a permanent empty tag set.
+type lazyTags struct {
+	cacheTags   map[string]any
+	tagsFetched atomic.Bool
+	tagsLock    sync.Mutex
+}
+
+// resolveTags runs fetch once and caches the result. fetch returning a nil map
+// is normalized to an empty one; to report tags that genuinely could not be
+// read, the caller should set the field's null state instead of routing through
+// here, so an unreadable tag set is never published as an authoritative empty
+// one.
+func (h *lazyTags) resolveTags(fetch func() (map[string]any, error)) (map[string]any, error) {
+	if h.tagsFetched.Load() {
+		return h.cacheTags, nil
+	}
+	h.tagsLock.Lock()
+	defer h.tagsLock.Unlock()
+	if h.tagsFetched.Load() {
+		return h.cacheTags, nil
+	}
+
+	tags, err := fetch()
+	if err != nil {
+		return nil, err
+	}
+	if tags == nil {
+		tags = map[string]any{}
+	}
+
+	h.cacheTags = tags
+	h.tagsFetched.Store(true)
+	return tags, nil
 }
 
 // tagsToMap is tagsToStringMap with a map[string]any result, the shape MQL

--- a/providers/aws/resources/aws_tags.go
+++ b/providers/aws/resources/aws_tags.go
@@ -4,9 +4,11 @@
 package resources
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 )
 
@@ -40,25 +42,40 @@ func tagsToStringMap[T any](tags []T, key func(T) *string, value func(T) *string
 //	}
 //
 //	func (a *mqlAwsRdsParameterGroup) tags() (map[string]any, error) {
-//		return a.resolveTags(func() (map[string]any, error) { ... })
+//		return a.resolveTags(&a.Tags, func() (map[string]any, error) { ... })
 //	}
 //
 // A resource with no tags caches an empty map, so an untagged resource costs
-// one call rather than one per read. Errors are not cached: a throttled or
-// briefly denied call is worth retrying, and caching the failure would turn it
-// into a permanent empty tag set.
+// one call rather than one per read. Errors are not cached: a throttled call is
+// worth retrying, and caching the failure would turn it into a permanent empty
+// tag set.
 type lazyTags struct {
 	cacheTags   map[string]any
 	tagsFetched atomic.Bool
 	tagsLock    sync.Mutex
 }
 
-// resolveTags runs fetch once and caches the result. fetch returning a nil map
-// is normalized to an empty one; to report tags that genuinely could not be
-// read, the caller should set the field's null state instead of routing through
-// here, so an unreadable tag set is never published as an authoritative empty
-// one.
-func (h *lazyTags) resolveTags(fetch func() (map[string]any, error)) (map[string]any, error) {
+// errTagsUnreadable reports that a tag lookup could not be performed at all, as
+// distinct from a resource that carries no tags. Access-denied is the usual
+// cause; Backup also raises it for resources it does not manage.
+//
+// The distinction matters because an empty tag map is an assertion. A scan role
+// without the tag permission would otherwise report every resource as untagged,
+// and an audit that exempts resources by tag, or requires one, would pass
+// vacuously over the whole account. An unreadable tag set cannot prove a match,
+// so we do not claim one. This mirrors the reasoning in fetchTagsConcurrently.
+var errTagsUnreadable = errors.New("tags could not be read")
+
+// resolveTags runs fetch once and caches the result, and is the only place tag
+// nullness is decided.
+//
+// fetch reports an unreadable tag set by returning errTagsUnreadable, which
+// marks field null rather than caching an empty map. It takes the field pointer
+// because only the caller knows which field to mark, and because setting the
+// state is the one way to make a computed map field surface as null:
+// GetOrCompute honors a state the accessor set itself. A nil map with no error
+// still means "no tags" and is normalized to an empty map.
+func (h *lazyTags) resolveTags(field *plugin.TValue[map[string]any], fetch func() (map[string]any, error)) (map[string]any, error) {
 	if h.tagsFetched.Load() {
 		return h.cacheTags, nil
 	}
@@ -70,6 +87,14 @@ func (h *lazyTags) resolveTags(fetch func() (map[string]any, error)) (map[string
 
 	tags, err := fetch()
 	if err != nil {
+		if errors.Is(err, errTagsUnreadable) {
+			// Cache the miss: a missing permission does not change mid-scan,
+			// and re-asking per read would cost a denied call every time.
+			field.State = plugin.StateIsSet | plugin.StateIsNull
+			h.cacheTags = nil
+			h.tagsFetched.Store(true)
+			return nil, nil
+		}
 		return nil, err
 	}
 	if tags == nil {

--- a/providers/aws/resources/aws_tags_test.go
+++ b/providers/aws/resources/aws_tags_test.go
@@ -4,10 +4,16 @@
 package resources
 
 import (
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	cstypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	elasticache_types "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	emrtypes "github.com/aws/aws-sdk-go-v2/service/emr/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,6 +115,170 @@ func TestEmrTagsToMap_StringMapShape(t *testing.T) {
 	})
 	// must be a map[string]string, and key/value must not be swapped
 	assert.Equal(t, map[string]string{"k": "v"}, got)
+}
+
+func TestElasticacheTagsToMap(t *testing.T) {
+	got := elasticacheTagsToMap([]elasticache_types.Tag{
+		{Key: aws.String("env"), Value: aws.String("prod")},
+		{Key: aws.String("empty"), Value: nil},
+		{Key: nil, Value: aws.String("dropped")},
+	})
+	assert.Equal(t, map[string]any{"env": "prod", "empty": ""}, got)
+}
+
+func TestConfigTagsToMap(t *testing.T) {
+	got := configTagsToMap([]cstypes.Tag{
+		{Key: aws.String("owner"), Value: aws.String("secops")},
+		{Key: aws.String("empty"), Value: nil},
+		{Key: nil, Value: aws.String("dropped")},
+	})
+	assert.Equal(t, map[string]any{"owner": "secops", "empty": ""}, got)
+}
+
+// TestBackupManagedArn pins the guard that decides whether Backup can read a
+// resource's tags at all. Getting this wrong in the permissive direction turns
+// every recovery point of a resource Backup does not fully manage into a
+// confident "no tags", which an audit filtering on a tag would silently accept.
+func TestBackupManagedArn(t *testing.T) {
+	tests := []struct {
+		name       string
+		arn        string
+		wantRegion string
+		wantOK     bool
+	}{
+		{
+			name:       "backup vault",
+			arn:        "arn:aws:backup:us-east-1:123456789012:backup-vault:Default",
+			wantRegion: "us-east-1",
+			wantOK:     true,
+		},
+		{
+			name:       "backup-managed recovery point",
+			arn:        "arn:aws:backup:eu-west-1:123456789012:recovery-point:1a2b3c4d",
+			wantRegion: "eu-west-1",
+			wantOK:     true,
+		},
+		{
+			name:   "dynamodb recovery point is not backup-managed",
+			arn:    "arn:aws:dynamodb:us-east-1:123456789012:table/orders/backup/01234567890123-abcdefgh",
+			wantOK: false,
+		},
+		{
+			name:   "ec2 recovery point is not backup-managed",
+			arn:    "arn:aws:ec2:us-east-1::image/ami-1234567890abcdef0",
+			wantOK: false,
+		},
+		{
+			name:   "unparseable arn",
+			arn:    "not-an-arn",
+			wantOK: false,
+		},
+		{
+			name:   "empty arn",
+			arn:    "",
+			wantOK: false,
+		},
+		{
+			name:   "service prefix must match exactly, not by prefix",
+			arn:    "arn:aws:backupstorage:us-east-1:123456789012:something/x",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			region, ok := backupManagedArn(tt.arn)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantRegion, region)
+		})
+	}
+}
+
+func TestLazyTagsResolveTags(t *testing.T) {
+	t.Run("fetches once and caches the result", func(t *testing.T) {
+		var h lazyTags
+		calls := 0
+		fetch := func() (map[string]any, error) {
+			calls++
+			return map[string]any{"env": "prod"}, nil
+		}
+
+		for i := 0; i < 3; i++ {
+			got, err := h.resolveTags(fetch)
+			require.NoError(t, err)
+			assert.Equal(t, map[string]any{"env": "prod"}, got)
+		}
+		assert.Equal(t, 1, calls, "fetch must run only on the first read")
+	})
+
+	t.Run("caches an empty tag set so an untagged resource costs one call", func(t *testing.T) {
+		var h lazyTags
+		calls := 0
+		fetch := func() (map[string]any, error) {
+			calls++
+			return map[string]any{}, nil
+		}
+
+		for i := 0; i < 3; i++ {
+			got, err := h.resolveTags(fetch)
+			require.NoError(t, err)
+			assert.Empty(t, got)
+		}
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("normalizes a nil map to empty", func(t *testing.T) {
+		var h lazyTags
+		got, err := h.resolveTags(func() (map[string]any, error) { return nil, nil })
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("does not cache an error", func(t *testing.T) {
+		var h lazyTags
+		calls := 0
+		fetch := func() (map[string]any, error) {
+			calls++
+			if calls == 1 {
+				return nil, errors.New("throttled")
+			}
+			return map[string]any{"env": "prod"}, nil
+		}
+
+		_, err := h.resolveTags(fetch)
+		require.Error(t, err)
+
+		// A throttled or briefly denied call must be retried rather than
+		// remembered as an empty tag set.
+		got, err := h.resolveTags(fetch)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"env": "prod"}, got)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("concurrent readers fetch once", func(t *testing.T) {
+		var h lazyTags
+		var calls atomic.Int64
+		fetch := func() (map[string]any, error) {
+			calls.Add(1)
+			time.Sleep(10 * time.Millisecond)
+			return map[string]any{"env": "prod"}, nil
+		}
+
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				got, err := h.resolveTags(fetch)
+				assert.NoError(t, err)
+				assert.Equal(t, map[string]any{"env": "prod"}, got)
+			}()
+		}
+		wg.Wait()
+		assert.Equal(t, int64(1), calls.Load())
+	})
 }
 
 func TestTagsToStringMap(t *testing.T) {

--- a/providers/aws/resources/aws_tags_test.go
+++ b/providers/aws/resources/aws_tags_test.go
@@ -5,10 +5,13 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
@@ -197,6 +200,7 @@ func TestBackupManagedArn(t *testing.T) {
 func TestLazyTagsResolveTags(t *testing.T) {
 	t.Run("fetches once and caches the result", func(t *testing.T) {
 		var h lazyTags
+		var field plugin.TValue[map[string]any]
 		calls := 0
 		fetch := func() (map[string]any, error) {
 			calls++
@@ -204,7 +208,7 @@ func TestLazyTagsResolveTags(t *testing.T) {
 		}
 
 		for i := 0; i < 3; i++ {
-			got, err := h.resolveTags(fetch)
+			got, err := h.resolveTags(&field, fetch)
 			require.NoError(t, err)
 			assert.Equal(t, map[string]any{"env": "prod"}, got)
 		}
@@ -213,6 +217,7 @@ func TestLazyTagsResolveTags(t *testing.T) {
 
 	t.Run("caches an empty tag set so an untagged resource costs one call", func(t *testing.T) {
 		var h lazyTags
+		var field plugin.TValue[map[string]any]
 		calls := 0
 		fetch := func() (map[string]any, error) {
 			calls++
@@ -220,23 +225,68 @@ func TestLazyTagsResolveTags(t *testing.T) {
 		}
 
 		for i := 0; i < 3; i++ {
-			got, err := h.resolveTags(fetch)
+			got, err := h.resolveTags(&field, fetch)
 			require.NoError(t, err)
 			assert.Empty(t, got)
 		}
 		assert.Equal(t, 1, calls)
+		assert.Zero(t, field.State, "an untagged resource is not null")
 	})
 
 	t.Run("normalizes a nil map to empty", func(t *testing.T) {
 		var h lazyTags
-		got, err := h.resolveTags(func() (map[string]any, error) { return nil, nil })
+		var field plugin.TValue[map[string]any]
+		got, err := h.resolveTags(&field, func() (map[string]any, error) { return nil, nil })
 		require.NoError(t, err)
 		require.NotNil(t, got)
 		assert.Empty(t, got)
 	})
 
-	t.Run("does not cache an error", func(t *testing.T) {
+	// An unreadable tag set must surface as null, never as an empty map. An
+	// empty map asserts "this resource has no tags", so a scan role missing the
+	// tag permission would otherwise make every tag-based audit pass vacuously.
+	t.Run("errTagsUnreadable marks the field null instead of empty", func(t *testing.T) {
 		var h lazyTags
+		var field plugin.TValue[map[string]any]
+		got, err := h.resolveTags(&field, func() (map[string]any, error) {
+			return nil, errTagsUnreadable
+		})
+		require.NoError(t, err, "an unreadable tag set is not a query error")
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+
+	t.Run("a wrapped errTagsUnreadable is still recognized", func(t *testing.T) {
+		var h lazyTags
+		var field plugin.TValue[map[string]any]
+		_, err := h.resolveTags(&field, func() (map[string]any, error) {
+			return nil, fmt.Errorf("listing tags: %w", errTagsUnreadable)
+		})
+		require.NoError(t, err)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+
+	t.Run("caches the unreadable result rather than re-asking", func(t *testing.T) {
+		var h lazyTags
+		var field plugin.TValue[map[string]any]
+		calls := 0
+		fetch := func() (map[string]any, error) {
+			calls++
+			return nil, errTagsUnreadable
+		}
+
+		for i := 0; i < 3; i++ {
+			_, err := h.resolveTags(&field, fetch)
+			require.NoError(t, err)
+		}
+		// A missing permission does not change mid-scan, so re-asking would
+		// only spend a denied call per read.
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("does not cache an ordinary error", func(t *testing.T) {
+		var h lazyTags
+		var field plugin.TValue[map[string]any]
 		calls := 0
 		fetch := func() (map[string]any, error) {
 			calls++
@@ -246,19 +296,57 @@ func TestLazyTagsResolveTags(t *testing.T) {
 			return map[string]any{"env": "prod"}, nil
 		}
 
-		_, err := h.resolveTags(fetch)
+		_, err := h.resolveTags(&field, fetch)
 		require.Error(t, err)
 
-		// A throttled or briefly denied call must be retried rather than
-		// remembered as an empty tag set.
-		got, err := h.resolveTags(fetch)
+		// A throttled call must be retried rather than remembered as an empty
+		// tag set.
+		got, err := h.resolveTags(&field, fetch)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]any{"env": "prod"}, got)
 		assert.Equal(t, 2, calls)
 	})
 
+	// The generated accessor reaches tags() through plugin.GetOrCompute, so the
+	// null state resolveTags sets is only useful if GetOrCompute honors a state
+	// the compute function set itself. This pins that interaction: without it
+	// the field would surface as an empty map and the nullness would be lost
+	// between resolveTags and the query result.
+	t.Run("GetOrCompute surfaces the null rather than an empty map", func(t *testing.T) {
+		var h lazyTags
+		var field plugin.TValue[map[string]any]
+
+		got := plugin.GetOrCompute(&field, func() (map[string]any, error) {
+			return h.resolveTags(&field, func() (map[string]any, error) {
+				return nil, errTagsUnreadable
+			})
+		})
+
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, got.State)
+		assert.Nil(t, got.Data)
+		assert.NoError(t, got.Error)
+	})
+
+	// The same path for a resource that really has no tags must NOT be null,
+	// or "no tags" becomes indistinguishable from "tags unreadable".
+	t.Run("GetOrCompute surfaces an untagged resource as an empty map", func(t *testing.T) {
+		var h lazyTags
+		var field plugin.TValue[map[string]any]
+
+		got := plugin.GetOrCompute(&field, func() (map[string]any, error) {
+			return h.resolveTags(&field, func() (map[string]any, error) {
+				return map[string]any{}, nil
+			})
+		})
+
+		assert.Equal(t, plugin.StateIsSet, got.State)
+		assert.NotNil(t, got.Data)
+		assert.Empty(t, got.Data)
+	})
+
 	t.Run("concurrent readers fetch once", func(t *testing.T) {
 		var h lazyTags
+		var field plugin.TValue[map[string]any]
 		var calls atomic.Int64
 		fetch := func() (map[string]any, error) {
 			calls.Add(1)
@@ -271,7 +359,7 @@ func TestLazyTagsResolveTags(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				got, err := h.resolveTags(fetch)
+				got, err := h.resolveTags(&field, fetch)
 				assert.NoError(t, err)
 				assert.Equal(t, map[string]any{"env": "prod"}, got)
 			}()


### PR DESCRIPTION
Adds `tags()` to 26 AWS resources: the first batch of a 148-resource gap.

## Why these were missing

AWS almost never returns tags in a list or describe response. Of 14 SDK response structs sampled across the gap (backup, datasync, fms, personalize, elasticache, route53resolver, eventbridge, glue, neptune, elbv2, organizations, ssm, bedrock), **none** carried an inline `Tags` field, while `ec2.Instance` does. The resources that already expose tags are largely the ones where tags came free; everything left needs its own tag call. That is the whole reason this gap exists, and why the provider already grew `fetchTagsConcurrently` and `batchFetchTags` as workarounds.

## Scope

148 of the 976 resource blocks in `aws.lr` are taggable and lack tags. This PR covers the 26 that policies actually query and where tag-based scoping or exemption matters. Every field is a computed `tags()`, never an eager `tags`, so `aws.rds.parameterGroups { name }` costs nothing.

| Mechanism | Resources | Cost |
|---|---|---|
| Free, tags already in a cached response | `iam.policy` | **0 new calls** |
| elbv2 `DescribeTags` | `elb.targetgroup`, `elb.listener`, `elb.listener.rule`, `elb.truststore` | 1/resource |
| `ListTagsForResource` | `rds` (5), `elasticache` (6), `backup` (4, via `ListTags`), `config` (3), `cloudwatch.metricsalarm`, `ssm.parameter`, `securityhub.hub` | 1/resource |

## Three findings worth review attention

**`aws.iam.group` is not in the batch.** IAM groups are not taggable at all: the SDK has no `TagGroup` or `ListGroupTags` operation. Users, roles, policies, and instance profiles are taggable; groups aren't.

**`iam.Policy` has an inline `Tags []Tag` that `ListPolicies` never populates.** AWS documents that list operations return a subset of attributes and omit tags. Reading tags from the lister would have reported "no tags" for every policy in the account, and an exemption keyed on a tag would have silently matched nothing. Tags instead come from the `GetPolicy` response that `loadPolicy()` already caches for `name`/`description`/`policyId`, so this resource costs no extra call. Confirmed live: a policy with 4 tags returns all 4.

**`backup.ListTags` only accepts `arn:aws:backup` ARNs.** A recovery point of a resource Backup does not fully manage keeps the source service's ARN (`arn:aws:dynamodb`, `arn:aws:ec2`, …), and `ListTags` rejects those. `aws.backup.vaultRecoveryPoint.tags` reports **null** for them rather than an empty map, since `{}` would read as "this recovery point has no tags" when the truth is that Backup cannot see them. `backupManagedArn` is table-tested for exactly this.

Also of note: `ssm.ListTagsForResource` is keyed on a resource **id and type**, not an ARN; for a parameter the id is the parameter name.

## Two things this PR fixes in passing

- **`mqlAwsRdsClusterParameterGroup.parameters` had a value receiver.** Adding `lazyTags` (which contains an `atomic.Bool`) made `go vet` flag it as a lock copy. The copy was already wrong, just undetectable until a no-copy type entered the struct.
- **`rds:ListTagsForResource` briefly vanished from `aws.permissions.json`.** Refactoring `svc := conn.Rds(region)` + `svc.ListTagsForResource(...)` into a chained one-liner dropped it: the permissions extractor matches the two-step form. All six new call sites use the form the extractor recognizes. Worth knowing generally, since a stylistic choice silently changes the IAM manifest customers scope their scan role with.

## Unreadable tags are null, not empty

An empty tag map is an assertion: it says "this resource has no tags". When a tag call is *denied*, that assertion is false and dangerous — a scan role without the tag permission would report every resource as untagged, and an audit that exempts resources by tag, or requires one, would pass vacuously over the whole account. This mirrors the reasoning already written into `fetchTagsConcurrently`.

So tag nullness is decided in exactly one place. Helpers report an unreadable tag set with the `errTagsUnreadable` sentinel; `resolveTags` takes the field pointer and marks it null, which is the only way a computed map field can surface as null, since `GetOrCompute` honors a state the accessor set itself. Unreadable results are cached — a missing permission does not change mid-scan.

This applies uniformly, including `elbv2TagsForArn` and Backup's not-managed-by-Backup case. One consequence: **`aws.rds.proxy.tags` changes behavior**, from `{}` on access-denied to null. It is the one pre-existing accessor that shares the RDS helper, and it is the same correction.

## Tests

`aws_tags_test.go` gains table tests for `backupManagedArn`, the new `elasticacheTagsToMap`/`configTagsToMap` accessors (a swapped Key/Value accessor yields an empty map rather than an error, so the failure is silent), and `lazyTags.resolveTags` covering fetch-once, empty-set caching, nil normalization, sentinel and wrapped-sentinel handling, unreadable-result caching, ordinary-error non-caching, and concurrent readers.

Two of those run **through `plugin.GetOrCompute`** rather than stopping at the `resolveTags` boundary, because that interaction is what the design depends on: they pin that an unreadable set surfaces as null and a genuinely untagged resource surfaces as an empty map. `go test ./...` and `go test -race` pass in `providers/aws/`.

## Live verification

Against a real account:

- **Tag maps matching the AWS CLI exactly:** `iam.policy` (4 tags), `ssm.parameter` (1 tag), `elasticache.subnetGroup` (3 tags)
- **Empty maps the CLI confirms are genuinely untagged:** `cloudwatch.metricsalarm`, `backup.vault`, `rds.parameterGroup`, `rds.clusterParameterGroup`, `rds.optionGroup`, `elasticache.parameterGroup`

The account has no target groups, config rules, Security Hub hub, backup plans, or global clusters, so those paths are unexercised against live AWS. They share the verified `ListTagsForResource` shape, but flagging it rather than implying full coverage.

## Deviation from plan, and follow-ups

**ELB tags are fetched one ARN at a time, not batched.** `DescribeTags` accepts up to 20 ARNs, but a computed field only knows its own ARN; batching would need a deferred per-region registry the listers populate. That is a real ~20x saving for `aws.elb.targetgroups { tags }` on a large account, but it is an optimization, it introduces shared connection state with its own race semantics, and `aws.elb.loadbalancer.tags()` is already single-ARN. Better done as its own change covering all five ELB resources consistently.

Other follow-ups:

- **The remaining 122 taggable resources** across 42 services, led by `bedrock` (18), `sagemaker` (9), `personalize` (8), `route53.resolver` (7), `apprunner` (5), `eventbridge` (5), `organization` (5).
- **`{}` vs null on access-denied, everywhere else.** Every tag accessor in this PR now reports null for an unreadable tag set, but the rest of the provider still returns `{}` when `Is400AccessDeniedError` fires, which publishes "no tags" as fact. `errTagsUnreadable` gives that sweep a mechanism; worth settling provider-wide rather than drifting per-file.
