### PR TITLE
⭐ digitalocean: add VPC reverse edges and mark duplicated ID fields deprecated

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -481,12 +481,16 @@ digitalocean.database @defaults("id name engine") {
   // Time the resource was created
   createdAt time
   // ID of the project the cluster belongs to
-  projectId string
+  //
+  // Deprecated in favor of `project`.
+  projectId @maturity("deprecated") string
   // Project the cluster belongs to
   project() digitalocean.project
   // Private network UUID
-  privateNetworkUuid string
-  // VPC the cluster is attached to (resolved from privateNetworkUuid)
+  //
+  // Deprecated in favor of `vpc`.
+  privateNetworkUuid @maturity("deprecated") string
+  // VPC the cluster is attached to
   vpc() digitalocean.vpc
   // Tags
   tags []string
@@ -960,7 +964,9 @@ digitalocean.loadBalancer @defaults("id name status") {
   // Number of nodes the load balancer is sized to; zero when sized by slug
   sizeUnit int
   // ID of the project the load balancer belongs to
-  projectId string
+  //
+  // Deprecated in favor of `project`.
+  projectId @maturity("deprecated") string
   // Project the load balancer belongs to
   project() digitalocean.project
   // Network visibility (EXTERNAL for internet-facing, INTERNAL for VPC-only)
@@ -1036,6 +1042,41 @@ digitalocean.vpc @defaults("id name region") {
   default bool
   // Uniform resource name (URN) identifying the VPC across DigitalOcean APIs
   urn string
+  // Droplets attached to the VPC
+  //
+  // Every droplet whose private interface sits on this network. Null when
+  // the account's droplet list could not be read, so an empty list always
+  // means the VPC genuinely holds no droplets.
+  droplets() []digitalocean.droplet
+  // Managed database clusters attached to the VPC
+  //
+  // Clusters whose private connection endpoint is served from this network.
+  // Null when the account's database list could not be read.
+  databases() []digitalocean.database
+  // Load balancers attached to the VPC
+  //
+  // Load balancers that forward to backends over this private network,
+  // including internal load balancers with no public address. Null when
+  // the account's load balancer list could not be read.
+  loadBalancers() []digitalocean.loadBalancer
+  // Kubernetes clusters attached to the VPC
+  //
+  // DOKS clusters whose worker nodes are placed on this network. Null when
+  // the account's cluster list could not be read.
+  kubernetesClusters() []digitalocean.kubernetes.cluster
+  // Managed NFS shares reachable from the VPC
+  //
+  // Shares that export a mount target into this network. A share can be
+  // reachable from several VPCs, so it may appear under more than one.
+  // Null when the account's NFS share list could not be read.
+  nfsShares() []digitalocean.nfs
+  // NAT gateways attached to the VPC
+  //
+  // Gateways that give this network outbound internet access without
+  // assigning public addresses to its members. A gateway can serve several
+  // VPCs, so it may appear under more than one. Null when the account's
+  // NAT gateway list could not be read.
+  natGateways() []digitalocean.vpcNatGateway
 }
 
 // DigitalOcean VPC peering
@@ -1181,7 +1222,9 @@ private digitalocean.kubernetes.nodePool @defaults("id name size") {
   // Node pool ID
   id string
   // Cluster ID (parent)
-  clusterId string
+  //
+  // Deprecated in favor of `cluster`.
+  clusterId @maturity("deprecated") string
   // Cluster this node pool belongs to
   cluster() digitalocean.kubernetes.cluster
   // Name
@@ -1488,13 +1531,17 @@ digitalocean.reservedIp @defaults("ip region") {
   // Region slug
   region string
   // Project ID
-  projectId string
+  //
+  // Deprecated in favor of `project`.
+  projectId @maturity("deprecated") string
   // Project the IP belongs to
   project() digitalocean.project
   // Whether the IP is locked
   locked bool
   // Droplet ID (0 if unassigned)
-  dropletId int
+  //
+  // Deprecated in favor of `droplet`.
+  dropletId @maturity("deprecated") int
   // Droplet the IP is routed to; null when unassigned
   droplet() digitalocean.droplet
 }
@@ -1832,7 +1879,9 @@ digitalocean.cdn @defaults("id origin") {
   // TTL in seconds
   ttl int
   // TLS certificate ID
-  certificateId string
+  //
+  // Deprecated in favor of `certificate`.
+  certificateId @maturity("deprecated") string
   // TLS certificate bound to the endpoint; null when none is configured
   certificate() digitalocean.certificate
   // Custom domain
@@ -2254,7 +2303,9 @@ digitalocean.vpcNatGateway @defaults("id name region state") {
   // TCP connection-tracking timeout, in seconds
   tcpTimeoutSeconds int
   // ID of the project the gateway belongs to
-  projectId string
+  //
+  // Deprecated in favor of `project`.
+  projectId @maturity("deprecated") string
   // Project the gateway belongs to
   project() digitalocean.project
   // Time the gateway was created
@@ -2323,7 +2374,9 @@ private digitalocean.nfs.snapshot @defaults("name status sizeGibibytes createdAt
   // Lifecycle status of the snapshot (CREATING, AVAILABLE, DELETING, or ERROR)
   status string
   // ID of the share the snapshot was taken from
-  shareId string
+  //
+  // Deprecated in favor of `share`.
+  shareId @maturity("deprecated") string
   // Share the snapshot was taken from
   share() digitalocean.nfs
   // Time the snapshot was created
@@ -2418,7 +2471,9 @@ digitalocean.reservedIpV6 @defaults("ip region") {
   // Time the address was reserved
   reservedAt time
   // Droplet ID the address is assigned to (0 if unassigned)
-  dropletId int
+  //
+  // Deprecated in favor of `droplet`.
+  dropletId @maturity("deprecated") int
   // Droplet the address is assigned to; null when unassigned
   droplet() digitalocean.droplet
 }

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -1466,6 +1466,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.vpc.urn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpc).GetUrn()).ToDataRes(types.String)
 	},
+	"digitalocean.vpc.droplets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetDroplets()).ToDataRes(types.Array(types.Resource("digitalocean.droplet")))
+	},
+	"digitalocean.vpc.databases": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetDatabases()).ToDataRes(types.Array(types.Resource("digitalocean.database")))
+	},
+	"digitalocean.vpc.loadBalancers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetLoadBalancers()).ToDataRes(types.Array(types.Resource("digitalocean.loadBalancer")))
+	},
+	"digitalocean.vpc.kubernetesClusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetKubernetesClusters()).ToDataRes(types.Array(types.Resource("digitalocean.kubernetes.cluster")))
+	},
+	"digitalocean.vpc.nfsShares": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetNfsShares()).ToDataRes(types.Array(types.Resource("digitalocean.nfs")))
+	},
+	"digitalocean.vpc.natGateways": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetNatGateways()).ToDataRes(types.Array(types.Resource("digitalocean.vpcNatGateway")))
+	},
 	"digitalocean.vpcPeering.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpcPeering).GetId()).ToDataRes(types.String)
 	},
@@ -4944,6 +4962,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.vpc.urn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanVpc).Urn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.droplets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).Droplets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.databases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).Databases, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.loadBalancers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).LoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.kubernetesClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).KubernetesClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.nfsShares": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).NfsShares, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.natGateways": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).NatGateways, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.vpcPeering.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11512,14 +11554,20 @@ type mqlDigitaloceanVpc struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDigitaloceanVpcInternal it will be used here
-	Id          plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Description plugin.TValue[string]
-	IpRange     plugin.TValue[string]
-	Region      plugin.TValue[string]
-	CreatedAt   plugin.TValue[*time.Time]
-	Default     plugin.TValue[bool]
-	Urn         plugin.TValue[string]
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	Description        plugin.TValue[string]
+	IpRange            plugin.TValue[string]
+	Region             plugin.TValue[string]
+	CreatedAt          plugin.TValue[*time.Time]
+	Default            plugin.TValue[bool]
+	Urn                plugin.TValue[string]
+	Droplets           plugin.TValue[[]any]
+	Databases          plugin.TValue[[]any]
+	LoadBalancers      plugin.TValue[[]any]
+	KubernetesClusters plugin.TValue[[]any]
+	NfsShares          plugin.TValue[[]any]
+	NatGateways        plugin.TValue[[]any]
 }
 
 // createDigitaloceanVpc creates a new instance of this resource
@@ -11589,6 +11637,102 @@ func (c *mqlDigitaloceanVpc) GetDefault() *plugin.TValue[bool] {
 
 func (c *mqlDigitaloceanVpc) GetUrn() *plugin.TValue[string] {
 	return &c.Urn
+}
+
+func (c *mqlDigitaloceanVpc) GetDroplets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Droplets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpc", c.__id, "droplets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.droplets()
+	})
+}
+
+func (c *mqlDigitaloceanVpc) GetDatabases() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Databases, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpc", c.__id, "databases")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.databases()
+	})
+}
+
+func (c *mqlDigitaloceanVpc) GetLoadBalancers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LoadBalancers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpc", c.__id, "loadBalancers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.loadBalancers()
+	})
+}
+
+func (c *mqlDigitaloceanVpc) GetKubernetesClusters() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.KubernetesClusters, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpc", c.__id, "kubernetesClusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.kubernetesClusters()
+	})
+}
+
+func (c *mqlDigitaloceanVpc) GetNfsShares() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.NfsShares, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpc", c.__id, "nfsShares")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.nfsShares()
+	})
+}
+
+func (c *mqlDigitaloceanVpc) GetNatGateways() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.NatGateways, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpc", c.__id, "natGateways")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.natGateways()
+	})
 }
 
 // mqlDigitaloceanVpcPeering for the digitalocean.vpcPeering resource

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -1069,11 +1069,17 @@ digitalocean.volume.tags 13.0.1
 digitalocean.volumes 13.0.1
 digitalocean.vpc 13.0.1
 digitalocean.vpc.createdAt 13.0.1
+digitalocean.vpc.databases 13.15.3
 digitalocean.vpc.default 13.0.1
 digitalocean.vpc.description 13.0.1
+digitalocean.vpc.droplets 13.15.3
 digitalocean.vpc.id 13.0.1
 digitalocean.vpc.ipRange 13.0.1
+digitalocean.vpc.kubernetesClusters 13.15.3
+digitalocean.vpc.loadBalancers 13.15.3
 digitalocean.vpc.name 13.0.1
+digitalocean.vpc.natGateways 13.15.3
+digitalocean.vpc.nfsShares 13.15.3
 digitalocean.vpc.region 13.0.1
 digitalocean.vpc.urn 13.10.2
 digitalocean.vpcNatGateway 13.4.2

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -86,6 +86,34 @@ type mqlDigitaloceanInternal struct {
 	backupPolicyIndexOnce sync.Once
 	backupPolicyIndex     map[int64]dropletBackupPolicy
 	backupPolicyIndexErr  error
+
+	// The vpc*Index maps invert the forward VPC reference each child
+	// carries, so digitalocean.vpc can report what sits on it. Each is
+	// keyed by VPC id and built once from the collection the child comes
+	// from. See digitalocean_vpc_members.go.
+	vpcDropletIndexOnce sync.Once
+	vpcDropletIndex     map[string][]any
+	vpcDropletIndexErr  error
+
+	vpcDatabaseIndexOnce sync.Once
+	vpcDatabaseIndex     map[string][]any
+	vpcDatabaseIndexErr  error
+
+	vpcLoadBalancerIndexOnce sync.Once
+	vpcLoadBalancerIndex     map[string][]any
+	vpcLoadBalancerIndexErr  error
+
+	vpcK8sClusterIndexOnce sync.Once
+	vpcK8sClusterIndex     map[string][]any
+	vpcK8sClusterIndexErr  error
+
+	vpcNfsShareIndexOnce sync.Once
+	vpcNfsShareIndex     map[string][]any
+	vpcNfsShareIndexErr  error
+
+	vpcNatGatewayIndexOnce sync.Once
+	vpcNatGatewayIndex     map[string][]any
+	vpcNatGatewayIndexErr  error
 }
 
 // partnerAttachmentByID resolves a partner attachment by its ID from the

--- a/providers/digitalocean/resources/digitalocean_vpc_members.go
+++ b/providers/digitalocean/resources/digitalocean_vpc_members.go
@@ -1,0 +1,240 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Reverse edges from digitalocean.vpc back to the resources that sit on it.
+//
+// Each child already carries a forward reference to its VPC, so the reverse
+// direction is a regrouping of collections the parent resource has usually
+// fetched anyway. Every index below is built once from the parent's own
+// accessor, which means asking all VPCs what they hold costs the same single
+// list call as asking one.
+
+// groupByVpcID buckets already-fetched resources by the VPC ids each one
+// reports. A resource attached to several VPCs lands under each of them, and
+// one reporting no VPC is dropped rather than filed under the empty id.
+func groupByVpcID(items []any, vpcIDsOf func(any) []string) map[string][]any {
+	idx := make(map[string][]any, len(items))
+	for _, item := range items {
+		for _, id := range vpcIDsOf(item) {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			idx[id] = append(idx[id], item)
+		}
+	}
+	return idx
+}
+
+// vpcMemberList selects one VPC's members out of a reverse index. The second
+// return is false when the answer is unknown rather than empty: the VPC has
+// no id to match on, or the collection the index is built from could not be
+// read. Callers turn that into a null field, because an empty list has to
+// keep meaning "nothing sits on this VPC".
+func vpcMemberList(idx map[string][]any, idxErr error, vpcID string) ([]any, bool) {
+	id := strings.TrimSpace(vpcID)
+	if id == "" || idxErr != nil {
+		return nil, false
+	}
+	found := idx[id]
+	out := make([]any, len(found))
+	copy(out, found)
+	return out, true
+}
+
+// vpcMembers answers one reverse edge, resolving the index through the
+// account-level parent so the underlying collection is fetched at most once
+// for the whole scan.
+func vpcMembers(
+	vpc *mqlDigitaloceanVpc,
+	target *plugin.TValue[[]any],
+	index func(*mqlDigitalocean) (map[string][]any, error),
+) ([]any, error) {
+	var (
+		idx    map[string][]any
+		idxErr error
+	)
+	if strings.TrimSpace(vpc.Id.Data) != "" {
+		parent, err := parentDigitalocean(vpc.MqlRuntime)
+		if err != nil {
+			return nil, err
+		}
+		idx, idxErr = index(parent)
+	}
+	members, ok := vpcMemberList(idx, idxErr, vpc.Id.Data)
+	if !ok {
+		target.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return members, nil
+}
+
+// stringsFromRawList narrows a runtime []string field, whose elements arrive
+// as any, dropping anything that is not a string.
+func stringsFromRawList(raw []any) []string {
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// --- Per-collection VPC id extractors ---
+
+func dropletVpcIDs(v any) []string {
+	d, ok := v.(*mqlDigitaloceanDroplet)
+	if !ok {
+		return nil
+	}
+	return []string{d.VpcUuid.Data}
+}
+
+func databaseVpcIDs(v any) []string {
+	d, ok := v.(*mqlDigitaloceanDatabase)
+	if !ok {
+		return nil
+	}
+	return []string{d.PrivateNetworkUuid.Data}
+}
+
+func loadBalancerVpcIDs(v any) []string {
+	lb, ok := v.(*mqlDigitaloceanLoadBalancer)
+	if !ok {
+		return nil
+	}
+	return []string{lb.VpcUuid.Data}
+}
+
+func kubernetesClusterVpcIDs(v any) []string {
+	c, ok := v.(*mqlDigitaloceanKubernetesCluster)
+	if !ok {
+		return nil
+	}
+	return []string{c.VpcUuid.Data}
+}
+
+func nfsShareVpcIDs(v any) []string {
+	n, ok := v.(*mqlDigitaloceanNfs)
+	if !ok {
+		return nil
+	}
+	return stringsFromRawList(n.VpcIds.Data)
+}
+
+func natGatewayVpcIDs(v any) []string {
+	g, ok := v.(*mqlDigitaloceanVpcNatGateway)
+	if !ok {
+		return nil
+	}
+	return g.vpcUUIDs
+}
+
+// --- Memoized reverse indexes on the account-level parent ---
+
+func (r *mqlDigitalocean) dropletsByVpc() (map[string][]any, error) {
+	r.vpcDropletIndexOnce.Do(func() {
+		droplets := r.GetDroplets()
+		if droplets.Error != nil {
+			r.vpcDropletIndexErr = droplets.Error
+			return
+		}
+		r.vpcDropletIndex = groupByVpcID(droplets.Data, dropletVpcIDs)
+	})
+	return r.vpcDropletIndex, r.vpcDropletIndexErr
+}
+
+func (r *mqlDigitalocean) databasesByVpc() (map[string][]any, error) {
+	r.vpcDatabaseIndexOnce.Do(func() {
+		databases := r.GetDatabases()
+		if databases.Error != nil {
+			r.vpcDatabaseIndexErr = databases.Error
+			return
+		}
+		r.vpcDatabaseIndex = groupByVpcID(databases.Data, databaseVpcIDs)
+	})
+	return r.vpcDatabaseIndex, r.vpcDatabaseIndexErr
+}
+
+func (r *mqlDigitalocean) loadBalancersByVpc() (map[string][]any, error) {
+	r.vpcLoadBalancerIndexOnce.Do(func() {
+		lbs := r.GetLoadBalancers()
+		if lbs.Error != nil {
+			r.vpcLoadBalancerIndexErr = lbs.Error
+			return
+		}
+		r.vpcLoadBalancerIndex = groupByVpcID(lbs.Data, loadBalancerVpcIDs)
+	})
+	return r.vpcLoadBalancerIndex, r.vpcLoadBalancerIndexErr
+}
+
+func (r *mqlDigitalocean) kubernetesClustersByVpc() (map[string][]any, error) {
+	r.vpcK8sClusterIndexOnce.Do(func() {
+		clusters := r.GetKubernetesClusters()
+		if clusters.Error != nil {
+			r.vpcK8sClusterIndexErr = clusters.Error
+			return
+		}
+		r.vpcK8sClusterIndex = groupByVpcID(clusters.Data, kubernetesClusterVpcIDs)
+	})
+	return r.vpcK8sClusterIndex, r.vpcK8sClusterIndexErr
+}
+
+func (r *mqlDigitalocean) nfsSharesByVpc() (map[string][]any, error) {
+	r.vpcNfsShareIndexOnce.Do(func() {
+		shares := r.GetNfsShares()
+		if shares.Error != nil {
+			r.vpcNfsShareIndexErr = shares.Error
+			return
+		}
+		r.vpcNfsShareIndex = groupByVpcID(shares.Data, nfsShareVpcIDs)
+	})
+	return r.vpcNfsShareIndex, r.vpcNfsShareIndexErr
+}
+
+func (r *mqlDigitalocean) natGatewaysByVpc() (map[string][]any, error) {
+	r.vpcNatGatewayIndexOnce.Do(func() {
+		gateways := r.GetVpcNatGateways()
+		if gateways.Error != nil {
+			r.vpcNatGatewayIndexErr = gateways.Error
+			return
+		}
+		r.vpcNatGatewayIndex = groupByVpcID(gateways.Data, natGatewayVpcIDs)
+	})
+	return r.vpcNatGatewayIndex, r.vpcNatGatewayIndexErr
+}
+
+// --- Reverse-edge accessors ---
+
+func (r *mqlDigitaloceanVpc) droplets() ([]any, error) {
+	return vpcMembers(r, &r.Droplets, (*mqlDigitalocean).dropletsByVpc)
+}
+
+func (r *mqlDigitaloceanVpc) databases() ([]any, error) {
+	return vpcMembers(r, &r.Databases, (*mqlDigitalocean).databasesByVpc)
+}
+
+func (r *mqlDigitaloceanVpc) loadBalancers() ([]any, error) {
+	return vpcMembers(r, &r.LoadBalancers, (*mqlDigitalocean).loadBalancersByVpc)
+}
+
+func (r *mqlDigitaloceanVpc) kubernetesClusters() ([]any, error) {
+	return vpcMembers(r, &r.KubernetesClusters, (*mqlDigitalocean).kubernetesClustersByVpc)
+}
+
+func (r *mqlDigitaloceanVpc) nfsShares() ([]any, error) {
+	return vpcMembers(r, &r.NfsShares, (*mqlDigitalocean).nfsSharesByVpc)
+}
+
+func (r *mqlDigitaloceanVpc) natGateways() ([]any, error) {
+	return vpcMembers(r, &r.NatGateways, (*mqlDigitalocean).natGatewaysByVpc)
+}

--- a/providers/digitalocean/resources/digitalocean_vpc_members_test.go
+++ b/providers/digitalocean/resources/digitalocean_vpc_members_test.go
@@ -1,0 +1,175 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func setStr(s string) plugin.TValue[string] {
+	return plugin.TValue[string]{Data: s, State: plugin.StateIsSet}
+}
+
+func setList(items ...any) plugin.TValue[[]any] {
+	return plugin.TValue[[]any]{Data: items, State: plugin.StateIsSet}
+}
+
+func TestGroupByVpcID(t *testing.T) {
+	a := &mqlDigitaloceanDroplet{Id: plugin.TValue[int64]{Data: 1, State: plugin.StateIsSet}, VpcUuid: setStr("vpc-a")}
+	b := &mqlDigitaloceanDroplet{Id: plugin.TValue[int64]{Data: 2, State: plugin.StateIsSet}, VpcUuid: setStr("vpc-a")}
+	unattached := &mqlDigitaloceanDroplet{Id: plugin.TValue[int64]{Data: 3, State: plugin.StateIsSet}, VpcUuid: setStr("")}
+	whitespace := &mqlDigitaloceanDroplet{Id: plugin.TValue[int64]{Data: 4, State: plugin.StateIsSet}, VpcUuid: setStr("   ")}
+
+	idx := groupByVpcID([]any{a, b, unattached, whitespace}, dropletVpcIDs)
+
+	assert.Equal(t, []any{a, b}, idx["vpc-a"], "both droplets land under their VPC")
+	assert.Empty(t, idx["vpc-b"], "a VPC with no members has no bucket")
+	assert.NotContains(t, idx, "", "a droplet with no VPC is dropped, not filed under the empty id")
+	assert.Len(t, idx, 1)
+}
+
+func TestGroupByVpcIDMultiAttach(t *testing.T) {
+	// An NFS share is reachable from several VPCs at once, so it has to
+	// appear under each of them rather than only the first.
+	share := &mqlDigitaloceanNfs{
+		Id:     setStr("share-1"),
+		VpcIds: setList("vpc-a", "vpc-b"),
+	}
+	onlyB := &mqlDigitaloceanNfs{Id: setStr("share-2"), VpcIds: setList("vpc-b")}
+	detached := &mqlDigitaloceanNfs{Id: setStr("share-3"), VpcIds: setList()}
+
+	idx := groupByVpcID([]any{share, onlyB, detached}, nfsShareVpcIDs)
+
+	assert.Equal(t, []any{share}, idx["vpc-a"])
+	assert.Equal(t, []any{share, onlyB}, idx["vpc-b"])
+	assert.Len(t, idx, 2)
+}
+
+func TestGroupByVpcIDSkipsForeignEntries(t *testing.T) {
+	// A cached collection holding an unexpected type must be skipped rather
+	// than panic the scan on a bare type assertion.
+	idx := groupByVpcID([]any{"not a droplet", nil, &mqlDigitaloceanDroplet{VpcUuid: setStr("vpc-a")}}, dropletVpcIDs)
+	assert.Len(t, idx["vpc-a"], 1)
+	assert.Len(t, idx, 1)
+}
+
+func TestVpcIDExtractors(t *testing.T) {
+	// Pins which field each collection is grouped by. Reading the wrong id
+	// field would silently report an empty VPC instead of failing.
+	tests := []struct {
+		name    string
+		item    any
+		extract func(any) []string
+		want    []string
+	}{
+		{
+			name:    "droplet uses vpcUuid",
+			item:    &mqlDigitaloceanDroplet{VpcUuid: setStr("vpc-a")},
+			extract: dropletVpcIDs,
+			want:    []string{"vpc-a"},
+		},
+		{
+			name:    "database uses privateNetworkUuid",
+			item:    &mqlDigitaloceanDatabase{PrivateNetworkUuid: setStr("vpc-b")},
+			extract: databaseVpcIDs,
+			want:    []string{"vpc-b"},
+		},
+		{
+			name:    "load balancer uses vpcUuid",
+			item:    &mqlDigitaloceanLoadBalancer{VpcUuid: setStr("vpc-c")},
+			extract: loadBalancerVpcIDs,
+			want:    []string{"vpc-c"},
+		},
+		{
+			name:    "kubernetes cluster uses vpcUuid",
+			item:    &mqlDigitaloceanKubernetesCluster{VpcUuid: setStr("vpc-d")},
+			extract: kubernetesClusterVpcIDs,
+			want:    []string{"vpc-d"},
+		},
+		{
+			name:    "nfs share uses vpcIds",
+			item:    &mqlDigitaloceanNfs{VpcIds: setList("vpc-e", "vpc-f")},
+			extract: nfsShareVpcIDs,
+			want:    []string{"vpc-e", "vpc-f"},
+		},
+		{
+			name: "nat gateway uses its cached attachment uuids",
+			item: &mqlDigitaloceanVpcNatGateway{
+				mqlDigitaloceanVpcNatGatewayInternal: mqlDigitaloceanVpcNatGatewayInternal{
+					vpcUUIDs: []string{"vpc-g", "vpc-h"},
+				},
+			},
+			extract: natGatewayVpcIDs,
+			want:    []string{"vpc-g", "vpc-h"},
+		},
+		{
+			name:    "wrong resource type yields nothing",
+			item:    &mqlDigitaloceanVpc{Id: setStr("vpc-a")},
+			extract: dropletVpcIDs,
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.extract(tt.item))
+		})
+	}
+}
+
+func TestNfsShareVpcIDsDropsNonStrings(t *testing.T) {
+	share := &mqlDigitaloceanNfs{VpcIds: setList("vpc-a", 42, nil, "vpc-b")}
+	assert.Equal(t, []string{"vpc-a", "vpc-b"}, nfsShareVpcIDs(share))
+}
+
+func TestVpcMemberList(t *testing.T) {
+	droplet := &mqlDigitaloceanDroplet{VpcUuid: setStr("vpc-a")}
+	idx := map[string][]any{"vpc-a": {droplet}}
+
+	t.Run("vpc with matches", func(t *testing.T) {
+		got, ok := vpcMemberList(idx, nil, "vpc-a")
+		require.True(t, ok)
+		assert.Equal(t, []any{droplet}, got)
+	})
+
+	t.Run("vpc with no matches is empty, not null", func(t *testing.T) {
+		got, ok := vpcMemberList(idx, nil, "vpc-b")
+		require.True(t, ok, "an empty result is a real answer")
+		assert.Empty(t, got)
+		assert.NotNil(t, got)
+	})
+
+	t.Run("unreadable collection is null, not empty", func(t *testing.T) {
+		got, ok := vpcMemberList(nil, errors.New("403 forbidden"), "vpc-a")
+		assert.False(t, ok, "an unreadable collection must not read as an empty VPC")
+		assert.Nil(t, got)
+	})
+
+	t.Run("empty vpc id is null", func(t *testing.T) {
+		got, ok := vpcMemberList(idx, nil, "")
+		assert.False(t, ok)
+		assert.Nil(t, got)
+
+		got, ok = vpcMemberList(idx, nil, "   ")
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("result is a copy of the cached bucket", func(t *testing.T) {
+		got, ok := vpcMemberList(idx, nil, "vpc-a")
+		require.True(t, ok)
+		got[0] = nil
+		assert.Equal(t, []any{droplet}, idx["vpc-a"], "the memoized index must not be mutated by a caller")
+	})
+}
+
+func TestStringsFromRawList(t *testing.T) {
+	assert.Equal(t, []string{}, stringsFromRawList(nil))
+	assert.Equal(t, []string{}, stringsFromRawList([]any{}))
+	assert.Equal(t, []string{"a", "b"}, stringsFromRawList([]any{"a", 1, true, nil, "b"}))
+}


### PR DESCRIPTION
`digitalocean.vpc` was a pure leaf with zero accessors. Every child already carried a forward reference to it and nothing pointed back, so the two questions people actually ask about a private network were not expressible in a single query.

## Before / after

**Before** — "what is on the default VPC" had to be asked from the other end, once per resource kind, and joined by hand:

```javascript
// no way to go from the VPC to its members; you start from the members
digitalocean.droplets.where(vpc.default == true) { name }
digitalocean.databases.where(vpc.default == true) { name }
digitalocean.loadBalancers.where(vpc.default == true) { name }
// ...and there is still no single VPC-shaped answer
```

**After**:

```javascript
digitalocean.vpcs.where(default == true) {
  name
  ipRange
  droplets { name }
  databases { name engine }
  loadBalancers { name network }
  kubernetesClusters { name version }
  nfsShares { name }
  natGateways { name state }
}
```

which makes "is the default VPC still holding production workloads" a one-liner:

```javascript
digitalocean.vpcs.where(default == true).all(droplets.length == 0)
```

## New accessors on `digitalocean.vpc`

| accessor | inverse of |
|---|---|
| `droplets() []digitalocean.droplet` | `droplet.vpc` |
| `databases() []digitalocean.database` | `database.vpc` |
| `loadBalancers() []digitalocean.loadBalancer` | `loadBalancer.vpc` |
| `kubernetesClusters() []digitalocean.kubernetes.cluster` | `kubernetes.cluster.vpc` |
| `nfsShares() []digitalocean.nfs` | `nfs.vpcs` |
| `natGateways() []digitalocean.vpcNatGateway` | `vpcNatGateway.vpcs` |

### No new API calls

Every edge is an in-memory filter over a collection the account-level resource already fetches. Each one is grouped once, behind a `sync.Once` index keyed by VPC id on `mqlDigitaloceanInternal`, following the provider's existing `vpcByID` / `dropletByIDs` convention. Asking every VPC what it holds costs the same single list call as asking one, and `NewResource` is not used anywhere in the change.

NFS shares and NAT gateways can attach to several VPCs at once, so they appear under each one they serve.

### Null discipline

A bare `nil` from a list accessor renders as `[]`, which would read as "nothing sits on this VPC" when the truth may be "the collection could not be read". Each accessor sets `StateIsSet | StateIsNull` in that case, so an empty list always means genuinely empty. `plugin.GetOrCompute` honors a proactively-set field, so the null survives.

## Deprecations (separate from the above)

Ten raw ID fields that an existing resource accessor now fully duplicates are marked `@maturity("deprecated")`. No behavior change, no `.lr.versions` bump, nothing removed.

| field | superseded by |
|---|---|
| `database.projectId` | `project` |
| `database.privateNetworkUuid` | `vpc` |
| `loadBalancer.projectId` | `project` |
| `reservedIp.projectId` | `project` |
| `reservedIp.dropletId` | `droplet` |
| `reservedIpV6.dropletId` | `droplet` |
| `vpcNatGateway.projectId` | `project` |
| `kubernetes.nodePool.clusterId` | `cluster` |
| `cdn.certificateId` | `certificate` |
| `nfs.snapshot.shareId` | `share` |

Deliberately **not** deprecated: `vpcPeering.vpcIds`, `nfs.vpcIds`, `partnerAttachment.vpcIds`, `partnerAttachment.children`. These are token lists a resource reference cannot round-trip, which is the documented exception.

## Tests

`digitalocean_vpc_members_test.go` covers the filter logic: a VPC with matches, a VPC with none (empty, not null), an unreadable collection (null, not empty), a member with an empty/whitespace VPC id, multi-VPC attachment, a foreign entry in a cached collection, and that the returned slice is a copy so a caller cannot mutate the memoized index. A table test pins which field each collection is grouped by, since reading the wrong id field would silently report an empty VPC rather than failing.

```
go build ./...    OK
go test ./...     ok  connection 1.480s / provider 1.909s / resources 1.994s
go test -race ./... ok  connection 1.914s / provider 2.634s / resources 2.128s
go vet ./...      OK
go mod tidy       no diff
```
