### PR TITLE
🐛 netlify: resolve references through the cached lists and degrade env vars on 403

### DIFF
--- a/providers/netlify/resources/dns.go
+++ b/providers/netlify/resources/dns.go
@@ -91,10 +91,23 @@ func (z *mqlNetlifyDnsZone) id() (string, error) {
 
 // site resolves the site the zone was created for. A zone added for a domain
 // that is not attached to a site has none.
+//
+// The match runs against the site list the root resource has already fetched,
+// so a query over many zones does not read one site per zone. A site outside
+// the scope the connection is narrowed to is absent from that list, so a miss
+// falls back to the direct lookup.
 func (z *mqlNetlifyDnsZone) site() (*mqlNetlifySite, error) {
 	if z.cacheSiteID == "" {
 		z.Site.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+
+	root, err := getNetlify(z.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if site, ok := findCachedResource(root.GetSites(), netlifySiteID, z.cacheSiteID); ok {
+		return site, nil
 	}
 
 	res, err := NewResource(z.MqlRuntime, "netlify.site", map[string]*llx.RawData{

--- a/providers/netlify/resources/envvars.go
+++ b/providers/netlify/resources/envvars.go
@@ -41,7 +41,18 @@ type envVarValueData struct {
 }
 
 func (a *mqlNetlifyAccount) environmentVariables() ([]any, error) {
-	return fetchEnvVars(a.MqlRuntime, a.Id.Data, "", nil)
+	res, err := fetchEnvVars(a.MqlRuntime, a.Id.Data, "", nil)
+	if err != nil {
+		// A member without administrative rights cannot read the account's
+		// variables. Reporting them as null keeps that apart from an account
+		// that has none, which an empty list would read as.
+		if connection.IsForbidden(err) {
+			a.EnvironmentVariables = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+			return nil, nil
+		}
+		return nil, err
+	}
+	return res, nil
 }
 
 // fetchEnvVars reads the environment variables of an account, optionally

--- a/providers/netlify/resources/netlify.go
+++ b/providers/netlify/resources/netlify.go
@@ -108,6 +108,34 @@ func getNetlify(runtime *plugin.Runtime) (*mqlNetlify, error) {
 	return res.(*mqlNetlify), nil
 }
 
+// findCachedResource looks for the entry identified by want in a list the root
+// resource has already fetched, so that resolving a reference on many records
+// costs one call for the whole scan rather than one call per record.
+//
+// A miss is reported rather than treated as an absence: the root lists are
+// narrowed by the account and site the connection is scoped to, so a record can
+// name something that is reachable but outside that scope. Callers fall back to
+// a direct lookup on a miss, which keeps the scoped-out case behaving as it did
+// before the list was consulted at all. An unreadable list is a miss for the
+// same reason.
+func findCachedResource[T any](list *plugin.TValue[[]any], id func(T) string, want string) (T, bool) {
+	var zero T
+	if want == "" || list.Error != nil || list.State&plugin.StateIsNull != 0 {
+		return zero, false
+	}
+	for _, it := range list.Data {
+		entry, ok := it.(T)
+		if ok && id(entry) == want {
+			return entry, true
+		}
+	}
+	return zero, false
+}
+
+func netlifyAccountID(a *mqlNetlifyAccount) string     { return a.Id.Data }
+func netlifySiteID(s *mqlNetlifySite) string           { return s.Id.Data }
+func netlifyDeployKeyID(k *mqlNetlifyDeployKey) string { return k.Id.Data }
+
 // --- root resource --------------------------------------------------------
 
 type userRecord struct {
@@ -161,15 +189,17 @@ func (n *mqlNetlifyUser) id() (string, error) {
 	return n.Id.Data, n.Id.Error
 }
 
-// sites flattens every site of every account in scope.
+// sites flattens every site of every account in scope. The account list is
+// read through its cached field so that querying accounts and sites together
+// walks the accounts endpoint once rather than once per field.
 func (n *mqlNetlify) sites() ([]any, error) {
-	accounts, err := n.accounts()
-	if err != nil {
-		return nil, err
+	accounts := n.GetAccounts()
+	if accounts.Error != nil {
+		return nil, accounts.Error
 	}
 
 	var res []any
-	for _, it := range accounts {
+	for _, it := range accounts.Data {
 		account := it.(*mqlNetlifyAccount)
 		sites := account.GetSites()
 		if sites.Error != nil {

--- a/providers/netlify/resources/resolve_test.go
+++ b/providers/netlify/resources/resolve_test.go
@@ -1,0 +1,107 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// The reference accessors resolve through a list the root resource already
+// fetched, falling back to a direct lookup on a miss. The fallback is what
+// keeps a record that names something outside the connection's account or site
+// scope resolving as it did before: those lists are narrowed by that scope, so
+// a scoped-out entry is a miss rather than an absence. These tests pin the miss
+// cases, because a miss reported as a hit would resolve the reference to null.
+
+func siteWithID(id string) *mqlNetlifySite {
+	return &mqlNetlifySite{Id: plugin.TValue[string]{Data: id, State: plugin.StateIsSet}}
+}
+
+func siteList(ids ...string) *plugin.TValue[[]any] {
+	data := make([]any, 0, len(ids))
+	for _, id := range ids {
+		data = append(data, siteWithID(id))
+	}
+	return &plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet}
+}
+
+func TestFindCachedResourceHit(t *testing.T) {
+	site, ok := findCachedResource(siteList("a", "b", "c"), netlifySiteID, "b")
+	if !ok {
+		t.Fatal("expected the site to resolve out of the cached list")
+	}
+	if site.Id.Data != "b" {
+		t.Errorf("resolved the wrong site: %q", site.Id.Data)
+	}
+}
+
+func TestFindCachedResourceFallsBackOnMiss(t *testing.T) {
+	tests := []struct {
+		name string
+		list *plugin.TValue[[]any]
+		want string
+	}{
+		{
+			// A site in an account the connection is not scoped to. The direct
+			// lookup still reaches it, so this must not resolve to null.
+			name: "outside the connection scope",
+			list: siteList("a", "b"),
+			want: "scoped-out",
+		},
+		{
+			// An empty scope, which is what a token that can reach no site at
+			// all sees. The reference is still worth attempting directly.
+			name: "empty list",
+			list: siteList(),
+			want: "a",
+		},
+		{
+			name: "unreadable list",
+			list: &plugin.TValue[[]any]{Error: errors.New("boom"), State: plugin.StateIsSet | plugin.StateIsNull},
+			want: "a",
+		},
+		{
+			name: "null list",
+			list: &plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull},
+			want: "a",
+		},
+		{
+			name: "no identifier to match on",
+			list: siteList("a"),
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			site, ok := findCachedResource(tc.list, netlifySiteID, tc.want)
+			if ok {
+				t.Fatalf("expected a miss so the caller falls back, got %q", site.Id.Data)
+			}
+			if site != nil {
+				t.Error("a miss must not report a resource")
+			}
+		})
+	}
+}
+
+// A list can hold an entry of another type once a caller passes the wrong
+// field. Skipping it keeps the scan from panicking on the type assertion.
+func TestFindCachedResourceSkipsForeignEntries(t *testing.T) {
+	list := &plugin.TValue[[]any]{
+		Data:  []any{&mqlNetlifyAccount{Id: plugin.TValue[string]{Data: "a", State: plugin.StateIsSet}}, siteWithID("a")},
+		State: plugin.StateIsSet,
+	}
+
+	site, ok := findCachedResource(list, netlifySiteID, "a")
+	if !ok {
+		t.Fatal("expected the site to resolve past the foreign entry")
+	}
+	if site.Id.Data != "a" {
+		t.Errorf("resolved the wrong site: %q", site.Id.Data)
+	}
+}

--- a/providers/netlify/resources/sites.go
+++ b/providers/netlify/resources/sites.go
@@ -209,10 +209,23 @@ func (s *mqlNetlifySite) id() (string, error) {
 }
 
 // account resolves the account the site is billed to and administered from.
+//
+// The match runs against the account list the root resource has already
+// fetched, so a query over many sites does not walk the accounts endpoint per
+// site. An account outside the scope the connection is narrowed to is absent
+// from that list, so a miss falls back to the direct lookup.
 func (s *mqlNetlifySite) account() (*mqlNetlifyAccount, error) {
 	if s.cacheAccountID == "" {
 		s.Account.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+
+	root, err := getNetlify(s.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if account, ok := findCachedResource(root.GetAccounts(), netlifyAccountID, s.cacheAccountID); ok {
+		return account, nil
 	}
 
 	res, err := NewResource(s.MqlRuntime, "netlify.account", map[string]*llx.RawData{
@@ -233,10 +246,23 @@ func (s *mqlNetlifySite) account() (*mqlNetlifyAccount, error) {
 
 // deployKey resolves the key the build clones the repository with. A site
 // building from a public repository or from manual uploads has none.
+//
+// The match runs against the deploy keys the root resource has already
+// fetched, so a query over many sites does not read one key per site. A key
+// registered by another account member is not in that list, so a miss falls
+// back to the direct lookup.
 func (s *mqlNetlifySite) deployKey() (*mqlNetlifyDeployKey, error) {
 	if s.cacheDeployKeyID == "" {
 		s.DeployKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+
+	root, err := getNetlify(s.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if key, ok := findCachedResource(root.GetDeployKeys(), netlifyDeployKeyID, s.cacheDeployKeyID); ok {
+		return key, nil
 	}
 
 	res, err := NewResource(s.MqlRuntime, "netlify.deployKey", map[string]*llx.RawData{
@@ -262,7 +288,19 @@ func (s *mqlNetlifySite) environmentVariables() ([]any, error) {
 
 	query := url.Values{}
 	query.Set("site_id", s.Id.Data)
-	return fetchEnvVars(s.MqlRuntime, s.cacheAccountID, s.Id.Data, query)
+
+	res, err := fetchEnvVars(s.MqlRuntime, s.cacheAccountID, s.Id.Data, query)
+	if err != nil {
+		// The variable endpoint is keyed on the account, so a token that can
+		// read the site without administering its account cannot read them.
+		// Reporting them as null keeps that apart from a site that has none.
+		if connection.IsForbidden(err) {
+			s.EnvironmentVariables = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+			return nil, nil
+		}
+		return nil, err
+	}
+	return res, nil
 }
 
 // --- build hooks ----------------------------------------------------------


### PR DESCRIPTION
## What

Fixes three N+1 reference accessors and two error-handling gaps in the netlify provider.

## Bug 1 — three reference accessors were N+1

`NewResource` runs the target resource's `init` **before** the runtime cache is consulted, so resolving a parent per child is one API call per child, not a cache hit. Three accessors did exactly that:

| Accessor | Per-record cost before | Query that pays it |
|---|---|---|
| `netlify.site.account` | a full paged `GET /accounts` walk | `netlify.sites { account { enforceMfa } }` |
| `netlify.site.deployKey` | `GET /deploy_keys/{id}` | `netlify.sites { deployKey { createdAt } }` |
| `netlify.dnsZone.site` | `GET /sites/{id}` | `netlify.dnsZones { site { forceSsl } }` |

That last one is the query the resource-development guide cites as the canonical reason typed references exist, and it was costing one `GET /sites/{id}` per zone.

Each accessor now scans the list the root resource has already fetched — `GetAccounts()`, `GetSites()`, `GetDeployKeys()`, whose `TValue` memoizes for the whole scan. This is the idiom `netlify.envVar.updatedBy` and `netlify.deployKey.sites` already use. The common case becomes a list lookup; the shared list is walked once.

### Why the fallback is kept

`root.GetAccounts()` / `GetSites()` apply the connection's `AccountFilter` / `SiteFilter`, whereas the `init` path they replace fetched unfiltered. A blind swap would make a site whose account sits outside the active scope — or a deploy key registered by another account member — resolve to **null** rather than to the resource that is genuinely reachable by id. That is a silent correctness regression, not a performance win.

So the shape is: **scan the memoized list, and on a miss fall back to the original `NewResource` call unchanged.** An unreadable or null list is treated as a miss for the same reason. That makes the change strictly an improvement — the common case gets faster, the scoped-out case behaves exactly as it did.

Every existing degradation path survives verbatim: `connection.IsForbidden` / `IsNotFound` (plus `errAccountNotFound` for `site.account`) still set `StateIsSet | StateIsNull`, and a real transport error is still returned as an error rather than converted into a null.

## Bug 2 — `netlify.sites` refetched the account list

`(*mqlNetlify).sites()` called the raw `accounts()` accessor instead of the memoized `GetAccounts()`, so `netlify.accounts` followed by `netlify.sites` walked `/accounts` twice.

`discovery.go` keeps its raw `root.accounts()` call — see the note at the bottom.

## Bug 3 — env-var accessors did not degrade on 403

`fetchEnvVars` returned the raw error, so `netlify.account.environmentVariables` and `netlify.site.environmentVariables` **failed the field** for a token that cannot read `/accounts/{id}/env`, while every sibling accessor in the provider degrades to null. Both now handle `connection.IsForbidden` the way `account.members()` does.

For a **list** accessor a bare `nil, nil` return is not enough: a list field with no explicit null state still renders as `[]`, which a policy reads as *"this account has no environment variables"* when the truth is *"this token cannot read them"*. Both accessors therefore set `plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}` on the field before returning.

`deployKey.sites()` is deliberately left alone — its bare `nil` return is what makes the documented `deployKeys.where(sites.length == 0)` query in the README work, and that one wants `[]`, not null.

## Tests

`resources/resolve_test.go` pins the scan-then-fallback contract without any live API: a hit resolves out of the cached list, and every miss shape (entry outside the connection scope, empty list, unreadable list, null list, no identifier to match on) reports a miss so the caller falls back rather than resolving to null. A foreign entry in the list is skipped rather than panicking on the type assertion.

```
$ cd providers/netlify && go build ./... && go test ./...
ok  	go.mondoo.com/mql/v13/providers/netlify/connection	0.850s
ok  	go.mondoo.com/mql/v13/providers/netlify/resources	1.155s
```

No `.lr` change, so no codegen and no `.lr.versions` edit.

## Note on `discovery.go`

`discover()` still calls `root.accounts()` directly rather than `GetAccounts()`. Discovery runs before the resource graph is live and its result is not reused by the subsequent per-asset scans (each discovered asset connects with its own runtime), so the memo would buy nothing there while binding discovery to a cached field it does not otherwise participate in. Left unchanged deliberately.
