### PR TITLE
⭐ stackit: resolve volume encryption keys and IAM role bindings to their resources

### DIFF
--- a/providers/stackit/resources/helpers.go
+++ b/providers/stackit/resources/helpers.go
@@ -313,6 +313,58 @@ func volumeRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlStac
 	return res.(*mqlStackitVolume), nil
 }
 
+// kmsKeyRef resolves a Key Management Service key by its bare UUID, marking the
+// given field null when the ID is empty or the project holds no such key.
+//
+// The lookup goes through the project-wide key index on the stackit.kms
+// singleton rather than NewResource: stackit.kms.key has no init, and its cache
+// key is qualified by the key ring, so a bare UUID cannot address one. Reading
+// a denied key ring already degrades to an empty listing upstream, which lands
+// here as a null reference rather than an error.
+func kmsKeyRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlStackitKmsKey]) (*mqlStackitKmsKey, error) {
+	if id == "" {
+		return markNull[mqlStackitKmsKey](field)
+	}
+	k, err := kmsResource(runtime)
+	if err != nil {
+		return nil, err
+	}
+	idx, err := k.keyIndexByID()
+	if err != nil {
+		return nil, err
+	}
+	key, ok := idx[id]
+	if !ok || key == nil {
+		return markNull[mqlStackitKmsKey](field)
+	}
+	return key, nil
+}
+
+// iamRoleRef resolves a project role by name, marking the given field null when
+// the name is empty or the role catalog does not define it.
+//
+// The lookup goes through the role index on the stackit.iam singleton rather
+// than NewResource: stackit.iam.role has no init and roles are only ever
+// produced by listing the catalog.
+func iamRoleRef(runtime *plugin.Runtime, name string, field *plugin.TValue[*mqlStackitIamRole]) (*mqlStackitIamRole, error) {
+	if name == "" {
+		return markNull[mqlStackitIamRole](field)
+	}
+	i, err := iamResource(runtime)
+	if err != nil {
+		return nil, err
+	}
+	idx, err := i.roleIndexByName()
+	if err != nil {
+		return nil, err
+	}
+	role, ok := idx[name]
+	if !ok || role == nil {
+		return markNull[mqlStackitIamRole](field)
+	}
+	return role, nil
+}
+
 // volumeRefs resolves a list of stackit.volume resources from their UUIDs,
 // skipping empty IDs.
 func volumeRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -413,6 +413,39 @@ func (r *mqlStackitVolume) sourceBackup() (*mqlStackitBackup, error) {
 	return res.(*mqlStackitBackup), nil
 }
 
+// encryptionKey resolves the customer-managed key that wraps the volume's
+// data-encryption key. Null for a platform-managed volume.
+func (r *mqlStackitVolume) encryptionKey() (*mqlStackitKmsKey, error) {
+	return kmsKeyRef(r.MqlRuntime, r.EncryptionKeyId.Data, &r.EncryptionKey)
+}
+
+// encryptionKeyVersionRef resolves the exact generation of key material the
+// volume is pinned to, so a check can read that version's state rather than the
+// key's newest one. Version numbers start at 1, so 0 means nothing is pinned.
+func (r *mqlStackitVolume) encryptionKeyVersionRef() (*mqlStackitKmsKeyVersion, error) {
+	field := &r.EncryptionKeyVersionRef
+	number := r.EncryptionKeyVersion.Data
+	if number == 0 {
+		return markNull[mqlStackitKmsKeyVersion](field)
+	}
+	key := r.GetEncryptionKey()
+	if key.Error != nil {
+		return nil, key.Error
+	}
+	if key.Data == nil {
+		return markNull[mqlStackitKmsKeyVersion](field)
+	}
+	versions := key.Data.GetVersions()
+	if versions.Error != nil {
+		return nil, versions.Error
+	}
+	v := findKmsKeyVersion(versions.Data, number)
+	if v == nil {
+		return markNull[mqlStackitKmsKeyVersion](field)
+	}
+	return v, nil
+}
+
 // ------------------------- snapshots -------------------------
 
 func (r *mqlStackit) snapshots() ([]any, error) {

--- a/providers/stackit/resources/iam.go
+++ b/providers/stackit/resources/iam.go
@@ -4,12 +4,85 @@
 package resources
 
 import (
+	"errors"
+	"sync"
+
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 // Authorization API works against any STACKIT resource by type/id. For
 // the stackit provider we scope it to the configured project.
 const authResourceTypeProject = "project"
+
+// mqlStackitIamInternal memoizes the project role catalog indexed by name.
+// stackit.iam.role has no init and no by-name lookup: roles exist only as the
+// result of ListRoles. One such call covers the whole project, so it is made
+// once and every member binding resolves its role against the shared index
+// rather than issuing a lookup of its own.
+type mqlStackitIamInternal struct {
+	roleIndexLock  sync.Mutex
+	roleIndexBuilt bool
+	roleIndex      map[string]*mqlStackitIamRole
+	roleIndexErr   error
+}
+
+// iamResource returns the stackit.iam singleton for this project. Its id is
+// constant per project, so CreateResource hands back the one cached instance
+// and with it the shared role index.
+func iamResource(runtime *plugin.Runtime) (*mqlStackitIam, error) {
+	res, err := CreateResource(runtime, "stackit.iam", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	i, ok := res.(*mqlStackitIam)
+	if !ok {
+		return nil, errors.New("stackit: unexpected type for the stackit.iam resource")
+	}
+	return i, nil
+}
+
+// roleIndexByName builds (once) and returns the project's roles indexed by
+// name. The failure is memoized alongside the value so a broken catalog read is
+// not retried once per member binding.
+func (r *mqlStackitIam) roleIndexByName() (map[string]*mqlStackitIamRole, error) {
+	r.roleIndexLock.Lock()
+	defer r.roleIndexLock.Unlock()
+	if r.roleIndexBuilt {
+		return r.roleIndex, r.roleIndexErr
+	}
+	r.roleIndexBuilt = true
+
+	roles := r.GetRoles()
+	if roles.Error != nil {
+		r.roleIndexErr = roles.Error
+		return nil, r.roleIndexErr
+	}
+	r.roleIndex = indexIamRolesByName(roles.Data)
+	return r.roleIndex, nil
+}
+
+// indexIamRolesByName indexes role resources by their name, which is unique
+// within a project. Entries that are not roles, and roles without a name, are
+// skipped; the first role wins on a duplicate name.
+func indexIamRolesByName(items []any) map[string]*mqlStackitIamRole {
+	idx := make(map[string]*mqlStackitIamRole, len(items))
+	for _, item := range items {
+		role, ok := item.(*mqlStackitIamRole)
+		if !ok || role == nil {
+			continue
+		}
+		name := role.Name.Data
+		if name == "" {
+			continue
+		}
+		if _, seen := idx[name]; seen {
+			continue
+		}
+		idx[name] = role
+	}
+	return idx
+}
 
 func (r *mqlStackitIam) members() ([]any, error) {
 	c := conn(r.MqlRuntime)
@@ -39,6 +112,12 @@ func (r *mqlStackitIam) members() ([]any, error) {
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// roleDetails resolves the binding's role name against the project role
+// catalog, turning a member binding into the permissions it actually grants.
+func (r *mqlStackitIamMember) roleDetails() (*mqlStackitIamRole, error) {
+	return iamRoleRef(r.MqlRuntime, r.Role.Data, &r.RoleDetails)
 }
 
 func (r *mqlStackitIamMember) id() (string, error) {

--- a/providers/stackit/resources/kms.go
+++ b/providers/stackit/resources/kms.go
@@ -4,12 +4,116 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
+	"sync"
 
 	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+// mqlStackitKmsInternal memoizes the project-wide key index that backs every
+// reference to a KMS key from elsewhere in the schema. stackit.kms.key has no
+// init and its cache key is ring-qualified, so a bare key UUID (which is all a
+// volume records) cannot address one; the only way to resolve it is to walk the
+// key rings. Doing that per referencing resource would cost 1 + N_rings calls
+// each, so it is done once and shared through the stackit.kms singleton.
+type mqlStackitKmsInternal struct {
+	keyIndexLock  sync.Mutex
+	keyIndexBuilt bool
+	keyIndex      map[string]*mqlStackitKmsKey
+	keyIndexErr   error
+}
+
+// kmsResource returns the stackit.kms singleton for this project. Its id is
+// constant per project, so CreateResource hands back the one cached instance
+// and with it the shared key index.
+func kmsResource(runtime *plugin.Runtime) (*mqlStackitKms, error) {
+	res, err := CreateResource(runtime, "stackit.kms", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	k, ok := res.(*mqlStackitKms)
+	if !ok {
+		return nil, errors.New("stackit: unexpected type for the stackit.kms resource")
+	}
+	return k, nil
+}
+
+// keyIndexByID builds (once) and returns the project's keys indexed by UUID.
+// The failure is memoized alongside the value: a denied or broken key-ring read
+// would otherwise be retried once per referencing resource.
+func (r *mqlStackitKms) keyIndexByID() (map[string]*mqlStackitKmsKey, error) {
+	r.keyIndexLock.Lock()
+	defer r.keyIndexLock.Unlock()
+	if r.keyIndexBuilt {
+		return r.keyIndex, r.keyIndexErr
+	}
+	r.keyIndexBuilt = true
+
+	rings := r.GetKeyRings()
+	if rings.Error != nil {
+		r.keyIndexErr = rings.Error
+		return nil, r.keyIndexErr
+	}
+
+	keys := []any{}
+	for _, ring := range rings.Data {
+		kr, ok := ring.(*mqlStackitKmsKeyRing)
+		if !ok {
+			continue
+		}
+		ringKeys := kr.GetKeys()
+		if ringKeys.Error != nil {
+			r.keyIndexErr = ringKeys.Error
+			return nil, r.keyIndexErr
+		}
+		keys = append(keys, ringKeys.Data...)
+	}
+
+	r.keyIndex = indexKmsKeysByID(keys)
+	return r.keyIndex, nil
+}
+
+// indexKmsKeysByID indexes key resources by their bare UUID. Keys are addressed
+// by ring plus id in the KMS API, but the resources that reference a key record
+// only the UUID, so that is what the index has to be keyed on. Entries that are
+// not keys, and keys without an id, are skipped; the first key wins on the
+// (service-anomalous) chance that one UUID shows up under two rings.
+func indexKmsKeysByID(items []any) map[string]*mqlStackitKmsKey {
+	idx := make(map[string]*mqlStackitKmsKey, len(items))
+	for _, item := range items {
+		key, ok := item.(*mqlStackitKmsKey)
+		if !ok || key == nil {
+			continue
+		}
+		id := key.Id.Data
+		if id == "" {
+			continue
+		}
+		if _, seen := idx[id]; seen {
+			continue
+		}
+		idx[id] = key
+	}
+	return idx
+}
+
+// findKmsKeyVersion picks the generation with the given version number out of a
+// key's version list, or nil when the key never had that generation.
+func findKmsKeyVersion(items []any, number int64) *mqlStackitKmsKeyVersion {
+	for _, item := range items {
+		v, ok := item.(*mqlStackitKmsKeyVersion)
+		if !ok || v == nil {
+			continue
+		}
+		if v.Number.Data == number {
+			return v
+		}
+	}
+	return nil
+}
 
 func (r *mqlStackitKms) keyRings() ([]any, error) {
 	c := conn(r.MqlRuntime)

--- a/providers/stackit/resources/refindex_test.go
+++ b/providers/stackit/resources/refindex_test.go
@@ -1,0 +1,326 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// kmsKey builds a bare key resource the way a listing would, without needing a
+// runtime: the index only ever reads Id.
+func kmsKey(id, keyRingId string) *mqlStackitKmsKey {
+	return &mqlStackitKmsKey{
+		Id:        plugin.TValue[string]{Data: id, State: plugin.StateIsSet},
+		KeyRingId: plugin.TValue[string]{Data: keyRingId, State: plugin.StateIsSet},
+	}
+}
+
+func kmsKeyVersion(number int64) *mqlStackitKmsKeyVersion {
+	return &mqlStackitKmsKeyVersion{
+		Number: plugin.TValue[int64]{Data: number, State: plugin.StateIsSet},
+	}
+}
+
+func iamRole(name string) *mqlStackitIamRole {
+	return &mqlStackitIamRole{
+		Name: plugin.TValue[string]{Data: name, State: plugin.StateIsSet},
+	}
+}
+
+// setList marks a []any field as already computed so the generated getter
+// returns it without reaching for a connection.
+func setList(items []any) plugin.TValue[[]any] {
+	return plugin.TValue[[]any]{Data: items, State: plugin.StateIsSet}
+}
+
+func TestIndexKmsKeysByID(t *testing.T) {
+	const (
+		ringA = "ring-a"
+		ringB = "ring-b"
+		keyA  = "11111111-1111-1111-1111-111111111111"
+		keyB  = "22222222-2222-2222-2222-222222222222"
+	)
+
+	t.Run("keys from several rings land in one index", func(t *testing.T) {
+		a := kmsKey(keyA, ringA)
+		b := kmsKey(keyB, ringB)
+		idx := indexKmsKeysByID([]any{a, b})
+
+		if len(idx) != 2 {
+			t.Fatalf("index size = %d, want 2", len(idx))
+		}
+		// a volume records only the bare UUID, so the ring-qualified key must
+		// still be reachable by that UUID alone
+		if got := idx[keyB]; got != b {
+			t.Fatalf("idx[%q] = %v, want the ring-b key", keyB, got)
+		}
+		if got := idx[keyB]; got != nil && got.KeyRingId.Data != ringB {
+			t.Fatalf("idx[%q].KeyRingId = %q, want %q", keyB, got.KeyRingId.Data, ringB)
+		}
+	})
+
+	t.Run("miss returns nothing", func(t *testing.T) {
+		idx := indexKmsKeysByID([]any{kmsKey(keyA, ringA)})
+		if got, ok := idx["33333333-3333-3333-3333-333333333333"]; ok || got != nil {
+			t.Fatalf("lookup of an unknown key = (%v, %v), want (nil, false)", got, ok)
+		}
+	})
+
+	t.Run("empty ids, nils, and foreign entries are skipped", func(t *testing.T) {
+		idx := indexKmsKeysByID([]any{
+			kmsKey("", ringA),
+			(*mqlStackitKmsKey)(nil),
+			iamRole("some.role"),
+			"not a resource",
+			nil,
+			kmsKey(keyA, ringA),
+		})
+		if len(idx) != 1 {
+			t.Fatalf("index size = %d, want 1 (only the well-formed key)", len(idx))
+		}
+		if _, ok := idx[""]; ok {
+			t.Fatal("index holds an entry under the empty key id")
+		}
+	})
+
+	t.Run("first key wins on a duplicate uuid", func(t *testing.T) {
+		first := kmsKey(keyA, ringA)
+		idx := indexKmsKeysByID([]any{first, kmsKey(keyA, ringB)})
+		if idx[keyA] != first {
+			t.Fatalf("idx[%q] = %v, want the first key seen", keyA, idx[keyA])
+		}
+	})
+
+	t.Run("empty listing yields an empty index, not nil", func(t *testing.T) {
+		if idx := indexKmsKeysByID(nil); idx == nil {
+			t.Fatal("indexKmsKeysByID(nil) = nil, want an empty map")
+		}
+	})
+}
+
+func TestKeyIndexByID(t *testing.T) {
+	const (
+		ringA = "ring-a"
+		keyA  = "11111111-1111-1111-1111-111111111111"
+		keyB  = "22222222-2222-2222-2222-222222222222"
+	)
+
+	t.Run("walks every ring once", func(t *testing.T) {
+		a := kmsKey(keyA, ringA)
+		b := kmsKey(keyB, "ring-b")
+		k := &mqlStackitKms{
+			KeyRings: setList([]any{
+				&mqlStackitKmsKeyRing{Keys: setList([]any{a})},
+				&mqlStackitKmsKeyRing{Keys: setList([]any{b})},
+				"not a key ring",
+			}),
+		}
+
+		idx, err := k.keyIndexByID()
+		if err != nil {
+			t.Fatalf("keyIndexByID() error = %v", err)
+		}
+		if idx[keyA] != a || idx[keyB] != b {
+			t.Fatalf("index = %v, want both keys", idx)
+		}
+
+		// the memo has to survive: mutating the source listing must not change
+		// what a second caller sees
+		k.KeyRings = setList(nil)
+		idx2, err := k.keyIndexByID()
+		if err != nil {
+			t.Fatalf("second keyIndexByID() error = %v", err)
+		}
+		if len(idx2) != 2 {
+			t.Fatalf("second call rebuilt the index (size %d), want the memoized one", len(idx2))
+		}
+	})
+
+	t.Run("an errored ring listing is memoized, not retried", func(t *testing.T) {
+		boom := errors.New("key rings unreadable")
+		k := &mqlStackitKms{
+			KeyRings: plugin.TValue[[]any]{Error: boom, State: plugin.StateIsSet | plugin.StateIsNull},
+		}
+
+		idx, err := k.keyIndexByID()
+		if !errors.Is(err, boom) {
+			t.Fatalf("keyIndexByID() error = %v, want %v", err, boom)
+		}
+		if idx != nil {
+			t.Fatalf("keyIndexByID() index = %v, want nil on error", idx)
+		}
+
+		// a second reference must get the same failure without a fresh read
+		k.KeyRings = setList([]any{&mqlStackitKmsKeyRing{Keys: setList([]any{kmsKey(keyA, ringA)})}})
+		if _, err := k.keyIndexByID(); !errors.Is(err, boom) {
+			t.Fatalf("second keyIndexByID() error = %v, want the memoized %v", err, boom)
+		}
+	})
+
+	t.Run("an errored key listing inside a ring surfaces", func(t *testing.T) {
+		boom := errors.New("keys unreadable")
+		k := &mqlStackitKms{
+			KeyRings: setList([]any{
+				&mqlStackitKmsKeyRing{Keys: plugin.TValue[[]any]{Error: boom, State: plugin.StateIsSet | plugin.StateIsNull}},
+			}),
+		}
+		if _, err := k.keyIndexByID(); !errors.Is(err, boom) {
+			t.Fatalf("keyIndexByID() error = %v, want %v", err, boom)
+		}
+	})
+
+	t.Run("concurrent readers share one index", func(t *testing.T) {
+		k := &mqlStackitKms{
+			KeyRings: setList([]any{
+				&mqlStackitKmsKeyRing{Keys: setList([]any{kmsKey(keyA, ringA)})},
+			}),
+		}
+
+		var wg sync.WaitGroup
+		got := make([]map[string]*mqlStackitKmsKey, 8)
+		for i := range got {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				idx, err := k.keyIndexByID()
+				if err != nil {
+					t.Errorf("keyIndexByID() error = %v", err)
+					return
+				}
+				got[i] = idx
+			}(i)
+		}
+		wg.Wait()
+
+		for i, idx := range got {
+			if idx == nil {
+				t.Fatalf("goroutine %d got a nil index", i)
+			}
+			if len(idx) != 1 {
+				t.Fatalf("goroutine %d index size = %d, want 1", i, len(idx))
+			}
+		}
+	})
+}
+
+func TestFindKmsKeyVersion(t *testing.T) {
+	v1 := kmsKeyVersion(1)
+	v3 := kmsKeyVersion(3)
+	items := []any{v1, "junk", (*mqlStackitKmsKeyVersion)(nil), v3}
+
+	if got := findKmsKeyVersion(items, 3); got != v3 {
+		t.Fatalf("findKmsKeyVersion(3) = %v, want version 3", got)
+	}
+	if got := findKmsKeyVersion(items, 2); got != nil {
+		t.Fatalf("findKmsKeyVersion(2) = %v, want nil", got)
+	}
+	if got := findKmsKeyVersion(nil, 1); got != nil {
+		t.Fatalf("findKmsKeyVersion over an empty list = %v, want nil", got)
+	}
+}
+
+func TestIndexIamRolesByName(t *testing.T) {
+	t.Run("hit and miss", func(t *testing.T) {
+		reader := iamRole("reader")
+		idx := indexIamRolesByName([]any{reader, iamRole("editor")})
+		if idx["reader"] != reader {
+			t.Fatalf("idx[reader] = %v, want the reader role", idx["reader"])
+		}
+		if got, ok := idx["owner"]; ok || got != nil {
+			t.Fatalf("lookup of an unbound role = (%v, %v), want (nil, false)", got, ok)
+		}
+	})
+
+	t.Run("empty names, nils, and foreign entries are skipped", func(t *testing.T) {
+		idx := indexIamRolesByName([]any{
+			iamRole(""),
+			(*mqlStackitIamRole)(nil),
+			kmsKey("some-key", "some-ring"),
+			42,
+			iamRole("reader"),
+		})
+		if len(idx) != 1 {
+			t.Fatalf("index size = %d, want 1 (only the well-formed role)", len(idx))
+		}
+	})
+
+	t.Run("first role wins on a duplicate name", func(t *testing.T) {
+		first := iamRole("reader")
+		idx := indexIamRolesByName([]any{first, iamRole("reader")})
+		if idx["reader"] != first {
+			t.Fatalf("idx[reader] = %v, want the first role seen", idx["reader"])
+		}
+	})
+
+	t.Run("empty catalog yields an empty index, not nil", func(t *testing.T) {
+		if idx := indexIamRolesByName(nil); idx == nil {
+			t.Fatal("indexIamRolesByName(nil) = nil, want an empty map")
+		}
+	})
+}
+
+func TestRoleIndexByName(t *testing.T) {
+	t.Run("built once and memoized", func(t *testing.T) {
+		reader := iamRole("reader")
+		i := &mqlStackitIam{Roles: setList([]any{reader})}
+
+		idx, err := i.roleIndexByName()
+		if err != nil {
+			t.Fatalf("roleIndexByName() error = %v", err)
+		}
+		if idx["reader"] != reader {
+			t.Fatalf("idx[reader] = %v, want the reader role", idx["reader"])
+		}
+
+		i.Roles = setList(nil)
+		idx2, err := i.roleIndexByName()
+		if err != nil {
+			t.Fatalf("second roleIndexByName() error = %v", err)
+		}
+		if len(idx2) != 1 {
+			t.Fatalf("second call rebuilt the index (size %d), want the memoized one", len(idx2))
+		}
+	})
+
+	t.Run("an errored catalog listing is memoized, not retried", func(t *testing.T) {
+		boom := errors.New("role catalog unreadable")
+		i := &mqlStackitIam{
+			Roles: plugin.TValue[[]any]{Error: boom, State: plugin.StateIsSet | plugin.StateIsNull},
+		}
+
+		if _, err := i.roleIndexByName(); !errors.Is(err, boom) {
+			t.Fatalf("roleIndexByName() error = %v, want %v", err, boom)
+		}
+
+		i.Roles = setList([]any{iamRole("reader")})
+		if _, err := i.roleIndexByName(); !errors.Is(err, boom) {
+			t.Fatalf("second roleIndexByName() error = %v, want the memoized %v", err, boom)
+		}
+	})
+
+	t.Run("concurrent readers share one index", func(t *testing.T) {
+		i := &mqlStackitIam{Roles: setList([]any{iamRole("reader")})}
+
+		var wg sync.WaitGroup
+		for n := 0; n < 8; n++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				idx, err := i.roleIndexByName()
+				if err != nil {
+					t.Errorf("roleIndexByName() error = %v", err)
+					return
+				}
+				if len(idx) != 1 {
+					t.Errorf("index size = %d, want 1", len(idx))
+				}
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -254,10 +254,30 @@ private stackit.volume @defaults("id name size status") {
   serverId string
   // Whether the volume is encrypted at rest
   encrypted bool
-  // KEK UUID used to wrap the volume data-encryption key; empty when using platform-managed encryption
-  encryptionKeyId string
+  // Key-encryption-key UUID that wraps the volume data-encryption key
+  //
+  // Deprecated in favor of encryptionKey, which resolves the same UUID to
+  // the Key Management Service key it names. Empty when the volume uses
+  // platform-managed encryption.
+  encryptionKeyId @maturity("deprecated") string
+  // Key that wraps the volume data-encryption key (nullable)
+  //
+  // Customer-managed key from Key Management Service whose material wraps
+  // this volume data-encryption key. Null when the volume relies on
+  // platform-managed encryption, and null when the key is no longer present
+  // in the project key rings. Follow it to read the key state, whether the
+  // key is importOnly, and the createdAt of its newest version, which is
+  // what a key-rotation check reads.
+  encryptionKey() stackit.kms.key
   // KEK version number; 0 when unset
   encryptionKeyVersion int
+  // Key version pinned by the volume (nullable)
+  //
+  // Generation of the key material identified by encryptionKeyVersion, so a
+  // volume can be checked against the state of the exact version that wraps
+  // it rather than the newest one. Null when no version is pinned or when
+  // that generation is no longer listed on the key.
+  encryptionKeyVersionRef() stackit.kms.key.version
   // Creation timestamp
   createdAt time
   // Last update timestamp
@@ -2898,6 +2918,14 @@ private stackit.iam.member @defaults("subject role") {
   subject string
   // Role assigned to the subject
   role string
+  // Role definition the binding grants (nullable)
+  //
+  // Catalog entry for the role named by role, carrying the permissions the
+  // binding actually confers on the subject. Follow it to turn a binding
+  // into the concrete actions it allows, which is what a least-privilege
+  // review compares against. Null when the project role catalog cannot be
+  // read or no longer defines that role.
+  roleDetails() stackit.iam.role
 }
 
 // STACKIT IAM role

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -839,8 +839,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.volume.encryptionKeyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetEncryptionKeyId()).ToDataRes(types.String)
 	},
+	"stackit.volume.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetEncryptionKey()).ToDataRes(types.Resource("stackit.kms.key"))
+	},
 	"stackit.volume.encryptionKeyVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetEncryptionKeyVersion()).ToDataRes(types.Int)
+	},
+	"stackit.volume.encryptionKeyVersionRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetEncryptionKeyVersionRef()).ToDataRes(types.Resource("stackit.kms.key.version"))
 	},
 	"stackit.volume.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetCreatedAt()).ToDataRes(types.Time)
@@ -2909,6 +2915,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.iam.member.role": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitIamMember).GetRole()).ToDataRes(types.String)
 	},
+	"stackit.iam.member.roleDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitIamMember).GetRoleDetails()).ToDataRes(types.Resource("stackit.iam.role"))
+	},
 	"stackit.iam.role.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitIamRole).GetName()).ToDataRes(types.String)
 	},
@@ -3419,8 +3428,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitVolume).EncryptionKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"stackit.volume.encryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).EncryptionKey, ok = plugin.RawToTValue[*mqlStackitKmsKey](v.Value, v.Error)
+		return
+	},
 	"stackit.volume.encryptionKeyVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitVolume).EncryptionKeyVersion, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"stackit.volume.encryptionKeyVersionRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).EncryptionKeyVersionRef, ok = plugin.RawToTValue[*mqlStackitKmsKeyVersion](v.Value, v.Error)
 		return
 	},
 	"stackit.volume.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6519,6 +6536,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitIamMember).Role, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"stackit.iam.member.roleDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitIamMember).RoleDetails, ok = plugin.RawToTValue[*mqlStackitIamRole](v.Value, v.Error)
+		return
+	},
 	"stackit.iam.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitIamRole).__id, ok = v.Value.(string)
 		return
@@ -7776,28 +7797,30 @@ type mqlStackitVolume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlStackitVolumeInternal it will be used here
-	Id                   plugin.TValue[string]
-	Name                 plugin.TValue[string]
-	Description          plugin.TValue[string]
-	Size                 plugin.TValue[int64]
-	Status               plugin.TValue[string]
-	AvailabilityZone     plugin.TValue[string]
-	PerformanceClass     plugin.TValue[string]
-	Bootable             plugin.TValue[bool]
-	ImageId              plugin.TValue[string]
-	Image                plugin.TValue[*mqlStackitImage]
-	SourceSnapshotId     plugin.TValue[string]
-	SourceSnapshot       plugin.TValue[*mqlStackitSnapshot]
-	SourceBackupId       plugin.TValue[string]
-	SourceBackup         plugin.TValue[*mqlStackitBackup]
-	Server               plugin.TValue[*mqlStackitServer]
-	ServerId             plugin.TValue[string]
-	Encrypted            plugin.TValue[bool]
-	EncryptionKeyId      plugin.TValue[string]
-	EncryptionKeyVersion plugin.TValue[int64]
-	CreatedAt            plugin.TValue[*time.Time]
-	UpdatedAt            plugin.TValue[*time.Time]
-	Labels               plugin.TValue[map[string]any]
+	Id                      plugin.TValue[string]
+	Name                    plugin.TValue[string]
+	Description             plugin.TValue[string]
+	Size                    plugin.TValue[int64]
+	Status                  plugin.TValue[string]
+	AvailabilityZone        plugin.TValue[string]
+	PerformanceClass        plugin.TValue[string]
+	Bootable                plugin.TValue[bool]
+	ImageId                 plugin.TValue[string]
+	Image                   plugin.TValue[*mqlStackitImage]
+	SourceSnapshotId        plugin.TValue[string]
+	SourceSnapshot          plugin.TValue[*mqlStackitSnapshot]
+	SourceBackupId          plugin.TValue[string]
+	SourceBackup            plugin.TValue[*mqlStackitBackup]
+	Server                  plugin.TValue[*mqlStackitServer]
+	ServerId                plugin.TValue[string]
+	Encrypted               plugin.TValue[bool]
+	EncryptionKeyId         plugin.TValue[string]
+	EncryptionKey           plugin.TValue[*mqlStackitKmsKey]
+	EncryptionKeyVersion    plugin.TValue[int64]
+	EncryptionKeyVersionRef plugin.TValue[*mqlStackitKmsKeyVersion]
+	CreatedAt               plugin.TValue[*time.Time]
+	UpdatedAt               plugin.TValue[*time.Time]
+	Labels                  plugin.TValue[map[string]any]
 }
 
 // createStackitVolume creates a new instance of this resource
@@ -7957,8 +7980,40 @@ func (c *mqlStackitVolume) GetEncryptionKeyId() *plugin.TValue[string] {
 	return &c.EncryptionKeyId
 }
 
+func (c *mqlStackitVolume) GetEncryptionKey() *plugin.TValue[*mqlStackitKmsKey] {
+	return plugin.GetOrCompute[*mqlStackitKmsKey](&c.EncryptionKey, func() (*mqlStackitKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.volume", c.__id, "encryptionKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitKmsKey), nil
+			}
+		}
+
+		return c.encryptionKey()
+	})
+}
+
 func (c *mqlStackitVolume) GetEncryptionKeyVersion() *plugin.TValue[int64] {
 	return &c.EncryptionKeyVersion
+}
+
+func (c *mqlStackitVolume) GetEncryptionKeyVersionRef() *plugin.TValue[*mqlStackitKmsKeyVersion] {
+	return plugin.GetOrCompute[*mqlStackitKmsKeyVersion](&c.EncryptionKeyVersionRef, func() (*mqlStackitKmsKeyVersion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.volume", c.__id, "encryptionKeyVersionRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitKmsKeyVersion), nil
+			}
+		}
+
+		return c.encryptionKeyVersionRef()
+	})
 }
 
 func (c *mqlStackitVolume) GetCreatedAt() *plugin.TValue[*time.Time] {
@@ -15495,7 +15550,7 @@ func (c *mqlStackitAlbCustomRuleCondition) GetTransformations() *plugin.TValue[[
 type mqlStackitKms struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitKmsInternal it will be used here
+	mqlStackitKmsInternal
 	KeyRings plugin.TValue[[]any]
 	Keys     plugin.TValue[[]any]
 }
@@ -15994,7 +16049,7 @@ func (c *mqlStackitKmsKeyVersion) GetPublicKey() *plugin.TValue[string] {
 type mqlStackitIam struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitIamInternal it will be used here
+	mqlStackitIamInternal
 	Members plugin.TValue[[]any]
 	Roles   plugin.TValue[[]any]
 }
@@ -16073,8 +16128,9 @@ type mqlStackitIamMember struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlStackitIamMemberInternal it will be used here
-	Subject plugin.TValue[string]
-	Role    plugin.TValue[string]
+	Subject     plugin.TValue[string]
+	Role        plugin.TValue[string]
+	RoleDetails plugin.TValue[*mqlStackitIamRole]
 }
 
 // createStackitIamMember creates a new instance of this resource
@@ -16120,6 +16176,22 @@ func (c *mqlStackitIamMember) GetSubject() *plugin.TValue[string] {
 
 func (c *mqlStackitIamMember) GetRole() *plugin.TValue[string] {
 	return &c.Role
+}
+
+func (c *mqlStackitIamMember) GetRoleDetails() *plugin.TValue[*mqlStackitIamRole] {
+	return plugin.GetOrCompute[*mqlStackitIamRole](&c.RoleDetails, func() (*mqlStackitIamRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.iam.member", c.__id, "roleDetails")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitIamRole), nil
+			}
+		}
+
+		return c.roleDetails()
+	})
 }
 
 // mqlStackitIamRole for the stackit.iam.role resource

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -140,6 +140,7 @@ stackit.dns.zones 13.0.0
 stackit.iam 13.0.1
 stackit.iam.member 13.0.1
 stackit.iam.member.role 13.0.1
+stackit.iam.member.roleDetails 13.6.2
 stackit.iam.member.subject 13.0.1
 stackit.iam.members 13.0.1
 stackit.iam.role 13.0.1
@@ -837,8 +838,10 @@ stackit.volume.bootable 13.0.0
 stackit.volume.createdAt 13.0.0
 stackit.volume.description 13.0.0
 stackit.volume.encrypted 13.0.0
+stackit.volume.encryptionKey 13.6.2
 stackit.volume.encryptionKeyId 13.0.1
 stackit.volume.encryptionKeyVersion 13.0.1
+stackit.volume.encryptionKeyVersionRef 13.6.2
 stackit.volume.id 13.0.0
 stackit.volume.image 13.0.0
 stackit.volume.imageId 13.0.0


### PR DESCRIPTION
Closes the stackit provider's two biggest missing security edges. Both targets
are fully modeled already, but nothing pointed at them, so the questions below
were unanswerable in a single query.

## 1. Which volumes are wrapped by a bad customer-managed key?

`stackit.volume` carried the KEK's bare UUID and nothing else, so the key's
state, its `importOnly` flag, and its rotation history were out of reach.

**Before** — the UUID is a dead end; the join has to happen outside MQL:

```
stackit.volumes { id encryptionKeyId }
stackit.kms.keys { id state importOnly }
```

**After** — the CMK-rotation question, in one query:

```
stackit.volumes.where(encrypted).all(
  encryptionKey.state == "active" &&
  encryptionKey.importOnly == false &&
  encryptionKey.versions.last.createdAt > time.now - 365*time.day
)
```

`encryptionKeyVersionRef` came along with it: a volume is pinned to one
generation of key material, so a check can read the state of the version that
actually wraps it rather than the key's newest one.

```
stackit.volumes { id encryptionKeyVersionRef { number state disabled } }
```

`encryptionKeyId` is now `@maturity("deprecated")` — the reference carries the
same UUID and can round-trip it.

## 2. What can a member actually do?

**Before** — `role` is a name with no way to reach its permissions:

```
stackit.iam.members { subject role }
```

**After** — the least-privilege question:

```
stackit.iam.members.where(roleDetails.permissions.any(_ == "iam.role.update"))
stackit.iam.members { subject role roleDetails { permissions } }
```

The raw `role` field stays as-is: it is the binding's own key half and remains
meaningful when the role catalog cannot be read.

## How the references resolve

**Neither target has an `init`**, so neither can be reached with `NewResource`:

- `stackit.kms.key` is addressed by `keyRing/id`, and the KMS GET needs both.
  A volume records only the bare key UUID, so a per-volume lookup could not
  even form the request; finding the key means walking the key rings.
- `stackit.iam.role` exists only as a result of `ListRoles`. There is no
  by-name endpoint.

`NewResource` also runs a target's `init` *before* the runtime cache is
consulted, so even where an init existed, resolving per item would cost one
call per item — here `N_volumes x (1 + N_rings)`.

Both edges instead resolve through a **project-wide index memoized on the
namespace singleton** (`stackit.kms`, `stackit.iam`). Those singletons have a
constant per-project `__id`, so `CreateResource` hands every caller the same
instance and with it the same index. One walk of the key rings and one
`ListRoles` serve the whole scan. The **failure is memoized alongside the
value**, so an unreadable listing degrades once instead of being retried per
volume or per binding.

## Verification

```
$ gofmt -l resources/
$ go build ./...
$ go test ./...
ok  	go.mondoo.com/mql/v13/providers/stackit/connection	0.736s
ok  	go.mondoo.com/mql/v13/providers/stackit/resources	1.102s
$ go test -race ./...
ok  	go.mondoo.com/mql/v13/providers/stackit/connection	1.679s
ok  	go.mondoo.com/mql/v13/providers/stackit/resources	2.282s
$ go vet ./...
$ go mod tidy   # no diff
```

New tests in `providers/stackit/resources/refindex_test.go` cover both index
builds and lookups: hit, miss, empty key/name, non-resource and nil entries,
duplicate keys, the ring-qualified key reachable by its bare UUID, an errored
listing (memoized, not retried), an errored key listing inside a ring, and
concurrent readers under `-race`.

## Noted, out of scope

`stackit.server` has no `affinityGroup` field even though the IaaS SDK returns
one, and the ALB / certificate / security-group-rule reference gaps from the
same audit are untouched here.
