### PR TITLE
⚡ okta: resolve typed references from the listed collections

### DIFF
--- a/providers/okta/resources/referenceCache.go
+++ b/providers/okta/resources/referenceCache.go
@@ -1,0 +1,182 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"sync"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Every typed reference in this provider resolves through NewResource, which
+// runs the target's init before the runtime cache is consulted and therefore
+// issues one GET per reference. Okta rate limits per endpoint per minute and
+// the plural resolvers fan out over id lists, so a resource-set binding with
+// 200 members costs 200 GetUser calls against the same endpoint the org would
+// serve as a handful of paged list requests.
+//
+// The helpers here look a reference up in the collection the root resource
+// holds first. That collection is fetched at most once per scan and is shared
+// by every reference that reads it, so resolving the same id twice, or
+// resolving an id that the scan has already listed, costs nothing.
+//
+// A miss is never an answer. What the org serves from a list endpoint is not
+// the same set as what it serves by id: the user list omits deprovisioned
+// users, the application list omits Okta's internal apps, and a licensed
+// feature the org does not have answers the list endpoint with 401 E0000015
+// and reports nothing at all. Reading any of those as "no such object" would
+// turn a call-count fix into a confident wrong answer, so an id that is absent
+// from the collection, a collection that failed to read, and a collection the
+// org will not serve all fall through to the NewResource path that was there
+// before. The result set is unchanged; only the number of calls it takes to
+// reach it goes down.
+
+// getOkta returns the root resource, whose collections the reference lookups
+// read. It is the runtime-cached singleton the query itself is rooted at, so
+// this neither fetches nor allocates once the query is under way.
+func getOkta(runtime *plugin.Runtime) (*mqlOkta, error) {
+	res, err := CreateResource(runtime, "okta", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	root, ok := res.(*mqlOkta)
+	if !ok {
+		return nil, fmt.Errorf("okta root resource has unexpected type %T", res)
+	}
+	return root, nil
+}
+
+// oktaCollectionLock serializes reaching the root resource and reading one of
+// its collections. Reference accessors are called from blocks the executor
+// runs in parallel, and neither step is synchronized on its own: CreateResource
+// checks the runtime cache and then writes it, so two accessors arriving at
+// once can each end up holding their own root, and the field memo they read
+// through (plugin.GetOrCompute) has no lock either. Between them, an unguarded
+// pair of accessors lists the same collection twice and races on the field
+// holding the first result.
+//
+// The lock is held across the read, which means it is held across the list
+// request the first accessor triggers. That is safe only because no root
+// collection lister resolves a reference itself; were one to start doing so it
+// would deadlock here rather than fail quietly.
+var oktaCollectionLock sync.Mutex
+
+// cachedOktaCollection reads one of the root resource's collections, returning
+// nil for every state that is not a readable list: an unreachable root, a list
+// that errored, and a list the org would not serve. Each of those is a miss,
+// and a miss falls back to the direct lookup.
+func cachedOktaCollection(runtime *plugin.Runtime, read func(*mqlOkta) *plugin.TValue[[]any]) []any {
+	oktaCollectionLock.Lock()
+	defer oktaCollectionLock.Unlock()
+
+	root, err := getOkta(runtime)
+	if err != nil {
+		return nil
+	}
+	return readableOktaList(read(root))
+}
+
+// readableOktaList returns the entries of a collection that was read, and nil
+// for one that was not. A list that errored and a list the org reported
+// nothing for are both absences rather than emptiness: answering a reference
+// out of either would report "no such object" for something that was never
+// looked at.
+func readableOktaList(list *plugin.TValue[[]any]) []any {
+	if list == nil || list.Error != nil || list.State&plugin.StateIsNull != 0 {
+		return nil
+	}
+	return list.Data
+}
+
+// findCachedOktaResource returns the entry a reference names, or reports a miss.
+// The type assertion is checked: a panic in an accessor takes down the whole
+// scan rather than the one field, and a list is not worth that risk.
+func findCachedOktaResource[T any](list []any, id func(T) string, want string) (T, bool) {
+	var zero T
+	if want == "" {
+		return zero, false
+	}
+	for _, entry := range list {
+		res, ok := entry.(T)
+		if ok && id(res) == want {
+			return res, true
+		}
+	}
+	return zero, false
+}
+
+// indexCachedOktaResources keys the entries a list of references names by id,
+// so a plural resolver walks the collection once rather than once per
+// reference. Ids the collection does not carry are simply absent from the
+// result, which is the miss the caller falls back on.
+func indexCachedOktaResources[T any](list []any, id func(T) string, want []string) map[string]T {
+	if len(list) == 0 || len(want) == 0 {
+		return nil
+	}
+
+	wanted := make(map[string]struct{}, len(want))
+	for _, w := range want {
+		if w != "" {
+			wanted[w] = struct{}{}
+		}
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+
+	index := make(map[string]T, len(wanted))
+	for _, entry := range list {
+		res, ok := entry.(T)
+		if !ok {
+			continue
+		}
+		key := id(res)
+		if _, ok := wanted[key]; !ok {
+			continue
+		}
+		index[key] = res
+	}
+	return index
+}
+
+// The id of a resource that failed to build is the empty string, which no
+// reference asks for, so a broken entry can never be mistaken for a match.
+
+func oktaUserID(r *mqlOktaUser) string { return r.Id.Data }
+
+func oktaGroupID(r *mqlOktaGroup) string { return r.Id.Data }
+
+func oktaApplicationID(r *mqlOktaApplication) string { return r.Id.Data }
+
+func oktaCustomRoleID(r *mqlOktaCustomRole) string { return r.Id.Data }
+
+func oktaUserTypeID(r *mqlOktaUserType) string { return r.Id.Data }
+
+func oktaRealmID(r *mqlOktaRealm) string { return r.Id.Data }
+
+func cachedOktaUsers(runtime *plugin.Runtime) []any {
+	return cachedOktaCollection(runtime, func(root *mqlOkta) *plugin.TValue[[]any] { return root.GetUsers() })
+}
+
+func cachedOktaGroups(runtime *plugin.Runtime) []any {
+	return cachedOktaCollection(runtime, func(root *mqlOkta) *plugin.TValue[[]any] { return root.GetGroups() })
+}
+
+func cachedOktaApplications(runtime *plugin.Runtime) []any {
+	return cachedOktaCollection(runtime, func(root *mqlOkta) *plugin.TValue[[]any] { return root.GetApplications() })
+}
+
+func cachedOktaCustomRoles(runtime *plugin.Runtime) []any {
+	return cachedOktaCollection(runtime, func(root *mqlOkta) *plugin.TValue[[]any] { return root.GetCustomRoles() })
+}
+
+func cachedOktaUserTypes(runtime *plugin.Runtime) []any {
+	return cachedOktaCollection(runtime, func(root *mqlOkta) *plugin.TValue[[]any] { return root.GetUserTypes() })
+}
+
+func cachedOktaRealms(runtime *plugin.Runtime) []any {
+	return cachedOktaCollection(runtime, func(root *mqlOkta) *plugin.TValue[[]any] { return root.GetRealms() })
+}

--- a/providers/okta/resources/referenceCache_test.go
+++ b/providers/okta/resources/referenceCache_test.go
@@ -1,0 +1,247 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+func testOktaUser(id string) *mqlOktaUser {
+	return &mqlOktaUser{
+		Id: plugin.TValue[string]{Data: id, State: plugin.StateIsSet},
+	}
+}
+
+func testOktaGroup(id string) *mqlOktaGroup {
+	return &mqlOktaGroup{
+		Id: plugin.TValue[string]{Data: id, State: plugin.StateIsSet},
+	}
+}
+
+// A readable list is the only state a reference may be answered from. Every
+// other state has to read as a miss, because a miss falls back to the direct
+// lookup while an empty answer would report the object as absent.
+func TestReadableOktaList(t *testing.T) {
+	entries := []any{testOktaUser("00u1")}
+
+	t.Run("fetched list", func(t *testing.T) {
+		list := &plugin.TValue[[]any]{Data: entries, State: plugin.StateIsSet}
+		assert.Equal(t, entries, readableOktaList(list))
+	})
+
+	t.Run("errored list", func(t *testing.T) {
+		list := &plugin.TValue[[]any]{
+			Data:  entries,
+			State: plugin.StateIsSet | plugin.StateIsNull,
+			Error: errors.New("api is having a bad day"),
+		}
+		assert.Nil(t, readableOktaList(list))
+	})
+
+	t.Run("null list", func(t *testing.T) {
+		// What an unlicensed feature leaves behind: read, but absent.
+		list := &plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+		assert.Nil(t, readableOktaList(list))
+	})
+
+	t.Run("unfetched list", func(t *testing.T) {
+		assert.Nil(t, readableOktaList(&plugin.TValue[[]any]{}))
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		list := &plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+		assert.Empty(t, readableOktaList(list))
+	})
+}
+
+func TestFindCachedOktaResource(t *testing.T) {
+	wanted := testOktaUser("00u2")
+	list := []any{testOktaUser("00u1"), wanted, testOktaUser("00u3")}
+
+	t.Run("hit returns the listed resource", func(t *testing.T) {
+		found, ok := findCachedOktaResource(list, oktaUserID, "00u2")
+		require.True(t, ok)
+		assert.Same(t, wanted, found)
+	})
+
+	t.Run("id absent from the list is a miss", func(t *testing.T) {
+		// A deprovisioned user is not in the user list but is still served by
+		// id, so this has to fall through rather than answer null.
+		found, ok := findCachedOktaResource(list, oktaUserID, "00uDeprovisioned")
+		assert.False(t, ok)
+		assert.Nil(t, found)
+	})
+
+	t.Run("empty id is a miss", func(t *testing.T) {
+		found, ok := findCachedOktaResource([]any{testOktaUser("")}, oktaUserID, "")
+		assert.False(t, ok)
+		assert.Nil(t, found)
+	})
+
+	t.Run("unreadable list is a miss", func(t *testing.T) {
+		found, ok := findCachedOktaResource(readableOktaList(&plugin.TValue[[]any]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		}), oktaUserID, "00u2")
+		assert.False(t, ok)
+		assert.Nil(t, found)
+	})
+
+	t.Run("entry of another type is skipped", func(t *testing.T) {
+		mixed := []any{testOktaGroup("00u2"), "not a resource", nil, wanted}
+		found, ok := findCachedOktaResource(mixed, oktaUserID, "00u2")
+		require.True(t, ok)
+		assert.Same(t, wanted, found)
+	})
+}
+
+func TestIndexCachedOktaResources(t *testing.T) {
+	first := testOktaUser("00u1")
+	second := testOktaUser("00u2")
+	list := []any{first, second, testOktaUser("00u3")}
+
+	t.Run("keys only the wanted ids", func(t *testing.T) {
+		index := indexCachedOktaResources(list, oktaUserID, []string{"00u1", "00u2"})
+		require.Len(t, index, 2)
+		assert.Same(t, first, index["00u1"])
+		assert.Same(t, second, index["00u2"])
+	})
+
+	t.Run("ids absent from the list are absent from the index", func(t *testing.T) {
+		index := indexCachedOktaResources(list, oktaUserID, []string{"00u1", "00uGone"})
+		require.Len(t, index, 1)
+		assert.Same(t, first, index["00u1"])
+
+		_, ok := index["00uGone"]
+		assert.False(t, ok)
+	})
+
+	t.Run("empty ids are never keyed", func(t *testing.T) {
+		index := indexCachedOktaResources([]any{testOktaUser("")}, oktaUserID, []string{""})
+		assert.Empty(t, index)
+
+		_, ok := index[""]
+		assert.False(t, ok)
+	})
+
+	t.Run("unreadable list indexes nothing", func(t *testing.T) {
+		unreadable := readableOktaList(&plugin.TValue[[]any]{
+			Error: errors.New("api is having a bad day"),
+			State: plugin.StateIsSet | plugin.StateIsNull,
+		})
+		index := indexCachedOktaResources(unreadable, oktaUserID, []string{"00u1"})
+		assert.Empty(t, index)
+
+		_, ok := index["00u1"]
+		assert.False(t, ok)
+	})
+
+	t.Run("no ids wanted", func(t *testing.T) {
+		assert.Empty(t, indexCachedOktaResources(list, oktaUserID, nil))
+	})
+
+	t.Run("entries of another type are skipped", func(t *testing.T) {
+		mixed := []any{testOktaGroup("00u1"), "not a resource", nil, second}
+		index := indexCachedOktaResources(mixed, oktaUserID, []string{"00u1", "00u2"})
+		require.Len(t, index, 1)
+		assert.Same(t, second, index["00u2"])
+	})
+
+	t.Run("group collection keys by group id", func(t *testing.T) {
+		group := testOktaGroup("00g1")
+		index := indexCachedOktaResources([]any{group}, oktaGroupID, []string{"00g1"})
+		require.Len(t, index, 1)
+		assert.Same(t, group, index["00g1"])
+	})
+}
+
+// Reference accessors are called from blocks the executor runs in parallel, so
+// the collection they share is read concurrently. Run under -race, this covers
+// the whole shared path: reaching the root through the runtime's resource
+// cache, reading its collection, and scanning it.
+func TestCachedOktaCollectionConcurrentReads(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+	root, err := getOkta(runtime)
+	require.NoError(t, err)
+
+	wanted := testOktaUser("00u2")
+	root.Users = plugin.TValue[[]any]{
+		Data:  []any{testOktaUser("00u1"), wanted, testOktaUser("00u3")},
+		State: plugin.StateIsSet,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			users := cachedOktaUsers(runtime)
+			found, ok := findCachedOktaResource(users, oktaUserID, "00u2")
+			assert.True(t, ok)
+			assert.Same(t, wanted, found)
+
+			index := indexCachedOktaResources(users, oktaUserID, []string{"00u2", "00uGone"})
+			assert.Same(t, wanted, index["00u2"])
+			assert.Len(t, index, 1)
+		}()
+	}
+	wg.Wait()
+}
+
+// The collection a reference is answered from is listed once no matter how many
+// accessors reach it at the same time. Without the lock the field memo carries
+// no synchronization of its own, so this is where a second list request, and a
+// race on the field holding the first one, would show up.
+func TestCachedOktaCollectionListsOnce(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+	entries := []any{testOktaUser("00u1"), testOktaUser("00u2")}
+	var lists atomic.Int64
+	read := func(root *mqlOkta) *plugin.TValue[[]any] {
+		return plugin.GetOrCompute(&root.Users, func() ([]any, error) {
+			lists.Add(1)
+			return entries, nil
+		})
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.Equal(t, entries, cachedOktaCollection(runtime, read))
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), lists.Load())
+}
+
+// A collection that could not be read is not retried per reference: the field
+// memo holds the failure, so the second accessor sees the same miss without
+// issuing a second request.
+func TestCachedOktaCollectionRemembersFailure(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+	var lists atomic.Int64
+	read := func(root *mqlOkta) *plugin.TValue[[]any] {
+		return plugin.GetOrCompute(&root.Users, func() ([]any, error) {
+			lists.Add(1)
+			return nil, errors.New("api is having a bad day")
+		})
+	}
+
+	for i := 0; i < 4; i++ {
+		assert.Nil(t, cachedOktaCollection(runtime, read))
+	}
+	assert.Equal(t, int64(1), lists.Load())
+}

--- a/providers/okta/resources/resourceSets.go
+++ b/providers/okta/resources/resourceSets.go
@@ -330,8 +330,13 @@ func (o *mqlOktaResourceSetBinding) groups() ([]any, error) {
 
 // --- shared typed-reference resolvers ---
 
-// Every resolver below reads the reference back through NewResource, which runs
-// the target's init and therefore issues a fetch. A reference can outlive the
+// Every resolver below first looks the reference up in the collection the root
+// resource holds, and only falls back to NewResource when the collection does
+// not carry it. See referenceCache.go for why a miss is a fallback rather than
+// an answer.
+//
+// The fallback reads the reference back through NewResource, which runs the
+// target's init and therefore issues a fetch. A reference can outlive the
 // object it names (a deleted user), point at something Okta does not serve from
 // the collection endpoint (an internal application), or carry a principal id
 // that is not the kind being resolved at all -- `createdBy` on an Okta-managed
@@ -343,6 +348,9 @@ func resolveOktaUserRef(runtime *plugin.Runtime, id string, field *plugin.TValue
 	if id == "" {
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+	if user, ok := findCachedOktaResource(cachedOktaUsers(runtime), oktaUserID, id); ok {
+		return user, nil
 	}
 	r, err := NewResource(runtime, "okta.user", map[string]*llx.RawData{
 		"id": llx.StringData(id),
@@ -362,6 +370,9 @@ func resolveOktaGroupRef(runtime *plugin.Runtime, id string, field *plugin.TValu
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
+	if group, ok := findCachedOktaResource(cachedOktaGroups(runtime), oktaGroupID, id); ok {
+		return group, nil
+	}
 	r, err := NewResource(runtime, "okta.group", map[string]*llx.RawData{
 		"id": llx.StringData(id),
 	})
@@ -379,6 +390,9 @@ func resolveOktaApplicationRef(runtime *plugin.Runtime, id string, field *plugin
 	if id == "" {
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+	if app, ok := findCachedOktaResource(cachedOktaApplications(runtime), oktaApplicationID, id); ok {
+		return app, nil
 	}
 	r, err := NewResource(runtime, "okta.application", map[string]*llx.RawData{
 		"id": llx.StringData(id),
@@ -398,6 +412,9 @@ func resolveOktaCustomRoleRef(runtime *plugin.Runtime, id string, field *plugin.
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
+	if role, ok := findCachedOktaResource(cachedOktaCustomRoles(runtime), oktaCustomRoleID, id); ok {
+		return role, nil
+	}
 	r, err := NewResource(runtime, "okta.customRole", map[string]*llx.RawData{
 		"id": llx.StringData(id),
 	})
@@ -415,6 +432,9 @@ func resolveOktaUserTypeRef(runtime *plugin.Runtime, id string, field *plugin.TV
 	if id == "" {
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+	if userType, ok := findCachedOktaResource(cachedOktaUserTypes(runtime), oktaUserTypeID, id); ok {
+		return userType, nil
 	}
 	r, err := NewResource(runtime, "okta.userType", map[string]*llx.RawData{
 		"id": llx.StringData(id),
@@ -434,6 +454,9 @@ func resolveOktaRealmRef(runtime *plugin.Runtime, id string, field *plugin.TValu
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
+	if realm, ok := findCachedOktaResource(cachedOktaRealms(runtime), oktaRealmID, id); ok {
+		return realm, nil
+	}
 	r, err := NewResource(runtime, "okta.realm", map[string]*llx.RawData{
 		"id": llx.StringData(id),
 	})
@@ -450,10 +473,22 @@ func resolveOktaRealmRef(runtime *plugin.Runtime, id string, field *plugin.TValu
 // The plural resolvers drop members the org no longer has rather than failing
 // the list, so one stale member id does not hide every other member alongside
 // it.
+//
+// They are also where the per-reference fetch hurt most: a binding that names
+// 200 members used to cost 200 calls to the endpoint the whole membership is
+// listed by. Keying the collection once and reading the ids out of it keeps a
+// membership of any size to the pages of that one list, and every id the
+// collection does not carry still goes the long way round.
 
 func resolveOktaUserRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
+	cached := indexCachedOktaResources(cachedOktaUsers(runtime), oktaUserID, ids)
+
 	list := make([]any, 0, len(ids))
 	for _, id := range ids {
+		if user, ok := cached[id]; ok {
+			list = append(list, user)
+			continue
+		}
 		r, err := NewResource(runtime, "okta.user", map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})
@@ -469,8 +504,14 @@ func resolveOktaUserRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
 }
 
 func resolveOktaGroupRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
+	cached := indexCachedOktaResources(cachedOktaGroups(runtime), oktaGroupID, ids)
+
 	list := make([]any, 0, len(ids))
 	for _, id := range ids {
+		if group, ok := cached[id]; ok {
+			list = append(list, group)
+			continue
+		}
 		r, err := NewResource(runtime, "okta.group", map[string]*llx.RawData{
 			"id": llx.StringData(id),
 		})


### PR DESCRIPTION
## The bug

Every typed reference in the okta provider resolves through `NewResource`, and the generated dispatcher runs a resource's `Init` **before** it consults the runtime cache (`providers/okta/resources/okta.lr.go:327-343`). Each `init` issues a live API GET. There was no memoization anywhere in the package, so resolving an id that was resolved a moment earlier, or one already sitting in a collection the scan has fully listed, refetched it.

This is shipped behavior across the provider's whole shared resolver library in `resourceSets.go`.

## Why it costs so much here

Okta rate limits **per endpoint per minute**, and the plural resolvers fan out over id lists. Today:

| query | calls before | calls after |
|---|---|---|
| resource-set binding with 200 members | 200 × `GetUser` | 1 × `ListUsers` (paged) |
| `okta.users { manager { login } }` over 5,000 users | up to 5,000 × `GetUser` | 0 extra, the user list is already in hand |
| `okta.users { realm { name } }` over 5,000 users | up to 5,000 × `GetRealm` | 1 × `ListRealms` |

All of it lands on the same endpoint the collection is listed by, so the per-endpoint bucket is exactly what the fan-out burns.

## The fix

Each resolver now looks the reference up in the collection the root `okta` resource holds, and falls back to the original `NewResource` path on a miss. The collection is read through the root's own field memo, so it is listed at most once per scan and shared with a query that lists it anyway.

Covered, singular and plural:

- `resolveOktaUserRef` / `resolveOktaUserRefs` → `okta.users`
- `resolveOktaGroupRef` / `resolveOktaGroupRefs` → `okta.groups`
- `resolveOktaApplicationRef` → `okta.applications`
- `resolveOktaCustomRoleRef` → `okta.customRoles`
- `resolveOktaUserTypeRef` → `okta.userTypes`
- `resolveOktaRealmRef` → `okta.realms`

## A miss falls back, so behavior is unchanged

This is the whole design. What an org serves from a list endpoint is not the same set as what it serves by id: the user list omits deprovisioned users, the application list omits Okta's internal apps, and a reference can name something the list simply does not carry. Every one of these is treated as a miss that falls through to the lookup that was there before, never as a null answer:

- the id is absent from the collection
- the collection failed to read
- the collection is null (`State & plugin.StateIsNull`)
- the id is empty (already short-circuited to a null field, as before)

The existing null discipline is preserved: the empty-id path still sets `StateIsSet | StateIsNull` on the field, and the system-principal degradation in `resolveOktaUserRef` is untouched. Everything pulled out of a cached list goes through a checked type assertion, because a panic in an accessor takes down the scan rather than the field.

### E0000015

Realms and device assurance are licensed features, and Okta answers an org without the license with **401 `E0000015`**, not with data. `okta.realms` already routes that through the provider's `isOktaFeatureUnavailable`. Because a miss is a fallback rather than an answer, an index built from an org that reports nothing cannot turn into "no such realm" for every lookup: those references resolve exactly as they did before, through `GetRealm`, and report null on the same 401.

## Concurrency

Reference accessors run in blocks the executor executes in parallel, and neither step on the path to a collection is synchronized: `CreateResource` checks the runtime cache and then writes it, so two accessors arriving together can each end up holding their own root resource, and `plugin.GetOrCompute` carries no lock either. Unguarded, a pair of accessors lists the same collection twice and races on the field holding the first result — `TestCachedOktaCollectionListsOnce` reproduces both (8 list calls and a race detector hit with the lock removed). A package-level mutex covers reaching the root and reading the collection.

## Tests

`referenceCache_test.go` covers the pure Go logic: a hit, an id absent from the list, an empty id, an errored list, a null list, an unfetched list, entries of another type in the list (the checked assertion), the plural index, and the concurrency behavior — listed once under 32 concurrent readers, and a failed read remembered rather than retried per reference.

```
go build ./...   ok
go vet ./...     ok
go test ./...    ok
go test -race ./...  ok
```

No `.lr`, `.lr.go` or `.lr.versions` change; `go mod tidy` produces no diff.
