### PR TITLE
🐛 goreleaser: disable buildx provenance/sbom so docker manifest create succeeds

### DIFF
--- a/.github/.goreleaser-edge.yml
+++ b/.github/.goreleaser-edge.yml
@@ -50,6 +50,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -64,6 +66,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -78,6 +82,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -91,6 +97,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -105,6 +113,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -119,6 +129,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -135,6 +147,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -149,6 +163,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -162,6 +178,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -175,6 +193,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -189,6 +209,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -203,6 +225,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:edge-latest-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/.github/.goreleaser-unstable.yml
+++ b/.github/.goreleaser-unstable.yml
@@ -114,6 +114,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -128,6 +130,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -142,6 +146,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -155,6 +161,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -169,6 +177,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -183,6 +193,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -199,6 +211,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -213,6 +227,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -227,6 +243,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -240,6 +258,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -254,6 +274,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -268,6 +290,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:{{ .Major }}-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -114,6 +114,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -129,6 +131,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -144,6 +148,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -158,6 +164,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -173,6 +181,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv6"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -188,6 +198,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv7"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -205,6 +217,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -220,6 +234,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-ubi-arm64-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -235,6 +251,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-amd64-rootless"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -249,6 +267,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-arm64v8-rootless"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -264,6 +284,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv6-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v6"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -279,6 +301,8 @@ dockers: # https://goreleaser.com/customization/docker/
       - "mondoo/{{ .ProjectName }}:latest-armv7-rootless"
     build_flag_templates:
       - "--platform=linux/arm/v7"
+      - "--provenance=false"
+      - "--sbom=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"


### PR DESCRIPTION
## Problem

The release job fails during the `docker manifests` phase:

```
docker manifests: failed to publish artifacts: failed to create mondoo/mql:13.33.2-ubi:
exit status 1: docker.io/mondoo/mql:13.33.2-ubi-amd64@sha256:aa14... is a manifest list
```

All individual images push fine; the failure is in the subsequent `docker manifest create` step, aborting at the first manifest in the list (the UBI one).

## Root cause

Docker Buildx ≥ 0.10 (Docker 23+) attaches a **provenance attestation by default** on `buildx build --push`. Because an attestation can't live in a plain image manifest, buildx wraps even a **single-platform** build into an OCI image index (a manifest list) containing the image + attestation manifests.

goreleaser assembles multi-arch tags with `docker manifest create`, which refuses to nest a manifest list inside another manifest list — hence `... is a manifest list`. It looks UBI-specific only because UBI is the first entry in `docker_manifests` and the step aborts there; the standard tags would fail identically.

## Fix

Add `--provenance=false` and `--sbom=false` to the `build_flag_templates` of **every** buildx docker build, so buildx pushes plain single-arch manifests that `docker manifest create` can consume. Applied across all three goreleaser configs (release, unstable, edge) since they share the same buildx + `docker_manifests` pattern.

Trade-off: the published images no longer carry provenance/SBOM attestations. Restoring them later would mean switching to a single multi-platform `buildx build --platform ...,... --push` (which builds the index itself, no `docker manifest create`) — a larger restructure left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)