### PR TITLE
🐛 version: cap provider release PR title at GitHub's 256-char limit

### DIFF
--- a/providers-sdk/v1/util/version/version.go
+++ b/providers-sdk/v1/util/version/version.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"go.mondoo.com/mql/v13/utils/stringx"
 
@@ -414,8 +415,17 @@ func (confs updateConfs) titles() []string {
 	return titles
 }
 
+// maxTitleLen is GitHub's maximum length (in characters) for a PR/issue title.
+const maxTitleLen = 256
+
 func (confs updateConfs) commitTitle() string {
-	return "🎉 " + strings.Join(confs.titles(), ", ")
+	title := titlePrefix + strings.Join(confs.titles(), ", ")
+	if utf8.RuneCountInString(title) <= maxTitleLen {
+		return title
+	}
+	// Too many providers to enumerate within GitHub's title limit; fall back to
+	// a count summary. The full per-provider list is in the PR body.
+	return fmt.Sprintf("%sRelease %d providers", titlePrefix, len(confs))
 }
 
 func (confs updateConfs) commitBody() string {

--- a/providers-sdk/v1/util/version/version_test.go
+++ b/providers-sdk/v1/util/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package main

--- a/providers-sdk/v1/util/version/version_test.go
+++ b/providers-sdk/v1/util/version/version_test.go
@@ -1,0 +1,43 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"fmt"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestCommitTitle_ShortListsProviders(t *testing.T) {
+	confs := updateConfs{
+		{name: "aws", version: "13.53.1"},
+		{name: "azure", version: "13.34.1"},
+	}
+	got := confs.commitTitle()
+	want := "🎉 aws-13.53.1, azure-13.34.1"
+	if got != want {
+		t.Fatalf("commitTitle() = %q, want %q", got, want)
+	}
+}
+
+func TestCommitTitle_LongFallsBackToCount(t *testing.T) {
+	// Build enough providers that the enumerated title exceeds GitHub's limit.
+	var confs updateConfs
+	for i := 0; i < 72; i++ {
+		confs = append(confs, &providerConf{
+			name:    fmt.Sprintf("provider%02d", i),
+			version: "13.0.1",
+		})
+	}
+
+	got := confs.commitTitle()
+	if utf8.RuneCountInString(got) > maxTitleLen {
+		t.Fatalf("commitTitle() length = %d chars, exceeds limit of %d: %q",
+			utf8.RuneCountInString(got), maxTitleLen, got)
+	}
+	want := "🎉 Release 72 providers"
+	if got != want {
+		t.Fatalf("commitTitle() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

The provider release workflow (`.github/workflows/release-providers.yml`) builds the PR title by joining **every** bumped provider as `name-version`. A recent release bumped 72 providers, producing a ~2,300-character title. GitHub caps PR/issue titles at 256 characters, so the `Create pull request` step failed:

```
Validation Failed: {"resource":"Issue","code":"custom","field":"title","message":"title is too long (maximum is 256 characters)"}
```

## Fix

`commitTitle()` in `providers-sdk/v1/util/version/version.go` now checks the enumerated title length (using `utf8.RuneCountInString`, since GitHub counts characters not bytes). When it fits within 256 chars it lists providers as before; otherwise it falls back to a `🎉 Release N providers` summary. The full per-provider list is unaffected — it still appears in the PR body via `commitBody()`.

## Tests

Added `version_test.go` covering both paths:
- short list → enumerated title
- 72 providers → `🎉 Release 72 providers`, asserted to stay under the 256-char limit

`go test` and `go vet` pass for the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)