### PR TITLE
🐛 mongodbatlas: resolve project references through the org listing instead of one GetProject per reference

### DIFF
--- a/providers/mongodbatlas/resources/access_lists.go
+++ b/providers/mongodbatlas/resources/access_lists.go
@@ -199,27 +199,11 @@ func (r *mqlMongodbatlasServiceAccount) projects() ([]any, error) {
 		}
 	}
 
-	root, err := rootMongodbatlas(r.MqlRuntime)
-	if err != nil {
-		return nil, err
-	}
-	projectsByID, err := root.orgProjectsByID()
-	if err != nil {
-		return nil, err
-	}
-
 	out := []any{}
 	for _, id := range groupIDs {
-		if p, ok := projectsByID[id]; ok {
-			out = append(out, p)
-			continue
-		}
-		// The organization listing did not cover this project, so fetch it
-		// directly. A failure here is reported rather than skipped: dropping
-		// the entry would under-report the account's reach.
-		proj, err := NewResource(r.MqlRuntime, "mongodbatlas.project", map[string]*llx.RawData{
-			"id": llx.StringData(id),
-		})
+		// A failure here is reported rather than skipped: dropping the entry
+		// would under-report the account's reach.
+		proj, err := resolveProject(r.MqlRuntime, id)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -205,15 +205,41 @@ func (r *mqlMongodbatlasOrgUser) projectRoles() ([]any, error) {
 	return out, nil
 }
 
-// project resolves the project the roles are granted on.
-func (r *mqlMongodbatlasOrgUserProjectRole) project() (*mqlMongodbatlasProject, error) {
-	proj, err := NewResource(r.MqlRuntime, "mongodbatlas.project", map[string]*llx.RawData{
-		"id": llx.StringData(r.cacheGroupID),
+// resolveProject returns the project with the given id, preferring the
+// organization's project listing so that a whole set of references costs one
+// API call. Hydrating each reference by id instead would run the project init,
+// and therefore a GetProject call, per reference. A project the organization
+// listing does not cover, such as one reached through a credential scoped
+// elsewhere, is fetched directly so it still resolves.
+func resolveProject(runtime *plugin.Runtime, id string) (*mqlMongodbatlasProject, error) {
+	root, err := rootMongodbatlas(runtime)
+	if err != nil {
+		return nil, err
+	}
+	projectsByID, err := root.orgProjectsByID()
+	if err != nil {
+		return nil, err
+	}
+	if p, ok := projectsByID[id]; ok {
+		return p, nil
+	}
+
+	res, err := NewResource(runtime, "mongodbatlas.project", map[string]*llx.RawData{
+		"id": llx.StringData(id),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return proj.(*mqlMongodbatlasProject), nil
+	proj, ok := res.(*mqlMongodbatlasProject)
+	if !ok || proj == nil {
+		return nil, fmt.Errorf("mongodbatlas.project with id %q could not be resolved", id)
+	}
+	return proj, nil
+}
+
+// project resolves the project the roles are granted on.
+func (r *mqlMongodbatlasOrgUserProjectRole) project() (*mqlMongodbatlasProject, error) {
+	return resolveProject(r.MqlRuntime, r.cacheGroupID)
 }
 
 // orgTeamsByID lists every team in the organization once and caches them by id
@@ -442,13 +468,7 @@ func (r *mqlMongodbatlasApiKeyRoleAssignment) project() (*mqlMongodbatlasProject
 		r.Project.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	proj, err := NewResource(r.MqlRuntime, "mongodbatlas.project", map[string]*llx.RawData{
-		"id": llx.StringData(r.cacheGroupID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return proj.(*mqlMongodbatlasProject), nil
+	return resolveProject(r.MqlRuntime, r.cacheGroupID)
 }
 
 func (r *mqlMongodbatlas) serviceAccounts() ([]any, error) {


### PR DESCRIPTION
## The bug

`mongodbatlas.orgUsers { projectRoles { project { name } } }` issued one `GetProject` API call per (user, project) pair.

`NewResource` runs the target resource's `init` **before** the runtime cache is consulted. So `initMongodbatlasProject` — and therefore `ProjectsApi.GetProject` — ran on every single reference, even for a project already hydrated by an earlier reference or by the project listing itself. Resolving a parent per child this way is an N+1, not a cache hit.

Two accessors did exactly that:

- `mqlMongodbatlasOrgUserProjectRole.project()`
- `mqlMongodbatlasApiKeyRoleAssignment.project()`

## The fix

The root resource already carries `orgProjectsByID()`, a `sync.Once`-backed memo whose doc-comment states this is precisely what it is for. It had only one consumer (`mongodbatlas.serviceAccount.projects`).

Both accessors now resolve through that memo, so the common case is a map lookup against a listing fetched once. The shared lookup is factored into `resolveProject`, and the service-account accessor that already used the memo now shares it rather than duplicating the block a third time.

**The direct fetch is kept as a fallback.** A project the organization listing does not cover — for example one reached through a credential scoped to a project in another org — must still resolve; dropping it would silently under-report the account's reach. That makes this a strict improvement: the common case becomes a map lookup, the rare case behaves exactly as it does today.

## Null semantics preserved

- `ApiKeyRoleAssignment.project()` keeps its `StateIsSet | StateIsNull` guard for an org-level role (empty `cacheGroupID`).
- `OrgUserProjectRole.project()` needs no such guard — an empty `groupId` is already skipped when the role resource is built.
- `resolveProject` never returns `nil, nil`: a map miss whose fallback yields nothing returns an error, so a singular resource accessor cannot hand the runtime an unset field.

## Related check

Every other `NewResource` call site in the provider was audited. There are only three in total, all for `mongodbatlas.project`, and all three are covered by this change. The provider's other memos (`orgTeamsByID`, `projectClustersByName`, `projectExportBucketsByID`, `projectAccessRolesByID`) each already have their consumer wired through them. The remaining `Get*` calls are singleton config reads (org settings, project settings, auditing, encryption-at-rest, federation), not per-item resolutions.

## Verification

Run from inside `providers/mongodbatlas/` (its own Go module):

```
$ go build ./...
BUILD OK

$ go test ./...
?   	go.mondoo.com/mql/v13/providers/mongodbatlas	[no test files]
?   	go.mondoo.com/mql/v13/providers/mongodbatlas/config	[no test files]
?   	go.mondoo.com/mql/v13/providers/mongodbatlas/connection	[no test files]
?   	go.mondoo.com/mql/v13/providers/mongodbatlas/gen	[no test files]
ok  	go.mondoo.com/mql/v13/providers/mongodbatlas/provider	1.070s
ok  	go.mondoo.com/mql/v13/providers/mongodbatlas/resources	1.482s

$ gofmt -l ./resources/ ./connection/ ./provider/
(no output)

$ go mod tidy
(no diff)
```

No `.lr` or schema change — Go-only, no codegen and no `.lr.versions` edit.
