### PR TITLE
🐛 openstack: resolve HA/DVR router ports and secret-valued Octavia TLS refs

### DIFF
--- a/providers/openstack/resources/network.go
+++ b/providers/openstack/resources/network.go
@@ -667,10 +667,29 @@ func (r *mqlOpenstackPort) server() (*mqlOpenstackComputeServer, error) {
 	return res.(*mqlOpenstackComputeServer), nil
 }
 
+// deviceOwnerIsRouter reports whether a port's deviceOwner marks the port as
+// owned by a Neutron router, which means its deviceId holds a router UUID.
+//
+// The "network:router" prefix covers the legacy and distributed interface
+// owners (network:router_interface, network:router_interface_distributed),
+// the external gateway port (network:router_gateway), the HA keepalived
+// interface (network:router_ha_interface) and the centralized SNAT port
+// (network:router_centralized_snat). DVR and HA deployments additionally use
+// network:ha_router_replicated_interface for every router interface
+// replicated onto a compute or network node, which does not carry that
+// prefix.
+//
+// network:dhcp is deliberately excluded: its device_id is a synthetic
+// "dhcp<host>-<network>" string rather than a resource UUID.
+func deviceOwnerIsRouter(deviceOwner string) bool {
+	return strings.HasPrefix(deviceOwner, "network:router") ||
+		deviceOwner == "network:ha_router_replicated_interface"
+}
+
 // router resolves the port's device to a router when the port is a router
-// interface or gateway (deviceOwner starts with "network:router").
+// interface, gateway, or replicated HA/DVR interface.
 func (r *mqlOpenstackPort) router() (*mqlOpenstackRouter, error) {
-	if r.cacheDeviceID == "" || !strings.HasPrefix(r.DeviceOwner.Data, "network:router") {
+	if r.cacheDeviceID == "" || !deviceOwnerIsRouter(r.DeviceOwner.Data) {
 		r.Router.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/openstack/resources/network_test.go
+++ b/providers/openstack/resources/network_test.go
@@ -9,6 +9,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDeviceOwnerIsRouter(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceOwner string
+		want        bool
+	}{
+		{"empty", "", false},
+		{"legacy router interface", "network:router_interface", true},
+		{"distributed router interface", "network:router_interface_distributed", true},
+		{"HA/DVR replicated interface", "network:ha_router_replicated_interface", true},
+		{"external gateway", "network:router_gateway", true},
+		{"HA keepalived interface", "network:router_ha_interface", true},
+		{"centralized SNAT", "network:router_centralized_snat", true},
+		{"DHCP agent port is not a router", "network:dhcp", false},
+		{"floating IP port is not a router", "network:floatingip", false},
+		{"floating IP agent gateway is not a router", "network:floatingip_agent_gateway", false},
+		{"compute port is not a router", "compute:nova", false},
+		{"load balancer port is not a router", "Octavia", false},
+		{"unowned port", "network:", false},
+		{"bare router word without namespace", "router_interface", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, deviceOwnerIsRouter(tt.deviceOwner))
+		})
+	}
+}
+
 func TestParseSegmentationID(t *testing.T) {
 	t.Run("empty string returns 0", func(t *testing.T) {
 		assert.Equal(t, int64(0), parseSegmentationID(""))

--- a/providers/openstack/resources/octavia.go
+++ b/providers/openstack/resources/octavia.go
@@ -46,6 +46,38 @@ func newKeymanagerContainerByRef(runtime *plugin.Runtime, ref string) (*mqlOpens
 	return res.(*mqlOpenstackKeymanagerContainer), nil
 }
 
+// barbicanRefIsSecret reports whether a Barbican ref URL points at a bare
+// secret (vs a container). Octavia accepts either for its TLS refs, and a
+// PKCS12 bundle stored as a single secret is the common form on modern
+// clouds. A ref that matches neither shape is left unresolved rather than
+// guessed at.
+func barbicanRefIsSecret(ref string) bool {
+	return strings.Contains(ref, "/secrets/")
+}
+
+// newKeymanagerSecretByRef resolves a Barbican secret ref URL to an
+// openstack.keymanager.secret resource. Returns (nil, nil) when ref is empty
+// or points at a container (not a bare secret) — callers MUST set
+// `<field>.State = StateIsSet | StateIsNull` before returning, otherwise the
+// runtime keeps the field unresolved.
+func newKeymanagerSecretByRef(runtime *plugin.Runtime, ref string) (*mqlOpenstackKeymanagerSecret, error) {
+	if !barbicanRefIsSecret(ref) {
+		return nil, nil
+	}
+	id := barbicanRefID(ref)
+	if id == "" {
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "openstack.keymanager.secret", map[string]*llx.RawData{
+		"id":        llx.StringData(id),
+		"secretRef": llx.StringData(ref),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackKeymanagerSecret), nil
+}
+
 // ---- openstack.octavia.loadBalancer ----
 
 type mqlOpenstackOctaviaLoadBalancerInternal struct {
@@ -408,6 +440,17 @@ func (r *mqlOpenstackOctaviaListener) defaultTlsContainer() (*mqlOpenstackKeyman
 	return res, nil
 }
 
+func (r *mqlOpenstackOctaviaListener) defaultTlsSecret() (*mqlOpenstackKeymanagerSecret, error) {
+	res, err := newKeymanagerSecretByRef(r.MqlRuntime, r.cacheDefaultTlsContainerRef)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		r.DefaultTlsSecret.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
 func (r *mqlOpenstackOctaviaListener) sniContainers() ([]any, error) {
 	out := make([]any, 0, len(r.cacheSniContainerRefs))
 	for _, ref := range r.cacheSniContainerRefs {
@@ -417,6 +460,20 @@ func (r *mqlOpenstackOctaviaListener) sniContainers() ([]any, error) {
 		}
 		if c != nil {
 			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (r *mqlOpenstackOctaviaListener) sniSecrets() ([]any, error) {
+	out := make([]any, 0, len(r.cacheSniContainerRefs))
+	for _, ref := range r.cacheSniContainerRefs {
+		s, err := newKeymanagerSecretByRef(r.MqlRuntime, ref)
+		if err != nil {
+			return nil, err
+		}
+		if s != nil {
+			out = append(out, s)
 		}
 	}
 	return out, nil
@@ -433,6 +490,17 @@ func (r *mqlOpenstackOctaviaListener) clientCATlsContainer() (*mqlOpenstackKeyma
 	return res, nil
 }
 
+func (r *mqlOpenstackOctaviaListener) clientCATlsSecret() (*mqlOpenstackKeymanagerSecret, error) {
+	res, err := newKeymanagerSecretByRef(r.MqlRuntime, r.cacheClientCATlsContainerRef)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		r.ClientCATlsSecret.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
 func (r *mqlOpenstackOctaviaListener) clientCRLContainer() (*mqlOpenstackKeymanagerContainer, error) {
 	res, err := newKeymanagerContainerByRef(r.MqlRuntime, r.cacheClientCRLContainerRef)
 	if err != nil {
@@ -440,6 +508,17 @@ func (r *mqlOpenstackOctaviaListener) clientCRLContainer() (*mqlOpenstackKeymana
 	}
 	if res == nil {
 		r.ClientCRLContainer.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
+func (r *mqlOpenstackOctaviaListener) clientCRLSecret() (*mqlOpenstackKeymanagerSecret, error) {
+	res, err := newKeymanagerSecretByRef(r.MqlRuntime, r.cacheClientCRLContainerRef)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		r.ClientCRLSecret.State = plugin.StateIsSet | plugin.StateIsNull
 	}
 	return res, nil
 }
@@ -648,6 +727,17 @@ func (r *mqlOpenstackOctaviaPool) caTlsContainer() (*mqlOpenstackKeymanagerConta
 	return res, nil
 }
 
+func (r *mqlOpenstackOctaviaPool) caTlsSecret() (*mqlOpenstackKeymanagerSecret, error) {
+	res, err := newKeymanagerSecretByRef(r.MqlRuntime, r.cacheCATlsContainerRef)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		r.CaTlsSecret.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
 func (r *mqlOpenstackOctaviaPool) crlContainer() (*mqlOpenstackKeymanagerContainer, error) {
 	res, err := newKeymanagerContainerByRef(r.MqlRuntime, r.cacheCRLContainerRef)
 	if err != nil {
@@ -659,6 +749,17 @@ func (r *mqlOpenstackOctaviaPool) crlContainer() (*mqlOpenstackKeymanagerContain
 	return res, nil
 }
 
+func (r *mqlOpenstackOctaviaPool) crlSecret() (*mqlOpenstackKeymanagerSecret, error) {
+	res, err := newKeymanagerSecretByRef(r.MqlRuntime, r.cacheCRLContainerRef)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		r.CrlSecret.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
 func (r *mqlOpenstackOctaviaPool) clientTlsContainer() (*mqlOpenstackKeymanagerContainer, error) {
 	res, err := newKeymanagerContainerByRef(r.MqlRuntime, r.cacheClientTlsContainerRef)
 	if err != nil {
@@ -666,6 +767,17 @@ func (r *mqlOpenstackOctaviaPool) clientTlsContainer() (*mqlOpenstackKeymanagerC
 	}
 	if res == nil {
 		r.ClientTlsContainer.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
+func (r *mqlOpenstackOctaviaPool) clientTlsSecret() (*mqlOpenstackKeymanagerSecret, error) {
+	res, err := newKeymanagerSecretByRef(r.MqlRuntime, r.cacheClientTlsContainerRef)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		r.ClientTlsSecret.State = plugin.StateIsSet | plugin.StateIsNull
 	}
 	return res, nil
 }

--- a/providers/openstack/resources/octavia_test.go
+++ b/providers/openstack/resources/octavia_test.go
@@ -23,10 +23,50 @@ func TestBarbicanRefIsContainer(t *testing.T) {
 		{"secret ref", "https://barbican.example/v1/secrets/abc", false},
 		{"order ref", "https://barbican.example/v1/orders/abc", false},
 		{"container in path segment", "https://example/v1/containers/uuid", true},
+		{"malformed ref", "not-a-barbican-ref", false},
+		{"bare uuid", "8a2f0e3c-1d4b-4f2a-9c11-0b7c2e5d6f31", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, barbicanRefIsContainer(tt.ref))
+		})
+	}
+}
+
+func TestBarbicanRefIsSecret(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want bool
+	}{
+		{"empty", "", false},
+		{"secret ref", "https://barbican.example/v1/secrets/abc", true},
+		{"container ref", "https://barbican.example/v1/containers/abc", false},
+		{"order ref", "https://barbican.example/v1/orders/abc", false},
+		{"malformed ref", "not-a-barbican-ref", false},
+		{"bare uuid", "8a2f0e3c-1d4b-4f2a-9c11-0b7c2e5d6f31", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, barbicanRefIsSecret(tt.ref))
+		})
+	}
+}
+
+// A ref resolves to at most one of the two Barbican resource kinds; a ref that
+// matches neither shape stays unresolved rather than being guessed at.
+func TestBarbicanRefKindsAreExclusive(t *testing.T) {
+	refs := []string{
+		"",
+		"https://barbican.example/v1/secrets/abc",
+		"https://barbican.example/v1/containers/abc",
+		"https://barbican.example/v1/orders/abc",
+		"not-a-barbican-ref",
+		"https://barbican.example/v1/secrets/",
+	}
+	for _, ref := range refs {
+		t.Run(ref, func(t *testing.T) {
+			assert.False(t, barbicanRefIsSecret(ref) && barbicanRefIsContainer(ref))
 		})
 	}
 }

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -820,7 +820,12 @@ private openstack.port @defaults("id name status macAddress") {
   project() openstack.project
   // Server this port is attached to; null when the port is not bound to a compute instance
   server() openstack.compute.server
-  // Router this port is attached to; null when the port is not a router interface or gateway
+  // Router this port is attached to
+  //
+  // Covers the legacy and distributed router interfaces, the external gateway
+  // port, the HA keepalived interface, the centralized SNAT port, and the
+  // replicated interfaces that DVR and HA deployments create on compute and
+  // network nodes. Null when the port is not owned by a router.
   router() openstack.router
   // Floating (public) IPs bound to this port; empty when none are bound
   floatingIps() []openstack.floatingIp
@@ -1417,12 +1422,36 @@ private openstack.octavia.listener @defaults("id name protocol protocolPort prov
   defaultPool() openstack.octavia.pool
   // Barbican container holding the listener's default TLS material; null when not set or when the ref points at a bare Barbican secret
   defaultTlsContainer() openstack.keymanager.container
+  // Barbican secret holding the listener's default TLS material
+  //
+  // Octavia accepts either a container or a bare secret for
+  // `default_tls_container_ref`, and a PKCS12 bundle stored as a single secret
+  // is the common form on modern clouds. Null when the ref is unset or names a
+  // container, in which case defaultTlsContainer carries the material instead.
+  // Check both to decide whether a listener terminates TLS.
+  defaultTlsSecret() openstack.keymanager.secret
   // Barbican containers used for SNI; empty when SNI is not configured
   sniContainers() []openstack.keymanager.container
+  // Barbican secrets used for SNI
+  //
+  // The entries of `sni_container_refs` that name a bare secret rather than a
+  // container. Empty when SNI is not configured or every ref names a
+  // container, which sniContainers then resolves.
+  sniSecrets() []openstack.keymanager.secret
   // Barbican container holding the client CA bundle for mTLS; null when not configured
   clientCATlsContainer() openstack.keymanager.container
+  // Barbican secret holding the client CA bundle for mTLS
+  //
+  // Null when the client CA ref is unset or names a container, which
+  // clientCATlsContainer then resolves.
+  clientCATlsSecret() openstack.keymanager.secret
   // Barbican container holding the client CRL list; null when not configured
   clientCRLContainer() openstack.keymanager.container
+  // Barbican secret holding the client CRL list
+  //
+  // Null when the CRL ref is unset or names a container, which
+  // clientCRLContainer then resolves.
+  clientCRLSecret() openstack.keymanager.secret
   // L7 policies attached to this listener
   l7Policies() []openstack.octavia.l7Policy
   // Whether the listener accepts connections from any source (allowedCidrs is empty or contains a public CIDR)
@@ -1481,10 +1510,25 @@ private openstack.octavia.pool @defaults("id name lbAlgorithm protocol provision
   subnet() openstack.subnet
   // Barbican container holding the CA bundle used to verify backend TLS; null when not set
   caTlsContainer() openstack.keymanager.container
+  // Barbican secret holding the CA bundle used to verify backend TLS
+  //
+  // Null when `ca_tls_container_ref` is unset or names a container, which
+  // caTlsContainer then resolves.
+  caTlsSecret() openstack.keymanager.secret
   // Barbican container holding the CRL list for backend TLS; null when not set
   crlContainer() openstack.keymanager.container
+  // Barbican secret holding the CRL list for backend TLS
+  //
+  // Null when `crl_container_ref` is unset or names a container, which
+  // crlContainer then resolves.
+  crlSecret() openstack.keymanager.secret
   // Barbican container holding the client cert/key bundle for backend mTLS; null when not set
   clientTlsContainer() openstack.keymanager.container
+  // Barbican secret holding the client cert/key bundle for backend mTLS
+  //
+  // Null when `tls_container_ref` is unset or names a container, which
+  // clientTlsContainer then resolves.
+  clientTlsSecret() openstack.keymanager.secret
   // Members in this pool
   members() []openstack.octavia.member
 }

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -2019,14 +2019,26 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.octavia.listener.defaultTlsContainer": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetDefaultTlsContainer()).ToDataRes(types.Resource("openstack.keymanager.container"))
 	},
+	"openstack.octavia.listener.defaultTlsSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetDefaultTlsSecret()).ToDataRes(types.Resource("openstack.keymanager.secret"))
+	},
 	"openstack.octavia.listener.sniContainers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetSniContainers()).ToDataRes(types.Array(types.Resource("openstack.keymanager.container")))
+	},
+	"openstack.octavia.listener.sniSecrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetSniSecrets()).ToDataRes(types.Array(types.Resource("openstack.keymanager.secret")))
 	},
 	"openstack.octavia.listener.clientCATlsContainer": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetClientCATlsContainer()).ToDataRes(types.Resource("openstack.keymanager.container"))
 	},
+	"openstack.octavia.listener.clientCATlsSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetClientCATlsSecret()).ToDataRes(types.Resource("openstack.keymanager.secret"))
+	},
 	"openstack.octavia.listener.clientCRLContainer": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetClientCRLContainer()).ToDataRes(types.Resource("openstack.keymanager.container"))
+	},
+	"openstack.octavia.listener.clientCRLSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetClientCRLSecret()).ToDataRes(types.Resource("openstack.keymanager.secret"))
 	},
 	"openstack.octavia.listener.l7Policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetL7Policies()).ToDataRes(types.Array(types.Resource("openstack.octavia.l7Policy")))
@@ -2097,11 +2109,20 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.octavia.pool.caTlsContainer": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaPool).GetCaTlsContainer()).ToDataRes(types.Resource("openstack.keymanager.container"))
 	},
+	"openstack.octavia.pool.caTlsSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaPool).GetCaTlsSecret()).ToDataRes(types.Resource("openstack.keymanager.secret"))
+	},
 	"openstack.octavia.pool.crlContainer": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaPool).GetCrlContainer()).ToDataRes(types.Resource("openstack.keymanager.container"))
 	},
+	"openstack.octavia.pool.crlSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaPool).GetCrlSecret()).ToDataRes(types.Resource("openstack.keymanager.secret"))
+	},
 	"openstack.octavia.pool.clientTlsContainer": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaPool).GetClientTlsContainer()).ToDataRes(types.Resource("openstack.keymanager.container"))
+	},
+	"openstack.octavia.pool.clientTlsSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaPool).GetClientTlsSecret()).ToDataRes(types.Resource("openstack.keymanager.secret"))
 	},
 	"openstack.octavia.pool.members": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaPool).GetMembers()).ToDataRes(types.Array(types.Resource("openstack.octavia.member")))
@@ -6483,16 +6504,32 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackOctaviaListener).DefaultTlsContainer, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerContainer](v.Value, v.Error)
 		return
 	},
+	"openstack.octavia.listener.defaultTlsSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).DefaultTlsSecret, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerSecret](v.Value, v.Error)
+		return
+	},
 	"openstack.octavia.listener.sniContainers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaListener).SniContainers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.listener.sniSecrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).SniSecrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"openstack.octavia.listener.clientCATlsContainer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaListener).ClientCATlsContainer, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerContainer](v.Value, v.Error)
 		return
 	},
+	"openstack.octavia.listener.clientCATlsSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).ClientCATlsSecret, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerSecret](v.Value, v.Error)
+		return
+	},
 	"openstack.octavia.listener.clientCRLContainer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaListener).ClientCRLContainer, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerContainer](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.listener.clientCRLSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).ClientCRLSecret, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerSecret](v.Value, v.Error)
 		return
 	},
 	"openstack.octavia.listener.l7Policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6591,12 +6628,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackOctaviaPool).CaTlsContainer, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerContainer](v.Value, v.Error)
 		return
 	},
+	"openstack.octavia.pool.caTlsSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaPool).CaTlsSecret, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerSecret](v.Value, v.Error)
+		return
+	},
 	"openstack.octavia.pool.crlContainer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaPool).CrlContainer, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerContainer](v.Value, v.Error)
 		return
 	},
+	"openstack.octavia.pool.crlSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaPool).CrlSecret, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerSecret](v.Value, v.Error)
+		return
+	},
 	"openstack.octavia.pool.clientTlsContainer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaPool).ClientTlsContainer, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerContainer](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.pool.clientTlsSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaPool).ClientTlsSecret, ok = plugin.RawToTValue[*mqlOpenstackKeymanagerSecret](v.Value, v.Error)
 		return
 	},
 	"openstack.octavia.pool.members": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -15675,9 +15724,13 @@ type mqlOpenstackOctaviaListener struct {
 	LoadBalancer          plugin.TValue[*mqlOpenstackOctaviaLoadBalancer]
 	DefaultPool           plugin.TValue[*mqlOpenstackOctaviaPool]
 	DefaultTlsContainer   plugin.TValue[*mqlOpenstackKeymanagerContainer]
+	DefaultTlsSecret      plugin.TValue[*mqlOpenstackKeymanagerSecret]
 	SniContainers         plugin.TValue[[]any]
+	SniSecrets            plugin.TValue[[]any]
 	ClientCATlsContainer  plugin.TValue[*mqlOpenstackKeymanagerContainer]
+	ClientCATlsSecret     plugin.TValue[*mqlOpenstackKeymanagerSecret]
 	ClientCRLContainer    plugin.TValue[*mqlOpenstackKeymanagerContainer]
+	ClientCRLSecret       plugin.TValue[*mqlOpenstackKeymanagerSecret]
 	L7Policies            plugin.TValue[[]any]
 	OpenToWorld           plugin.TValue[bool]
 }
@@ -15863,6 +15916,22 @@ func (c *mqlOpenstackOctaviaListener) GetDefaultTlsContainer() *plugin.TValue[*m
 	})
 }
 
+func (c *mqlOpenstackOctaviaListener) GetDefaultTlsSecret() *plugin.TValue[*mqlOpenstackKeymanagerSecret] {
+	return plugin.GetOrCompute[*mqlOpenstackKeymanagerSecret](&c.DefaultTlsSecret, func() (*mqlOpenstackKeymanagerSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.listener", c.__id, "defaultTlsSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackKeymanagerSecret), nil
+			}
+		}
+
+		return c.defaultTlsSecret()
+	})
+}
+
 func (c *mqlOpenstackOctaviaListener) GetSniContainers() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.SniContainers, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -15876,6 +15945,22 @@ func (c *mqlOpenstackOctaviaListener) GetSniContainers() *plugin.TValue[[]any] {
 		}
 
 		return c.sniContainers()
+	})
+}
+
+func (c *mqlOpenstackOctaviaListener) GetSniSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SniSecrets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.listener", c.__id, "sniSecrets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.sniSecrets()
 	})
 }
 
@@ -15895,6 +15980,22 @@ func (c *mqlOpenstackOctaviaListener) GetClientCATlsContainer() *plugin.TValue[*
 	})
 }
 
+func (c *mqlOpenstackOctaviaListener) GetClientCATlsSecret() *plugin.TValue[*mqlOpenstackKeymanagerSecret] {
+	return plugin.GetOrCompute[*mqlOpenstackKeymanagerSecret](&c.ClientCATlsSecret, func() (*mqlOpenstackKeymanagerSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.listener", c.__id, "clientCATlsSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackKeymanagerSecret), nil
+			}
+		}
+
+		return c.clientCATlsSecret()
+	})
+}
+
 func (c *mqlOpenstackOctaviaListener) GetClientCRLContainer() *plugin.TValue[*mqlOpenstackKeymanagerContainer] {
 	return plugin.GetOrCompute[*mqlOpenstackKeymanagerContainer](&c.ClientCRLContainer, func() (*mqlOpenstackKeymanagerContainer, error) {
 		if c.MqlRuntime.HasRecording {
@@ -15908,6 +16009,22 @@ func (c *mqlOpenstackOctaviaListener) GetClientCRLContainer() *plugin.TValue[*mq
 		}
 
 		return c.clientCRLContainer()
+	})
+}
+
+func (c *mqlOpenstackOctaviaListener) GetClientCRLSecret() *plugin.TValue[*mqlOpenstackKeymanagerSecret] {
+	return plugin.GetOrCompute[*mqlOpenstackKeymanagerSecret](&c.ClientCRLSecret, func() (*mqlOpenstackKeymanagerSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.listener", c.__id, "clientCRLSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackKeymanagerSecret), nil
+			}
+		}
+
+		return c.clientCRLSecret()
 	})
 }
 
@@ -15959,8 +16076,11 @@ type mqlOpenstackOctaviaPool struct {
 	HealthMonitor      plugin.TValue[*mqlOpenstackOctaviaHealthMonitor]
 	Subnet             plugin.TValue[*mqlOpenstackSubnet]
 	CaTlsContainer     plugin.TValue[*mqlOpenstackKeymanagerContainer]
+	CaTlsSecret        plugin.TValue[*mqlOpenstackKeymanagerSecret]
 	CrlContainer       plugin.TValue[*mqlOpenstackKeymanagerContainer]
+	CrlSecret          plugin.TValue[*mqlOpenstackKeymanagerSecret]
 	ClientTlsContainer plugin.TValue[*mqlOpenstackKeymanagerContainer]
+	ClientTlsSecret    plugin.TValue[*mqlOpenstackKeymanagerSecret]
 	Members            plugin.TValue[[]any]
 }
 
@@ -16157,6 +16277,22 @@ func (c *mqlOpenstackOctaviaPool) GetCaTlsContainer() *plugin.TValue[*mqlOpensta
 	})
 }
 
+func (c *mqlOpenstackOctaviaPool) GetCaTlsSecret() *plugin.TValue[*mqlOpenstackKeymanagerSecret] {
+	return plugin.GetOrCompute[*mqlOpenstackKeymanagerSecret](&c.CaTlsSecret, func() (*mqlOpenstackKeymanagerSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.pool", c.__id, "caTlsSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackKeymanagerSecret), nil
+			}
+		}
+
+		return c.caTlsSecret()
+	})
+}
+
 func (c *mqlOpenstackOctaviaPool) GetCrlContainer() *plugin.TValue[*mqlOpenstackKeymanagerContainer] {
 	return plugin.GetOrCompute[*mqlOpenstackKeymanagerContainer](&c.CrlContainer, func() (*mqlOpenstackKeymanagerContainer, error) {
 		if c.MqlRuntime.HasRecording {
@@ -16173,6 +16309,22 @@ func (c *mqlOpenstackOctaviaPool) GetCrlContainer() *plugin.TValue[*mqlOpenstack
 	})
 }
 
+func (c *mqlOpenstackOctaviaPool) GetCrlSecret() *plugin.TValue[*mqlOpenstackKeymanagerSecret] {
+	return plugin.GetOrCompute[*mqlOpenstackKeymanagerSecret](&c.CrlSecret, func() (*mqlOpenstackKeymanagerSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.pool", c.__id, "crlSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackKeymanagerSecret), nil
+			}
+		}
+
+		return c.crlSecret()
+	})
+}
+
 func (c *mqlOpenstackOctaviaPool) GetClientTlsContainer() *plugin.TValue[*mqlOpenstackKeymanagerContainer] {
 	return plugin.GetOrCompute[*mqlOpenstackKeymanagerContainer](&c.ClientTlsContainer, func() (*mqlOpenstackKeymanagerContainer, error) {
 		if c.MqlRuntime.HasRecording {
@@ -16186,6 +16338,22 @@ func (c *mqlOpenstackOctaviaPool) GetClientTlsContainer() *plugin.TValue[*mqlOpe
 		}
 
 		return c.clientTlsContainer()
+	})
+}
+
+func (c *mqlOpenstackOctaviaPool) GetClientTlsSecret() *plugin.TValue[*mqlOpenstackKeymanagerSecret] {
+	return plugin.GetOrCompute[*mqlOpenstackKeymanagerSecret](&c.ClientTlsSecret, func() (*mqlOpenstackKeymanagerSecret, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.octavia.pool", c.__id, "clientTlsSecret")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackKeymanagerSecret), nil
+			}
+		}
+
+		return c.clientTlsSecret()
 	})
 }
 

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -906,10 +906,13 @@ openstack.octavia.listener.allowedCidrs 13.0.1
 openstack.octavia.listener.alpnProtocols 13.0.1
 openstack.octavia.listener.clientAuthentication 13.0.1
 openstack.octavia.listener.clientCATlsContainer 13.0.1
+openstack.octavia.listener.clientCATlsSecret 13.8.2
 openstack.octavia.listener.clientCRLContainer 13.0.1
+openstack.octavia.listener.clientCRLSecret 13.8.2
 openstack.octavia.listener.connectionLimit 13.0.1
 openstack.octavia.listener.defaultPool 13.0.1
 openstack.octavia.listener.defaultTlsContainer 13.0.1
+openstack.octavia.listener.defaultTlsSecret 13.8.2
 openstack.octavia.listener.description 13.0.1
 openstack.octavia.listener.hstsIncludeSubdomains 13.0.1
 openstack.octavia.listener.id 13.0.1
@@ -923,6 +926,7 @@ openstack.octavia.listener.protocol 13.0.1
 openstack.octavia.listener.protocolPort 13.0.1
 openstack.octavia.listener.provisioningStatus 13.0.1
 openstack.octavia.listener.sniContainers 13.0.1
+openstack.octavia.listener.sniSecrets 13.8.2
 openstack.octavia.listener.tags 13.0.1
 openstack.octavia.listener.timeoutClientData 13.0.1
 openstack.octavia.listener.timeoutMemberConnect 13.0.1
@@ -979,8 +983,11 @@ openstack.octavia.pool 13.0.1
 openstack.octavia.pool.adminStateUp 13.0.1
 openstack.octavia.pool.alpnProtocols 13.0.1
 openstack.octavia.pool.caTlsContainer 13.0.1
+openstack.octavia.pool.caTlsSecret 13.8.2
 openstack.octavia.pool.clientTlsContainer 13.0.1
+openstack.octavia.pool.clientTlsSecret 13.8.2
 openstack.octavia.pool.crlContainer 13.0.1
+openstack.octavia.pool.crlSecret 13.8.2
 openstack.octavia.pool.description 13.0.1
 openstack.octavia.pool.healthMonitor 13.0.1
 openstack.octavia.pool.id 13.0.1


### PR DESCRIPTION
Two confirmed correctness bugs in the openstack provider, both of the same shape: a field reads as "nothing configured" while something **is** configured. That is the worst failure mode for a security audit, because the check passes on data that was never actually read.

## 1. HA/DVR router ports silently unlinked

`openstack.port.router` discriminated the port's owner with a prefix match on `network:router`. That misses `network:ha_router_replicated_interface`, the `device_owner` Neutron assigns to every router interface replicated onto a compute or network node under DVR or HA. On any cloud running distributed or highly-available routers (most production OpenStack), those ports resolved `router()` to null, so a query walking ports to their routers silently skipped them.

The matcher is now a named predicate, `deviceOwnerIsRouter`, covering:

| `deviceOwner` | resolves to a router |
|---|---|
| `network:router_interface` | yes |
| `network:router_interface_distributed` | yes |
| `network:router_gateway` | yes |
| `network:router_ha_interface` | yes |
| `network:router_centralized_snat` | yes |
| `network:ha_router_replicated_interface` | **yes (was missed)** |
| `network:dhcp` | no, by design |
| `network:floatingip`, `network:floatingip_agent_gateway`, `compute:*` | no |

`network:dhcp` is deliberately left unresolved: its `device_id` is a synthetic `dhcp<host>-<network>` string rather than a resource UUID, so there is nothing to resolve it against.

## 2. TLS-configured listeners reading as having no TLS material

Octavia accepts either a Barbican **container** or a bare Barbican **secret** for its TLS refs, and a PKCS12 bundle stored as a single secret is the common form on modern clouds. `newKeymanagerContainerByRef` bails out on any ref that does not contain `/containers/`, so a listener whose TLS material is a bare secret reported `defaultTlsContainer` as null. That reads as "no TLS material configured" on a listener that terminates TLS.

Secret-valued accessors now sit alongside the container ones:

- `openstack.octavia.listener`: `defaultTlsSecret`, `sniSecrets`, `clientCATlsSecret`, `clientCRLSecret`
- `openstack.octavia.pool`: `caTlsSecret`, `crlSecret`, `clientTlsSecret`

They resolve to the already-modeled `openstack.keymanager.secret`, whose `secretRef` field documents exactly these strings.

The existing container accessors keep their meaning and type unchanged. They still return null for a secret ref, which is now correct rather than misleading, since the sibling secret accessor carries the value. A ref matching neither shape (malformed, or an order ref) stays unresolved on both rather than being guessed at.

## Tests

Table tests for both branchy matchers, each covering the empty string, a malformed ref, a container ref, and a secret ref, plus every `deviceOwner` value in the table above. An exclusivity test asserts no ref ever resolves as both a container and a secret.

```
$ go build ./...
$ go test ./...
ok  	go.mondoo.com/mql/v13/providers/openstack/connection	1.350s
ok  	go.mondoo.com/mql/v13/providers/openstack/resources	0.954s
```

`.lr.versions` entries added at `13.8.2` (provider is at `13.8.1`); `config.go` is not bumped.
