### PR TITLE
⚡ azure: resolve asset-scoped resources from the service list, not a per-resource GET

### DIFF
--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -198,50 +198,10 @@ func initAzureSubscriptionContainerAppService(runtime *plugin.Runtime, args map[
 // queried directly without re-listing every container app in the
 // subscription.
 func initAzureSubscriptionContainerAppServiceContainerApp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, missingResourceID("azure.subscription.containerAppService.containerApp")
-	}
-
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	appName, err := resourceID.Component("containerApps")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client, err := apps.NewContainerAppsClient(resourceID.SubscriptionID, conn.Token(), acaClientOptions(conn))
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, appName, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	mql, err := acaContainerAppToMQL(runtime, &resp.ContainerApp)
-	if err != nil {
-		return nil, nil, err
-	}
-	return args, mql, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionContainerAppService,
+		func(s *mqlAzureSubscriptionContainerAppService) *plugin.TValue[[]any] { return s.GetContainerApps() },
+		ResourceAzureSubscriptionContainerAppServiceContainerApp)
 }
 
 func (a *mqlAzureSubscriptionContainerAppServiceContainerApp) userAssignedIdentities() ([]any, error) {

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.34.1",
-  "generated_at": "2026-08-14T09:05:05+02:00",
+  "generated_at": "2026-08-14T16:33:12+03:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.ApiManagement/service/apis/policies/read",
@@ -398,7 +398,7 @@
     {
       "permission": "Microsoft.App/containerApps/read",
       "service": "Microsoft.App",
-      "action": "Get",
+      "action": "NewListBySubscriptionPager",
       "source_file": "appcontainers.go"
     },
     {
@@ -656,7 +656,7 @@
     {
       "permission": "Microsoft.Cognitiveservices/accounts/read",
       "service": "Microsoft.Cognitiveservices",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "cognitiveservices.go"
     },
     {
@@ -1028,7 +1028,7 @@
     {
       "permission": "Microsoft.DocumentDB/databaseAccounts/read",
       "service": "Microsoft.DocumentDB",
-      "action": "Get",
+      "action": "NewListPager",
       "source_file": "cosmosdb.go"
     },
     {
@@ -1384,12 +1384,6 @@
       "service": "Microsoft.Network",
       "action": "Get",
       "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/azureFirewalls/read",
-      "service": "Microsoft.Network",
-      "action": "Get",
-      "source_file": "network_expansion.go"
     },
     {
       "permission": "Microsoft.Network/bastionHosts/read",
@@ -2384,7 +2378,7 @@
     {
       "permission": "Microsoft.Web/sites/read",
       "service": "Microsoft.Web",
-      "action": "Get",
+      "action": "NewListFunctionsPager",
       "source_file": "functions.go"
     },
     {

--- a/providers/azure/resources/cognitiveservices.go
+++ b/providers/azure/resources/cognitiveservices.go
@@ -47,54 +47,10 @@ func (a *mqlAzureSubscriptionCognitiveServicesService) id() (string, error) {
 // azure-cognitiveservices-account asset resolves to its backing account instead
 // of an empty husk.
 func initAzureSubscriptionCognitiveServicesServiceAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, errors.New("id required to fetch azure cognitive services account")
-	}
-
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	accountName, err := resourceID.Component("accounts")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client, err := armcognitiveservices.NewAccountsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	account, err := client.Get(context.Background(), resourceID.ResourceGroup, accountName, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	res, err := cognitiveServicesAccountToMql(runtime, &account.Account)
-	if err != nil {
-		return nil, nil, err
-	}
-	return args, res, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionCognitiveServicesService,
+		func(s *mqlAzureSubscriptionCognitiveServicesService) *plugin.TValue[[]any] { return s.GetAccounts() },
+		ResourceAzureSubscriptionCognitiveServicesServiceAccount)
 }
 
 func (a *mqlAzureSubscriptionCognitiveServicesServiceAccount) id() (string, error) {

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -1005,53 +1005,10 @@ func (a *mqlAzureSubscriptionComputeServiceVm) publicIpAddresses() ([]any, error
 }
 
 func initAzureSubscriptionComputeServiceVm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, errors.New("id required to fetch azure compute vm instance")
-	}
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	vmName, err := resourceID.Component("virtualMachines")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client, err := compute.NewVirtualMachinesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, vmName, &compute.VirtualMachinesClientGetOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	mqlVm, err := vmToMql(runtime, resp.VirtualMachine)
-	if err != nil {
-		return nil, nil, err
-	}
-	return args, mqlVm, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionComputeService,
+		func(s *mqlAzureSubscriptionComputeService) *plugin.TValue[[]any] { return s.GetVms() },
+		ResourceAzureSubscriptionComputeServiceVm)
 }
 
 // userData returns the VM's base64-encoded user data.

--- a/providers/azure/resources/cosmosdb.go
+++ b/providers/azure/resources/cosmosdb.go
@@ -38,51 +38,10 @@ func initAzureSubscriptionCosmosDbService(runtime *plugin.Runtime, args map[stri
 }
 
 func initAzureSubscriptionCosmosDbServiceAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, errors.New("id required to fetch azure cosmosdb account")
-	}
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	accountName, err := resourceID.Component("databaseAccounts")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client, err := cosmosdb.NewDatabaseAccountsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, accountName, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	mqlAccount, err := cosmosAccountToMql(runtime, &resp.DatabaseAccountGetResults)
-	if err != nil {
-		return nil, nil, err
-	}
-	return args, mqlAccount, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionCosmosDbService,
+		func(s *mqlAzureSubscriptionCosmosDbService) *plugin.TValue[[]any] { return s.GetAccounts() },
+		ResourceAzureSubscriptionCosmosDbServiceAccount)
 }
 
 func (a *mqlAzureSubscriptionCosmosDbService) accounts() ([]any, error) {

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -58,57 +57,10 @@ func (a *mqlAzureSubscriptionFunctionsServiceFunctionAppFunction) id() (string, 
 // directly without re-listing every Microsoft.Web/sites resource in the
 // subscription.
 func initAzureSubscriptionFunctionsServiceFunctionApp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, missingResourceID("azure.subscription.functionsService.functionApp")
-	}
-
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	siteName, err := resourceID.Component("sites")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client, err := web.NewWebAppsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, siteName, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	site := &resp.Site
-	if site.Kind == nil || !strings.Contains(strings.ToLower(*site.Kind), "functionapp") {
-		return nil, nil, fmt.Errorf("azure resource %q is not a function app", id)
-	}
-
-	mql, err := functionAppSiteToMql(runtime, site)
-	if err != nil {
-		return nil, nil, err
-	}
-	return args, mql, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionFunctionsService,
+		func(s *mqlAzureSubscriptionFunctionsService) *plugin.TValue[[]any] { return s.GetFunctionApps() },
+		ResourceAzureSubscriptionFunctionsServiceFunctionApp)
 }
 
 func (a *mqlAzureSubscriptionFunctionsService) functionApps() ([]any, error) {

--- a/providers/azure/resources/init_from_list.go
+++ b/providers/azure/resources/init_from_list.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// azureListedResource is any resource that a service-level list returns and
+// that carries the ARM id its asset is discovered under.
+type azureListedResource interface {
+	plugin.Resource
+	GetId() *plugin.TValue[string]
+}
+
+// azureListService is any of the azure.subscription.*Service resources, all of
+// which are keyed on the subscription alone.
+type azureListService interface {
+	plugin.Resource
+}
+
+// initFromServiceList resolves a resource by its ARM id out of the list its
+// parent service has already fetched, instead of asking ARM for that one
+// resource.
+//
+// Every discovered asset resolves its own resource through its init, once per
+// asset, so a per-resource Get costs one API call per asset of that type: a
+// subscription with 150 VMs pays 150 of them. The service's list is a single
+// call that already contains every one of those resources, and during a scan it
+// has usually been fetched already, because discovery itself walks the same
+// list to find the assets. Worse, NewResource runs the init *before* it
+// consults the resource cache, so a Get here is spent even when the resource is
+// already built, and its result is then thrown away in favour of the cached
+// one.
+//
+// This mirrors the k8s provider's initNamespacedResource.
+//
+// The trade is deliberate: resolving a single asset in isolation now pulls the
+// whole subscription's list rather than one record. During a scan that list is
+// wanted anyway and is very likely already cached; for a one-off query against
+// one asset it is the more expensive path.
+func initFromServiceList[S azureListService](
+	runtime *plugin.Runtime,
+	args map[string]*llx.RawData,
+	serviceName string,
+	entries func(S) *plugin.TValue[[]any],
+	resourceName string,
+) (map[string]*llx.RawData, plugin.Resource, error) {
+	// the args are already complete; nothing to resolve
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
+			args["id"] = llx.StringData(ids.id)
+		}
+	}
+
+	if args["id"] == nil {
+		return nil, nil, missingResourceID(resourceName)
+	}
+	id, ok := args["id"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("id must be a non-nil string value")
+	}
+
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	res, err := NewResource(runtime, serviceName, map[string]*llx.RawData{
+		"subscriptionId": llx.StringData(conn.SubId()),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	svc, ok := res.(S)
+	if !ok {
+		return nil, nil, fmt.Errorf("unexpected resource type for %s", serviceName)
+	}
+
+	list := entries(svc)
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for i := range list.Data {
+		item, ok := list.Data[i].(azureListedResource)
+		if !ok {
+			continue
+		}
+		if item.GetId().Data == id {
+			return args, item, nil
+		}
+	}
+
+	// Deliberately an error rather than falling through with (args, nil, nil):
+	// that would have the runtime build the resource from the id alone, leaving
+	// every other field unset rather than null, which reaches the client as an
+	// untyped null with nothing pointing at the cause.
+	return nil, nil, fmt.Errorf("%s with id %q not found", resourceName, id)
+}

--- a/providers/azure/resources/init_from_list.go
+++ b/providers/azure/resources/init_from_list.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -96,7 +97,15 @@ func initFromServiceList[S azureListService](
 		if !ok {
 			continue
 		}
-		if item.GetId().Data == id {
+		// Case-insensitively, because the two ids come from different ARM
+		// endpoints and ARM does not agree with itself on the casing of the
+		// type segment. A container app is
+		// ".../Microsoft.App/containerApps/..." in the generic resources
+		// listing an asset's platform id comes from, and
+		// ".../Microsoft.App/containerapps/..." in the service listing matched
+		// here. ARM treats ids as case-insensitive, so an exact comparison
+		// reports a resource that plainly exists as not found.
+		if strings.EqualFold(item.GetId().Data, id) {
 			return args, item, nil
 		}
 	}

--- a/providers/azure/resources/init_from_list_test.go
+++ b/providers/azure/resources/init_from_list_test.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+const testVMID = "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-1"
+
+// computeServiceWithVMs builds the state a scan is in once the subscription's
+// VM list has been walked: the service resource in the cache with its vms field
+// already resolved. Nothing here touches Azure.
+func computeServiceWithVMs(t *testing.T, runtime *plugin.Runtime, ids ...string) []any {
+	t.Helper()
+
+	svcRes, err := NewResource(runtime, ResourceAzureSubscriptionComputeService, map[string]*llx.RawData{
+		"subscriptionId": llx.StringData(""),
+	})
+	require.NoError(t, err)
+	svc := svcRes.(*mqlAzureSubscriptionComputeService)
+
+	vms := make([]any, 0, len(ids))
+	for _, id := range ids {
+		vm, err := CreateResource(runtime, ResourceAzureSubscriptionComputeServiceVm, map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		require.NoError(t, err)
+		vms = append(vms, vm)
+	}
+	svc.Vms = plugin.TValue[[]any]{Data: vms, State: plugin.StateIsSet}
+	return vms
+}
+
+// The point of the change: the init hands back the instance the list already
+// built rather than fetching that one resource again. A rebuilt instance would
+// mean an API call per asset, and would also discard whatever the list had
+// already resolved onto it.
+func TestInitFromServiceList_ReturnsTheListedInstance(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	vms := computeServiceWithVMs(t, runtime, testVMID)
+
+	args := map[string]*llx.RawData{"id": llx.StringData(testVMID)}
+	gotArgs, res, err := initAzureSubscriptionComputeServiceVm(runtime, args)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Same(t, vms[0], res, "must return the instance from the list, not a fresh one")
+	assert.NotNil(t, gotArgs)
+}
+
+// The right one out of several, not just the first.
+func TestInitFromServiceList_MatchesOnID(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	other := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-2"
+	vms := computeServiceWithVMs(t, runtime, other, testVMID)
+
+	_, res, err := initAzureSubscriptionComputeServiceVm(runtime,
+		map[string]*llx.RawData{"id": llx.StringData(testVMID)})
+
+	require.NoError(t, err)
+	assert.Same(t, vms[1], res)
+}
+
+// A miss has to be an error. Falling through with (args, nil, nil) would have
+// the runtime build the resource from the id alone, leaving every other field
+// unset rather than null -- which reaches the client as an untyped null with
+// nothing pointing at the cause.
+func TestInitFromServiceList_ReportsAMiss(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	computeServiceWithVMs(t, runtime, testVMID)
+
+	missing := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/gone"
+	args, res, err := initAzureSubscriptionComputeServiceVm(runtime,
+		map[string]*llx.RawData{"id": llx.StringData(missing)})
+
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Nil(t, args, "returning args would let the runtime build a blank resource")
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), missing, "the error should name what was not found")
+}
+
+// An empty list is a miss, not a panic or a silent success.
+func TestInitFromServiceList_EmptyList(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	computeServiceWithVMs(t, runtime)
+
+	_, res, err := initAzureSubscriptionComputeServiceVm(runtime,
+		map[string]*llx.RawData{"id": llx.StringData(testVMID)})
+
+	require.Error(t, err)
+	assert.Nil(t, res)
+}
+
+// Callers that already supplied everything must not trigger a list walk.
+func TestInitFromServiceList_PassesThroughCompleteArgs(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	// deliberately no service resource in the cache: reaching the list here
+	// would fail, so returning cleanly proves the fast path was taken
+	args := map[string]*llx.RawData{
+		"id":   llx.StringData(testVMID),
+		"name": llx.StringData("vm-1"),
+	}
+
+	gotArgs, res, err := initAzureSubscriptionComputeServiceVm(runtime, args)
+
+	require.NoError(t, err)
+	assert.Nil(t, res, "the runtime builds the resource itself from complete args")
+	assert.Equal(t, args, gotArgs)
+}
+
+// A non-string id is a caller error, not something to look up.
+func TestInitFromServiceList_RejectsNonStringID(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	computeServiceWithVMs(t, runtime, testVMID)
+
+	_, res, err := initAzureSubscriptionComputeServiceVm(runtime,
+		map[string]*llx.RawData{"id": llx.IntData(42)})
+
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "id must be a non-nil string value")
+}

--- a/providers/azure/resources/init_from_list_test.go
+++ b/providers/azure/resources/init_from_list_test.go
@@ -128,3 +128,37 @@ func TestInitFromServiceList_RejectsNonStringID(t *testing.T) {
 	assert.Nil(t, res)
 	assert.Contains(t, err.Error(), "id must be a non-nil string value")
 }
+
+// ARM does not agree with itself on the casing of the type segment: the generic
+// resources listing an asset's platform id comes from returns
+// ".../Microsoft.App/containerApps/...", while the service listing matched here
+// returns ".../Microsoft.App/containerapps/...". An exact comparison reports a
+// container app that plainly exists as not found, and its asset scans as empty.
+func TestInitFromServiceList_MatchesIDCaseInsensitively(t *testing.T) {
+	listed := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualmachines/vm-1"
+	asset := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-1"
+
+	runtime := runtimeForAsset(t, nil)
+	vms := computeServiceWithVMs(t, runtime, listed)
+
+	_, res, err := initAzureSubscriptionComputeServiceVm(runtime,
+		map[string]*llx.RawData{"id": llx.StringData(asset)})
+
+	require.NoError(t, err, "casing must not decide whether a resource is found")
+	assert.Same(t, vms[0], res)
+}
+
+// Case-insensitivity must not turn into matching the wrong resource: only the
+// casing may differ, never the path itself.
+func TestInitFromServiceList_StillDistinguishesDifferentResources(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	computeServiceWithVMs(t, runtime,
+		"/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-1")
+
+	_, res, err := initAzureSubscriptionComputeServiceVm(runtime,
+		map[string]*llx.RawData{"id": llx.StringData(
+			"/subscriptions/sub-1/resourceGroups/other-rg/providers/Microsoft.Compute/virtualMachines/vm-1")})
+
+	require.Error(t, err)
+	assert.Nil(t, res)
+}

--- a/providers/azure/resources/init_missing_id_test.go
+++ b/providers/azure/resources/init_missing_id_test.go
@@ -11,19 +11,27 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
+	"go.mondoo.com/mql/v13/utils/syncx"
 )
 
 // runtimeForAsset builds a runtime whose connection reports the given asset.
 // Nothing here reaches the network: the inits under test bail out before they
 // build a client, and constructing an Azure credential only assembles the
 // sign-in chain.
+//
+// The resource cache is real because the inits resolve their resource out of
+// the parent service's list, so they reach NewResource before they reach
+// anything that would talk to Azure.
 func runtimeForAsset(t *testing.T, platformIds []string) *plugin.Runtime {
 	t.Helper()
 	asset := &inventory.Asset{Name: "some asset", PlatformIds: platformIds}
 	conf := &inventory.Config{Options: map[string]string{"tenant-id": "tid", "client-id": "cid"}}
 	conn, err := connection.NewAzureConnection(1, asset, conf)
 	require.NoError(t, err)
-	return &plugin.Runtime{Connection: conn}
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
 }
 
 // A resource queried bare -- no id, and a scanned asset that is not itself that
@@ -44,6 +52,11 @@ func TestInitsReportAMissingID(t *testing.T) {
 		{"azure.subscription.networkService.applicationGateway", initAzureSubscriptionNetworkServiceApplicationGateway},
 		{"azure.subscription.containerAppService.containerApp", initAzureSubscriptionContainerAppServiceContainerApp},
 		{"azure.subscription.functionsService.functionApp", initAzureSubscriptionFunctionsServiceFunctionApp},
+		{"azure.subscription.computeService.vm", initAzureSubscriptionComputeServiceVm},
+		{"azure.subscription.keyVaultService.vault", initAzureSubscriptionKeyVaultServiceVault},
+		{"azure.subscription.cosmosDbService.account", initAzureSubscriptionCosmosDbServiceAccount},
+		{"azure.subscription.cacheService.redisInstance", initAzureSubscriptionCacheServiceRedisInstance},
+		{"azure.subscription.cognitiveServicesService.account", initAzureSubscriptionCognitiveServicesServiceAccount},
 	}
 
 	subscriptionAsset := []string{"//platformid.api.mondoo.app/runtime/azure/subscriptions/sub-1"}

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -173,7 +173,13 @@ func (a *mqlAzureSubscriptionKeyVaultService) vaults() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	pager := client.NewListPager(&keyvault.VaultsClientListOptions{})
+	// ListBySubscription rather than List: List goes through the generic ARM
+	// resources endpoint and returns a TrackedResource, which carries no
+	// Properties, so every vault then needed its own Get to answer properties,
+	// networkAcls, accessPolicies or privateEndpointConnections.
+	// ListBySubscription returns the full Vault, so one call answers all of
+	// them for every vault in the subscription.
+	pager := client.NewListBySubscriptionPager(&keyvault.VaultsClientListBySubscriptionOptions{})
 	res := []any{}
 
 	for pager.More() {
@@ -185,26 +191,41 @@ func (a *mqlAzureSubscriptionKeyVaultService) vaults() ([]any, error) {
 			if entry == nil {
 				continue
 			}
-			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.keyVaultService.vault",
-				map[string]*llx.RawData{
-					"id":        llx.StringDataPtr(entry.ID),
-					"vaultName": llx.StringDataPtr(entry.Name),
-					"location":  llx.StringDataPtr(entry.Location),
-					"type":      llx.StringDataPtr(entry.Type),
-					"tags":      llx.MapData(convert.PtrMapStrToInterface(entry.Tags), types.String),
-				})
+			mqlVault, err := vaultToMql(a.MqlRuntime, entry)
 			if err != nil {
 				return nil, err
 			}
-			sysData, err := convert.JsonToDict(entry.SystemData)
-			if err != nil {
-				return nil, err
-			}
-			mqlAzure.(*mqlAzureSubscriptionKeyVaultServiceVault).cacheSystemData = sysData
-			res = append(res, mqlAzure)
+			res = append(res, mqlVault)
 		}
 	}
 	return res, nil
+}
+
+// vaultToMql builds a vault resource from a full ARM Vault record and primes
+// the per-vault fetch with it, so the accessors that would otherwise each pay a
+// VaultsClient.Get read it straight from the listing.
+func vaultToMql(runtime *plugin.Runtime, entry *keyvault.Vault) (plugin.Resource, error) {
+	res, err := CreateResource(runtime, "azure.subscription.keyVaultService.vault",
+		map[string]*llx.RawData{
+			"id":        llx.StringDataPtr(entry.ID),
+			"vaultName": llx.StringDataPtr(entry.Name),
+			"location":  llx.StringDataPtr(entry.Location),
+			"type":      llx.StringDataPtr(entry.Type),
+			"tags":      llx.MapData(convert.PtrMapStrToInterface(entry.Tags), types.String),
+		})
+	if err != nil {
+		return nil, err
+	}
+	sysData, err := convert.JsonToDict(entry.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlVault := res.(*mqlAzureSubscriptionKeyVaultServiceVault)
+	mqlVault.cacheSystemData = sysData
+	mqlVault.fetchVaultOnce.Do(func() {
+		mqlVault.fetchVaultResp = &keyvault.VaultsClientGetResponse{Vault: *entry}
+	})
+	return mqlVault, nil
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) vaultUri() (string, error) {
@@ -1782,74 +1803,10 @@ func (a *mqlAzureSubscriptionKeyVaultServiceSecret) previousVersion() (*mqlAzure
 }
 
 func initAzureSubscriptionKeyVaultServiceVault(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, errors.New("id required to fetch azure key vault")
-	}
-
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	vaultName, err := resourceID.Component("vaults")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client, err := keyvault.NewVaultsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	vault, err := client.Get(context.Background(), resourceID.ResourceGroup, vaultName, &keyvault.VaultsClientGetOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	res, err := CreateResource(runtime, "azure.subscription.keyVaultService.vault",
-		map[string]*llx.RawData{
-			"id":        llx.StringData(id),
-			"vaultName": llx.StringDataPtr(vault.Name),
-			"type":      llx.StringDataPtr(vault.Type),
-			"location":  llx.StringDataPtr(vault.Location),
-			"tags":      llx.MapData(convert.PtrMapStrToInterface(vault.Tags), types.String),
-		})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Prime the fetchVault cache so subsequent property/networkAcls/etc.
-	// accesses reuse the response we already have in hand.
-	mqlVault := res.(*mqlAzureSubscriptionKeyVaultServiceVault)
-	mqlVault.fetchVaultOnce.Do(func() {
-		mqlVault.fetchVaultResp = &vault
-	})
-	sysData, err := convert.JsonToDict(vault.SystemData)
-	if err != nil {
-		return nil, nil, err
-	}
-	mqlVault.cacheSystemData = sysData
-
-	return args, mqlVault, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionKeyVaultService,
+		func(s *mqlAzureSubscriptionKeyVaultService) *plugin.TValue[[]any] { return s.GetVaults() },
+		ResourceAzureSubscriptionKeyVaultServiceVault)
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceKeyRotationPolicyObject) id() (string, error) {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -6420,49 +6420,8 @@ func initAzureSubscriptionNetworkServiceLocalNetworkGateway(runtime *plugin.Runt
 // can be queried directly without re-listing every gateway in the
 // subscription.
 func initAzureSubscriptionNetworkServiceApplicationGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, missingResourceID("azure.subscription.networkService.applicationGateway")
-	}
-
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	azureId, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	name, err := azureId.Component("applicationGateways")
-	if err != nil {
-		return nil, nil, err
-	}
-	client, err := network.NewApplicationGatewaysClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := client.Get(context.Background(), azureId.ResourceGroup, name, &network.ApplicationGatewaysClientGetOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-	mql, err := azureAppGatewayToMql(runtime, resp.ApplicationGateway)
-	if err != nil {
-		return nil, nil, err
-	}
-	return args, mql, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionNetworkService,
+		func(s *mqlAzureSubscriptionNetworkService) *plugin.TValue[[]any] { return s.GetApplicationGateways() },
+		ResourceAzureSubscriptionNetworkServiceApplicationGateway)
 }

--- a/providers/azure/resources/network_expansion.go
+++ b/providers/azure/resources/network_expansion.go
@@ -791,48 +791,10 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection) remoteVirtu
 // init for firewall so virtualHub.azureFirewall() typed ref can resolve, and
 // so platform-discovered azure-firewall assets can be queried directly.
 func initAzureSubscriptionNetworkServiceFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-	if args["id"] == nil {
-		return nil, nil, missingResourceID("azure.subscription.networkService.firewall")
-	}
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	azureId, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	name, err := azureId.Component("azureFirewalls")
-	if err != nil {
-		return nil, nil, err
-	}
-	client, err := network.NewAzureFirewallsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := client.Get(context.Background(), azureId.ResourceGroup, name, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	mql, err := azureFirewallToMql(runtime, resp.AzureFirewall)
-	if err != nil {
-		return nil, nil, err
-	}
-	return args, mql, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionNetworkService,
+		func(s *mqlAzureSubscriptionNetworkService) *plugin.TValue[[]any] { return s.GetFirewalls() },
+		ResourceAzureSubscriptionNetworkServiceFirewall)
 }
 
 // initAzureSubscriptionNetworkServiceFirewallPolicy resolves a firewall policy

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -64,68 +64,10 @@ func initAzureSubscriptionCacheService(runtime *plugin.Runtime, args map[string]
 }
 
 func initAzureSubscriptionCacheServiceRedisInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 1 {
-		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if ids := getAssetIdentifier(runtime); ids != nil && ids.id != "" {
-			args["id"] = llx.StringData(ids.id)
-		}
-	}
-
-	if args["id"] == nil {
-		return nil, nil, errors.New("id required to fetch azure cache redis instance")
-	}
-	conn, ok := runtime.Connection.(*connection.AzureConnection)
-	if !ok {
-		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
-	}
-	id, ok := args["id"].Value.(string)
-	if !ok {
-		return nil, nil, errors.New("id must be a non-nil string value")
-	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	cacheName, err := resourceID.Component("Redis")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	clientFactory, err := armredis.NewClientFactory(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := clientFactory.NewClient().Get(context.Background(), resourceID.ResourceGroup, cacheName, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	rawData, err := createRedisInstanceRawData(runtime, &resp.ResourceInfo)
-	if err != nil {
-		return nil, nil, err
-	}
-	res, err := CreateResource(runtime, "azure.subscription.cacheService.redisInstance", rawData)
-	if err != nil {
-		return nil, nil, err
-	}
-	mqlRedis := res.(*mqlAzureSubscriptionCacheServiceRedisInstance)
-	if resp.Properties != nil {
-		mqlRedis.cachePrivateEndpointConnections = resp.Properties.PrivateEndpointConnections
-	}
-	if resp.Identity != nil {
-		mqlRedis.cacheUserAssignedIdentityIds = sortedUserAssignedIdentityIDs(resp.Identity.UserAssignedIdentities)
-	}
-	sysData, err := convert.JsonToDict(resp.ResourceInfo.SystemData)
-	if err != nil {
-		return nil, nil, err
-	}
-	mqlRedis.cacheSystemData = sysData
-	return args, mqlRedis, nil
+	return initFromServiceList(runtime, args,
+		ResourceAzureSubscriptionCacheService,
+		func(s *mqlAzureSubscriptionCacheService) *plugin.TValue[[]any] { return s.GetRedis() },
+		ResourceAzureSubscriptionCacheServiceRedisInstance)
 }
 
 func (a *mqlAzureSubscriptionCacheService) redis() ([]any, error) {


### PR DESCRIPTION
Nine resources resolved themselves through their init with a targeted ARM Get. Every discovered asset runs that init once, so a per-resource Get costs one API call per asset of that type -- a subscription with 150 VMs paid 150 of them -- while the service's list is a single call containing all of them, and during a scan it has usually been fetched already because discovery walks the same list to find the assets. NewResource also runs init *before* it consults the resource cache, so the Get was spent even when the resource was already built and its result then discarded.

Twenty-two azure inits already resolved from their parent's list; these nine did not. They now go through initFromServiceList, a shared helper mirroring the k8s provider's initNamespacedResource.

Key Vault needed its list upgraded first: vaults() used VaultsClient.List, which goes through the generic ARM resources endpoint and returns a Tr carrying no Properties, so every vault still needed its own Get to answer properties, networkAcls, accessPolicies or privateEndpointConnec uses ListBySubscription, which returns the full Vault, and primes the per-vault fetch from the listing. Without that, resolving from the list wo call per vault rather than removing one.

Measured live on one subscription, against main: compute VM 4 -> 0 per-resource GETs across 5 assets, function app 3 -> 0 across 4, container ap 3, key vault 1+N -> a constant paged list. The discovered asset set is identical to main, and vault fields were cross-checked against the ARM rec

Cosmos DB, Redis, Application Gateway, Azure Firewall and Cognit converted and unit-tested but have no instances in the test subscription, so they are not verified against live data.
