### PR TITLE
⭐ nutanix: resolve four reference ids the list responses already carry

### DIFF
--- a/providers/nutanix/resources/image.go
+++ b/providers/nutanix/resources/image.go
@@ -33,7 +33,50 @@ func newMqlImage(runtime *plugin.Runtime, img *vmmcontent.Image) (*mqlNutanixIma
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlNutanixImage), nil
+	mqlImage := res.(*mqlNutanixImage)
+	mqlImage.cacheClusterIds = img.ClusterLocationExtIds
+	if img.OwnerExtId != nil {
+		mqlImage.cacheOwnerId = *img.OwnerExtId
+	}
+	return mqlImage, nil
+}
+
+type mqlNutanixImageInternal struct {
+	cacheClusterIds []string
+	cacheOwnerId    string
+}
+
+func (a *mqlNutanixImage) clusters() ([]any, error) {
+	res := []any{}
+	for _, clusterID := range a.cacheClusterIds {
+		if clusterID == "" {
+			continue
+		}
+		cluster, err := clusterByID(a.MqlRuntime, clusterID)
+		if err != nil {
+			return nil, err
+		}
+		if cluster == nil {
+			continue
+		}
+		res = append(res, cluster)
+	}
+	return res, nil
+}
+
+func (a *mqlNutanixImage) owner() (*mqlNutanixIamUser, error) {
+	if a.cacheOwnerId == "" {
+		a.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := userByID(a.MqlRuntime, a.cacheOwnerId)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		a.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
 }
 
 func listImages(conn *connection.NutanixConnection) ([]vmmcontent.Image, error) {

--- a/providers/nutanix/resources/network.go
+++ b/providers/nutanix/resources/network.go
@@ -85,11 +85,32 @@ func newMqlVpc(runtime *plugin.Runtime, v *netconfig.Vpc) (*mqlNutanixNetworkVpc
 	}
 	mqlVpc := res.(*mqlNutanixNetworkVpc)
 	mqlVpc.cacheOwnerId = ownerId
+	for i := range v.ExternalSubnets {
+		if ref := v.ExternalSubnets[i].SubnetReference; ref != nil && *ref != "" {
+			mqlVpc.cacheExternalSubnetIds = append(mqlVpc.cacheExternalSubnetIds, *ref)
+		}
+	}
 	return mqlVpc, nil
 }
 
 type mqlNutanixNetworkVpcInternal struct {
-	cacheOwnerId string
+	cacheOwnerId           string
+	cacheExternalSubnetIds []string
+}
+
+func (a *mqlNutanixNetworkVpc) externalSubnets() ([]any, error) {
+	res := []any{}
+	for _, subnetID := range a.cacheExternalSubnetIds {
+		subnet, err := subnetByID(a.MqlRuntime, subnetID)
+		if err != nil {
+			return nil, err
+		}
+		if subnet == nil {
+			continue
+		}
+		res = append(res, subnet)
+	}
+	return res, nil
 }
 
 func (a *mqlNutanixNetworkVpc) owner() (*mqlNutanixIamUser, error) {

--- a/providers/nutanix/resources/nutanix.go
+++ b/providers/nutanix/resources/nutanix.go
@@ -651,28 +651,40 @@ func (a *mqlNutanixClusterNode) host() (*mqlNutanixHost, error) {
 		a.Host.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	if h, ok := cachedResource[*mqlNutanixHost](a.MqlRuntime, "nutanix.host", a.cacheNodeUuid); ok {
+	res, err := hostByID(a.MqlRuntime, a.cacheClusterId, a.cacheNodeUuid)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		a.Host.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
+// hostByID resolves a host by the pair of identifiers the clustermgmt API
+// needs, the external UUID of the owning cluster and the external UUID of the
+// host itself, returning the cached resource when it was already created
+// during this scan. A nil result means the host could not be found.
+func hostByID(runtime *plugin.Runtime, clusterID, hostID string) (*mqlNutanixHost, error) {
+	if h, ok := cachedResource[*mqlNutanixHost](runtime, "nutanix.host", hostID); ok {
 		return h, nil
 	}
-	conn := a.MqlRuntime.Connection.(*connection.NutanixConnection)
-	clusterID, nodeUUID := a.cacheClusterId, a.cacheNodeUuid
+	conn := runtime.Connection.(*connection.NutanixConnection)
 	resp, err := guard(conn.CmgMu(), func() (*clustermgmtconfig.GetHostApiResponse, error) {
-		return conn.ClustersApi().GetHostById(&clusterID, &nodeUUID)
+		return conn.ClustersApi().GetHostById(&clusterID, &hostID)
 	})
 	if err != nil {
 		return nil, err
 	}
 	data := resp.GetData()
 	if data == nil {
-		a.Host.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	host, ok := data.(clustermgmtconfig.Host)
 	if !ok {
-		a.Host.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return newMqlHost(a.MqlRuntime, &host)
+	return newMqlHost(runtime, &host)
 }
 
 func newMqlHost(runtime *plugin.Runtime, h *clustermgmtconfig.Host) (*mqlNutanixHost, error) {
@@ -1452,28 +1464,14 @@ func (a *mqlNutanixVm) host() (*mqlNutanixHost, error) {
 		a.Host.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	if h, ok := cachedResource[*mqlNutanixHost](a.MqlRuntime, "nutanix.host", a.hostExtId); ok {
-		return h, nil
-	}
-	conn := a.MqlRuntime.Connection.(*connection.NutanixConnection)
-	clusterID, hostID := a.clusterExtId, a.hostExtId
-	resp, err := guard(conn.CmgMu(), func() (*clustermgmtconfig.GetHostApiResponse, error) {
-		return conn.ClustersApi().GetHostById(&clusterID, &hostID)
-	})
+	res, err := hostByID(a.MqlRuntime, a.clusterExtId, a.hostExtId)
 	if err != nil {
 		return nil, err
 	}
-	data := resp.GetData()
-	if data == nil {
+	if res == nil {
 		a.Host.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
 	}
-	host, ok := data.(clustermgmtconfig.Host)
-	if !ok {
-		a.Host.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	return newMqlHost(a.MqlRuntime, &host)
+	return res, nil
 }
 
 func clusterByID(runtime *plugin.Runtime, clusterID string) (*mqlNutanixCluster, error) {

--- a/providers/nutanix/resources/nutanix.lr
+++ b/providers/nutanix/resources/nutanix.lr
@@ -405,6 +405,14 @@ private nutanix.image @defaults("id name type") {
   sizeBytes int
   // When the image was created
   createTime time
+  // Clusters the image is placed on
+  //
+  // Clusters that hold a copy of the image. An image with no cluster
+  // placements is registered in Prism Central but cannot back a disk on any
+  // cluster, so the list is empty for such images.
+  clusters() []nutanix.cluster
+  // Owner of the image
+  owner() nutanix.iam.user
 }
 
 // Nutanix virtual machine
@@ -912,6 +920,13 @@ private nutanix.network.vpc @defaults("name vpcType") {
   projectName string
   // Owner of the VPC
   owner() nutanix.iam.user
+  // External subnets the VPC is attached to
+  //
+  // Subnets that carry traffic between the VPC and networks outside it. Their
+  // isNatEnabled field tells you whether that egress is source-NATed or
+  // routed with the VPC's own addresses, so a VPC attached to an external
+  // subnet with NAT disabled exposes its internal prefixes directly.
+  externalSubnets() []nutanix.network.subnet
 }
 
 // Nutanix subnet
@@ -1069,6 +1084,12 @@ private nutanix.storage.container @defaults("name replicationFactor isEncrypted"
   cluster() nutanix.cluster
   // Owner of the storage container
   owner() nutanix.iam.user
+  // Host the container is pinned to
+  //
+  // Host that holds the single copy of the container's data when the
+  // replication factor is 1. Null for containers with a replication factor
+  // above 1, which are not pinned to a host.
+  affinityHost() nutanix.host
 }
 
 // Nutanix volume group

--- a/providers/nutanix/resources/nutanix.lr.go
+++ b/providers/nutanix/resources/nutanix.lr.go
@@ -635,6 +635,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nutanix.image.createTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixImage).GetCreateTime()).ToDataRes(types.Time)
 	},
+	"nutanix.image.clusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNutanixImage).GetClusters()).ToDataRes(types.Array(types.Resource("nutanix.cluster")))
+	},
+	"nutanix.image.owner": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNutanixImage).GetOwner()).ToDataRes(types.Resource("nutanix.iam.user"))
+	},
 	"nutanix.vm.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixVm).GetId()).ToDataRes(types.String)
 	},
@@ -1151,6 +1157,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nutanix.network.vpc.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixNetworkVpc).GetOwner()).ToDataRes(types.Resource("nutanix.iam.user"))
 	},
+	"nutanix.network.vpc.externalSubnets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNutanixNetworkVpc).GetExternalSubnets()).ToDataRes(types.Array(types.Resource("nutanix.network.subnet")))
+	},
 	"nutanix.network.subnet.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixNetworkSubnet).GetId()).ToDataRes(types.String)
 	},
@@ -1324,6 +1333,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"nutanix.storage.container.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixStorageContainer).GetOwner()).ToDataRes(types.Resource("nutanix.iam.user"))
+	},
+	"nutanix.storage.container.affinityHost": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNutanixStorageContainer).GetAffinityHost()).ToDataRes(types.Resource("nutanix.host"))
 	},
 	"nutanix.storage.volumeGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNutanixStorageVolumeGroup).GetId()).ToDataRes(types.String)
@@ -1974,6 +1986,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"nutanix.image.createTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNutanixImage).CreateTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"nutanix.image.clusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNutanixImage).Clusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"nutanix.image.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNutanixImage).Owner, ok = plugin.RawToTValue[*mqlNutanixIamUser](v.Value, v.Error)
 		return
 	},
 	"nutanix.vm.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2716,6 +2736,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlNutanixNetworkVpc).Owner, ok = plugin.RawToTValue[*mqlNutanixIamUser](v.Value, v.Error)
 		return
 	},
+	"nutanix.network.vpc.externalSubnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNutanixNetworkVpc).ExternalSubnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"nutanix.network.subnet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNutanixNetworkSubnet).__id, ok = v.Value.(string)
 		return
@@ -2958,6 +2982,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"nutanix.storage.container.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNutanixStorageContainer).Owner, ok = plugin.RawToTValue[*mqlNutanixIamUser](v.Value, v.Error)
+		return
+	},
+	"nutanix.storage.container.affinityHost": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNutanixStorageContainer).AffinityHost, ok = plugin.RawToTValue[*mqlNutanixHost](v.Value, v.Error)
 		return
 	},
 	"nutanix.storage.volumeGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4378,7 +4406,7 @@ func (c *mqlNutanixHostDisk) GetStorageTier() *plugin.TValue[string] {
 type mqlNutanixImage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlNutanixImageInternal it will be used here
+	mqlNutanixImageInternal
 	Id          plugin.TValue[string]
 	TenantId    plugin.TValue[string]
 	Name        plugin.TValue[string]
@@ -4386,6 +4414,8 @@ type mqlNutanixImage struct {
 	Type        plugin.TValue[string]
 	SizeBytes   plugin.TValue[int64]
 	CreateTime  plugin.TValue[*time.Time]
+	Clusters    plugin.TValue[[]any]
+	Owner       plugin.TValue[*mqlNutanixIamUser]
 }
 
 // createNutanixImage creates a new instance of this resource
@@ -4446,6 +4476,38 @@ func (c *mqlNutanixImage) GetSizeBytes() *plugin.TValue[int64] {
 
 func (c *mqlNutanixImage) GetCreateTime() *plugin.TValue[*time.Time] {
 	return &c.CreateTime
+}
+
+func (c *mqlNutanixImage) GetClusters() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Clusters, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nutanix.image", c.__id, "clusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.clusters()
+	})
+}
+
+func (c *mqlNutanixImage) GetOwner() *plugin.TValue[*mqlNutanixIamUser] {
+	return plugin.GetOrCompute[*mqlNutanixIamUser](&c.Owner, func() (*mqlNutanixIamUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nutanix.image", c.__id, "owner")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlNutanixIamUser), nil
+			}
+		}
+
+		return c.owner()
+	})
 }
 
 // mqlNutanixVm for the nutanix.vm resource
@@ -5919,6 +5981,7 @@ type mqlNutanixNetworkVpc struct {
 	ProjectId                      plugin.TValue[string]
 	ProjectName                    plugin.TValue[string]
 	Owner                          plugin.TValue[*mqlNutanixIamUser]
+	ExternalSubnets                plugin.TValue[[]any]
 }
 
 // createNutanixNetworkVpc creates a new instance of this resource
@@ -6006,6 +6069,22 @@ func (c *mqlNutanixNetworkVpc) GetOwner() *plugin.TValue[*mqlNutanixIamUser] {
 		}
 
 		return c.owner()
+	})
+}
+
+func (c *mqlNutanixNetworkVpc) GetExternalSubnets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ExternalSubnets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nutanix.network.vpc", c.__id, "externalSubnets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.externalSubnets()
 	})
 }
 
@@ -6358,6 +6437,7 @@ type mqlNutanixStorageContainer struct {
 	TenantId                             plugin.TValue[string]
 	Cluster                              plugin.TValue[*mqlNutanixCluster]
 	Owner                                plugin.TValue[*mqlNutanixIamUser]
+	AffinityHost                         plugin.TValue[*mqlNutanixHost]
 }
 
 // createNutanixStorageContainer creates a new instance of this resource
@@ -6509,6 +6589,22 @@ func (c *mqlNutanixStorageContainer) GetOwner() *plugin.TValue[*mqlNutanixIamUse
 		}
 
 		return c.owner()
+	})
+}
+
+func (c *mqlNutanixStorageContainer) GetAffinityHost() *plugin.TValue[*mqlNutanixHost] {
+	return plugin.GetOrCompute[*mqlNutanixHost](&c.AffinityHost, func() (*mqlNutanixHost, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nutanix.storage.container", c.__id, "affinityHost")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlNutanixHost), nil
+			}
+		}
+
+		return c.affinityHost()
 	})
 }
 

--- a/providers/nutanix/resources/nutanix.lr.versions
+++ b/providers/nutanix/resources/nutanix.lr.versions
@@ -210,10 +210,12 @@ nutanix.iam.user.tenantId 13.1.4
 nutanix.iam.user.userType 13.0.0
 nutanix.iam.user.username 13.0.0
 nutanix.image 13.1.4
+nutanix.image.clusters 13.3.4
 nutanix.image.createTime 13.1.4
 nutanix.image.description 13.1.4
 nutanix.image.id 13.1.4
 nutanix.image.name 13.1.4
+nutanix.image.owner 13.3.4
 nutanix.image.sizeBytes 13.1.4
 nutanix.image.tenantId 13.1.4
 nutanix.image.type 13.1.4
@@ -257,6 +259,7 @@ nutanix.network.subnet.vpc 13.0.0
 nutanix.network.vpc 13.0.0
 nutanix.network.vpc.description 13.0.0
 nutanix.network.vpc.externalRoutingDomainReference 13.0.0
+nutanix.network.vpc.externalSubnets 13.3.4
 nutanix.network.vpc.externallyRoutablePrefixes 13.0.0
 nutanix.network.vpc.id 13.0.0
 nutanix.network.vpc.name 13.0.0
@@ -269,6 +272,7 @@ nutanix.network.vpc.vpcType 13.0.0
 nutanix.roles 13.0.0
 nutanix.samlIdentityProviders 13.0.0
 nutanix.storage.container 13.0.0
+nutanix.storage.container.affinityHost 13.3.4
 nutanix.storage.container.cacheDeduplication 13.0.0
 nutanix.storage.container.cluster 13.0.0
 nutanix.storage.container.compressionDelaySecs 13.0.0

--- a/providers/nutanix/resources/references_test.go
+++ b/providers/nutanix/resources/references_test.go
@@ -1,0 +1,347 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	clustermgmtconfig "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	netconfig "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
+	vmmcontent "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// ---------------------------------------------------------------------------
+// nutanix.image
+// ---------------------------------------------------------------------------
+
+func TestNewMqlImageCachesReferences(t *testing.T) {
+	runtime := newTestRuntime()
+
+	img, err := newMqlImage(runtime, &vmmcontent.Image{
+		ExtId:                 sp("image-1"),
+		Name:                  sp("ubuntu-22.04"),
+		ClusterLocationExtIds: []string{"cluster-a", "cluster-b"},
+		OwnerExtId:            sp("owner-1"),
+	})
+	if err != nil {
+		t.Fatalf("newMqlImage returned error: %v", err)
+	}
+	if got, want := len(img.cacheClusterIds), 2; got != want {
+		t.Fatalf("cacheClusterIds len = %d, want %d", got, want)
+	}
+	if img.cacheClusterIds[0] != "cluster-a" || img.cacheClusterIds[1] != "cluster-b" {
+		t.Errorf("cacheClusterIds = %v, want [cluster-a cluster-b]", img.cacheClusterIds)
+	}
+	if img.cacheOwnerId != "owner-1" {
+		t.Errorf("cacheOwnerId = %q, want owner-1", img.cacheOwnerId)
+	}
+}
+
+// An image with no owner and no cluster placements must decode to the safe
+// reading: no cached ids at all, so neither accessor invents a reference.
+func TestNewMqlImageAbsentReferences(t *testing.T) {
+	runtime := newTestRuntime()
+
+	img, err := newMqlImage(runtime, &vmmcontent.Image{
+		ExtId: sp("image-2"),
+		Name:  sp("no-placement"),
+	})
+	if err != nil {
+		t.Fatalf("newMqlImage returned error: %v", err)
+	}
+	if len(img.cacheClusterIds) != 0 {
+		t.Errorf("cacheClusterIds = %v, want empty", img.cacheClusterIds)
+	}
+	if img.cacheOwnerId != "" {
+		t.Errorf("cacheOwnerId = %q, want empty", img.cacheOwnerId)
+	}
+}
+
+// clusters() on an image with no placements returns an empty list without
+// reaching for the connection, which is nil on the test runtime: a lookup
+// attempt would panic here rather than pass.
+func TestImageClustersWithoutPlacements(t *testing.T) {
+	img := &mqlNutanixImage{MqlRuntime: newTestRuntime()}
+
+	got, err := img.clusters()
+	if err != nil {
+		t.Fatalf("clusters returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("clusters = %v, want empty", got)
+	}
+}
+
+// An empty string inside the placement list is not a cluster; resolving it
+// would issue a GET for the empty id.
+func TestImageClustersSkipsEmptyIDs(t *testing.T) {
+	img := &mqlNutanixImage{MqlRuntime: newTestRuntime()}
+	img.cacheClusterIds = []string{"", ""}
+
+	got, err := img.clusters()
+	if err != nil {
+		t.Fatalf("clusters returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("clusters = %v, want empty", got)
+	}
+}
+
+func TestImageClustersResolvesFromCache(t *testing.T) {
+	runtime := newTestRuntime()
+	seedResource(t, runtime, "nutanix.cluster", "cluster-a")
+	seedResource(t, runtime, "nutanix.cluster", "cluster-b")
+
+	img := &mqlNutanixImage{MqlRuntime: runtime}
+	img.cacheClusterIds = []string{"cluster-a", "cluster-b"}
+
+	got, err := img.clusters()
+	if err != nil {
+		t.Fatalf("clusters returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("clusters len = %d, want 2", len(got))
+	}
+	for i, want := range []string{"cluster-a", "cluster-b"} {
+		cluster, ok := got[i].(*mqlNutanixCluster)
+		if !ok {
+			t.Fatalf("clusters[%d] is %T, want *mqlNutanixCluster", i, got[i])
+		}
+		if cluster.MqlID() != want {
+			t.Errorf("clusters[%d] id = %q, want %q", i, cluster.MqlID(), want)
+		}
+	}
+}
+
+func TestImageOwnerAbsentIsNull(t *testing.T) {
+	img := &mqlNutanixImage{MqlRuntime: newTestRuntime()}
+
+	got, err := img.owner()
+	if err != nil {
+		t.Fatalf("owner returned error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("owner = %v, want nil", got)
+	}
+	assertNullState(t, "image.owner", img.Owner.State)
+}
+
+func TestImageOwnerResolvesFromCache(t *testing.T) {
+	runtime := newTestRuntime()
+	seedResource(t, runtime, "nutanix.iam.user", "owner-1")
+
+	img := &mqlNutanixImage{MqlRuntime: runtime}
+	img.cacheOwnerId = "owner-1"
+
+	got, err := img.owner()
+	if err != nil {
+		t.Fatalf("owner returned error: %v", err)
+	}
+	if got == nil || got.MqlID() != "owner-1" {
+		t.Fatalf("owner = %v, want the cached user owner-1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// nutanix.network.vpc
+// ---------------------------------------------------------------------------
+
+func TestNewMqlVpcCachesExternalSubnets(t *testing.T) {
+	runtime := newTestRuntime()
+
+	vpc, err := newMqlVpc(runtime, &netconfig.Vpc{
+		ExtId: sp("vpc-1"),
+		Name:  sp("prod"),
+		ExternalSubnets: []netconfig.ExternalSubnet{
+			{SubnetReference: sp("subnet-a")},
+			// A reference the API left out or blanked is not a subnet.
+			{SubnetReference: nil},
+			{SubnetReference: sp("")},
+			{SubnetReference: sp("subnet-b")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newMqlVpc returned error: %v", err)
+	}
+	if got, want := len(vpc.cacheExternalSubnetIds), 2; got != want {
+		t.Fatalf("cacheExternalSubnetIds = %v, want %d entries", vpc.cacheExternalSubnetIds, want)
+	}
+	if vpc.cacheExternalSubnetIds[0] != "subnet-a" || vpc.cacheExternalSubnetIds[1] != "subnet-b" {
+		t.Errorf("cacheExternalSubnetIds = %v, want [subnet-a subnet-b]", vpc.cacheExternalSubnetIds)
+	}
+}
+
+func TestVpcExternalSubnetsWithoutAttachments(t *testing.T) {
+	vpc := &mqlNutanixNetworkVpc{MqlRuntime: newTestRuntime()}
+
+	got, err := vpc.externalSubnets()
+	if err != nil {
+		t.Fatalf("externalSubnets returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("externalSubnets = %v, want empty", got)
+	}
+}
+
+func TestVpcExternalSubnetsResolveFromCache(t *testing.T) {
+	runtime := newTestRuntime()
+	seedResource(t, runtime, "nutanix.network.subnet", "subnet-a")
+
+	vpc := &mqlNutanixNetworkVpc{MqlRuntime: runtime}
+	vpc.cacheExternalSubnetIds = []string{"subnet-a"}
+
+	got, err := vpc.externalSubnets()
+	if err != nil {
+		t.Fatalf("externalSubnets returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("externalSubnets len = %d, want 1", len(got))
+	}
+	subnet, ok := got[0].(*mqlNutanixNetworkSubnet)
+	if !ok {
+		t.Fatalf("externalSubnets[0] is %T, want *mqlNutanixNetworkSubnet", got[0])
+	}
+	if subnet.MqlID() != "subnet-a" {
+		t.Errorf("externalSubnets[0] id = %q, want subnet-a", subnet.MqlID())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// nutanix.storage.container
+// ---------------------------------------------------------------------------
+
+func TestNewMqlStorageContainerCachesAffinityHost(t *testing.T) {
+	runtime := newTestRuntime()
+
+	container, err := newMqlStorageContainer(runtime, &clustermgmtconfig.StorageContainer{
+		ExtId:             sp("container-1"),
+		Name:              sp("rf1"),
+		ClusterExtId:      sp("cluster-a"),
+		AffinityHostExtId: sp("host-1"),
+	})
+	if err != nil {
+		t.Fatalf("newMqlStorageContainer returned error: %v", err)
+	}
+	if container.cacheAffinityHostId != "host-1" {
+		t.Errorf("cacheAffinityHostId = %q, want host-1", container.cacheAffinityHostId)
+	}
+	if container.cacheClusterId != "cluster-a" {
+		t.Errorf("cacheClusterId = %q, want cluster-a", container.cacheClusterId)
+	}
+}
+
+// A container with a replication factor above 1 carries no affinity host; the
+// absent pointer must not turn into a lookup for the empty id.
+func TestNewMqlStorageContainerAbsentAffinityHost(t *testing.T) {
+	runtime := newTestRuntime()
+
+	container, err := newMqlStorageContainer(runtime, &clustermgmtconfig.StorageContainer{
+		ExtId:        sp("container-2"),
+		Name:         sp("rf2"),
+		ClusterExtId: sp("cluster-a"),
+	})
+	if err != nil {
+		t.Fatalf("newMqlStorageContainer returned error: %v", err)
+	}
+	if container.cacheAffinityHostId != "" {
+		t.Errorf("cacheAffinityHostId = %q, want empty", container.cacheAffinityHostId)
+	}
+
+	got, err := container.affinityHost()
+	if err != nil {
+		t.Fatalf("affinityHost returned error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("affinityHost = %v, want nil", got)
+	}
+	assertNullState(t, "storage.container.affinityHost", container.AffinityHost.State)
+}
+
+// The host lookup needs both halves of the key. A container whose cluster is
+// unknown cannot be resolved, and must report null rather than call the API
+// with an empty cluster id.
+func TestStorageContainerAffinityHostWithoutCluster(t *testing.T) {
+	container := &mqlNutanixStorageContainer{MqlRuntime: newTestRuntime()}
+	container.cacheAffinityHostId = "host-1"
+
+	got, err := container.affinityHost()
+	if err != nil {
+		t.Fatalf("affinityHost returned error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("affinityHost = %v, want nil", got)
+	}
+	assertNullState(t, "storage.container.affinityHost", container.AffinityHost.State)
+}
+
+func TestStorageContainerAffinityHostResolvesFromCache(t *testing.T) {
+	runtime := newTestRuntime()
+	seedResource(t, runtime, "nutanix.host", "host-1")
+
+	container := &mqlNutanixStorageContainer{MqlRuntime: runtime}
+	container.cacheClusterId = "cluster-a"
+	container.cacheAffinityHostId = "host-1"
+
+	got, err := container.affinityHost()
+	if err != nil {
+		t.Fatalf("affinityHost returned error: %v", err)
+	}
+	if got == nil || got.MqlID() != "host-1" {
+		t.Fatalf("affinityHost = %v, want the cached host host-1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hostByID
+// ---------------------------------------------------------------------------
+
+// hostByID takes (clusterID, hostID) because GetHostById needs both, but the
+// runtime cache is keyed on the host id alone. Seeding an entry under the
+// cluster id as well pins the argument order: swapping the two would return
+// the wrong host instead of failing loudly.
+func TestHostByIDCacheKeyIsTheHostID(t *testing.T) {
+	runtime := newTestRuntime()
+	seedResource(t, runtime, "nutanix.host", "host-1")
+	seedResource(t, runtime, "nutanix.host", "cluster-a")
+
+	got, err := hostByID(runtime, "cluster-a", "host-1")
+	if err != nil {
+		t.Fatalf("hostByID returned error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("hostByID = nil, want the cached host host-1")
+	}
+	if got.MqlID() != "host-1" {
+		t.Errorf("hostByID resolved %q, want host-1 (cluster and host ids are swapped)", got.MqlID())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// seedResource puts a resource of the given kind into the runtime cache under
+// the id, standing in for one built earlier in the scan.
+func seedResource(t *testing.T, runtime *plugin.Runtime, name, id string) {
+	t.Helper()
+	_, err := CreateResource(runtime, name, map[string]*llx.RawData{
+		"__id": llx.StringData(id),
+		"id":   llx.StringData(id),
+	})
+	if err != nil {
+		t.Fatalf("seeding %s %q: %v", name, id, err)
+	}
+}
+
+func assertNullState(t *testing.T, field string, state plugin.State) {
+	t.Helper()
+	if state&plugin.StateIsSet == 0 {
+		t.Errorf("%s: StateIsSet not set; the runtime would re-fetch the field", field)
+	}
+	if state&plugin.StateIsNull == 0 {
+		t.Errorf("%s: StateIsNull not set; a nil result would read as unset", field)
+	}
+}

--- a/providers/nutanix/resources/storage.go
+++ b/providers/nutanix/resources/storage.go
@@ -107,6 +107,9 @@ func newMqlStorageContainer(runtime *plugin.Runtime, c *clustermgmtconfig.Storag
 	if c.OwnerExtId != nil {
 		mqlContainer.cacheOwnerId = *c.OwnerExtId
 	}
+	if c.AffinityHostExtId != nil {
+		mqlContainer.cacheAffinityHostId = *c.AffinityHostExtId
+	}
 	return mqlContainer, nil
 }
 
@@ -144,8 +147,9 @@ func (a *mqlNutanixCluster) storageContainers() ([]any, error) {
 }
 
 type mqlNutanixStorageContainerInternal struct {
-	cacheClusterId string
-	cacheOwnerId   string
+	cacheClusterId      string
+	cacheOwnerId        string
+	cacheAffinityHostId string
 }
 
 func (a *mqlNutanixStorageContainer) owner() (*mqlNutanixIamUser, error) {
@@ -174,6 +178,21 @@ func (a *mqlNutanixStorageContainer) cluster() (*mqlNutanixCluster, error) {
 	}
 	if res == nil {
 		a.Cluster.State = plugin.StateIsSet | plugin.StateIsNull
+	}
+	return res, nil
+}
+
+func (a *mqlNutanixStorageContainer) affinityHost() (*mqlNutanixHost, error) {
+	if a.cacheAffinityHostId == "" || a.cacheClusterId == "" {
+		a.AffinityHost.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := hostByID(a.MqlRuntime, a.cacheClusterId, a.cacheAffinityHostId)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		a.AffinityHost.State = plugin.StateIsSet | plugin.StateIsNull
 	}
 	return res, nil
 }


### PR DESCRIPTION
All four of these values were already arriving in list responses the provider decodes, and the mapping code threw every one of them away. No new API surface is needed to expose them; this is reference data that was being fetched and discarded.

| Resource | SDK value dropped | New accessor |
|---|---|---|
| `nutanix.image` | `Image.ClusterLocationExtIds` | `clusters() []nutanix.cluster` |
| `nutanix.image` | `Image.OwnerExtId` | `owner() nutanix.iam.user` |
| `nutanix.network.vpc` | `Vpc.ExternalSubnets[].SubnetReference` | `externalSubnets() []nutanix.network.subnet` |
| `nutanix.storage.container` | `StorageContainer.AffinityHostExtId` | `affinityHost() nutanix.host` |

### The VPC case

A VPC's egress path runs through its external subnets, and whether that egress is source-NATed is a property of the subnet, not the VPC. Before, the subnet references were not in the schema at all, so the join could not be expressed in MQL: you had to list VPCs, list subnets separately, and correlate the two by hand outside the query.

Before:

```
# no way to get from a VPC to the subnets it egresses through
nutanix.vpcs { name snatIps externallyRoutablePrefixes }
```

After:

```
nutanix.vpcs.where(externalSubnets.any(isNatEnabled == false)) {
  name
  externallyRoutablePrefixes
  externalSubnets { name ipPrefix isNatEnabled }
}
```

### hostByID

`GetHostById` needs both the cluster id and the host id, and that two-argument lookup was written out inline twice, in `nutanix.vm.host` and `nutanix.cluster.node.host`. It is now a single `hostByID(runtime, clusterID, hostID)` helper next to the existing `clusterByID` / `userByID` / `subnetByID`, used by both original callers and by the new `affinityHost` accessor. The duplication is gone and the null-state handling now lives in one place per caller rather than being repeated on each of the helper's three miss paths.

### Notes

- Resolution goes through the existing `<thing>ByID` helpers, which check the runtime cache first. For images the cost is bounded by the number of distinct clusters: the first GET caches under `__id` and the rest are cache hits.
- New `.lr.versions` entries are at `13.3.4`, the next patch after the provider's current `13.3.3`. `config.go` is untouched.
- Unit tests cover the mapping and the null paths: an absent `OwnerExtId` and an absent `AffinityHostExtId` decode to the safe reading rather than a lookup for the empty id, an empty `ClusterLocationExtIds` yields an empty list without touching the API, a nil or blank `SubnetReference` is skipped, and `hostByID` keys the cache on the host id so a swap of its two arguments is caught.
