### PR TITLE
⭐ proxmox: resolve node and storage names to typed references on guests, volumes and Ceph daemons

### DIFF
--- a/providers/proxmox/connection/connection.go
+++ b/providers/proxmox/connection/connection.go
@@ -59,6 +59,13 @@ type PveConnection struct {
 	backups backupIndex
 	// corosync memoizes the join configuration, which several fields read.
 	corosync corosyncCache
+	// nodes memoizes the node listing so that resolving the node behind a
+	// guest, a Ceph daemon, or a volume costs one sweep for the whole
+	// cluster rather than one per item.
+	nodes nodeIndex
+	// storages memoizes the storage listing for the same reason, on behalf
+	// of the disks, mount points, and volumes that name their pool.
+	storages storageIndex
 }
 
 // ID and ParentID implement the plugin.Connection interface.

--- a/providers/proxmox/connection/node.go
+++ b/providers/proxmox/connection/node.go
@@ -3,7 +3,10 @@
 
 package connection
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // ---------------------------------------------------------------------------
 // Node listing
@@ -17,6 +20,68 @@ type NodeInfo struct {
 func (c *PveConnection) GetNodes() ([]NodeInfo, error) {
 	var nodes []NodeInfo
 	return nodes, c.apiGet("/nodes", &nodes)
+}
+
+// ---------------------------------------------------------------------------
+// Node index
+// ---------------------------------------------------------------------------
+
+// NodeDetail is one node as the index reports it: the /nodes row joined with
+// the address the cluster status advertises for that node.
+type NodeDetail struct {
+	Name   string
+	Status string
+	// IP is the address from the cluster status. It is empty on a
+	// standalone host, which has no cluster membership row at all.
+	IP string
+}
+
+// nodeIndex memoizes the cluster's node listing, keyed by node name. Node
+// references hang off every guest, every Ceph daemon, and every storage
+// volume, so resolving them per item would re-list the cluster once per
+// item. Building the map once turns that fan-out into a single pair of
+// calls. The error is memoized alongside the value so a token that cannot
+// read /nodes fails once instead of on every lookup.
+type nodeIndex struct {
+	once   sync.Once
+	byName map[string]NodeDetail
+	err    error
+}
+
+// LookupNode returns the node with the given name. The boolean result is
+// false when the cluster has no such node, which lets callers report a
+// dangling reference as null instead of fabricating a blank node.
+func (c *PveConnection) LookupNode(name string) (NodeDetail, bool, error) {
+	c.nodes.once.Do(c.buildNodeIndex)
+	if c.nodes.err != nil {
+		return NodeDetail{}, false, c.nodes.err
+	}
+	n, ok := c.nodes.byName[name]
+	return n, ok, nil
+}
+
+func (c *PveConnection) buildNodeIndex() {
+	nodes, err := c.GetNodes()
+	if err != nil {
+		c.nodes.err = fmt.Errorf("failed to index nodes: %w", err)
+		return
+	}
+	// The advertised address lives in the cluster status, not the nodes
+	// list. A standalone host has no cluster status to read, so a failure
+	// here leaves the addresses empty rather than failing every lookup.
+	addrs := map[string]string{}
+	if entries, statusErr := c.GetClusterStatus(); statusErr == nil {
+		for _, e := range entries {
+			if e.Type == "node" {
+				addrs[e.Name] = e.IP
+			}
+		}
+	}
+	index := make(map[string]NodeDetail, len(nodes))
+	for _, n := range nodes {
+		index[n.Node] = NodeDetail{Name: n.Node, Status: n.Status, IP: addrs[n.Node]}
+	}
+	c.nodes.byName = index
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/proxmox/connection/node_index_test.go
+++ b/providers/proxmox/connection/node_index_test.go
@@ -1,0 +1,127 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupNode_Hit(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes", []map[string]any{
+		{"node": "pve1", "status": "online"},
+		{"node": "pve2", "status": "offline"},
+	})
+	f.route("/cluster/status", []map[string]any{
+		{"type": "cluster", "name": "prod"},
+		{"type": "node", "name": "pve1", "ip": "10.0.0.11"},
+		{"type": "node", "name": "pve2", "ip": "10.0.0.12"},
+	})
+	conn := f.conn()
+
+	n, found, err := conn.LookupNode("pve2")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "pve2", n.Name)
+	require.Equal(t, "offline", n.Status)
+	require.Equal(t, "10.0.0.12", n.IP)
+}
+
+func TestLookupNode_Miss(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes", []map[string]any{{"node": "pve1", "status": "online"}})
+	f.route("/cluster/status", []map[string]any{})
+	conn := f.conn()
+
+	// A node name that is no longer in the cluster must report "not found"
+	// rather than an error, so the caller can render the reference as null.
+	n, found, err := conn.LookupNode("decommissioned")
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, NodeDetail{}, n)
+}
+
+func TestLookupNode_EmptyName(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes", []map[string]any{{"node": "pve1", "status": "online"}})
+	f.route("/cluster/status", []map[string]any{})
+	conn := f.conn()
+
+	_, found, err := conn.LookupNode("")
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+// TestLookupNode_StandaloneHostHasNoClusterStatus pins that a host with no
+// cluster membership still resolves. /cluster/status is unavailable there, and
+// treating that as fatal would make every node reference on a standalone host
+// fail instead of simply reporting no address.
+func TestLookupNode_StandaloneHostHasNoClusterStatus(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes", []map[string]any{{"node": "pve", "status": "online"}})
+	f.errorRoute("/cluster/status", 501, "no cluster")
+	conn := f.conn()
+
+	n, found, err := conn.LookupNode("pve")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "online", n.Status)
+	require.Empty(t, n.IP)
+}
+
+// TestLookupNode_ErrorMemoized pins that an unreadable node listing fails
+// every lookup with the same error and is not retried per item.
+func TestLookupNode_ErrorMemoized(t *testing.T) {
+	f := newFakePVE(t)
+	f.errorRoute("/nodes", 403, "Permission check failed")
+	conn := f.conn()
+
+	for i := 0; i < 3; i++ {
+		_, found, err := conn.LookupNode("pve1")
+		require.Error(t, err)
+		require.False(t, found)
+	}
+
+	var attempts int
+	for _, path := range f.requests {
+		if path == "/nodes" {
+			attempts++
+		}
+	}
+	require.Equal(t, 1, attempts, "a failed node listing must not be retried per lookup")
+}
+
+// TestLookupNode_IndexesOnce is the property the whole index exists for: node
+// references hang off every guest and every Ceph daemon, so resolving them
+// must not re-list the cluster once per item.
+func TestLookupNode_IndexesOnce(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/nodes", []map[string]any{
+		{"node": "pve1", "status": "online"},
+		{"node": "pve2", "status": "online"},
+	})
+	f.route("/cluster/status", []map[string]any{
+		{"type": "node", "name": "pve1", "ip": "10.0.0.11"},
+	})
+	conn := f.conn()
+
+	for _, name := range []string{"pve1", "pve2", "pve1", "gone", "pve2"} {
+		_, _, err := conn.LookupNode(name)
+		require.NoError(t, err)
+	}
+
+	var nodeCalls, statusCalls int
+	for _, path := range f.requests {
+		switch path {
+		case "/nodes":
+			nodeCalls++
+		case "/cluster/status":
+			statusCalls++
+		}
+	}
+	require.Equal(t, 1, nodeCalls, "node listing must be fetched once per connection")
+	require.Equal(t, 1, statusCalls, "cluster status must be fetched once per connection")
+}

--- a/providers/proxmox/connection/storage.go
+++ b/providers/proxmox/connection/storage.go
@@ -3,7 +3,10 @@
 
 package connection
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // ---------------------------------------------------------------------------
 // Storage pools
@@ -58,6 +61,46 @@ func normalizeClusterStorageEnabled(storages []StorageInfo) {
 			storages[i].Enabled = 1
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Storage index
+// ---------------------------------------------------------------------------
+
+// storageIndex memoizes the cluster's storage listing, keyed by storage name.
+// Every guest disk, mount point, and stored volume names the pool it sits on,
+// so resolving those references per item would re-list every storage once per
+// item. The error is memoized alongside the value so an unreadable listing
+// fails once instead of on every lookup.
+type storageIndex struct {
+	once   sync.Once
+	byName map[string]StorageInfo
+	err    error
+}
+
+// LookupStorage returns the storage with the given name. The boolean result
+// is false when the cluster has no such storage, which lets callers report a
+// dangling reference as null instead of fabricating a blank storage.
+func (c *PveConnection) LookupStorage(name string) (StorageInfo, bool, error) {
+	c.storages.once.Do(c.buildStorageIndex)
+	if c.storages.err != nil {
+		return StorageInfo{}, false, c.storages.err
+	}
+	s, ok := c.storages.byName[name]
+	return s, ok, nil
+}
+
+func (c *PveConnection) buildStorageIndex() {
+	storages, err := c.GetStorages()
+	if err != nil {
+		c.storages.err = fmt.Errorf("failed to index storages: %w", err)
+		return
+	}
+	index := make(map[string]StorageInfo, len(storages))
+	for _, s := range storages {
+		index[s.Storage] = s
+	}
+	c.storages.byName = index
 }
 
 // ---------------------------------------------------------------------------

--- a/providers/proxmox/connection/storage_index_test.go
+++ b/providers/proxmox/connection/storage_index_test.go
@@ -1,0 +1,114 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupStorage_Hit(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/storage", []map[string]any{
+		{"storage": "local", "type": "dir", "content": "iso,vztmpl"},
+		{"storage": "pbs", "type": "pbs", "content": "backup", "shared": 1, "encryption-key": "autogen"},
+	})
+	conn := f.conn()
+
+	s, found, err := conn.LookupStorage("pbs")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "pbs", s.Storage)
+	require.Equal(t, "backup", s.Content)
+	require.Equal(t, 1, s.Shared)
+	require.Equal(t, "autogen", s.EncryptionKey)
+}
+
+// TestLookupStorage_NormalizesEnabled pins that the index carries the same
+// normalized Enabled the direct listing does, rather than the raw cluster
+// config shape where every storage reads as disabled.
+func TestLookupStorage_NormalizesEnabled(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/storage", []map[string]any{
+		{"storage": "on", "disable": 0},
+		{"storage": "off", "disable": 1},
+	})
+	conn := f.conn()
+
+	on, found, err := conn.LookupStorage("on")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, 1, on.Enabled)
+
+	off, found, err := conn.LookupStorage("off")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, 0, off.Enabled)
+}
+
+func TestLookupStorage_Miss(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/storage", []map[string]any{{"storage": "local", "type": "dir"}})
+	conn := f.conn()
+
+	s, found, err := conn.LookupStorage("removed-pool")
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, StorageInfo{}, s)
+}
+
+func TestLookupStorage_EmptyName(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/storage", []map[string]any{{"storage": "local", "type": "dir"}})
+	conn := f.conn()
+
+	_, found, err := conn.LookupStorage("")
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+// TestLookupStorage_ErrorMemoized pins that an unreadable storage listing
+// fails every lookup with the same error and is not retried per item.
+func TestLookupStorage_ErrorMemoized(t *testing.T) {
+	f := newFakePVE(t)
+	f.errorRoute("/storage", 403, "Permission check failed")
+	conn := f.conn()
+
+	for i := 0; i < 3; i++ {
+		_, found, err := conn.LookupStorage("local")
+		require.Error(t, err)
+		require.False(t, found)
+	}
+
+	var attempts int
+	for _, path := range f.requests {
+		if path == "/storage" {
+			attempts++
+		}
+	}
+	require.Equal(t, 1, attempts, "a failed storage listing must not be retried per lookup")
+}
+
+func TestLookupStorage_IndexesOnce(t *testing.T) {
+	f := newFakePVE(t)
+	f.route("/storage", []map[string]any{
+		{"storage": "local", "type": "dir"},
+		{"storage": "local-lvm", "type": "lvmthin"},
+	})
+	conn := f.conn()
+
+	for _, name := range []string{"local", "local-lvm", "local", "gone"} {
+		_, _, err := conn.LookupStorage(name)
+		require.NoError(t, err)
+	}
+
+	var calls int
+	for _, path := range f.requests {
+		if path == "/storage" {
+			calls++
+		}
+	}
+	require.Equal(t, 1, calls, "storage listing must be fetched once per connection")
+}

--- a/providers/proxmox/resources/init.go
+++ b/providers/proxmox/resources/init.go
@@ -130,34 +130,31 @@ func initProxmoxStorage(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return args, nil, nil
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
-	storages, err := conn.GetStorages()
+	s, found, err := conn.LookupStorage(storageID)
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, s := range storages {
-		if s.Storage != storageID {
-			continue
-		}
-		var usagePct float64
-		if s.UsedFrac > 0 {
-			usagePct = s.UsedFrac * 100.0
-		} else if s.Total > 0 {
-			usagePct = float64(s.Used) / float64(s.Total) * 100.0
-		}
-		args["type"] = llx.StringData(s.Type)
-		args["content"] = llx.StringData(s.Content)
-		args["path"] = llx.StringData(s.Path)
-		args["nodes"] = llx.StringData(s.Nodes)
-		args["enabled"] = llx.BoolData(s.Enabled != 0)
-		args["shared"] = llx.BoolData(s.Shared != 0)
-		args["total"] = llx.IntData(s.Total)
-		args["used"] = llx.IntData(s.Used)
-		args["available"] = llx.IntData(s.Avail)
-		args["usagePercent"] = llx.FloatData(usagePct)
-		args["encrypted"] = llx.BoolData(s.EncryptionKey != "")
-		args["encryptionKey"] = llx.StringData(s.EncryptionKey)
+	if !found {
 		return args, nil, nil
 	}
+	var usagePct float64
+	if s.UsedFrac > 0 {
+		usagePct = s.UsedFrac * 100.0
+	} else if s.Total > 0 {
+		usagePct = float64(s.Used) / float64(s.Total) * 100.0
+	}
+	args["type"] = llx.StringData(s.Type)
+	args["content"] = llx.StringData(s.Content)
+	args["path"] = llx.StringData(s.Path)
+	args["nodes"] = llx.StringData(s.Nodes)
+	args["enabled"] = llx.BoolData(s.Enabled != 0)
+	args["shared"] = llx.BoolData(s.Shared != 0)
+	args["total"] = llx.IntData(s.Total)
+	args["used"] = llx.IntData(s.Used)
+	args["available"] = llx.IntData(s.Avail)
+	args["usagePercent"] = llx.FloatData(usagePct)
+	args["encrypted"] = llx.BoolData(s.EncryptionKey != "")
+	args["encryptionKey"] = llx.StringData(s.EncryptionKey)
 	return args, nil, nil
 }
 
@@ -203,25 +200,18 @@ func initProxmoxNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
-	nodes, err := conn.GetNodes()
+	n, found, err := conn.LookupNode(name)
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, n := range nodes {
-		if n.Node != name {
-			continue
-		}
-		args["status"] = llx.StringData(n.Status)
-		// The IP lives in cluster status, not the nodes list. Fetch only
-		// when present; a single-node standalone host has no cluster row.
-		entries, _ := conn.GetClusterStatus()
-		for _, e := range entries {
-			if e.Type == "node" && e.Name == name {
-				args["ip"] = llx.StringData(e.IP)
-				break
-			}
-		}
+	if !found {
 		return args, nil, nil
+	}
+	args["status"] = llx.StringData(n.Status)
+	// The address comes from the cluster status, which a standalone host
+	// has no row in. The index leaves it empty in that case.
+	if n.IP != "" {
+		args["ip"] = llx.StringData(n.IP)
 	}
 	return args, nil, nil
 }

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -573,7 +573,10 @@ proxmox.cluster.haResource @defaults("id type status") {
   // Desired state (started, stopped, disabled)
   state string
   // HA group
-  group string
+  //
+  // Deprecated in favor of `groupRef`, which resolves the same group as
+  // an HA group resource.
+  group @maturity("deprecated") string
   // VM this resource refers to when `type` is `vm`; null otherwise
   vm() proxmox.vm
   // Container this resource refers to when `type` is `ct`; null otherwise
@@ -769,6 +772,12 @@ proxmox.vm @defaults("id name status") {
   name string
   // Node this VM is running on
   node string
+  // Host the VM runs on
+  //
+  // Resolves `node` against the cluster, giving access to the host's
+  // status, address, kernel, subscription level, and firewall from the
+  // VM itself. Null when the named node is no longer in the cluster.
+  nodeRef() proxmox.node
   // Current status (running, stopped, paused)
   status string
 
@@ -964,7 +973,10 @@ proxmox.vm.disk @defaults("id storage size") {
   // Disk ID (scsi0, virtio0, ide0, ...)
   id string
   // Storage pool name
-  storage string
+  //
+  // Deprecated in favor of `storageRef`, which resolves the same pool
+  // as a storage resource.
+  storage @maturity("deprecated") string
   // Disk size in bytes
   size int
   // Disk format (qcow2, raw, vmdk)
@@ -1091,12 +1103,24 @@ proxmox.storage.volume @defaults("volid contentType createdAt size") {
   volid string
   // Storage holding the volume
   storage string
+  // Storage pool the volume sits on
+  //
+  // Resolves `storage` against the cluster, so a volume can be audited
+  // against the pool's encryption setting, sharing, content classes,
+  // and capacity. Null when the named storage is no longer configured.
+  storageRef() proxmox.storage
   // Node the volume was listed from
   //
   // A shared storage reports one copy from a single node. A local
   // storage holds an independent copy on each node, so the same guest
   // can have separate volumes here per node.
   node string
+  // Host the volume was listed from
+  //
+  // Resolves `node` against the cluster. For a local storage this is
+  // the host that physically holds this copy. Null when the named node
+  // is no longer in the cluster.
+  nodeRef() proxmox.node
   // Content class of the volume
   //
   // One of `backup`, `iso`, `vztmpl`, `images`, `rootdir`, or
@@ -1474,7 +1498,10 @@ proxmox.group @defaults("id comment") {
   // Group comment/description
   comment string
   // User IDs that belong to this group
-  memberIds []string
+  //
+  // Deprecated in favor of `members`, which resolves the same accounts
+  // as user resources.
+  memberIds @maturity("deprecated") []string
   // Members of this group resolved as user resources
   members() []proxmox.user
 }
@@ -1498,7 +1525,10 @@ proxmox.acl @defaults("path type ugid roleId propagate") {
   // Identifier of the user, group, or token the grant applies to
   ugid string
   // Role ID granted at this path
-  roleId string
+  //
+  // Deprecated in favor of `role`, which resolves the same role as a
+  // role resource carrying its privilege list.
+  roleId @maturity("deprecated") string
   // Whether the grant propagates to child paths
   propagate bool
   // Resolved role
@@ -1647,6 +1677,13 @@ proxmox.container @defaults("id name status unprivileged") {
   name string
   // Node this container is running on
   node string
+  // Host the container runs on
+  //
+  // Resolves `node` against the cluster, giving access to the host's
+  // status, address, kernel, subscription level, and firewall from the
+  // container itself. Null when the named node is no longer in the
+  // cluster.
+  nodeRef() proxmox.node
   // Current status (running, stopped)
   status string
 
@@ -1815,7 +1852,10 @@ proxmox.container.mountPoint @defaults("id storage mountPath size") {
   // Mount point ID (rootfs, mp0, mp1, ...)
   id string
   // Backing storage name
-  storage string
+  //
+  // Deprecated in favor of `storageRef`, which resolves the same pool
+  // as a storage resource.
+  storage @maturity("deprecated") string
   // Size in bytes
   size int
   // Path inside the container
@@ -1852,7 +1892,10 @@ proxmox.backup.job @defaults("id schedule storage enabled") {
   // Schedule (systemd-calendar expression, e.g. `mon..fri 03:00`)
   schedule string
   // Storage name backups are written to
-  storage string
+  //
+  // Deprecated in favor of `targetStorage`, which resolves the same
+  // pool as a storage resource.
+  storage @maturity("deprecated") string
   // Dump mode (snapshot, suspend, stop)
   mode string
   // Job comment
@@ -2092,9 +2135,15 @@ proxmox.replication.job @defaults("id schedule source target disabled") {
   // Schedule expression (systemd-calendar)
   schedule string
   // Source node name
-  source string
+  //
+  // Deprecated in favor of `sourceNode`, which resolves the same host
+  // as a node resource.
+  source @maturity("deprecated") string
   // Target node name
-  target string
+  //
+  // Deprecated in favor of `targetNode`, which resolves the same host
+  // as a node resource.
+  target @maturity("deprecated") string
   // Job type (local for built-in storage replication)
   type string
   // Job comment
@@ -2158,7 +2207,10 @@ proxmox.sdn.vnet @defaults("vnet zone tag") {
   // VNet identifier
   vnet string
   // Parent zone identifier
-  zone string
+  //
+  // Deprecated in favor of `zoneRef`, which resolves the same zone as
+  // an SDN zone resource.
+  zone @maturity("deprecated") string
   // Friendly alias
   alias string
   // VLAN/VXLAN tag identifier
@@ -2192,7 +2244,10 @@ proxmox.sdn.subnet @defaults("id cidr gateway") {
   // DNS prefix appended to records created for this subnet
   dnsZonePrefix string
   // Parent vnet identifier
-  vnet string
+  //
+  // Deprecated in favor of `vnetRef`, which resolves the same vnet as
+  // an SDN vnet resource.
+  vnet @maturity("deprecated") string
   // Resolved parent vnet
   vnetRef() proxmox.sdn.vnet
 }
@@ -2446,6 +2501,12 @@ proxmox.ceph.monitor @defaults("name host quorum state") {
   name string
   // Node the monitor runs on
   host string
+  // Host the monitor runs on
+  //
+  // Resolves `host` against the cluster, so a monitor out of quorum can
+  // be checked against the state of the node running it. Null when the
+  // named host is no longer in the cluster.
+  node() proxmox.node
   // Address the monitor advertises, in Ceph format (usually `IP:PORT/NONCE`)
   addr string
   // Whether the monitor is part of the current quorum
@@ -2479,6 +2540,12 @@ proxmox.ceph.manager @defaults("name host state") {
   name string
   // Node the manager runs on
   host string
+  // Host the manager runs on
+  //
+  // Resolves `host` against the cluster, so a stopped manager can be
+  // checked against the state of the node running it. Null when the
+  // named host is no longer in the cluster.
+  node() proxmox.node
   // Address the manager advertises, in Ceph format
   addr string
   // Manager state
@@ -2510,6 +2577,12 @@ proxmox.ceph.metadataServer @defaults("name host state fsName") {
   name string
   // Node the metadata server runs on
   host string
+  // Host the metadata server runs on
+  //
+  // Resolves `host` against the cluster, so a file system left without
+  // an active daemon can be traced to the node running it. Null when
+  // the named host is no longer in the cluster.
+  node() proxmox.node
   // Address the metadata server advertises, in Ceph format
   addr string
   // Ceph-reported run state (e.g. `up:active`, `up:standby`, `up:standby-replay`)
@@ -2517,7 +2590,10 @@ proxmox.ceph.metadataServer @defaults("name host state fsName") {
   // Rank within the file system; -1 for standby daemons not bound to a rank
   rank int
   // Name of the CephFS this daemon is bound to; empty for unbound standbys
-  fsName string
+  //
+  // Deprecated in favor of `fileSystem`, which resolves the same file
+  // system as a CephFS resource.
+  fsName @maturity("deprecated") string
   // CephFS this daemon serves; null for unbound standbys
   fileSystem() proxmox.ceph.filesystem
   // Whether the standby is polling the active daemon for faster recovery
@@ -2548,6 +2624,12 @@ proxmox.ceph.osd @defaults("id host up inCluster deviceClass") {
   name string
   // Node the daemon runs on
   host string
+  // Host the daemon runs on
+  //
+  // Resolves `host` against the cluster, so a down or out OSD can be
+  // checked against the state of the node holding its backing device.
+  // Null when the named host is no longer in the cluster.
+  node() proxmox.node
   // Whether the daemon is running
   //
   // Null when the CRUSH tree reports no status for this OSD.

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -1068,6 +1068,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.vm.node": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxVm).GetNode()).ToDataRes(types.String)
 	},
+	"proxmox.vm.nodeRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxVm).GetNodeRef()).ToDataRes(types.Resource("proxmox.node"))
+	},
 	"proxmox.vm.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxVm).GetStatus()).ToDataRes(types.String)
 	},
@@ -1329,8 +1332,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.storage.volume.storage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxStorageVolume).GetStorage()).ToDataRes(types.String)
 	},
+	"proxmox.storage.volume.storageRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxStorageVolume).GetStorageRef()).ToDataRes(types.Resource("proxmox.storage"))
+	},
 	"proxmox.storage.volume.node": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxStorageVolume).GetNode()).ToDataRes(types.String)
+	},
+	"proxmox.storage.volume.nodeRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxStorageVolume).GetNodeRef()).ToDataRes(types.Resource("proxmox.node"))
 	},
 	"proxmox.storage.volume.contentType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxStorageVolume).GetContentType()).ToDataRes(types.String)
@@ -1760,6 +1769,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.container.node": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxContainer).GetNode()).ToDataRes(types.String)
+	},
+	"proxmox.container.nodeRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxContainer).GetNodeRef()).ToDataRes(types.Resource("proxmox.node"))
 	},
 	"proxmox.container.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxContainer).GetStatus()).ToDataRes(types.String)
@@ -2439,6 +2451,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.ceph.monitor.host": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephMonitor).GetHost()).ToDataRes(types.String)
 	},
+	"proxmox.ceph.monitor.node": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCephMonitor).GetNode()).ToDataRes(types.Resource("proxmox.node"))
+	},
 	"proxmox.ceph.monitor.addr": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephMonitor).GetAddr()).ToDataRes(types.String)
 	},
@@ -2469,6 +2484,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"proxmox.ceph.manager.host": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephManager).GetHost()).ToDataRes(types.String)
 	},
+	"proxmox.ceph.manager.node": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCephManager).GetNode()).ToDataRes(types.Resource("proxmox.node"))
+	},
 	"proxmox.ceph.manager.addr": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephManager).GetAddr()).ToDataRes(types.String)
 	},
@@ -2492,6 +2510,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.ceph.metadataServer.host": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephMetadataServer).GetHost()).ToDataRes(types.String)
+	},
+	"proxmox.ceph.metadataServer.node": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCephMetadataServer).GetNode()).ToDataRes(types.Resource("proxmox.node"))
 	},
 	"proxmox.ceph.metadataServer.addr": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephMetadataServer).GetAddr()).ToDataRes(types.String)
@@ -2531,6 +2552,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"proxmox.ceph.osd.host": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephOsd).GetHost()).ToDataRes(types.String)
+	},
+	"proxmox.ceph.osd.node": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlProxmoxCephOsd).GetNode()).ToDataRes(types.Resource("proxmox.node"))
 	},
 	"proxmox.ceph.osd.up": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlProxmoxCephOsd).GetUp()).ToDataRes(types.Bool)
@@ -3558,6 +3582,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxVm).Node, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"proxmox.vm.nodeRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxVm).NodeRef, ok = plugin.RawToTValue[*mqlProxmoxNode](v.Value, v.Error)
+		return
+	},
 	"proxmox.vm.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxVm).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -3930,8 +3958,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxStorageVolume).Storage, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"proxmox.storage.volume.storageRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxStorageVolume).StorageRef, ok = plugin.RawToTValue[*mqlProxmoxStorage](v.Value, v.Error)
+		return
+	},
 	"proxmox.storage.volume.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxStorageVolume).Node, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.storage.volume.nodeRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxStorageVolume).NodeRef, ok = plugin.RawToTValue[*mqlProxmoxNode](v.Value, v.Error)
 		return
 	},
 	"proxmox.storage.volume.contentType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4580,6 +4616,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.container.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxContainer).Node, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.container.nodeRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxContainer).NodeRef, ok = plugin.RawToTValue[*mqlProxmoxNode](v.Value, v.Error)
 		return
 	},
 	"proxmox.container.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5574,6 +5614,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxCephMonitor).Host, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"proxmox.ceph.monitor.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCephMonitor).Node, ok = plugin.RawToTValue[*mqlProxmoxNode](v.Value, v.Error)
+		return
+	},
 	"proxmox.ceph.monitor.addr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxCephMonitor).Addr, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5618,6 +5662,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlProxmoxCephManager).Host, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"proxmox.ceph.manager.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCephManager).Node, ok = plugin.RawToTValue[*mqlProxmoxNode](v.Value, v.Error)
+		return
+	},
 	"proxmox.ceph.manager.addr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxCephManager).Addr, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -5652,6 +5700,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.ceph.metadataServer.host": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxCephMetadataServer).Host, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.ceph.metadataServer.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCephMetadataServer).Node, ok = plugin.RawToTValue[*mqlProxmoxNode](v.Value, v.Error)
 		return
 	},
 	"proxmox.ceph.metadataServer.addr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5708,6 +5760,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"proxmox.ceph.osd.host": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlProxmoxCephOsd).Host, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"proxmox.ceph.osd.node": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlProxmoxCephOsd).Node, ok = plugin.RawToTValue[*mqlProxmoxNode](v.Value, v.Error)
 		return
 	},
 	"proxmox.ceph.osd.up": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8499,6 +8555,7 @@ type mqlProxmoxVm struct {
 	Id              plugin.TValue[int64]
 	Name            plugin.TValue[string]
 	Node            plugin.TValue[string]
+	NodeRef         plugin.TValue[*mqlProxmoxNode]
 	Status          plugin.TValue[string]
 	Cpu             plugin.TValue[float64]
 	Maxcpu          plugin.TValue[int64]
@@ -8594,6 +8651,22 @@ func (c *mqlProxmoxVm) GetName() *plugin.TValue[string] {
 
 func (c *mqlProxmoxVm) GetNode() *plugin.TValue[string] {
 	return &c.Node
+}
+
+func (c *mqlProxmoxVm) GetNodeRef() *plugin.TValue[*mqlProxmoxNode] {
+	return plugin.GetOrCompute[*mqlProxmoxNode](&c.NodeRef, func() (*mqlProxmoxNode, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.vm", c.__id, "nodeRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxNode), nil
+			}
+		}
+
+		return c.nodeRef()
+	})
 }
 
 func (c *mqlProxmoxVm) GetStatus() *plugin.TValue[string] {
@@ -9414,7 +9487,9 @@ type mqlProxmoxStorageVolume struct {
 	mqlProxmoxStorageVolumeInternal
 	Volid                 plugin.TValue[string]
 	Storage               plugin.TValue[string]
+	StorageRef            plugin.TValue[*mqlProxmoxStorage]
 	Node                  plugin.TValue[string]
+	NodeRef               plugin.TValue[*mqlProxmoxNode]
 	ContentType           plugin.TValue[string]
 	Format                plugin.TValue[string]
 	Size                  plugin.TValue[int64]
@@ -9471,8 +9546,40 @@ func (c *mqlProxmoxStorageVolume) GetStorage() *plugin.TValue[string] {
 	return &c.Storage
 }
 
+func (c *mqlProxmoxStorageVolume) GetStorageRef() *plugin.TValue[*mqlProxmoxStorage] {
+	return plugin.GetOrCompute[*mqlProxmoxStorage](&c.StorageRef, func() (*mqlProxmoxStorage, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.storage.volume", c.__id, "storageRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxStorage), nil
+			}
+		}
+
+		return c.storageRef()
+	})
+}
+
 func (c *mqlProxmoxStorageVolume) GetNode() *plugin.TValue[string] {
 	return &c.Node
+}
+
+func (c *mqlProxmoxStorageVolume) GetNodeRef() *plugin.TValue[*mqlProxmoxNode] {
+	return plugin.GetOrCompute[*mqlProxmoxNode](&c.NodeRef, func() (*mqlProxmoxNode, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.storage.volume", c.__id, "nodeRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxNode), nil
+			}
+		}
+
+		return c.nodeRef()
+	})
 }
 
 func (c *mqlProxmoxStorageVolume) GetContentType() *plugin.TValue[string] {
@@ -11063,6 +11170,7 @@ type mqlProxmoxContainer struct {
 	Id                 plugin.TValue[int64]
 	Name               plugin.TValue[string]
 	Node               plugin.TValue[string]
+	NodeRef            plugin.TValue[*mqlProxmoxNode]
 	Status             plugin.TValue[string]
 	Cpu                plugin.TValue[float64]
 	Maxcpu             plugin.TValue[int64]
@@ -11152,6 +11260,22 @@ func (c *mqlProxmoxContainer) GetName() *plugin.TValue[string] {
 
 func (c *mqlProxmoxContainer) GetNode() *plugin.TValue[string] {
 	return &c.Node
+}
+
+func (c *mqlProxmoxContainer) GetNodeRef() *plugin.TValue[*mqlProxmoxNode] {
+	return plugin.GetOrCompute[*mqlProxmoxNode](&c.NodeRef, func() (*mqlProxmoxNode, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.container", c.__id, "nodeRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxNode), nil
+			}
+		}
+
+		return c.nodeRef()
+	})
 }
 
 func (c *mqlProxmoxContainer) GetStatus() *plugin.TValue[string] {
@@ -13516,6 +13640,7 @@ type mqlProxmoxCephMonitor struct {
 	// optional: if you define mqlProxmoxCephMonitorInternal it will be used here
 	Name             plugin.TValue[string]
 	Host             plugin.TValue[string]
+	Node             plugin.TValue[*mqlProxmoxNode]
 	Addr             plugin.TValue[string]
 	Quorum           plugin.TValue[bool]
 	Rank             plugin.TValue[int64]
@@ -13566,6 +13691,22 @@ func (c *mqlProxmoxCephMonitor) GetHost() *plugin.TValue[string] {
 	return &c.Host
 }
 
+func (c *mqlProxmoxCephMonitor) GetNode() *plugin.TValue[*mqlProxmoxNode] {
+	return plugin.GetOrCompute[*mqlProxmoxNode](&c.Node, func() (*mqlProxmoxNode, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.ceph.monitor", c.__id, "node")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxNode), nil
+			}
+		}
+
+		return c.node()
+	})
+}
+
 func (c *mqlProxmoxCephMonitor) GetAddr() *plugin.TValue[string] {
 	return &c.Addr
 }
@@ -13605,6 +13746,7 @@ type mqlProxmoxCephManager struct {
 	// optional: if you define mqlProxmoxCephManagerInternal it will be used here
 	Name             plugin.TValue[string]
 	Host             plugin.TValue[string]
+	Node             plugin.TValue[*mqlProxmoxNode]
 	Addr             plugin.TValue[string]
 	State            plugin.TValue[string]
 	Service          plugin.TValue[bool]
@@ -13653,6 +13795,22 @@ func (c *mqlProxmoxCephManager) GetHost() *plugin.TValue[string] {
 	return &c.Host
 }
 
+func (c *mqlProxmoxCephManager) GetNode() *plugin.TValue[*mqlProxmoxNode] {
+	return plugin.GetOrCompute[*mqlProxmoxNode](&c.Node, func() (*mqlProxmoxNode, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.ceph.manager", c.__id, "node")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxNode), nil
+			}
+		}
+
+		return c.node()
+	})
+}
+
 func (c *mqlProxmoxCephManager) GetAddr() *plugin.TValue[string] {
 	return &c.Addr
 }
@@ -13684,6 +13842,7 @@ type mqlProxmoxCephMetadataServer struct {
 	// optional: if you define mqlProxmoxCephMetadataServerInternal it will be used here
 	Name             plugin.TValue[string]
 	Host             plugin.TValue[string]
+	Node             plugin.TValue[*mqlProxmoxNode]
 	Addr             plugin.TValue[string]
 	State            plugin.TValue[string]
 	Rank             plugin.TValue[int64]
@@ -13734,6 +13893,22 @@ func (c *mqlProxmoxCephMetadataServer) GetName() *plugin.TValue[string] {
 
 func (c *mqlProxmoxCephMetadataServer) GetHost() *plugin.TValue[string] {
 	return &c.Host
+}
+
+func (c *mqlProxmoxCephMetadataServer) GetNode() *plugin.TValue[*mqlProxmoxNode] {
+	return plugin.GetOrCompute[*mqlProxmoxNode](&c.Node, func() (*mqlProxmoxNode, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.ceph.metadataServer", c.__id, "node")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxNode), nil
+			}
+		}
+
+		return c.node()
+	})
 }
 
 func (c *mqlProxmoxCephMetadataServer) GetAddr() *plugin.TValue[string] {
@@ -13796,6 +13971,7 @@ type mqlProxmoxCephOsd struct {
 	Id               plugin.TValue[int64]
 	Name             plugin.TValue[string]
 	Host             plugin.TValue[string]
+	Node             plugin.TValue[*mqlProxmoxNode]
 	Up               plugin.TValue[bool]
 	InCluster        plugin.TValue[bool]
 	Status           plugin.TValue[string]
@@ -13859,6 +14035,22 @@ func (c *mqlProxmoxCephOsd) GetName() *plugin.TValue[string] {
 
 func (c *mqlProxmoxCephOsd) GetHost() *plugin.TValue[string] {
 	return &c.Host
+}
+
+func (c *mqlProxmoxCephOsd) GetNode() *plugin.TValue[*mqlProxmoxNode] {
+	return plugin.GetOrCompute[*mqlProxmoxNode](&c.Node, func() (*mqlProxmoxNode, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("proxmox.ceph.osd", c.__id, "node")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlProxmoxNode), nil
+			}
+		}
+
+		return c.node()
+	})
 }
 
 func (c *mqlProxmoxCephOsd) GetUp() *plugin.TValue[bool] {

--- a/providers/proxmox/resources/proxmox.lr.versions
+++ b/providers/proxmox/resources/proxmox.lr.versions
@@ -74,6 +74,7 @@ proxmox.ceph.manager.cephVersionShort 0.3.6
 proxmox.ceph.manager.directoryExists 0.3.6
 proxmox.ceph.manager.host 0.3.6
 proxmox.ceph.manager.name 0.3.6
+proxmox.ceph.manager.node 0.4.2
 proxmox.ceph.manager.service 0.3.6
 proxmox.ceph.manager.state 0.3.6
 proxmox.ceph.managers 0.3.6
@@ -86,6 +87,7 @@ proxmox.ceph.metadataServer.fileSystem 0.3.6
 proxmox.ceph.metadataServer.fsName 0.3.6
 proxmox.ceph.metadataServer.host 0.3.6
 proxmox.ceph.metadataServer.name 0.3.6
+proxmox.ceph.metadataServer.node 0.4.2
 proxmox.ceph.metadataServer.rank 0.3.6
 proxmox.ceph.metadataServer.service 0.3.6
 proxmox.ceph.metadataServer.standbyReplay 0.3.6
@@ -98,6 +100,7 @@ proxmox.ceph.monitor.cephVersionShort 0.3.6
 proxmox.ceph.monitor.directoryExists 0.3.6
 proxmox.ceph.monitor.host 0.3.6
 proxmox.ceph.monitor.name 0.3.6
+proxmox.ceph.monitor.node 0.4.2
 proxmox.ceph.monitor.quorum 0.3.6
 proxmox.ceph.monitor.rank 0.3.6
 proxmox.ceph.monitor.service 0.3.6
@@ -121,6 +124,7 @@ proxmox.ceph.osd.host 0.3.6
 proxmox.ceph.osd.id 0.3.6
 proxmox.ceph.osd.inCluster 0.3.6
 proxmox.ceph.osd.name 0.3.6
+proxmox.ceph.osd.node 0.4.2
 proxmox.ceph.osd.objectStore 0.3.6
 proxmox.ceph.osd.percentUsed 0.3.6
 proxmox.ceph.osd.reweight 0.3.6
@@ -242,6 +246,7 @@ proxmox.container.network.name 0.1.9
 proxmox.container.network.tag 0.1.9
 proxmox.container.networks 0.1.9
 proxmox.container.node 0.1.9
+proxmox.container.nodeRef 0.4.2
 proxmox.container.onboot 0.1.9
 proxmox.container.osType 0.1.9
 proxmox.container.passthroughDevice 0.1.9
@@ -650,11 +655,13 @@ proxmox.storage.volume.encrypted 0.3.6
 proxmox.storage.volume.encryptionFingerprint 0.3.6
 proxmox.storage.volume.format 0.3.6
 proxmox.storage.volume.node 0.3.6
+proxmox.storage.volume.nodeRef 0.4.2
 proxmox.storage.volume.notes 0.3.6
 proxmox.storage.volume.parent 0.3.6
 proxmox.storage.volume.protected 0.3.6
 proxmox.storage.volume.size 0.3.6
 proxmox.storage.volume.storage 0.3.6
+proxmox.storage.volume.storageRef 0.4.2
 proxmox.storage.volume.used 0.3.6
 proxmox.storage.volume.verification 0.3.6
 proxmox.storage.volume.vm 0.3.6
@@ -742,6 +749,7 @@ proxmox.vm.network.model 0.1.1
 proxmox.vm.network.tag 0.1.1
 proxmox.vm.networks 0.1.1
 proxmox.vm.node 0.1.1
+proxmox.vm.nodeRef 0.4.2
 proxmox.vm.osType 0.1.1
 proxmox.vm.pciDevice 0.1.9
 proxmox.vm.pciDevice.address 0.1.9

--- a/providers/proxmox/resources/replication.go
+++ b/providers/proxmox/resources/replication.go
@@ -49,25 +49,11 @@ func (r *mqlProxmox) replicationJobs() ([]any, error) {
 }
 
 func (r *mqlProxmoxReplicationJob) sourceNode() (*mqlProxmoxNode, error) {
-	return replicationNodeRef(r.MqlRuntime, r.Source.Data, &r.SourceNode)
+	return resolveNodeRef(r.MqlRuntime, r.Source.Data, &r.SourceNode)
 }
 
 func (r *mqlProxmoxReplicationJob) targetNode() (*mqlProxmoxNode, error) {
-	return replicationNodeRef(r.MqlRuntime, r.Target.Data, &r.TargetNode)
-}
-
-func replicationNodeRef(runtime *plugin.Runtime, name string, slot *plugin.TValue[*mqlProxmoxNode]) (*mqlProxmoxNode, error) {
-	if name == "" {
-		slot.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
-	}
-	res, err := NewResource(runtime, "proxmox.node", map[string]*llx.RawData{
-		"name": llx.StringData(name),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlProxmoxNode), nil
+	return resolveNodeRef(r.MqlRuntime, r.Target.Data, &r.TargetNode)
 }
 
 // ensureGuestKind reads /cluster/resources once to determine whether this

--- a/providers/proxmox/resources/xrefs.go
+++ b/providers/proxmox/resources/xrefs.go
@@ -8,10 +8,11 @@ import (
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/proxmox/connection"
 )
 
 // ---------------------------------------------------------------------------
-// vm.disk / container.mountPoint → storage
+// vm.disk / container.mountPoint / storage.volume → storage
 // ---------------------------------------------------------------------------
 
 func (r *mqlProxmoxVmDisk) storageRef() (*mqlProxmoxStorage, error) {
@@ -22,8 +23,29 @@ func (r *mqlProxmoxContainerMountPoint) storageRef() (*mqlProxmoxStorage, error)
 	return resolveStorageRef(r.MqlRuntime, r.Storage.Data, &r.StorageRef)
 }
 
+func (r *mqlProxmoxStorageVolume) storageRef() (*mqlProxmoxStorage, error) {
+	return resolveStorageRef(r.MqlRuntime, r.Storage.Data, &r.StorageRef)
+}
+
+// resolveStorageRef turns a storage name into a storage resource. The name is
+// checked against the connection's storage index first: a name the cluster no
+// longer configures is reported as null rather than handed to NewResource,
+// whose init would otherwise build a storage with every field unset.
 func resolveStorageRef(runtime *plugin.Runtime, storageID string, slot *plugin.TValue[*mqlProxmoxStorage]) (*mqlProxmoxStorage, error) {
 	if storageID == "" {
+		slot.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.PveConnection)
+	if !ok {
+		slot.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	_, found, err := conn.LookupStorage(storageID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
 		slot.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -34,6 +56,70 @@ func resolveStorageRef(runtime *plugin.Runtime, storageID string, slot *plugin.T
 		return nil, err
 	}
 	return res.(*mqlProxmoxStorage), nil
+}
+
+// ---------------------------------------------------------------------------
+// vm / container / storage.volume / ceph daemons → node
+// ---------------------------------------------------------------------------
+
+func (r *mqlProxmoxVm) nodeRef() (*mqlProxmoxNode, error) {
+	return resolveNodeRef(r.MqlRuntime, r.Node.Data, &r.NodeRef)
+}
+
+func (r *mqlProxmoxContainer) nodeRef() (*mqlProxmoxNode, error) {
+	return resolveNodeRef(r.MqlRuntime, r.Node.Data, &r.NodeRef)
+}
+
+func (r *mqlProxmoxStorageVolume) nodeRef() (*mqlProxmoxNode, error) {
+	return resolveNodeRef(r.MqlRuntime, r.Node.Data, &r.NodeRef)
+}
+
+func (r *mqlProxmoxCephMonitor) node() (*mqlProxmoxNode, error) {
+	return resolveNodeRef(r.MqlRuntime, r.Host.Data, &r.Node)
+}
+
+func (r *mqlProxmoxCephManager) node() (*mqlProxmoxNode, error) {
+	return resolveNodeRef(r.MqlRuntime, r.Host.Data, &r.Node)
+}
+
+func (r *mqlProxmoxCephMetadataServer) node() (*mqlProxmoxNode, error) {
+	return resolveNodeRef(r.MqlRuntime, r.Host.Data, &r.Node)
+}
+
+func (r *mqlProxmoxCephOsd) node() (*mqlProxmoxNode, error) {
+	return resolveNodeRef(r.MqlRuntime, r.Host.Data, &r.Node)
+}
+
+// resolveNodeRef turns a node name into a node resource. Node names are
+// cluster-unique, so the name alone identifies the host. The name is checked
+// against the connection's node index first, which both keeps the whole fleet
+// of guests and daemons down to a single node listing and lets a name the
+// cluster no longer knows be reported as null instead of a blank node.
+func resolveNodeRef(runtime *plugin.Runtime, name string, slot *plugin.TValue[*mqlProxmoxNode]) (*mqlProxmoxNode, error) {
+	if name == "" {
+		slot.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	conn, ok := runtime.Connection.(*connection.PveConnection)
+	if !ok {
+		slot.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	_, found, err := conn.LookupNode(name)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		slot.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(runtime, "proxmox.node", map[string]*llx.RawData{
+		"name": llx.StringData(name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlProxmoxNode), nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`proxmox.vm.node` and `proxmox.container.node` are the two most-queried foreign keys in the schema, and both were bare strings — while `proxmox.replication.job` right next door already resolved its node names through `sourceNode()` / `targetNode()`.

**Before** — the join is not expressible; you get a name and stop there:

```mql
proxmox.vms {
  name
  node        // "pve2", and that is the end of the road
}
```

**After** — the host is a resource:

```mql
proxmox.vms.where(status == "running") {
  name
  nodeRef {
    name
    status
    subscriptionLevel
    kernelVersion
    firewallOptions { enable }
  }
}
```

## New accessors (8)

| Resource | Source field | Accessor | Target |
|---|---|---|---|
| `proxmox.vm` | `node` | `nodeRef()` | `proxmox.node` |
| `proxmox.container` | `node` | `nodeRef()` | `proxmox.node` |
| `proxmox.storage.volume` | `storage` | `storageRef()` | `proxmox.storage` |
| `proxmox.storage.volume` | `node` | `nodeRef()` | `proxmox.node` |
| `proxmox.ceph.monitor` | `host` | `node()` | `proxmox.node` |
| `proxmox.ceph.manager` | `host` | `node()` | `proxmox.node` |
| `proxmox.ceph.metadataServer` | `host` | `node()` | `proxmox.node` |
| `proxmox.ceph.osd` | `host` | `node()` | `proxmox.node` |

`proxmox.storage.volume` already resolved its *guest* (`vm()` / `container()`) but not the storage it sits on, which is what `storageRef()` closes.

## The connection-level index is what makes this affordable

`NewResource` runs the target's `init` **before** the runtime cache is consulted, and `initProxmoxNode` made two API calls of its own (`GetNodes` + `GetClusterStatus`). Both of those were uncached. A naive `vm.nodeRef()` on a **60-guest cluster would have been 120 HTTP calls** just to name the hosts.

`PveConnection` now carries a `sync.Once` **node index** and **storage index**, modelled on the existing `backupIndex` and sitting alongside the Ceph, backup, and corosync memos it already had. Each memoizes its **error** as well as its value, so a token that cannot read `/nodes` fails once instead of once per guest. `initProxmoxNode` and `initProxmoxStorage` were refactored to read through the indexes, so the whole fleet now costs **one node listing, one cluster status, and one storage listing** — regardless of guest count.

Checking the index before calling `NewResource` also fixes a second-order bug: a node or storage name the cluster no longer knows is now reported as **null**, rather than being handed to an `init` that would fall through and build a resource with every field unset.

`replicationNodeRef` and `resolveStorageRef` are refactored onto the shared helpers rather than duplicated. Every singular accessor sets `StateIsSet | StateIsNull` before returning nil, and the connection type assertion uses the comma-ok form so a bad cast can't panic a scan.

## Deprecations (schema only, listed separately from the above)

Ten raw fields that an **existing** accessor already fully duplicates are marked `@maturity("deprecated")`, following the precedent set by `proxmox.user.groups`:

| Field | Superseded by |
|---|---|
| `proxmox.vm.disk.storage` | `storageRef()` |
| `proxmox.container.mountPoint.storage` | `storageRef()` |
| `proxmox.cluster.haResource.group` | `groupRef()` |
| `proxmox.acl.roleId` | `role()` |
| `proxmox.backup.job.storage` | `targetStorage()` |
| `proxmox.replication.job.source` / `.target` | `sourceNode()` / `targetNode()` |
| `proxmox.sdn.vnet.zone` | `zoneRef()` |
| `proxmox.sdn.subnet.vnet` | `vnetRef()` |
| `proxmox.ceph.metadataServer.fsName` | `fileSystem()` |
| `proxmox.group.memberIds` | `members()` |

**Deliberately not deprecated:**
- The `node` / `storage` / `host` fields gaining accessors here — they remain the join keys users write `.where(node == "pve1")` against.
- `proxmox.storage.volume.vmid` and `proxmox.replication.job.vmid` — their ref pair is discriminated (`vm()` xor `container()`), so the raw VMID is the only field that answers "which guest" without branching.

Deprecation does not bump a `.lr.versions` entry; those lines are untouched. The 8 new entries land at `0.4.2`, the next patch after the shipped `0.4.1`. `config.go` is not bumped.

## Testing

New unit tests cover both indexes: hit, miss, empty key, errored listing (asserting the failure is memoized and not retried), and the fetched-once property. A standalone-host case pins that a missing `/cluster/status` leaves the address empty rather than failing every node reference.

```
$ go build ./...
$ go test ./...
ok  	go.mondoo.com/mql/v13/providers/proxmox/connection	1.747s
ok  	go.mondoo.com/mql/v13/providers/proxmox/resources	1.332s

$ go test -race ./...
ok  	go.mondoo.com/mql/v13/providers/proxmox/connection	2.595s
ok  	go.mondoo.com/mql/v13/providers/proxmox/resources	2.326s
```

`go mod tidy` produces no diff. Codegen is idempotent across two runs.
