### PR TITLE
🐛 aws: report an unreadable alarm tag set as null, not as untagged

### DIFF
--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -970,7 +970,7 @@ func (a *mqlAwsCloudwatchMetricsalarm) tags() (map[string]any, error) {
 		})
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return nil, nil
+				return nil, errTagsUnreadable
 			}
 			return nil, err
 		}


### PR DESCRIPTION
## What

`aws.cloudwatch.metricsalarm.tags` returns `nil, nil` when
`ListTagsForResource` is denied. `resolveTags` reads that as a successful
fetch of no tags, normalizes it to an empty map and caches it — so the alarm
reports itself as carrying **no tags** when the tags were simply never read.

That is exactly what `errTagsUnreadable` exists for, and the other 25
accessors added in #9813 already use it. This makes the alarm accessor match
them.

## Why it matters

An empty tag map is an assertion. A scan role without
`cloudwatch:ListTagsForResource` reports every alarm in the account as
untagged, so an audit that exempts resources by tag — or requires one —
passes vacuously over all of them. `null` cannot prove a match, which is the
point.

## Verification

Found and confirmed during a live provider-verification run against a real
account, using an IAM role denied `cloudwatch:ListTagsForResource` and
`rds:ListTagsForResource`, with `aws.rds.parameterGroup` as the control.

| | before | after |
|---|---|---|
| alarm carrying 6 tags, tag read **denied** | `tags: {}` | `tags: null` |
| rds parameter group, tag read **denied** (control) | `tags: null` | `tags: null` |
| alarm carrying 6 tags, permission **granted** | 6 tags | 6 tags |
| genuinely untagged alarm, permission **granted** | `tags: {}` | `tags: {}` |

The same run verified all 26 accessors from #9813 against live
infrastructure; this was the only one that deviated.

## Tests

No new unit test: the change swaps one sentinel to restore the contract that
`TestLazyTagsResolveTags` already pins (`errTagsUnreadable` → field null).
Exercising the denied branch itself would need an AWS client stub, which the
provider's test suite has no harness for; it is covered by the live
verification above instead.
