### PR TITLE
🐛 aws: report an unreadable tag set as null across the provider

### DIFF
--- a/providers/aws/resources/aws_apprunner.go
+++ b/providers/aws/resources/aws_apprunner.go
@@ -376,7 +376,7 @@ func (a *mqlAwsApprunnerService) tags() (map[string]any, error) {
 	resp, err := svc.ListTagsForResource(ctx, &apprunner.ListTagsForResourceInput{ResourceArn: aws.String(a.Arn.Data)})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -311,7 +311,7 @@ func (a *mqlAwsCloudfrontDistribution) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (a *mqlAwsCloudfrontFunction) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -407,7 +407,7 @@ func (a *mqlAwsCloudtrailTrail) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -961,7 +961,7 @@ func (a *mqlAwsCloudtrailEventDataStore) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -1154,7 +1154,7 @@ func (a *mqlAwsCloudtrailChannel) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -772,7 +772,7 @@ func (a *mqlAwsEcrRepository) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -203,7 +203,7 @@ func (a *mqlAwsElasticacheCluster) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_elasticbeanstalk.go
+++ b/providers/aws/resources/aws_elasticbeanstalk.go
@@ -114,7 +114,7 @@ func (a *mqlAwsElasticbeanstalkApplication) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (a *mqlAwsElasticbeanstalkEnvironment) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -425,7 +425,7 @@ func (a *mqlAwsElasticbeanstalkApplicationVersion) tags() (map[string]any, error
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_eventbridge.go
+++ b/providers/aws/resources/aws_eventbridge.go
@@ -146,7 +146,7 @@ func (a *mqlAwsEventbridgeEventBus) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (a *mqlAwsEventbridgeRule) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_globalaccelerator.go
+++ b/providers/aws/resources/aws_globalaccelerator.go
@@ -95,7 +95,7 @@ func (a *mqlAwsGlobalacceleratorAccelerator) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_glue.go
+++ b/providers/aws/resources/aws_glue.go
@@ -239,7 +239,7 @@ func (a *mqlAwsGlueCrawler) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (a *mqlAwsGlueJob) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -968,7 +968,7 @@ func (a *mqlAwsGlueWorkflow) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -1187,7 +1187,7 @@ func (a *mqlAwsGlueTrigger) tags() (map[string]any, error) {
 	resp, err := svc.GetTags(ctx, &glue.GetTagsInput{ResourceArn: &arn})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -1289,7 +1289,7 @@ func (a *mqlAwsGlueSchemaRegistry) tags() (map[string]any, error) {
 	resp, err := svc.GetTags(ctx, &glue.GetTagsInput{ResourceArn: &arn})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -1458,7 +1458,7 @@ func (a *mqlAwsGlueSchema) tags() (map[string]any, error) {
 	resp, err := svc.GetTags(ctx, &glue.GetTagsInput{ResourceArn: &arn})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -365,7 +365,7 @@ func (a *mqlAwsIamUser) tags() (map[string]any, error) {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return map[string]any{}, nil
+				return markTagsUnreadable(&a.Tags)
 			}
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func (a *mqlAwsIamRole) tags() (map[string]any, error) {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return map[string]any{}, nil
+				return markTagsUnreadable(&a.Tags)
 			}
 			return nil, err
 		}
@@ -407,7 +407,7 @@ func (a *mqlAwsIamInstanceProfile) tags() (map[string]any, error) {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return map[string]any{}, nil
+				return markTagsUnreadable(&a.Tags)
 			}
 			return nil, err
 		}

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -492,7 +492,7 @@ func (a *mqlAwsKmsKey) tags() (map[string]any, error) {
 			// AWS-managed keys reject ListResourceTags with AccessDenied;
 			// treat that as no tags rather than failing managedBy/tags.
 			if Is400AccessDeniedError(err) {
-				return nil, nil
+				return markTagsUnreadable(&a.Tags)
 			}
 			return nil, err
 		}

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -163,7 +163,7 @@ func (a *mqlAwsNeptuneCluster) tags() (map[string]any, error) {
 	resp, err := svc.ListTagsForResource(ctx, &neptune.ListTagsForResourceInput{ResourceName: &arnVal})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -486,7 +486,7 @@ func (a *mqlAwsSqsQueue) tags() (map[string]any, error) {
 	resp, err := svc.ListQueueTags(ctx, &sqs.ListQueueTagsInput{QueueUrl: aws.String(a.Url.Data)})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_ssm_documents.go
+++ b/providers/aws/resources/aws_ssm_documents.go
@@ -453,7 +453,7 @@ func (a *mqlAwsSsmPatchBaseline) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -563,7 +563,7 @@ func (a *mqlAwsSsmMaintenanceWindow) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_tags.go
+++ b/providers/aws/resources/aws_tags.go
@@ -66,6 +66,30 @@ type lazyTags struct {
 // so we do not claim one. This mirrors the reasoning in fetchTagsConcurrently.
 var errTagsUnreadable = errors.New("tags could not be read")
 
+// markTagsUnreadable marks a computed tags field null and reports no tags, for
+// an accessor that reads its tags directly rather than caching them through
+// lazyTags.
+//
+// Setting the state is the one way to make a computed map field surface as
+// null: returning a nil map on its own is indistinguishable from a resource
+// that carries no tags, because the runtime normalizes it to an empty map.
+// GetOrCompute honors a state the accessor set itself.
+func markTagsUnreadable(field *plugin.TValue[map[string]any]) (map[string]any, error) {
+	field.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}
+
+// tagsOrUnreadable adapts a shared tag helper that reports an unreadable tag
+// set as errTagsUnreadable to an accessor that must express it as a null field.
+// The helper cannot mark the field itself: it serves several resources and does
+// not know which one it is answering for.
+func tagsOrUnreadable(field *plugin.TValue[map[string]any], tags map[string]any, err error) (map[string]any, error) {
+	if errors.Is(err, errTagsUnreadable) {
+		return markTagsUnreadable(field)
+	}
+	return tags, err
+}
+
 // resolveTags runs fetch once and caches the result, and is the only place tag
 // nullness is decided.
 //

--- a/providers/aws/resources/aws_tags_test.go
+++ b/providers/aws/resources/aws_tags_test.go
@@ -385,3 +385,96 @@ func TestTagsToStringMap(t *testing.T) {
 		assert.Equal(t, map[string]string{"a": "1", "b": ""}, got)
 	})
 }
+
+// markTagsUnreadable is what an accessor that reads its tags directly, rather
+// than caching them through lazyTags, uses to express "the tags could not be
+// read". The assertions that matter are about nullness: an empty map claims
+// the resource carries no tags, and a tag-based audit run by a role missing
+// the tag permission would pass vacuously over every such resource.
+func TestMarkTagsUnreadable(t *testing.T) {
+	t.Run("marks the field null and reports no tags", func(t *testing.T) {
+		var field plugin.TValue[map[string]any]
+
+		got, err := markTagsUnreadable(&field)
+
+		require.NoError(t, err, "an unreadable tag set is not a query error")
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+
+	// The state has to survive GetOrCompute, not merely be set on the field:
+	// GetOrCompute only honors a proactively set state, and would otherwise
+	// store the returned nil map as the field's value.
+	t.Run("surfaces as null through GetOrCompute, not as an empty map", func(t *testing.T) {
+		var field plugin.TValue[map[string]any]
+
+		res := plugin.GetOrCompute(&field, func() (map[string]any, error) {
+			return markTagsUnreadable(&field)
+		})
+
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, res.State)
+		assert.Nil(t, res.Data)
+		assert.NotEqual(t, map[string]any{}, res.Data, "null must not degrade to an empty map")
+	})
+
+	// The contrast case: a resource that genuinely carries no tags is not null.
+	t.Run("an untagged resource stays empty rather than null", func(t *testing.T) {
+		var field plugin.TValue[map[string]any]
+
+		res := plugin.GetOrCompute(&field, func() (map[string]any, error) {
+			return map[string]any{}, nil
+		})
+
+		assert.NotEqual(t, plugin.StateIsSet|plugin.StateIsNull, res.State)
+		assert.Empty(t, res.Data)
+		assert.NotNil(t, res.Data)
+	})
+}
+
+// tagsOrUnreadable adapts the shared per-service tag helpers, which report an
+// unreadable tag set as errTagsUnreadable because they serve several resources
+// and cannot know which field to mark.
+func TestTagsOrUnreadable(t *testing.T) {
+	t.Run("passes a real tag set through untouched", func(t *testing.T) {
+		var field plugin.TValue[map[string]any]
+		tags := map[string]any{"env": "prod"}
+
+		got, err := tagsOrUnreadable(&field, tags, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, tags, got)
+		assert.Zero(t, field.State, "a readable tag set is not null")
+	})
+
+	t.Run("turns errTagsUnreadable into a null field", func(t *testing.T) {
+		var field plugin.TValue[map[string]any]
+
+		got, err := tagsOrUnreadable(&field, nil, errTagsUnreadable)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+
+	t.Run("recognizes a wrapped errTagsUnreadable", func(t *testing.T) {
+		var field plugin.TValue[map[string]any]
+
+		_, err := tagsOrUnreadable(&field, nil, fmt.Errorf("listing tags: %w", errTagsUnreadable))
+
+		require.NoError(t, err)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+
+	// A throttle or a network failure is a real error. Reporting it as "no
+	// tags readable" would hide a transient fault behind a permanent-looking
+	// null, so it propagates instead.
+	t.Run("propagates an ordinary error and leaves the field alone", func(t *testing.T) {
+		var field plugin.TValue[map[string]any]
+		boom := errors.New("throttled")
+
+		_, err := tagsOrUnreadable(&field, nil, boom)
+
+		assert.ErrorIs(t, err, boom)
+		assert.Zero(t, field.State)
+	})
+}

--- a/providers/aws/resources/aws_timestream.go
+++ b/providers/aws/resources/aws_timestream.go
@@ -121,7 +121,7 @@ func (a *mqlAwsTimestreamLiveanalyticsDatabase) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}

--- a/providers/aws/resources/aws_vpclattice.go
+++ b/providers/aws/resources/aws_vpclattice.go
@@ -197,16 +197,20 @@ func vpcLatticeAuthPolicy(svc *vpclattice.Client, resourceArn string) (string, e
 
 func (a *mqlAwsVpclatticeServiceNetwork) tags() (map[string]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	return vpcLatticeTags(conn.VpcLattice(a.Region.Data), a.Arn.Data)
+	tags, err := vpcLatticeTags(conn.VpcLattice(a.Region.Data), a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
+// vpcLatticeTags lists the tags on a VPC Lattice resource. A denied call is
+// reported as errTagsUnreadable, which each caller turns into a null tags field
+// rather than an empty one.
 func vpcLatticeTags(svc *vpclattice.Client, resourceArn string) (map[string]any, error) {
 	resp, err := svc.ListTagsForResource(context.Background(), &vpclattice.ListTagsForResourceInput{
 		ResourceArn: &resourceArn,
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return map[string]any{}, nil
+			return nil, errTagsUnreadable
 		}
 		return nil, err
 	}
@@ -428,7 +432,8 @@ func (a *mqlAwsVpclatticeService) hasWildcardAuthPolicy() (bool, error) {
 
 func (a *mqlAwsVpclatticeService) tags() (map[string]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	return vpcLatticeTags(conn.VpcLattice(a.Region.Data), a.Arn.Data)
+	tags, err := vpcLatticeTags(conn.VpcLattice(a.Region.Data), a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsVpclatticeService) listeners() ([]any, error) {
@@ -541,7 +546,8 @@ type mqlAwsVpclatticeTargetGroupInternal struct {
 
 func (a *mqlAwsVpclatticeTargetGroup) tags() (map[string]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	return vpcLatticeTags(conn.VpcLattice(a.Region.Data), a.Arn.Data)
+	tags, err := vpcLatticeTags(conn.VpcLattice(a.Region.Data), a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 // mqlAwsVpclatticeListenerInternal carries the region of the service the
@@ -553,7 +559,8 @@ type mqlAwsVpclatticeListenerInternal struct {
 
 func (a *mqlAwsVpclatticeListener) tags() (map[string]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	return vpcLatticeTags(conn.VpcLattice(a.region), a.Arn.Data)
+	tags, err := vpcLatticeTags(conn.VpcLattice(a.region), a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 // services resolves the services routing traffic to this target group. A target

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -38,8 +38,9 @@ func (a *mqlAwsWaf) id() (string, error) {
 }
 
 // wafTagsForArn lists the tags on a WAF resource, resolving the WAF endpoint
-// from the resource's scope. Returns nil on access-denied so a missing
-// wafv2:ListTagsForResource permission degrades gracefully.
+// from the resource's scope. A missing wafv2:ListTagsForResource permission is
+// reported as errTagsUnreadable, which each caller turns into a null tags
+// field rather than an empty one.
 func wafTagsForArn(runtime *plugin.Runtime, scope, arn string) (map[string]any, error) {
 	conn := runtime.Connection.(*connection.AwsConnection)
 	svc := conn.Wafv2(wafRegionForScope(scope))
@@ -54,7 +55,7 @@ func wafTagsForArn(runtime *plugin.Runtime, scope, arn string) (map[string]any, 
 		})
 		if err != nil {
 			if Is400AccessDeniedError(err) {
-				return nil, nil
+				return nil, errTagsUnreadable
 			}
 			return nil, err
 		}
@@ -78,19 +79,23 @@ func wafTagsForArn(runtime *plugin.Runtime, scope, arn string) (map[string]any, 
 }
 
 func (a *mqlAwsWafAcl) tags() (map[string]any, error) {
-	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsWafRulegroup) tags() (map[string]any, error) {
-	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsWafIpset) tags() (map[string]any, error) {
-	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsWafRegexPatternSet) tags() (map[string]any, error) {
-	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsWafAcl) id() (string, error) {

--- a/providers/aws/resources/aws_workspaces.go
+++ b/providers/aws/resources/aws_workspaces.go
@@ -225,7 +225,7 @@ func (a *mqlAwsWorkspacesDirectory) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (a *mqlAwsWorkspacesWorkspace) tags() (map[string]any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return nil, nil
+			return markTagsUnreadable(&a.Tags)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
## What

33 tag accessors across the AWS provider treated a denied
`ListTagsForResource` as a successful read of *no tags*, returning an empty
map. This applies the rule #9813 established, and #9825 completed for that
change, to the rest of the provider.

Services touched: apprunner, cloudfront, cloudtrail, ecr, elasticache,
elasticbeanstalk, eventbridge, globalaccelerator, glue, iam, kms, neptune,
sqs, ssm, timestream, vpclattice, waf, workspaces.

## Why it matters

An empty tag map is an assertion — it says the resource carries no tags. A
scan role without the tag permission reported every affected resource as
untagged, so an audit that exempts resources by tag, or requires one, passed
vacuously over the whole account.

This is not hypothetical even for a fully-permissioned role: **AWS itself
denies `kms:ListResourceTags` on AWS-managed KMS keys**, so every such key in
every account was reporting "no tags" as fact.

## How

These accessors read their tags directly rather than caching through
`lazyTags`, so returning `errTagsUnreadable` would surface as a query error
instead of a null field. Two small helpers in `aws_tags.go`:

- `markTagsUnreadable(field)` — sets `StateIsSet|StateIsNull` the way
  `resolveTags` does. Setting the state is the only way a computed map field
  surfaces as null; a bare nil map is normalized to `{}`.
- `tagsOrUnreadable(field, tags, err)` — adapts the two shared helpers
  (`wafTagsForArn`, `vpcLatticeTags`) that serve several resources each and
  cannot know which field to mark. Mirrors the existing
  `mqlAwsRdsProxy.tags()` pattern.

## Behavior change

For a scan role lacking tag permissions these fields now read `null` instead
of `{}`. That is the intent: a null cannot prove a tag match, so an audit
fails loudly rather than passing on data that was never read. Resources with
readable tags are unaffected.

## Verification

Live, against a real account, comparing full credentials against a role that
denies each resource's tag action:

| resource | permitted | denied |
|---|---|---|
| `iam.instanceProfile` | 6 `{}` | **6 null** |
| `iam.user` | 13 tagged, 9 `{}` | **22 null** |
| `iam.role` | 19 tagged, 98 `{}` | **117 null** |
| `kms.key` | 1 tagged, 17 `{}`, 1 null | **19 null** |
| `eventbridge.eventBus` | 1 `{}` | **1 null** |
| `waf.acl` (via `tagsOrUnreadable`) | 1 `{}` | **1 null** |

Tagged resources still return their tags, and the `{}` results were confirmed
genuinely untagged against the AWS API rather than assumed. The one `null`
under full credentials is the AWS-managed KMS key described above.

`cloudtrail.trail` was not exercised — the account's only trail is homed in
another region — and the remaining services had no resources to test against;
those sites are the same one-line mechanical change as the verified ones.

## Tests

7 new cases in `aws_tags_test.go` covering both helpers, including one that
asserts the null survives `plugin.GetOrCompute` rather than degrading to an
empty map, and its contrast case (a genuinely untagged resource stays `{}`).
Full `go test ./...` in `providers/aws` passes.

No schema change, so no `.lr`, `.lr.versions` or `permissions.json` churn.
