### PR TITLE
⭐ tailscale: resolve the identity graph across devices, users, keys and webhooks

### DIFF
--- a/providers/tailscale/resources/identity.go
+++ b/providers/tailscale/resources/identity.go
@@ -1,0 +1,284 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// memo caches the result of one computation, error included, and shares it
+// across every resource that needs it.
+//
+// The cross-resource references are read once per referring resource, so a
+// per-reference fetch would scale with the size of the tailnet. Caching the
+// error alongside the value matters just as much: a tailnet whose user list
+// cannot be read would otherwise retry the failing call once per device.
+//
+// done is atomic rather than a plain bool so a reader that observes it set
+// also observes the value and error written before it, without taking the
+// lock. This mirrors the settingsFetched memo on the tailnet resource.
+type memo[T any] struct {
+	lock  sync.Mutex
+	done  atomic.Bool
+	value T
+	err   error
+}
+
+func (m *memo[T]) get(compute func() (T, error)) (T, error) {
+	if m.done.Load() {
+		return m.value, m.err
+	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.done.Load() {
+		return m.value, m.err
+	}
+	m.value, m.err = compute()
+	m.done.Store(true)
+	return m.value, m.err
+}
+
+// userIndex resolves an account by either of the two handles the Tailscale API
+// uses to name one.
+//
+// The handles are not interchangeable at the API: a device and a webhook name
+// their account by login name, while a tailnet key names it by user id, and
+// Users().Get accepts only the id. Indexing the one user list under both keys
+// is what lets all three references resolve without a per-item request.
+type userIndex map[string]*mqlTailscaleUser
+
+// buildUserIndex keys the tailnet's users by login name and by id. Ids are
+// applied second so that in the improbable event a login name collides with
+// another account's id, the id wins and `tailscale.user(id:)` semantics hold.
+func buildUserIndex(users []any) userIndex {
+	index := make(userIndex, len(users)*2)
+
+	for _, entry := range users {
+		// Comma-ok rather than a bare assertion: an unexpected entry in a
+		// cached list would otherwise panic inside a provider goroutine and
+		// take down the whole scan, not just this query.
+		user, ok := entry.(*mqlTailscaleUser)
+		if !ok || user == nil {
+			continue
+		}
+		if login := user.LoginName.Data; login != "" && user.LoginName.Error == nil {
+			index[login] = user
+		}
+	}
+
+	for _, entry := range users {
+		user, ok := entry.(*mqlTailscaleUser)
+		if !ok || user == nil {
+			continue
+		}
+		if id := user.Id.Data; id != "" && user.Id.Error == nil {
+			index[id] = user
+		}
+	}
+
+	return index
+}
+
+// lookup returns the account named by key, or nil when the tailnet has no such
+// account. An empty key names nobody and never matches.
+func (i userIndex) lookup(key string) *mqlTailscaleUser {
+	if key == "" {
+		return nil
+	}
+	return i[key]
+}
+
+// resolveUserIndex returns the tailnet's user index, building it from a single
+// Users().List on first use.
+func (t *mqlTailscale) resolveUserIndex() (userIndex, error) {
+	return t.userIndexMemo.get(func() (userIndex, error) {
+		users, err := t.users()
+		if err != nil {
+			return nil, err
+		}
+		return buildUserIndex(users), nil
+	})
+}
+
+// resolveDevices returns the tailnet's device list, fetched once and shared by
+// every user that reports the devices registered to it.
+func (t *mqlTailscale) resolveDevices() ([]any, error) {
+	return t.deviceListMemo.get(t.devices)
+}
+
+// resolveAuthKeys returns the tailnet's key list, fetched once and shared by
+// every user that reports the keys it owns. The list endpoint returns ids
+// only, so building this costs one request per key; re-walking it per user
+// would multiply that by the size of the tailnet.
+func (t *mqlTailscale) resolveAuthKeys() ([]any, error) {
+	return t.authKeyListMemo.get(t.authKeys)
+}
+
+// lookupTailscaleUser resolves an account named by id or by login name.
+//
+// It goes through the tailnet's memoized user list rather than
+// NewResource("tailscale.user"): that init runs before the runtime cache is
+// consulted and would issue a Users().Get per reference, and it accepts only
+// an id, so a login name would come back as an error. Resolving out of the
+// list also hands back the same resource instances the tailnet's users field
+// produced, because CreateResource returns the cache hit on a matching id.
+func lookupTailscaleUser(runtime *plugin.Runtime, key string) (*mqlTailscaleUser, error) {
+	if key == "" {
+		return nil, nil
+	}
+
+	tailnet, err := getMqlTailscale(runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	index, err := tailnet.resolveUserIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	return index.lookup(key), nil
+}
+
+// owner resolves the account a device is registered to. A tagged device and a
+// device shared in from another tailnet are attributed to no account here, so
+// both report null.
+func (d *mqlTailscaleDevice) owner() (*mqlTailscaleUser, error) {
+	if d.User.Error != nil {
+		return nil, d.User.Error
+	}
+
+	user, err := lookupTailscaleUser(d.MqlRuntime, d.User.Data)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		d.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return user, nil
+}
+
+// user resolves the account a tailnet key was issued under. A key whose owner
+// has since left the tailnet reports null.
+func (k *mqlTailscaleAuthKey) user() (*mqlTailscaleUser, error) {
+	if k.UserId.Error != nil {
+		return nil, k.UserId.Error
+	}
+
+	user, err := lookupTailscaleUser(k.MqlRuntime, k.UserId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		k.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return user, nil
+}
+
+// creator resolves the account that registered a webhook endpoint. Tailscale
+// keeps reporting the creator's login name after the account leaves the
+// tailnet, so this reports null while creatorLoginName still names them.
+func (w *mqlTailscaleWebhook) creator() (*mqlTailscaleUser, error) {
+	if w.CreatorLoginName.Error != nil {
+		return nil, w.CreatorLoginName.Error
+	}
+
+	user, err := lookupTailscaleUser(w.MqlRuntime, w.CreatorLoginName.Data)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		w.Creator.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return user, nil
+}
+
+// devicesRegisteredBy selects the devices attributed to a login name. An empty
+// login name names nobody, so nothing matches it, including a device that
+// carries no user of its own.
+func devicesRegisteredBy(devices []any, loginName string) []any {
+	matches := []any{}
+	if loginName == "" {
+		return matches
+	}
+
+	for _, entry := range devices {
+		device, ok := entry.(*mqlTailscaleDevice)
+		if !ok || device == nil {
+			continue
+		}
+		if device.User.Error == nil && device.User.Data == loginName {
+			matches = append(matches, device)
+		}
+	}
+	return matches
+}
+
+// authKeysOwnedBy selects the tailnet keys issued under a user id. An empty id
+// names nobody, so nothing matches it.
+func authKeysOwnedBy(keys []any, userId string) []any {
+	matches := []any{}
+	if userId == "" {
+		return matches
+	}
+
+	for _, entry := range keys {
+		key, ok := entry.(*mqlTailscaleAuthKey)
+		if !ok || key == nil {
+			continue
+		}
+		if key.UserId.Error == nil && key.UserId.Data == userId {
+			matches = append(matches, key)
+		}
+	}
+	return matches
+}
+
+// devices lists the devices registered to this account. The tailnet's device
+// list backs it, so reporting this for every user costs one request rather
+// than one per user.
+func (u *mqlTailscaleUser) devices() ([]any, error) {
+	if u.LoginName.Error != nil {
+		return nil, u.LoginName.Error
+	}
+
+	tailnet, err := getMqlTailscale(u.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	devices, err := tailnet.resolveDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	return devicesRegisteredBy(devices, u.LoginName.Data), nil
+}
+
+// authKeys lists the tailnet keys issued under this account, drawn from the
+// tailnet's key list so the per-key metadata fetch happens once for the whole
+// tailnet rather than once per user.
+func (u *mqlTailscaleUser) authKeys() ([]any, error) {
+	if u.Id.Error != nil {
+		return nil, u.Id.Error
+	}
+
+	tailnet, err := getMqlTailscale(u.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	keys, err := tailnet.resolveAuthKeys()
+	if err != nil {
+		return nil, err
+	}
+
+	return authKeysOwnedBy(keys, u.Id.Data), nil
+}

--- a/providers/tailscale/resources/identity.go
+++ b/providers/tailscale/resources/identity.go
@@ -55,7 +55,10 @@ type userIndex map[string]*mqlTailscaleUser
 // applied second so that in the improbable event a login name collides with
 // another account's id, the id wins and `tailscale.user(id:)` semantics hold.
 func buildUserIndex(users []any) userIndex {
-	index := make(userIndex, len(users)*2)
+	// One entry per user is a lower bound rather than the final size, since an
+	// account contributes both a login name and an id. Sizing to the count we
+	// know keeps the hint free of arithmetic; the map grows past it on its own.
+	index := make(userIndex, len(users))
 
 	for _, entry := range users {
 		// Comma-ok rather than a bare assertion: an unexpected entry in a

--- a/providers/tailscale/resources/identity_test.go
+++ b/providers/tailscale/resources/identity_test.go
@@ -1,0 +1,227 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func stringValue(s string) plugin.TValue[string] {
+	return plugin.TValue[string]{Data: s, State: plugin.StateIsSet}
+}
+
+func testUser(id, loginName string) *mqlTailscaleUser {
+	return &mqlTailscaleUser{
+		Id:        stringValue(id),
+		LoginName: stringValue(loginName),
+	}
+}
+
+func testDevice(id, user string) *mqlTailscaleDevice {
+	return &mqlTailscaleDevice{
+		Id:   stringValue(id),
+		User: stringValue(user),
+	}
+}
+
+func testAuthKey(id, userId string) *mqlTailscaleAuthKey {
+	return &mqlTailscaleAuthKey{
+		Id:     stringValue(id),
+		UserId: stringValue(userId),
+	}
+}
+
+func TestBuildUserIndexAndLookup(t *testing.T) {
+	alice := testUser("uid-alice", "alice@example.com")
+	bob := testUser("uid-bob", "bob@example.com")
+	index := buildUserIndex([]any{alice, bob})
+
+	t.Run("hit by id", func(t *testing.T) {
+		// A tailnet key names its owner by user id.
+		assert.Same(t, alice, index.lookup("uid-alice"))
+	})
+
+	t.Run("hit by login name", func(t *testing.T) {
+		// A device and a webhook name their account by login name, which
+		// Users().Get would reject. Indexing both handles is the whole point.
+		assert.Same(t, bob, index.lookup("bob@example.com"))
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		// A departed account still named by a webhook's creatorLoginName.
+		assert.Nil(t, index.lookup("carol@example.com"))
+	})
+
+	t.Run("empty key names nobody", func(t *testing.T) {
+		// A tagged device carries no user. It must not collide with an
+		// account that happens to index under the empty string.
+		assert.Nil(t, index.lookup(""))
+	})
+}
+
+func TestBuildUserIndexSkipsUnusableEntries(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		index := buildUserIndex(nil)
+		assert.Empty(t, index)
+		assert.Nil(t, index.lookup("uid-alice"))
+	})
+
+	t.Run("entry of another type is skipped, not asserted", func(t *testing.T) {
+		// A bare type assertion here would panic inside a provider goroutine
+		// and take down the entire scan rather than this one query.
+		alice := testUser("uid-alice", "alice@example.com")
+		index := buildUserIndex([]any{testDevice("d1", "alice@example.com"), nil, alice})
+		assert.Same(t, alice, index.lookup("uid-alice"))
+		assert.Len(t, index, 2)
+	})
+
+	t.Run("blank handles are not indexed", func(t *testing.T) {
+		index := buildUserIndex([]any{testUser("", "")})
+		assert.Empty(t, index)
+	})
+
+	t.Run("a user with only one handle is still reachable", func(t *testing.T) {
+		u := testUser("uid-shared", "")
+		index := buildUserIndex([]any{u})
+		assert.Same(t, u, index.lookup("uid-shared"))
+		assert.Len(t, index, 1)
+	})
+
+	t.Run("an errored handle is not indexed", func(t *testing.T) {
+		u := testUser("uid-alice", "alice@example.com")
+		u.LoginName = plugin.TValue[string]{Error: errors.New("unreadable"), State: plugin.StateIsSet | plugin.StateIsNull}
+		index := buildUserIndex([]any{u})
+		assert.Same(t, u, index.lookup("uid-alice"))
+		assert.Nil(t, index.lookup("alice@example.com"))
+	})
+
+	t.Run("an id wins over a colliding login name", func(t *testing.T) {
+		// Improbable, but the id is the handle the API treats as canonical,
+		// so resolution stays deterministic if the two ever collide.
+		byLogin := testUser("uid-1", "shared-handle")
+		byId := testUser("shared-handle", "other@example.com")
+		index := buildUserIndex([]any{byLogin, byId})
+		assert.Same(t, byId, index.lookup("shared-handle"))
+	})
+}
+
+func TestDevicesRegisteredBy(t *testing.T) {
+	laptop := testDevice("d1", "alice@example.com")
+	phone := testDevice("d2", "alice@example.com")
+	server := testDevice("d3", "bob@example.com")
+	tagged := testDevice("d4", "")
+	devices := []any{laptop, phone, server, tagged, nil, testUser("uid-x", "x@example.com")}
+
+	t.Run("selects only the account's devices", func(t *testing.T) {
+		got := devicesRegisteredBy(devices, "alice@example.com")
+		assert.Equal(t, []any{laptop, phone}, got)
+	})
+
+	t.Run("account with nothing enrolled reports empty, not null", func(t *testing.T) {
+		got := devicesRegisteredBy(devices, "carol@example.com")
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty login name matches nothing, including a tagged device", func(t *testing.T) {
+		got := devicesRegisteredBy(devices, "")
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty device list", func(t *testing.T) {
+		got := devicesRegisteredBy(nil, "alice@example.com")
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+}
+
+func TestAuthKeysOwnedBy(t *testing.T) {
+	oauth := testAuthKey("k1", "uid-alice")
+	preauth := testAuthKey("k2", "uid-alice")
+	other := testAuthKey("k3", "uid-bob")
+	orphan := testAuthKey("k4", "")
+	keys := []any{oauth, preauth, other, orphan, nil, testDevice("d1", "alice@example.com")}
+
+	t.Run("selects only the account's keys", func(t *testing.T) {
+		assert.Equal(t, []any{oauth, preauth}, authKeysOwnedBy(keys, "uid-alice"))
+	})
+
+	t.Run("account owning no keys reports empty, not null", func(t *testing.T) {
+		got := authKeysOwnedBy(keys, "uid-carol")
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty user id matches nothing", func(t *testing.T) {
+		got := authKeysOwnedBy(keys, "")
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+}
+
+func TestMemo(t *testing.T) {
+	t.Run("computes once and shares the value", func(t *testing.T) {
+		var m memo[int]
+		calls := 0
+		compute := func() (int, error) {
+			calls++
+			return 42, nil
+		}
+
+		for i := 0; i < 3; i++ {
+			got, err := m.get(compute)
+			require.NoError(t, err)
+			assert.Equal(t, 42, got)
+		}
+		assert.Equal(t, 1, calls, "the underlying list must be fetched once, not once per reference")
+	})
+
+	t.Run("a failed read is not retried per reference", func(t *testing.T) {
+		var m memo[int]
+		calls := 0
+		wantErr := errors.New("user list unavailable")
+		compute := func() (int, error) {
+			calls++
+			return 0, wantErr
+		}
+
+		for i := 0; i < 3; i++ {
+			_, err := m.get(compute)
+			assert.ErrorIs(t, err, wantErr)
+		}
+		assert.Equal(t, 1, calls, "a tailnet whose user list cannot be read must not retry once per device")
+	})
+
+	t.Run("concurrent readers see one computation", func(t *testing.T) {
+		var m memo[int]
+		var mu sync.Mutex
+		calls := 0
+		compute := func() (int, error) {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			return 7, nil
+		}
+
+		var wg sync.WaitGroup
+		for i := 0; i < 64; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				got, err := m.get(compute)
+				assert.NoError(t, err)
+				assert.Equal(t, 7, got)
+			}()
+		}
+		wg.Wait()
+		assert.Equal(t, 1, calls)
+	})
+}

--- a/providers/tailscale/resources/tailscale.go
+++ b/providers/tailscale/resources/tailscale.go
@@ -19,10 +19,18 @@ import (
 // share the result of a single TailnetSettings API call. settingsFetched is
 // atomic because the accessors that read it are distinct MQL fields, which the
 // runtime may resolve concurrently.
+//
+// The three memos below back the cross-resource references. Each one is read
+// once per referring resource, so without memoization a tailnet of N devices
+// would issue N user lists. See identity.go.
 type mqlTailscaleInternal struct {
 	settingsLock    sync.Mutex
 	settingsFetched atomic.Bool
 	settings        *tsclient.TailnetSettings
+
+	userIndexMemo   memo[userIndex]
+	deviceListMemo  memo[[]any]
+	authKeyListMemo memo[[]any]
 }
 
 func (r *mqlTailscale) id() (string, error) {

--- a/providers/tailscale/resources/tailscale.lr
+++ b/providers/tailscale/resources/tailscale.lr
@@ -97,8 +97,21 @@ tailscale.device @defaults("id hostname os") {
   os string
   // MagicDNS name of the device
   name string
-  // User who registered the device. For untagged devices this is also the device owner.
-  user string
+  // Login name of the user who registered the device
+  //
+  // Deprecated in favor of owner, whose loginName carries the same value
+  // and which resolves the account itself.
+  user @maturity("deprecated") string
+  // User account that registered the device
+  //
+  // The account the device is attributed to, which for an untagged device
+  // is also its owner. Resolving it turns a device inventory into an
+  // access review: the role, status, and lastSeenAt of the person behind
+  // each machine, so a suspended or long-idle account whose machines are
+  // still enrolled becomes a single query. Null for a tagged device and
+  // for a device shared in from another tailnet, neither of which is
+  // attributed to an account in this tailnet.
+  owner() tailscale.user
   // An identity for the device that is separate from human users (used as part of an ACL to restrict access)
   tags []string
   // List of Tailscale IP addresses for the device, including both IPv4 and IPv6 addresses
@@ -228,6 +241,23 @@ tailscale.user @defaults("id displayName type") {
   lastSeenAt time
   // Whether the user is currently connected to the tailnet
   currentlyConnected bool
+  // Devices the user registered
+  //
+  // The devices in the tailnet attributed to this account, which
+  // deviceCount reports only as a number. Reading the devices themselves
+  // is what turns an offboarding review into an answer: the machines a
+  // suspended account still has enrolled, whether any of them advertises
+  // a subnet route or an exit node, and when each was last seen. Empty
+  // for an account that registered nothing.
+  devices() []tailscale.device
+  // Tailnet keys the user owns
+  //
+  // Pre-auth keys, OAuth clients, and federated identities issued under
+  // this account. A credential outlives the session that created it, so
+  // an account that has left the tailnet can still own an unrevoked
+  // OAuth client with write scopes. Empty for an account that owns no
+  // credentials.
+  authKeys() []tailscale.authKey
 }
 
 // Tailscale tailnet ACL (access control list) policy
@@ -365,7 +395,18 @@ private tailscale.authKey @defaults("id keyType description expires revoked") {
   // Human-readable description set when the key was created
   description string
   // ID of the user that owns the key
-  userId string
+  //
+  // Deprecated in favor of user, whose id carries the same value and
+  // which resolves the account itself.
+  userId @maturity("deprecated") string
+  // User account that owns the key
+  //
+  // The account the credential was issued under. A long-lived credential
+  // outlives the session that created it, so pairing the key with its
+  // owner is what surfaces an OAuth client holding write scopes that
+  // belongs to a suspended or departed account. Null when the owning
+  // account is no longer present in the tailnet.
+  user() tailscale.user
   // API scopes granted to an OAuth client or federated identity
   //
   // For example `devices:core:read` or `all:write`. Empty for pre-auth
@@ -425,7 +466,19 @@ private tailscale.webhook @defaults("endpointId providerType endpointUrl") {
   // Receiver shape (`slack`, `mattermost`, `googlechat`, `discord`, or empty for the generic Tailscale format)
   providerType string
   // Login name of the user that registered the endpoint
+  //
+  // Retained alongside creator because Tailscale keeps reporting the
+  // login name after the account leaves the tailnet, at which point it is
+  // the only surviving record of who registered the endpoint.
   creatorLoginName string
+  // User account that registered the endpoint
+  //
+  // The account behind creatorLoginName, which is what tells an audit
+  // whether the person routing tailnet events off-platform is still an
+  // active member and what role they hold. Null when the creator has
+  // since left the tailnet, in which case creatorLoginName is the only
+  // remaining record.
+  creator() tailscale.user
   // Time the endpoint was registered
   created time
   // Time the endpoint subscription was last modified

--- a/providers/tailscale/resources/tailscale.lr.go
+++ b/providers/tailscale/resources/tailscale.lr.go
@@ -211,6 +211,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"tailscale.device.user": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleDevice).GetUser()).ToDataRes(types.String)
 	},
+	"tailscale.device.owner": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleDevice).GetOwner()).ToDataRes(types.Resource("tailscale.user"))
+	},
 	"tailscale.device.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleDevice).GetTags()).ToDataRes(types.Array(types.String))
 	},
@@ -334,6 +337,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"tailscale.user.currentlyConnected": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleUser).GetCurrentlyConnected()).ToDataRes(types.Bool)
 	},
+	"tailscale.user.devices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleUser).GetDevices()).ToDataRes(types.Array(types.Resource("tailscale.device")))
+	},
+	"tailscale.user.authKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleUser).GetAuthKeys()).ToDataRes(types.Array(types.Resource("tailscale.authKey")))
+	},
 	"tailscale.aclPolicy.tailnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAclPolicy).GetTailnet()).ToDataRes(types.String)
 	},
@@ -412,6 +421,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"tailscale.authKey.userId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAuthKey).GetUserId()).ToDataRes(types.String)
 	},
+	"tailscale.authKey.user": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleAuthKey).GetUser()).ToDataRes(types.Resource("tailscale.user"))
+	},
 	"tailscale.authKey.scopes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAuthKey).GetScopes()).ToDataRes(types.Array(types.String))
 	},
@@ -471,6 +483,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"tailscale.webhook.creatorLoginName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleWebhook).GetCreatorLoginName()).ToDataRes(types.String)
+	},
+	"tailscale.webhook.creator": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleWebhook).GetCreator()).ToDataRes(types.Resource("tailscale.user"))
 	},
 	"tailscale.webhook.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleWebhook).GetCreated()).ToDataRes(types.Time)
@@ -656,6 +671,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlTailscaleDevice).User, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"tailscale.device.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleDevice).Owner, ok = plugin.RawToTValue[*mqlTailscaleUser](v.Value, v.Error)
+		return
+	},
 	"tailscale.device.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleDevice).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -824,6 +843,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlTailscaleUser).CurrentlyConnected, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"tailscale.user.devices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleUser).Devices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"tailscale.user.authKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleUser).AuthKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"tailscale.aclPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleAclPolicy).__id, ok = v.Value.(string)
 		return
@@ -936,6 +963,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlTailscaleAuthKey).UserId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"tailscale.authKey.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleAuthKey).User, ok = plugin.RawToTValue[*mqlTailscaleUser](v.Value, v.Error)
+		return
+	},
 	"tailscale.authKey.scopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleAuthKey).Scopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1018,6 +1049,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"tailscale.webhook.creatorLoginName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleWebhook).CreatorLoginName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"tailscale.webhook.creator": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleWebhook).Creator, ok = plugin.RawToTValue[*mqlTailscaleUser](v.Value, v.Error)
 		return
 	},
 	"tailscale.webhook.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1395,6 +1430,7 @@ type mqlTailscaleDevice struct {
 	Os                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	User                      plugin.TValue[string]
+	Owner                     plugin.TValue[*mqlTailscaleUser]
 	Tags                      plugin.TValue[[]any]
 	Addresses                 plugin.TValue[[]any]
 	ClientVersion             plugin.TValue[string]
@@ -1485,6 +1521,22 @@ func (c *mqlTailscaleDevice) GetName() *plugin.TValue[string] {
 
 func (c *mqlTailscaleDevice) GetUser() *plugin.TValue[string] {
 	return &c.User
+}
+
+func (c *mqlTailscaleDevice) GetOwner() *plugin.TValue[*mqlTailscaleUser] {
+	return plugin.GetOrCompute[*mqlTailscaleUser](&c.Owner, func() (*mqlTailscaleUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("tailscale.device", c.__id, "owner")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlTailscaleUser), nil
+			}
+		}
+
+		return c.owner()
+	})
 }
 
 func (c *mqlTailscaleDevice) GetTags() *plugin.TValue[[]any] {
@@ -1620,6 +1672,8 @@ type mqlTailscaleUser struct {
 	CreatedAt          plugin.TValue[*time.Time]
 	LastSeenAt         plugin.TValue[*time.Time]
 	CurrentlyConnected plugin.TValue[bool]
+	Devices            plugin.TValue[[]any]
+	AuthKeys           plugin.TValue[[]any]
 }
 
 // createTailscaleUser creates a new instance of this resource
@@ -1705,6 +1759,38 @@ func (c *mqlTailscaleUser) GetLastSeenAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlTailscaleUser) GetCurrentlyConnected() *plugin.TValue[bool] {
 	return &c.CurrentlyConnected
+}
+
+func (c *mqlTailscaleUser) GetDevices() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Devices, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("tailscale.user", c.__id, "devices")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.devices()
+	})
+}
+
+func (c *mqlTailscaleUser) GetAuthKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AuthKeys, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("tailscale.user", c.__id, "authKeys")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.authKeys()
+	})
 }
 
 // mqlTailscaleAclPolicy for the tailscale.aclPolicy resource
@@ -1872,6 +1958,7 @@ type mqlTailscaleAuthKey struct {
 	KeyType          plugin.TValue[string]
 	Description      plugin.TValue[string]
 	UserId           plugin.TValue[string]
+	User             plugin.TValue[*mqlTailscaleUser]
 	Scopes           plugin.TValue[[]any]
 	Audience         plugin.TValue[string]
 	Issuer           plugin.TValue[string]
@@ -1941,6 +2028,22 @@ func (c *mqlTailscaleAuthKey) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlTailscaleAuthKey) GetUserId() *plugin.TValue[string] {
 	return &c.UserId
+}
+
+func (c *mqlTailscaleAuthKey) GetUser() *plugin.TValue[*mqlTailscaleUser] {
+	return plugin.GetOrCompute[*mqlTailscaleUser](&c.User, func() (*mqlTailscaleUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("tailscale.authKey", c.__id, "user")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlTailscaleUser), nil
+			}
+		}
+
+		return c.user()
+	})
 }
 
 func (c *mqlTailscaleAuthKey) GetScopes() *plugin.TValue[[]any] {
@@ -2020,6 +2123,7 @@ type mqlTailscaleWebhook struct {
 	EndpointUrl      plugin.TValue[string]
 	ProviderType     plugin.TValue[string]
 	CreatorLoginName plugin.TValue[string]
+	Creator          plugin.TValue[*mqlTailscaleUser]
 	Created          plugin.TValue[*time.Time]
 	LastModified     plugin.TValue[*time.Time]
 	Subscriptions    plugin.TValue[[]any]
@@ -2076,6 +2180,22 @@ func (c *mqlTailscaleWebhook) GetProviderType() *plugin.TValue[string] {
 
 func (c *mqlTailscaleWebhook) GetCreatorLoginName() *plugin.TValue[string] {
 	return &c.CreatorLoginName
+}
+
+func (c *mqlTailscaleWebhook) GetCreator() *plugin.TValue[*mqlTailscaleUser] {
+	return plugin.GetOrCompute[*mqlTailscaleUser](&c.Creator, func() (*mqlTailscaleUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("tailscale.webhook", c.__id, "creator")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlTailscaleUser), nil
+			}
+		}
+
+		return c.creator()
+	})
 }
 
 func (c *mqlTailscaleWebhook) GetCreated() *plugin.TValue[*time.Time] {

--- a/providers/tailscale/resources/tailscale.lr.versions
+++ b/providers/tailscale/resources/tailscale.lr.versions
@@ -47,6 +47,7 @@ tailscale.authKey.scopes 13.3.11
 tailscale.authKey.subject 13.3.11
 tailscale.authKey.tags 13.1.8
 tailscale.authKey.updated 13.3.11
+tailscale.authKey.user 13.3.12
 tailscale.authKey.userId 13.1.8
 tailscale.authKeys 13.1.8
 tailscale.device 11.0.0
@@ -76,6 +77,7 @@ tailscale.device.name 11.0.0
 tailscale.device.nodeId 13.3.11
 tailscale.device.nodeKey 11.0.0
 tailscale.device.os 11.0.0
+tailscale.device.owner 13.3.12
 tailscale.device.postureHardwareAddresses 13.3.11
 tailscale.device.postureIdentityDisabled 13.3.11
 tailscale.device.postureSerialNumbers 13.3.11
@@ -117,9 +119,11 @@ tailscale.service.tags 13.3.11
 tailscale.services 13.3.11
 tailscale.tailnet 11.0.0
 tailscale.user 11.0.0
+tailscale.user.authKeys 13.3.12
 tailscale.user.createdAt 11.0.0
 tailscale.user.currentlyConnected 13.0.7
 tailscale.user.deviceCount 11.0.0
+tailscale.user.devices 13.3.12
 tailscale.user.displayName 11.0.0
 tailscale.user.id 11.0.0
 tailscale.user.lastSeenAt 11.0.0
@@ -134,6 +138,7 @@ tailscale.users 11.0.0
 tailscale.usersRoleAllowedToJoinExternalTailnets 13.0.7
 tailscale.webhook 13.1.8
 tailscale.webhook.created 13.1.8
+tailscale.webhook.creator 13.3.12
 tailscale.webhook.creatorLoginName 13.1.8
 tailscale.webhook.endpointId 13.1.8
 tailscale.webhook.endpointUrl 13.1.8


### PR DESCRIPTION
The tailscale provider shipped with zero cross-resource references. Every accessor was a root-to-child list (`devices()`, `users()`, `authKeys()`, ...) and nothing pointed sideways, even though three raw strings name a `tailscale.user` the provider already models. `user.deviceCount` stood in for a traversal that did not exist.

## What each edge unlocks

| Edge | The audit it answers |
|---|---|
| `tailscale.device.owner` | A suspended or long-idle account whose machines are still enrolled, and whether any of them advertises a subnet route or an exit node. |
| `tailscale.user.devices` | The reverse: the offboarding review. What does this departed person still have on the network? |
| `tailscale.authKey.user` | An OAuth client holding `all:write` scopes that belongs to an account that has left. The credential outlives the session that created it. |
| `tailscale.user.authKeys` | Every long-lived credential issued under one account, in one place. |
| `tailscale.webhook.creator` | Whether the person routing tailnet events off-platform is still an active member, and what role they hold. |

## Before / after

Finding the still-enrolled machines of accounts that are no longer active used to mean reading two lists and joining them by hand, outside MQL:

```
// before: a count, and a login name you cannot follow
tailscale.users.where(status == "suspended") { loginName deviceCount }
tailscale.devices { user hostname advertisedRoutes }
```

Now it is one query:

```
// after
tailscale.users.where(status == "suspended") {
  loginName
  devices { hostname lastSeenAt advertisedRoutes authorized }
  authKeys.where(!isRevoked) { id keyType scopes }
}

// and from the other direction
tailscale.devices.where(advertisedRoutes.length > 0) {
  hostname
  owner { loginName role status lastSeenAt }
}

tailscale.webhooks { endpointUrl creatorLoginName creator { role status } }
```

## The login-name-vs-id trap

`device.user` and `webhook.creatorLoginName` carry a **login name**; `authKey.userId` carries a **user id**. `initTailscaleUser` accepts only an id and calls `Users().Get(id)`, so resolving a login name through `NewResource` returns an error. Accessors log and continue on a failed resolution, so that would have surfaced as a silently empty field, invisible without live data.

All three singular references instead resolve through a user index keyed by **both** handles, built once from a single `Users().List` (which returns fully populated objects). Login names are indexed first and ids second, so an id wins on the improbable collision.

## Resolution is memoized

`NewResource` runs a resource's `init` before the runtime cache is consulted, so per-item resolution would be one API call per referring resource. The user index, the device list, and the key list are each memoized on `mqlTailscaleInternal`, alongside the existing `settingsLock` / `settingsFetched` memo. The **error** is memoized too, so a tailnet whose user list cannot be read does not retry that call once per device. The key list matters most: its list endpoint returns ids only, so building it already costs one `Keys().Get` per key, and re-walking it per user would multiply that by the size of the tailnet.

Resolving out of the memoized lists also hands back the *same* resource instances the tailnet's own `devices()` / `users()` produced, because `CreateResource` returns the cache hit on a matching `__id`.

## Null discipline

Every singular accessor sets `StateIsSet | StateIsNull` before returning `nil, nil`. A tagged device, a device shared in from another tailnet, and a webhook whose creator has left the tailnet all legitimately have no account, and each reports null rather than an error. The list accessors return an empty list only when the read succeeded and nothing matched; a failed read propagates the error rather than rendering as `[]`. Everything pulled out of a cached list uses a comma-ok assertion, since a bare assertion panic inside an accessor kills the whole scan.

## Deprecations

- `tailscale.device.user` -> `@maturity("deprecated")`, fully duplicated by `owner.loginName`.
- `tailscale.authKey.userId` -> `@maturity("deprecated")`, the ref carries the identical value.
- `tailscale.webhook.creatorLoginName` is **kept**. Tailscale keeps reporting the login name after the creator leaves the tailnet, exactly where the ref resolves to null, so the raw string is then the only surviving record of who registered the endpoint. Its doc comment now says so.

`.lr.versions` entries for the deprecated fields are unchanged; the five new fields are at `13.3.12`, the next patch after the provider's current `13.3.11`. `config.go` is not bumped.

## Tests

`resources/identity_test.go` covers the pure Go logic: index build and lookup (hit by id, hit by login name, miss, empty key, blank handles, an errored handle, an entry of the wrong type, id-over-login-name precedence), the two reverse-edge filters (match, no match, empty key, empty list), and the memo (computes once, caches the error instead of retrying, and one computation under 64 concurrent readers).

```
$ go build ./... && go test ./... && go test -race ./...
ok  	go.mondoo.com/mql/v13/providers/tailscale/connection	2.395s
ok  	go.mondoo.com/mql/v13/providers/tailscale/resources	2.380s
```
