### PR TITLE
db providers: auto discovery returns the server, not every database

### DIFF
--- a/providers/mongo/connection/platform.go
+++ b/providers/mongo/connection/platform.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	// DiscoveryAuto is the default discovery target; it behaves like DiscoveryAll.
+	// DiscoveryAuto is the default discovery target. It returns the server
+	// alone, because that is the asset the benchmarks and most policies apply
+	// to. Per-database assets are opt-in through DiscoveryAll or
+	// DiscoveryDatabases: emitting them by default turned a clean scan into one
+	// scored asset and N "asset doesn't support any policies" errors.
 	DiscoveryAuto = "auto"
 	// DiscoveryAll discovers the server plus every database as its own asset.
 	DiscoveryAll = "all"

--- a/providers/mongo/provider/discover.go
+++ b/providers/mongo/provider/discover.go
@@ -24,7 +24,7 @@ func (s *Service) discover(conn *connection.MongoConnection) (*inventory.Invento
 		return nil, nil
 	}
 	if !stringx.ContainsAnyOf(conf.Discover.Targets,
-		connection.DiscoveryAll, connection.DiscoveryAuto, connection.DiscoveryDatabases) {
+		connection.DiscoveryAll, connection.DiscoveryDatabases) {
 		return nil, nil
 	}
 

--- a/providers/mssql/connection/platform.go
+++ b/providers/mssql/connection/platform.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	// DiscoveryAuto is the default discovery target; it behaves like DiscoveryAll.
+	// DiscoveryAuto is the default discovery target. It returns the server
+	// alone, because that is the asset the benchmarks and most policies apply
+	// to. Per-database assets are opt-in through DiscoveryAll or
+	// DiscoveryDatabases: emitting them by default turned a clean scan into one
+	// scored asset and N "asset doesn't support any policies" errors.
 	DiscoveryAuto = "auto"
 	// DiscoveryAll discovers the instance plus every online database as its own asset.
 	DiscoveryAll = "all"

--- a/providers/mssql/provider/discover.go
+++ b/providers/mssql/provider/discover.go
@@ -26,7 +26,7 @@ func (s *Service) discover(conn *connection.MssqlConnection) (*inventory.Invento
 	}
 
 	if !stringx.ContainsAnyOf(conf.Discover.Targets,
-		connection.DiscoveryAll, connection.DiscoveryAuto, connection.DiscoveryDatabases) {
+		connection.DiscoveryAll, connection.DiscoveryDatabases) {
 		return nil, nil
 	}
 

--- a/providers/mysqldb/connection/platform.go
+++ b/providers/mysqldb/connection/platform.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	// DiscoveryAuto is the default discovery target; it behaves like DiscoveryAll.
+	// DiscoveryAuto is the default discovery target. It returns the server
+	// alone, because that is the asset the benchmarks and most policies apply
+	// to. Per-database assets are opt-in through DiscoveryAll or
+	// DiscoveryDatabases: emitting them by default turned a clean scan into one
+	// scored asset and N "asset doesn't support any policies" errors.
 	DiscoveryAuto = "auto"
 	// DiscoveryAll discovers the server plus every schema as its own asset.
 	DiscoveryAll = "all"

--- a/providers/mysqldb/provider/discover.go
+++ b/providers/mysqldb/provider/discover.go
@@ -23,7 +23,7 @@ func (s *Service) discover(conn *connection.MysqldbConnection) (*inventory.Inven
 		return nil, nil
 	}
 	if !stringx.ContainsAnyOf(conf.Discover.Targets,
-		connection.DiscoveryAll, connection.DiscoveryAuto, connection.DiscoveryDatabases) {
+		connection.DiscoveryAll, connection.DiscoveryDatabases) {
 		return nil, nil
 	}
 

--- a/providers/postgresdb/connection/platform.go
+++ b/providers/postgresdb/connection/platform.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	// DiscoveryAuto is the default discovery target; it behaves like DiscoveryAll.
+	// DiscoveryAuto is the default discovery target. It returns the server
+	// alone, because that is the asset the benchmarks and most policies apply
+	// to. Per-database assets are opt-in through DiscoveryAll or
+	// DiscoveryDatabases: emitting them by default turned a clean scan into one
+	// scored asset and N "asset doesn't support any policies" errors.
 	DiscoveryAuto = "auto"
 	// DiscoveryAll discovers the server plus every connectable database as its own asset.
 	DiscoveryAll = "all"

--- a/providers/postgresdb/provider/discover.go
+++ b/providers/postgresdb/provider/discover.go
@@ -23,7 +23,7 @@ func (s *Service) discover(conn *connection.PostgresdbConnection) (*inventory.In
 		return nil, nil
 	}
 	if !stringx.ContainsAnyOf(conf.Discover.Targets,
-		connection.DiscoveryAll, connection.DiscoveryAuto, connection.DiscoveryDatabases) {
+		connection.DiscoveryAll, connection.DiscoveryDatabases) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## The problem

Scanning a PostgreSQL server with a hardening policy gives one scored asset and thirteen errors:

```
13 discovered · 14 scanned · 13 errored

Asset: (PostgreSQL Database) template1
error: rpc error: code = InvalidArgument desc = asset doesn't support any policies
... ×13
```

`DiscoveryAuto` was aliased to `DiscoveryAll`:

```go
// DiscoveryAuto is the default discovery target; it behaves like DiscoveryAll.
DiscoveryAuto = "auto"
```

so the default emitted one asset per connectable database — including `template1`, `postgres` and every leftover `tmpl_*`. Most policies for these providers apply to the **server**, so each database asset can only ever report "doesn't support any policies".

The scan was behaving correctly and looked completely broken. That is the whole of the user-visible failure: the one asset anyone cared about scored fine and was buried under thirteen errors.

## The change

`auto` returns the server alone. Per-database assets remain available and become opt-in via `--discover databases` or `--discover all` — where someone who wants them would look.

Applies to the four providers that fan out this way: **postgresdb, mysqldb, mssql, mongo**. `cassandra` and `oracledb` already emit a single asset and are untouched.

## Verification

Against a live PostgreSQL 18 with 13 databases, using a real policy bundle:

| invocation | assets | errors |
|---|---|---|
| **default** | **1** | **0** — was 14 assets / 13 errors |
| `--discover instance` | 1 | 0 |
| `--discover databases` | 14 | unchanged |
| `--discover all` | 14 | unchanged |

The server still scores identically (`HIGH (75)`, same 13 findings) — only the noise is gone.

All four provider modules build and their tests pass.

## Note

This is a default-behaviour change. Anyone relying on bare `cnspec scan postgresdb` to enumerate databases needs `--discover databases`. Given the default currently produces an error per database for every server-scoped policy, that seems like the right trade — but it is worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
