### PR TITLE
✨ providers: register the db2 provider in the defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ To learn about Mondoo Platform, read the [Mondoo Platform docs](https://mondoo.c
 | HashiCorp Cloud Platform      | `hcp`                      | `mql shell hcp --client-id CLIENT_ID --client-secret CLIENT_SECRET`                                                                             |
 | Hetzner Cloud projects        | `hetzner`                  | `mql shell hetzner --token API_TOKEN`                                                                                                           |
 | Hugging Face                  | `huggingface`              | `mql shell huggingface --token HF_TOKEN`                                                                                                        |
+| IBM Db2 database              | `db2`                      | `mql shell db2 db.contoso.com --database TESTDB --user auditor --ask-pass`                                                                      |
 | OPC UA IoT devices            | `opcua`                    | `mql shell opcua`                                                                                                                               |
 | IP address information        | `ipinfo`                   | `mql shell ipinfo`                                                                                                                              |
 | IPMI-enabled devices          | `ipmi`                     | `mql shell ipmi user@HOST`                                                                                                                      |

--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -321,6 +321,21 @@ var DefaultProviders Providers = map[string]*Provider{
 		},
 	},
 
+	"db2": {
+		Provider: &plugin.Provider{
+			Name:            "db2",
+			ID:              "go.mondoo.com/mql-enterprise-providers/providers/db2",
+			ConnectionTypes: []string{"db2"},
+			Connectors: []plugin.Connector{
+				{
+					Name:  "db2",
+					Use:   "db2 [host]",
+					Short: "an IBM Db2 database",
+				},
+			},
+		},
+	},
+
 	"digitalocean": {
 		Provider: &plugin.Provider{
 			Name:            "digitalocean",


### PR DESCRIPTION
## What

Registers the `db2` provider (shipped from `mql-enterprise-providers`) in `providers/defaults.go`, and adds it to the README connection table.

```go
"db2": {
    Provider: &plugin.Provider{
        Name:            "db2",
        ID:              "go.mondoo.com/mql-enterprise-providers/providers/db2",
        ConnectionTypes: []string{"db2"},
        Connectors: []plugin.Connector{
            {
                Name:  "db2",
                Use:   "db2 [host]",
                Short: "an IBM Db2 database",
            },
        },
    },
},
```

## Why

`DefaultProviders` is the lookup table `EnsureProvider` consults when no *installed* provider matches a connector (`providers/providers.go:450`). With no `db2` entry, a `db2` connection on a machine that doesn't already have the provider installed never reached the on-demand `Install()` path — it returned `ProviderNotFoundError` (which the `FIXME` right above notes panics in the CLI).

Values are taken verbatim from the provider's own `config.Config` / `dist/db2.json`, so the ID and connection type match what the installed plugin reports.

## Note on the "auto-generated" header

`providers/defaults.go` carries a `This file is auto-generated by 'make providers/defaults'` header, but the generator only enumerates provider directories that exist in *this* repo. Running it deletes every enterprise-repo entry (`ai`, `bigip`, `checkpoint`, `fortios`, `junos`, `panos`, `unifi`, `networkdevices`, `networkdiscovery`, `yara`). That is why this entry is hand-added, matching how the existing enterprise providers are carried. `.github/workflows/pr-test-generated-files.yaml` never runs `make providers/defaults`, so CI does not fight this.

## Testing

- `go build ./providers/` — clean.
- `go test ./providers/ -run TestDefaultProviders` — passes (the guard that every local provider dir is registered).
- Temporary check (removed before commit) confirming all four `Providers.Lookup` paths resolve:

```
provider=db2                                            -> db2 (go.mondoo.com/mql-enterprise-providers/providers/db2)
conn type=db2                                           -> db2 (...)
conn name=db2                                           -> db2 (...)
id=go.mondoo.com/mql-enterprise-providers/providers/db2 -> db2 (...)
```

## Follow-up

`oracledb` (also from `mql-enterprise-providers`, at `1.0.0`) is missing from `defaults.go` and the README for the same reason, and `checkpoint` is in `defaults.go` but absent from the README table. Happy to fold those in here or send them separately.
