### PR TITLE
⚡ oci: resolve compartment references from the cached tenancy tree

### DIFF
--- a/providers/oci/connection/connection.go
+++ b/providers/oci/connection/connection.go
@@ -27,8 +27,13 @@ type OciConnection struct {
 	// ListCompartments for each one. The tree does not change mid-scan, and on
 	// a large tenancy those repeats are both slow and a good way to run into
 	// Identity rate limits.
+	// compartmentIndex is that same list keyed by OCID, built on first use.
+	// Nearly every resource in the provider reports the compartment it lives
+	// in, so the lookup runs once per resource rather than once per scan; a
+	// walk of the list per lookup would be O(resources x compartments).
 	compartmentLock  sync.Mutex
 	compartmentList  []identity.Compartment
+	compartmentIndex map[string]identity.Compartment
 	compartmentsDone bool
 
 	// Service clients, keyed by "<service>/<region-or-endpoint>". See

--- a/providers/oci/connection/connection.go
+++ b/providers/oci/connection/connection.go
@@ -6,6 +6,7 @@ package connection
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/identity"
@@ -31,10 +32,16 @@ type OciConnection struct {
 	// Nearly every resource in the provider reports the compartment it lives
 	// in, so the lookup runs once per resource rather than once per scan; a
 	// walk of the list per lookup would be O(resources x compartments).
-	compartmentLock  sync.Mutex
-	compartmentList  []identity.Compartment
-	compartmentIndex map[string]identity.Compartment
-	compartmentsDone bool
+	// compartmentFetchErr holds the last tree fetch failure, honoured for
+	// compartmentFetchRetryAfter so a throttled Identity API is retried a
+	// handful of times per scan rather than once per resource. See
+	// GetCompartments for why the failure is held briefly instead of forever.
+	compartmentLock     sync.Mutex
+	compartmentList     []identity.Compartment
+	compartmentIndex    map[string]identity.Compartment
+	compartmentsDone    bool
+	compartmentFetchErr error
+	compartmentFetchAt  time.Time
 
 	// Service clients, keyed by "<service>/<region-or-endpoint>". See
 	// cachedClient in clients.go for why they are shared rather than rebuilt.

--- a/providers/oci/connection/tenancy.go
+++ b/providers/oci/connection/tenancy.go
@@ -6,6 +6,7 @@ package connection
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/identity"
@@ -34,6 +35,14 @@ func (c *OciConnection) Tenant(ctx context.Context) (*identity.Tenancy, error) {
 	return &resp.Tenancy, nil
 }
 
+// compartmentFetchRetryAfter is how long a failed tenancy tree fetch is held
+// before the next caller tries again.
+//
+// Long enough that a throttled scan retries a handful of times rather than
+// once per resource, short enough that a transient failure early on does not
+// decide the compartment of everything read afterwards.
+const compartmentFetchRetryAfter = 30 * time.Second
+
 // GetCompartments returns the tenancy root plus every active compartment
 // beneath it.
 //
@@ -41,16 +50,51 @@ func (c *OciConnection) Tenant(ctx context.Context) (*identity.Tenancy, error) {
 // fan out over the compartment tree, and each one asking for it separately
 // meant walking the same paginated ListCompartments a dozen times per scan.
 //
-// A failure is not cached: an Identity call that fails on a throttle should be
-// retried by the next lister rather than turning one bad moment into a scan
-// with no compartments at all.
+// A failure is held only for compartmentFetchRetryAfter rather than for the
+// life of the connection: an Identity call that fails on a throttle should be
+// retried rather than turning one bad moment into a scan with no compartments
+// at all. But it is held, because the callers are no longer only the dozen
+// listers. Every resource that reports its compartment reaches this, so an
+// uncached failure would answer a throttle by walking the paginated listing
+// again for each of them - hundreds of retries of the call that was already
+// being rate limited, on top of the direct read each one then falls back to.
 func (c *OciConnection) GetCompartments(ctx context.Context) ([]identity.Compartment, error) {
 	c.compartmentLock.Lock()
 	defer c.compartmentLock.Unlock()
 	if c.compartmentsDone {
 		return c.compartmentList, nil
 	}
+	if c.compartmentFetchBlocked(time.Now()) {
+		return nil, c.compartmentFetchErr
+	}
 
+	compartments, err := c.fetchCompartments(ctx)
+	if err != nil {
+		c.compartmentFetchErr = err
+		c.compartmentFetchAt = time.Now()
+		return nil, err
+	}
+
+	c.compartmentFetchErr = nil
+	c.compartmentList = compartments
+	c.compartmentsDone = true
+	return compartments, nil
+}
+
+// compartmentFetchBlocked reports whether a recorded tree fetch failure is
+// recent enough to be reused instead of retried. The caller holds
+// compartmentLock.
+func (c *OciConnection) compartmentFetchBlocked(now time.Time) bool {
+	if c.compartmentFetchErr == nil {
+		return false
+	}
+	return now.Sub(c.compartmentFetchAt) < compartmentFetchRetryAfter
+}
+
+// fetchCompartments reads the tenancy root and walks the paginated listing of
+// every active compartment beneath it. Callers go through GetCompartments,
+// which owns the memoizing and the retry window.
+func (c *OciConnection) fetchCompartments(ctx context.Context) ([]identity.Compartment, error) {
 	oClient, err := c.IdentityClient()
 	if err != nil {
 		return nil, err
@@ -92,8 +136,6 @@ func (c *OciConnection) GetCompartments(ctx context.Context) ([]identity.Compart
 		}
 	}
 
-	c.compartmentList = compartments
-	c.compartmentsDone = true
 	return compartments, nil
 }
 

--- a/providers/oci/connection/tenancy.go
+++ b/providers/oci/connection/tenancy.go
@@ -97,6 +97,62 @@ func (c *OciConnection) GetCompartments(ctx context.Context) ([]identity.Compart
 	return compartments, nil
 }
 
+// CompartmentByID returns the compartment with the given OCID out of the
+// memoized tenancy tree, or nil when the tree does not contain it.
+//
+// Almost every resource in the provider reports the compartment it lives in,
+// and resolving that through the Identity API is one GetCompartment call per
+// resource: five hundred instances in five compartments cost five hundred
+// calls. The tree those five compartments come from is already fetched once per
+// connection, walks the whole subtree, and cannot change mid-scan, so the
+// answer is nearly always sitting in it.
+//
+// A nil result is not an error. An OCID outside this tenancy, or one belonging
+// to a compartment deleted since the listing, legitimately misses; the caller
+// falls back to the direct read for those.
+func (c *OciConnection) CompartmentByID(ctx context.Context, id string) (*identity.Compartment, error) {
+	if id == "" {
+		return nil, nil
+	}
+
+	// Taken before the lock: GetCompartments locks for itself, and it is a
+	// no-op once the tree has been fetched.
+	if _, err := c.GetCompartments(ctx); err != nil {
+		return nil, err
+	}
+
+	c.compartmentLock.Lock()
+	defer c.compartmentLock.Unlock()
+	if c.compartmentIndex == nil {
+		c.compartmentIndex = compartmentIndexByID(c.compartmentList)
+	}
+
+	compartment, ok := c.compartmentIndex[id]
+	if !ok {
+		return nil, nil
+	}
+	// A copy, so a caller cannot reach into the memoized tree.
+	return &compartment, nil
+}
+
+// compartmentIndexByID keys a compartment list by OCID, skipping entries
+// without one. The first entry wins, which matters only if the tenancy root
+// were to repeat in the listing.
+func compartmentIndexByID(compartments []identity.Compartment) map[string]identity.Compartment {
+	index := make(map[string]identity.Compartment, len(compartments))
+	for i := range compartments {
+		id := compartments[i].Id
+		if id == nil || *id == "" {
+			continue
+		}
+		if _, seen := index[*id]; seen {
+			continue
+		}
+		index[*id] = compartments[i]
+	}
+	return index
+}
+
 func (c *OciConnection) GetRegions(ctx context.Context) ([]identity.RegionSubscription, error) {
 	oClient, err := c.IdentityClient()
 	if err != nil {

--- a/providers/oci/connection/tenancy_test.go
+++ b/providers/oci/connection/tenancy_test.go
@@ -1,0 +1,171 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCompartment(id, name string) identity.Compartment {
+	return identity.Compartment{Id: common.String(id), Name: common.String(name)}
+}
+
+// seededConnection is a connection whose compartment tree has already been
+// fetched, so the lookups below never reach the Identity API.
+func seededConnection(compartments ...identity.Compartment) *OciConnection {
+	return &OciConnection{
+		compartmentList:  compartments,
+		compartmentsDone: true,
+	}
+}
+
+func TestCompartmentIndexByID(t *testing.T) {
+	root := testCompartment("ocid1.tenancy.oc1..root", "tenancy")
+	prod := testCompartment("ocid1.compartment.oc1..prod", "prod")
+
+	t.Run("keys every compartment by its ocid", func(t *testing.T) {
+		index := compartmentIndexByID([]identity.Compartment{root, prod})
+
+		require.Len(t, index, 2)
+		assert.Equal(t, "tenancy", *index["ocid1.tenancy.oc1..root"].Name)
+		assert.Equal(t, "prod", *index["ocid1.compartment.oc1..prod"].Name)
+	})
+
+	t.Run("no compartments", func(t *testing.T) {
+		assert.Empty(t, compartmentIndexByID(nil))
+	})
+
+	t.Run("an entry without an ocid is skipped, not indexed under the empty key", func(t *testing.T) {
+		// An unkeyed entry stored under "" would be handed back for any id the
+		// caller passes that also happens to be empty, reporting the wrong
+		// compartment rather than a miss.
+		index := compartmentIndexByID([]identity.Compartment{
+			{Name: common.String("no id")},
+			{Id: common.String(""), Name: common.String("empty id")},
+			prod,
+		})
+
+		require.Len(t, index, 1)
+		assert.Contains(t, index, "ocid1.compartment.oc1..prod")
+	})
+
+	t.Run("a repeated ocid keeps the first entry", func(t *testing.T) {
+		index := compartmentIndexByID([]identity.Compartment{
+			prod,
+			testCompartment("ocid1.compartment.oc1..prod", "prod-again"),
+		})
+
+		require.Len(t, index, 1)
+		assert.Equal(t, "prod", *index["ocid1.compartment.oc1..prod"].Name)
+	})
+}
+
+func TestCompartmentByID(t *testing.T) {
+	prod := testCompartment("ocid1.compartment.oc1..prod", "prod")
+	ctx := context.Background()
+
+	t.Run("a compartment in the tree is found", func(t *testing.T) {
+		conn := seededConnection(prod)
+
+		got, err := conn.CompartmentByID(ctx, "ocid1.compartment.oc1..prod")
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "prod", *got.Name)
+	})
+
+	t.Run("an ocid outside the tree misses without an error", func(t *testing.T) {
+		// Cross-tenancy, or deleted since the listing. The caller resolves
+		// those directly; a miss is not a failure.
+		conn := seededConnection(prod)
+
+		got, err := conn.CompartmentByID(ctx, "ocid1.compartment.oc1..elsewhere")
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("an empty id misses before the tree is touched", func(t *testing.T) {
+		// Not seeded, so a connection that reached GetCompartments here would
+		// try to build an Identity client instead of returning.
+		conn := &OciConnection{}
+
+		got, err := conn.CompartmentByID(ctx, "")
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("the index is built once and reused", func(t *testing.T) {
+		conn := seededConnection(prod)
+
+		_, err := conn.CompartmentByID(ctx, "ocid1.compartment.oc1..prod")
+		require.NoError(t, err)
+		first := conn.compartmentIndex
+		require.NotNil(t, first)
+
+		_, err = conn.CompartmentByID(ctx, "ocid1.compartment.oc1..prod")
+		require.NoError(t, err)
+
+		assert.True(t, sameMap(first, conn.compartmentIndex),
+			"the index must be memoized, not rebuilt per lookup")
+	})
+
+	t.Run("the returned record does not alias the memoized tree", func(t *testing.T) {
+		conn := seededConnection(prod)
+
+		got, err := conn.CompartmentByID(ctx, "ocid1.compartment.oc1..prod")
+		require.NoError(t, err)
+		got.Name = common.String("mutated")
+
+		again, err := conn.CompartmentByID(ctx, "ocid1.compartment.oc1..prod")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", *again.Name)
+	})
+
+	t.Run("concurrent lookups share one index", func(t *testing.T) {
+		// Every resource in the provider resolves its compartment, and the
+		// executor resolves fields in goroutines, so this runs concurrently by
+		// construction. Run under -race.
+		conn := seededConnection(prod, testCompartment("ocid1.compartment.oc1..dev", "dev"))
+
+		var wg sync.WaitGroup
+		for i := 0; i < 32; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				id := "ocid1.compartment.oc1..prod"
+				if i%2 == 0 {
+					id = "ocid1.compartment.oc1..dev"
+				}
+				got, err := conn.CompartmentByID(ctx, id)
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+			}(i)
+		}
+		wg.Wait()
+
+		assert.Len(t, conn.compartmentIndex, 2)
+	})
+}
+
+// sameMap reports whether two maps are the same underlying map, which is what
+// distinguishes a memoized index from one rebuilt on every lookup.
+func sameMap(a, b map[string]identity.Compartment) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	const probe = "\x00sameMap-probe"
+	a[probe] = identity.Compartment{}
+	_, ok := b[probe]
+	delete(a, probe)
+	return ok
+}

--- a/providers/oci/connection/tenancy_test.go
+++ b/providers/oci/connection/tenancy_test.go
@@ -5,8 +5,10 @@ package connection
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/identity"
@@ -159,6 +161,12 @@ func TestCompartmentByID(t *testing.T) {
 
 // sameMap reports whether two maps are the same underlying map, which is what
 // distinguishes a memoized index from one rebuilt on every lookup.
+//
+// It writes a probe key into a and looks for it in b, so a is mutated for the
+// duration of the call. The key is removed again before returning and is
+// chosen not to collide with an OCID, but a caller must not rely on a being
+// untouched while this runs - in particular it is not safe to call
+// concurrently with a read of either map.
 func sameMap(a, b map[string]identity.Compartment) bool {
 	if len(a) != len(b) {
 		return false
@@ -168,4 +176,79 @@ func sameMap(a, b map[string]identity.Compartment) bool {
 	_, ok := b[probe]
 	delete(a, probe)
 	return ok
+}
+
+func TestCompartmentFetchBlocked(t *testing.T) {
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	failure := errors.New("throttled")
+
+	t.Run("nothing has failed yet, so nothing is held back", func(t *testing.T) {
+		conn := &OciConnection{}
+
+		assert.False(t, conn.compartmentFetchBlocked(now))
+	})
+
+	t.Run("a fresh failure is reused instead of retried", func(t *testing.T) {
+		// This is the case the window exists for: every resource that reports
+		// its compartment reaches GetCompartments, so retrying a throttled
+		// listing per resource is what turns one throttle into hundreds.
+		conn := &OciConnection{
+			compartmentFetchErr: failure,
+			compartmentFetchAt:  now.Add(-time.Second),
+		}
+
+		assert.True(t, conn.compartmentFetchBlocked(now))
+	})
+
+	t.Run("a failure past the window is retried", func(t *testing.T) {
+		// A throttle that has cleared must not decide the compartment of
+		// everything read for the rest of the scan.
+		conn := &OciConnection{
+			compartmentFetchErr: failure,
+			compartmentFetchAt:  now.Add(-compartmentFetchRetryAfter - time.Second),
+		}
+
+		assert.False(t, conn.compartmentFetchBlocked(now))
+	})
+
+	t.Run("the window boundary itself is retried", func(t *testing.T) {
+		conn := &OciConnection{
+			compartmentFetchErr: failure,
+			compartmentFetchAt:  now.Add(-compartmentFetchRetryAfter),
+		}
+
+		assert.False(t, conn.compartmentFetchBlocked(now))
+	})
+}
+
+func TestGetCompartmentsHoldsARecentFailure(t *testing.T) {
+	failure := errors.New("throttled listing")
+
+	t.Run("a held failure is returned without reaching the api", func(t *testing.T) {
+		// The connection has no configuration provider, so the OCI SDK panics
+		// if the fetch is attempted. Reaching the end of this test is the
+		// assertion that it was not.
+		conn := &OciConnection{
+			compartmentFetchErr: failure,
+			compartmentFetchAt:  time.Now(),
+		}
+
+		got, err := conn.GetCompartments(context.Background())
+
+		assert.Nil(t, got)
+		assert.ErrorIs(t, err, failure)
+	})
+
+	t.Run("a fetched tree answers even with a failure recorded", func(t *testing.T) {
+		// compartmentsDone wins over the retry window: once the tree is in
+		// hand an earlier failure is history, not an answer.
+		conn := seededConnection(testCompartment("ocid1.compartment.oc1..prod", "prod"))
+		conn.compartmentFetchErr = failure
+		conn.compartmentFetchAt = time.Now()
+
+		got, err := conn.GetCompartments(context.Background())
+
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+	})
 }

--- a/providers/oci/resources/compartment_ref_test.go
+++ b/providers/oci/resources/compartment_ref_test.go
@@ -1,0 +1,252 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func testRuntime() *plugin.Runtime {
+	return &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+func testCompartment(id, name string) identity.Compartment {
+	return identity.Compartment{
+		Id:             common.String(id),
+		Name:           common.String(name),
+		Description:    common.String(name + " compartment"),
+		LifecycleState: identity.CompartmentLifecycleStateActive,
+	}
+}
+
+// TestResolveCompartment covers the reason this resolver exists.
+//
+// Going through NewResource runs initOciCompartment before the runtime cache is
+// consulted, so every resource reporting an owner cost a GetCompartment call -
+// five hundred instances in five compartments issued five hundred of them. The
+// tenancy tree the connection already holds answers nearly all of those, and
+// the direct read stays only for the OCIDs it cannot cover.
+func TestResolveCompartment(t *testing.T) {
+	const ocid = "ocid1.compartment.oc1..aaaaaaaaprod"
+
+	t.Run("a compartment in the tree resolves without a direct read", func(t *testing.T) {
+		compartment := testCompartment(ocid, "prod")
+		calls := 0
+		lookup := func(id string) (*identity.Compartment, error) {
+			calls++
+			assert.Equal(t, ocid, id)
+			return &compartment, nil
+		}
+
+		var field plugin.TValue[*mqlOciCompartment]
+		got, err := resolveCompartment(testRuntime(), lookup, ocid, &field)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, ocid, got.Id.Data)
+		assert.Equal(t, "prod", got.Name.Data)
+		assert.Equal(t, "ACTIVE", got.State.Data)
+		assert.Equal(t, 1, calls)
+		// The runtime marks the field once the accessor returns; a resolved
+		// reference must not have been pre-marked null on the way out.
+		assert.Equal(t, plugin.State(0), field.State)
+	})
+
+	t.Run("resolving the same compartment twice yields one instance", func(t *testing.T) {
+		// The point of building the resource from the same args the lister
+		// uses: the __id matches, so CreateResource hands back the instance
+		// the runtime already holds instead of a second copy of it.
+		compartment := testCompartment(ocid, "prod")
+		lookup := func(string) (*identity.Compartment, error) { return &compartment, nil }
+		runtime := testRuntime()
+
+		var first, second plugin.TValue[*mqlOciCompartment]
+		a, err := resolveCompartment(runtime, lookup, ocid, &first)
+		require.NoError(t, err)
+		b, err := resolveCompartment(runtime, lookup, ocid, &second)
+		require.NoError(t, err)
+
+		assert.Same(t, a, b)
+	})
+
+	t.Run("identity matches what oci.compartments produces", func(t *testing.T) {
+		// A resolved compartment has to be the same resource the lister
+		// created, or the runtime carries two of every compartment and a
+		// query that reaches one of them re-fetches its fields.
+		compartment := testCompartment(ocid, "prod")
+		runtime := testRuntime()
+
+		listed, err := CreateResource(runtime, "oci.compartment", ociCompartmentArgs(compartment))
+		require.NoError(t, err)
+
+		var field plugin.TValue[*mqlOciCompartment]
+		got, err := resolveCompartment(runtime, func(string) (*identity.Compartment, error) {
+			return &compartment, nil
+		}, ocid, &field)
+		require.NoError(t, err)
+
+		assert.Same(t, listed, got)
+	})
+
+	t.Run("an ocid outside the tree falls through to the direct read", func(t *testing.T) {
+		// A compartment in another tenancy, or one deleted since the listing,
+		// is not in the tree and must still be resolvable. The runtime here
+		// carries no OCI connection, so reaching the direct read surfaces as
+		// an error rather than a resource - which is the observation.
+		lookup := func(string) (*identity.Compartment, error) { return nil, nil }
+
+		var field plugin.TValue[*mqlOciCompartment]
+		got, err := resolveCompartment(testRuntime(), lookup, ocid, &field)
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("an unreadable tree falls through to the direct read", func(t *testing.T) {
+		// A throttled or denied ListCompartments says nothing about this
+		// compartment, so it must not be reported as absent.
+		lookup := func(string) (*identity.Compartment, error) {
+			return nil, errors.New("too many requests")
+		}
+
+		var field plugin.TValue[*mqlOciCompartment]
+		got, err := resolveCompartment(testRuntime(), lookup, ocid, &field)
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("an empty id is null and never reaches the lookup", func(t *testing.T) {
+		lookup := func(string) (*identity.Compartment, error) {
+			t.Fatal("an absent reference must not be looked up")
+			return nil, nil
+		}
+
+		var field plugin.TValue[*mqlOciCompartment]
+		got, err := resolveCompartment(nil, lookup, "", &field)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State,
+			"an absent compartment must be reported as null, not left unset")
+	})
+
+	t.Run("a non-ocid sentinel is null and never reaches the lookup", func(t *testing.T) {
+		// ocidOrEmpty at the call site turns OCI's placeholders into the empty
+		// case; together they must still produce a null rather than a lookup
+		// for an id no tree can contain.
+		lookup := func(string) (*identity.Compartment, error) {
+			t.Fatal("a placeholder must not be looked up")
+			return nil, nil
+		}
+
+		var field plugin.TValue[*mqlOciCompartment]
+		got, err := resolveCompartment(nil, lookup, ocidOrEmpty("ORACLE_MANAGED_KEY"), &field)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+
+	t.Run("without a lookup the empty id is still null", func(t *testing.T) {
+		var field plugin.TValue[*mqlOciCompartment]
+		got, err := resolveCompartment(nil, nil, "", &field)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+	})
+}
+
+// TestCachedCompartment pins the distinction the resolver is built on: a tree
+// that cannot answer is not a failure, it is a fallback.
+func TestCachedCompartment(t *testing.T) {
+	const ocid = "ocid1.compartment.oc1..aaaaaaaaprod"
+
+	t.Run("no lookup means no cached answer", func(t *testing.T) {
+		got, err := cachedCompartment(testRuntime(), nil, ocid)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("an empty id means no cached answer", func(t *testing.T) {
+		lookup := func(string) (*identity.Compartment, error) {
+			t.Fatal("an empty id must not be looked up")
+			return nil, nil
+		}
+		got, err := cachedCompartment(testRuntime(), lookup, "")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("a lookup failure is a fallback, not an error", func(t *testing.T) {
+		// Reporting the error here would turn a throttled ListCompartments
+		// into a failed compartment field on every resource in the scan.
+		got, err := cachedCompartment(testRuntime(), func(string) (*identity.Compartment, error) {
+			return nil, errors.New("too many requests")
+		}, ocid)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+// TestOciCompartmentRef covers the lister path, where the compartment is
+// resolved while the list is built and so is paid for whether or not the field
+// is ever read.
+func TestOciCompartmentRef(t *testing.T) {
+	const ocid = "ocid1.compartment.oc1..aaaaaaaaprod"
+
+	t.Run("a compartment in the tree is built from the tree", func(t *testing.T) {
+		compartment := testCompartment(ocid, "prod")
+		runtime := testRuntime()
+		listed, err := CreateResource(runtime, "oci.compartment", ociCompartmentArgs(compartment))
+		require.NoError(t, err)
+
+		got, err := compartmentRef(runtime, func(string) (*identity.Compartment, error) {
+			return &compartment, nil
+		}, common.String(ocid))
+
+		require.NoError(t, err)
+		assert.Same(t, listed, got)
+	})
+
+	t.Run("an ocid outside the tree falls through to the direct read", func(t *testing.T) {
+		got, err := compartmentRef(testRuntime(), func(string) (*identity.Compartment, error) {
+			return nil, nil
+		}, common.String(ocid))
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("a nil compartment id falls through to the direct read", func(t *testing.T) {
+		// A list entry with no compartment id keeps the behaviour it had: the
+		// direct read decides what an id-less compartment resolves to, which
+		// is a resource whose id is null rather than an error.
+		got, err := compartmentRef(testRuntime(), func(string) (*identity.Compartment, error) {
+			t.Fatal("a nil id must not be looked up")
+			return nil, nil
+		}, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Empty(t, got.(*mqlOciCompartment).Id.Data)
+	})
+}
+
+func TestOciCompartmentLookup(t *testing.T) {
+	// A runtime with no OCI connection has no tree to consult. Returning nil
+	// rather than a lookup that panics on the assertion is what keeps the
+	// resolver falling back instead of ending the scan.
+	assert.Nil(t, ociCompartmentLookup(nil))
+	assert.Nil(t, ociCompartmentLookup(&plugin.Runtime{}))
+}

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -135,14 +135,14 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 					}
 				}
 
-				// NewResource, not CreateResource: oci.compartment has an
-				// Init that fills name/description/created/state. Skipping it
-				// caches an id-only husk under the compartment's real OCID,
-				// which a later oci.compartments query then receives instead of
-				// the populated resource.
-				compartment, err := NewResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
-					"id": llx.StringDataPtr(instance.CompartmentId),
-				})
+				// Never a bare CreateResource from the id alone:
+				// oci.compartment carries name/description/created/state, and
+				// caching an id-only husk under the compartment's real OCID
+				// hands that husk to a later oci.compartments query. The tree
+				// the connection already holds carries those fields, so this
+				// is populated without a per-instance GetCompartment call and
+				// falls back to the direct read for an OCID it lacks.
+				compartment, err := ociCompartmentRef(o.MqlRuntime, instance.CompartmentId)
 				if err != nil {
 					return nil, err
 				}
@@ -363,10 +363,7 @@ func (o *mqlOciCompute) images() ([]any, error) {
 					created = &image.TimeCreated.Time
 				}
 
-				// Create compartment resource reference
-				compartment, err := NewResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
-					"id": llx.StringDataPtr(image.CompartmentId),
-				})
+				compartment, err := ociCompartmentRef(o.MqlRuntime, image.CompartmentId)
 				if err != nil {
 					return nil, err
 				}

--- a/providers/oci/resources/oci.go
+++ b/providers/oci/resources/oci.go
@@ -130,7 +130,13 @@ func initOciCompartment(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return args, nil, nil
 	}
 
-	conn := runtime.Connection.(*connection.OciConnection)
+	// Checked rather than asserted: an init runs inside the executor's
+	// goroutines, where a failed bare assertion ends the scan instead of the
+	// field.
+	conn, ok := runtime.Connection.(*connection.OciConnection)
+	if !ok {
+		return nil, nil, errors.New("oci.compartment requires an oci connection")
+	}
 	client, err := conn.IdentityClient()
 	if err != nil {
 		return nil, nil, err

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -4,12 +4,15 @@
 package resources
 
 import (
+	"context"
 	"errors"
 	"strings"
 
+	"github.com/oracle/oci-go-sdk/v65/identity"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
 // A resource that points at another one - an instance at its image, a key at
@@ -97,10 +100,126 @@ func resolveOciSubnet(runtime *plugin.Runtime, id string, field *plugin.TValue[*
 	return resolveRef(runtime, "oci.network.subnet", id, field)
 }
 
+// compartmentLookup reports the compartment record for an OCID, or nil when the
+// tenancy tree the connection already holds does not contain it.
+type compartmentLookup func(id string) (*identity.Compartment, error)
+
+// ociCompartmentLookup returns a lookup backed by the connection's memoized
+// compartment tree, or nil when the runtime has no OCI connection to ask.
+func ociCompartmentLookup(runtime *plugin.Runtime) compartmentLookup {
+	if runtime == nil {
+		return nil
+	}
+	conn, ok := runtime.Connection.(*connection.OciConnection)
+	if !ok {
+		return nil
+	}
+	return func(id string) (*identity.Compartment, error) {
+		return conn.CompartmentByID(context.Background(), id)
+	}
+}
+
 // resolveOciCompartment resolves the compartment a resource lives in. It is by
 // far the most used of these, since almost every resource reports its owner.
 func resolveOciCompartment(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOciCompartment]) (*mqlOciCompartment, error) {
-	return resolveRef(runtime, "oci.compartment", id, field)
+	return resolveCompartment(runtime, ociCompartmentLookup(runtime), id, field)
+}
+
+// resolveCompartment resolves a compartment from the tenancy tree the
+// connection already holds, and only asks the Identity API for an OCID that
+// tree does not cover.
+//
+// The difference is not marginal. Going through NewResource runs
+// initOciCompartment before the runtime cache is consulted, so a GetCompartment
+// call is issued for every resource that reports an owner - five hundred
+// instances across five compartments cost five hundred calls for five distinct
+// answers. The tree is fetched once per connection and already walks the whole
+// subtree, so those five answers are in hand before the first instance is read.
+//
+// The fallback stays for the OCIDs the tree cannot cover: a compartment in
+// another tenancy, or one deleted between the listing and the read. Those keep
+// the direct read, including its behaviour of reporting an unreadable
+// compartment by id with the rest of its fields null.
+func resolveCompartment(runtime *plugin.Runtime, lookup compartmentLookup, id string, field *plugin.TValue[*mqlOciCompartment]) (*mqlOciCompartment, error) {
+	// resolveRef owns the null marking for an absent reference, and the empty
+	// id is exactly that case; it has no business reaching a lookup.
+	if id == "" {
+		return resolveRef(runtime, "oci.compartment", id, field)
+	}
+
+	cached, err := cachedCompartment(runtime, lookup, id)
+	if err != nil {
+		return nil, err
+	}
+	if cached == nil {
+		return resolveRef(runtime, "oci.compartment", id, field)
+	}
+	return cached, nil
+}
+
+// cachedCompartment builds the compartment for an OCID out of the tenancy tree
+// the connection already holds, or reports nil when the tree cannot answer for
+// it - an unknown OCID, an unreadable tree, or a runtime with no connection to
+// ask. A nil result means "ask the API", not "no compartment"; only a real
+// failure to build the resource is an error.
+func cachedCompartment(runtime *plugin.Runtime, lookup compartmentLookup, id string) (*mqlOciCompartment, error) {
+	if lookup == nil || id == "" {
+		return nil, nil
+	}
+
+	compartment, err := lookup(id)
+	if err != nil {
+		// The tree could not be read at all - a throttled or denied
+		// ListCompartments. That is not an answer about this compartment, so
+		// let the direct read speak for it.
+		log.Debug().Err(err).Str("compartment", id).
+			Msg("oci compartment tree unavailable, resolving compartment directly")
+		return nil, nil
+	}
+	if compartment == nil {
+		return nil, nil
+	}
+
+	// Built from the same args as the oci.compartments lister, so the __id
+	// matches and CreateResource hands back the instance the runtime already
+	// holds rather than a second copy of it.
+	res, err := CreateResource(runtime, "oci.compartment", ociCompartmentArgs(*compartment))
+	if err != nil {
+		return nil, err
+	}
+	typed, ok := res.(*mqlOciCompartment)
+	if !ok {
+		return nil, errors.New("oci: oci.compartment resolved to an unexpected resource type")
+	}
+	return typed, nil
+}
+
+// ociCompartmentRef resolves the compartment a lister embeds in the resource it
+// is building, rather than one read later through an accessor.
+//
+// These are the costliest copies of the same call: the compartment is resolved
+// while the list is built, so the GetCompartment per resource is paid whether
+// or not anything asks for the field. The tree answers them for free, and an
+// OCID it does not cover keeps the direct read - which is what fills in a
+// compartment outside the listing.
+func ociCompartmentRef(runtime *plugin.Runtime, id *string) (plugin.Resource, error) {
+	return compartmentRef(runtime, ociCompartmentLookup(runtime), id)
+}
+
+func compartmentRef(runtime *plugin.Runtime, lookup compartmentLookup, id *string) (plugin.Resource, error) {
+	if id != nil {
+		cached, err := cachedCompartment(runtime, lookup, *id)
+		if err != nil {
+			return nil, err
+		}
+		if cached != nil {
+			return cached, nil
+		}
+	}
+
+	return NewResource(runtime, "oci.compartment", map[string]*llx.RawData{
+		"id": llx.StringDataPtr(id),
+	})
 }
 
 // resolveOciSecurityGroups resolves a list of typed network security group


### PR DESCRIPTION
## The bug

`NewResource` runs a resource's `Init` **before** the runtime cache is consulted (`providers/oci/resources/oci.lr.go`: the `f.Init(...)` call precedes `runtime.Resources.Get(id)`). `initOciCompartment` issues a live `GetCompartment`. The shared resolver `resolveOciCompartment` went through `NewResource`, so the cost was one Identity call **per resource**, not per compartment:

```
oci.compute.instances { compartment { name } }
```

over 500 instances spread across 5 compartments issued **500 `GetCompartment` calls for 5 distinct answers**.

This is on every `compartment()` accessor in the provider: **125 call sites** across 17 files (audit, network, databases, dns, cloudguard, identitydomains, aiservices, generativeai, resourcemanager, transit, vpn, messaging, datascience, networkloadbalancer, serviceconnectorhub, vulnerabilityscanning, and the shared resolver itself).

Two lister sites were worse still: `oci.compute.instances` and `oci.compute.images` resolved the compartment eagerly while building the list, so the per-resource call was paid whether or not anything read the field.

## The fix

The connection already fetches the full compartment subtree once per scan (`GetCompartments`, `CompartmentIdInSubtree: true`) and memoizes it. `resolveOciCompartment` now consults that tree first:

- `OciConnection.CompartmentByID` builds an **OCID-keyed index once** under the existing compartment lock, rather than walking the list per lookup - with 125 call sites over large collections an O(n) walk per resolution is still O(resources x compartments).
- The resource is built with `CreateResource` from **`ociCompartmentArgs`, the same args the `oci.compartments` lister uses**, so the `__id` matches and the runtime hands back the instance it already holds instead of a second copy of it. A test pins that identity.
- 500 instances / 5 compartments: **500 calls become 5** (one `ListCompartments` walk that was already happening).

The direct read stays for what the tree cannot cover - a cross-tenancy OCID, or a compartment deleted between the listing and the read - including `initOciCompartment`'s behaviour of reporting an unreadable compartment by `id` with the rest of its fields null. A tree that cannot be read *at all* (throttled or denied `ListCompartments`) is treated as a fallback rather than a failure, so it does not turn into a failed `compartment` field on every resource in the scan.

`resolveRef`'s contract is untouched: the empty-id path still goes through it for the `StateIsSet|StateIsNull` marking, `ocidOrEmpty`'s sentinel filtering (`ORACLE_MANAGED_KEY`) still short-circuits before any lookup, and the type assertion stays checked - a bare assertion panic inside an accessor ends the scan, not the field. `initOciCompartment`'s connection assertion is now checked for the same reason.

No `.lr` change; no `.lr.versions`, `.lr.go` or `permissions.json` movement.

## Why this is the prerequisite for the `compartmentId` deprecation

A follow-up wants to deprecate ~33 raw `compartmentId` fields in favour of the typed `compartment` accessor. That must not land before this: today the raw field is free while `compartment.id` costs an API call, so deprecating first would push every consumer onto the expensive path. With this merged, the typed accessor is as cheap as the raw string and the deprecation is safe.

## Tests

New pure-Go coverage for the resolver and the index:

- `providers/oci/resources/compartment_ref_test.go` - hit from the cached index (and no direct read), identity shared with `oci.compartments`, miss falling through, unreadable tree falling through, empty id and `ORACLE_MANAGED_KEY` sentinel null paths, lister-path `ociCompartmentRef`.
- `providers/oci/connection/tenancy_test.go` - index-building edge cases (missing/empty/duplicate OCIDs), hit/miss/empty lookups, index memoized rather than rebuilt, returned record does not alias the memoized tree, and 32 concurrent lookups (the executor resolves fields in goroutines).

```
$ cd providers/oci && go build ./... && go test ./...
ok  	go.mondoo.com/mql/v13/providers/oci/connection	7.881s
ok  	go.mondoo.com/mql/v13/providers/oci/provider	2.130s
ok  	go.mondoo.com/mql/v13/providers/oci/resources	1.689s

$ go test -race -count=1 ./connection/ ./resources/
ok  	go.mondoo.com/mql/v13/providers/oci/connection	10.454s
ok  	go.mondoo.com/mql/v13/providers/oci/resources	3.998s

$ go vet ./...   # clean
$ go mod tidy    # no diff
```
