### PR TITLE
⚡ azure: stage discovery by subscription so assets share one resource cache

### DIFF
--- a/providers/azure/connection/client_subscriptions.go
+++ b/providers/azure/connection/client_subscriptions.go
@@ -24,6 +24,23 @@ func NewSubscriptionsClient(token azcore.TokenCredential, clientOptions policy.C
 	}
 }
 
+// GetSubscription reads a single subscription by id. Staged discovery uses it
+// when it is already scoped to one subscription and needs a field the
+// connection options do not carry, such as the subscription's tags.
+func (client *subscriptionsClient) GetSubscription(subscriptionID string) (subscriptions.Subscription, error) {
+	subscriptionsC, err := subscriptions.NewClient(client.token, &arm.ClientOptions{
+		ClientOptions: client.clientOptions,
+	})
+	if err != nil {
+		return subscriptions.Subscription{}, err
+	}
+	resp, err := subscriptionsC.Get(context.Background(), subscriptionID, &subscriptions.ClientGetOptions{})
+	if err != nil {
+		return subscriptions.Subscription{}, err
+	}
+	return resp.Subscription, nil
+}
+
 func (client *subscriptionsClient) GetSubscriptions(filter SubscriptionsFilter) ([]subscriptions.Subscription, error) {
 	subscriptionsC, err := subscriptions.NewClient(client.token, &arm.ClientOptions{
 		ClientOptions: client.clientOptions,

--- a/providers/azure/connection/filters.go
+++ b/providers/azure/connection/filters.go
@@ -122,6 +122,15 @@ func (f GeneralDiscoveryFilters) MatchesExcludeTags(resourceTags map[string]stri
 	return false
 }
 
+// SubscriptionTagFilterPrefix is the --filters key prefix that names the tags
+// to attribute to a subscription's assets, as in
+// `--filters subscription-tag:env=prod`. Staged discovery also writes it: a
+// stage-2 connection is scoped to exactly one subscription, so "the tags of
+// this subscription" and "the tag override for this connection" are the same
+// thing, and stage 1 can hand over the tags it already read rather than making
+// stage 2 fetch them again.
+const SubscriptionTagFilterPrefix = "subscription-tag:"
+
 // DiscoveryFiltersFromOpts parses the raw --filters key/value options into the
 // typed DiscoveryFilters. It is nil-safe: a nil opts map yields empty filters.
 func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
@@ -135,7 +144,7 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 			ExcludeTags: parseMapOpt(opts, "exclude:tag:"),
 		},
 		PropagateSubscriptionTags: filteropts.ParseBoolOpt(opts, "propagate-subscription-tags", false),
-		SubscriptionTags:          parseMapOpt(opts, "subscription-tag:"),
+		SubscriptionTags:          parseMapOpt(opts, SubscriptionTagFilterPrefix),
 	}
 }
 

--- a/providers/azure/resources/azure.go
+++ b/providers/azure/resources/azure.go
@@ -21,10 +21,15 @@ import (
 type mqlAzureInternal struct {
 	sub *mqlAzureSubscription
 
-	// The tenant's management group hierarchy, fetched at most once per scan.
-	// It lives here rather than on a subscription because it spans every
-	// subscription in the tenant, and one entities listing answers parentage,
-	// children, and subtree counts for the whole tree.
+	// The tenant's management group hierarchy. It lives here rather than on a
+	// subscription because it spans every subscription in the tenant, and one
+	// entities listing answers parentage, children, and subtree counts for the
+	// whole tree.
+	//
+	// Fetched at most once per resource cache, which under staged discovery is
+	// once per subscription: the assets inside a subscription share their
+	// subscription's cache, so the first of them to ask pays for the listing
+	// and the rest read this.
 	mgOnce     sync.Once
 	mgEntities []*armmanagementgroups.EntityInfo
 	mgErr      error

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.34.0",
-  "generated_at": "2026-08-10T18:30:41+02:00",
+  "version": "13.34.1",
+  "generated_at": "2026-08-14T09:05:05+02:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.ApiManagement/service/apis/policies/read",
@@ -1880,7 +1880,7 @@
     {
       "permission": "Microsoft.Resources/subscriptions/read",
       "service": "Microsoft.Resources",
-      "action": "NewListPager",
+      "action": "Get",
       "source_file": "client_subscriptions.go"
     },
     {

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -62,6 +62,17 @@ const (
 	DiscoveryFirewalls               = "firewalls"
 	DiscoveryContainerApps           = "container-apps"
 	DiscoveryCognitiveServices       = "cognitiveservices-accounts"
+
+	// optionSubscriptionAssetEmitted marks a connection config that stage 1 of
+	// staged discovery built for a subscription it has already emitted as an
+	// asset.
+	//
+	// Stage 2 runs from two places: a subscription asset stage 1 emitted, and a
+	// root connection the caller scoped to one subscription on the command
+	// line. In the first case the subscription asset exists already; in the
+	// second nothing has emitted it, and without this marker the run would
+	// silently lose it -- the legacy path emits it in both cases.
+	optionSubscriptionAssetEmitted = "azure-subscription-asset-emitted"
 )
 
 // Auto includes all API resources except storage containers (which require
@@ -196,6 +207,11 @@ type mqlObject struct {
 type subWithConfig struct {
 	sub  subscriptions.Subscription
 	conf *inventory.Config
+	// assetOpts are applied when conf is cloned for each asset discovered
+	// inside this subscription. Stage 2 of staged discovery uses it to point
+	// every one of them at the subscription's connection, so they share a
+	// single MQL resource cache instead of each rebuilding their own.
+	assetOpts []inventory.CloneOption
 }
 
 func MondooAzureInstanceID(instanceID string) string {
@@ -222,11 +238,64 @@ func getDiscoveryTargets(config *inventory.Config) []string {
 	return targets
 }
 
+// Discover routes to the appropriate discovery path based on whether the client
+// has opted in to staged discovery via plugin.OptionStagedDiscovery.
+//
+// TODO(v15): remove discoverLegacy and the OptionStagedDiscovery toggle. Staged
+// discovery should be the only path.
 func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.Inventory, error) {
 	conn, ok := runtime.Connection.(*connection.AzureConnection)
 	if !ok {
 		return nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
+
+	switch stage, subId := discoveryStageFor(rootConf); stage {
+	case stageSubscription:
+		return discoverSubscriptionStage(runtime, conn, rootConf, subId)
+	case stageTenant:
+		return discoverTenantStage(conn, rootConf)
+	default:
+		return discoverLegacy(runtime, conn, rootConf)
+	}
+}
+
+// discoveryStage names the discovery path a connection takes.
+type discoveryStage int
+
+const (
+	// stageLegacy is the single-pass path taken by clients that have not opted
+	// in to staged discovery.
+	stageLegacy discoveryStage = iota
+	// stageTenant is stage 1: discover the subscriptions, nothing inside them.
+	stageTenant
+	// stageSubscription is stage 2: discover the resources of one subscription.
+	stageSubscription
+)
+
+// discoveryStageFor decides which discovery path a connection config takes, and
+// for stage 2 returns the subscription it is scoped to.
+//
+// A staged connection that already names a subscription has no tenant level
+// left to walk, so it goes straight to stage 2. That covers both the
+// subscription assets stage 1 emits and a caller who scoped the whole run to
+// one subscription on the command line.
+func discoveryStageFor(cfg *inventory.Config) (discoveryStage, string) {
+	if _, staged := cfg.GetOptions()[plugin.OptionStagedDiscovery]; !staged {
+		return stageLegacy, ""
+	}
+	if subId := cfg.GetOptions()[connection.OptionSubscriptionID]; subId != "" {
+		return stageSubscription, subId
+	}
+	return stageTenant, ""
+}
+
+// discoverLegacy is the original single-pass discovery: every subscription and
+// every resource inside all of them, enumerated in one call and attached to the
+// connection that started the scan. Kept for clients that do not set
+// plugin.OptionStagedDiscovery.
+//
+// TODO(v15): remove once all supported clients set the flag.
+func discoverLegacy(runtime *plugin.Runtime, conn *connection.AzureConnection, rootConf *inventory.Config) (*inventory.Inventory, error) {
 	assets := []*inventory.Asset{}
 	filter := conn.Filters.Subscriptions
 	// note: we always need the subscriptions, either to return them as assets or discover resources inside the subs
@@ -238,7 +307,14 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 	subsWithConfigs := make([]subWithConfig, len(subs))
 	for i := range subs {
 		sub := subs[i]
-		subsWithConfigs[i] = subWithConfig{sub: sub, conf: getSubConfig(conn.Conf, sub)}
+		subsWithConfigs[i] = subWithConfig{
+			sub:  sub,
+			conf: getSubConfig(conn.Conf, sub, inventory.WithoutDiscovery()),
+			// No parent connection: on this path every discovered asset gets a
+			// runtime and a resource cache of its own, and re-fetches whatever
+			// it needs. That is the cost staged discovery exists to remove.
+			assetOpts: []inventory.CloneOption{inventory.WithoutDiscovery()},
+		}
 	}
 
 	targets := getDiscoveryTargets(rootConf)
@@ -250,9 +326,186 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 	if stringx.ContainsAnyOf(targets, DiscoverySubscriptions) {
 		// we've already discovered those, simply add them as assets
 		for _, s := range subsWithConfigs {
-			assets = append(assets, subToAsset(s))
+			assets = append(assets, subToAsset(s, inventory.WithoutDiscovery()))
 		}
 	}
+
+	assets = append(assets, discoverResources(runtime, conn, subsWithConfigs, targets)...)
+
+	if conn.Filters.PropagateSubscriptionTags {
+		applySubscriptionTags(conn.Filters.SubscriptionTags, subsWithConfigs, assets)
+	}
+
+	log.Debug().Int("assets", len(assets)).Msg("azure.discovery> discovery complete")
+	return &inventory.Inventory{
+		Spec: &inventory.InventorySpec{
+			Assets: assets,
+		},
+	}, nil
+}
+
+// discoverTenantStage is stage 1 of staged discovery: it discovers the
+// subscriptions this credential can see and emits one asset per subscription,
+// each carrying the connection config that runs stage 2 when the client
+// connects to it. No resources are listed here.
+//
+// The subscription configs deliberately do not name a parent connection. Each
+// subscription gets its own runtime and its own MQL resource cache, so closing
+// a subscription releases everything discovered beneath it -- and, just as
+// importantly, one subscription's cached azure.subscription.* resources can
+// never be handed to an asset in another subscription. Several azure resources
+// read the subscription from the connection rather than from their own id
+// (azure.subscription itself among them), so a cache shared across
+// subscriptions would answer with the wrong one rather than fail.
+func discoverTenantStage(conn *connection.AzureConnection, rootConf *inventory.Config) (*inventory.Inventory, error) {
+	subs, err := discoverSubscriptions(conn, conn.Filters.Subscriptions)
+	if err != nil {
+		return nil, err
+	}
+
+	targets := getDiscoveryTargets(rootConf)
+	log.Debug().
+		Int("subscriptions", len(subs)).
+		Strs("targets", targets).
+		Msg("azure.discovery> stage 1: discovering subscriptions")
+
+	subsWithConfigs, assets := tenantStageAssets(rootConf, subs, targets)
+
+	if conn.Filters.PropagateSubscriptionTags {
+		applySubscriptionTags(conn.Filters.SubscriptionTags, subsWithConfigs, assets)
+	}
+
+	return &inventory.Inventory{
+		Spec: &inventory.InventorySpec{
+			Assets: assets,
+		},
+	}, nil
+}
+
+// tenantStageAssets turns the subscriptions stage 1 discovered into the assets
+// it emits, along with the carriers the tag propagation needs.
+//
+// Each subscription's config is cloned without WithoutDiscovery on purpose: the
+// discovery targets it carries are what make stage 2 run when the client
+// connects to it. A subscription is only worth scanning in its own right when
+// the caller asked for subscriptions -- when it is not a target it is still
+// emitted, so that the client connects to it and stage 2 runs, but stripping
+// its platform ids keeps the scanner from treating it as an asset to scan.
+func tenantStageAssets(rootConf *inventory.Config, subs []subscriptions.Subscription, targets []string) ([]subWithConfig, []*inventory.Asset) {
+	scannable := stringx.ContainsAnyOf(targets, DiscoverySubscriptions)
+
+	subsWithConfigs := make([]subWithConfig, len(subs))
+	assets := make([]*inventory.Asset, 0, len(subs))
+	for i := range subs {
+		conf := getSubConfig(rootConf, subs[i])
+		conf.Options[optionSubscriptionAssetEmitted] = "true"
+		subsWithConfigs[i] = subWithConfig{sub: subs[i], conf: conf}
+		asset := subToAsset(subsWithConfigs[i])
+		if !scannable {
+			asset.PlatformIds = nil
+		}
+		assets = append(assets, asset)
+	}
+	return subsWithConfigs, assets
+}
+
+// stageOneEmittedSubscription reports whether the subscription this connection
+// is scoped to has already been emitted as an asset by stage 1.
+func stageOneEmittedSubscription(cfg *inventory.Config) bool {
+	_, ok := cfg.GetOptions()[optionSubscriptionAssetEmitted]
+	return ok
+}
+
+// discoverSubscriptionStage is stage 2 of staged discovery: it lists the
+// resources inside one subscription. It runs when the client connects to a
+// subscription asset emitted by stage 1, or when the caller scoped the whole
+// run to a single subscription.
+//
+// Every asset it emits names this connection as its parent, so the plugin
+// service hands them all the subscription runtime's resource cache. That is
+// what stops a subscription-wide read -- the app service list, a web app's
+// slots and site config, a VM's instance view -- from being re-fetched once per
+// asset: the first asset to ask pays for it and the rest read the cached
+// resource. All of it is released when the subscription is closed.
+func discoverSubscriptionStage(runtime *plugin.Runtime, conn *connection.AzureConnection, invConfig *inventory.Config, subId string) (*inventory.Inventory, error) {
+	targets := getDiscoveryTargets(invConfig)
+	log.Debug().
+		Str("subscription", subId).
+		Strs("targets", targets).
+		Msg("azure.discovery> stage 2: discovering resources in subscription")
+
+	// When the caller scoped the run to one subscription there was no stage 1,
+	// so nothing has emitted the subscription itself yet and this stage has to.
+	// That needs its display name, which the connection options do not carry.
+	emitSubscription := !stageOneEmittedSubscription(invConfig) &&
+		stringx.ContainsAnyOf(targets, DiscoverySubscriptions)
+	needsTags := conn.Filters.PropagateSubscriptionTags && len(conn.Filters.SubscriptionTags) == 0
+
+	swc := subWithConfig{
+		sub:  subscriptionRecord(conn, invConfig, subId, emitSubscription || needsTags),
+		conf: invConfig,
+		assetOpts: []inventory.CloneOption{
+			// These are leaves: nothing below them to discover.
+			inventory.WithoutDiscovery(),
+			inventory.WithParentConnectionId(invConfig.Id),
+		},
+	}
+	subsWithConfigs := []subWithConfig{swc}
+
+	assets := []*inventory.Asset{}
+	if emitSubscription {
+		assets = append(assets, subToAsset(swc, inventory.WithoutDiscovery()))
+	}
+	assets = append(assets, discoverResources(runtime, conn, subsWithConfigs, targets)...)
+
+	if conn.Filters.PropagateSubscriptionTags {
+		applySubscriptionTags(conn.Filters.SubscriptionTags, subsWithConfigs, assets)
+	}
+
+	log.Debug().
+		Str("subscription", subId).
+		Int("assets", len(assets)).
+		Msg("azure.discovery> stage 2 complete")
+	return &inventory.Inventory{
+		Spec: &inventory.InventorySpec{
+			Assets: assets,
+		},
+	}, nil
+}
+
+// subscriptionRecord rebuilds the subscription a stage-2 connection is scoped
+// to. The ids come from the connection options stage 1 wrote, which is all the
+// resource listing needs, so the common case costs no API call.
+//
+// full asks ARM for the rest of the record, for the two callers that need a
+// field the options do not carry: the display name of a subscription asset this
+// stage has to emit itself, and the tags when they are being propagated and no
+// override supplied them. A failure there costs those fields, not the
+// discovery.
+func subscriptionRecord(conn *connection.AzureConnection, invConfig *inventory.Config, subId string, full bool) subscriptions.Subscription {
+	sub := subscriptions.Subscription{SubscriptionID: &subId}
+	if tenantId := invConfig.Options[connection.OptionTenantID]; tenantId != "" {
+		sub.TenantID = &tenantId
+	}
+	if !full {
+		return sub
+	}
+
+	record, err := connection.NewSubscriptionsClient(conn.Token(), conn.ClientOptions()).GetSubscription(subId)
+	if err != nil {
+		log.Warn().Err(err).Str("subscription", subId).
+			Msg("could not read the subscription record, discovering without its name and tags")
+		return sub
+	}
+	return record
+}
+
+// discoverResources lists the assets inside the given subscriptions for every
+// active discovery target. Shared by the legacy single-pass path, which passes
+// every subscription in the tenant, and by stage 2 of staged discovery, which
+// passes exactly one.
+func discoverResources(runtime *plugin.Runtime, conn *connection.AzureConnection, subsWithConfigs []subWithConfig, targets []string) []*inventory.Asset {
+	assets := []*inventory.Asset{}
 
 	// A failure in one discovery target must not zero the whole inventory. The
 	// compute path in particular has no access-denied degrade of its own, so a
@@ -291,16 +544,7 @@ func Discover(runtime *plugin.Runtime, rootConf *inventory.Config) (*inventory.I
 		return discoverGeneric(conn, subsWithConfigs, targets)
 	})
 
-	if conn.Filters.PropagateSubscriptionTags {
-		applySubscriptionTags(conn.Filters.SubscriptionTags, subsWithConfigs, assets)
-	}
-
-	log.Debug().Int("assets", len(assets)).Msg("azure.discovery> discovery complete")
-	return &inventory.Inventory{
-		Spec: &inventory.InventorySpec{
-			Assets: assets,
-		},
-	}, nil
+	return assets
 }
 
 func discoverInstancesApi(runtime *plugin.Runtime, subsWithConfigs []subWithConfig, filters connection.GeneralDiscoveryFilters) ([]*inventory.Asset, error) {
@@ -338,7 +582,7 @@ func discoverInstancesApi(runtime *plugin.Runtime, subsWithConfigs []subWithConf
 					service:      "compute",
 					objectType:   "vm-api",
 				},
-			}, subWithConfig.conf, false)
+			}, subWithConfig.conf, false, subWithConfig.assetOpts...)
 			labels, err := getInstancesLabels(vm)
 			if err != nil {
 				return nil, err
@@ -391,7 +635,7 @@ func discoverInstances(runtime *plugin.Runtime, subsWithConfigs []subWithConfig,
 					service:      "compute",
 					objectType:   "vm",
 				},
-			}, subWithConfig.conf, false)
+			}, subWithConfig.conf, false, subWithConfig.assetOpts...)
 			for _, ip := range ipAddresses.Data {
 				ipAddress := ip.(*mqlAzureSubscriptionNetworkServiceIpAddress)
 				// TODO: we need to make this work via another provider maybe?
@@ -499,7 +743,7 @@ func discoverGeneric(conn *connection.AzureConnection, subsWithConfigs []subWith
 						service:      spec.service,
 						objectType:   spec.objectType,
 					},
-				}, swc.conf, spec.includeObjectTypeInUrl)
+				}, swc.conf, spec.includeObjectTypeInUrl, swc.assetOpts...)
 				if asset != nil {
 					assets = append(assets, asset)
 				}
@@ -566,7 +810,7 @@ func discoverStorageAccountsContainers(runtime *plugin.Runtime, subsWithConfig [
 						service:      "storage",
 						objectType:   "container",
 					},
-				}, subWithConfig.conf, true)
+				}, subWithConfig.conf, true, subWithConfig.assetOpts...)
 				assets = append(assets, asset)
 			}
 		}
@@ -651,10 +895,14 @@ func discoverSubscriptions(conn *connection.AzureConnection, filter connection.S
 	return subs, nil
 }
 
-func subToAsset(subWithConfig subWithConfig) *inventory.Asset {
+// subToAsset builds the asset for a subscription. cloneOpts are passed to
+// Clone: the legacy path strips discovery from the result, while stage 1 of
+// staged discovery keeps it, because the targets on a subscription's config are
+// what make stage 2 run when the client connects to it.
+func subToAsset(subWithConfig subWithConfig, cloneOpts ...inventory.CloneOption) *inventory.Asset {
 	sub := subWithConfig.sub
 	conf := subWithConfig.conf
-	copyConf := conf.Clone(inventory.WithoutDiscovery())
+	copyConf := conf.Clone(cloneOpts...)
 	platformId := "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + convert.ToValue(sub.SubscriptionID)
 	tenantId := "unknown"
 	if sub.TenantID != nil {
@@ -742,9 +990,14 @@ func applySubscriptionTags(override map[string]string, subs []subWithConfig, ass
 }
 
 // creates a config with filled in subscription and tenant id, this config can be used by the subscription asset
-// or any assets that are discovered within that subscription
-func getSubConfig(rootConf *inventory.Config, sub subscriptions.Subscription) *inventory.Config {
-	cfg := rootConf.Clone(inventory.WithoutDiscovery())
+// or any assets that are discovered within that subscription.
+//
+// cloneOpts are passed straight to Clone. Stage 1 of staged discovery passes
+// none, keeping the discovery targets that make stage 2 run; the legacy path
+// passes WithoutDiscovery, because nothing below a subscription discovers
+// anything further on that path.
+func getSubConfig(rootConf *inventory.Config, sub subscriptions.Subscription, cloneOpts ...inventory.CloneOption) *inventory.Config {
+	cfg := rootConf.Clone(cloneOpts...)
 	if cfg.Options == nil {
 		cfg.Options = map[string]string{}
 	}
@@ -865,7 +1118,12 @@ func getTitleFamily(azureObject azureObject) (azureObjectPlatformInfo, error) {
 	return azureObjectPlatformInfo{}, fmt.Errorf("missing runtime info for azure object service %s type %s", azureObject.service, azureObject.objectType)
 }
 
-func mqlObjectToAsset(mqlObject mqlObject, parentConf *inventory.Config, includeObjectTypeInUrl bool) *inventory.Asset {
+// mqlObjectToAsset builds the asset for a single discovered azure resource.
+// cloneOpts are passed to Clone; callers hand it the owning subscription's
+// assetOpts, which always strip discovery and, under staged discovery, also
+// name the subscription connection as the parent so the asset shares its
+// resource cache.
+func mqlObjectToAsset(mqlObject mqlObject, parentConf *inventory.Config, includeObjectTypeInUrl bool, cloneOpts ...inventory.CloneOption) *inventory.Asset {
 	if mqlObject.name == "" {
 		mqlObject.name = mqlObject.azureObject.id
 	}
@@ -874,7 +1132,7 @@ func mqlObjectToAsset(mqlObject mqlObject, parentConf *inventory.Config, include
 		return nil
 	}
 	platformid := AzureObjectPlatformId(mqlObject.azureObject.id)
-	cfg := parentConf.Clone(inventory.WithoutDiscovery())
+	cfg := parentConf.Clone(cloneOpts...)
 	cfg.PlatformId = platformid
 
 	tenantId := "unknown"

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -63,16 +63,19 @@ const (
 	DiscoveryContainerApps           = "container-apps"
 	DiscoveryCognitiveServices       = "cognitiveservices-accounts"
 
-	// optionSubscriptionAssetEmitted marks a connection config that stage 1 of
-	// staged discovery built for a subscription it has already emitted as an
-	// asset.
+	// optionBuiltByTenantStage marks a connection config that stage 1 of staged
+	// discovery built for a subscription, meaning stage 1 has already read that
+	// subscription's record and acted on it.
 	//
 	// Stage 2 runs from two places: a subscription asset stage 1 emitted, and a
 	// root connection the caller scoped to one subscription on the command
-	// line. In the first case the subscription asset exists already; in the
-	// second nothing has emitted it, and without this marker the run would
-	// silently lose it -- the legacy path emits it in both cases.
-	optionSubscriptionAssetEmitted = "azure-subscription-asset-emitted"
+	// line. Two things follow from which of the two it is. Stage 1 emits the
+	// subscription asset, so stage 2 has to emit it itself when stage 1 never
+	// ran, or the run silently loses it -- the legacy path emits it either way.
+	// And stage 1 resolves the subscription's tags from the listing it already
+	// paid for, so when it ran, whatever it did not hand over genuinely is not
+	// there and stage 2 has no reason to ask ARM again.
+	optionBuiltByTenantStage = "azure-tenant-stage"
 )
 
 // Auto includes all API resources except storage containers (which require
@@ -369,7 +372,7 @@ func discoverTenantStage(conn *connection.AzureConnection, rootConf *inventory.C
 		Strs("targets", targets).
 		Msg("azure.discovery> stage 1: discovering subscriptions")
 
-	subsWithConfigs, assets := tenantStageAssets(rootConf, subs, targets)
+	subsWithConfigs, assets := tenantStageAssets(rootConf, subs, targets, conn.Filters)
 
 	if conn.Filters.PropagateSubscriptionTags {
 		applySubscriptionTags(conn.Filters.SubscriptionTags, subsWithConfigs, assets)
@@ -391,14 +394,23 @@ func discoverTenantStage(conn *connection.AzureConnection, rootConf *inventory.C
 // the caller asked for subscriptions -- when it is not a target it is still
 // emitted, so that the client connects to it and stage 2 runs, but stripping
 // its platform ids keeps the scanner from treating it as an asset to scan.
-func tenantStageAssets(rootConf *inventory.Config, subs []subscriptions.Subscription, targets []string) ([]subWithConfig, []*inventory.Asset) {
+func tenantStageAssets(rootConf *inventory.Config, subs []subscriptions.Subscription, targets []string, filters connection.DiscoveryFilters) ([]subWithConfig, []*inventory.Asset) {
 	scannable := stringx.ContainsAnyOf(targets, DiscoverySubscriptions)
+	// The subscription list already returned each subscription's tags. Hand
+	// them to stage 2 through the config rather than leaving it to ask ARM for
+	// a record it would only read the tags off -- that would be one GET per
+	// subscription for data this stage is holding. A caller-supplied override
+	// means the tags are not ours to decide, so it is left alone.
+	carryTags := filters.PropagateSubscriptionTags && len(filters.SubscriptionTags) == 0
 
 	subsWithConfigs := make([]subWithConfig, len(subs))
 	assets := make([]*inventory.Asset, 0, len(subs))
 	for i := range subs {
 		conf := getSubConfig(rootConf, subs[i])
-		conf.Options[optionSubscriptionAssetEmitted] = "true"
+		conf.Options[optionBuiltByTenantStage] = "true"
+		if carryTags {
+			carrySubscriptionTags(conf, subs[i])
+		}
 		subsWithConfigs[i] = subWithConfig{sub: subs[i], conf: conf}
 		asset := subToAsset(subsWithConfigs[i])
 		if !scannable {
@@ -409,11 +421,32 @@ func tenantStageAssets(rootConf *inventory.Config, subs []subscriptions.Subscrip
 	return subsWithConfigs, assets
 }
 
-// stageOneEmittedSubscription reports whether the subscription this connection
-// is scoped to has already been emitted as an asset by stage 1.
-func stageOneEmittedSubscription(cfg *inventory.Config) bool {
-	_, ok := cfg.GetOptions()[optionSubscriptionAssetEmitted]
+// builtByTenantStage reports whether stage 1 built this connection config, and
+// so has already emitted the subscription as an asset and resolved its tags.
+func builtByTenantStage(cfg *inventory.Config) bool {
+	_, ok := cfg.GetOptions()[optionBuiltByTenantStage]
 	return ok
+}
+
+// carrySubscriptionTags writes a subscription's ARM tags onto the config stage 2
+// will connect with, in the same form the --filters flag uses, so stage 2 reads
+// them off conn.Filters.SubscriptionTags like any other override.
+func carrySubscriptionTags(cfg *inventory.Config, sub subscriptions.Subscription) {
+	if len(sub.Tags) == 0 {
+		return
+	}
+	if cfg.Discover == nil {
+		cfg.Discover = &inventory.Discovery{}
+	}
+	if cfg.Discover.Filter == nil {
+		cfg.Discover.Filter = map[string]string{}
+	}
+	for k, v := range sub.Tags {
+		if k == "" || v == nil || *v == "" {
+			continue
+		}
+		cfg.Discover.Filter[connection.SubscriptionTagFilterPrefix+k] = *v
+	}
 }
 
 // discoverSubscriptionStage is stage 2 of staged discovery: it lists the
@@ -437,9 +470,14 @@ func discoverSubscriptionStage(runtime *plugin.Runtime, conn *connection.AzureCo
 	// When the caller scoped the run to one subscription there was no stage 1,
 	// so nothing has emitted the subscription itself yet and this stage has to.
 	// That needs its display name, which the connection options do not carry.
-	emitSubscription := !stageOneEmittedSubscription(invConfig) &&
-		stringx.ContainsAnyOf(targets, DiscoverySubscriptions)
-	needsTags := conn.Filters.PropagateSubscriptionTags && len(conn.Filters.SubscriptionTags) == 0
+	fromTenantStage := builtByTenantStage(invConfig)
+	emitSubscription := !fromTenantStage && stringx.ContainsAnyOf(targets, DiscoverySubscriptions)
+	// Stage 1 hands over the tags it read from the subscription listing, so
+	// after it ran an empty set means the subscription has no tags -- not that
+	// they are still to be fetched. Asking ARM here would be one GET per
+	// subscription for something already known.
+	needsTags := !fromTenantStage &&
+		conn.Filters.PropagateSubscriptionTags && len(conn.Filters.SubscriptionTags) == 0
 
 	swc := subWithConfig{
 		sub:  subscriptionRecord(conn, invConfig, subId, emitSubscription || needsTags),

--- a/providers/azure/resources/staged_discovery_test.go
+++ b/providers/azure/resources/staged_discovery_test.go
@@ -1,0 +1,335 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+func TestDiscoveryStageFor(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *inventory.Config
+		wantStage discoveryStage
+		wantSub   string
+	}{
+		{
+			name:      "no options at all",
+			cfg:       &inventory.Config{},
+			wantStage: stageLegacy,
+		},
+		{
+			name: "client that does not set the flag stays on the legacy path",
+			cfg: &inventory.Config{Options: map[string]string{
+				connection.OptionSubscriptionID: "sub-1",
+			}},
+			wantStage: stageLegacy,
+		},
+		{
+			name: "staged root connection walks the tenant",
+			cfg: &inventory.Config{Options: map[string]string{
+				plugin.OptionStagedDiscovery: "true",
+			}},
+			wantStage: stageTenant,
+		},
+		{
+			// the flag is a presence check, not a truthiness check -- the k8s
+			// provider sets it to the empty string
+			name: "empty flag value still opts in",
+			cfg: &inventory.Config{Options: map[string]string{
+				plugin.OptionStagedDiscovery: "",
+			}},
+			wantStage: stageTenant,
+		},
+		{
+			name: "staged connection scoped to a subscription runs stage 2",
+			cfg: &inventory.Config{Options: map[string]string{
+				plugin.OptionStagedDiscovery:    "true",
+				connection.OptionSubscriptionID: "sub-1",
+			}},
+			wantStage: stageSubscription,
+			wantSub:   "sub-1",
+		},
+		{
+			name: "empty subscription id is not a scope",
+			cfg: &inventory.Config{Options: map[string]string{
+				plugin.OptionStagedDiscovery:    "true",
+				connection.OptionSubscriptionID: "",
+			}},
+			wantStage: stageTenant,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stage, subId := discoveryStageFor(test.cfg)
+			assert.Equal(t, test.wantStage, stage)
+			assert.Equal(t, test.wantSub, subId)
+		})
+	}
+}
+
+func stagedRootConfig(targets ...string) *inventory.Config {
+	return &inventory.Config{
+		Type: "azure",
+		Id:   7,
+		Options: map[string]string{
+			plugin.OptionStagedDiscovery: "true",
+			connection.OptionTenantID:    "tenant-1",
+		},
+		Discover: &inventory.Discovery{Targets: targets},
+	}
+}
+
+func testSubscription(id string) subscriptions.Subscription {
+	return subscriptions.Subscription{
+		SubscriptionID: to.Ptr(id),
+		TenantID:       to.Ptr("tenant-1"),
+		DisplayName:    to.Ptr("sub " + id),
+	}
+}
+
+// A stage-1 subscription asset has to stay discoverable: the targets it carries
+// are the only thing that makes the provider run stage 2 when the client
+// connects to it. Stripping them here would end the traversal at the
+// subscription and no resource would ever be discovered.
+func TestTenantStageAssets_SubscriptionConfigTriggersStage2(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	subs := []subscriptions.Subscription{testSubscription("sub-1"), testSubscription("sub-2")}
+
+	swcs, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf))
+	require.Len(t, assets, 2)
+	require.Len(t, swcs, 2)
+
+	for i, asset := range assets {
+		require.Len(t, asset.Connections, 1)
+		cfg := asset.Connections[0]
+
+		stage, subId := discoveryStageFor(cfg)
+		assert.Equal(t, stageSubscription, stage, "asset %d should route to stage 2", i)
+		assert.Equal(t, *subs[i].SubscriptionID, subId)
+
+		require.NotNil(t, cfg.Discover)
+		assert.NotEmpty(t, cfg.Discover.Targets, "targets must survive so stage 2 knows what to look for")
+	}
+}
+
+// The whole point of the stage boundary: a subscription must not inherit
+// another connection's resource cache. Several azure resources read the
+// subscription from the connection rather than from their own id, so a shared
+// cache would answer with the wrong subscription rather than fail.
+func TestTenantStageAssets_SubscriptionsGetTheirOwnCache(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	subs := []subscriptions.Subscription{testSubscription("sub-1"), testSubscription("sub-2")}
+
+	_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf))
+
+	for _, asset := range assets {
+		assert.Zero(t, asset.Connections[0].ParentConnectionId,
+			"a subscription must not share a resource cache with anything above it")
+	}
+}
+
+func TestTenantStageAssets_ScannableWhenSubscriptionsAreTargeted(t *testing.T) {
+	tests := []struct {
+		name             string
+		targets          []string
+		wantPlatformIds  bool
+		subscriptionName string
+	}{
+		{name: "auto includes subscriptions", targets: []string{DiscoveryAuto}, wantPlatformIds: true},
+		{name: "all includes subscriptions", targets: []string{DiscoveryAll}, wantPlatformIds: true},
+		{name: "explicitly targeted", targets: []string{DiscoverySubscriptions}, wantPlatformIds: true},
+		{name: "mixed targets keep them scannable", targets: []string{DiscoverySubscriptions, DiscoveryInstancesApi}, wantPlatformIds: true},
+		{name: "traversal only", targets: []string{DiscoveryInstancesApi}, wantPlatformIds: false},
+		{name: "traversal only, several targets", targets: []string{DiscoveryInstancesApi, DiscoveryKeyVaults}, wantPlatformIds: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rootConf := stagedRootConfig(test.targets...)
+			subs := []subscriptions.Subscription{testSubscription("sub-1")}
+
+			_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf))
+			require.Len(t, assets, 1)
+
+			if test.wantPlatformIds {
+				assert.NotEmpty(t, assets[0].PlatformIds,
+					"a targeted subscription must stay scannable")
+			} else {
+				assert.Empty(t, assets[0].PlatformIds,
+					"an untargeted subscription is a traversal node, not an asset to scan")
+			}
+			// Either way it must still be connectable, or stage 2 never runs.
+			require.Len(t, assets[0].Connections, 1)
+			stage, _ := discoveryStageFor(assets[0].Connections[0])
+			assert.Equal(t, stageSubscription, stage)
+		})
+	}
+}
+
+// Stage 2 hands every asset the subscription connection as its parent. That is
+// the fix for the duplicate ARM traffic: the plugin service gives all of them
+// the subscription runtime's resource cache, so a subscription-wide list is
+// paid for once instead of once per asset.
+func TestSubscriptionStageAssetOpts_ShareTheSubscriptionCache(t *testing.T) {
+	subConf := &inventory.Config{
+		Type: "azure",
+		Id:   42,
+		Options: map[string]string{
+			plugin.OptionStagedDiscovery:    "true",
+			connection.OptionSubscriptionID: "sub-1",
+			connection.OptionTenantID:       "tenant-1",
+		},
+		Discover: &inventory.Discovery{Targets: []string{DiscoveryAuto}},
+	}
+
+	swc := subWithConfig{
+		conf: subConf,
+		assetOpts: []inventory.CloneOption{
+			inventory.WithoutDiscovery(),
+			inventory.WithParentConnectionId(subConf.Id),
+		},
+	}
+
+	asset := mqlObjectToAsset(mqlObject{
+		name: "vault-1",
+		azureObject: azureObject{
+			id:           "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/vault-1",
+			subscription: "sub-1",
+			tenant:       to.Ptr("tenant-1"),
+			location:     "westeurope",
+			service:      "keyvault",
+			objectType:   "vault",
+		},
+	}, swc.conf, false, swc.assetOpts...)
+
+	require.NotNil(t, asset)
+	require.Len(t, asset.Connections, 1)
+	cfg := asset.Connections[0]
+
+	assert.Equal(t, uint32(42), cfg.ParentConnectionId,
+		"a resource must share its subscription's resource cache")
+	// A leaf that still carried discovery targets would re-run stage 2 for the
+	// whole subscription, once per resource.
+	assert.Empty(t, cfg.GetDiscover().GetTargets(), "resources are leaves, they discover nothing")
+	stage, _ := discoveryStageFor(cfg)
+	assert.Equal(t, stageSubscription, stage)
+	assert.Equal(t, "sub-1", cfg.Options[connection.OptionSubscriptionID])
+}
+
+// The legacy path must keep behaving exactly as it did: no parent connection,
+// no discovery on the children.
+func TestLegacyAssetOpts_Unchanged(t *testing.T) {
+	rootConf := &inventory.Config{
+		Type:     "azure",
+		Id:       9,
+		Options:  map[string]string{},
+		Discover: &inventory.Discovery{Targets: []string{DiscoveryAuto}},
+	}
+	sub := testSubscription("sub-1")
+
+	subConf := getSubConfig(rootConf, sub, inventory.WithoutDiscovery())
+	assert.Empty(t, subConf.GetDiscover().GetTargets(), "legacy sub configs do not re-discover")
+	assert.Equal(t, "sub-1", subConf.Options[connection.OptionSubscriptionID])
+	assert.Equal(t, "tenant-1", subConf.Options[connection.OptionTenantID])
+
+	swc := subWithConfig{
+		conf:      subConf,
+		assetOpts: []inventory.CloneOption{inventory.WithoutDiscovery()},
+	}
+	asset := mqlObjectToAsset(mqlObject{
+		name: "vault-1",
+		azureObject: azureObject{
+			id:           "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/vault-1",
+			subscription: "sub-1",
+			tenant:       to.Ptr("tenant-1"),
+			location:     "westeurope",
+			service:      "keyvault",
+			objectType:   "vault",
+		},
+	}, swc.conf, false, swc.assetOpts...)
+
+	require.NotNil(t, asset)
+	require.Len(t, asset.Connections, 1)
+	assert.Zero(t, asset.Connections[0].ParentConnectionId,
+		"the legacy path never shared a resource cache; it must not start now")
+	assert.Empty(t, asset.Connections[0].GetDiscover().GetTargets())
+}
+
+// Stage 1 writes the ids stage 2 needs into the connection options, so stage 2
+// can rebuild the subscription record without asking ARM for it again.
+func TestSubscriptionRecord_FromConnectionOptions(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	_, assets := tenantStageAssets(rootConf, []subscriptions.Subscription{testSubscription("sub-1")}, getDiscoveryTargets(rootConf))
+	subConf := assets[0].Connections[0]
+
+	conn := &connection.AzureConnection{}
+	sub := subscriptionRecord(conn, subConf, "sub-1", false)
+
+	require.NotNil(t, sub.SubscriptionID)
+	assert.Equal(t, "sub-1", *sub.SubscriptionID)
+	require.NotNil(t, sub.TenantID)
+	assert.Equal(t, "tenant-1", *sub.TenantID)
+}
+
+func TestSubscriptionRecord_MissingTenantStaysNil(t *testing.T) {
+	cfg := &inventory.Config{Options: map[string]string{
+		connection.OptionSubscriptionID: "sub-1",
+	}}
+
+	sub := subscriptionRecord(&connection.AzureConnection{}, cfg, "sub-1", false)
+	require.NotNil(t, sub.SubscriptionID)
+	assert.Equal(t, "sub-1", *sub.SubscriptionID)
+	assert.Nil(t, sub.TenantID, "an unknown tenant must stay unknown, not become the empty string")
+}
+
+// Stage 1 marks the subscription configs it has emitted assets for, so stage 2
+// knows whether it has to emit the subscription itself. Reaching stage 2 from a
+// command line scoped to one subscription means no stage 1 ran and nothing has
+// emitted it -- the legacy path emits it either way, so this one must too.
+func TestStageOneEmittedSubscription(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	_, assets := tenantStageAssets(rootConf, []subscriptions.Subscription{testSubscription("sub-1")}, getDiscoveryTargets(rootConf))
+	require.Len(t, assets, 1)
+
+	assert.True(t, stageOneEmittedSubscription(assets[0].Connections[0]),
+		"stage 1 already emitted this subscription as an asset")
+
+	cliScoped := &inventory.Config{Options: map[string]string{
+		plugin.OptionStagedDiscovery:    "true",
+		connection.OptionSubscriptionID: "sub-1",
+	}}
+	assert.False(t, stageOneEmittedSubscription(cliScoped),
+		"a command-line scoped run never went through stage 1")
+}
+
+// Nothing beyond the ids is needed here, so the record must not be fetched.
+func TestSubscriptionRecord_SkipsTheFetchWhenNothingNeedsIt(t *testing.T) {
+	cfg := &inventory.Config{Options: map[string]string{
+		connection.OptionSubscriptionID: "sub-1",
+		connection.OptionTenantID:       "tenant-1",
+	}}
+	conn := &connection.AzureConnection{
+		Filters: connection.DiscoveryFilters{
+			PropagateSubscriptionTags: true,
+			SubscriptionTags:          map[string]string{"env": "prod"},
+		},
+	}
+
+	// A fetch here would panic on the nil credential, so reaching the end of
+	// this call is the assertion.
+	sub := subscriptionRecord(conn, cfg, "sub-1", false)
+	require.NotNil(t, sub.SubscriptionID)
+	assert.Equal(t, "sub-1", *sub.SubscriptionID)
+	assert.Empty(t, sub.Tags)
+}

--- a/providers/azure/resources/staged_discovery_test.go
+++ b/providers/azure/resources/staged_discovery_test.go
@@ -106,7 +106,7 @@ func TestTenantStageAssets_SubscriptionConfigTriggersStage2(t *testing.T) {
 	rootConf := stagedRootConfig(DiscoveryAuto)
 	subs := []subscriptions.Subscription{testSubscription("sub-1"), testSubscription("sub-2")}
 
-	swcs, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf))
+	swcs, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf), connection.DiscoveryFilters{})
 	require.Len(t, assets, 2)
 	require.Len(t, swcs, 2)
 
@@ -131,7 +131,7 @@ func TestTenantStageAssets_SubscriptionsGetTheirOwnCache(t *testing.T) {
 	rootConf := stagedRootConfig(DiscoveryAuto)
 	subs := []subscriptions.Subscription{testSubscription("sub-1"), testSubscription("sub-2")}
 
-	_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf))
+	_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf), connection.DiscoveryFilters{})
 
 	for _, asset := range assets {
 		assert.Zero(t, asset.Connections[0].ParentConnectionId,
@@ -159,7 +159,7 @@ func TestTenantStageAssets_ScannableWhenSubscriptionsAreTargeted(t *testing.T) {
 			rootConf := stagedRootConfig(test.targets...)
 			subs := []subscriptions.Subscription{testSubscription("sub-1")}
 
-			_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf))
+			_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf), connection.DiscoveryFilters{})
 			require.Len(t, assets, 1)
 
 			if test.wantPlatformIds {
@@ -270,7 +270,7 @@ func TestLegacyAssetOpts_Unchanged(t *testing.T) {
 // can rebuild the subscription record without asking ARM for it again.
 func TestSubscriptionRecord_FromConnectionOptions(t *testing.T) {
 	rootConf := stagedRootConfig(DiscoveryAuto)
-	_, assets := tenantStageAssets(rootConf, []subscriptions.Subscription{testSubscription("sub-1")}, getDiscoveryTargets(rootConf))
+	_, assets := tenantStageAssets(rootConf, []subscriptions.Subscription{testSubscription("sub-1")}, getDiscoveryTargets(rootConf), connection.DiscoveryFilters{})
 	subConf := assets[0].Connections[0]
 
 	conn := &connection.AzureConnection{}
@@ -293,24 +293,47 @@ func TestSubscriptionRecord_MissingTenantStaysNil(t *testing.T) {
 	assert.Nil(t, sub.TenantID, "an unknown tenant must stay unknown, not become the empty string")
 }
 
-// Stage 1 marks the subscription configs it has emitted assets for, so stage 2
-// knows whether it has to emit the subscription itself. Reaching stage 2 from a
-// command line scoped to one subscription means no stage 1 ran and nothing has
-// emitted it -- the legacy path emits it either way, so this one must too.
-func TestStageOneEmittedSubscription(t *testing.T) {
+// Stage 1 marks the configs it builds, which tells stage 2 both that the
+// subscription asset already exists and that its tags have already been
+// resolved. Reaching stage 2 from a command line scoped to one subscription
+// means no stage 1 ran and neither is true.
+func TestBuiltByTenantStage(t *testing.T) {
 	rootConf := stagedRootConfig(DiscoveryAuto)
-	_, assets := tenantStageAssets(rootConf, []subscriptions.Subscription{testSubscription("sub-1")}, getDiscoveryTargets(rootConf))
+	_, assets := tenantStageAssets(rootConf, []subscriptions.Subscription{testSubscription("sub-1")}, getDiscoveryTargets(rootConf), connection.DiscoveryFilters{})
 	require.Len(t, assets, 1)
 
-	assert.True(t, stageOneEmittedSubscription(assets[0].Connections[0]),
-		"stage 1 already emitted this subscription as an asset")
+	assert.True(t, builtByTenantStage(assets[0].Connections[0]),
+		"stage 1 built this config, so it emitted the subscription and read its tags")
 
 	cliScoped := &inventory.Config{Options: map[string]string{
 		plugin.OptionStagedDiscovery:    "true",
 		connection.OptionSubscriptionID: "sub-1",
 	}}
-	assert.False(t, stageOneEmittedSubscription(cliScoped),
+	assert.False(t, builtByTenantStage(cliScoped),
 		"a command-line scoped run never went through stage 1")
+}
+
+// The bug this guards: a subscription with no tags carries none, so an empty
+// set at stage 2 is ambiguous unless the stage-1 marker disambiguates it.
+// Without that, every untagged subscription in the tenant costs a GET.
+func TestTenantStageAssets_UntaggedSubscriptionNeedsNoFetch(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	rootConf.Discover.Filter = map[string]string{"propagate-subscription-tags": "true"}
+	// No tags at all on this one.
+	subs := []subscriptions.Subscription{testSubscription("sub-1")}
+	filters := connection.DiscoveryFiltersFromOpts(rootConf.Discover.Filter)
+
+	_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf), filters)
+	require.Len(t, assets, 1)
+	cfg := assets[0].Connections[0]
+
+	stage2 := connection.DiscoveryFiltersFromOpts(cfg.GetDiscover().GetFilter())
+	require.True(t, stage2.PropagateSubscriptionTags)
+	require.Empty(t, stage2.SubscriptionTags, "there were none to carry")
+
+	// The marker is what stops stage 2 reading that empty set as "not fetched yet".
+	assert.True(t, builtByTenantStage(cfg),
+		"an untagged subscription must still be recognised as resolved by stage 1")
 }
 
 // Nothing beyond the ids is needed here, so the record must not be fetched.
@@ -332,4 +355,82 @@ func TestSubscriptionRecord_SkipsTheFetchWhenNothingNeedsIt(t *testing.T) {
 	require.NotNil(t, sub.SubscriptionID)
 	assert.Equal(t, "sub-1", *sub.SubscriptionID)
 	assert.Empty(t, sub.Tags)
+}
+
+func taggedSubscription(id string, tags map[string]string) subscriptions.Subscription {
+	sub := testSubscription(id)
+	sub.Tags = map[string]*string{}
+	for k, v := range tags {
+		sub.Tags[k] = to.Ptr(v)
+	}
+	return sub
+}
+
+// The subscription list already returns each subscription's tags. Stage 1 hands
+// them to stage 2 through the config, so stage 2 never has to spend a GET per
+// subscription on a record it would only read the tags off.
+func TestTenantStageAssets_CarriesSubscriptionTagsToStage2(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	// Derived the way the connection derives it, so the flag reaches stage 2
+	// the same way it does in production.
+	rootConf.Discover.Filter = map[string]string{"propagate-subscription-tags": "true"}
+	subs := []subscriptions.Subscription{
+		taggedSubscription("sub-1", map[string]string{"env": "prod", "team": "infra"}),
+		taggedSubscription("sub-2", map[string]string{"env": "dev"}),
+	}
+	filters := connection.DiscoveryFiltersFromOpts(rootConf.Discover.Filter)
+	require.True(t, filters.PropagateSubscriptionTags)
+
+	_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf), filters)
+	require.Len(t, assets, 2)
+
+	// What stage 2 will see once its connection parses the config.
+	stage2Filters := func(a *inventory.Asset) connection.DiscoveryFilters {
+		return connection.DiscoveryFiltersFromOpts(a.Connections[0].GetDiscover().GetFilter())
+	}
+
+	assert.Equal(t, map[string]string{"env": "prod", "team": "infra"},
+		stage2Filters(assets[0]).SubscriptionTags)
+	// Each subscription carries only its own tags -- the configs must not share
+	// a filter map, or every subscription would inherit the last one's tags.
+	assert.Equal(t, map[string]string{"env": "dev"},
+		stage2Filters(assets[1]).SubscriptionTags)
+
+	// With the tags already in hand, stage 2 has no reason to fetch the record.
+	for _, a := range assets {
+		f := stage2Filters(a)
+		assert.True(t, f.PropagateSubscriptionTags, "propagation must survive to stage 2")
+		assert.False(t, f.PropagateSubscriptionTags && len(f.SubscriptionTags) == 0,
+			"stage 2 must not need an extra GetSubscription call")
+	}
+}
+
+// A caller-supplied override decides the tags, so stage 1 must not overwrite it
+// with what ARM reported.
+func TestTenantStageAssets_CallerTagOverrideWins(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	rootConf.Discover.Filter = map[string]string{
+		"propagate-subscription-tags":                  "true",
+		connection.SubscriptionTagFilterPrefix + "env": "override",
+	}
+	subs := []subscriptions.Subscription{taggedSubscription("sub-1", map[string]string{"env": "prod"})}
+	filters := connection.DiscoveryFiltersFromOpts(rootConf.Discover.Filter)
+
+	_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf), filters)
+	require.Len(t, assets, 1)
+
+	got := connection.DiscoveryFiltersFromOpts(assets[0].Connections[0].GetDiscover().GetFilter())
+	assert.Equal(t, map[string]string{"env": "override"}, got.SubscriptionTags)
+}
+
+// Propagation is off by default; nothing should be written in that case.
+func TestTenantStageAssets_NoTagsCarriedWhenPropagationIsOff(t *testing.T) {
+	rootConf := stagedRootConfig(DiscoveryAuto)
+	subs := []subscriptions.Subscription{taggedSubscription("sub-1", map[string]string{"env": "prod"})}
+
+	_, assets := tenantStageAssets(rootConf, subs, getDiscoveryTargets(rootConf), connection.DiscoveryFilters{})
+	require.Len(t, assets, 1)
+
+	got := connection.DiscoveryFiltersFromOpts(assets[0].Connections[0].GetDiscover().GetFilter())
+	assert.Empty(t, got.SubscriptionTags)
 }


### PR DESCRIPTION
Azure discovery never set ParentConnectionId, so every discovered asset got its own runtime and its own MQL resource cache. Nothing was shared, and each asset re-fetched the subscription-scoped reads it needed from scratch. On a customer scan that meant 42,590 ARM calls against 9,448 distinct URLs, with the App Service reads (slots, config/web, config/metadata/list) running at 36x. The redundancy earned enough 429s to stall the scan outright.

Discovery now routes on plugin.OptionStagedDiscovery:

  - stage 1 lists the subscriptions and emits one asset each, with no parent connection. Each subscription gets its own runtime and cache, so closing one releases everything beneath it -- and no subscription can ever be served another's cached resources. That isolation is load-bearing: initAzureSubscription resolves through conn.SubId() and memoizes onto the azure singleton, and 107 call sites read the subscription off the connection rather than off their own id, so a shared cache would answer with the wrong subscription rather than fail.

  - stage 2 lists the resources of one subscription and names that connection as every asset's parent, so the plugin service hands them all the subscription runtime's cache. The first asset to ask pays for a subscription-wide read and the rest get a cache hit.

Measured on a 15-subscription tenant, same provider version, 21 assets each resolving azure.subscription.web.apps: 21 -> 1 calls to Microsoft.Web/sites, 44 -> 3 ARM calls in total, with identical asset sets on both paths.

The legacy single-pass path is untouched for clients that do not set the flag, and is marked TODO(v15).

Reaching stage 2 from a command line scoped with --subscription means stage 1 never ran, so nothing had emitted the subscription asset. Stage configs it has emitted, and stage 2 emits the subscription itself when that mark is absent, matching the legacy path.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.co