### PR TITLE
🐛 ollama: report an unlisted running model as null, deprecate the duplicate model field

### DIFF
--- a/providers/ollama/resources/ollama.go
+++ b/providers/ollama/resources/ollama.go
@@ -205,6 +205,17 @@ func modelRef(name string) (registry, namespace, repository, tag string) {
 	return ref.Host, ref.Namespace, ref.Model, ref.Tag
 }
 
+// errModelNotFound reports that the Ollama instance does not list the
+// requested model. Callers that can legitimately reference a model which is
+// not installed use errors.Is to tell absence apart from a transport failure.
+var errModelNotFound = errors.New("ollama model not found")
+
+// modelNotFoundError names the missing model while keeping errModelNotFound in
+// the chain, so the message stays useful without forcing callers to match on it.
+func modelNotFoundError(name string) error {
+	return fmt.Errorf("%w: %q", errModelNotFound, name)
+}
+
 // initOllamaModel resolves an installed model from just its name, so a
 // cross-reference like ollama.runningModel.model returns full, real metadata
 // (size, modifiedAt, digest, ...) rather than placeholder values. Models
@@ -239,7 +250,7 @@ func initOllamaModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		}
 	}
 
-	return nil, nil, fmt.Errorf("ollama model %q not found", name)
+	return nil, nil, modelNotFoundError(name)
 }
 
 func (r *mqlOllama) runningModels() ([]interface{}, error) {
@@ -490,6 +501,13 @@ func (r *mqlOllamaRunningModel) model() (*mqlOllamaModel, error) {
 		"name": llx.StringData(r.GetName().Data),
 	})
 	if err != nil {
+		// /api/ps can report a model that /api/tags does not list: one that was
+		// loaded and then deleted, or a cloud-resident model. That is a real
+		// absence, not a failure to read. Any other error still propagates.
+		if errors.Is(err, errModelNotFound) {
+			r.Model.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return res.(*mqlOllamaModel), nil

--- a/providers/ollama/resources/ollama.lr
+++ b/providers/ollama/resources/ollama.lr
@@ -87,7 +87,11 @@ ollama.model @defaults("name family parameterSize") {
   // Model name (e.g., "llama3.1:latest")
   name string
   // Canonical model identifier
-  model string
+  //
+  // Deprecated in favor of name, which always carries the same value. The
+  // Ollama server assigns both from the model's shortest display name, so
+  // the two fields never differ.
+  model @maturity("deprecated") string
   // Last modification time
   modifiedAt time
   // Total size in bytes

--- a/providers/ollama/resources/ollama_test.go
+++ b/providers/ollama/resources/ollama_test.go
@@ -4,10 +4,23 @@
 package resources
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestModelNotFoundError(t *testing.T) {
+	err := modelNotFoundError("llama3.1:latest")
+
+	assert.True(t, errors.Is(err, errModelNotFound),
+		"a missing model must stay classifiable, so ollama.runningModel.model reports null instead of failing")
+	assert.Contains(t, err.Error(), `"llama3.1:latest"`, "the message still names the model")
+
+	assert.False(t, errors.Is(fmt.Errorf("dial tcp 127.0.0.1:11434: connect: connection refused"), errModelNotFound),
+		"a transport failure must never be degraded to a missing model")
+}
 
 func TestModelRef(t *testing.T) {
 	t.Run("short name inherits the ollama defaults", func(t *testing.T) {


### PR DESCRIPTION
Two bugs in the ollama provider.

## 1. `ollama.runningModel.model` failed the field instead of reporting null

`runningModel.model()` resolves the installed model through `NewResource(runtime, "ollama.model", {name})`, which runs `initOllamaModel`. That init lists `/api/tags` and returns an error when the name is not in the list — so any error, including a legitimate absence, failed the whole field.

The absence is real, not hypothetical. `/api/ps` and `/api/tags` are different views:

- `/api/ps` reports what is **loaded in memory** right now.
- `/api/tags` reports what is **installed on disk**.

A model can be in the first and not the second: it was loaded and then deleted while still resident, or it is cloud-resident and executes off-instance (the schema already models this with `cloud` and `remoteHost`). In those cases the correct answer is "there is no installed model for this", not a failed query.

`initOllamaModel` now returns a sentinel `errModelNotFound` (wrapped with `%w`, so the message still names the model), and the accessor classifies it with `errors.Is`, setting `plugin.StateIsSet | plugin.StateIsNull` and returning nil — the project rule for singular resource accessors. Every other error still propagates, so a transport failure is never silently degraded to "no such model"; a unit test pins both halves of that split.

The only other caller of `initOllamaModel` is a direct `ollama.model(name: ...)` lookup, where error propagation is still the correct behavior and is unchanged. `ollama.models` builds its resources with `CreateResource`, which skips the init entirely.

## 2. `ollama.model.model` deprecated as a duplicate of `ollama.model.name`

The two fields are byte-identical. Upstream, the Ollama server assigns both from the same expression — `name.DisplayShortest()` in `server/model_list_cache.go` — when it builds the `/api/tags` response, so no model can ever have one value differ from the other.

Per the duplicate-ID-field rule, the field is marked `@maturity("deprecated")` and its doc-comment points at `name`. The field itself stays, so nothing breaks for existing queries. The `.lr.versions` entry is deliberately unchanged: deprecation does not bump a field's version. `Version` in `config/config.go` is untouched.

Regeneration produced no diff in the tracked generated files; the `@maturity` annotation lands only in the gitignored `*.resources.json` schema artifact.

## Verification

```
$ go build ./...
$ go test ./...
?   	go.mondoo.com/mql/v13/providers/ollama	[no test files]
?   	go.mondoo.com/mql/v13/providers/ollama/config	[no test files]
ok  	go.mondoo.com/mql/v13/providers/ollama/connection	0.852s
?   	go.mondoo.com/mql/v13/providers/ollama/gen	[no test files]
ok  	go.mondoo.com/mql/v13/providers/ollama/provider	1.278s
ok  	go.mondoo.com/mql/v13/providers/ollama/resources	1.347s
```

`go mod tidy` inside `providers/ollama/` produces no diff.
