### PR TITLE
ci: migrate go-test-providers runner to arc-runners

### DIFF
--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -132,7 +132,7 @@ jobs:
   go-test-providers:
     needs: detect-changed-providers
     runs-on:
-      group: Default
+      group: arc-runners
     timeout-minutes: 120
     steps:
       - name: Checkout code


### PR DESCRIPTION
Follow-up to #8716.

The `go-test-providers` job in `.github/workflows/pr-test-lint.yml` was left on `group: Default` while the other jobs in the same file moved to `group: arc-runners`. The workflow-runner audit (which resolves multi-job workflows) flagged it as the last mql workflow still on the old pool.

One-line fix: `group: Default` → `group: arc-runners`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)