### PR TITLE
🐛 neon: fix null project back-refs, an organization N+1, and a data race

### DIFF
--- a/providers/neon/resources/discovery.go
+++ b/providers/neon/resources/discovery.go
@@ -82,9 +82,11 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 	}
 
 	if wantProjects {
-		// Projects are listed from the root rather than per organization so a
-		// personal API key, whose projects belong to no organization, still
-		// discovers them.
+		// The root collects projects per organization, because the list
+		// endpoint rejects a request that does not name one, so discovery emits
+		// assets for exactly the projects a plain query would see. A project
+		// that belongs to no organization is not among them and is reached by
+		// naming it instead, as neon.project(id: "...").
 		projects := root.GetProjects()
 		if projects.Error != nil {
 			return nil, projects.Error

--- a/providers/neon/resources/neon.go
+++ b/providers/neon/resources/neon.go
@@ -113,9 +113,35 @@ func getNeon(runtime *plugin.Runtime) (*mqlNeon, error) {
 	return res.(*mqlNeon), nil
 }
 
+// cachedResource returns a resource the runtime already holds under the given
+// name and identifier. NewResource runs a resource's init before it consults
+// this cache, so a lookup that falls back to it would re-read the API once per
+// caller without this check.
+func cachedResource[T plugin.Resource](runtime *plugin.Runtime, name, id string) (T, bool) {
+	var empty T
+	if id == "" {
+		return empty, false
+	}
+	res, ok := runtime.Resources.Get(name + "\x00" + id)
+	if !ok {
+		return empty, false
+	}
+	typed, ok := res.(T)
+	if !ok {
+		return empty, false
+	}
+	return typed, true
+}
+
 // projectByID resolves a project from the root resource's project list. Going
 // through the cached list keeps a query that walks from many children back to
 // their project down to the one call the list already made.
+//
+// That list only holds the projects of the organizations the API key can
+// enumerate. A project outside it, either a personal project that belongs to no
+// organization or one in an organization the key can read but not list, is read
+// from the project endpoint instead, so a child still reaches its project
+// rather than reporting none.
 func projectByID(runtime *plugin.Runtime, projectID string) (*mqlNeonProject, error) {
 	if projectID == "" {
 		return nil, nil
@@ -135,6 +161,54 @@ func projectByID(runtime *plugin.Runtime, projectID string) (*mqlNeonProject, er
 		if ok && project.Id.Data == projectID {
 			return project, nil
 		}
+	}
+
+	if project, ok := cachedResource[*mqlNeonProject](runtime, "neon.project", projectID); ok {
+		return project, nil
+	}
+
+	res, err := NewResource(runtime, "neon.project", map[string]*llx.RawData{
+		"id": llx.StringData(projectID),
+	})
+	if err != nil {
+		// A project the key cannot read is reported as absent rather than
+		// failing the query that reached it.
+		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return res.(*mqlNeonProject), nil
+}
+
+// organizationByID resolves an organization from the root resource's
+// organization list. Reusing that list keeps a query that walks from many
+// projects to their organization down to the one call the list already made,
+// instead of a read per project.
+func organizationByID(runtime *plugin.Runtime, orgID string) (*mqlNeonOrganization, error) {
+	if orgID == "" {
+		return nil, nil
+	}
+
+	root, err := getNeon(runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	organizations := root.GetOrganizations()
+	// An organization list the key cannot read is not an answer about any one
+	// organization, so a caller is left to read it directly.
+	if organizations.Error == nil {
+		for _, it := range organizations.Data {
+			org, ok := it.(*mqlNeonOrganization)
+			if ok && org.Id.Data == orgID {
+				return org, nil
+			}
+		}
+	}
+
+	if org, ok := cachedResource[*mqlNeonOrganization](runtime, "neon.organization", orgID); ok {
+		return org, nil
 	}
 	return nil, nil
 }

--- a/providers/neon/resources/organizations.go
+++ b/providers/neon/resources/organizations.go
@@ -39,7 +39,7 @@ func (n *mqlNeon) organizations() ([]any, error) {
 		// through the user endpoint, so fall back to the one it is scoped to.
 		if connection.IsForbidden(err) {
 			if orgID := c.OrganizationFilter(); orgID != "" {
-				org, err := n.organizationByID(orgID)
+				org, err := n.fetchOrganization(orgID)
 				if err != nil {
 					return nil, err
 				}
@@ -70,9 +70,9 @@ func (n *mqlNeon) organizations() ([]any, error) {
 	return res, nil
 }
 
-// organizationByID reads a single organization directly, which is the only path
-// available to a key that cannot enumerate them.
-func (n *mqlNeon) organizationByID(orgID string) (*mqlNeonOrganization, error) {
+// fetchOrganization reads a single organization directly, which is the only
+// path available to a key that cannot enumerate them.
+func (n *mqlNeon) fetchOrganization(orgID string) (*mqlNeonOrganization, error) {
 	c := neonConn(n.MqlRuntime)
 
 	var rec organizationRecord

--- a/providers/neon/resources/projects.go
+++ b/providers/neon/resources/projects.go
@@ -213,10 +213,23 @@ func newNeonProject(runtime *plugin.Runtime, rec *projectRecord) (*mqlNeonProjec
 	project := res.(*mqlNeonProject)
 	project.cacheOrgID = strPtr(rec.OrgID)
 	if rec.Owner != nil {
-		project.ownerEmail_ = rec.Owner.Email
-		project.ownerFetched.Store(true)
+		project.seedOwnerEmail(rec.Owner.Email)
 	}
 	return project, nil
+}
+
+// seedOwnerEmail records the owner a project payload carried so the read that
+// the list endpoint cannot answer is skipped. It takes the same lock the lazy
+// read takes, because CreateResource hands back an instance it already holds
+// when one exists, and another query may be inside that read on it.
+func (p *mqlNeonProject) seedOwnerEmail(email string) {
+	p.ownerLock.Lock()
+	defer p.ownerLock.Unlock()
+	if p.ownerFetched.Load() {
+		return
+	}
+	p.ownerEmail_ = email
+	p.ownerFetched.Store(true)
 }
 
 // ownerEmail reports the account that owns the project. The list endpoint omits
@@ -316,6 +329,18 @@ func (p *mqlNeonProject) organization() (*mqlNeonOrganization, error) {
 		return nil, nil
 	}
 
+	// The organization list the root already fetched answers this for every
+	// project of an organization the key can enumerate, which is one call for
+	// the whole query rather than one per project.
+	org, err := organizationByID(p.MqlRuntime, p.cacheOrgID)
+	if err != nil {
+		return nil, err
+	}
+	if org != nil {
+		return org, nil
+	}
+
+	// An organization the key cannot enumerate is read directly.
 	res, err := NewResource(p.MqlRuntime, "neon.organization", map[string]*llx.RawData{
 		"id": llx.StringData(p.cacheOrgID),
 	})
@@ -355,7 +380,10 @@ func (p *mqlNeonProject) permissions() ([]any, error) {
 	var res []any
 	for i := range records {
 		rec := records[i]
+		// A grant is read through its project, so the cache key carries the
+		// project it was read from and cannot alias one in another project.
 		permission, err := CreateResource(p.MqlRuntime, "neon.project.permission", map[string]*llx.RawData{
+			"__id":           llx.StringData(p.Id.Data + "/" + rec.ID),
 			"id":             llx.StringData(rec.ID),
 			"grantedToEmail": llx.StringData(rec.GrantedToEmail),
 			"grantedAt":      llx.TimeDataPtr(rec.GrantedAt.Time()),
@@ -416,7 +444,10 @@ func (p *mqlNeonProject) jwksEndpoints() ([]any, error) {
 			roleNames = *rec.RoleNames
 		}
 
+		// A key set is read through its project, so the cache key carries the
+		// project it was read from and cannot alias one in another project.
 		endpoint, err := CreateResource(p.MqlRuntime, "neon.project.jwksEndpoint", map[string]*llx.RawData{
+			"__id":         llx.StringData(p.Id.Data + "/" + rec.ID),
 			"id":           llx.StringData(rec.ID),
 			"jwksUrl":      llx.StringData(rec.JwksURL),
 			"providerName": llx.StringData(rec.ProviderName),

--- a/providers/neon/resources/resolve_test.go
+++ b/providers/neon/resources/resolve_test.go
@@ -1,0 +1,256 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// The cross-resource accessors resolve a parent without an API call whenever
+// the runtime already holds it. These tests pin that resolution: which lookups
+// answer from what the query already fetched, and which fall through to a read.
+// A regression here is silent, because a lookup that finds nothing reports the
+// reference as null rather than failing.
+
+func testRuntime() *plugin.Runtime {
+	return &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+// seedRoot puts a root resource with already-resolved lists in the runtime, so
+// getNeon hands it back instead of building one that would call the API.
+func seedRoot(runtime *plugin.Runtime, projects, organizations []any) *mqlNeon {
+	root := &mqlNeon{MqlRuntime: runtime, __id: "neon"}
+	root.Projects = plugin.TValue[[]any]{Data: projects, State: plugin.StateIsSet}
+	root.Organizations = plugin.TValue[[]any]{Data: organizations, State: plugin.StateIsSet}
+	runtime.Resources.Set("neon\x00neon", root)
+	return root
+}
+
+func testProject(runtime *plugin.Runtime, id string) *mqlNeonProject {
+	return &mqlNeonProject{
+		MqlRuntime: runtime,
+		__id:       id,
+		Id:         plugin.TValue[string]{Data: id, State: plugin.StateIsSet},
+	}
+}
+
+func testOrganization(runtime *plugin.Runtime, id string) *mqlNeonOrganization {
+	return &mqlNeonOrganization{
+		MqlRuntime: runtime,
+		__id:       id,
+		Id:         plugin.TValue[string]{Data: id, State: plugin.StateIsSet},
+	}
+}
+
+func TestProjectByIDResolvesFromTheProjectList(t *testing.T) {
+	runtime := testRuntime()
+	want := testProject(runtime, "proj-2")
+	seedRoot(runtime, []any{testProject(runtime, "proj-1"), want}, nil)
+
+	got, err := projectByID(runtime, "proj-2")
+	if err != nil {
+		t.Fatalf("projectByID: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected the project from the list, got %v", got)
+	}
+}
+
+// A personal project belongs to no organization, so it is not in the list the
+// root collects per organization. It is still reachable, and a branch or
+// endpoint of it must report its project rather than null.
+func TestProjectByIDResolvesAProjectMissingFromTheList(t *testing.T) {
+	runtime := testRuntime()
+	seedRoot(runtime, []any{testProject(runtime, "proj-1")}, nil)
+
+	personal := testProject(runtime, "proj-personal")
+	runtime.Resources.Set("neon.project\x00proj-personal", personal)
+
+	got, err := projectByID(runtime, "proj-personal")
+	if err != nil {
+		t.Fatalf("projectByID: %v", err)
+	}
+	if got != personal {
+		t.Fatalf("expected the project the runtime already holds, got %v", got)
+	}
+}
+
+func TestProjectByIDWithoutAnIDResolvesToNothing(t *testing.T) {
+	runtime := testRuntime()
+	seedRoot(runtime, nil, nil)
+
+	got, err := projectByID(runtime, "")
+	if err != nil {
+		t.Fatalf("projectByID: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no project, got %v", got)
+	}
+}
+
+func TestOrganizationByIDResolvesFromTheOrganizationList(t *testing.T) {
+	runtime := testRuntime()
+	want := testOrganization(runtime, "org-2")
+	seedRoot(runtime, nil, []any{testOrganization(runtime, "org-1"), want})
+
+	got, err := organizationByID(runtime, "org-2")
+	if err != nil {
+		t.Fatalf("organizationByID: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected the organization from the list, got %v", got)
+	}
+}
+
+func TestOrganizationByIDResolvesOneMissingFromTheList(t *testing.T) {
+	runtime := testRuntime()
+	seedRoot(runtime, nil, []any{testOrganization(runtime, "org-1")})
+
+	other := testOrganization(runtime, "org-other")
+	runtime.Resources.Set("neon.organization\x00org-other", other)
+
+	got, err := organizationByID(runtime, "org-other")
+	if err != nil {
+		t.Fatalf("organizationByID: %v", err)
+	}
+	if got != other {
+		t.Fatalf("expected the organization the runtime already holds, got %v", got)
+	}
+}
+
+// An organization neither listed nor already held resolves to nothing, which is
+// the signal for the caller to read it directly.
+func TestOrganizationByIDResolvesToNothingWhenUnknown(t *testing.T) {
+	runtime := testRuntime()
+	seedRoot(runtime, nil, []any{testOrganization(runtime, "org-1")})
+
+	got, err := organizationByID(runtime, "org-unknown")
+	if err != nil {
+		t.Fatalf("organizationByID: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no organization, got %v", got)
+	}
+}
+
+// An organization list the key cannot read is not an answer about any one
+// organization, so the lookup reports nothing rather than the list's error.
+func TestOrganizationByIDIgnoresAnUnreadableList(t *testing.T) {
+	runtime := testRuntime()
+	root := seedRoot(runtime, nil, nil)
+	root.Organizations = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+
+	got, err := organizationByID(runtime, "org-1")
+	if err != nil {
+		t.Fatalf("organizationByID: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no organization, got %v", got)
+	}
+}
+
+func TestNewNeonProjectSeedsTheOwnerFromThePayload(t *testing.T) {
+	runtime := testRuntime()
+	orgID := "org-1"
+	rec := projectRecord{
+		ID:    "proj-1",
+		Name:  "production",
+		OrgID: &orgID,
+		Owner: &projectOwnerRecord{Email: "ada@example.com"},
+	}
+
+	project, err := newNeonProject(runtime, &rec)
+	if err != nil {
+		t.Fatalf("newNeonProject: %v", err)
+	}
+	if project.cacheOrgID != "org-1" {
+		t.Errorf("organization linkage not cached: %q", project.cacheOrgID)
+	}
+
+	owner, err := project.ownerEmail()
+	if err != nil {
+		t.Fatalf("ownerEmail: %v", err)
+	}
+	if owner != "ada@example.com" {
+		t.Errorf("expected the owner from the payload, got %q", owner)
+	}
+}
+
+// The list endpoint omits the owner, so a project already built from the
+// project endpoint must keep the owner it has when the same project comes back
+// through a list.
+func TestNewNeonProjectKeepsAKnownOwner(t *testing.T) {
+	runtime := testRuntime()
+
+	first, err := newNeonProject(runtime, &projectRecord{
+		ID:    "proj-1",
+		Owner: &projectOwnerRecord{Email: "ada@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("newNeonProject: %v", err)
+	}
+
+	second, err := newNeonProject(runtime, &projectRecord{ID: "proj-1"})
+	if err != nil {
+		t.Fatalf("newNeonProject: %v", err)
+	}
+	if second != first {
+		t.Fatal("expected the project the runtime already holds")
+	}
+
+	owner, err := second.ownerEmail()
+	if err != nil {
+		t.Fatalf("ownerEmail: %v", err)
+	}
+	if owner != "ada@example.com" {
+		t.Errorf("owner was lost on the second read: %q", owner)
+	}
+}
+
+// A denied owner read is memoized as an answer, and a later payload must not
+// quietly replace it, or the field would flip between reads of the same project.
+func TestSeedOwnerEmailDoesNotOverwriteAnAnsweredRead(t *testing.T) {
+	project := &mqlNeonProject{}
+	project.ownerFetched.Store(true)
+
+	project.seedOwnerEmail("ada@example.com")
+
+	if project.ownerEmail_ != "" {
+		t.Errorf("expected the answered read to stand, got %q", project.ownerEmail_)
+	}
+}
+
+// CreateResource hands back an instance it already holds, so two queries can
+// seed the same project at once. Run with -race, this pins that the seed is
+// synchronized with the read it memoizes for.
+func TestSeedOwnerEmailIsSafeUnderConcurrency(t *testing.T) {
+	project := &mqlNeonProject{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			project.seedOwnerEmail("ada@example.com")
+		}()
+	}
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if project.ownerFetched.Load() && project.ownerEmail_ != "ada@example.com" {
+				t.Error("a seeded project reported an owner it was never given")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if project.ownerEmail_ != "ada@example.com" {
+		t.Errorf("expected the seeded owner, got %q", project.ownerEmail_)
+	}
+}


### PR DESCRIPTION
Four correctness fixes in the neon provider's cross-resource resolution path, plus a comment that asserted behavior the code did not have.

## `branch.project` and `endpoint.project` are null for a personal project

**What a user sees:** with a personal API key, `neon.project.branches { name project { name } }` reports `project` as **null** on every branch, and the same for `neon.project.endpoints { project { ... } }`. Nothing errors; the reference is simply empty, so any policy that walks from a branch back to its project silently evaluates against nothing.

**Why:** `projectByID` resolved only against the root's project list. `neon.projects` builds that list by iterating organization IDs, because `GET /projects` rejects a request that does not name one. A personal project belongs to no organization, so it is never in the list. The same happens for an organization whose projects the key can read but which it cannot enumerate through `/users/me/organizations`.

**Fix:** on a list miss, resolve the project through its own endpoint (`neon.project` already has an `Init` that accepts `id`). The fallback first checks the runtime cache directly, because `NewResource` runs a resource's `init` *before* consulting that cache; without the check, a project with 30 branches would be re-read 30 times. With it, the miss costs one read for the whole query.

## `project.organization` was one API call per project

**What a user sees:** `neon.projects { organization { requireMfa } }` on a 40-project organization issues 40 `GET /organizations/{id}` calls for an organization the query had already fetched. Correct output, ~40x the round-trips.

**Fix:** a new `organizationByID` mirrors the existing `projectByID` and answers from the organization list the root already holds. The `NewResource` call stays as the fallback for an organization the key cannot enumerate, which the code already contemplated.

## Data race on the memoized owner email

`newNeonProject` wrote `ownerEmail_` and set `ownerFetched` *after* `CreateResource`, which returns an instance it already holds when one exists — an instance another goroutine may be inside `ownerEmail()` on. The double-check lock protected the reader but not this writer, so two goroutines could write the field concurrently. The seed now takes the same `ownerLock`, and does not overwrite an already-answered read (including the memoized denial).

`TestSeedOwnerEmailIsSafeUnderConcurrency` was confirmed to fail under `-race` against the old unsynchronized write before the fix was applied.

## Unqualified cache keys on two resources (defensive)

`neon.project.permission` and `neon.project.jwksEndpoint` passed no `__id` and fell back to the bare API id, while every sibling (`neon.branch`, `neon.endpoint`, `neon.role`, `neon.database`, `neon.vpcEndpoint`) qualifies with the project id. **No collision was observed and this is not a fixed bug** — the ids may well be global. Qualifying them costs nothing and removes the question, so it is applied here as a consistency/robustness change rather than as a fix.

## The discovery comment

`discovery.go` claimed "Projects are listed from the root rather than per organization so a personal API key, whose projects belong to no organization, still discovers them." That is not what the code does, and it cannot be made true: the Neon list endpoint 400s without an `org_id`, so there is no call that enumerates organization-less projects. **The comment is corrected rather than the code**, and now says that discovery emits assets for exactly the projects a plain query sees, and that a project belonging to no organization is reached by naming it (`neon.project(id: "...")`) instead.

## Verification

Run from inside `providers/neon/` (its own Go module):

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	go.mondoo.com/mql/v13/providers/neon/connection	1.921s
ok  	go.mondoo.com/mql/v13/providers/neon/resources	2.232s
$ go test -race ./...
ok  	go.mondoo.com/mql/v13/providers/neon/connection	2.401s
ok  	go.mondoo.com/mql/v13/providers/neon/resources	2.452s
```

New tests in `resources/resolve_test.go` cover the resolution logic offline, with a runtime whose lists are pre-resolved: list hit, list miss falling through to what the runtime already holds, empty id, an unreadable organization list, the owner seed surviving a second creation from a list payload that omits it, and the concurrency case above.

No schema change: `neon.lr` and `neon.lr.versions` are untouched.
