### PR TITLE
✨ windows: key the print-driver purl on the hardware ID

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -10694,6 +10694,14 @@ windows.printerDriver @defaults("name version manufacturer") {
   // identify a driver: "PCL 6 Driver" and "PostScript3 Driver" name page
   // description languages that every printer vendor ships a driver for.
   purl string
+  // Identifier the vendor declares in the driver INF
+  //
+  // For example "RICOHPCL6DriveforUP".
+  // Unlike name this does not change between releases: Windows uses it to rank
+  // and upgrade drivers, so a vendor that changed it would break updates for
+  // every existing installation. It is what purl is keyed on. Empty for some
+  // drivers, in which case purl falls back to the name.
+  hardwareId string
   // Vendor driver version in dotted form, for example "3.0.0.0"
   //
   // Windows stores this packed into a single 64-bit integer holding four

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -11136,6 +11136,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.printerDriver.purl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsPrinterDriver).GetPurl()).ToDataRes(types.String)
 	},
+	"windows.printerDriver.hardwareId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsPrinterDriver).GetHardwareId()).ToDataRes(types.String)
+	},
 	"windows.printerDriver.version": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsPrinterDriver).GetVersion()).ToDataRes(types.String)
 	},
@@ -26692,6 +26695,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.printerDriver.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsPrinterDriver).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.printerDriver.hardwareId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsPrinterDriver).HardwareId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"windows.printerDriver.version": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -70579,6 +70586,7 @@ type mqlWindowsPrinterDriver struct {
 	// optional: if you define mqlWindowsPrinterDriverInternal it will be used here
 	Name           plugin.TValue[string]
 	Purl           plugin.TValue[string]
+	HardwareId     plugin.TValue[string]
 	Version        plugin.TValue[string]
 	ModelVersion   plugin.TValue[int64]
 	Manufacturer   plugin.TValue[string]
@@ -70633,6 +70641,10 @@ func (c *mqlWindowsPrinterDriver) GetName() *plugin.TValue[string] {
 
 func (c *mqlWindowsPrinterDriver) GetPurl() *plugin.TValue[string] {
 	return &c.Purl
+}
+
+func (c *mqlWindowsPrinterDriver) GetHardwareId() *plugin.TValue[string] {
+	return &c.HardwareId
 }
 
 func (c *mqlWindowsPrinterDriver) GetVersion() *plugin.TValue[string] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -3789,6 +3789,7 @@ windows.printerDriver.configFile 13.40.6
 windows.printerDriver.dataFile 13.40.6
 windows.printerDriver.driverPath 13.40.6
 windows.printerDriver.environment 13.40.6
+windows.printerDriver.hardwareId 13.40.6
 windows.printerDriver.infPath 13.40.6
 windows.printerDriver.manufacturer 13.40.6
 windows.printerDriver.modelVersion 13.40.6

--- a/providers/os/resources/windows/printerdriver.go
+++ b/providers/os/resources/windows/printerdriver.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -28,7 +29,7 @@ import (
 // object as an object rather than a one-element array, which would otherwise
 // need two parse paths.
 const PrinterDriversScript = `
-@(Get-PrinterDriver -ErrorAction SilentlyContinue | Select-Object -Property Name,PrinterEnvironment,Manufacturer,DriverVersion,MajorVersion,InfPath,ConfigFile,DataFile,DriverPath,PrintProcessor) | ConvertTo-Json -Compress
+@(Get-PrinterDriver -ErrorAction SilentlyContinue | Select-Object -Property Name,PrinterEnvironment,Manufacturer,DriverVersion,MajorVersion,HardwareID,InfPath,ConfigFile,DataFile,DriverPath,PrintProcessor) | ConvertTo-Json -Compress
 `
 
 // PrinterDriver is one driver as the spooler reports it.
@@ -42,7 +43,12 @@ type PrinterDriver struct {
 	DriverVersion uint64 `json:"DriverVersion"`
 	// MajorVersion is the driver MODEL version (2, 3, 4) — the spooler
 	// interface generation, not the vendor's release number.
-	MajorVersion   int64  `json:"MajorVersion"`
+	MajorVersion int64 `json:"MajorVersion"`
+	// HardwareID is the identifier the vendor declares in the driver's INF.
+	// Unlike Name it does not change between releases — Windows uses it to rank
+	// and upgrade drivers, so a vendor that changed it would break updates for
+	// every existing installation. See Purl.
+	HardwareID     string `json:"HardwareID"`
 	InfPath        string `json:"InfPath"`
 	ConfigFile     string `json:"ConfigFile"`
 	DataFile       string `json:"DataFile"`
@@ -163,20 +169,83 @@ func VendorToken(manufacturer string) string {
 	return strings.Trim(token, "-")
 }
 
+// releaseSuffixPattern matches a release number a vendor appends to a driver
+// name: the "V4.34" in "RICOH PCL6 UniversalDriver V4.34".
+//
+// Anchored to the END of the string, which is the whole point. Real driver
+// names carry "V4" in two different roles:
+//
+//	RICOH PCL6 UniversalDriver V4.34    V4.34 is the release      -> strip
+//	RICOH PCL6 V4 UniversalDriver V2.0  V4 is the driver MODEL    -> keep
+//
+// Anchoring separates them without knowing anything about either.
+var releaseSuffixPattern = regexp.MustCompile(`(?i)\s+v?\d+(?:\.\d+)+\s*$`)
+
+// driverNameToken reduces a driver Name to a token that survives an update.
+//
+// Strips a leading vendor word and a trailing release, because a name carrying
+// its own release number changes with every driver update and so cannot be an
+// identity. Used only when HardwareID is unavailable — see Purl.
+func driverNameToken(name, manufacturer string) string {
+	name = releaseSuffixPattern.ReplaceAllString(strings.TrimSpace(name), "")
+
+	// Drop a leading vendor word ("RICOH PCL6 …" -> "PCL6 …") so the token does
+	// not repeat the namespace it already sits in.
+	if vendor := VendorToken(manufacturer); vendor != "" {
+		if fields := strings.Fields(name); len(fields) > 1 && purlToken(fields[0]) == vendor {
+			name = strings.Join(fields[1:], " ")
+		}
+	}
+	return purlToken(name)
+}
+
 // Purl is the package URL identifying this driver, empty when it cannot be
 // identified.
 //
-// Returns nothing rather than a partial identity when the manufacturer or name
-// is missing. A vendor-less driver PURL would match whatever advisory happened
-// to carry the same driver name, and driver names are emphatically not unique
-// across vendors, so guessing here attaches one vendor's vulnerability to
-// another vendor's driver.
+// # The identity is HardwareID, not Name
+//
+// The name the spooler reports carries the driver's own release number, so it
+// changes with every update. The hardware ID does not. Two published Ricoh
+// universal-print-driver packages, 2.3 years and nine minor versions apart,
+// declare the same one:
+//
+//	4.12.0.0 (2016)  "RICOH PCL6 UniversalDriver V4.12"  RICOHPCL6DriveforUP
+//	4.21.0.0 (2019)  "RICOH PCL6 UniversalDriver V4.21"  RICOHPCL6DriveforUP
+//
+// So a PURL keyed on the name identifies a release, while one keyed on the
+// hardware ID identifies the product — which is what anything tracking a
+// driver across upgrades needs.
+//
+// Name is left exactly as the spooler reported it; only the identity is
+// canonicalised.
+//
+// # Fallback
+//
+// A driver with no hardware ID falls back to the name with its vendor prefix
+// and trailing release removed. That is a degraded identity: it is stable
+// across releases but not across a vendor rewording its product.
+//
+// # Why an empty result rather than a partial one
+//
+// Returns nothing when the manufacturer or the token is missing. A vendor-less
+// driver PURL would match whatever advisory happened to carry the same driver
+// name, and driver names are emphatically not unique across vendors — every
+// printer vendor ships something called "PCL 6 Driver" — so guessing here
+// attaches one vendor's vulnerability to another vendor's driver.
 func (d PrinterDriver) Purl() string {
 	vendor := VendorToken(d.Manufacturer)
-	name := purlToken(d.Name)
-	if vendor == "" || name == "" {
+	if vendor == "" {
 		return ""
 	}
+
+	name := purlToken(d.HardwareID)
+	if name == "" {
+		name = driverNameToken(d.Name, d.Manufacturer)
+	}
+	if name == "" {
+		return ""
+	}
+
 	p := "pkg:windows-driver/" + vendor + "/" + name
 	if v := d.DottedVersion(); v != "" {
 		p += "@" + v

--- a/providers/os/resources/windows/printerdriver_test.go
+++ b/providers/os/resources/windows/printerdriver_test.go
@@ -37,15 +37,16 @@ func TestParsePrinterDrivers(t *testing.T) {
 // TestDottedVersionUnpacksTheWindowsEncoding: Windows packs a driver version
 // into one 64-bit integer as four 16-bit fields, most significant first, so the
 // raw value is meaningless on its own. Vendors publish the dotted form.
-func TestDottedVersionUnpacksTheWindowsEncoding(t *testing.T) {
-	// Build the packed value from its four fields rather than writing the
-	// shifts inline: an inline "a<<48 | 0<<32 | c<<16 | 0" reads as documenting
-	// all four positions but the zero terms are no-ops, which staticcheck
-	// rightly flags as a mistake waiting to happen.
-	packed := func(a, b, c, d uint64) uint64 {
-		return a<<48 | b<<32 | c<<16 | d
-	}
+// packed builds Windows' packed 64-bit driver version from its four fields.
+//
+// Written as a helper rather than inline: an inline "a<<48 | 0<<32 | c<<16 | 0"
+// reads as documenting all four positions but the zero terms are no-ops, which
+// staticcheck rightly flags as a mistake waiting to happen.
+func packed(a, b, c, d uint64) uint64 {
+	return a<<48 | b<<32 | c<<16 | d
+}
 
+func TestDottedVersionUnpacksTheWindowsEncoding(t *testing.T) {
 	for _, tc := range []struct {
 		packed uint64
 		want   string
@@ -148,4 +149,101 @@ func TestPurlOnRealVendorDriverNames(t *testing.T) {
 		got := PrinterDriver{Name: name, Manufacturer: "RICOH"}.Purl()
 		assert.Equal(t, want, got, "name %q", name)
 	}
+}
+
+// TestPurlIsKeyedOnTheHardwareID is the property the whole identity rests on:
+// a driver keeps the same PURL across an update.
+//
+// Both rows are real. Two published Ricoh universal-print-driver packages, 2.3
+// years and nine minor versions apart, register a NAME carrying their own
+// release while declaring the SAME hardware ID in their INF:
+//
+//	oemsetup.inf DriverVer 11/07/2016,4.12.0.0 -> "RICOH PCL6 UniversalDriver V4.12"
+//	oemsetup.inf DriverVer 01/28/2019,4.21.0.0 -> "RICOH PCL6 UniversalDriver V4.21"
+//	both: USBPRINT\RICOHPCL6DriveforUP, LPTENUM\RICOHPCL6DriveforUP, RICOHPCL6DriveforUP
+//
+// Keyed on the name these are two different packages; keyed on the hardware ID
+// they are one product at two versions, which is what an upgrade actually is.
+func TestPurlIsKeyedOnTheHardwareID(t *testing.T) {
+	v412 := PrinterDriver{
+		Name:          "RICOH PCL6 UniversalDriver V4.12",
+		Manufacturer:  "RICOH",
+		HardwareID:    "RICOHPCL6DriveforUP",
+		DriverVersion: packed(4, 12, 0, 0),
+	}
+	v421 := PrinterDriver{
+		Name:          "RICOH PCL6 UniversalDriver V4.21",
+		Manufacturer:  "RICOH",
+		HardwareID:    "RICOHPCL6DriveforUP",
+		DriverVersion: packed(4, 21, 0, 0),
+	}
+
+	assert.Equal(t, "pkg:windows-driver/ricoh/ricohpcl6driveforup@4.12.0.0", v412.Purl())
+	assert.Equal(t, "pkg:windows-driver/ricoh/ricohpcl6driveforup@4.21.0.0", v421.Purl())
+
+	// The identity is the same across the upgrade; only the version moves.
+	assert.Equal(t, purlWithoutVersion(v412.Purl()), purlWithoutVersion(v421.Purl()),
+		"an update must not change the driver's identity")
+}
+
+// TestPurlFallsBackToTheNameWithoutAHardwareID. Some drivers report none, and a
+// degraded identity beats no finding — but it must at least survive an update,
+// so the release is stripped from the name.
+func TestPurlFallsBackToTheNameWithoutAHardwareID(t *testing.T) {
+	v412 := PrinterDriver{Name: "RICOH PCL6 UniversalDriver V4.12", Manufacturer: "RICOH", DriverVersion: packed(4, 12, 0, 0)}
+	v421 := PrinterDriver{Name: "RICOH PCL6 UniversalDriver V4.21", Manufacturer: "RICOH", DriverVersion: packed(4, 21, 0, 0)}
+
+	assert.Equal(t, "pkg:windows-driver/ricoh/pcl6-universaldriver@4.12.0.0", v412.Purl())
+	assert.Equal(t, "pkg:windows-driver/ricoh/pcl6-universaldriver@4.21.0.0", v421.Purl())
+	assert.Equal(t, purlWithoutVersion(v412.Purl()), purlWithoutVersion(v421.Purl()))
+}
+
+// TestDriverNameTokenKeepsTheModelVersion is the trap the trailing anchor
+// exists for. Both names contain "V4", in different roles:
+//
+//	RICOH PCL6 UniversalDriver V4.34    V4.34 is the release   -> stripped
+//	RICOH PCL6 V4 UniversalDriver V2.0  V4 is the driver MODEL -> kept
+//
+// Stripping "V4" from the second would merge two different products, which
+// have different advisories and different bounds.
+func TestDriverNameTokenKeepsTheModelVersion(t *testing.T) {
+	assert.Equal(t, "pcl6-universaldriver",
+		driverNameToken("RICOH PCL6 UniversalDriver V4.34", "RICOH"))
+	assert.Equal(t, "pcl6-v4-universaldriver",
+		driverNameToken("RICOH PCL6 V4 UniversalDriver V2.0", "RICOH"))
+	assert.NotEqual(t,
+		driverNameToken("RICOH PCL6 UniversalDriver V4.34", "RICOH"),
+		driverNameToken("RICOH PCL6 V4 UniversalDriver V2.0", "RICOH"))
+
+	// A name with no release suffix is unchanged apart from the vendor prefix.
+	assert.Equal(t, "ps-universaldriver", driverNameToken("RICOH PS UniversalDriver", "RICOH"))
+
+	// The leading word is dropped only when it IS the manufacturer, since the
+	// vendor already forms the PURL namespace and repeating it says nothing.
+	assert.Equal(t, "print-to-pdf", driverNameToken("Microsoft Print To PDF", "Microsoft Corp"))
+	// A different vendor's name in the string is part of the product, not a
+	// prefix: dropping it would merge unrelated drivers under one identity.
+	assert.Equal(t, "hp-laserjet-driver", driverNameToken("HP LaserJet Driver", "RICOH"))
+}
+
+// TestPurlOnCapturedWindowsDrivers uses the four drivers a real Windows 11 host
+// reported, verbatim, including the GUID hardware IDs Microsoft's class drivers
+// declare. A GUID is as stable an identity as a vendor string.
+func TestPurlOnCapturedWindowsDrivers(t *testing.T) {
+	for _, tc := range []struct{ name, hwid, want string }{
+		{"Universal Print Class Driver", "{6d170653-5280-44c2-ba44-2c04bc9d46da}", "pkg:windows-driver/microsoft/6d170653-5280-44c2-ba44-2c04bc9d46da"},
+		{"Microsoft Print To PDF", "{084f01fa-e634-4d77-83ee-074817c03581}", "pkg:windows-driver/microsoft/084f01fa-e634-4d77-83ee-074817c03581"},
+	} {
+		d := PrinterDriver{Name: tc.name, Manufacturer: "Microsoft", HardwareID: tc.hwid}
+		assert.Equal(t, tc.want, d.Purl(), "driver %q", tc.name)
+	}
+}
+
+// purlWithoutVersion drops the @version so two releases can be compared on
+// identity alone.
+func purlWithoutVersion(p string) string {
+	if i := strings.LastIndex(p, "@"); i > 0 {
+		return p[:i]
+	}
+	return p
 }

--- a/providers/os/resources/windows_printerdriver.go
+++ b/providers/os/resources/windows_printerdriver.go
@@ -45,6 +45,7 @@ func (r *mqlWindowsPrinterDrivers) list() ([]any, error) {
 		res, err := CreateResource(r.MqlRuntime, "windows.printerDriver", map[string]*llx.RawData{
 			"name":           llx.StringData(d.Name),
 			"purl":           llx.StringData(d.Purl()),
+			"hardwareId":     llx.StringData(d.HardwareID),
 			"version":        llx.StringData(d.DottedVersion()),
 			"modelVersion":   llx.IntData(d.MajorVersion),
 			"manufacturer":   llx.StringData(d.Manufacturer),


### PR DESCRIPTION
A print driver's purl changed with **every driver update**, because the name the spooler reports carries the driver's own release number. That makes the purl identify a *release* rather than a *product*, so nothing can follow a driver across an upgrade.

`Get-PrinterDriver` also reports `HardwareID` — the identifier the vendor declares in the driver INF. It does not change between releases: Windows uses it to rank and upgrade drivers, so a vendor that changed it would break updates for every existing installation.

## The evidence

Two published Ricoh universal-print-driver packages, 2.3 years and nine minor versions apart:

| `oemsetup.inf` DriverVer | name registered with the spooler | HardwareID |
|---|---|---|
| 2016-11-07, 4.12.0.0 | `RICOH PCL6 UniversalDriver **V4.12**` | `RICOHPCL6DriveforUP` |
| 2019-01-28, 4.21.0.0 | `RICOH PCL6 UniversalDriver **V4.21**` | `RICOHPCL6DriveforUP` |

Keyed on the name those are two unrelated packages. Keyed on the hardware ID they are one product at two versions — which is what an upgrade actually is.

## Verified on a real host

Scanned a Windows 11 Pro machine; every driver reports a hardware ID:

```
Microsoft Print To PDF
  pkg:windows-driver/microsoft/084f01fa-e634-4d77-83ee-074817c03581@10.0.26100.4484
Universal Print Class Driver
  pkg:windows-driver/microsoft/6d170653-5280-44c2-ba44-2c04bc9d46da@10.0.26100.8875
```

Microsoft's class drivers use a GUID rather than a vendor string — just as stable, just as usable as a key.

`name` is left **exactly** as the spooler reported it. Only the identity is canonicalised, so a reader still sees the driver they recognise.

## Fallback, and the trap in it

A driver reporting no hardware ID falls back to its name with the vendor prefix and a **trailing** release token removed. Trailing-only is load-bearing, because real names carry `V4` in two different roles:

```
RICOH PCL6 UniversalDriver V4.34    ->  pcl6-universaldriver      (V4.34 = release)
RICOH PCL6 V4 UniversalDriver V2.0  ->  pcl6-v4-universaldriver   (V4 = driver model)
```

Anchoring the strip to the end separates them without knowing anything about either. Merging those two would join products that ship separate advisories, so the test asserts they stay distinct.

## Note on compatibility

This changes the purl a driver reports. `windows.printerDrivers` is in no released tag yet, so nothing downstream depends on the old form.

## Test plan

```
go test ./providers/os/resources/windows/
go build ./providers/os/...
```

Green, plus the live scan above. Codegen (`lr go` / `lr versions`) was run after the implementation existed, and the `.lr` diff is additions-only (8 insertions, 0 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)