### PR TITLE
✨ alicloud: close 13 dangling reference gaps across ECS, ACK, SLS, NAS and FC

### DIFF
--- a/providers/alicloud/resources/alb.go
+++ b/providers/alicloud/resources/alb.go
@@ -329,6 +329,7 @@ func (r *mqlAlicloudAlbLoadBalancer) listeners() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			mqlListener.parentLoadBalancer = r
 			res = append(res, mqlListener)
 		}
 		if resp.Body.NextToken == nil || *resp.Body.NextToken == "" {
@@ -342,6 +343,12 @@ func (r *mqlAlicloudAlbLoadBalancer) listeners() ([]any, error) {
 // mqlAlicloudAlbListenerInternal caches the forward server-group ids and
 // memoizes the GetListenerAttribute detail (for certificates and mTLS state).
 type mqlAlicloudAlbListenerInternal struct {
+	// parentLoadBalancer is the load balancer the listener was listed from. A
+	// listener exists only as a child of its load balancer, so carrying the
+	// parent from the listing context resolves the reference without an API
+	// call.
+	parentLoadBalancer *mqlAlicloudAlbLoadBalancer
+
 	region              string
 	listenerId          string
 	cacheServerGroupIds []string
@@ -398,6 +405,14 @@ func newAlbListener(runtime *plugin.Runtime, region string, l *albclient.ListLis
 	mqlListener.listenerId = listenerID
 	mqlListener.cacheServerGroupIds = sgIds
 	return mqlListener, nil
+}
+
+func (r *mqlAlicloudAlbListener) loadBalancer() (*mqlAlicloudAlbLoadBalancer, error) {
+	if r.parentLoadBalancer == nil {
+		r.LoadBalancer.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return r.parentLoadBalancer, nil
 }
 
 func (r *mqlAlicloudAlbListener) id() (string, error) {

--- a/providers/alicloud/resources/alicloud.lr
+++ b/providers/alicloud/resources/alicloud.lr
@@ -121,6 +121,8 @@ alicloud.ram.user {
 alicloud.ram.accessKey {
   // User name that owns the access key
   userName string
+  // RAM user that owns the access key
+  user() alicloud.ram.user
   // Access key ID
   accessKeyId string
   // Key status
@@ -443,6 +445,11 @@ alicloud.ecs.instance @defaults("instanceId instanceName status instanceType") {
   deploymentSetId string
   // Name of the SSH key pair used by the instance
   keyPairName string
+  // SSH key pair used by the instance
+  //
+  // Null on an instance launched without a key pair, and on one whose key pair
+  // has since been deleted.
+  keyPair() alicloud.ecs.keypair
   // Whether release protection is enabled
   deletionProtection bool
   // Whether the instance is I/O optimized
@@ -687,7 +694,13 @@ alicloud.ecs.securitygroup @defaults("securityGroupId securityGroupName security
   // Security group description
   description string
   // VPC ID the security group belongs to
-  vpcId string
+  //
+  // Deprecated in favor of vpc.
+  vpcId @maturity("deprecated") string
+  // VPC the security group belongs to
+  //
+  // Null on a classic-network security group, which is not in a VPC.
+  vpc() alicloud.vpc.network
   // Security group type
   //
   // One of normal or enterprise.
@@ -1709,7 +1722,12 @@ alicloud.slb.loadBalancer {
 // available through config.
 alicloud.slb.listener {
   // ID of the CLB instance that the listener belongs to
+  //
+  // Not deprecated alongside the ALB and NLB equivalents: a CLB listener has no
+  // id of its own and is keyed by this id together with its protocol and port.
   loadBalancerId string
+  // CLB instance that the listener belongs to
+  loadBalancer() alicloud.slb.loadBalancer
   // Protocol used by the listener
   //
   // One of http, https, tcp, or udp.
@@ -2369,6 +2387,11 @@ alicloud.vpc.flowLog {
   aggregationInterval int
   // Name of the Log Service project that receives the records
   projectName string
+  // Log Service project that receives the records
+  //
+  // Null when the flow log names no project, and when the project lives in
+  // another account that the scan cannot read.
+  project() alicloud.log.project
   // Name of the Log Service logstore that receives the records
   logStoreName string
   // ID of the resource group the flow log belongs to
@@ -2682,6 +2705,8 @@ alicloud.log.logstore {
   regionId string
   // Name of the project that contains the logstore
   projectName string
+  // Project that contains the logstore
+  project() alicloud.log.project
   // Logstore name, used with the project name as the lookup key
   name string
   // Number of days ingested logs are retained; 3650 means permanent retention
@@ -2892,7 +2917,13 @@ alicloud.resourceManager.folder {
   // Folder name
   folderName string
   // ID of the parent folder, empty for the root folder
-  parentFolderId string
+  //
+  // Deprecated in favor of parentFolder.
+  parentFolderId @maturity("deprecated") string
+  // Parent folder in the resource directory hierarchy
+  //
+  // Null on the root folder, which has no parent.
+  parentFolder() alicloud.resourceManager.folder
   // Time the folder was created
   createTime time
 }
@@ -3111,7 +3142,12 @@ alicloud.cs.nodePool {
   // Region ID the node pool resides in
   regionId string
   // ID of the cluster the node pool belongs to
+  //
+  // Not deprecated alongside the other duplicated identifiers: a node pool id is
+  // unique only within its cluster, so the node pool is keyed by both.
   clusterId string
+  // Cluster the node pool belongs to
+  cluster() alicloud.cs.cluster
   // Node pool ID, used as the lookup key
   nodePoolId string
   // Node pool name
@@ -3144,6 +3180,11 @@ alicloud.cs.nodePool {
   imageType string
   // ID of the image used for nodes
   imageId string
+  // Image the node pool launches nodes from
+  //
+  // Null on a node pool that names no image, and on one whose image is not
+  // visible to the account, for example a public image that has been retired.
+  image() alicloud.ecs.image
   // Node billing method
   //
   // Either PrePaid (subscription) or PostPaid (pay-as-you-go).
@@ -3322,7 +3363,11 @@ alicloud.alb.listener {
   // Listener ID, used as the lookup key
   listenerId string
   // ID of the load balancer the listener belongs to
-  loadBalancerId string
+  //
+  // Deprecated in favor of loadBalancer.
+  loadBalancerId @maturity("deprecated") string
+  // Load balancer the listener belongs to
+  loadBalancer() alicloud.alb.loadBalancer
   // Listener protocol, one of HTTP, HTTPS, or QUIC
   protocol string
   // Port the listener serves on
@@ -3494,7 +3539,11 @@ alicloud.nlb.listener {
   // Listener ID, used as the lookup key
   listenerId string
   // ID of the load balancer the listener belongs to
-  loadBalancerId string
+  //
+  // Deprecated in favor of loadBalancer.
+  loadBalancerId @maturity("deprecated") string
+  // Load balancer the listener belongs to
+  loadBalancer() alicloud.nlb.loadBalancer
   // Listener protocol, one of TCP, UDP, or TCPSSL
   protocol string
   // Port the listener serves on
@@ -3678,6 +3727,8 @@ alicloud.fc.trigger {
   regionId string
   // Name of the function the trigger belongs to
   functionName string
+  // Function the trigger belongs to
+  function() alicloud.fc.function
   // Trigger name, used with the function name as the lookup key
   triggerName string
   // System-generated trigger ID
@@ -3806,7 +3857,11 @@ alicloud.nas.mountTarget {
   // Region ID the mount target resides in
   regionId string
   // ID of the file system the mount target belongs to
-  fileSystemId string
+  //
+  // Deprecated in favor of fileSystem.
+  fileSystemId @maturity("deprecated") string
+  // File system the mount target belongs to
+  fileSystem() alicloud.nas.fileSystem
   // Mount target domain (the mount address), used as the lookup key
   mountTargetDomain string
   // Mount target status, for example Active or Inactive

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -683,6 +683,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.ram.accessKey.userName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamAccessKey).GetUserName()).ToDataRes(types.String)
 	},
+	"alicloud.ram.accessKey.user": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRamAccessKey).GetUser()).ToDataRes(types.Resource("alicloud.ram.user"))
+	},
 	"alicloud.ram.accessKey.accessKeyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRamAccessKey).GetAccessKeyId()).ToDataRes(types.String)
 	},
@@ -938,6 +941,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.ecs.instance.keyPairName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsInstance).GetKeyPairName()).ToDataRes(types.String)
 	},
+	"alicloud.ecs.instance.keyPair": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudEcsInstance).GetKeyPair()).ToDataRes(types.Resource("alicloud.ecs.keypair"))
+	},
 	"alicloud.ecs.instance.deletionProtection": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsInstance).GetDeletionProtection()).ToDataRes(types.Bool)
 	},
@@ -1168,6 +1174,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.ecs.securitygroup.vpcId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsSecuritygroup).GetVpcId()).ToDataRes(types.String)
+	},
+	"alicloud.ecs.securitygroup.vpc": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudEcsSecuritygroup).GetVpc()).ToDataRes(types.Resource("alicloud.vpc.network"))
 	},
 	"alicloud.ecs.securitygroup.securityGroupType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudEcsSecuritygroup).GetSecurityGroupType()).ToDataRes(types.String)
@@ -2048,6 +2057,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.slb.listener.loadBalancerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudSlbListener).GetLoadBalancerId()).ToDataRes(types.String)
 	},
+	"alicloud.slb.listener.loadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudSlbListener).GetLoadBalancer()).ToDataRes(types.Resource("alicloud.slb.loadBalancer"))
+	},
 	"alicloud.slb.listener.protocol": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudSlbListener).GetProtocol()).ToDataRes(types.String)
 	},
@@ -2624,6 +2636,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.vpc.flowLog.projectName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcFlowLog).GetProjectName()).ToDataRes(types.String)
 	},
+	"alicloud.vpc.flowLog.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudVpcFlowLog).GetProject()).ToDataRes(types.Resource("alicloud.log.project"))
+	},
 	"alicloud.vpc.flowLog.logStoreName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudVpcFlowLog).GetLogStoreName()).ToDataRes(types.String)
 	},
@@ -2903,6 +2918,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.log.logstore.projectName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudLogLogstore).GetProjectName()).ToDataRes(types.String)
 	},
+	"alicloud.log.logstore.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudLogLogstore).GetProject()).ToDataRes(types.Resource("alicloud.log.project"))
+	},
 	"alicloud.log.logstore.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudLogLogstore).GetName()).ToDataRes(types.String)
 	},
@@ -3088,6 +3106,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.resourceManager.folder.parentFolderId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudResourceManagerFolder).GetParentFolderId()).ToDataRes(types.String)
+	},
+	"alicloud.resourceManager.folder.parentFolder": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudResourceManagerFolder).GetParentFolder()).ToDataRes(types.Resource("alicloud.resourceManager.folder"))
 	},
 	"alicloud.resourceManager.folder.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudResourceManagerFolder).GetCreateTime()).ToDataRes(types.Time)
@@ -3275,6 +3296,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.cs.nodePool.clusterId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsNodePool).GetClusterId()).ToDataRes(types.String)
 	},
+	"alicloud.cs.nodePool.cluster": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudCsNodePool).GetCluster()).ToDataRes(types.Resource("alicloud.cs.cluster"))
+	},
 	"alicloud.cs.nodePool.nodePoolId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsNodePool).GetNodePoolId()).ToDataRes(types.String)
 	},
@@ -3322,6 +3346,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.cs.nodePool.imageId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsNodePool).GetImageId()).ToDataRes(types.String)
+	},
+	"alicloud.cs.nodePool.image": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudCsNodePool).GetImage()).ToDataRes(types.Resource("alicloud.ecs.image"))
 	},
 	"alicloud.cs.nodePool.instanceChargeType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudCsNodePool).GetInstanceChargeType()).ToDataRes(types.String)
@@ -3518,6 +3545,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.alb.listener.loadBalancerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudAlbListener).GetLoadBalancerId()).ToDataRes(types.String)
 	},
+	"alicloud.alb.listener.loadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudAlbListener).GetLoadBalancer()).ToDataRes(types.Resource("alicloud.alb.loadBalancer"))
+	},
 	"alicloud.alb.listener.protocol": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudAlbListener).GetProtocol()).ToDataRes(types.String)
 	},
@@ -3697,6 +3727,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.nlb.listener.loadBalancerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNlbListener).GetLoadBalancerId()).ToDataRes(types.String)
+	},
+	"alicloud.nlb.listener.loadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudNlbListener).GetLoadBalancer()).ToDataRes(types.Resource("alicloud.nlb.loadBalancer"))
 	},
 	"alicloud.nlb.listener.protocol": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNlbListener).GetProtocol()).ToDataRes(types.String)
@@ -3899,6 +3932,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.fc.trigger.functionName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudFcTrigger).GetFunctionName()).ToDataRes(types.String)
 	},
+	"alicloud.fc.trigger.function": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudFcTrigger).GetFunction()).ToDataRes(types.Resource("alicloud.fc.function"))
+	},
 	"alicloud.fc.trigger.triggerName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudFcTrigger).GetTriggerName()).ToDataRes(types.String)
 	},
@@ -4015,6 +4051,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"alicloud.nas.mountTarget.fileSystemId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNasMountTarget).GetFileSystemId()).ToDataRes(types.String)
+	},
+	"alicloud.nas.mountTarget.fileSystem": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudNasMountTarget).GetFileSystem()).ToDataRes(types.Resource("alicloud.nas.fileSystem"))
 	},
 	"alicloud.nas.mountTarget.mountTargetDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudNasMountTarget).GetMountTargetDomain()).ToDataRes(types.String)
@@ -5194,6 +5233,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudRamAccessKey).UserName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.ram.accessKey.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRamAccessKey).User, ok = plugin.RawToTValue[*mqlAlicloudRamUser](v.Value, v.Error)
+		return
+	},
 	"alicloud.ram.accessKey.accessKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudRamAccessKey).AccessKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5562,6 +5605,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudEcsInstance).KeyPairName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.ecs.instance.keyPair": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudEcsInstance).KeyPair, ok = plugin.RawToTValue[*mqlAlicloudEcsKeypair](v.Value, v.Error)
+		return
+	},
 	"alicloud.ecs.instance.deletionProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudEcsInstance).DeletionProtection, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -5884,6 +5931,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.ecs.securitygroup.vpcId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudEcsSecuritygroup).VpcId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.ecs.securitygroup.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudEcsSecuritygroup).Vpc, ok = plugin.RawToTValue[*mqlAlicloudVpcNetwork](v.Value, v.Error)
 		return
 	},
 	"alicloud.ecs.securitygroup.securityGroupType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7122,6 +7173,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudSlbListener).LoadBalancerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.slb.listener.loadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudSlbListener).LoadBalancer, ok = plugin.RawToTValue[*mqlAlicloudSlbLoadBalancer](v.Value, v.Error)
+		return
+	},
 	"alicloud.slb.listener.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudSlbListener).Protocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -7926,6 +7981,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudVpcFlowLog).ProjectName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.vpc.flowLog.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudVpcFlowLog).Project, ok = plugin.RawToTValue[*mqlAlicloudLogProject](v.Value, v.Error)
+		return
+	},
 	"alicloud.vpc.flowLog.logStoreName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudVpcFlowLog).LogStoreName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8330,6 +8389,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudLogLogstore).ProjectName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.log.logstore.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudLogLogstore).Project, ok = plugin.RawToTValue[*mqlAlicloudLogProject](v.Value, v.Error)
+		return
+	},
 	"alicloud.log.logstore.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudLogLogstore).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8596,6 +8659,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.resourceManager.folder.parentFolderId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudResourceManagerFolder).ParentFolderId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.resourceManager.folder.parentFolder": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudResourceManagerFolder).ParentFolder, ok = plugin.RawToTValue[*mqlAlicloudResourceManagerFolder](v.Value, v.Error)
 		return
 	},
 	"alicloud.resourceManager.folder.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8866,6 +8933,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudCsNodePool).ClusterId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.cs.nodePool.cluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudCsNodePool).Cluster, ok = plugin.RawToTValue[*mqlAlicloudCsCluster](v.Value, v.Error)
+		return
+	},
 	"alicloud.cs.nodePool.nodePoolId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudCsNodePool).NodePoolId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8928,6 +8999,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.cs.nodePool.imageId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudCsNodePool).ImageId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.cs.nodePool.image": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudCsNodePool).Image, ok = plugin.RawToTValue[*mqlAlicloudEcsImage](v.Value, v.Error)
 		return
 	},
 	"alicloud.cs.nodePool.instanceChargeType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9202,6 +9277,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudAlbListener).LoadBalancerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.alb.listener.loadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudAlbListener).LoadBalancer, ok = plugin.RawToTValue[*mqlAlicloudAlbLoadBalancer](v.Value, v.Error)
+		return
+	},
 	"alicloud.alb.listener.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudAlbListener).Protocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -9456,6 +9535,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.nlb.listener.loadBalancerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudNlbListener).LoadBalancerId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.nlb.listener.loadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudNlbListener).LoadBalancer, ok = plugin.RawToTValue[*mqlAlicloudNlbLoadBalancer](v.Value, v.Error)
 		return
 	},
 	"alicloud.nlb.listener.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9742,6 +9825,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAlicloudFcTrigger).FunctionName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"alicloud.fc.trigger.function": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudFcTrigger).Function, ok = plugin.RawToTValue[*mqlAlicloudFcFunction](v.Value, v.Error)
+		return
+	},
 	"alicloud.fc.trigger.triggerName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudFcTrigger).TriggerName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -9908,6 +9995,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.nas.mountTarget.fileSystemId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudNasMountTarget).FileSystemId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.nas.mountTarget.fileSystem": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudNasMountTarget).FileSystem, ok = plugin.RawToTValue[*mqlAlicloudNasFileSystem](v.Value, v.Error)
 		return
 	},
 	"alicloud.nas.mountTarget.mountTargetDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11838,6 +11929,7 @@ type mqlAlicloudRamAccessKey struct {
 	__id       string
 	// optional: if you define mqlAlicloudRamAccessKeyInternal it will be used here
 	UserName    plugin.TValue[string]
+	User        plugin.TValue[*mqlAlicloudRamUser]
 	AccessKeyId plugin.TValue[string]
 	Status      plugin.TValue[string]
 	CreateDate  plugin.TValue[*time.Time]
@@ -11882,6 +11974,22 @@ func (c *mqlAlicloudRamAccessKey) MqlID() string {
 
 func (c *mqlAlicloudRamAccessKey) GetUserName() *plugin.TValue[string] {
 	return &c.UserName
+}
+
+func (c *mqlAlicloudRamAccessKey) GetUser() *plugin.TValue[*mqlAlicloudRamUser] {
+	return plugin.GetOrCompute[*mqlAlicloudRamUser](&c.User, func() (*mqlAlicloudRamUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ram.accessKey", c.__id, "user")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudRamUser), nil
+			}
+		}
+
+		return c.user()
+	})
 }
 
 func (c *mqlAlicloudRamAccessKey) GetAccessKeyId() *plugin.TValue[string] {
@@ -12572,6 +12680,7 @@ type mqlAlicloudEcsInstance struct {
 	StoppedMode             plugin.TValue[string]
 	DeploymentSetId         plugin.TValue[string]
 	KeyPairName             plugin.TValue[string]
+	KeyPair                 plugin.TValue[*mqlAlicloudEcsKeypair]
 	DeletionProtection      plugin.TValue[bool]
 	IoOptimized             plugin.TValue[bool]
 	GpuAmount               plugin.TValue[int64]
@@ -12766,6 +12875,22 @@ func (c *mqlAlicloudEcsInstance) GetDeploymentSetId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudEcsInstance) GetKeyPairName() *plugin.TValue[string] {
 	return &c.KeyPairName
+}
+
+func (c *mqlAlicloudEcsInstance) GetKeyPair() *plugin.TValue[*mqlAlicloudEcsKeypair] {
+	return plugin.GetOrCompute[*mqlAlicloudEcsKeypair](&c.KeyPair, func() (*mqlAlicloudEcsKeypair, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ecs.instance", c.__id, "keyPair")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudEcsKeypair), nil
+			}
+		}
+
+		return c.keyPair()
+	})
 }
 
 func (c *mqlAlicloudEcsInstance) GetDeletionProtection() *plugin.TValue[bool] {
@@ -13349,6 +13474,7 @@ type mqlAlicloudEcsSecuritygroup struct {
 	SecurityGroupName plugin.TValue[string]
 	Description       plugin.TValue[string]
 	VpcId             plugin.TValue[string]
+	Vpc               plugin.TValue[*mqlAlicloudVpcNetwork]
 	SecurityGroupType plugin.TValue[string]
 	CreationTime      plugin.TValue[*time.Time]
 	RegionId          plugin.TValue[string]
@@ -13410,6 +13536,22 @@ func (c *mqlAlicloudEcsSecuritygroup) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlAlicloudEcsSecuritygroup) GetVpcId() *plugin.TValue[string] {
 	return &c.VpcId
+}
+
+func (c *mqlAlicloudEcsSecuritygroup) GetVpc() *plugin.TValue[*mqlAlicloudVpcNetwork] {
+	return plugin.GetOrCompute[*mqlAlicloudVpcNetwork](&c.Vpc, func() (*mqlAlicloudVpcNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.ecs.securitygroup", c.__id, "vpc")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudVpcNetwork), nil
+			}
+		}
+
+		return c.vpc()
+	})
 }
 
 func (c *mqlAlicloudEcsSecuritygroup) GetSecurityGroupType() *plugin.TValue[string] {
@@ -16198,8 +16340,9 @@ func (c *mqlAlicloudSlbLoadBalancer) GetInternetFacing() *plugin.TValue[bool] {
 type mqlAlicloudSlbListener struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAlicloudSlbListenerInternal it will be used here
+	mqlAlicloudSlbListenerInternal
 	LoadBalancerId      plugin.TValue[string]
+	LoadBalancer        plugin.TValue[*mqlAlicloudSlbLoadBalancer]
 	Protocol            plugin.TValue[string]
 	ListenerPort        plugin.TValue[int64]
 	BackendServerPort   plugin.TValue[int64]
@@ -16258,6 +16401,22 @@ func (c *mqlAlicloudSlbListener) MqlID() string {
 
 func (c *mqlAlicloudSlbListener) GetLoadBalancerId() *plugin.TValue[string] {
 	return &c.LoadBalancerId
+}
+
+func (c *mqlAlicloudSlbListener) GetLoadBalancer() *plugin.TValue[*mqlAlicloudSlbLoadBalancer] {
+	return plugin.GetOrCompute[*mqlAlicloudSlbLoadBalancer](&c.LoadBalancer, func() (*mqlAlicloudSlbLoadBalancer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.slb.listener", c.__id, "loadBalancer")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudSlbLoadBalancer), nil
+			}
+		}
+
+		return c.loadBalancer()
+	})
 }
 
 func (c *mqlAlicloudSlbListener) GetProtocol() *plugin.TValue[string] {
@@ -17826,6 +17985,7 @@ type mqlAlicloudVpcFlowLog struct {
 	IpVersion           plugin.TValue[string]
 	AggregationInterval plugin.TValue[int64]
 	ProjectName         plugin.TValue[string]
+	Project             plugin.TValue[*mqlAlicloudLogProject]
 	LogStoreName        plugin.TValue[string]
 	ResourceGroupId     plugin.TValue[string]
 	ResourceGroup       plugin.TValue[*mqlAlicloudResourceManagerResourceGroup]
@@ -17925,6 +18085,22 @@ func (c *mqlAlicloudVpcFlowLog) GetAggregationInterval() *plugin.TValue[int64] {
 
 func (c *mqlAlicloudVpcFlowLog) GetProjectName() *plugin.TValue[string] {
 	return &c.ProjectName
+}
+
+func (c *mqlAlicloudVpcFlowLog) GetProject() *plugin.TValue[*mqlAlicloudLogProject] {
+	return plugin.GetOrCompute[*mqlAlicloudLogProject](&c.Project, func() (*mqlAlicloudLogProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.vpc.flowLog", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudLogProject), nil
+			}
+		}
+
+		return c.project()
+	})
 }
 
 func (c *mqlAlicloudVpcFlowLog) GetLogStoreName() *plugin.TValue[string] {
@@ -18855,6 +19031,7 @@ type mqlAlicloudLogLogstore struct {
 	mqlAlicloudLogLogstoreInternal
 	RegionId          plugin.TValue[string]
 	ProjectName       plugin.TValue[string]
+	Project           plugin.TValue[*mqlAlicloudLogProject]
 	Name              plugin.TValue[string]
 	Ttl               plugin.TValue[int64]
 	HotTtl            plugin.TValue[int64]
@@ -18915,6 +19092,22 @@ func (c *mqlAlicloudLogLogstore) GetRegionId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudLogLogstore) GetProjectName() *plugin.TValue[string] {
 	return &c.ProjectName
+}
+
+func (c *mqlAlicloudLogLogstore) GetProject() *plugin.TValue[*mqlAlicloudLogProject] {
+	return plugin.GetOrCompute[*mqlAlicloudLogProject](&c.Project, func() (*mqlAlicloudLogProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.log.logstore", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudLogProject), nil
+			}
+		}
+
+		return c.project()
+	})
 }
 
 func (c *mqlAlicloudLogLogstore) GetName() *plugin.TValue[string] {
@@ -19521,6 +19714,7 @@ type mqlAlicloudResourceManagerFolder struct {
 	FolderId       plugin.TValue[string]
 	FolderName     plugin.TValue[string]
 	ParentFolderId plugin.TValue[string]
+	ParentFolder   plugin.TValue[*mqlAlicloudResourceManagerFolder]
 	CreateTime     plugin.TValue[*time.Time]
 }
 
@@ -19571,6 +19765,22 @@ func (c *mqlAlicloudResourceManagerFolder) GetFolderName() *plugin.TValue[string
 
 func (c *mqlAlicloudResourceManagerFolder) GetParentFolderId() *plugin.TValue[string] {
 	return &c.ParentFolderId
+}
+
+func (c *mqlAlicloudResourceManagerFolder) GetParentFolder() *plugin.TValue[*mqlAlicloudResourceManagerFolder] {
+	return plugin.GetOrCompute[*mqlAlicloudResourceManagerFolder](&c.ParentFolder, func() (*mqlAlicloudResourceManagerFolder, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.resourceManager.folder", c.__id, "parentFolder")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudResourceManagerFolder), nil
+			}
+		}
+
+		return c.parentFolder()
+	})
 }
 
 func (c *mqlAlicloudResourceManagerFolder) GetCreateTime() *plugin.TValue[*time.Time] {
@@ -20163,6 +20373,7 @@ type mqlAlicloudCsNodePool struct {
 	mqlAlicloudCsNodePoolInternal
 	RegionId                   plugin.TValue[string]
 	ClusterId                  plugin.TValue[string]
+	Cluster                    plugin.TValue[*mqlAlicloudCsCluster]
 	NodePoolId                 plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Type                       plugin.TValue[string]
@@ -20179,6 +20390,7 @@ type mqlAlicloudCsNodePool struct {
 	KeyPair                    plugin.TValue[string]
 	ImageType                  plugin.TValue[string]
 	ImageId                    plugin.TValue[string]
+	Image                      plugin.TValue[*mqlAlicloudEcsImage]
 	InstanceChargeType         plugin.TValue[string]
 	DesiredSize                plugin.TValue[int64]
 	MultiAzPolicy              plugin.TValue[string]
@@ -20260,6 +20472,22 @@ func (c *mqlAlicloudCsNodePool) GetClusterId() *plugin.TValue[string] {
 	return &c.ClusterId
 }
 
+func (c *mqlAlicloudCsNodePool) GetCluster() *plugin.TValue[*mqlAlicloudCsCluster] {
+	return plugin.GetOrCompute[*mqlAlicloudCsCluster](&c.Cluster, func() (*mqlAlicloudCsCluster, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.cs.nodePool", c.__id, "cluster")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudCsCluster), nil
+			}
+		}
+
+		return c.cluster()
+	})
+}
+
 func (c *mqlAlicloudCsNodePool) GetNodePoolId() *plugin.TValue[string] {
 	return &c.NodePoolId
 }
@@ -20334,6 +20562,22 @@ func (c *mqlAlicloudCsNodePool) GetImageType() *plugin.TValue[string] {
 
 func (c *mqlAlicloudCsNodePool) GetImageId() *plugin.TValue[string] {
 	return &c.ImageId
+}
+
+func (c *mqlAlicloudCsNodePool) GetImage() *plugin.TValue[*mqlAlicloudEcsImage] {
+	return plugin.GetOrCompute[*mqlAlicloudEcsImage](&c.Image, func() (*mqlAlicloudEcsImage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.cs.nodePool", c.__id, "image")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudEcsImage), nil
+			}
+		}
+
+		return c.image()
+	})
 }
 
 func (c *mqlAlicloudCsNodePool) GetInstanceChargeType() *plugin.TValue[string] {
@@ -20866,6 +21110,7 @@ type mqlAlicloudAlbListener struct {
 	RegionId         plugin.TValue[string]
 	ListenerId       plugin.TValue[string]
 	LoadBalancerId   plugin.TValue[string]
+	LoadBalancer     plugin.TValue[*mqlAlicloudAlbLoadBalancer]
 	Protocol         plugin.TValue[string]
 	Port             plugin.TValue[int64]
 	Status           plugin.TValue[string]
@@ -20928,6 +21173,22 @@ func (c *mqlAlicloudAlbListener) GetListenerId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudAlbListener) GetLoadBalancerId() *plugin.TValue[string] {
 	return &c.LoadBalancerId
+}
+
+func (c *mqlAlicloudAlbListener) GetLoadBalancer() *plugin.TValue[*mqlAlicloudAlbLoadBalancer] {
+	return plugin.GetOrCompute[*mqlAlicloudAlbLoadBalancer](&c.LoadBalancer, func() (*mqlAlicloudAlbLoadBalancer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.alb.listener", c.__id, "loadBalancer")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudAlbLoadBalancer), nil
+			}
+		}
+
+		return c.loadBalancer()
+	})
 }
 
 func (c *mqlAlicloudAlbListener) GetProtocol() *plugin.TValue[string] {
@@ -21468,6 +21729,7 @@ type mqlAlicloudNlbListener struct {
 	RegionId             plugin.TValue[string]
 	ListenerId           plugin.TValue[string]
 	LoadBalancerId       plugin.TValue[string]
+	LoadBalancer         plugin.TValue[*mqlAlicloudNlbLoadBalancer]
 	Protocol             plugin.TValue[string]
 	Port                 plugin.TValue[int64]
 	Status               plugin.TValue[string]
@@ -21532,6 +21794,22 @@ func (c *mqlAlicloudNlbListener) GetListenerId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudNlbListener) GetLoadBalancerId() *plugin.TValue[string] {
 	return &c.LoadBalancerId
+}
+
+func (c *mqlAlicloudNlbListener) GetLoadBalancer() *plugin.TValue[*mqlAlicloudNlbLoadBalancer] {
+	return plugin.GetOrCompute[*mqlAlicloudNlbLoadBalancer](&c.LoadBalancer, func() (*mqlAlicloudNlbLoadBalancer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.nlb.listener", c.__id, "loadBalancer")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudNlbLoadBalancer), nil
+			}
+		}
+
+		return c.loadBalancer()
+	})
 }
 
 func (c *mqlAlicloudNlbListener) GetProtocol() *plugin.TValue[string] {
@@ -22115,6 +22393,7 @@ type mqlAlicloudFcTrigger struct {
 	mqlAlicloudFcTriggerInternal
 	RegionId          plugin.TValue[string]
 	FunctionName      plugin.TValue[string]
+	Function          plugin.TValue[*mqlAlicloudFcFunction]
 	TriggerName       plugin.TValue[string]
 	TriggerId         plugin.TValue[string]
 	Type              plugin.TValue[string]
@@ -22175,6 +22454,22 @@ func (c *mqlAlicloudFcTrigger) GetRegionId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudFcTrigger) GetFunctionName() *plugin.TValue[string] {
 	return &c.FunctionName
+}
+
+func (c *mqlAlicloudFcTrigger) GetFunction() *plugin.TValue[*mqlAlicloudFcFunction] {
+	return plugin.GetOrCompute[*mqlAlicloudFcFunction](&c.Function, func() (*mqlAlicloudFcFunction, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.fc.trigger", c.__id, "function")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudFcFunction), nil
+			}
+		}
+
+		return c.function()
+	})
 }
 
 func (c *mqlAlicloudFcTrigger) GetTriggerName() *plugin.TValue[string] {
@@ -22516,6 +22811,7 @@ type mqlAlicloudNasMountTarget struct {
 	mqlAlicloudNasMountTargetInternal
 	RegionId          plugin.TValue[string]
 	FileSystemId      plugin.TValue[string]
+	FileSystem        plugin.TValue[*mqlAlicloudNasFileSystem]
 	MountTargetDomain plugin.TValue[string]
 	Status            plugin.TValue[string]
 	NetworkType       plugin.TValue[string]
@@ -22568,6 +22864,22 @@ func (c *mqlAlicloudNasMountTarget) GetRegionId() *plugin.TValue[string] {
 
 func (c *mqlAlicloudNasMountTarget) GetFileSystemId() *plugin.TValue[string] {
 	return &c.FileSystemId
+}
+
+func (c *mqlAlicloudNasMountTarget) GetFileSystem() *plugin.TValue[*mqlAlicloudNasFileSystem] {
+	return plugin.GetOrCompute[*mqlAlicloudNasFileSystem](&c.FileSystem, func() (*mqlAlicloudNasFileSystem, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.nas.mountTarget", c.__id, "fileSystem")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudNasFileSystem), nil
+			}
+		}
+
+		return c.fileSystem()
+	})
 }
 
 func (c *mqlAlicloudNasMountTarget) GetMountTargetDomain() *plugin.TValue[string] {

--- a/providers/alicloud/resources/alicloud.lr.versions
+++ b/providers/alicloud/resources/alicloud.lr.versions
@@ -39,6 +39,7 @@ alicloud.alb.listener.gzipEnabled 13.0.1
 alicloud.alb.listener.http2Enabled 13.0.1
 alicloud.alb.listener.idleTimeout 13.0.1
 alicloud.alb.listener.listenerId 13.0.1
+alicloud.alb.listener.loadBalancer 13.3.2
 alicloud.alb.listener.loadBalancerId 13.0.1
 alicloud.alb.listener.mutualTlsEnabled 13.0.1
 alicloud.alb.listener.port 13.0.1
@@ -349,6 +350,7 @@ alicloud.cs.nodePool.autoScalingType 13.0.1
 alicloud.cs.nodePool.autoUpgrade 13.0.1
 alicloud.cs.nodePool.autoVulFix 13.0.1
 alicloud.cs.nodePool.cisEnabled 13.0.1
+alicloud.cs.nodePool.cluster 13.3.2
 alicloud.cs.nodePool.clusterId 13.0.1
 alicloud.cs.nodePool.cmsEnabled 13.0.1
 alicloud.cs.nodePool.cpuPolicy 13.0.1
@@ -357,6 +359,7 @@ alicloud.cs.nodePool.dataDisks 13.0.1
 alicloud.cs.nodePool.desiredSize 13.0.1
 alicloud.cs.nodePool.failedNodes 13.0.1
 alicloud.cs.nodePool.healthyNodes 13.0.1
+alicloud.cs.nodePool.image 13.3.2
 alicloud.cs.nodePool.imageId 13.0.1
 alicloud.cs.nodePool.imageType 13.0.1
 alicloud.cs.nodePool.instanceChargeType 13.0.1
@@ -466,6 +469,7 @@ alicloud.ecs.instance.internetExposed 13.0.0
 alicloud.ecs.instance.internetMaxBandwidthIn 13.0.0
 alicloud.ecs.instance.internetMaxBandwidthOut 13.0.0
 alicloud.ecs.instance.ioOptimized 13.0.0
+alicloud.ecs.instance.keyPair 13.3.2
 alicloud.ecs.instance.keyPairName 13.0.0
 alicloud.ecs.instance.localStorageAmount 13.0.0
 alicloud.ecs.instance.localStorageCapacity 13.0.0
@@ -539,6 +543,7 @@ alicloud.ecs.securitygroup.securityGroupId 13.0.0
 alicloud.ecs.securitygroup.securityGroupName 13.0.0
 alicloud.ecs.securitygroup.securityGroupType 13.0.0
 alicloud.ecs.securitygroup.tags 13.0.0
+alicloud.ecs.securitygroup.vpc 13.3.2
 alicloud.ecs.securitygroup.vpcId 13.0.0
 alicloud.ess 13.2.5
 alicloud.ess.scalingConfiguration 13.2.5
@@ -638,6 +643,7 @@ alicloud.fc.functions 13.0.1
 alicloud.fc.trigger 13.0.1
 alicloud.fc.trigger.createdTime 13.0.1
 alicloud.fc.trigger.description 13.0.1
+alicloud.fc.trigger.function 13.3.2
 alicloud.fc.trigger.functionName 13.0.1
 alicloud.fc.trigger.httpUrlInternet 13.0.1
 alicloud.fc.trigger.httpUrlIntranet 13.0.1
@@ -710,6 +716,7 @@ alicloud.log.logstore.lastModifyTime 13.0.1
 alicloud.log.logstore.maxSplitShard 13.0.1
 alicloud.log.logstore.mode 13.0.1
 alicloud.log.logstore.name 13.0.1
+alicloud.log.logstore.project 13.3.2
 alicloud.log.logstore.projectName 13.0.1
 alicloud.log.logstore.regionId 13.0.1
 alicloud.log.logstore.shardCount 13.0.1
@@ -828,6 +835,7 @@ alicloud.nas.fileSystems 13.0.1
 alicloud.nas.mountTarget 13.0.1
 alicloud.nas.mountTarget.accessGroup 13.0.1
 alicloud.nas.mountTarget.accessGroupName 13.0.1
+alicloud.nas.mountTarget.fileSystem 13.3.2
 alicloud.nas.mountTarget.fileSystemId 13.0.1
 alicloud.nas.mountTarget.mountTargetDomain 13.0.1
 alicloud.nas.mountTarget.networkType 13.0.1
@@ -846,6 +854,7 @@ alicloud.nlb.listener.cps 13.0.1
 alicloud.nlb.listener.description 13.0.1
 alicloud.nlb.listener.idleTimeout 13.0.1
 alicloud.nlb.listener.listenerId 13.0.1
+alicloud.nlb.listener.loadBalancer 13.3.2
 alicloud.nlb.listener.loadBalancerId 13.0.1
 alicloud.nlb.listener.port 13.0.1
 alicloud.nlb.listener.protocol 13.0.1
@@ -975,6 +984,7 @@ alicloud.ram.accessKey 13.0.0
 alicloud.ram.accessKey.accessKeyId 13.0.0
 alicloud.ram.accessKey.createDate 13.0.0
 alicloud.ram.accessKey.status 13.0.0
+alicloud.ram.accessKey.user 13.3.2
 alicloud.ram.accessKey.userName 13.0.0
 alicloud.ram.group 13.0.0
 alicloud.ram.group.attachedPolicies 13.2.5
@@ -1156,6 +1166,7 @@ alicloud.resourceManager.folder 13.0.1
 alicloud.resourceManager.folder.createTime 13.0.1
 alicloud.resourceManager.folder.folderId 13.0.1
 alicloud.resourceManager.folder.folderName 13.0.1
+alicloud.resourceManager.folder.parentFolder 13.3.2
 alicloud.resourceManager.folder.parentFolderId 13.0.1
 alicloud.resourceManager.folders 13.0.1
 alicloud.resourceManager.masterAccountId 13.0.1
@@ -1277,6 +1288,7 @@ alicloud.slb.listener.config 13.0.0
 alicloud.slb.listener.description 13.0.0
 alicloud.slb.listener.enableHttp2 13.0.0
 alicloud.slb.listener.listenerPort 13.0.0
+alicloud.slb.listener.loadBalancer 13.3.2
 alicloud.slb.listener.loadBalancerId 13.0.0
 alicloud.slb.listener.protocol 13.0.0
 alicloud.slb.listener.scheduler 13.0.0
@@ -1366,6 +1378,7 @@ alicloud.vpc.flowLog.ipVersion 13.0.1
 alicloud.vpc.flowLog.logStoreName 13.0.1
 alicloud.vpc.flowLog.logstore 13.0.1
 alicloud.vpc.flowLog.network 13.0.1
+alicloud.vpc.flowLog.project 13.3.2
 alicloud.vpc.flowLog.projectName 13.0.1
 alicloud.vpc.flowLog.regionId 13.0.1
 alicloud.vpc.flowLog.resourceGroup 13.3.2

--- a/providers/alicloud/resources/cs.go
+++ b/providers/alicloud/resources/cs.go
@@ -682,6 +682,46 @@ func (r *mqlAlicloudCsNodePool) id() (string, error) {
 	return r.ClusterId.Data + "/" + r.NodePoolId.Data, nil
 }
 
+// cluster resolves the ACK cluster the node pool belongs to. A node pool cannot
+// outlive its cluster, so a failure to read it is a real error. The cluster is
+// already in the resource cache whenever the node pool was reached through it,
+// which the cluster init consults before calling the API.
+func (r *mqlAlicloudCsNodePool) cluster() (*mqlAlicloudCsCluster, error) {
+	if r.ClusterId.Data == "" {
+		r.Cluster.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "alicloud.cs.cluster", map[string]*llx.RawData{
+		"clusterId": llx.StringData(r.ClusterId.Data),
+		"regionId":  llx.StringData(r.RegionId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAlicloudCsCluster), nil
+}
+
+// image resolves the image the node pool launches nodes from.
+//
+// A node pool can name an image the account can no longer read, for example a
+// retired public image or one shared from another account, so an image that
+// does not resolve yields null rather than failing the node pool.
+func (r *mqlAlicloudCsNodePool) image() (*mqlAlicloudEcsImage, error) {
+	imageID := r.ImageId.Data
+	if imageID == "" {
+		r.Image.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	image, err := resolveEcsImage(r.MqlRuntime, r.region, imageID)
+	if err != nil || image == nil {
+		log.Debug().Err(err).Str("image", imageID).Str("region", r.region).
+			Msg("alicloud> could not resolve node pool image")
+		r.Image.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return image, nil
+}
+
 func (r *mqlAlicloudCsNodePool) systemDiskKmsKey() (*mqlAlicloudKmsKey, error) {
 	if r.cacheSystemDiskKmsKeyId == "" {
 		r.SystemDiskKmsKey.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/alicloud/resources/ecs.go
+++ b/providers/alicloud/resources/ecs.go
@@ -459,6 +459,27 @@ func (r *mqlAlicloudEcsInstance) image() (*mqlAlicloudEcsImage, error) {
 	return resolveEcsImage(r.MqlRuntime, r.cacheRegion, r.cacheImageID)
 }
 
+// keyPair resolves the SSH key pair the instance was launched with.
+//
+// A key pair can be deleted while the instances launched from it keep running
+// and keep reporting its name, so a name that no longer resolves is an expected
+// state rather than a failure, and yields null.
+func (r *mqlAlicloudEcsInstance) keyPair() (*mqlAlicloudEcsKeypair, error) {
+	name := r.KeyPairName.Data
+	if name == "" {
+		r.KeyPair.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	keyPair, err := resolveEcsKeypair(r.MqlRuntime, r.RegionId.Data, name)
+	if err != nil || keyPair == nil {
+		log.Debug().Err(err).Str("keyPair", name).Str("region", r.RegionId.Data).
+			Msg("alicloud> could not resolve instance key pair")
+		r.KeyPair.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return keyPair, nil
+}
+
 func (r *mqlAlicloudEcsInstance) id() (string, error) {
 	return r.RegionId.Data + "/" + r.InstanceId.Data, nil
 }
@@ -1043,6 +1064,17 @@ func newEcsSecuritygroup(runtime *plugin.Runtime, region string, sg *ecsclient.D
 		return nil, err
 	}
 	return resource.(*mqlAlicloudEcsSecuritygroup), nil
+}
+
+// vpc resolves the VPC the security group is scoped to. A classic-network
+// security group reports no VPC and resolves to null; a VPC-scoped group cannot
+// outlive its VPC, so a failure to read it is a real error.
+func (r *mqlAlicloudEcsSecuritygroup) vpc() (*mqlAlicloudVpcNetwork, error) {
+	if r.VpcId.Data == "" {
+		r.Vpc.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return resolveVpcNetwork(r.MqlRuntime, r.RegionId.Data, r.VpcId.Data)
 }
 
 func (r *mqlAlicloudEcsSecuritygroup) id() (string, error) {

--- a/providers/alicloud/resources/fc.go
+++ b/providers/alicloud/resources/fc.go
@@ -357,6 +357,26 @@ func newFcTrigger(runtime *plugin.Runtime, region, functionName string, t *fccli
 	return mqlTrigger, nil
 }
 
+// function resolves the function the trigger belongs to. A trigger cannot
+// outlive its function, so a failure to read it is a real error. The function is
+// already in the resource cache whenever the trigger was reached through it,
+// which the function init consults before calling the API.
+func (r *mqlAlicloudFcTrigger) function() (*mqlAlicloudFcFunction, error) {
+	name := r.FunctionName.Data
+	if name == "" {
+		r.Function.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "alicloud.fc.function", map[string]*llx.RawData{
+		"functionName": llx.StringData(name),
+		"regionId":     llx.StringData(r.RegionId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAlicloudFcFunction), nil
+}
+
 func (r *mqlAlicloudFcTrigger) id() (string, error) {
 	return r.RegionId.Data + "/" + r.FunctionName.Data + "/" + r.TriggerName.Data, nil
 }

--- a/providers/alicloud/resources/flowlog.go
+++ b/providers/alicloud/resources/flowlog.go
@@ -191,6 +191,18 @@ func (r *mqlAlicloudVpcFlowLog) logstore() (*mqlAlicloudLogLogstore, error) {
 	return store, nil
 }
 
+// project resolves the Log Service project the flow log delivers to. The flow
+// log outlives its delivery target, so a project that no longer exists (or that
+// lives in another account) yields null rather than failing the flow log.
+func (r *mqlAlicloudVpcFlowLog) project() (*mqlAlicloudLogProject, error) {
+	project, err := resolveLogProject(r.MqlRuntime, r.RegionId.Data, r.ProjectName.Data)
+	if err != nil || project == nil {
+		r.Project.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return project, nil
+}
+
 func (r *mqlAlicloudVpcFlowLog) network() (*mqlAlicloudVpcNetwork, error) {
 	if !strings.EqualFold(r.ResourceType.Data, "VPC") {
 		r.Network.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/alicloud/resources/listener_refs_test.go
+++ b/providers/alicloud/resources/listener_refs_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// TestListenerLoadBalancerWithoutParent covers the case where a listener was
+// constructed without the load balancer it was listed from.
+//
+// The reference must resolve to an explicit null. Returning (nil, nil) without
+// marking the field set leaves it unset, which crosses the plugin boundary as a
+// primitive with no type information and surfaces client-side as a coercion
+// error rather than a null.
+func TestListenerLoadBalancerWithoutParent(t *testing.T) {
+	t.Run("slb", func(t *testing.T) {
+		l := &mqlAlicloudSlbListener{}
+		got, err := l.loadBalancer()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, l.LoadBalancer.State)
+	})
+	t.Run("alb", func(t *testing.T) {
+		l := &mqlAlicloudAlbListener{}
+		got, err := l.loadBalancer()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, l.LoadBalancer.State)
+	})
+	t.Run("nlb", func(t *testing.T) {
+		l := &mqlAlicloudNlbListener{}
+		got, err := l.loadBalancer()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, l.LoadBalancer.State)
+	})
+}
+
+// TestListenerLoadBalancerReturnsParent confirms the reference hands back the
+// load balancer carried from the listing context, without an API call.
+func TestListenerLoadBalancerReturnsParent(t *testing.T) {
+	t.Run("slb", func(t *testing.T) {
+		lb := &mqlAlicloudSlbLoadBalancer{}
+		l := &mqlAlicloudSlbListener{}
+		l.parentLoadBalancer = lb
+		got, err := l.loadBalancer()
+		require.NoError(t, err)
+		assert.Same(t, lb, got)
+	})
+	t.Run("alb", func(t *testing.T) {
+		lb := &mqlAlicloudAlbLoadBalancer{}
+		l := &mqlAlicloudAlbListener{}
+		l.parentLoadBalancer = lb
+		got, err := l.loadBalancer()
+		require.NoError(t, err)
+		assert.Same(t, lb, got)
+	})
+	t.Run("nlb", func(t *testing.T) {
+		lb := &mqlAlicloudNlbLoadBalancer{}
+		l := &mqlAlicloudNlbListener{}
+		l.parentLoadBalancer = lb
+		got, err := l.loadBalancer()
+		require.NoError(t, err)
+		assert.Same(t, lb, got)
+	})
+}

--- a/providers/alicloud/resources/nas.go
+++ b/providers/alicloud/resources/nas.go
@@ -254,6 +254,27 @@ func (r *mqlAlicloudNasMountTarget) vswitch() (*mqlAlicloudVpcVswitch, error) {
 	return resolveVpcVswitch(r.MqlRuntime, r.RegionId.Data, r.cacheVswitchId)
 }
 
+// fileSystem resolves the file system the mount target belongs to. A mount
+// target cannot outlive its file system, so a failure to read it is a real
+// error. The file system is already in the resource cache whenever the mount
+// target was reached through it, which the file system init consults before
+// calling the API.
+func (r *mqlAlicloudNasMountTarget) fileSystem() (*mqlAlicloudNasFileSystem, error) {
+	fsID := r.FileSystemId.Data
+	if fsID == "" {
+		r.FileSystem.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "alicloud.nas.fileSystem", map[string]*llx.RawData{
+		"fileSystemId": llx.StringData(fsID),
+		"regionId":     llx.StringData(r.RegionId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAlicloudNasFileSystem), nil
+}
+
 func (r *mqlAlicloudNasMountTarget) accessGroup() (*mqlAlicloudNasAccessGroup, error) {
 	name := r.AccessGroupName.Data
 	if name == "" {

--- a/providers/alicloud/resources/nlb.go
+++ b/providers/alicloud/resources/nlb.go
@@ -266,6 +266,7 @@ func (r *mqlAlicloudNlbLoadBalancer) listeners() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			mqlListener.parentLoadBalancer = r
 			res = append(res, mqlListener)
 		}
 		if resp.Body.NextToken == nil || *resp.Body.NextToken == "" {
@@ -279,9 +280,23 @@ func (r *mqlAlicloudNlbLoadBalancer) listeners() ([]any, error) {
 // mqlAlicloudNlbListenerInternal caches the region and forward server-group id
 // for the typed serverGroup() reference.
 type mqlAlicloudNlbListenerInternal struct {
+	// parentLoadBalancer is the load balancer the listener was listed from. A
+	// listener exists only as a child of its load balancer, so carrying the
+	// parent from the listing context resolves the reference without an API
+	// call.
+	parentLoadBalancer *mqlAlicloudNlbLoadBalancer
+
 	region             string
 	listenerId         string
 	cacheServerGroupId string
+}
+
+func (r *mqlAlicloudNlbListener) loadBalancer() (*mqlAlicloudNlbLoadBalancer, error) {
+	if r.parentLoadBalancer == nil {
+		r.LoadBalancer.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return r.parentLoadBalancer, nil
 }
 
 func newNlbListener(runtime *plugin.Runtime, region string, l *nlbclient.ListListenersResponseBodyListeners) (*mqlAlicloudNlbListener, error) {

--- a/providers/alicloud/resources/ram.go
+++ b/providers/alicloud/resources/ram.go
@@ -708,6 +708,23 @@ func (r *mqlAlicloudRamUser) loginProfile() (any, error) {
 	return out, nil
 }
 
+// user resolves the RAM user that owns the access key. A key cannot outlive its
+// user, so a failure to read the user is a real error.
+func (r *mqlAlicloudRamAccessKey) user() (*mqlAlicloudRamUser, error) {
+	userName := r.UserName.Data
+	if userName == "" {
+		r.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "alicloud.ram.user", map[string]*llx.RawData{
+		"userName": llx.StringData(userName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAlicloudRamUser), nil
+}
+
 func (r *mqlAlicloudRamAccessKey) id() (string, error) {
 	return r.UserName.Data + "/" + r.AccessKeyId.Data, nil
 }

--- a/providers/alicloud/resources/resourcemanager.go
+++ b/providers/alicloud/resources/resourcemanager.go
@@ -445,6 +445,24 @@ func initAlicloudResourceManagerFolder(runtime *plugin.Runtime, args map[string]
 	return nil, res, nil
 }
 
+// parentFolder resolves the folder that contains this folder. The root folder
+// has no parent and resolves to null; any other folder cannot outlive its
+// parent, so a failure to read it is a real error.
+func (r *mqlAlicloudResourceManagerFolder) parentFolder() (*mqlAlicloudResourceManagerFolder, error) {
+	parentID := r.ParentFolderId.Data
+	if parentID == "" {
+		r.ParentFolder.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "alicloud.resourceManager.folder", map[string]*llx.RawData{
+		"folderId": llx.StringData(parentID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAlicloudResourceManagerFolder), nil
+}
+
 func (r *mqlAlicloudResourceManagerFolder) id() (string, error) {
 	return r.FolderId.Data, nil
 }

--- a/providers/alicloud/resources/slb.go
+++ b/providers/alicloud/resources/slb.go
@@ -259,6 +259,7 @@ func (r *mqlAlicloudSlbLoadBalancer) listeners() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			listener.(*mqlAlicloudSlbListener).parentLoadBalancer = r
 			res = append(res, listener)
 		}
 
@@ -303,6 +304,22 @@ func (r *mqlAlicloudSlbLoadBalancer) backendServers() ([]any, error) {
 		})
 	}
 	return res, nil
+}
+
+// mqlAlicloudSlbListenerInternal holds the load balancer the listener was
+// listed from. A listener exists only as a child of its load balancer, so
+// carrying the parent from the listing context resolves the reference without
+// an API call and without a by-id lookup that the SLB resource does not have.
+type mqlAlicloudSlbListenerInternal struct {
+	parentLoadBalancer *mqlAlicloudSlbLoadBalancer
+}
+
+func (r *mqlAlicloudSlbListener) loadBalancer() (*mqlAlicloudSlbLoadBalancer, error) {
+	if r.parentLoadBalancer == nil {
+		r.LoadBalancer.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return r.parentLoadBalancer, nil
 }
 
 func (r *mqlAlicloudSlbListener) id() (string, error) {

--- a/providers/alicloud/resources/sls.go
+++ b/providers/alicloud/resources/sls.go
@@ -341,6 +341,20 @@ func initAlicloudLogLogstore(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	return nil, res, nil
 }
 
+// project resolves the Log Service project that contains the logstore. A
+// logstore cannot outlive its project, so a failure to read it is a real error.
+func (r *mqlAlicloudLogLogstore) project() (*mqlAlicloudLogProject, error) {
+	project, err := resolveLogProject(r.MqlRuntime, r.RegionId.Data, r.ProjectName.Data)
+	if err != nil {
+		return nil, err
+	}
+	if project == nil {
+		r.Project.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return project, nil
+}
+
 func (r *mqlAlicloudLogLogstore) id() (string, error) {
 	return r.region + "/" + r.projectName + "/" + r.name, nil
 }


### PR DESCRIPTION
> Follow-up to #9829, which added the resource group reference. That one merged, so this targets `main` directly.

## What

Thirteen fields named another modeled resource but resolved only to a string. In most cases a sibling resource already had the reference, so these read as omissions rather than design:

| Resource | Had | Was missing |
|---|---|---|
| `ecs.instance` | `keyPairName` | `keyPair` — `ess.scalingConfiguration` already had it |
| `ecs.securitygroup` | `vpcId` | `vpc` — every other VPC-scoped resource had it |
| `cs.nodePool` | `clusterId`, `imageId` | `cluster`, `image` |
| `log.logstore` | `projectName` | `project` — the only child with no parent edge |
| `vpc.flowLog` | `projectName` | `project` — `logstore` was already there |
| `nas.mountTarget` | `fileSystemId` | `fileSystem` |
| `fc.trigger` | `functionName` | `function` |
| `ram.accessKey` | `userName` | `user` |
| `resourceManager.folder` | `parentFolderId` | `parentFolder` |
| `slb`/`alb`/`nlb.listener` | `loadBalancerId` | `loadBalancer` |

Queries this makes expressible:

```javascript
// which instances share a key pair, and how old is it
alicloud.ecs.instances { instanceId keyPair { keyPairName creationTime } }

// node pools running an image that is no longer current
alicloud.cs.clusters.nodePools.where(image.imageId != null) { name cluster.name image.imageName }

// flatten every listener, then name the load balancer that owns a weak one
alicloud.alb.loadBalancers.listeners.where(securityPolicyId == "tls_cipher_policy_1_0")
  { listenerId loadBalancer.name loadBalancer.addressType }
```

## Notes for review

- **The listener references cost nothing.** A listener exists only as a child of its load balancer, so the parent is carried from the listing context on the listener's internal struct instead of being resolved by id. This also sidesteps the fact that the CLB load balancer has no by-id `init` — adding one just to resolve a reference we already hold would be new API-calling code for no gain.
- **Everything else resolves through an existing `init`**, all of which probe `runtime.Resources` before calling the API, so a reference reached from its parent is a cache hit.
- **Null vs error was decided per reference, by whether it can legitimately dangle.** A key pair can be deleted while instances launched from it keep reporting its name; a node pool can name an image the account can no longer read; a flow log outlives the Log Service project it delivers to. Those three log at debug and resolve to null. A security group's VPC, a logstore's project and a mount target's file system cannot dangle, so those propagate the error rather than quietly reporting null.
- **Two raw ids are deliberately *not* deprecated**, and the schema says why inline: `slb.listener.loadBalancerId` and `cs.nodePool.clusterId` are part of what keys those resources (a CLB listener has no id of its own; a node pool id is unique only within its cluster). Marking them would invite a later removal sweep to break the cache key rather than just drop a duplicate. The other five raw ids are marked `@maturity("deprecated")`.
- `cs.nodePool.keyPair` is left alone: the raw field is already named `keyPair` (a name string, not an id), so adding the reference means renaming a shipped field. Worth doing, but it's a breaking change and belongs in its own PR.

## Testing

- `go build ./...` and `go test ./...` clean in `providers/alicloud/`
- New tests pin the listener reference's null contract — returning `(nil, nil)` without setting `StateIsSet|StateIsNull` leaves the field *unset*, which crosses the plugin boundary as a primitive with no type information and surfaces client-side as a coercion error instead of a null. The rest of the accessors are thin wrappers over existing resolvers with no logic to assert.
- **Not live-verified** — no Alibaba Cloud credentials available. Owed alongside the other unverified alicloud stacks.
