### PR TITLE
⚡ Cancel heavy CI when the review bot requests changes

### DIFF
--- a/.github/workflows/cancel-heavy-ci-on-changes-requested.yml
+++ b/.github/workflows/cancel-heavy-ci-on-changes-requested.yml
@@ -1,0 +1,44 @@
+name: Cancel heavy CI on changes requested
+
+# When the Mondoo code-review bot requests changes on a PR, cancel the
+# in-progress expensive arc-runner test runs to stop wasting self-hosted
+# compute on code that's already known to need work. The cheap ubuntu-hosted
+# jobs live in the same run, so cancelling the run stops them too -- that's
+# fine, they're fast and free; the next push (or "Ready for review") starts a
+# fresh run.
+#
+# Scoped deliberately to the bot's `changes_requested` so a human reviewer
+# asking for changes does NOT wipe out CI they may still want to see. The bot
+# can produce false positives, so treat this as a cost optimisation, not a gate.
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  actions: write # required to cancel workflow runs
+
+jobs:
+  cancel-heavy-ci:
+    if: >-
+      github.event.review.state == 'changes_requested' &&
+      github.event.review.user.login == 'mondoo-code-review[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel in-progress heavy CI runs for this PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # The PR head commit the review was submitted against; matches the
+          # head_sha of the workflow runs we want to cancel.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Workflows that contain the expensive arc-runner jobs.
+          for wf in pr-test-lint.yml pr-test-generated-files.yaml; do
+            for id in $(gh run list --repo "$REPO" --workflow "$wf" \
+                          --commit "$HEAD_SHA" --status in_progress \
+                          --json databaseId --jq '.[].databaseId'); do
+              echo "Cancelling in-progress run $id ($wf) for $HEAD_SHA"
+              gh run cancel "$id" --repo "$REPO" || true
+            done
+          done


### PR DESCRIPTION
## What
A small `pull_request_review`-triggered workflow that **cancels the in-progress expensive arc-runner test runs** when the **mondoo-code-review** bot submits a `changes_requested` review — so we stop burning self-hosted compute on a PR that's already flagged as needing work.

Answers the recurring "the bot flagged critical but all the other jobs kept running" — GitHub won't link an external check to your Actions runs, so this does it explicitly.

## How it's scoped (deliberately conservative)
- **Only the bot's `changes_requested`** triggers it (`github.event.review.user.login == 'mondoo-code-review[bot]'`). A **human** requesting changes does *not* cancel CI — they may want to see results.
- **Only the heavy-CI workflows** (`pr-test-lint.yml`, `pr-test-generated-files.yaml`) for the reviewed **head SHA** are cancelled.
- Uses the built-in `GITHUB_TOKEN` with `actions: write`.

## Caveats to weigh before merging
1. **GitHub cancels at the *run* level, not the job level** — so the cheap `ubuntu-latest` jobs in those runs get cancelled too. That's fine (they're fast/free), but worth knowing.
2. **The bot has false positives** (see the repo's own review guidance). A wrong "critical" would cancel a good run; you'd re-push to restart. Net-positive on cost only if the bot's critical findings are usually right.
3. A **re-push** or **"Ready for review"** starts a fresh run — nothing is permanently blocked.

## Alternative
If you'd rather this live in the review bot itself (so it also works outside mql), the same effect is the bot calling `POST /actions/runs/{id}/cancel` on a blocking review — but that's a bot-side change. This workflow is the self-serve version.

Draft — for evaluation, not necessarily merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)