### PR TITLE
✨ aws: expose region on secretsmanager secrets and EMR clusters

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -8569,6 +8569,11 @@ aws.secretsmanager {
 aws.secretsmanager.secret @defaults("arn name") {
   // ARN for the secret
   arn string
+  // Region the secret lives in
+  //
+  // Distinct from `primaryRegion`, which AWS only returns for secrets that are
+  // replicated to other Regions and is empty for every other secret.
+  region string
   // Creation date of the secret
   createdAt time
   // Description of the secret
@@ -9509,6 +9514,8 @@ aws.emr {
 private aws.emr.cluster @defaults("arn") {
   // ARN for the cluster
   arn string
+  // Region the cluster lives in
+  region string
   // Name of the cluster
   name string
   // An approximation of the cost of the cluster, represented in m1.small/hours

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -13688,6 +13688,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.secretsmanager.secret.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetArn()).ToDataRes(types.String)
 	},
+	"aws.secretsmanager.secret.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSecretsmanagerSecret).GetRegion()).ToDataRes(types.String)
+	},
 	"aws.secretsmanager.secret.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSecretsmanagerSecret).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -14659,6 +14662,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.emr.cluster.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetArn()).ToDataRes(types.String)
+	},
+	"aws.emr.cluster.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEmrCluster).GetRegion()).ToDataRes(types.String)
 	},
 	"aws.emr.cluster.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEmrCluster).GetName()).ToDataRes(types.String)
@@ -49712,6 +49718,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSecretsmanagerSecret).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.secretsmanager.secret.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSecretsmanagerSecret).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.secretsmanager.secret.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSecretsmanagerSecret).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -51138,6 +51148,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.emr.cluster.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEmrCluster).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.emr.cluster.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEmrCluster).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.emr.cluster.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -117443,6 +117457,7 @@ type mqlAwsSecretsmanagerSecret struct {
 	__id       string
 	mqlAwsSecretsmanagerSecretInternal
 	Arn                  plugin.TValue[string]
+	Region               plugin.TValue[string]
 	CreatedAt            plugin.TValue[*time.Time]
 	Description          plugin.TValue[string]
 	KmsKey               plugin.TValue[*mqlAwsKmsKey]
@@ -117508,6 +117523,10 @@ func (c *mqlAwsSecretsmanagerSecret) MqlID() string {
 
 func (c *mqlAwsSecretsmanagerSecret) GetArn() *plugin.TValue[string] {
 	return &c.Arn
+}
+
+func (c *mqlAwsSecretsmanagerSecret) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 func (c *mqlAwsSecretsmanagerSecret) GetCreatedAt() *plugin.TValue[*time.Time] {
@@ -121235,6 +121254,7 @@ type mqlAwsEmrCluster struct {
 	__id       string
 	mqlAwsEmrClusterInternal
 	Arn                        plugin.TValue[string]
+	Region                     plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	NormalizedInstanceHours    plugin.TValue[int64]
 	OutpostArn                 plugin.TValue[string]
@@ -121318,6 +121338,10 @@ func (c *mqlAwsEmrCluster) MqlID() string {
 
 func (c *mqlAwsEmrCluster) GetArn() *plugin.TValue[string] {
 	return &c.Arn
+}
+
+func (c *mqlAwsEmrCluster) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 func (c *mqlAwsEmrCluster) GetName() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5102,6 +5102,7 @@ aws.emr.cluster.name 11.15.2
 aws.emr.cluster.normalizedInstanceHours 11.15.2
 aws.emr.cluster.outpostArn 11.15.2
 aws.emr.cluster.placementGroups 13.21.4
+aws.emr.cluster.region 13.53.1
 aws.emr.cluster.releaseLabel 13.21.4
 aws.emr.cluster.repoUpgradeOnBoot 13.21.4
 aws.emr.cluster.scaleDownBehavior 13.21.4
@@ -10037,6 +10038,7 @@ aws.secretsmanager.secret.nextRotationDate 11.15.2
 aws.secretsmanager.secret.owningService 11.15.2
 aws.secretsmanager.secret.policyStatements 13.32.2
 aws.secretsmanager.secret.primaryRegion 11.15.2
+aws.secretsmanager.secret.region 13.53.1
 aws.secretsmanager.secret.replicaRegion 13.6.3
 aws.secretsmanager.secret.replicaRegion.id 13.6.3
 aws.secretsmanager.secret.replicaRegion.kmsKey 13.12.1

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -87,6 +87,7 @@ func (a *mqlAwsEmr) getClusters(conn *connection.AwsConnection) []*jobpool.Job {
 					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.emr.cluster",
 						map[string]*llx.RawData{
 							"arn":                     llx.StringDataPtr(cluster.ClusterArn),
+							"region":                  llx.StringData(region),
 							"name":                    llx.StringDataPtr(cluster.Name),
 							"normalizedInstanceHours": llx.IntDataDefault(cluster.NormalizedInstanceHours, 0),
 							"outpostArn":              llx.StringDataPtr(cluster.OutpostArn),

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -84,6 +84,7 @@ func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.R
 	}
 
 	args["arn"] = llx.StringDataPtr(resp.ARN)
+	args["region"] = llx.StringData(region)
 	args["createdAt"] = llx.TimeDataPtr(resp.CreatedDate)
 	args["description"] = llx.StringDataPtr(resp.Description)
 	args["lastAccessedDate"] = llx.TimeDataPtr(resp.LastAccessedDate)
@@ -225,6 +226,7 @@ func (a *mqlAwsSecretsmanager) getSecrets(conn *connection.AwsConnection) []*job
 				for _, secret := range secrets.SecretList {
 					args := map[string]*llx.RawData{
 						"arn":              llx.StringDataPtr(secret.ARN),
+						"region":           llx.StringData(region),
 						"createdAt":        llx.TimeDataPtr(secret.CreatedDate),
 						"description":      llx.StringDataPtr(secret.Description),
 						"lastAccessedDate": llx.TimeDataPtr(secret.LastAccessedDate),


### PR DESCRIPTION
Adds `region` to `aws.secretsmanager.secret` and `aws.emr.cluster`.

Both resources are regional, but neither exposed the Region it lives in, so anything grouping, filtering, or displaying by Region had nothing to read.

### Why

Found while auditing the AWS asset-overview pages in `mondoohq/server` (mondoohq/server#18492). Every other regional AWS resource renders a **Region** row; Secrets Manager secrets and EMR clusters had to be left blank because the provider exposes no such field.

### The value was already in hand

Neither change fetches anything new — the Region was already computed and simply never assigned:

- `aws.secretsmanager.secret` — `initAwsSecretsmanagerSecret` derives it via `GetRegionFromArn` to pick the right regional client, and `getSecrets` iterates `conn.Regions()`.
- `aws.emr.cluster` — `getClusters` iterates `conn.Regions()`. `initAwsEmrCluster` resolves through that same list, so the one assignment covers both entry points.

### `primaryRegion` is not a substitute

`aws.secretsmanager.secret` already had `primaryRegion`, but AWS returns `PrimaryRegion` from `DescribeSecret`/`ListSecrets` **only for secrets replicated to other Regions** — it is empty for every non-replicated secret, i.e. the common case. The doc comment on the new field calls this out so the two don't get conflated later.

### Verification

```
go build ./...                     # providers/aws, clean
go test ./resources/...
ok  go.mondoo.com/mql/v13/providers/aws/resources          14.066s
ok  go.mondoo.com/mql/v13/providers/aws/resources/awsiam    6.415s
ok  go.mondoo.com/mql/v13/providers/aws/resources/awspolicy  4.012s
```

Generated files (`aws.lr.go`, `aws.lr.versions`) refreshed via `make providers/build/aws`; both new fields are stamped `13.53.1`. `aws.permissions.json` regenerated unchanged — no new IAM permission is required.

### Follow-up

Once this ships and the server picks up the new provider version, the asset overview can add the Region row to the secretsmanager-secret and emr-cluster groups. Other gaps found in the same audit are **not** fixable and are deliberately not attempted here: IAM groups cannot be tagged in AWS at all, ECS containers have no tags of their own (they belong to the task), and Security Groups / SNS topics / Lambda / CloudTrail expose no creation timestamp via any API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
