### PR TITLE
⚡ azure: resolve typed references from the service list before fetching them

### DIFF
--- a/.claude/skills/provider-api-call-dedup/SKILL.md
+++ b/.claude/skills/provider-api-call-dedup/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: provider-api-call-dedup
+description: >-
+  Use when a provider scan is slow, times out, or trips rate limits (429,
+  throttling, Retry-After), when the same request URL appears many times in a
+  debug log, when an asset's fields look like they cost one API call per
+  scanned asset, or when auditing any provider under providers/ for redundant
+  per-asset API traffic. Applies to aws, azure, gcp, k8s, okta and any other
+  provider, since the resource cache and init dispatch are shared machinery.
+---
+
+# Deduplicating provider API calls
+
+## Overview
+
+Two pieces of shared mql machinery decide how many times a provider asks the
+same question. Both fail quietly: the scan still returns correct data, it just
+costs N times more calls than it needs, and the redundancy is what provokes
+throttling.
+
+**Mechanism 1 — the resource cache is per connection.** `providers.Coordinator`
+gives every discovered asset its own `Runtime`, and MQL resource values live in
+`runtime.Resources`. Unless a provider says otherwise, nothing is shared: data
+that belongs to a subscription / project / account is re-fetched once per asset
+beneath it. See *The parent-child cache model* below.
+
+**Mechanism 2 — `init` runs before the cache is read.** In the generated
+`<provider>.lr.go`, `NewResource` calls `f.Init(runtime, args)` and only *then*
+checks `runtime.Resources.Get(id)`. An init that performs I/O therefore spends
+its call once per asset, and on a cache hit its freshly built resource is thrown
+away in favour of the cached one.
+
+## The parent-child cache model
+
+Worth understanding on its own, not just for init migration: it governs every
+cross-asset reuse decision a provider makes.
+
+A child asset opts in by carrying `ParentConnectionId` on its inventory config,
+set at discovery time with `inventory.WithParentConnectionId(parentID)`. At
+connect time `providers-sdk/v1/plugin/service.go` resolves the parent and does:
+
+```go
+runtime.Resources = parentRuntime.Resources   // the same map, not a copy
+```
+
+That one assignment has consequences well past list/get:
+
+| Property | Consequence |
+|---|---|
+| It shares the **map object**, not a snapshot | Anything any asset resolves becomes visible to every sibling, in both directions, for the parent's lifetime |
+| Reuse is per **resolved field**, not per call | A `sync.Once` on an Internal struct, a memoizer hung on a root resource, a lazily fetched sub-object — all of it is shared once the instance is |
+| Identity is `resourceName + "\x00" + __id` | Sharing only pays when the `__id` is stable across assets. An `__id` that embeds the asset, or is empty, silently defeats it |
+| Writes are shared too | Internal-struct caches must be safe for concurrent use once assets can be scanned in parallel |
+| Lifetime is the **parent's** | Children look the parent up at connect time; if it is already closed they fall back to their own cache and `service.go` logs `parent connection not found`. Memory frees only when the parent closes |
+| It is same-provider only | `runtime.go`'s `crossProviderAsset` clears the parent id before handing an asset to another provider |
+
+**Choosing the scope is a correctness decision, not a performance knob.** Share
+at the level the data belongs to. Share *above* it and resources that read their
+scope from the connection answer for the wrong scope — silently, because a
+wrong-but-present answer never errors. Share *below* it and nothing is reused.
+
+**Three ways to share, picked by what the data is keyed on:**
+
+| Pattern | Use when | Example |
+|---|---|---|
+| Parent connection id | Data belongs to a scope that has its own connection | aws, gcp, k8s, github discovery |
+| Memoizer on a root MQL resource | Data is not attached to any one resource, but is scope-wide | github `mqlGithubInternal.memoize` for `getUser`/`getOrg` |
+| Process-wide cache keyed by identity | Data outlives connections entirely and is keyed on credentials, not scope | azure `credentialCache`; `plugin.Service.Memoizer` |
+
+The second only works if the first is in place — a memoizer on a root resource
+is per resource cache, so without parenting it is per asset. Reach for the third
+when there is no connection to hang the scope on.
+
+## When to use
+
+- A scan times out, or raising parallelism makes it worse rather than better
+- Debug logs show the same request URL tens of times
+- Adding a provider's resources to a scan multiplies API traffic
+- Before shipping a new provider, as a design review of its inits and discovery
+
+**Not for:** a provider that is genuinely slow because the API is slow, or one
+that fetches too much per call. Measure first — this skill only removes
+*repeats*.
+
+## Phase 1 — Measure before touching anything
+
+Everything below is worthless without a before/after number. Providers log
+their calls at debug (azure: `apiTracePolicy` in `connection/connection.go`); if
+yours does not, add an equivalent per-call log line first.
+
+```bash
+mql run <provider> <scope-flags> --discover <target> -c "<query>" --log-level debug > before.log 2>&1
+
+# total vs distinct, grouped by URL shape
+grep "api call" before.log | sed -E 's/.*url=([^ ]+).*/\1/' \
+  | sed -E 's#/resourceGroups/[^/]+/#/RG/#; s#/[^/]+$#/{name}#' \
+  | sort | uniq -c | sort -rn
+```
+
+A/B against the released provider by moving your build aside and letting mql
+reinstall the published one:
+
+```bash
+P=~/.config/mondoo/providers/<provider>
+mv $P /tmp/mine && mql run ... > released.log 2>&1; rm -rf $P && mv /tmp/mine $P
+```
+
+**Three measurement traps that will fool you.** Each of these produced a wrong
+conclusion in the work this skill came from:
+
+| Trap | Guard |
+|---|---|
+| The binary under test is not yours — mql auto-updates providers, and A/B swaps leave the published build installed | Put a unique debug line in your build and `grep -c` it in every log before reading any number |
+| Counting output lines instead of resolved values — a field that errors still prints a line | Count `field: "` (resolved) against `field: no data` separately |
+| Trace logs usually strip the query string, so paginated list calls collapse onto one URL and read as duplication | Confirm a suspected duplicate is constant as asset count grows; if it is, it is pagination |
+
+## Phase 2 — Classify every init
+
+`classify-inits.awk` sorts a provider's init functions into three buckets:
+
+```bash
+awk -f .claude/skills/provider-api-call-dedup/classify-inits.awk providers/<name>/resources/*.go | sort
+```
+
+| Bucket | Meaning |
+|---|---|
+| `ARGS-ONLY` | Fills args, no I/O. Fine. |
+| `FROM-LIST` | Resolves out of a parent list. The target state. |
+| `API-CALL` | Fetches one resource itself. **Candidate.** |
+
+Then intersect `API-CALL` with the provider's **discovery targets** — that
+intersection is where the cost is, because a discovery target resolves its own
+resource once per asset:
+
+```bash
+grep -n "Discovery[A-Z][A-Za-z]* *=" providers/<name>/resources/discovery.go
+grep -l "getAssetIdentifier\|getAssetName" providers/<name>/resources/*.go
+```
+
+An `API-CALL` init that is *not* a discovery target is reached through typed
+accessors instead, usually near 1:1. Lower priority.
+
+## Phase 3 — Scope the resource cache
+
+```bash
+rg -n "WithParentConnectionId" providers/<name> -g '*.go' | grep -v _test
+```
+
+No hits means every asset is paying for its own copy of everything. Fix that
+first: it is the larger win and it makes Phase 4 measurable. Hits mean the
+provider shares *something* — read them and write down **at which level**, then
+run the gate below anyway, because sharing at the wrong level is the more
+dangerous state of the two.
+
+**Check the scope is safe.** Find every place a resource reads its scope from
+the *connection* rather than from its own id or args:
+
+```bash
+# whatever the provider calls its scope: SubId, ProjectID, AccountId, ResourceID
+rg -c "conn\.(SubId|ProjectID|AccountId|ResourceID)\(\)" providers/<name>/resources -g '*.go'
+```
+
+Every hit is a place where a cache shared across two scopes returns **the wrong
+scope's answer instead of failing**. The sharp test is per init: does it honour
+`args` for the scope, and only fall back to the connection when they are absent?
+An init that reads the connection unconditionally will answer for whichever
+scope connected first.
+
+```bash
+# inits that fall back to the connection without first honouring args
+rg -l "conn\.(SubId|ProjectID|AccountId|ResourceID)\(\)" providers/<name>/resources -g '*.go'
+```
+
+`initGcpProject` (`providers/gcp/resources/project.go`) is the worked fix: it
+resolves the project the *caller* asked for and documents why in place. Also
+look for a singleton memo on a root resource (azure pins the subscription on
+`mqlAzure.sub`), which pins the first scope connected for the whole run.
+
+If the provider discovers many scopes from one root connection, there is no
+per-scope connection to parent onto yet — that is what staged discovery builds.
+**REQUIRED SUB-SKILL:** use `staged-discovery` for that half.
+
+## Phase 4 — Migrate inits to resolve from the list
+
+Target shape, mirroring k8s's `initNamespacedResource`
+(`providers/k8s/resources/common.go`): resolve the parent service, walk its
+already-fetched list, return the instance that is there. With more than a couple
+of resources, write one shared generic helper rather than copying the body.
+
+**Run three pre-flight checks per resource. Skipping the second or third ships a
+regression.**
+
+1. **Does a sibling list accessor exist** returning the same resource type?
+2. **Do the list and the init build the resource the same way?** If they share a
+   builder (`fooToMql`), migrating is a pure win. If the init sets fields or
+   primes caches the list does not, the list is a *reduced projection* and
+   migrating **adds** a call per resource. Fix the list first — often a
+   different SDK pager returns full objects (azure Key Vault: `List` returns a
+   bare `TrackedResource`, `ListBySubscription` returns the full `Vault`).
+3. **Do both ids come from the same API?** An asset's id usually comes from a
+   generic inventory endpoint while the list comes from a service endpoint, and
+   clouds do not agree with themselves on casing between the two. Match with
+   `strings.EqualFold`, never `==`.
+
+Two rules for the body:
+
+- A miss is an **error**, never `return args, nil, nil` — falling through has the
+  runtime build a blank resource whose fields are unset rather than null, which
+  surfaces client-side as an untyped null with nothing pointing at the cause.
+- Keep the `len(args) > N` fast path, so callers that already supplied
+  everything do not trigger a list walk.
+
+**State the trade in the PR.** Resolving one asset in isolation now pulls the
+whole scope's list instead of one record. That is right during a scan, where the
+list is wanted anyway, and wrong for a one-off shell query against a single
+asset.
+
+## Gotchas
+
+| Symptom | Cause |
+|---|---|
+| Child assets re-fetch everything despite a parent id | Parent runtime already closed, or the parent id belongs to another provider. `service.go` logs `parent connection not found` — grep for it |
+| A whole scope's assets report another scope's data | Cache shared above the scope the resources read off the connection |
+| Traversal ends at the parent; no leaf assets appear | Child config was cloned `WithoutDiscovery()`; the next stage needs its targets |
+| Every leaf re-runs discovery for the whole scope | Leaf config kept its discovery targets; leaves must be cloned `WithoutDiscovery()` |
+| Init-resolved asset reports "not found" for a resource that exists | Case-sensitive id comparison |
+| Migrating an init *increased* calls | The list is a reduced projection; pre-flight check 2 |
+| Field count looks right but every value is empty | Counting lines, not resolved values |
+
+## Done criteria
+
+- Before/after call counts from the same query, both logs provenance-checked
+- Per-resource calls equal the number of **distinct resources**, not assets
+- The discovered asset set is byte-identical to the base branch
+- At least one migrated resource cross-checked against the cloud CLI, not just
+  against itself
+- Resources with no test infrastructure are named as unverified in the PR
+- Unit tests for the shared helper: resolve, miss-is-an-error, empty list,
+  fast path, casing-only difference matches, different path still does not

--- a/.claude/skills/provider-api-call-dedup/classify-inits.awk
+++ b/.claude/skills/provider-api-call-dedup/classify-inits.awk
@@ -1,0 +1,46 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Sorts a provider's resource init functions by whether they call the API.
+#
+#   awk -f classify-inits.awk providers/<name>/resources/*.go | sort
+#
+# Output: <bucket>\t<file>:<line>\t<func>
+#
+#   ARGS-ONLY  fills args and returns; no I/O. Fine as-is.
+#   FROM-LIST  reads a parent resource's list accessor. The target state.
+#   API-CALL   builds a client and fetches one resource itself. Candidate for
+#              migration -- costs one call per asset of that type.
+#   API+LIST   does both; read it by hand, it is usually a partial migration.
+#
+# The buckets are a triage heuristic, not a verdict: confirm by reading the
+# function before migrating it. In particular, an API-CALL init that is not a
+# discovery target is reached through typed accessors rather than once per
+# asset, so it is much cheaper than one that is.
+
+/^func init[A-Z]/ {
+  inFunc = 1
+  name = $2
+  sub(/\(.*/, "", name)
+  start = FNR
+  body = ""
+  next
+}
+
+inFunc && /^}/ {
+  # builds a client, or reads a single record, or walks a pager
+  api = (body ~ /New[A-Za-z]*Client\(/) || (body ~ /\.Get\(ctx/) || (body ~ /NextPage\(/)
+  # calls a generated list accessor on a parent resource, e.g. GetVms()
+  lst = (body ~ /\.Get[A-Z][A-Za-z]*\(\)/)
+
+  if (api && lst)       bucket = "API+LIST"
+  else if (api)         bucket = "API-CALL"
+  else if (lst)         bucket = "FROM-LIST"
+  else                  bucket = "ARGS-ONLY"
+
+  printf "%s\t%s:%d\t%s\n", bucket, FILENAME, start, name
+  inFunc = 0
+  next
+}
+
+inFunc { body = body "\n" $0 }

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.34.1",
-  "generated_at": "2026-08-14T16:33:12+03:00",
+  "version": "13.34.2",
+  "generated_at": "2026-08-14T17:27:51+03:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.ApiManagement/service/apis/policies/read",

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -465,6 +465,17 @@ func initAzureSubscriptionManagedIdentity(runtime *plugin.Runtime, args map[stri
 	}
 
 	conn := runtime.Connection.(*connection.AzureConnection)
+	// The subscription's list already holds this managed identity, and holds it for every
+	// other reference to it too. Only pay for a Get when the list cannot
+	// answer -- a reference into another subscription, or one since deleted.
+	if mi := lookupInServiceList(runtime, ResourceAzureSubscriptionAuthorizationService,
+		func(s *mqlAzureSubscriptionAuthorizationService) *plugin.TValue[[]any] {
+			return s.GetManagedIdentities()
+		},
+		id); mi != nil {
+		return args, mi, nil
+	}
+
 	client, err := armmsi.NewUserAssignedIdentitiesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/init_from_list.go
+++ b/providers/azure/resources/init_from_list.go
@@ -116,3 +116,65 @@ func initFromServiceList[S azureListService](
 	// untyped null with nothing pointing at the cause.
 	return nil, nil, fmt.Errorf("%s with id %q not found", resourceName, id)
 }
+
+// lookupInServiceList finds a resource by ARM id in the list its parent service
+// has already fetched, and returns nil when it is not there.
+//
+// This is the half of the pattern for typed references rather than for assets.
+// A reference resolves through NewResource once per referring resource, and
+// because NewResource runs the init before it consults the cache, the same
+// target is re-fetched for every reference to it -- 30 network interfaces
+// referenced twice each cost 60 Gets, all of which the service's own list
+// already answered.
+//
+// Unlike initFromServiceList, a miss here is not an error. A typed reference
+// may legitimately point outside the current scope: at another subscription, or
+// at a resource since deleted, or at one the caller cannot read. Callers keep
+// their own fetch as the fallback and degrade the way they always did.
+func lookupInServiceList[S azureListService](
+	runtime *plugin.Runtime,
+	serviceName string,
+	entries func(S) *plugin.TValue[[]any],
+	id string,
+) plugin.Resource {
+	if id == "" {
+		return nil
+	}
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil
+	}
+
+	// Only this connection's own subscription has a list to consult. A
+	// reference into another subscription has to fall through to the caller's
+	// fetch, or we would report it missing when it is merely elsewhere.
+	resourceID, err := ParseResourceID(id)
+	if err != nil || !strings.EqualFold(resourceID.SubscriptionID, conn.SubId()) {
+		return nil
+	}
+
+	res, err := NewResource(runtime, serviceName, map[string]*llx.RawData{
+		"subscriptionId": llx.StringData(conn.SubId()),
+	})
+	if err != nil {
+		return nil
+	}
+	svc, ok := res.(S)
+	if !ok {
+		return nil
+	}
+	list := entries(svc)
+	if list.Error != nil {
+		return nil
+	}
+	for i := range list.Data {
+		item, ok := list.Data[i].(azureListedResource)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(item.GetId().Data, id) {
+			return item
+		}
+	}
+	return nil
+}

--- a/providers/azure/resources/init_from_list_test.go
+++ b/providers/azure/resources/init_from_list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
 )
 
 const testVMID = "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-1"
@@ -20,8 +21,9 @@ const testVMID = "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Com
 func computeServiceWithVMs(t *testing.T, runtime *plugin.Runtime, ids ...string) []any {
 	t.Helper()
 
+	conn := runtime.Connection.(*connection.AzureConnection)
 	svcRes, err := NewResource(runtime, ResourceAzureSubscriptionComputeService, map[string]*llx.RawData{
-		"subscriptionId": llx.StringData(""),
+		"subscriptionId": llx.StringData(conn.SubId()),
 	})
 	require.NoError(t, err)
 	svc := svcRes.(*mqlAzureSubscriptionComputeService)
@@ -161,4 +163,57 @@ func TestInitFromServiceList_StillDistinguishesDifferentResources(t *testing.T) 
 
 	require.Error(t, err)
 	assert.Nil(t, res)
+}
+
+// lookupInServiceList backs typed references rather than assets, so its
+// contract differs from initFromServiceList's: a miss returns nil and the
+// caller falls back to its own fetch, because a reference may legitimately
+// point at something outside this scope.
+func TestLookupInServiceList(t *testing.T) {
+	computeSvcList := func(s *mqlAzureSubscriptionComputeService) *plugin.TValue[[]any] { return s.GetVms() }
+
+	t.Run("hit returns the listed instance", func(t *testing.T) {
+		runtime := runtimeForAsset(t, nil)
+		vms := computeServiceWithVMs(t, runtime, testVMID)
+
+		got := lookupInServiceList(runtime, ResourceAzureSubscriptionComputeService, computeSvcList, testVMID)
+		assert.Same(t, vms[0], got)
+	})
+
+	t.Run("miss returns nil rather than an error", func(t *testing.T) {
+		runtime := runtimeForAsset(t, nil)
+		computeServiceWithVMs(t, runtime, testVMID)
+
+		gone := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/gone"
+		assert.Nil(t, lookupInServiceList(runtime, ResourceAzureSubscriptionComputeService, computeSvcList, gone))
+	})
+
+	t.Run("casing only differences still match", func(t *testing.T) {
+		listed := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualmachines/vm-1"
+		runtime := runtimeForAsset(t, nil)
+		vms := computeServiceWithVMs(t, runtime, listed)
+
+		got := lookupInServiceList(runtime, ResourceAzureSubscriptionComputeService, computeSvcList, testVMID)
+		assert.Same(t, vms[0], got)
+	})
+
+	// The list only covers the connection's own subscription. Reporting a
+	// cross-subscription reference as absent would send the caller down its
+	// fallback anyway, but consulting the list first wastes the walk -- and if
+	// two subscriptions ever held the same resource name, would match wrongly.
+	t.Run("reference into another subscription is not looked up", func(t *testing.T) {
+		runtime := runtimeForAsset(t, nil)
+		computeServiceWithVMs(t, runtime, testVMID)
+
+		elsewhere := "/subscriptions/sub-2/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-1"
+		assert.Nil(t, lookupInServiceList(runtime, ResourceAzureSubscriptionComputeService, computeSvcList, elsewhere))
+	})
+
+	t.Run("empty id and unparseable id are misses", func(t *testing.T) {
+		runtime := runtimeForAsset(t, nil)
+		computeServiceWithVMs(t, runtime, testVMID)
+
+		assert.Nil(t, lookupInServiceList(runtime, ResourceAzureSubscriptionComputeService, computeSvcList, ""))
+		assert.Nil(t, lookupInServiceList(runtime, ResourceAzureSubscriptionComputeService, computeSvcList, "not-an-arm-id"))
+	})
 }

--- a/providers/azure/resources/init_missing_id_test.go
+++ b/providers/azure/resources/init_missing_id_test.go
@@ -25,7 +25,7 @@ import (
 func runtimeForAsset(t *testing.T, platformIds []string) *plugin.Runtime {
 	t.Helper()
 	asset := &inventory.Asset{Name: "some asset", PlatformIds: platformIds}
-	conf := &inventory.Config{Options: map[string]string{"tenant-id": "tid", "client-id": "cid"}}
+	conf := &inventory.Config{Options: map[string]string{"tenant-id": "tid", "client-id": "cid", "subscription-id": "sub-1"}}
 	conn, err := connection.NewAzureConnection(1, asset, conf)
 	require.NoError(t, err)
 	return &plugin.Runtime{

--- a/providers/azure/resources/loganalytics.go
+++ b/providers/azure/resources/loganalytics.go
@@ -204,6 +204,15 @@ func initAzureSubscriptionMonitorServiceWorkspace(runtime *plugin.Runtime, args 
 	}
 
 	ctx := context.Background()
+	// The subscription's list already holds this workspace, and holds it for every
+	// other reference to it too. Only pay for a Get when the list cannot
+	// answer -- a reference into another subscription, or one since deleted.
+	if ws := lookupInServiceList(runtime, ResourceAzureSubscriptionMonitorService,
+		func(s *mqlAzureSubscriptionMonitorService) *plugin.TValue[[]any] { return s.GetWorkspaces() },
+		id); ws != nil {
+		return args, ws, nil
+	}
+
 	client, err := armoperationalinsights.NewWorkspacesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2171,6 +2171,17 @@ func initAzureSubscriptionNetworkServiceInterface(runtime *plugin.Runtime, args 
 	if err != nil {
 		return args, nil, nil
 	}
+
+	// The subscription's interface list already holds this one, and holds it
+	// for every other reference to it too. Only pay for a Get when the list
+	// cannot answer -- an interface in another subscription, or one since
+	// deleted.
+	if iface := lookupInServiceList(runtime, ResourceAzureSubscriptionNetworkService,
+		func(s *mqlAzureSubscriptionNetworkService) *plugin.TValue[[]any] { return s.GetInterfaces() },
+		id); iface != nil {
+		return args, iface, nil
+	}
+
 	client, err := network.NewInterfacesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network_nic_ipconfig.go
+++ b/providers/azure/resources/network_nic_ipconfig.go
@@ -162,6 +162,15 @@ func initAzureSubscriptionNetworkServiceIpAddress(runtime *plugin.Runtime, args 
 	if err != nil {
 		return nil, nil, err
 	}
+	// The subscription's list already holds this public IP, and holds it for every
+	// other reference to it too. Only pay for a Get when the list cannot
+	// answer -- a reference into another subscription, or one since deleted.
+	if ip := lookupInServiceList(runtime, ResourceAzureSubscriptionNetworkService,
+		func(s *mqlAzureSubscriptionNetworkService) *plugin.TValue[[]any] { return s.GetPublicIpAddresses() },
+		id); ip != nil {
+		return args, ip, nil
+	}
+
 	client, err := network.NewPublicIPAddressesClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})


### PR DESCRIPTION
Follow-up to #9848. Same root cause, different blast radius.

## The problem

A typed reference (`nsg.interfaces`, `sqlServer.systemAssignedIdentity`, …) resolves through `NewResource` once per **referring resource**, and `NewResource` runs the resource's `init` *before* it consults the cache. So the same target is re-fetched for every reference to it, and the freshly built resource is then discarded in favour of the cached one.

Where #9848 fixed inits that cost one call per **asset**, these cost one call per **reference**.

## Measured

Same query, same subscription, before and after:

```
azure.subscription.network.securityGroups { interfaces { name } }

                      before   after
per-NIC GETs             60       0
total ARM calls          67       9
resolved NIC names     2670    2670   <- identical set and counts
```

60 GETs against 30 distinct interfaces — every one of which the subscription's own interface list already contained. Now 2 paged list calls.

## Why this needed a second helper

Every one of these inits deliberately soft-fails, with comments explaining why:

> The interface may be inaccessible (deleted, cross-subscription, or access denied); fall back to the bare reference rather than failing the surrounding query.

Putting them on `initFromServiceList` from #9848 would have turned that graceful degradation into a hard "not found" — failing a query over a resource that merely lives in another subscription.

`lookupInServiceList` returns `nil` on a miss instead, and each init keeps its existing fetch as the fallback, so **no existing behaviour changes**. It also skips the list entirely when the reference points into another subscription, since this connection only lists its own. Same shape as gcp's `initGcpProjectComputeServiceSubnetwork`.

## Scope

| resource | referring files | status |
|---|---|---|
| `networkService.interface` | 1 | **measured, 60 → 0** |
| `managedIdentity` | 8 | converted, not exercised live |
| `networkService.ipAddress` | 2 | converted, not exercised live |
| `monitorService.workspace` | 2 | converted, not exercised live |

The three unmeasured ones go through the same helper and are covered by its tests, but the test subscription has nothing that exercises the reference path: its NICs have no public IPs attached, its one SQL server has no system-assigned identity, and nothing references its workspaces. Flagging rather than implying a win I did not observe.

**`networkService.subnet` is deliberately excluded** despite having the highest fan-in here (12 referring files). There is no service-level subnet list — subnets live under vnets — so resolving from a list would mean walking every vnet's subnets, which is not obviously cheaper than one targeted `Get` and may be worse. It needs its own design pass.

Also spotted but not fixed: `initAzureSubscriptionNetworkServiceSubnet` returns `args, nil, nil` when its `Get` fails, which is the blank-resource fall-through `CLAUDE.md` warns about. Separate bug, separate change.

## Tests

Ten unit tests on the two helpers, including the cross-subscription guard, case-insensitive matching, miss-returns-nil, and the empty/unparseable-id cases. The cross-subscription guard caught a bad test fixture during development — the fake connection had no subscription set.

`go test ./...`, `go vet` and `gofmt` clean. Permission set unchanged (330); the `permissions.json` diff is only the version bump from the 13.34.2 release.

## Also included: `.claude/skills/provider-api-call-dedup`

The audit-and-migrate recipe generalised past azure, since both defects live in shared machinery — the resource cache is per connection unless discovery passes `WithParentConnectionId`, and the generated `NewResource` runs `init` before consulting it.

Ships `classify-inits.awk`, which buckets every init as `ARGS-ONLY` / `FROM-LIST` / `API-CALL`. Run against providers it was not derived from: **0** API-calling inits for k8s (the provider the target pattern comes from), 1 for aws, 19 candidates for gcp — and working the gcp list by hand confirms its discovery targets are already migrated and its one outlier is list-first-with-fallback.

Documents the parent-child cache model in its own right, plus the traps that produced wrong conclusions while doing this work by hand: measuring a binary that was not the local build, counting output lines rather than resolved values, stripped query strings making pagination read as duplication, migrating onto a list that returns a reduced projection, and comparing ARM ids case-sensitively across endpoints that disagree on casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)