### PR TITLE
⭐ alicloud: resolve resourceGroupId to a typed resource group on 27 resources

### DIFF
--- a/providers/alicloud/resources/alicloud.lr
+++ b/providers/alicloud/resources/alicloud.lr
@@ -463,6 +463,8 @@ alicloud.ecs.instance @defaults("instanceId instanceName status instanceType") {
   localStorageCapacity int
   // Resource group ID the instance belongs to
   resourceGroupId string
+  // Resource group that contains the instance
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Network type of the instance
   //
   // One of classic or vpc.
@@ -664,6 +666,8 @@ alicloud.ecs.keypair @defaults("keyPairName") {
   creationTime time
   // Resource group ID the key pair belongs to
   resourceGroupId string
+  // Resource group that contains the key pair
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Region ID of the key pair
   regionId string
   // Tags on the key pair, as key-value pairs
@@ -694,6 +698,8 @@ alicloud.ecs.securitygroup @defaults("securityGroupId securityGroupName security
   regionId string
   // Resource group ID the security group belongs to
   resourceGroupId string
+  // Resource group that contains the security group
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Tags on the security group, as key-value pairs
   tags map[string]string
   // Inbound and outbound rules of the security group
@@ -837,6 +843,8 @@ alicloud.ess.scalingGroup @defaults("name scalingGroupId lifecycleState totalCap
   maxInstanceLifetime int
   // ID of the resource group the scaling group belongs to
   resourceGroupId string
+  // Resource group that contains the scaling group
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // ID of the launch template the group creates instances from
   //
   // Empty on a group that launches from a scaling configuration instead. When
@@ -1072,6 +1080,8 @@ alicloud.vpc.network {
   creationTime time
   // Resource group ID the VPC belongs to
   resourceGroupId string
+  // Resource group that contains the VPC
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // User CIDR blocks associated with the VPC
   userCidrs []string
   // vSwitches in the VPC
@@ -1153,6 +1163,8 @@ alicloud.vpc.vswitch {
   networkAcl() alicloud.vpc.networkAcl
   // Resource group ID the vSwitch belongs to
   resourceGroupId string
+  // Resource group that contains the vSwitch
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // vSwitch sharing status
   //
   // Empty for a regular vSwitch, Shared once the vSwitch is shared, or Sharing
@@ -1190,6 +1202,8 @@ alicloud.vpc.routeTable {
   creationTime time
   // Resource group ID the route table belongs to
   resourceGroupId string
+  // Resource group that contains the route table
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // vSwitches associated with the route table
   vswitches() []alicloud.vpc.vswitch
   // Gateway IDs associated with the route table
@@ -1287,6 +1301,8 @@ alicloud.vpc.natGateway {
   regionId string
   // Resource group ID the NAT gateway belongs to
   resourceGroupId string
+  // Resource group that contains the NAT gateway
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // SNAT table IDs of the NAT gateway
   snatTableIds []string
   // DNAT (forward) table IDs of the NAT gateway
@@ -1375,6 +1391,8 @@ alicloud.vpc.eipAddress {
   regionId string
   // Resource group ID the EIP belongs to
   resourceGroupId string
+  // Resource group that contains the elastic IP address
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // VPC the EIP is associated with
   vpc() alicloud.vpc.network
   // Zone the EIP belongs to
@@ -1492,6 +1510,8 @@ alicloud.oss.bucket {
   extranetEndpoint string
   // ID of the resource group the bucket belongs to
   resourceGroupId string
+  // Resource group that contains the bucket
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Access control list grant
   //
   // The canned ACL applied to the bucket. One of private, public-read, or
@@ -1661,6 +1681,8 @@ alicloud.slb.loadBalancer {
   modificationProtectionReason string
   // ID of the resource group that the CLB instance belongs to
   resourceGroupId string
+  // Resource group that contains the load balancer
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Tags attached to the CLB instance, as key-value pairs
   tags map[string]string
   // Listeners configured on the CLB instance
@@ -1839,6 +1861,8 @@ alicloud.rds.instance {
   masterInstance() alicloud.rds.instance
   // ID of the resource group the instance belongs to
   resourceGroupId string
+  // Resource group that contains the instance
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Storage capacity of the instance in GB
   dbInstanceStorage() int
   // Port on which the instance listens for connections
@@ -1961,6 +1985,8 @@ alicloud.redis.instance {
   editionType string
   // ID of the resource group the instance belongs to
   resourceGroupId string
+  // Resource group that contains the instance
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Time the instance was created
   createTime time
   // Time the subscription instance expires
@@ -2086,6 +2112,8 @@ alicloud.mongodb.instance {
   lockMode string
   // ID of the resource group the instance belongs to
   resourceGroupId string
+  // Resource group that contains the instance
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Tags attached to the instance, keyed by tag key
   tags map[string]string
   // VPC hosting the instance
@@ -2241,6 +2269,8 @@ alicloud.polardb.cluster {
   deletionLock int
   // ID of the resource group the cluster belongs to
   resourceGroupId string
+  // Resource group that contains the cluster
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Serverless cluster type, for example AgileServerless or SteadyServerless (empty for non-serverless clusters)
   serverlessType string
   // Network type
@@ -2343,6 +2373,8 @@ alicloud.vpc.flowLog {
   logStoreName string
   // ID of the resource group the flow log belongs to
   resourceGroupId string
+  // Resource group that contains the flow log
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Time the flow log was created
   creationTime time
   // Delivery state of the records to Log Service
@@ -2620,6 +2652,8 @@ alicloud.log.project {
   owner string
   // ID of the resource group the project belongs to
   resourceGroupId string
+  // Resource group that contains the project
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Data-redundancy type of the project storage, for example LRS or ZRS
   dataRedundancyType string
   // Whether the recycle bin is enabled for the project
@@ -2810,6 +2844,8 @@ alicloud.resourceManager {
   folders() []alicloud.resourceManager.folder
   // Control policies in the resource directory, both system and custom
   controlPolicies() []alicloud.resourceManager.controlPolicy
+  // Resource groups in the account
+  resourceGroups() []alicloud.resourceManager.resourceGroup
 }
 
 // Resource Directory account
@@ -2859,6 +2895,36 @@ alicloud.resourceManager.folder {
   parentFolderId string
   // Time the folder was created
   createTime time
+}
+
+// Resource group
+//
+// A single resource group in an Alibaba Cloud account, keyed by
+// resourceGroupId, for example
+// `alicloud.resourceManager.resourceGroups.where(name == "production")`. A
+// resource group is the ownership and billing boundary that most Alibaba Cloud
+// resources are placed into, and RAM policies are commonly scoped to one.
+// Exposes the group identifier, its display name, lifecycle status, owning
+// account, and tags. Resources across the provider reach their group through a
+// resourceGroup field, so an audit can select or exclude an environment by
+// group rather than by an opaque identifier.
+alicloud.resourceManager.resourceGroup @defaults("resourceGroupId name displayName status") {
+  // Resource group ID, used as the lookup key
+  resourceGroupId string
+  // Unique identifier of the resource group within the account
+  name string
+  // Display name of the resource group
+  displayName string
+  // ID of the account that owns the resource group
+  accountId string
+  // Lifecycle status
+  //
+  // One of Creating, OK, PendingDelete, or Deleting.
+  status string
+  // Time the resource group was created
+  createDate time
+  // Tags applied to the resource group
+  tags map[string]string
 }
 
 // Resource Directory control policy
@@ -2964,6 +3030,8 @@ alicloud.cs.cluster {
   size int
   // ID of the resource group the cluster belongs to
   resourceGroupId string
+  // Resource group that contains the cluster
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Zone ID the cluster's managed resources reside in
   zoneId string
   // Time zone configured for the cluster
@@ -3052,6 +3120,8 @@ alicloud.cs.nodePool {
   type string
   // ID of the resource group the node pool belongs to
   resourceGroupId string
+  // Resource group that contains the node pool
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Whether this is the cluster's default node pool
   isDefault bool
   // Time the node pool was created
@@ -3206,6 +3276,8 @@ alicloud.alb.loadBalancer {
   bandwidthPackageId string
   // ID of the resource group the load balancer belongs to
   resourceGroupId string
+  // Resource group that contains the load balancer
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Time the load balancer was created
   createTime time
   // Whether deletion protection is enabled
@@ -3307,6 +3379,8 @@ alicloud.alb.serverGroup {
   serverCount int
   // ID of the resource group the server group belongs to
   resourceGroupId string
+  // Resource group that contains the server group
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Time the server group was created
   createTime time
   // Whether cross-zone load balancing is enabled
@@ -3375,6 +3449,8 @@ alicloud.nlb.loadBalancer {
   dnsName string
   // ID of the resource group the load balancer belongs to
   resourceGroupId string
+  // Resource group that contains the load balancer
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Time the load balancer was created
   createTime time
   // ID of the bandwidth package bound to the load balancer, empty when none
@@ -3488,6 +3564,8 @@ alicloud.nlb.serverGroup {
   healthCheckConnectPort int
   // ID of the resource group the server group belongs to
   resourceGroupId string
+  // Resource group that contains the server group
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Tags applied to the server group
   tags map[string]string
   // VPC the server group belongs to
@@ -3559,6 +3637,8 @@ alicloud.fc.function {
   instanceConcurrency int
   // ID of the resource group the function belongs to
   resourceGroupId string
+  // Resource group that contains the function
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Environment variables configured on the function
   //
   // Audit these for plaintext secrets; values are returned as configured.
@@ -3700,6 +3780,8 @@ alicloud.nas.fileSystem {
   encrypted bool
   // ID of the resource group the file system belongs to
   resourceGroupId string
+  // Resource group that contains the file system
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Time the file system was created
   createTime time
   // Tags applied to the file system
@@ -4690,6 +4772,8 @@ alicloud.cen.instance @defaults("cenId name status protectionLevel") {
   ipv6Level string
   // Resource group ID the CEN belongs to
   resourceGroupId string
+  // Resource group that contains the CEN instance
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Time the CEN was created
   creationTime time
   // Tags on the CEN, as key-value pairs
@@ -4787,6 +4871,8 @@ alicloud.vpc.vpnGateway @defaults("vpnGatewayId name status internetIp") {
   endTime time
   // Resource group ID the gateway belongs to
   resourceGroupId string
+  // Resource group that contains the VPN gateway
+  resourceGroup() alicloud.resourceManager.resourceGroup
   // Tags on the gateway, as key-value pairs
   tags map[string]string
   // VPC the gateway is attached to

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -69,6 +69,7 @@ const (
 	ResourceAlicloudResourceManager              string = "alicloud.resourceManager"
 	ResourceAlicloudResourceManagerAccount       string = "alicloud.resourceManager.account"
 	ResourceAlicloudResourceManagerFolder        string = "alicloud.resourceManager.folder"
+	ResourceAlicloudResourceManagerResourceGroup string = "alicloud.resourceManager.resourceGroup"
 	ResourceAlicloudResourceManagerControlPolicy string = "alicloud.resourceManager.controlPolicy"
 	ResourceAlicloudCs                           string = "alicloud.cs"
 	ResourceAlicloudCsCluster                    string = "alicloud.cs.cluster"
@@ -335,6 +336,10 @@ func init() {
 		"alicloud.resourceManager.folder": {
 			Init:   initAlicloudResourceManagerFolder,
 			Create: createAlicloudResourceManagerFolder,
+		},
+		"alicloud.resourceManager.resourceGroup": {
+			Init:   initAlicloudResourceManagerResourceGroup,
+			Create: createAlicloudResourceManagerResourceGroup,
 		},
 		"alicloud.resourceManager.controlPolicy": {
 			// to override args, implement: initAlicloudResourceManagerControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -960,6 +965,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.ecs.instance.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsInstance).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.ecs.instance.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudEcsInstance).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.ecs.instance.networkType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsInstance).GetNetworkType()).ToDataRes(types.String)
 	},
@@ -1140,6 +1148,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.ecs.keypair.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsKeypair).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.ecs.keypair.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudEcsKeypair).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.ecs.keypair.regionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsKeypair).GetRegionId()).ToDataRes(types.String)
 	},
@@ -1169,6 +1180,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.ecs.securitygroup.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsSecuritygroup).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.ecs.securitygroup.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudEcsSecuritygroup).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.ecs.securitygroup.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsSecuritygroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -1295,6 +1309,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.ess.scalingGroup.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEssScalingGroup).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.ess.scalingGroup.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudEssScalingGroup).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.ess.scalingGroup.launchTemplateId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEssScalingGroup).GetLaunchTemplateId()).ToDataRes(types.String)
@@ -1473,6 +1490,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.vpc.network.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcNetwork).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.vpc.network.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcNetwork).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.vpc.network.userCidrs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcNetwork).GetUserCidrs()).ToDataRes(types.Array(types.String))
 	},
@@ -1557,6 +1577,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.vpc.vswitch.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcVswitch).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.vpc.vswitch.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcVswitch).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.vpc.vswitch.shareType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcVswitch).GetShareType()).ToDataRes(types.String)
 	},
@@ -1589,6 +1612,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.vpc.routeTable.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcRouteTable).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.vpc.routeTable.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcRouteTable).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.vpc.routeTable.vswitches": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcRouteTable).GetVswitches()).ToDataRes(types.Array(types.Resource("alicloud.vpc.vswitch")))
@@ -1689,6 +1715,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.vpc.natGateway.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcNatGateway).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.vpc.natGateway.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcNatGateway).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.vpc.natGateway.snatTableIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcNatGateway).GetSnatTableIds()).ToDataRes(types.Array(types.String))
 	},
@@ -1775,6 +1804,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.vpc.eipAddress.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcEipAddress).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.vpc.eipAddress.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcEipAddress).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.vpc.eipAddress.vpc": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcEipAddress).GetVpc()).ToDataRes(types.Resource("alicloud.vpc.network"))
@@ -1880,6 +1912,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.oss.bucket.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudOssBucket).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.oss.bucket.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudOssBucket).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.oss.bucket.acl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudOssBucket).GetAcl()).ToDataRes(types.String)
@@ -1994,6 +2029,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.slb.loadBalancer.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudSlbLoadBalancer).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.slb.loadBalancer.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudSlbLoadBalancer).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.slb.loadBalancer.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudSlbLoadBalancer).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -2139,6 +2177,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.rds.instance.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRdsInstance).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.rds.instance.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRdsInstance).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.rds.instance.dbInstanceStorage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRdsInstance).GetDbInstanceStorage()).ToDataRes(types.Int)
 	},
@@ -2243,6 +2284,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.redis.instance.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRedisInstance).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.redis.instance.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRedisInstance).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.redis.instance.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRedisInstance).GetCreateTime()).ToDataRes(types.Time)
@@ -2354,6 +2398,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.mongodb.instance.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudMongodbInstance).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.mongodb.instance.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudMongodbInstance).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.mongodb.instance.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudMongodbInstance).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -2502,6 +2549,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.polardb.cluster.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudPolardbCluster).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.polardb.cluster.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudPolardbCluster).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.polardb.cluster.serverlessType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudPolardbCluster).GetServerlessType()).ToDataRes(types.String)
 	},
@@ -2579,6 +2629,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.vpc.flowLog.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcFlowLog).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.vpc.flowLog.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcFlowLog).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.vpc.flowLog.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcFlowLog).GetCreationTime()).ToDataRes(types.Time)
@@ -2820,6 +2873,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.log.project.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudLogProject).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.log.project.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudLogProject).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.log.project.dataRedundancyType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudLogProject).GetDataRedundancyType()).ToDataRes(types.String)
 	},
@@ -2991,6 +3047,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.resourceManager.controlPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudResourceManager).GetControlPolicies()).ToDataRes(types.Array(types.Resource("alicloud.resourceManager.controlPolicy")))
 	},
+	"alicloud.resourceManager.resourceGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManager).GetResourceGroups()).ToDataRes(types.Array(types.Resource("alicloud.resourceManager.resourceGroup")))
+	},
 	"alicloud.resourceManager.account.accountId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudResourceManagerAccount).GetAccountId()).ToDataRes(types.String)
 	},
@@ -3032,6 +3091,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.resourceManager.folder.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudResourceManagerFolder).GetCreateTime()).ToDataRes(types.Time)
+	},
+	"alicloud.resourceManager.resourceGroup.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerResourceGroup).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.resourceManager.resourceGroup.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerResourceGroup).GetName()).ToDataRes(types.String)
+	},
+	"alicloud.resourceManager.resourceGroup.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerResourceGroup).GetDisplayName()).ToDataRes(types.String)
+	},
+	"alicloud.resourceManager.resourceGroup.accountId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerResourceGroup).GetAccountId()).ToDataRes(types.String)
+	},
+	"alicloud.resourceManager.resourceGroup.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerResourceGroup).GetStatus()).ToDataRes(types.String)
+	},
+	"alicloud.resourceManager.resourceGroup.createDate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerResourceGroup).GetCreateDate()).ToDataRes(types.Time)
+	},
+	"alicloud.resourceManager.resourceGroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerResourceGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"alicloud.resourceManager.controlPolicy.policyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudResourceManagerControlPolicy).GetPolicyId()).ToDataRes(types.String)
@@ -3123,6 +3203,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.cs.cluster.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsCluster).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.cs.cluster.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudCsCluster).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.cs.cluster.zoneId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsCluster).GetZoneId()).ToDataRes(types.String)
 	},
@@ -3203,6 +3286,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.cs.nodePool.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsNodePool).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.cs.nodePool.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudCsNodePool).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.cs.nodePool.isDefault": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsNodePool).GetIsDefault()).ToDataRes(types.Bool)
@@ -3384,6 +3470,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.alb.loadBalancer.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudAlbLoadBalancer).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.alb.loadBalancer.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudAlbLoadBalancer).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.alb.loadBalancer.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudAlbLoadBalancer).GetCreateTime()).ToDataRes(types.Time)
 	},
@@ -3495,6 +3584,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.alb.serverGroup.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudAlbServerGroup).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.alb.serverGroup.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudAlbServerGroup).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.alb.serverGroup.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudAlbServerGroup).GetCreateTime()).ToDataRes(types.Time)
 	},
@@ -3560,6 +3652,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.nlb.loadBalancer.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNlbLoadBalancer).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.nlb.loadBalancer.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudNlbLoadBalancer).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.nlb.loadBalancer.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNlbLoadBalancer).GetCreateTime()).ToDataRes(types.Time)
@@ -3693,6 +3788,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.nlb.serverGroup.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNlbServerGroup).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.nlb.serverGroup.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudNlbServerGroup).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.nlb.serverGroup.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNlbServerGroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -3761,6 +3859,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.fc.function.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudFcFunction).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.fc.function.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudFcFunction).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.fc.function.environmentVariables": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudFcFunction).GetEnvironmentVariables()).ToDataRes(types.Map(types.String, types.String))
@@ -3893,6 +3994,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.nas.fileSystem.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNasFileSystem).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.nas.fileSystem.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudNasFileSystem).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.nas.fileSystem.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNasFileSystem).GetCreateTime()).ToDataRes(types.Time)
@@ -4767,6 +4871,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.cen.instance.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCenInstance).GetResourceGroupId()).ToDataRes(types.String)
 	},
+	"alicloud.cen.instance.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudCenInstance).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
+	},
 	"alicloud.cen.instance.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCenInstance).GetCreationTime()).ToDataRes(types.Time)
 	},
@@ -4859,6 +4966,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.vpc.vpnGateway.resourceGroupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcVpnGateway).GetResourceGroupId()).ToDataRes(types.String)
+	},
+	"alicloud.vpc.vpnGateway.resourceGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcVpnGateway).GetResourceGroup()).ToDataRes(types.Resource("alicloud.resourceManager.resourceGroup"))
 	},
 	"alicloud.vpc.vpnGateway.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcVpnGateway).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -5488,6 +5598,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudEcsInstance).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.ecs.instance.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudEcsInstance).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.ecs.instance.networkType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudEcsInstance).NetworkType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5740,6 +5854,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudEcsKeypair).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.ecs.keypair.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudEcsKeypair).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.ecs.keypair.regionId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudEcsKeypair).RegionId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5782,6 +5900,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.ecs.securitygroup.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudEcsSecuritygroup).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.ecs.securitygroup.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudEcsSecuritygroup).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.ecs.securitygroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5962,6 +6084,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.ess.scalingGroup.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudEssScalingGroup).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.ess.scalingGroup.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudEssScalingGroup).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.ess.scalingGroup.launchTemplateId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6212,6 +6338,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudVpcNetwork).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.vpc.network.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcNetwork).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.vpc.network.userCidrs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcNetwork).UserCidrs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -6328,6 +6458,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudVpcVswitch).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.vpc.vswitch.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcVswitch).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.vpc.vswitch.shareType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcVswitch).ShareType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -6374,6 +6508,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.vpc.routeTable.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcRouteTable).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.vpc.routeTable.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcRouteTable).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.vpc.routeTable.vswitches": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6512,6 +6650,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudVpcNatGateway).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.vpc.natGateway.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcNatGateway).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.vpc.natGateway.snatTableIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcNatGateway).SnatTableIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -6630,6 +6772,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.vpc.eipAddress.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcEipAddress).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.vpc.eipAddress.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcEipAddress).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.vpc.eipAddress.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6782,6 +6928,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.oss.bucket.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudOssBucket).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.oss.bucket.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudOssBucket).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.oss.bucket.acl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6942,6 +7092,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.slb.loadBalancer.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudSlbLoadBalancer).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.slb.loadBalancer.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudSlbLoadBalancer).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.slb.loadBalancer.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7148,6 +7302,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudRdsInstance).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.rds.instance.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRdsInstance).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.rds.instance.dbInstanceStorage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudRdsInstance).DbInstanceStorage, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -7294,6 +7452,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.redis.instance.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudRedisInstance).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.redis.instance.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRedisInstance).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.redis.instance.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7450,6 +7612,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.mongodb.instance.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudMongodbInstance).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.mongodb.instance.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudMongodbInstance).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.mongodb.instance.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7656,6 +7822,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudPolardbCluster).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.polardb.cluster.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudPolardbCluster).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.polardb.cluster.serverlessType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudPolardbCluster).ServerlessType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7762,6 +7932,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.vpc.flowLog.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcFlowLog).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.vpc.flowLog.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcFlowLog).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.vpc.flowLog.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8112,6 +8286,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudLogProject).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.log.project.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudLogProject).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.log.project.dataRedundancyType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudLogProject).DataRedundancyType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8356,6 +8534,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudResourceManager).ControlPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"alicloud.resourceManager.resourceGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManager).ResourceGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"alicloud.resourceManager.account.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudResourceManagerAccount).__id, ok = v.Value.(string)
 		return
@@ -8418,6 +8600,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.resourceManager.folder.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudResourceManagerFolder).CreateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).__id, ok = v.Value.(string)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.accountId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).AccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.createDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).CreateDate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.resourceGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerResourceGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"alicloud.resourceManager.controlPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8552,6 +8766,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudCsCluster).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.cs.cluster.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudCsCluster).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.cs.cluster.zoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudCsCluster).ZoneId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8662,6 +8880,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.cs.nodePool.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudCsNodePool).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.cs.nodePool.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudCsNodePool).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.cs.nodePool.isDefault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8912,6 +9134,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudAlbLoadBalancer).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.alb.loadBalancer.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudAlbLoadBalancer).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.alb.loadBalancer.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudAlbLoadBalancer).CreateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -9068,6 +9294,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudAlbServerGroup).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.alb.serverGroup.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudAlbServerGroup).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.alb.serverGroup.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudAlbServerGroup).CreateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -9162,6 +9392,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.nlb.loadBalancer.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudNlbLoadBalancer).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.nlb.loadBalancer.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudNlbLoadBalancer).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.nlb.loadBalancer.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9348,6 +9582,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudNlbServerGroup).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.nlb.serverGroup.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudNlbServerGroup).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.nlb.serverGroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudNlbServerGroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -9446,6 +9684,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.fc.function.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudFcFunction).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.fc.function.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudFcFunction).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.fc.function.environmentVariables": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9634,6 +9876,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.nas.fileSystem.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudNasFileSystem).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.nas.fileSystem.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudNasFileSystem).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.nas.fileSystem.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10916,6 +11162,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudCenInstance).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.cen.instance.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudCenInstance).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
+		return
+	},
 	"alicloud.cen.instance.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudCenInstance).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -11046,6 +11296,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.vpc.vpnGateway.resourceGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcVpnGateway).ResourceGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.vpc.vpnGateway.resourceGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcVpnGateway).ResourceGroup, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerResourceGroup](v.Value, v.Error)
 		return
 	},
 	"alicloud.vpc.vpnGateway.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12327,6 +12581,7 @@ type mqlAlicloudEcsInstance struct {
 	LocalStorageAmount      plugin.TValue[int64]
 	LocalStorageCapacity    plugin.TValue[int64]
 	ResourceGroupId         plugin.TValue[string]
+	ResourceGroup           plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	NetworkType             plugin.TValue[string]
 	Vpc                     plugin.TValue[*mqlAlicloudVpcNetwork]
 	Vswitch                 plugin.TValue[*mqlAlicloudVpcVswitch]
@@ -12547,6 +12802,22 @@ func (c *mqlAlicloudEcsInstance) GetLocalStorageCapacity() *plugin.TValue[int64]
 
 func (c *mqlAlicloudEcsInstance) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudEcsInstance) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ecs.instance", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudEcsInstance) GetNetworkType() *plugin.TValue[string] {
@@ -12987,6 +13258,7 @@ type mqlAlicloudEcsKeypair struct {
 	KeyPairFingerPrint plugin.TValue[string]
 	CreationTime       plugin.TValue[*time.Time]
 	ResourceGroupId    plugin.TValue[string]
+	ResourceGroup      plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	RegionId           plugin.TValue[string]
 	Tags               plugin.TValue[map[string]any]
 }
@@ -13044,6 +13316,22 @@ func (c *mqlAlicloudEcsKeypair) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
 }
 
+func (c *mqlAlicloudEcsKeypair) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ecs.keypair", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
+}
+
 func (c *mqlAlicloudEcsKeypair) GetRegionId() *plugin.TValue[string] {
 	return &c.RegionId
 }
@@ -13065,6 +13353,7 @@ type mqlAlicloudEcsSecuritygroup struct {
 	CreationTime      plugin.TValue[*time.Time]
 	RegionId          plugin.TValue[string]
 	ResourceGroupId   plugin.TValue[string]
+	ResourceGroup     plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Tags              plugin.TValue[map[string]any]
 	Permissions       plugin.TValue[[]any]
 	Instances         plugin.TValue[[]any]
@@ -13137,6 +13426,22 @@ func (c *mqlAlicloudEcsSecuritygroup) GetRegionId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudEcsSecuritygroup) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudEcsSecuritygroup) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ecs.securitygroup", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudEcsSecuritygroup) GetTags() *plugin.TValue[map[string]any] {
@@ -13435,6 +13740,7 @@ type mqlAlicloudEssScalingGroup struct {
 	SystemSuspended            plugin.TValue[bool]
 	MaxInstanceLifetime        plugin.TValue[int64]
 	ResourceGroupId            plugin.TValue[string]
+	ResourceGroup              plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	LaunchTemplateId           plugin.TValue[string]
 	LaunchTemplateVersion      plugin.TValue[string]
 	CreationTime               plugin.TValue[*time.Time]
@@ -13556,6 +13862,22 @@ func (c *mqlAlicloudEssScalingGroup) GetMaxInstanceLifetime() *plugin.TValue[int
 
 func (c *mqlAlicloudEssScalingGroup) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudEssScalingGroup) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ess.scalingGroup", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudEssScalingGroup) GetLaunchTemplateId() *plugin.TValue[string] {
@@ -14110,6 +14432,7 @@ type mqlAlicloudVpcNetwork struct {
 	VRouterId            plugin.TValue[string]
 	CreationTime         plugin.TValue[*time.Time]
 	ResourceGroupId      plugin.TValue[string]
+	ResourceGroup        plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	UserCidrs            plugin.TValue[[]any]
 	Vswitches            plugin.TValue[[]any]
 	NatGateways          plugin.TValue[[]any]
@@ -14215,6 +14538,22 @@ func (c *mqlAlicloudVpcNetwork) GetCreationTime() *plugin.TValue[*time.Time] {
 
 func (c *mqlAlicloudVpcNetwork) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudVpcNetwork) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.network", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudVpcNetwork) GetUserCidrs() *plugin.TValue[[]any] {
@@ -14346,6 +14685,7 @@ type mqlAlicloudVpcVswitch struct {
 	RouteTableType          plugin.TValue[string]
 	NetworkAcl              plugin.TValue[*mqlAlicloudVpcNetworkAcl]
 	ResourceGroupId         plugin.TValue[string]
+	ResourceGroup           plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	ShareType               plugin.TValue[string]
 	OwnerId                 plugin.TValue[int64]
 	Tags                    plugin.TValue[map[string]any]
@@ -14488,6 +14828,22 @@ func (c *mqlAlicloudVpcVswitch) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
 }
 
+func (c *mqlAlicloudVpcVswitch) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.vswitch", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
+}
+
 func (c *mqlAlicloudVpcVswitch) GetShareType() *plugin.TValue[string] {
 	return &c.ShareType
 }
@@ -14513,6 +14869,7 @@ type mqlAlicloudVpcRouteTable struct {
 	Status                 plugin.TValue[string]
 	CreationTime           plugin.TValue[*time.Time]
 	ResourceGroupId        plugin.TValue[string]
+	ResourceGroup          plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Vswitches              plugin.TValue[[]any]
 	GatewayIds             plugin.TValue[[]any]
 	AssociateType          plugin.TValue[string]
@@ -14605,6 +14962,22 @@ func (c *mqlAlicloudVpcRouteTable) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
 }
 
+func (c *mqlAlicloudVpcRouteTable) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.routeTable", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
+}
+
 func (c *mqlAlicloudVpcRouteTable) GetVswitches() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Vswitches, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -14684,6 +15057,7 @@ type mqlAlicloudVpcNatGateway struct {
 	AutoPay                   plugin.TValue[bool]
 	RegionId                  plugin.TValue[string]
 	ResourceGroupId           plugin.TValue[string]
+	ResourceGroup             plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	SnatTableIds              plugin.TValue[[]any]
 	ForwardTableIds           plugin.TValue[[]any]
 	FullNatTableIds           plugin.TValue[[]any]
@@ -14838,6 +15212,22 @@ func (c *mqlAlicloudVpcNatGateway) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
 }
 
+func (c *mqlAlicloudVpcNatGateway) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.natGateway", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
+}
+
 func (c *mqlAlicloudVpcNatGateway) GetSnatTableIds() *plugin.TValue[[]any] {
 	return &c.SnatTableIds
 }
@@ -14893,6 +15283,7 @@ type mqlAlicloudVpcEipAddress struct {
 	PublicIpAddressPoolId     plugin.TValue[string]
 	RegionId                  plugin.TValue[string]
 	ResourceGroupId           plugin.TValue[string]
+	ResourceGroup             plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Vpc                       plugin.TValue[*mqlAlicloudVpcNetwork]
 	Zone                      plugin.TValue[string]
 	BandwidthPackageId        plugin.TValue[string]
@@ -15032,6 +15423,22 @@ func (c *mqlAlicloudVpcEipAddress) GetRegionId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudVpcEipAddress) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudVpcEipAddress) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.eipAddress", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudVpcEipAddress) GetVpc() *plugin.TValue[*mqlAlicloudVpcNetwork] {
@@ -15292,6 +15699,7 @@ type mqlAlicloudOssBucket struct {
 	IntranetEndpoint       plugin.TValue[string]
 	ExtranetEndpoint       plugin.TValue[string]
 	ResourceGroupId        plugin.TValue[string]
+	ResourceGroup          plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Acl                    plugin.TValue[string]
 	Versioning             plugin.TValue[string]
 	Encryption             plugin.TValue[any]
@@ -15376,6 +15784,22 @@ func (c *mqlAlicloudOssBucket) GetExtranetEndpoint() *plugin.TValue[string] {
 
 func (c *mqlAlicloudOssBucket) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudOssBucket) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.oss.bucket", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudOssBucket) GetAcl() *plugin.TValue[string] {
@@ -15566,6 +15990,7 @@ type mqlAlicloudSlbLoadBalancer struct {
 	ModificationProtectionStatus plugin.TValue[string]
 	ModificationProtectionReason plugin.TValue[string]
 	ResourceGroupId              plugin.TValue[string]
+	ResourceGroup                plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Tags                         plugin.TValue[map[string]any]
 	Listeners                    plugin.TValue[[]any]
 	BackendServers               plugin.TValue[[]any]
@@ -15719,6 +16144,22 @@ func (c *mqlAlicloudSlbLoadBalancer) GetModificationProtectionReason() *plugin.T
 
 func (c *mqlAlicloudSlbLoadBalancer) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudSlbLoadBalancer) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.slb.loadBalancer", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudSlbLoadBalancer) GetTags() *plugin.TValue[map[string]any] {
@@ -15978,6 +16419,7 @@ type mqlAlicloudRdsInstance struct {
 	DeletionProtection    plugin.TValue[bool]
 	MasterInstance        plugin.TValue[*mqlAlicloudRdsInstance]
 	ResourceGroupId       plugin.TValue[string]
+	ResourceGroup         plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	DbInstanceStorage     plugin.TValue[int64]
 	Port                  plugin.TValue[int64]
 	Tags                  plugin.TValue[map[string]any]
@@ -16162,6 +16604,22 @@ func (c *mqlAlicloudRdsInstance) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
 }
 
+func (c *mqlAlicloudRdsInstance) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.rds.instance", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
+}
+
 func (c *mqlAlicloudRdsInstance) GetDbInstanceStorage() *plugin.TValue[int64] {
 	return plugin.GetOrCompute[int64](&c.DbInstanceStorage, func() (int64, error) {
 		return c.dbInstanceStorage()
@@ -16317,6 +16775,7 @@ type mqlAlicloudRedisInstance struct {
 	PackageType      plugin.TValue[string]
 	EditionType      plugin.TValue[string]
 	ResourceGroupId  plugin.TValue[string]
+	ResourceGroup    plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	CreateTime       plugin.TValue[*time.Time]
 	EndTime          plugin.TValue[*time.Time]
 	Tags             plugin.TValue[map[string]any]
@@ -16489,6 +16948,22 @@ func (c *mqlAlicloudRedisInstance) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
 }
 
+func (c *mqlAlicloudRedisInstance) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.redis.instance", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
+}
+
 func (c *mqlAlicloudRedisInstance) GetCreateTime() *plugin.TValue[*time.Time] {
 	return &c.CreateTime
 }
@@ -16640,6 +17115,7 @@ type mqlAlicloudMongodbInstance struct {
 	LastDowngradeTime     plugin.TValue[string]
 	LockMode              plugin.TValue[string]
 	ResourceGroupId       plugin.TValue[string]
+	ResourceGroup         plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Tags                  plugin.TValue[map[string]any]
 	Vpc                   plugin.TValue[*mqlAlicloudVpcNetwork]
 	Vswitch               plugin.TValue[*mqlAlicloudVpcVswitch]
@@ -16805,6 +17281,22 @@ func (c *mqlAlicloudMongodbInstance) GetLockMode() *plugin.TValue[string] {
 
 func (c *mqlAlicloudMongodbInstance) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudMongodbInstance) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.mongodb.instance", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudMongodbInstance) GetTags() *plugin.TValue[map[string]any] {
@@ -17059,6 +17551,7 @@ type mqlAlicloudPolardbCluster struct {
 	LockMode             plugin.TValue[string]
 	DeletionLock         plugin.TValue[int64]
 	ResourceGroupId      plugin.TValue[string]
+	ResourceGroup        plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	ServerlessType       plugin.TValue[string]
 	DbClusterNetworkType plugin.TValue[string]
 	AiType               plugin.TValue[string]
@@ -17247,6 +17740,22 @@ func (c *mqlAlicloudPolardbCluster) GetResourceGroupId() *plugin.TValue[string] 
 	return &c.ResourceGroupId
 }
 
+func (c *mqlAlicloudPolardbCluster) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.polardb.cluster", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
+}
+
 func (c *mqlAlicloudPolardbCluster) GetServerlessType() *plugin.TValue[string] {
 	return &c.ServerlessType
 }
@@ -17319,6 +17828,7 @@ type mqlAlicloudVpcFlowLog struct {
 	ProjectName         plugin.TValue[string]
 	LogStoreName        plugin.TValue[string]
 	ResourceGroupId     plugin.TValue[string]
+	ResourceGroup       plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	CreationTime        plugin.TValue[*time.Time]
 	DeliverStatus       plugin.TValue[string]
 	DeliverErrorMessage plugin.TValue[string]
@@ -17423,6 +17933,22 @@ func (c *mqlAlicloudVpcFlowLog) GetLogStoreName() *plugin.TValue[string] {
 
 func (c *mqlAlicloudVpcFlowLog) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudVpcFlowLog) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.flowLog", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudVpcFlowLog) GetCreationTime() *plugin.TValue[*time.Time] {
@@ -18195,6 +18721,7 @@ type mqlAlicloudLogProject struct {
 	Status             plugin.TValue[string]
 	Owner              plugin.TValue[string]
 	ResourceGroupId    plugin.TValue[string]
+	ResourceGroup      plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	DataRedundancyType plugin.TValue[string]
 	RecycleBinEnabled  plugin.TValue[bool]
 	InternalEndpoint   plugin.TValue[string]
@@ -18263,6 +18790,22 @@ func (c *mqlAlicloudLogProject) GetOwner() *plugin.TValue[string] {
 
 func (c *mqlAlicloudLogProject) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudLogProject) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.log.project", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudLogProject) GetDataRedundancyType() *plugin.TValue[string] {
@@ -18718,6 +19261,7 @@ type mqlAlicloudResourceManager struct {
 	Accounts             plugin.TValue[[]any]
 	Folders              plugin.TValue[[]any]
 	ControlPolicies      plugin.TValue[[]any]
+	ResourceGroups       plugin.TValue[[]any]
 }
 
 // createAlicloudResourceManager creates a new instance of this resource
@@ -18844,6 +19388,22 @@ func (c *mqlAlicloudResourceManager) GetControlPolicies() *plugin.TValue[[]any] 
 		}
 
 		return c.controlPolicies()
+	})
+}
+
+func (c *mqlAlicloudResourceManager) GetResourceGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ResourceGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.resourceManager", c.__id, "resourceGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resourceGroups()
 	})
 }
 
@@ -19017,6 +19577,85 @@ func (c *mqlAlicloudResourceManagerFolder) GetCreateTime() *plugin.TValue[*time.
 	return &c.CreateTime
 }
 
+// mqlAlicloudResourceManagerResourceGroup for the alicloud.resourceManager.resourceGroup resource
+type mqlAlicloudResourceManagerResourceGroup struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAlicloudResourceManagerResourceGroupInternal it will be used here
+	ResourceGroupId plugin.TValue[string]
+	Name            plugin.TValue[string]
+	DisplayName     plugin.TValue[string]
+	AccountId       plugin.TValue[string]
+	Status          plugin.TValue[string]
+	CreateDate      plugin.TValue[*time.Time]
+	Tags            plugin.TValue[map[string]any]
+}
+
+// createAlicloudResourceManagerResourceGroup creates a new instance of this resource
+func createAlicloudResourceManagerResourceGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAlicloudResourceManagerResourceGroup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("alicloud.resourceManager.resourceGroup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) MqlName() string {
+	return "alicloud.resourceManager.resourceGroup"
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) GetResourceGroupId() *plugin.TValue[string] {
+	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) GetAccountId() *plugin.TValue[string] {
+	return &c.AccountId
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) GetCreateDate() *plugin.TValue[*time.Time] {
+	return &c.CreateDate
+}
+
+func (c *mqlAlicloudResourceManagerResourceGroup) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
+}
+
 // mqlAlicloudResourceManagerControlPolicy for the alicloud.resourceManager.controlPolicy resource
 type mqlAlicloudResourceManagerControlPolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -19188,6 +19827,7 @@ type mqlAlicloudCsCluster struct {
 	DeletionProtection        plugin.TValue[bool]
 	Size                      plugin.TValue[int64]
 	ResourceGroupId           plugin.TValue[string]
+	ResourceGroup             plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	ZoneId                    plugin.TValue[string]
 	Timezone                  plugin.TValue[string]
 	ApiServerPublicEndpoint   plugin.TValue[string]
@@ -19330,6 +19970,22 @@ func (c *mqlAlicloudCsCluster) GetSize() *plugin.TValue[int64] {
 
 func (c *mqlAlicloudCsCluster) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudCsCluster) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.cs.cluster", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudCsCluster) GetZoneId() *plugin.TValue[string] {
@@ -19511,6 +20167,7 @@ type mqlAlicloudCsNodePool struct {
 	Name                       plugin.TValue[string]
 	Type                       plugin.TValue[string]
 	ResourceGroupId            plugin.TValue[string]
+	ResourceGroup              plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	IsDefault                  plugin.TValue[bool]
 	Created                    plugin.TValue[*time.Time]
 	Updated                    plugin.TValue[*time.Time]
@@ -19617,6 +20274,22 @@ func (c *mqlAlicloudCsNodePool) GetType() *plugin.TValue[string] {
 
 func (c *mqlAlicloudCsNodePool) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudCsNodePool) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.cs.nodePool", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudCsNodePool) GetIsDefault() *plugin.TValue[bool] {
@@ -19943,6 +20616,7 @@ type mqlAlicloudAlbLoadBalancer struct {
 	BusinessStatus               plugin.TValue[string]
 	BandwidthPackageId           plugin.TValue[string]
 	ResourceGroupId              plugin.TValue[string]
+	ResourceGroup                plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	CreateTime                   plugin.TValue[*time.Time]
 	DeletionProtectionEnabled    plugin.TValue[bool]
 	ModificationProtectionStatus plugin.TValue[string]
@@ -20044,6 +20718,22 @@ func (c *mqlAlicloudAlbLoadBalancer) GetBandwidthPackageId() *plugin.TValue[stri
 
 func (c *mqlAlicloudAlbLoadBalancer) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudAlbLoadBalancer) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.alb.loadBalancer", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudAlbLoadBalancer) GetCreateTime() *plugin.TValue[*time.Time] {
@@ -20322,6 +21012,7 @@ type mqlAlicloudAlbServerGroup struct {
 	Scheduler            plugin.TValue[string]
 	ServerCount          plugin.TValue[int64]
 	ResourceGroupId      plugin.TValue[string]
+	ResourceGroup        plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	CreateTime           plugin.TValue[*time.Time]
 	CrossZoneEnabled     plugin.TValue[bool]
 	HealthCheckEnabled   plugin.TValue[bool]
@@ -20404,6 +21095,22 @@ func (c *mqlAlicloudAlbServerGroup) GetServerCount() *plugin.TValue[int64] {
 
 func (c *mqlAlicloudAlbServerGroup) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudAlbServerGroup) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.alb.serverGroup", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudAlbServerGroup) GetCreateTime() *plugin.TValue[*time.Time] {
@@ -20548,6 +21255,7 @@ type mqlAlicloudNlbLoadBalancer struct {
 	Ipv6AddressType              plugin.TValue[string]
 	DnsName                      plugin.TValue[string]
 	ResourceGroupId              plugin.TValue[string]
+	ResourceGroup                plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	CreateTime                   plugin.TValue[*time.Time]
 	BandwidthPackageId           plugin.TValue[string]
 	CrossZoneEnabled             plugin.TValue[bool]
@@ -20640,6 +21348,22 @@ func (c *mqlAlicloudNlbLoadBalancer) GetDnsName() *plugin.TValue[string] {
 
 func (c *mqlAlicloudNlbLoadBalancer) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudNlbLoadBalancer) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.nlb.loadBalancer", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudNlbLoadBalancer) GetCreateTime() *plugin.TValue[*time.Time] {
@@ -20902,6 +21626,7 @@ type mqlAlicloudNlbServerGroup struct {
 	HealthCheckType         plugin.TValue[string]
 	HealthCheckConnectPort  plugin.TValue[int64]
 	ResourceGroupId         plugin.TValue[string]
+	ResourceGroup           plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Tags                    plugin.TValue[map[string]any]
 	Vpc                     plugin.TValue[*mqlAlicloudVpcNetwork]
 }
@@ -21001,6 +21726,22 @@ func (c *mqlAlicloudNlbServerGroup) GetHealthCheckConnectPort() *plugin.TValue[i
 
 func (c *mqlAlicloudNlbServerGroup) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudNlbServerGroup) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.nlb.serverGroup", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudNlbServerGroup) GetTags() *plugin.TValue[map[string]any] {
@@ -21109,6 +21850,7 @@ type mqlAlicloudFcFunction struct {
 	InternetAccess       plugin.TValue[bool]
 	InstanceConcurrency  plugin.TValue[int64]
 	ResourceGroupId      plugin.TValue[string]
+	ResourceGroup        plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	EnvironmentVariables plugin.TValue[map[string]any]
 	CustomContainerImage plugin.TValue[string]
 	LogStore             plugin.TValue[string]
@@ -21236,6 +21978,22 @@ func (c *mqlAlicloudFcFunction) GetInstanceConcurrency() *plugin.TValue[int64] {
 
 func (c *mqlAlicloudFcFunction) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudFcFunction) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.fc.function", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudFcFunction) GetEnvironmentVariables() *plugin.TValue[map[string]any] {
@@ -21591,6 +22349,7 @@ type mqlAlicloudNasFileSystem struct {
 	EncryptType     plugin.TValue[int64]
 	Encrypted       plugin.TValue[bool]
 	ResourceGroupId plugin.TValue[string]
+	ResourceGroup   plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	CreateTime      plugin.TValue[*time.Time]
 	Tags            plugin.TValue[map[string]any]
 	KmsKey          plugin.TValue[*mqlAlicloudKmsKey]
@@ -21692,6 +22451,22 @@ func (c *mqlAlicloudNasFileSystem) GetEncrypted() *plugin.TValue[bool] {
 
 func (c *mqlAlicloudNasFileSystem) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudNasFileSystem) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.nas.fileSystem", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudNasFileSystem) GetCreateTime() *plugin.TValue[*time.Time] {
@@ -24785,6 +25560,7 @@ type mqlAlicloudCenInstance struct {
 	ProtectionLevel plugin.TValue[string]
 	Ipv6Level       plugin.TValue[string]
 	ResourceGroupId plugin.TValue[string]
+	ResourceGroup   plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	CreationTime    plugin.TValue[*time.Time]
 	Tags            plugin.TValue[map[string]any]
 	Attachments     plugin.TValue[[]any]
@@ -24848,6 +25624,22 @@ func (c *mqlAlicloudCenInstance) GetIpv6Level() *plugin.TValue[string] {
 
 func (c *mqlAlicloudCenInstance) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudCenInstance) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.cen.instance", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudCenInstance) GetCreationTime() *plugin.TValue[*time.Time] {
@@ -24995,6 +25787,7 @@ type mqlAlicloudVpcVpnGateway struct {
 	CreateTime        plugin.TValue[*time.Time]
 	EndTime           plugin.TValue[*time.Time]
 	ResourceGroupId   plugin.TValue[string]
+	ResourceGroup     plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
 	Tags              plugin.TValue[map[string]any]
 	Vpc               plugin.TValue[*mqlAlicloudVpcNetwork]
 	Vswitch           plugin.TValue[*mqlAlicloudVpcVswitch]
@@ -25116,6 +25909,22 @@ func (c *mqlAlicloudVpcVpnGateway) GetEndTime() *plugin.TValue[*time.Time] {
 
 func (c *mqlAlicloudVpcVpnGateway) GetResourceGroupId() *plugin.TValue[string] {
 	return &c.ResourceGroupId
+}
+
+func (c *mqlAlicloudVpcVpnGateway) GetResourceGroup() *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerResourceGroup](&c.ResourceGroup, func() (*mqlAlicloudResourceManagerResourceGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.vpnGateway", c.__id, "resourceGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerResourceGroup), nil
+			}
+		}
+
+		return c.resourceGroup()
+	})
 }
 
 func (c *mqlAlicloudVpcVpnGateway) GetTags() *plugin.TValue[map[string]any] {

--- a/providers/alicloud/resources/alicloud.lr.versions
+++ b/providers/alicloud/resources/alicloud.lr.versions
@@ -69,6 +69,7 @@ alicloud.alb.loadBalancer.loadBalancerId 13.0.1
 alicloud.alb.loadBalancer.modificationProtectionStatus 13.0.1
 alicloud.alb.loadBalancer.name 13.0.1
 alicloud.alb.loadBalancer.regionId 13.0.1
+alicloud.alb.loadBalancer.resourceGroup 13.3.2
 alicloud.alb.loadBalancer.resourceGroupId 13.0.1
 alicloud.alb.loadBalancer.securityGroups 13.0.1
 alicloud.alb.loadBalancer.status 13.0.1
@@ -85,6 +86,7 @@ alicloud.alb.serverGroup.healthCheckProtocol 13.0.1
 alicloud.alb.serverGroup.name 13.0.1
 alicloud.alb.serverGroup.protocol 13.0.1
 alicloud.alb.serverGroup.regionId 13.0.1
+alicloud.alb.serverGroup.resourceGroup 13.3.2
 alicloud.alb.serverGroup.resourceGroupId 13.0.1
 alicloud.alb.serverGroup.scheduler 13.0.1
 alicloud.alb.serverGroup.serverCount 13.0.1
@@ -150,6 +152,7 @@ alicloud.cen.instance.description 13.2.5
 alicloud.cen.instance.ipv6Level 13.2.5
 alicloud.cen.instance.name 13.2.5
 alicloud.cen.instance.protectionLevel 13.2.5
+alicloud.cen.instance.resourceGroup 13.3.2
 alicloud.cen.instance.resourceGroupId 13.2.5
 alicloud.cen.instance.status 13.2.5
 alicloud.cen.instance.tags 13.2.5
@@ -323,6 +326,7 @@ alicloud.cs.cluster.privateZone 13.0.1
 alicloud.cs.cluster.profile 13.0.1
 alicloud.cs.cluster.proxyMode 13.0.1
 alicloud.cs.cluster.regionId 13.0.1
+alicloud.cs.cluster.resourceGroup 13.3.2
 alicloud.cs.cluster.resourceGroupId 13.0.1
 alicloud.cs.cluster.rrsaEnabled 13.0.1
 alicloud.cs.cluster.securityGroup 13.0.1
@@ -370,6 +374,7 @@ alicloud.cs.nodePool.nodePoolId 13.0.1
 alicloud.cs.nodePool.nodePoolState 13.0.1
 alicloud.cs.nodePool.ramRole 13.0.1
 alicloud.cs.nodePool.regionId 13.0.1
+alicloud.cs.nodePool.resourceGroup 13.3.2
 alicloud.cs.nodePool.resourceGroupId 13.0.1
 alicloud.cs.nodePool.runtime 13.0.1
 alicloud.cs.nodePool.runtimeVersion 13.0.1
@@ -476,6 +481,7 @@ alicloud.ecs.instance.privateIpAddresses 13.0.0
 alicloud.ecs.instance.publicIpAddresses 13.0.0
 alicloud.ecs.instance.ramRole 13.2.5
 alicloud.ecs.instance.regionId 13.0.0
+alicloud.ecs.instance.resourceGroup 13.3.2
 alicloud.ecs.instance.resourceGroupId 13.0.0
 alicloud.ecs.instance.securityGroupIds 13.0.0
 alicloud.ecs.instance.securityGroups 13.0.0
@@ -498,6 +504,7 @@ alicloud.ecs.keypair.creationTime 13.0.0
 alicloud.ecs.keypair.keyPairFingerPrint 13.0.0
 alicloud.ecs.keypair.keyPairName 13.0.0
 alicloud.ecs.keypair.regionId 13.0.0
+alicloud.ecs.keypair.resourceGroup 13.3.2
 alicloud.ecs.keypair.resourceGroupId 13.0.0
 alicloud.ecs.keypair.tags 13.0.0
 alicloud.ecs.securityGroups 13.0.0
@@ -526,6 +533,7 @@ alicloud.ecs.securitygroup.permission.sourcePrefixListId 13.0.0
 alicloud.ecs.securitygroup.permission.sourceSecurityGroup 13.0.0
 alicloud.ecs.securitygroup.permissions 13.0.0
 alicloud.ecs.securitygroup.regionId 13.0.0
+alicloud.ecs.securitygroup.resourceGroup 13.3.2
 alicloud.ecs.securitygroup.resourceGroupId 13.0.0
 alicloud.ecs.securitygroup.securityGroupId 13.0.0
 alicloud.ecs.securitygroup.securityGroupName 13.0.0
@@ -582,6 +590,7 @@ alicloud.ess.scalingGroup.modificationTime 13.2.5
 alicloud.ess.scalingGroup.multiAZPolicy 13.2.5
 alicloud.ess.scalingGroup.name 13.2.5
 alicloud.ess.scalingGroup.regionId 13.2.5
+alicloud.ess.scalingGroup.resourceGroup 13.3.2
 alicloud.ess.scalingGroup.resourceGroupId 13.2.5
 alicloud.ess.scalingGroup.scalingConfigurations 13.2.5
 alicloud.ess.scalingGroup.scalingGroupId 13.2.5
@@ -614,6 +623,7 @@ alicloud.fc.function.logProject 13.0.1
 alicloud.fc.function.logStore 13.0.1
 alicloud.fc.function.memorySize 13.0.1
 alicloud.fc.function.regionId 13.0.1
+alicloud.fc.function.resourceGroup 13.3.2
 alicloud.fc.function.resourceGroupId 13.0.1
 alicloud.fc.function.runtime 13.0.1
 alicloud.fc.function.securityGroup 13.0.1
@@ -717,6 +727,7 @@ alicloud.log.project.name 13.0.1
 alicloud.log.project.owner 13.0.1
 alicloud.log.project.recycleBinEnabled 13.0.1
 alicloud.log.project.regionId 13.0.1
+alicloud.log.project.resourceGroup 13.3.2
 alicloud.log.project.resourceGroupId 13.0.1
 alicloud.log.project.status 13.0.1
 alicloud.log.projects 13.0.1
@@ -754,6 +765,7 @@ alicloud.mongodb.instance.regionId 13.0.0
 alicloud.mongodb.instance.releaseProtection 13.0.0
 alicloud.mongodb.instance.releaseTime 13.0.0
 alicloud.mongodb.instance.replicationFactor 13.0.0
+alicloud.mongodb.instance.resourceGroup 13.3.2
 alicloud.mongodb.instance.resourceGroupId 13.0.0
 alicloud.mongodb.instance.secondaryZoneId 13.0.0
 alicloud.mongodb.instance.securityGroupIds 13.0.0
@@ -806,6 +818,7 @@ alicloud.nas.fileSystem.mountTargets 13.0.1
 alicloud.nas.fileSystem.protocolType 13.0.1
 alicloud.nas.fileSystem.redundancyType 13.0.1
 alicloud.nas.fileSystem.regionId 13.0.1
+alicloud.nas.fileSystem.resourceGroup 13.3.2
 alicloud.nas.fileSystem.resourceGroupId 13.0.1
 alicloud.nas.fileSystem.status 13.0.1
 alicloud.nas.fileSystem.storageType 13.0.1
@@ -858,6 +871,7 @@ alicloud.nlb.loadBalancer.loadBalancerId 13.0.1
 alicloud.nlb.loadBalancer.modificationProtectionStatus 13.0.1
 alicloud.nlb.loadBalancer.name 13.0.1
 alicloud.nlb.loadBalancer.regionId 13.0.1
+alicloud.nlb.loadBalancer.resourceGroup 13.3.2
 alicloud.nlb.loadBalancer.resourceGroupId 13.0.1
 alicloud.nlb.loadBalancer.securityGroups 13.0.1
 alicloud.nlb.loadBalancer.status 13.0.1
@@ -876,6 +890,7 @@ alicloud.nlb.serverGroup.name 13.0.1
 alicloud.nlb.serverGroup.preserveClientIpEnabled 13.0.1
 alicloud.nlb.serverGroup.protocol 13.0.1
 alicloud.nlb.serverGroup.regionId 13.0.1
+alicloud.nlb.serverGroup.resourceGroup 13.3.2
 alicloud.nlb.serverGroup.resourceGroupId 13.0.1
 alicloud.nlb.serverGroup.scheduler 13.0.1
 alicloud.nlb.serverGroup.serverCount 13.0.1
@@ -904,6 +919,7 @@ alicloud.oss.bucket.name 13.0.0
 alicloud.oss.bucket.policy 13.0.0
 alicloud.oss.bucket.publicAccessBlock 13.0.0
 alicloud.oss.bucket.region 13.0.0
+alicloud.oss.bucket.resourceGroup 13.3.2
 alicloud.oss.bucket.resourceGroupId 13.0.0
 alicloud.oss.bucket.sseAlgorithm 13.0.0
 alicloud.oss.bucket.storageClass 13.0.0
@@ -937,6 +953,7 @@ alicloud.polardb.cluster.lockMode 13.0.0
 alicloud.polardb.cluster.memorySize 13.0.0
 alicloud.polardb.cluster.payType 13.0.0
 alicloud.polardb.cluster.regionId 13.0.0
+alicloud.polardb.cluster.resourceGroup 13.3.2
 alicloud.polardb.cluster.resourceGroupId 13.0.0
 alicloud.polardb.cluster.serverlessType 13.0.0
 alicloud.polardb.cluster.sslEnabled 13.0.0
@@ -1058,6 +1075,7 @@ alicloud.rds.instance.masterInstance 13.0.0
 alicloud.rds.instance.payType 13.0.0
 alicloud.rds.instance.port 13.0.0
 alicloud.rds.instance.regionId 13.0.0
+alicloud.rds.instance.resourceGroup 13.3.2
 alicloud.rds.instance.resourceGroupId 13.0.0
 alicloud.rds.instance.securityGroupIds 13.0.0
 alicloud.rds.instance.securityGroups 13.2.5
@@ -1095,6 +1113,7 @@ alicloud.redis.instance.port 13.0.0
 alicloud.redis.instance.privateIp 13.0.0
 alicloud.redis.instance.qps 13.0.0
 alicloud.redis.instance.regionId 13.0.0
+alicloud.redis.instance.resourceGroup 13.3.2
 alicloud.redis.instance.resourceGroupId 13.0.0
 alicloud.redis.instance.secondaryZoneId 13.0.0
 alicloud.redis.instance.securityGroupIds 13.0.0
@@ -1143,6 +1162,15 @@ alicloud.resourceManager.masterAccountId 13.0.1
 alicloud.resourceManager.masterAccountName 13.0.1
 alicloud.resourceManager.memberDeletionStatus 13.0.1
 alicloud.resourceManager.resourceDirectoryId 13.0.1
+alicloud.resourceManager.resourceGroup 13.3.2
+alicloud.resourceManager.resourceGroup.accountId 13.3.2
+alicloud.resourceManager.resourceGroup.createDate 13.3.2
+alicloud.resourceManager.resourceGroup.displayName 13.3.2
+alicloud.resourceManager.resourceGroup.name 13.3.2
+alicloud.resourceManager.resourceGroup.resourceGroupId 13.3.2
+alicloud.resourceManager.resourceGroup.status 13.3.2
+alicloud.resourceManager.resourceGroup.tags 13.3.2
+alicloud.resourceManager.resourceGroups 13.3.2
 alicloud.resourceManager.rootFolderId 13.0.1
 alicloud.sas 13.2.5
 alicloud.sas.alarmEvent 13.2.5
@@ -1277,6 +1305,7 @@ alicloud.slb.loadBalancer.modificationProtectionStatus 13.0.0
 alicloud.slb.loadBalancer.networkType 13.0.0
 alicloud.slb.loadBalancer.payType 13.0.0
 alicloud.slb.loadBalancer.regionId 13.0.0
+alicloud.slb.loadBalancer.resourceGroup 13.3.2
 alicloud.slb.loadBalancer.resourceGroupId 13.0.0
 alicloud.slb.loadBalancer.slaveZoneId 13.0.0
 alicloud.slb.loadBalancer.status 13.0.0
@@ -1313,6 +1342,7 @@ alicloud.vpc.eipAddress.netmode 13.0.0
 alicloud.vpc.eipAddress.privateIpAddress 13.0.0
 alicloud.vpc.eipAddress.publicIpAddressPoolId 13.0.0
 alicloud.vpc.eipAddress.regionId 13.0.0
+alicloud.vpc.eipAddress.resourceGroup 13.3.2
 alicloud.vpc.eipAddress.resourceGroupId 13.0.0
 alicloud.vpc.eipAddress.secondLimited 13.0.0
 alicloud.vpc.eipAddress.securityProtectionTypes 13.0.0
@@ -1338,6 +1368,7 @@ alicloud.vpc.flowLog.logstore 13.0.1
 alicloud.vpc.flowLog.network 13.0.1
 alicloud.vpc.flowLog.projectName 13.0.1
 alicloud.vpc.flowLog.regionId 13.0.1
+alicloud.vpc.flowLog.resourceGroup 13.3.2
 alicloud.vpc.flowLog.resourceGroupId 13.0.1
 alicloud.vpc.flowLog.resourceId 13.0.1
 alicloud.vpc.flowLog.resourceType 13.0.1
@@ -1372,6 +1403,7 @@ alicloud.vpc.natGateway.networkType 13.0.0
 alicloud.vpc.natGateway.privateLinkEnabled 13.0.0
 alicloud.vpc.natGateway.privateLinkMode 13.0.0
 alicloud.vpc.natGateway.regionId 13.0.0
+alicloud.vpc.natGateway.resourceGroup 13.3.2
 alicloud.vpc.natGateway.resourceGroupId 13.0.0
 alicloud.vpc.natGateway.securityProtectionEnabled 13.0.0
 alicloud.vpc.natGateway.snatTableIds 13.0.0
@@ -1397,6 +1429,7 @@ alicloud.vpc.network.isDefault 13.0.0
 alicloud.vpc.network.natGateways 13.0.0
 alicloud.vpc.network.ownerId 13.0.0
 alicloud.vpc.network.regionId 13.0.0
+alicloud.vpc.network.resourceGroup 13.3.2
 alicloud.vpc.network.resourceGroupId 13.0.0
 alicloud.vpc.network.routeTables 13.0.0
 alicloud.vpc.network.status 13.0.0
@@ -1428,6 +1461,7 @@ alicloud.vpc.routeTable.creationTime 13.0.0
 alicloud.vpc.routeTable.description 13.0.0
 alicloud.vpc.routeTable.gatewayIds 13.0.0
 alicloud.vpc.routeTable.ownerId 13.0.0
+alicloud.vpc.routeTable.resourceGroup 13.3.2
 alicloud.vpc.routeTable.resourceGroupId 13.0.0
 alicloud.vpc.routeTable.routeEntries 13.0.0
 alicloud.vpc.routeTable.routePropagationEnable 13.0.0
@@ -1485,6 +1519,7 @@ alicloud.vpc.vpnGateway.ipsecVpnEnabled 13.2.5
 alicloud.vpc.vpnGateway.name 13.2.5
 alicloud.vpc.vpnGateway.networkType 13.2.5
 alicloud.vpc.vpnGateway.regionId 13.2.5
+alicloud.vpc.vpnGateway.resourceGroup 13.3.2
 alicloud.vpc.vpnGateway.resourceGroupId 13.2.5
 alicloud.vpc.vpnGateway.spec 13.2.5
 alicloud.vpc.vpnGateway.sslMaxConnections 13.2.5
@@ -1507,6 +1542,7 @@ alicloud.vpc.vswitch.ipv6CidrBlock 13.0.0
 alicloud.vpc.vswitch.isDefault 13.0.0
 alicloud.vpc.vswitch.networkAcl 13.0.0
 alicloud.vpc.vswitch.ownerId 13.0.0
+alicloud.vpc.vswitch.resourceGroup 13.3.2
 alicloud.vpc.vswitch.resourceGroupId 13.0.0
 alicloud.vpc.vswitch.routeTable 13.0.0
 alicloud.vpc.vswitch.routeTableType 13.0.0

--- a/providers/alicloud/resources/resource_group_refs.go
+++ b/providers/alicloud/resources/resource_group_refs.go
@@ -1,0 +1,120 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// Resource group ownership references.
+//
+// Every resource that reports a resource group id resolves it to the group
+// itself through resolveResourceGroup, which shares one ListResourceGroups
+// call across the whole scan. Keeping the accessors together makes it visible
+// which resources participate; adding a resourceGroupId field to a resource
+// without an accessor here leaves the id unresolvable.
+
+func (r *mqlAlicloudAlbLoadBalancer) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudAlbServerGroup) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudCenInstance) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudCsCluster) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudCsNodePool) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudEcsInstance) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudEcsKeypair) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudEcsSecuritygroup) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudEssScalingGroup) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudFcFunction) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudLogProject) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudMongodbInstance) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudNasFileSystem) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudNlbLoadBalancer) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudNlbServerGroup) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudOssBucket) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudPolardbCluster) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudRdsInstance) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudRedisInstance) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudSlbLoadBalancer) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudVpcEipAddress) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudVpcFlowLog) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudVpcNatGateway) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudVpcNetwork) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudVpcRouteTable) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudVpcVpnGateway) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}
+
+func (r *mqlAlicloudVpcVswitch) resourceGroup() (*mqlAlicloudResourceManagerResourceGroup, error) {
+	return resolveResourceGroup(r.MqlRuntime, r.ResourceGroupId.Data, &r.ResourceGroup)
+}

--- a/providers/alicloud/resources/resourcemanager.go
+++ b/providers/alicloud/resources/resourcemanager.go
@@ -16,7 +16,19 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/alicloud/connection"
+	"go.mondoo.com/mql/v13/types"
 )
+
+// rmPageDone reports whether a Resource Management listing has returned its
+// last page. A short page ends the walk; so does reaching the reported total,
+// which the API omits (as 0) on some listings. Both guards are needed: without
+// the short-page check a listing whose total is absent would page forever.
+func rmPageDone(itemCount int, pageNumber, pageSize, total int32) bool {
+	if itemCount < int(pageSize) {
+		return true
+	}
+	return total > 0 && pageNumber*pageSize >= total
+}
 
 // rmParseTime parses a Resource Management ISO-8601 timestamp, which may carry
 // fractional seconds. Returns nil on a nil or unparseable input.
@@ -33,11 +45,19 @@ func rmParseTime(s *string) *time.Time {
 }
 
 // mqlAlicloudResourceManagerInternal memoizes the resource directory detail
-// shared by the identity accessors.
+// shared by the identity accessors, and the account's resource groups, which
+// back the resourceGroup reference on every resource that carries a resource
+// group id.
 type mqlAlicloudResourceManagerInternal struct {
 	dirLock    sync.Mutex
 	dirFetched atomic.Bool
 	dir        *rmclient.GetResourceDirectoryResponseBodyResourceDirectory
+
+	groupsLock    sync.Mutex
+	groupsFetched atomic.Bool
+	groupsErr     error
+	groups        []any
+	groupsByID    map[string]*mqlAlicloudResourceManagerResourceGroup
 }
 
 func (r *mqlAlicloudResourceManager) id() (string, error) {
@@ -226,7 +246,7 @@ func (r *mqlAlicloudResourceManager) accounts() ([]any, error) {
 		}
 
 		total := tea.Int32Value(resp.Body.TotalCount)
-		if len(items) < int(pageSize) || (total > 0 && pageNumber*pageSize >= total) {
+		if rmPageDone(len(items), pageNumber, pageSize, total) {
 			break
 		}
 		pageNumber++
@@ -285,7 +305,7 @@ func (r *mqlAlicloudResourceManager) folders() ([]any, error) {
 				queue = append(queue, tea.StringValue(f.FolderId))
 			}
 			total := tea.Int32Value(resp.Body.TotalCount)
-			if len(items) < int(pageSize) || (total > 0 && pageNumber*pageSize >= total) {
+			if rmPageDone(len(items), pageNumber, pageSize, total) {
 				break
 			}
 			pageNumber++
@@ -342,7 +362,7 @@ func (r *mqlAlicloudResourceManager) controlPolicies() ([]any, error) {
 				res = append(res, resource)
 			}
 			total := tea.Int32Value(resp.Body.TotalCount)
-			if len(items) < int(pageSize) || (total > 0 && pageNumber*pageSize >= total) {
+			if rmPageDone(len(items), pageNumber, pageSize, total) {
 				break
 			}
 			pageNumber++
@@ -426,6 +446,162 @@ func initAlicloudResourceManagerFolder(runtime *plugin.Runtime, args map[string]
 
 func (r *mqlAlicloudResourceManagerFolder) id() (string, error) {
 	return r.FolderId.Data, nil
+}
+
+// loadResourceGroups lists every resource group in the account once and indexes
+// it by id.
+//
+// Unlike directory(), a failure is cached alongside the result. Resource groups
+// are resolved from the resourceGroup reference of every ECS instance, bucket,
+// cluster and load balancer in a scan, so an uncached error would turn one
+// denied ListResourceGroups call into one call per resource.
+func (r *mqlAlicloudResourceManager) loadResourceGroups() error {
+	if r.groupsFetched.Load() {
+		return r.groupsErr
+	}
+	r.groupsLock.Lock()
+	defer r.groupsLock.Unlock()
+	if r.groupsFetched.Load() {
+		return r.groupsErr
+	}
+
+	groups := []any{}
+	byID := map[string]*mqlAlicloudResourceManagerResourceGroup{}
+	err := func() error {
+		conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+		client, err := conn.ResourceManagerClient()
+		if err != nil {
+			return err
+		}
+
+		pageNumber := int32(1)
+		pageSize := int32(100)
+		for {
+			resp, err := client.ListResourceGroups(&rmclient.ListResourceGroupsRequest{
+				IncludeTags: tea.Bool(true),
+				PageNumber:  tea.Int32(pageNumber),
+				PageSize:    tea.Int32(pageSize),
+			})
+			if err != nil {
+				return err
+			}
+			if resp == nil || resp.Body == nil || resp.Body.ResourceGroups == nil {
+				break
+			}
+
+			items := resp.Body.ResourceGroups.ResourceGroup
+			for _, g := range items {
+				if g == nil || tea.StringValue(g.Id) == "" {
+					continue
+				}
+				resource, err := newResourceManagerResourceGroup(r.MqlRuntime, g)
+				if err != nil {
+					return err
+				}
+				groups = append(groups, resource)
+				byID[tea.StringValue(g.Id)] = resource
+			}
+
+			total := tea.Int32Value(resp.Body.TotalCount)
+			if rmPageDone(len(items), pageNumber, pageSize, total) {
+				break
+			}
+			pageNumber++
+		}
+		return nil
+	}()
+
+	if err != nil {
+		r.groupsErr = err
+	} else {
+		r.groups = groups
+		r.groupsByID = byID
+	}
+	r.groupsFetched.Store(true)
+	return r.groupsErr
+}
+
+func (r *mqlAlicloudResourceManager) resourceGroups() ([]any, error) {
+	if err := r.loadResourceGroups(); err != nil {
+		return nil, err
+	}
+	return r.groups, nil
+}
+
+// resourceGroupByID returns the resource group with the given id, or nil when
+// the account has no such group.
+func (r *mqlAlicloudResourceManager) resourceGroupByID(id string) (*mqlAlicloudResourceManagerResourceGroup, error) {
+	if err := r.loadResourceGroups(); err != nil {
+		return nil, err
+	}
+	return r.groupsByID[id], nil
+}
+
+// resourceGroupTagsToMap flattens the nested tag envelope ListResourceGroups
+// returns. A tag with no key is dropped rather than creating an empty-string
+// key, and a tag with no value maps to the empty string.
+func resourceGroupTagsToMap(tags *rmclient.ListResourceGroupsResponseBodyResourceGroupsResourceGroupTags) map[string]any {
+	res := map[string]any{}
+	if tags == nil {
+		return res
+	}
+	for _, t := range tags.Tag {
+		if t == nil || tea.StringValue(t.TagKey) == "" {
+			continue
+		}
+		res[tea.StringValue(t.TagKey)] = tea.StringValue(t.TagValue)
+	}
+	return res
+}
+
+// newResourceManagerResourceGroup builds a resource group resource from a
+// ListResourceGroups entry.
+func newResourceManagerResourceGroup(runtime *plugin.Runtime, g *rmclient.ListResourceGroupsResponseBodyResourceGroupsResourceGroup) (*mqlAlicloudResourceManagerResourceGroup, error) {
+	resource, err := CreateResource(runtime, "alicloud.resourceManager.resourceGroup", map[string]*llx.RawData{
+		"__id":            llx.StringDataPtr(g.Id),
+		"resourceGroupId": llx.StringDataPtr(g.Id),
+		"name":            llx.StringDataPtr(g.Name),
+		"displayName":     llx.StringDataPtr(g.DisplayName),
+		"accountId":       llx.StringDataPtr(g.AccountId),
+		"status":          llx.StringDataPtr(g.Status),
+		"createDate":      llx.TimeDataPtr(rmParseTime(g.CreateDate)),
+		"tags":            llx.MapData(resourceGroupTagsToMap(g.Tags), types.String),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resource.(*mqlAlicloudResourceManagerResourceGroup), nil
+}
+
+// initAlicloudResourceManagerResourceGroup resolves a resource group by id from
+// the account's group listing, which is fetched once and shared with every
+// resourceGroup reference in the scan.
+func initAlicloudResourceManagerResourceGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	groupID, err := requiredStringArg(args, "resourceGroupId", "alicloud.resourceManager.resourceGroup")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rm, err := resourceManagerResource(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	group, err := rm.resourceGroupByID(groupID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if group == nil {
+		return nil, nil, fmt.Errorf("alicloud.resourceManager.resourceGroup %q not found", groupID)
+	}
+	return nil, group, nil
+}
+
+func (r *mqlAlicloudResourceManagerResourceGroup) id() (string, error) {
+	return r.ResourceGroupId.Data, nil
 }
 
 func (r *mqlAlicloudResourceManagerControlPolicy) id() (string, error) {

--- a/providers/alicloud/resources/resourcemanager.go
+++ b/providers/alicloud/resources/resourcemanager.go
@@ -12,6 +12,7 @@ import (
 
 	rmclient "github.com/alibabacloud-go/resourcemanager-20200331/v3/client"
 	tea "github.com/alibabacloud-go/tea/tea"
+	"github.com/rs/zerolog/log"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -491,7 +492,19 @@ func (r *mqlAlicloudResourceManager) loadResourceGroups() error {
 
 			items := resp.Body.ResourceGroups.ResourceGroup
 			for _, g := range items {
-				if g == nil || tea.StringValue(g.Id) == "" {
+				if g == nil {
+					continue
+				}
+				// Id is the rg- identifier that every other resource reports as
+				// its resourceGroupId, so it is the only usable key. Name is a
+				// separate account-unique label and cannot stand in for it. A
+				// group without an id can be neither keyed nor referenced, so
+				// it is dropped, but not silently: the resources that belong to
+				// it would otherwise report a null resource group with no
+				// explanation.
+				if tea.StringValue(g.Id) == "" {
+					log.Warn().Str("name", tea.StringValue(g.Name)).
+						Msg("alicloud> skipping resource group without an id")
 					continue
 				}
 				resource, err := newResourceManagerResourceGroup(r.MqlRuntime, g)

--- a/providers/alicloud/resources/resourcemanager_test.go
+++ b/providers/alicloud/resources/resourcemanager_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	rmclient "github.com/alibabacloud-go/resourcemanager-20200331/v3/client"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRmPageDone covers the Resource Management pagination guard. The failure
+// this protects against is silent: an endpoint that reports no total and always
+// returns a full page would page forever without the short-page check, and a
+// listing cut off one page early reports a partial account as the whole account.
+func TestRmPageDone(t *testing.T) {
+	t.Run("short page ends the walk", func(t *testing.T) {
+		assert.True(t, rmPageDone(37, 1, 100, 0))
+	})
+	t.Run("empty page ends the walk", func(t *testing.T) {
+		assert.True(t, rmPageDone(0, 3, 100, 0))
+	})
+	t.Run("full page with no reported total continues", func(t *testing.T) {
+		assert.False(t, rmPageDone(100, 1, 100, 0))
+	})
+	t.Run("full page short of the total continues", func(t *testing.T) {
+		assert.False(t, rmPageDone(100, 1, 100, 250))
+	})
+	t.Run("full page reaching the total ends the walk", func(t *testing.T) {
+		assert.True(t, rmPageDone(100, 3, 100, 250))
+	})
+	t.Run("full page exactly at the total ends the walk", func(t *testing.T) {
+		assert.True(t, rmPageDone(100, 2, 100, 200))
+	})
+}
+
+// TestResourceGroupTagsToMap covers the tag envelope flattening. A resource
+// group's tags select environments in an audit, so a dropped or empty-keyed tag
+// silently changes which resources a query matches.
+func TestResourceGroupTagsToMap(t *testing.T) {
+	tag := func(k, v *string) *rmclient.ListResourceGroupsResponseBodyResourceGroupsResourceGroupTags {
+		return &rmclient.ListResourceGroupsResponseBodyResourceGroupsResourceGroupTags{
+			Tag: []*rmclient.ListResourceGroupsResponseBodyResourceGroupsResourceGroupTagsTag{
+				{TagKey: k, TagValue: v},
+			},
+		}
+	}
+
+	t.Run("nil envelope yields an empty map, not nil", func(t *testing.T) {
+		got := resourceGroupTagsToMap(nil)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+	t.Run("key and value are carried through", func(t *testing.T) {
+		got := resourceGroupTagsToMap(tag(strp("env"), strp("production")))
+		assert.Equal(t, map[string]any{"env": "production"}, got)
+	})
+	t.Run("nil value becomes an empty string", func(t *testing.T) {
+		got := resourceGroupTagsToMap(tag(strp("env"), nil))
+		assert.Equal(t, map[string]any{"env": ""}, got)
+	})
+	t.Run("nil key is dropped", func(t *testing.T) {
+		assert.Empty(t, resourceGroupTagsToMap(tag(nil, strp("production"))))
+	})
+	t.Run("empty key is dropped", func(t *testing.T) {
+		assert.Empty(t, resourceGroupTagsToMap(tag(strp(""), strp("production"))))
+	})
+	t.Run("nil tag entry is skipped", func(t *testing.T) {
+		tags := &rmclient.ListResourceGroupsResponseBodyResourceGroupsResourceGroupTags{
+			Tag: []*rmclient.ListResourceGroupsResponseBodyResourceGroupsResourceGroupTagsTag{
+				nil,
+				{TagKey: strp("env"), TagValue: strp("staging")},
+			},
+		}
+		assert.Equal(t, map[string]any{"env": "staging"}, resourceGroupTagsToMap(tags))
+	})
+}

--- a/providers/alicloud/resources/typed_refs.go
+++ b/providers/alicloud/resources/typed_refs.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	vpcclient "github.com/alibabacloud-go/vpc-20160428/v6/client"
+	"github.com/rs/zerolog/log"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -312,6 +313,50 @@ func scopedInitIDArgs(runtime *plugin.Runtime, args map[string]*llx.RawData, sco
 		return args
 	}
 	return map[string]*llx.RawData{idField: llx.StringData(id)}
+}
+
+// resourceManagerResource returns the shared alicloud.resourceManager instance.
+// It memoizes the account's resource group listing, so every resourceGroup
+// reference in a scan resolves against one ListResourceGroups call.
+func resourceManagerResource(runtime *plugin.Runtime) (*mqlAlicloudResourceManager, error) {
+	res, err := CreateResource(runtime, "alicloud.resourceManager", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAlicloudResourceManager), nil
+}
+
+// resolveResourceGroup returns the resource group that owns a resource, given
+// the resource's resource group id.
+//
+// A resource group that cannot be read resolves to null rather than failing the
+// caller: Resource Management is a separate service that an account may not
+// have permission for, and one unreadable group must not fail a query over
+// every instance in a region. The lookup is warned once per resource so the
+// null is attributable, and alicloud.resourceManager.resourceGroups still
+// surfaces the underlying error for anyone querying the groups directly.
+func resolveResourceGroup(runtime *plugin.Runtime, groupID string, field *plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]) (*mqlAlicloudResourceManagerResourceGroup, error) {
+	if groupID == "" {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	rm, err := resourceManagerResource(runtime)
+	if err != nil {
+		return nil, err
+	}
+	group, err := rm.resourceGroupByID(groupID)
+	if err != nil {
+		log.Warn().Err(err).Str("resourceGroupId", groupID).
+			Msg("alicloud> unable to resolve resource group")
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	if group == nil {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return group, nil
 }
 
 // requiredStringArg reads a required non-empty string argument from an init

--- a/providers/alicloud/resources/typed_refs.go
+++ b/providers/alicloud/resources/typed_refs.go
@@ -343,7 +343,10 @@ func resolveResourceGroup(runtime *plugin.Runtime, groupID string, field *plugin
 
 	rm, err := resourceManagerResource(runtime)
 	if err != nil {
-		return nil, err
+		log.Warn().Err(err).Str("resourceGroupId", groupID).
+			Msg("alicloud> unable to reach the resource manager")
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 	group, err := rm.resourceGroupByID(groupID)
 	if err != nil {


### PR DESCRIPTION
## What

`resourceGroupId` appears on **27 resources** in the alicloud provider and resolved to nothing — there was no resource group resource in the schema at all. The ownership and billing boundary that most Alibaba Cloud accounts are organized around, and that RAM policies are commonly scoped to, could only be queried as an opaque `rg-` string.

This adds `alicloud.resourceManager.resourceGroup` and a `resourceGroup` reference on every resource that reports a group id.

**Before**

```javascript
alicloud.ecs.instances.where(resourceGroupId == "rg-acfmxazb4ph6aiy")
```

**After**

```javascript
alicloud.ecs.instances.where(resourceGroup.name == "production")
alicloud.oss.buckets.where(resourceGroup.name == "sandbox" && isPublic)
alicloud.cs.clusters.where(resourceGroup.tags["env"] == "prod")
```

## Resources that gained `resourceGroup`

ECS (instance, keypair, securitygroup) · VPC (network, vswitch, routeTable, natGateway, eipAddress, flowLog, vpnGateway) · OSS bucket · SLB/ALB/NLB (loadBalancer ×3, serverGroup ×2) · RDS, Redis, MongoDB, PolarDB · ACK (cluster, nodePool) · FC function · NAS fileSystem · CEN instance · Log Service project · Auto Scaling scalingGroup

## Notes for review

- **One API call per scan.** `ListResourceGroups` returns the whole account, so the listing is fetched once and indexed by id on the shared `alicloud.resourceManager` instance. Resolving the reference on 500 ECS instances costs one call, not 500 — this is why the accessors go through `resolveResourceGroup` rather than `NewResource` (which would run an init per item, before the cache is consulted).
- **Unreadable groups resolve to null, with a warning.** Resource Management is a separate service that an account may not have permission for. Failing the reference would fail a query over every instance in a region, so the failure is cached and degraded to null; `alicloud.resourceManager.resourceGroups` still returns the underlying error for anyone querying the groups directly.
- **The raw `resourceGroupId` fields are kept, not deprecated.** They come from each resource's own API and are readable without Resource Management permissions, so they aren't a strict duplicate of the reference.
- `alicloud.waf.defenseResource` has a pre-existing `resourceGroup string` field from the WAF API. It's left alone here — giving it a reference means renaming that field, which is breaking.
- No new dependencies: `resourcemanager-20200331/v3` was already in `go.mod`.
- Drive-by: the pagination termination guard was written out four times in `resourcemanager.go`; extracted to `rmPageDone` and unit tested, since the new lister needed the same guard.

## Testing

- `go build ./...` and `go test ./...` clean in `providers/alicloud/`
- New unit tests cover the pagination guard (including the stuck-cursor case where the API reports no total) and the tag envelope decoding (nil envelope, nil entry, nil key, nil value)
- **Not live-verified** — no Alibaba Cloud credentials available. Batched provider-verification is owed along with the other unverified alicloud stacks.
