### PR TITLE
🐛 azure: drop deprecated wafPolicyId from securityPolicy @defaults

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -14060,7 +14060,7 @@ azure.subscription.frontDoorService.profile @defaults("id name location") {
 }
 
 // Azure Front Door security policy associating a WAF policy with domains
-private azure.subscription.frontDoorService.profile.securityPolicy @defaults("id name policyType wafPolicyId") {
+private azure.subscription.frontDoorService.profile.securityPolicy @defaults("id name policyType provisioningState") {
   // Security policy resource ID
   id string
   // Security policy name


### PR DESCRIPTION
## Problem

`azure.subscription.frontDoorService.profile.securityPolicy` lists the deprecated `wafPolicyId` field in its `@defaults`:

```
private azure.subscription.frontDoorService.profile.securityPolicy @defaults("id name policyType wafPolicyId") {
```

Default fields are compiled into every query that materializes the resource, so the deprecated field becomes a datapoint whether or not the query author referenced it. That makes cnspec's `query-deprecated-symbol` lint **unfixable from content**.

Reproduced with a query that never mentions the field:

```yaml
mql: |
  azure.subscription.frontDoor.profiles.all(securityPolicies.length > 0)
```

```
query-deprecated-symbol  warning  query 'probe-i' uses deprecated field
  'azure.subscription.frontDoorService.profile.securityPolicy.wafPolicyId'
```

The lint is behaving correctly — the compiled query really does fetch the deprecated field. The defect is the `@defaults` list.

## Fix

Swap `wafPolicyId` for `provisioningState`, a stable non-deprecated field suitable for default display. The replacement field `wafPolicy` is a resource rather than a scalar, so it is deliberately not added to defaults.

## Verification

Rebuilt and installed the provider, then linted the cnspec content that triggered this (paired with mondoohq/cnspec#3251, which migrates the query itself to `wafPolicy`):

```
$ cnspec policy lint content/mondoo-azure-security.mql.yaml
→ valid policy bundle(s)
```

Both changes are required: the content fix alone leaves the warning (defaults expansion), and this fix alone leaves it too (the query explicitly used `wafPolicyId`).

## Related, not fixed here

A scan of all `.lr` files found 15 more resources whose `@defaults` reference a deprecated field, each with the same unfixable-from-content consequence. Left out of this PR because each needs its own judgment on a replacement field:

- `azure`: `networkService.privateEndpoint.serviceconnection` (`privateLinkServiceId`), `cloudDefenderService` (`defenderForServers.enabled`, `defenderForContainers.enabled`)
- `aws`: `vpc.routetable` (`routes.length`), `efs.filesystem.replicationDestination`, `efs.mountTarget`, `ecs.service`, `backup.plan.rule.copyAction`, `ec2.networkacl.association`, `ec2.instanceConnectEndpoint`, `ec2.instance.device`, `directoryservice.vpcSettings`, `directoryservice.connectSettings`, `kinesis.firehoseDeliveryStream.destination.s3`, `msk.cluster.serverlessConfig.vpcConfig`
- `gcp`: `pubsubService.topic.config` (`kmsKeyName`)
- `claude`: `organization.workspace.member` (`userId`)

Happy to follow up with a sweep if that is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)