### PR TITLE
⚡ Skip heavy arc-runner test jobs on draft PRs

### DIFF
--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -2,7 +2,17 @@ name: Generated Code Test
 
 ## Only trigger tests if source is changing
 on:
+  # Run on PRs so the arc-runner job can be skipped while the PR is a draft
+  # (see the `if` guard below); ready_for_review re-triggers it.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "**.proto"
+      - "**.lr"
+      - "**.go"
+  # Still validate merges to main.
   push:
+    branches: [main]
     paths:
       - "**.proto"
       - "**.lr"
@@ -22,6 +32,7 @@ permissions:
 jobs:
   # Check if there is any dirty change for generated files
   generated-files:
+    if: ${{ !github.event.pull_request.draft }} # skip on draft PRs (runs on ready_for_review / push to main)
     runs-on:
       group: arc-runners
     steps:

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -2,7 +2,21 @@ name: Code Test
 
 ## Only trigger tests if source is changing
 on:
+  # Run on PRs so the expensive arc-runner test jobs can be skipped while the PR
+  # is a draft (see the per-job `if` guards). `ready_for_review` re-triggers them.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "**.go"
+      - "**.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/pr-test-lint.yml"
+      - ".github/workflows/reusable-lint-providers.yml"
+      - "**.toml" # run tests when any recording changed
+  # Still validate merges to main.
   push:
+    branches: [main]
     paths:
       - "**.go"
       - "**.mod"
@@ -34,7 +48,7 @@ jobs:
       - name: Determine changed providers
         id: changed
         env:
-          # Empty on push events (this workflow only triggers on push);
+          # Set on pull_request events; empty on push to main, where
           # scripts/changed-providers.sh falls back to merge-base with origin/main.
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash scripts/changed-providers.sh
@@ -100,6 +114,7 @@ jobs:
   # separate go-test-providers job. This always runs: the core scope can be
   # affected by any change, and go-auto-approve depends on it.
   go-test:
+    if: ${{ !github.event.pull_request.draft }} # skip on draft PRs (runs on ready_for_review / push to main)
     runs-on:
       group: arc-runners
     timeout-minutes: 120
@@ -131,6 +146,7 @@ jobs:
   # changed list is empty (e.g. pushes to main), every provider is tested.
   go-test-providers:
     needs: detect-changed-providers
+    if: ${{ !github.event.pull_request.draft }} # skip on draft PRs (runs on ready_for_review / push to main)
     runs-on:
       group: arc-runners
     timeout-minutes: 120
@@ -188,6 +204,7 @@ jobs:
           path: "report_*.xml"
 
   go-test-integration:
+    if: ${{ !github.event.pull_request.draft }} # skip on draft PRs (runs on ready_for_review / push to main)
     runs-on:
       group: arc-runners
     timeout-minutes: 120
@@ -249,7 +266,9 @@ jobs:
     # github.event.commits[0].author.username (the git commit author) because git commit
     # metadata is user-controlled and can be spoofed by anyone via git config.
     # github.actor is set by GitHub's authentication layer and is tamper-proof.
-    if: ${{ (startsWith(github.ref, 'refs/heads/version/providers_update_') || startsWith(github.ref, 'refs/heads/version/deps_update_')) && github.actor == 'mondoo-tools' }}
+    # This workflow now triggers on pull_request, where github.ref is the merge
+    # ref (refs/pull/N/merge). Match the PR's source branch via github.head_ref.
+    if: ${{ (startsWith(github.head_ref, 'version/providers_update_') || startsWith(github.head_ref, 'version/deps_update_')) && github.actor == 'mondoo-tools' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -266,9 +266,9 @@ jobs:
     # github.event.commits[0].author.username (the git commit author) because git commit
     # metadata is user-controlled and can be spoofed by anyone via git config.
     # github.actor is set by GitHub's authentication layer and is tamper-proof.
-    # This workflow now triggers on pull_request, where github.ref is the merge
-    # ref (refs/pull/N/merge). Match the PR's source branch via github.head_ref.
-    if: ${{ (startsWith(github.head_ref, 'version/providers_update_') || startsWith(github.head_ref, 'version/deps_update_')) && github.actor == 'mondoo-tools' }}
+    # Triggers on both pull_request (github.head_ref = the PR's source branch) and
+    # push to main (github.head_ref is empty there, so fall back to github.ref_name).
+    if: ${{ (startsWith(github.head_ref || github.ref_name, 'version/providers_update_') || startsWith(github.head_ref || github.ref_name, 'version/deps_update_')) && github.actor == 'mondoo-tools' }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## What
Skip the three expensive **arc-runner** test jobs while a PR is a **draft**, and run them when it's marked **Ready for review** (and on pushes to `main`).

The heavy jobs (each 120-min timeout, self-hosted compute):
- `go-test`
- `go-test-providers`
- `go-test-integration`

Everything else stays on GitHub-hosted `ubuntu-latest` and is unaffected.

## How
- `pr-test-lint.yml` + `pr-test-generated-files.yaml`: `push` → **`pull_request`** (`types: [opened, synchronize, reopened, ready_for_review]`) + `push: { branches: [main] }`. The `pull_request` context is what gives us `draft` status.
- Each heavy job gets `if: ${{ !github.event.pull_request.draft }}`.
- `go-auto-approve`: its branch check moves `github.ref` → **`github.head_ref`** (on `pull_request`, `github.ref` is the merge ref, so the old check would never match the mondoo-tools bump branches).

Combined with the existing `cancel-in-progress` concurrency, this cuts wasted arc-runner time during draft iteration and review-bot commit churn.

## ⚠️ Please review carefully
1. **`go-auto-approve` / auto-merge flow** — the `github.head_ref` change is the delicate bit. Worth confirming against a `version/providers_update_*` bump PR before relying on it.
2. **Merge order** — best to land **#9814** first (it moves `go-test-providers` off `Default` onto `arc-runners`); this branch still shows it on `Default`. There may be a trivial adjacent-line conflict to resolve when the second of the two merges.
3. **Self-demo** — this PR is a draft, so the heavy jobs are skipped here. Marking it **Ready for review** will run them (best done after #9814 so `go-test-providers` is on `arc-runners`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)