### PR TITLE
⚡ snowflake: index databases, schemas and warehouses account-wide

### DIFF
--- a/providers/snowflake/resources/databases.go
+++ b/providers/snowflake/resources/databases.go
@@ -63,10 +63,17 @@ func initSnowflakeDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData
 // resolveDatabaseRef returns the typed database a name refers to, or a null
 // resource when the name is empty. Shared by the schema, row-access-policy, and
 // network-rule resources.
+//
+// The account's database index answers this without a statement. Anything the
+// index cannot answer, including an index that could not be read at all, falls
+// through to the per-name lookup in initSnowflakeDatabase.
 func resolveDatabaseRef(runtime *plugin.Runtime, name string, field *plugin.TValue[*mqlSnowflakeDatabase]) (*mqlSnowflakeDatabase, error) {
 	if name == "" {
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+	if database, ok := indexedDatabase(runtime, name); ok {
+		return newMqlSnowflakeDatabase(runtime, database)
 	}
 	res, err := NewResource(runtime, "snowflake.database", map[string]*llx.RawData{
 		"name": llx.StringData(name),

--- a/providers/snowflake/resources/object_index.go
+++ b/providers/snowflake/resources/object_index.go
@@ -1,0 +1,219 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/snowflake/connection"
+)
+
+// Account-wide name indexes for the objects other resources point at.
+//
+// A reference such as snowflake.table.database is resolved through NewResource,
+// and NewResource runs the target's init before the runtime cache is consulted.
+// The init issues a statement, so a reference held by N objects costs N
+// statements even though every one of them resolves against the same small set
+// of objects. Listing an account's tables and reading each one's database was
+// one SHOW DATABASES LIKE per table.
+//
+// Each index is one account-wide statement, memoized on the account resource
+// together with its error, so an unreadable listing is not retried per item.
+// This mirrors the roleIndex and userIndex the role hierarchy already uses.
+//
+// A miss is never an answer. An index that could not be read, an index that was
+// truncated (SHOW output is row-capped, so a very large account can produce a
+// partial listing), and a name the account simply does not list all fall
+// through to the per-item lookup that was there before, which is what keeps the
+// change monotonic: the same references resolve, with fewer statements.
+//
+// Tables and stages are deliberately not indexed. Their references have a
+// single caller each (a materialized view's source table, a stream's table, an
+// external table's stage), and the per-item lookups they use are already scoped
+// with IN SCHEMA plus LIKE. An account-wide SHOW TABLES or SHOW STAGES walks
+// every schema in the account, so for those two an index would be more work
+// than the lookups it replaces, and on an account big enough for the row cap to
+// bite it would be paid on top of them.
+
+// memoIndex holds one account-wide name index and the outcome of building it.
+//
+// The failure is memoized alongside the value: a scanning role that cannot read
+// the listing cannot read it on the next item either, so retrying would
+// multiply statements against exactly the account already refusing them.
+type memoIndex[T any] struct {
+	once  sync.Once
+	index map[string]T
+	err   error
+}
+
+// get returns the memoized index, running build on the first call. MQL
+// evaluates blocks in goroutines, so many resources reach the same index at
+// once; sync.Once is what makes them share one listing rather than race to
+// issue their own, and it establishes the happens-before that lets every reader
+// see the finished map.
+func (m *memoIndex[T]) get(build func() (map[string]T, error)) (map[string]T, error) {
+	m.once.Do(func() {
+		m.index, m.err = build()
+	})
+	return m.index, m.err
+}
+
+// lookupIndexed returns the entry an index holds for key. A nil index (the
+// listing failed, so nothing was built), an empty key, and a name that is not
+// present are all reported the same way, because the caller treats all three as
+// a miss and falls back.
+func lookupIndexed[T any](index map[string]T, key string) (T, bool) {
+	var zero T
+	if index == nil || key == "" {
+		return zero, false
+	}
+	entry, ok := index[key]
+	if !ok {
+		return zero, false
+	}
+	return entry, true
+}
+
+// databaseIndexKey normalizes a database name into its index key. Snowflake
+// reports identifiers quoted in some result sets and bare in others, so both the
+// build and the lookup go through the SDK's identifier type rather than using
+// the raw string.
+func databaseIndexKey(name string) string {
+	return sdk.NewAccountObjectIdentifier(name).Name()
+}
+
+// schemaIndexKey normalizes a database/schema pair into its index key. Schemas
+// are only unique within a database, so the key is the qualified name.
+func schemaIndexKey(databaseName, name string) string {
+	if databaseName == "" || name == "" {
+		return ""
+	}
+	return sdk.NewDatabaseObjectIdentifier(databaseName, name).FullyQualifiedName()
+}
+
+// warehouseIndexKey normalizes a warehouse name into its index key.
+func warehouseIndexKey(name string) string {
+	return sdk.NewAccountObjectIdentifier(name).Name()
+}
+
+func buildDatabaseIndex(databases []sdk.Database) map[string]sdk.Database {
+	index := make(map[string]sdk.Database, len(databases))
+	for i := range databases {
+		key := databaseIndexKey(databases[i].Name)
+		if key == "" {
+			continue
+		}
+		index[key] = databases[i]
+	}
+	return index
+}
+
+func buildSchemaIndex(schemas []sdk.Schema) map[string]sdk.Schema {
+	index := make(map[string]sdk.Schema, len(schemas))
+	for i := range schemas {
+		key := schemaIndexKey(schemas[i].DatabaseName, schemas[i].Name)
+		if key == "" {
+			continue
+		}
+		index[key] = schemas[i]
+	}
+	return index
+}
+
+func buildWarehouseIndex(warehouses []sdk.Warehouse) map[string]sdk.Warehouse {
+	index := make(map[string]sdk.Warehouse, len(warehouses))
+	for i := range warehouses {
+		key := warehouseIndexKey(warehouses[i].Name)
+		if key == "" {
+			continue
+		}
+		index[key] = warehouses[i]
+	}
+	return index
+}
+
+// databaseIndex maps database names to the SHOW DATABASES row describing them.
+func (r *mqlSnowflakeAccount) databaseIndex() (map[string]sdk.Database, error) {
+	return r.cachedDatabaseIndex.get(func() (map[string]sdk.Database, error) {
+		conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
+		databases, err := conn.Client().Databases.Show(context.Background(), &sdk.ShowDatabasesOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return buildDatabaseIndex(databases), nil
+	})
+}
+
+// schemaIndex maps qualified schema names to the SHOW SCHEMAS row describing
+// them.
+func (r *mqlSnowflakeAccount) schemaIndex() (map[string]sdk.Schema, error) {
+	return r.cachedSchemaIndex.get(func() (map[string]sdk.Schema, error) {
+		conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
+		schemas, err := conn.Client().Schemas.Show(context.Background(), &sdk.ShowSchemaOptions{
+			In: &sdk.SchemaIn{Account: sdk.Bool(true)},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return buildSchemaIndex(schemas), nil
+	})
+}
+
+// warehouseIndex maps warehouse names to the SHOW WAREHOUSES row describing
+// them.
+func (r *mqlSnowflakeAccount) warehouseIndex() (map[string]sdk.Warehouse, error) {
+	return r.cachedWarehouseIndex.get(func() (map[string]sdk.Warehouse, error) {
+		conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
+		warehouses, err := conn.Client().Warehouses.Show(context.Background(), &sdk.ShowWarehouseOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return buildWarehouseIndex(warehouses), nil
+	})
+}
+
+// indexedDatabase returns the indexed row for a database name, or false when the
+// caller should fall back to the per-name lookup.
+func indexedDatabase(runtime *plugin.Runtime, name string) (sdk.Database, bool) {
+	account, err := snowflakeAccount(runtime)
+	if err != nil {
+		return sdk.Database{}, false
+	}
+	index, err := account.databaseIndex()
+	if err != nil {
+		return sdk.Database{}, false
+	}
+	return lookupIndexed(index, databaseIndexKey(name))
+}
+
+// indexedSchema returns the indexed row for a database/schema pair, or false
+// when the caller should fall back to the per-name lookup.
+func indexedSchema(runtime *plugin.Runtime, databaseName, name string) (sdk.Schema, bool) {
+	account, err := snowflakeAccount(runtime)
+	if err != nil {
+		return sdk.Schema{}, false
+	}
+	index, err := account.schemaIndex()
+	if err != nil {
+		return sdk.Schema{}, false
+	}
+	return lookupIndexed(index, schemaIndexKey(databaseName, name))
+}
+
+// indexedWarehouse returns the indexed row for a warehouse name, or false when
+// the caller should fall back to the per-name lookup.
+func indexedWarehouse(runtime *plugin.Runtime, name string) (sdk.Warehouse, bool) {
+	account, err := snowflakeAccount(runtime)
+	if err != nil {
+		return sdk.Warehouse{}, false
+	}
+	index, err := account.warehouseIndex()
+	if err != nil {
+		return sdk.Warehouse{}, false
+	}
+	return lookupIndexed(index, warehouseIndexKey(name))
+}

--- a/providers/snowflake/resources/object_index_test.go
+++ b/providers/snowflake/resources/object_index_test.go
@@ -1,0 +1,234 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseIndexKey(t *testing.T) {
+	t.Run("a bare name is its own key", func(t *testing.T) {
+		assert.Equal(t, "PROD", databaseIndexKey("PROD"))
+	})
+
+	t.Run("a quoted identifier keys the same as the bare name", func(t *testing.T) {
+		// SHOW output quotes identifiers in some result sets and not others, so
+		// the key has to survive the round trip either way.
+		assert.Equal(t, databaseIndexKey("PROD"), databaseIndexKey(`"PROD"`))
+	})
+
+	t.Run("case is preserved, not folded", func(t *testing.T) {
+		// Snowflake stores an unquoted identifier upper-cased and reports the
+		// stored form, so the two are different objects, not two spellings of
+		// one. Folding here would make a lowercase-named database shadow an
+		// uppercase one.
+		assert.NotEqual(t, databaseIndexKey("PROD"), databaseIndexKey("prod"))
+	})
+
+	t.Run("an empty name has an empty key", func(t *testing.T) {
+		assert.Equal(t, "", databaseIndexKey(""))
+	})
+}
+
+func TestSchemaIndexKey(t *testing.T) {
+	t.Run("the key is qualified by database", func(t *testing.T) {
+		// PUBLIC exists in every database, so an unqualified key would collapse
+		// them all onto one entry.
+		assert.NotEqual(t, schemaIndexKey("PROD", "PUBLIC"), schemaIndexKey("STAGING", "PUBLIC"))
+	})
+
+	t.Run("quoted parts key the same as bare parts", func(t *testing.T) {
+		assert.Equal(t, schemaIndexKey("PROD", "PUBLIC"), schemaIndexKey(`"PROD"`, `"PUBLIC"`))
+	})
+
+	t.Run("either coordinate empty yields an empty key", func(t *testing.T) {
+		assert.Equal(t, "", schemaIndexKey("", "PUBLIC"))
+		assert.Equal(t, "", schemaIndexKey("PROD", ""))
+		assert.Equal(t, "", schemaIndexKey("", ""))
+	})
+
+	t.Run("a dot in a name cannot collide with a different split", func(t *testing.T) {
+		assert.NotEqual(t, schemaIndexKey("PROD.PUBLIC", "T"), schemaIndexKey("PROD", "PUBLIC.T"))
+	})
+}
+
+func TestWarehouseIndexKey(t *testing.T) {
+	assert.Equal(t, "COMPUTE_WH", warehouseIndexKey("COMPUTE_WH"))
+	assert.Equal(t, warehouseIndexKey("COMPUTE_WH"), warehouseIndexKey(`"COMPUTE_WH"`))
+	assert.Equal(t, "", warehouseIndexKey(""))
+}
+
+func TestBuildDatabaseIndex(t *testing.T) {
+	index := buildDatabaseIndex([]sdk.Database{
+		{Name: "PROD", Owner: "SYSADMIN"},
+		{Name: `"QUOTED_DB"`, Owner: "ACCOUNTADMIN"},
+		{Name: "", Owner: "NOBODY"},
+	})
+
+	t.Run("a listed database is found by name", func(t *testing.T) {
+		db, ok := lookupIndexed(index, databaseIndexKey("PROD"))
+		require.True(t, ok)
+		assert.Equal(t, "SYSADMIN", db.Owner)
+	})
+
+	t.Run("a quoted listing is found by its bare name", func(t *testing.T) {
+		db, ok := lookupIndexed(index, databaseIndexKey("QUOTED_DB"))
+		require.True(t, ok)
+		assert.Equal(t, "ACCOUNTADMIN", db.Owner)
+	})
+
+	t.Run("a nameless row is dropped rather than keyed empty", func(t *testing.T) {
+		// An empty key would otherwise be handed out for every empty lookup.
+		assert.Len(t, index, 2)
+	})
+
+	t.Run("a name the account does not list is a miss", func(t *testing.T) {
+		_, ok := lookupIndexed(index, databaseIndexKey("ABSENT"))
+		assert.False(t, ok)
+	})
+
+	t.Run("a differently cased name is a miss, not a wrong hit", func(t *testing.T) {
+		// The resolver falls back to the per-name lookup on this, which is what
+		// the behavior was before the index existed.
+		_, ok := lookupIndexed(index, databaseIndexKey("prod"))
+		assert.False(t, ok)
+	})
+}
+
+func TestBuildSchemaIndex(t *testing.T) {
+	index := buildSchemaIndex([]sdk.Schema{
+		{Name: "PUBLIC", DatabaseName: "PROD", Owner: "SYSADMIN"},
+		{Name: "PUBLIC", DatabaseName: "STAGING", Owner: "DEVELOPER"},
+		{Name: "PUBLIC", DatabaseName: ""},
+		{Name: "", DatabaseName: "PROD"},
+	})
+
+	t.Run("same-named schemas in different databases stay distinct", func(t *testing.T) {
+		prod, ok := lookupIndexed(index, schemaIndexKey("PROD", "PUBLIC"))
+		require.True(t, ok)
+		assert.Equal(t, "SYSADMIN", prod.Owner)
+
+		staging, ok := lookupIndexed(index, schemaIndexKey("STAGING", "PUBLIC"))
+		require.True(t, ok)
+		assert.Equal(t, "DEVELOPER", staging.Owner)
+	})
+
+	t.Run("a row missing either coordinate is dropped", func(t *testing.T) {
+		assert.Len(t, index, 2)
+	})
+
+	t.Run("a schema in an unlisted database is a miss", func(t *testing.T) {
+		_, ok := lookupIndexed(index, schemaIndexKey("ARCHIVE", "PUBLIC"))
+		assert.False(t, ok)
+	})
+}
+
+func TestBuildWarehouseIndex(t *testing.T) {
+	index := buildWarehouseIndex([]sdk.Warehouse{
+		{Name: "COMPUTE_WH", Owner: "SYSADMIN"},
+		{Name: ""},
+	})
+
+	wh, ok := lookupIndexed(index, warehouseIndexKey("COMPUTE_WH"))
+	require.True(t, ok)
+	assert.Equal(t, "SYSADMIN", wh.Owner)
+
+	assert.Len(t, index, 1)
+
+	_, ok = lookupIndexed(index, warehouseIndexKey("ABSENT_WH"))
+	assert.False(t, ok)
+}
+
+func TestLookupIndexed(t *testing.T) {
+	t.Run("a nil index misses instead of panicking", func(t *testing.T) {
+		// This is the shape of an index whose listing failed: nothing was built,
+		// so every lookup has to fall through to the per-item path.
+		var index map[string]sdk.Database
+		_, ok := lookupIndexed(index, "PROD")
+		assert.False(t, ok)
+	})
+
+	t.Run("an empty key misses", func(t *testing.T) {
+		index := map[string]sdk.Database{"": {Name: "surprise"}}
+		_, ok := lookupIndexed(index, "")
+		assert.False(t, ok)
+	})
+
+	t.Run("a miss returns the zero value", func(t *testing.T) {
+		index := map[string]sdk.Database{"PROD": {Name: "PROD"}}
+		db, ok := lookupIndexed(index, "ABSENT")
+		assert.False(t, ok)
+		assert.Equal(t, sdk.Database{}, db)
+	})
+}
+
+// TestMemoIndex covers the memo the account indexes are built on. MQL evaluates
+// blocks in goroutines, so many resources reach the same index at once; the
+// listing must run once and every reader must observe the same map and the same
+// error.
+func TestMemoIndex(t *testing.T) {
+	t.Run("a successful listing runs once and is shared", func(t *testing.T) {
+		var (
+			memo  memoIndex[sdk.Database]
+			calls atomic.Int64
+		)
+		build := func() (map[string]sdk.Database, error) {
+			calls.Add(1)
+			return buildDatabaseIndex([]sdk.Database{{Name: "PROD"}}), nil
+		}
+
+		results := make([]map[string]sdk.Database, 32)
+		var wg sync.WaitGroup
+		for i := range results {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				got, err := memo.get(build)
+				assert.NoError(t, err)
+				results[i] = got
+			}(i)
+		}
+		wg.Wait()
+
+		assert.Equal(t, int64(1), calls.Load())
+		for i := range results {
+			_, ok := lookupIndexed(results[i], databaseIndexKey("PROD"))
+			assert.True(t, ok)
+		}
+	})
+
+	t.Run("a failed listing is memoized, not retried per reader", func(t *testing.T) {
+		var (
+			memo  memoIndex[sdk.Database]
+			calls atomic.Int64
+		)
+		build := func() (map[string]sdk.Database, error) {
+			calls.Add(1)
+			return nil, assert.AnError
+		}
+
+		var wg sync.WaitGroup
+		for range 32 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				got, err := memo.get(build)
+				assert.Error(t, err)
+				// A failed listing leaves a nil index, which every lookup has to
+				// treat as a miss so the caller falls back.
+				_, ok := lookupIndexed(got, databaseIndexKey("PROD"))
+				assert.False(t, ok)
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(t, int64(1), calls.Load())
+	})
+}

--- a/providers/snowflake/resources/parameters.go
+++ b/providers/snowflake/resources/parameters.go
@@ -21,6 +21,8 @@ import (
 //
 // SHOW PARAMETERS backs parameters and networkPolicy. The grant cache and the
 // role and user name indexes back the role hierarchy walks; see role_graph.go.
+// The database, schema, and warehouse indexes back the references other
+// resources hold to those objects; see object_index.go.
 type mqlSnowflakeAccountInternal struct {
 	parametersOnce      sync.Once
 	cachedParameters    []*sdk.Parameter
@@ -36,6 +38,10 @@ type mqlSnowflakeAccountInternal struct {
 	userIndexOnce      sync.Once
 	cachedUserIndex    map[string]sdk.User
 	cachedUserIndexErr error
+
+	cachedDatabaseIndex  memoIndex[sdk.Database]
+	cachedSchemaIndex    memoIndex[sdk.Schema]
+	cachedWarehouseIndex memoIndex[sdk.Warehouse]
 }
 
 // showAccountParameters fetches the account-level parameters from Snowflake,

--- a/providers/snowflake/resources/schemas.go
+++ b/providers/snowflake/resources/schemas.go
@@ -60,10 +60,17 @@ func initSnowflakeSchema(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 // resolveSchemaRef returns the typed schema a database/name pair refers to, or a
 // null resource when either coordinate is empty. Shared by the row-access-policy
 // and network-rule resources.
+//
+// The account's schema index answers this without a statement. Anything the
+// index cannot answer, including an index that could not be read at all, falls
+// through to the per-name lookup in initSnowflakeSchema.
 func resolveSchemaRef(runtime *plugin.Runtime, databaseName, schemaName string, field *plugin.TValue[*mqlSnowflakeSchema]) (*mqlSnowflakeSchema, error) {
 	if databaseName == "" || schemaName == "" {
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+	if schema, ok := indexedSchema(runtime, databaseName, schemaName); ok {
+		return newMqlSnowflakeSchema(runtime, schema)
 	}
 	res, err := NewResource(runtime, "snowflake.schema", map[string]*llx.RawData{
 		"databaseName": llx.StringData(databaseName),

--- a/providers/snowflake/resources/warehouse.go
+++ b/providers/snowflake/resources/warehouse.go
@@ -54,9 +54,17 @@ func initSnowflakeWarehouse(runtime *plugin.Runtime, args map[string]*llx.RawDat
 // error) when no such warehouse is listable (dropped, or not visible to the
 // caller). Callers treat a nil result as a null typed reference rather than
 // failing the query.
+//
+// The account's warehouse index answers this without a statement. Anything the
+// index cannot answer, including an index that could not be read at all, falls
+// through to the SHOW WAREHOUSES LIKE below, so a name the index misses is
+// still confirmed against Snowflake before it is reported as absent.
 func snowflakeWarehouseByName(runtime *plugin.Runtime, name string) (*mqlSnowflakeWarehouse, error) {
 	if name == "" {
 		return nil, nil
+	}
+	if warehouse, ok := indexedWarehouse(runtime, name); ok {
+		return newMqlSnowflakeWarehouse(runtime, warehouse)
 	}
 	conn := runtime.Connection.(*connection.SnowflakeConnection)
 	warehouses, err := conn.Client().Warehouses.Show(context.Background(), &sdk.ShowWarehouseOptions{Like: &sdk.Like{Pattern: sdk.String(name)}})


### PR DESCRIPTION
## The bug

`NewResource` runs a resource's `Init` **before** the runtime cache is consulted, and each `init` issues a live SQL statement. Every reference to a database, schema, or warehouse therefore costs **one SQL round trip per referencing object**, not one per distinct target.

```
snowflake.account.tables { database { owner } }
```

On a 2,000-table account that is **2,000 `SHOW DATABASES LIKE` statements** against the same handful of databases. This is shipped behavior. The fan-out is wide: `resolveDatabaseRef` has 15 callers, `resolveSchemaRef` 13, the warehouse resolvers 6.

## The fix

Extend the pattern the provider already has. `roleIndex()` / `userIndex()` in `role_graph.go` build one account-wide listing, memoized on the singleton account resource together with its error so a failed read is not retried per item. This adds the same for the three high fan-out targets:

| Resolver | Was | Now |
|---|---|---|
| `resolveDatabaseRef` | `SHOW DATABASES LIKE` per object | one `SHOW DATABASES` for the scan |
| `resolveSchemaRef` | `SHOW SCHEMAS ... IN DATABASE` per object | one `SHOW SCHEMAS IN ACCOUNT` for the scan |
| `snowflakeWarehouseByName` | `SHOW WAREHOUSES LIKE` per object | one `SHOW WAREHOUSES` for the scan |

The 2,000 statements in the example above become **1**.

### Identifier normalization

Keys go through the SDK's identifier types on **both** the build and the lookup side, never string concatenation:

- databases / warehouses: `sdk.NewAccountObjectIdentifier(name).Name()` — a quoted identifier keys the same as a bare one
- schemas: `sdk.NewDatabaseObjectIdentifier(db, name).FullyQualifiedName()` — `PUBLIC` exists in every database, so the key has to stay qualified, and the quoted form means a dot inside a name cannot collide with a different split

Getting this wrong would mean the index misses every time and the account pays a full listing *on top of* the per-item call — strictly worse. It is covered by tests.

### A miss is never an answer

Four things are all treated as a MISS that **falls through to the existing `NewResource` path unchanged**:

- the index could not be read (permissions, transport)
- the index is nil
- the name is empty
- the name is simply not present

So an unreadable or out-of-scope reference cannot be converted into a confident null — the change is strictly monotonic: **same answers, fewer statements**. This also covers the `SHOW` row cap: on an account large enough to truncate a listing, the missing names fall back to the lookup that was there before.

Every resolver's existing null discipline (`plugin.StateIsSet | plugin.StateIsNull` on the empty path) is untouched, and nothing is pulled out of a cached collection with a bare type assertion.

## Deliberately skipped: tables and stages

`resolveTableRef`, `resolveTableRefByFQN`, and `resolveStageRef` are left as they are.

1. **Low fan-out.** One caller each — a materialized view's source table, a stream's table, an external table's stage — against 15 and 13 for databases and schemas.
2. **The per-item lookup is already cheap.** They are scoped with `IN SCHEMA` plus `LIKE`, unlike `SHOW DATABASES LIKE`, which is account-wide anyway and so costs the same as the listing that replaces it.
3. **The index would be the expensive half.** An account-wide `SHOW TABLES` / `SHOW STAGES` walks every schema in the account. For a query touching one table that is more work than the lookup it replaces, and on an account big enough for the row cap to bite it would be paid *on top of* the fallbacks.

## Why this lands first

An audit of this provider also proposed ~52 typed accessors, including spreading `database()` / `schema()` to 13 more resources and an `ownerRole()` sweep across 12. **None of that is in this PR.** This fix is its prerequisite: adding those accessors before this lands would multiply the existing N+1 by roughly 13x.

## Verification

Run from inside `providers/snowflake/` (its own Go module):

```
$ go build ./...
(no output)

$ go test ./...
?   	go.mondoo.com/mql/v13/providers/snowflake	[no test files]
?   	go.mondoo.com/mql/v13/providers/snowflake/config	[no test files]
ok  	go.mondoo.com/mql/v13/providers/snowflake/connection	1.670s
?   	go.mondoo.com/mql/v13/providers/snowflake/gen	[no test files]
ok  	go.mondoo.com/mql/v13/providers/snowflake/provider	2.658s
ok  	go.mondoo.com/mql/v13/providers/snowflake/resources	2.544s

$ go test -race ./...
ok  	go.mondoo.com/mql/v13/providers/snowflake/connection	2.658s
ok  	go.mondoo.com/mql/v13/providers/snowflake/provider	2.797s
ok  	go.mondoo.com/mql/v13/providers/snowflake/resources	3.046s

$ go mod tidy   # no diff to go.mod / go.sum
$ gofmt -l .    # clean
```

New tests in `resources/object_index_test.go` cover index build and lookup: bare vs quoted identifiers, case preserved rather than folded (a differently cased name is a miss that falls back, not a wrong hit), qualified schema keys, a dot inside a name, empty names dropped rather than keyed empty, a nil index, an errored index memoized rather than retried, and 32 concurrent readers sharing one build.

No `.lr`, `.lr.go`, or `.lr.versions` change — this is behavior-preserving.
