### PR TITLE
⚡ azure: answer a repeated reference from the resource cache instead of refetching

### DIFF
--- a/.claude/skills/provider-api-call-dedup/SKILL.md
+++ b/.claude/skills/provider-api-call-dedup/SKILL.md
@@ -30,6 +30,11 @@ checks `runtime.Resources.Get(id)`. An init that performs I/O therefore spends
 its call once per asset, and on a cache hit its freshly built resource is thrown
 away in favour of the cached one.
 
+It has to be this way in general: the cache key is the resolved resource's
+`MqlID()`, which for a resource whose identity is computed during init is not
+knowable beforehand. The opening exists only for callers that already supply
+the id — see *cache-first* in Phase 4.
+
 ## The parent-child cache model
 
 Worth understanding on its own, not just for init migration: it governs every
@@ -71,6 +76,24 @@ The second only works if the first is in place — a memoizer on a root resource
 is per resource cache, so without parenting it is per asset. Reach for the third
 when there is no connection to hang the scope on.
 
+### What already caches, and what it misses
+
+Before concluding something is re-fetched, know which of the three existing
+layers should have caught it. Two of them are easy to mistake for full coverage:
+
+| Layer | Where | Covers |
+|---|---|---|
+| `GetData` cache check | `plugin/service.go` | The client asking for a field on a resource id already in the cache. No init runs. |
+| `GetOrCompute` | `plugin/runtime.go` | A field memoized on the **referring instance**, so `nicA.subnet` computes once however often it is read |
+| `NewResource` cache check | generated `<provider>.lr.go` | A resource whose init already ran — but only **after** that init has run and fetched |
+
+What none of them covers: **a new referring instance resolving a reference for
+the first time.** Thirty NICs on four subnets means thirty separate `Subnet`
+fields, thirty `NewResource` calls, thirty inits, thirty fetches — for four
+subnets. `GetOrCompute` does not help because each NIC has its own field;
+`GetData` does not help because the provider is minting the reference rather
+than being asked for a field on a known id.
+
 ## When to use
 
 - A scan times out, or raising parallelism makes it worse rather than better
@@ -105,7 +128,7 @@ P=~/.config/mondoo/providers/<provider>
 mv $P /tmp/mine && mql run ... > released.log 2>&1; rm -rf $P && mv /tmp/mine $P
 ```
 
-**Three measurement traps that will fool you.** Each of these produced a wrong
+**Four measurement traps that will fool you.** Each of these produced a wrong
 conclusion in the work this skill came from:
 
 | Trap | Guard |
@@ -113,6 +136,12 @@ conclusion in the work this skill came from:
 | The binary under test is not yours — mql auto-updates providers, and A/B swaps leave the published build installed | Put a unique debug line in your build and `grep -c` it in every log before reading any number |
 | Counting output lines instead of resolved values — a field that errors still prints a line | Count `field: "` (resolved) against `field: no data` separately |
 | Trace logs usually strip the query string, so paginated list calls collapse onto one URL and read as duplication | Confirm a suspected duplicate is constant as asset count grows; if it is, it is pagination |
+| **The probe never reaches the code you changed**, so before and after match and the fix reads as useless | A/B against a build with the change *neutered*. If neutered and real produce **identical** counts, suspect the probe, not the fix — then confirm the path by reading the accessor |
+
+That last one is the expensive mistake. A typed reference may be resolved by an
+accessor that fetches inline rather than through `NewResource`, in which case it
+never enters the init and no init-level change can move its numbers. Verify the
+path reaches your code before concluding anything from a flat A/B.
 
 ## Phase 2 — Classify every init
 
@@ -138,7 +167,34 @@ grep -l "getAssetIdentifier\|getAssetName" providers/<name>/resources/*.go
 ```
 
 An `API-CALL` init that is *not* a discovery target is reached through typed
-accessors instead, usually near 1:1. Lower priority.
+accessors instead — one call per **reference** rather than per asset. Its cost
+is set by fan-in, so count the referring call sites before sizing it:
+
+```bash
+rg -c "NewResource\([^)]*\"<resource.mql.name>\"" providers/<name>/resources/*.go | grep -v _test
+```
+
+### The classifier's blind spot: accessors that never reach an init
+
+**`classify-inits.awk` only reads `init` functions, so an accessor that builds a
+client and fetches inline is invisible to it.** Such an accessor never calls
+`NewResource`, never enters an init, and therefore cannot be fixed by anything
+in Phase 4 — while an audit that only ran the classifier will read as complete.
+
+This is not a rare shape. In azure it is roughly **110 singular accessors that
+fetch inline** against 169 `NewResource` call sites, so the init-level work
+reaches a bit over half the surface.
+
+```bash
+# accessors returning a single resource, that build a client themselves
+rg -n "^func \(a \*mql\w+\) \w+\(\) \(\*mql\w+, error\) \{" -A 25 \
+   providers/<name>/resources/*.go | rg -c "New\w+Client\("
+```
+
+Treat that count as a separate backlog and **say so in the writeup**, or the
+audit overstates its own coverage. Sizing it properly is its own exercise: an
+inline accessor caches through `GetOrCompute` on its referring instance, so it
+repeats per referrer, not per read.
 
 ## Phase 3 — Scope the resource cache
 
@@ -180,12 +236,51 @@ If the provider discovers many scopes from one root connection, there is no
 per-scope connection to parent onto yet — that is what staged discovery builds.
 **REQUIRED SUB-SKILL:** use `staged-discovery` for that half.
 
-## Phase 4 — Migrate inits to resolve from the list
+## Phase 4 — Migrate inits
+
+Three shapes, picked by what the init is resolving. They compose in this order:
+**cache first, then the list, then fetch.**
+
+| Shape | Use for | Miss behaviour |
+|---|---|---|
+| **cache-first** | Anything where the caller supplies the id | Fall through to the next shape |
+| **from-list** | An **asset** the scan was handed | **Error** — the asset should be there |
+| **list-first-with-fallback** | A **typed reference** | Fall through to the existing fetch |
+
+### Cache-first
+
+`NewResource` cannot check the cache before the init in general, because the key
+is the resolved `MqlID()`. But when the caller already supplied the id — which
+reference resolution always does — the key is known up front, so the init can
+look it up before spending a call:
+
+```go
+if cached := cachedResource(runtime, ResourceFooBar, id); cached != nil {
+    return args, cached, nil
+}
+```
+
+Cheap, no pre-flight needed, and the only option when there is no list to
+resolve from. The lookup is exact, because that is how the runtime keys the
+cache; a casing mismatch simply falls through to the fetch, as today.
+
+### From-list and list-first
 
 Target shape, mirroring k8s's `initNamespacedResource`
 (`providers/k8s/resources/common.go`): resolve the parent service, walk its
 already-fetched list, return the instance that is there. With more than a couple
 of resources, write one shared generic helper rather than copying the body.
+
+**Asset inits and reference inits need different miss behaviour.** For an asset,
+a miss means something is wrong — error. For a typed reference, a miss is
+routine: it may point at another scope, at something deleted, or at something
+the caller cannot read. Existing inits usually say so in a comment; converting
+them to a hard error turns graceful degradation into a failed query. Give
+references a lookup that returns nil and let the caller keep its own fetch.
+
+A reference lookup should also **skip the list when the id names a different
+scope** than the connection — the list only covers this one, so consulting it
+wastes the walk and risks matching a same-named resource elsewhere.
 
 **Run three pre-flight checks per resource. Skipping the second or third ships a
 regression.**
@@ -204,9 +299,10 @@ regression.**
 
 Two rules for the body:
 
-- A miss is an **error**, never `return args, nil, nil` — falling through has the
-  runtime build a blank resource whose fields are unset rather than null, which
-  surfaces client-side as an untyped null with nothing pointing at the cause.
+- For an **asset** init, a miss is an **error**, never `return args, nil, nil` —
+  falling through has the runtime build a blank resource whose fields are unset
+  rather than null, which surfaces client-side as an untyped null with nothing
+  pointing at the cause.
 - Keep the `len(args) > N` fast path, so callers that already supplied
   everything do not trigger a list walk.
 
@@ -225,12 +321,17 @@ asset.
 | Every leaf re-runs discovery for the whole scope | Leaf config kept its discovery targets; leaves must be cloned `WithoutDiscovery()` |
 | Init-resolved asset reports "not found" for a resource that exists | Case-sensitive id comparison |
 | Migrating an init *increased* calls | The list is a reduced projection; pre-flight check 2 |
+| A reference resolves fine but the fix changes nothing | The accessor fetches inline and never enters an init — see the classifier's blind spot |
+| A converted reference now errors where it used to return a bare reference | A reference miss must fall through, not error; only asset inits error |
 | Field count looks right but every value is empty | Counting lines, not resolved values |
 
 ## Done criteria
 
-- Before/after call counts from the same query, both logs provenance-checked
+- Before/after call counts from the same query, both logs provenance-checked,
+  and the probe confirmed to reach the changed code
 - Per-resource calls equal the number of **distinct resources**, not assets
+- Accessors that fetch inline are counted and reported as out of scope, so the
+  audit does not overstate its coverage
 - The discovered asset set is byte-identical to the base branch
 - At least one migrated resource cross-checked against the cloud CLI, not just
   against itself

--- a/.claude/skills/provider-api-call-dedup/SKILL.md
+++ b/.claude/skills/provider-api-call-dedup/SKILL.md
@@ -181,20 +181,31 @@ client and fetches inline is invisible to it.** Such an accessor never calls
 `NewResource`, never enters an init, and therefore cannot be fixed by anything
 in Phase 4 — while an audit that only ran the classifier will read as complete.
 
-This is not a rare shape. In azure it is roughly **110 singular accessors that
-fetch inline** against 169 `NewResource` call sites, so the init-level work
-reaches a bit over half the surface.
+Enumerate them properly rather than grepping for client construction in a
+window — that over-counts badly. In azure a real enumeration gives **43** inline
+accessors against 126 that go through `NewResource`.
 
 ```bash
-# accessors returning a single resource, that build a client themselves
-rg -n "^func \(a \*mql\w+\) \w+\(\) \(\*mql\w+, error\) \{" -A 25 \
-   providers/<name>/resources/*.go | rg -c "New\w+Client\("
+awk -f .claude/skills/provider-api-call-dedup/classify-accessors.awk \
+    providers/<name>/resources/*.go | cut -f1 | sort | uniq -c
 ```
 
-Treat that count as a separate backlog and **say so in the writeup**, or the
-audit overstates its own coverage. Sizing it properly is its own exercise: an
-inline accessor caches through `GetOrCompute` on its referring instance, so it
-repeats per referrer, not per read.
+**Then split them by fan-in, because most are not worth touching.** An inline
+accessor falls into one of two kinds:
+
+| Kind | Shape | Worth fixing |
+|---|---|---|
+| **Owned sub-object** | A config child belonging to exactly one parent — a database's audit policy, a storage account's management policy, a site's auth settings | **No.** One fetch per parent is the floor, and `GetOrCompute` already memoizes it on that parent. Nothing repeats |
+| **Shared resource** | A subnet, a public IP, a firewall policy, a disk — something several resources point at | **Yes.** Fan-in means repeats, and nothing dedupes them |
+
+In azure that split is roughly 30 owned sub-objects (all the SQL policies,
+storage config, web auth settings, Defender plans) against ~12 shared targets.
+So the backlog is small and specific, not half the provider. Measure fan-in per
+target before proposing anything:
+
+```bash
+rg -c "\"<target.mql.name>\"" providers/<name>/resources/*.go | grep -v _test | wc -l
+```
 
 ## Phase 3 — Scope the resource cache
 

--- a/.claude/skills/provider-api-call-dedup/classify-accessors.awk
+++ b/.claude/skills/provider-api-call-dedup/classify-accessors.awk
@@ -1,0 +1,69 @@
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Companion to classify-inits.awk, covering the half it cannot see.
+#
+#   awk -f classify-accessors.awk providers/<name>/resources/*.go | sort
+#
+# classify-inits.awk reads init functions. But a typed reference can also be
+# resolved by the accessor itself, which builds a client and fetches inline and
+# so never enters an init at all. Those are invisible to that script and cannot
+# be fixed by anything done at the init level.
+#
+# This one reads the accessors instead: functions shaped
+#
+#   func (a *mqlFoo) bar() (*mqlBaz, error)
+#
+# i.e. returning a single resource, which is what a typed reference looks like.
+#
+# Output: <bucket>\t<file>:<line>\t<signature>
+#
+#   INLINE   builds a client and fetches; never calls NewResource. Not reachable
+#            from init-level work. Triage by fan-in before doing anything (see
+#            below).
+#   VIA-NEW  calls NewResource, so it routes through the target's init and the
+#            init-level fixes apply.
+#   NO-IO    reads what it already has. Fine.
+#
+# TRIAGE THE INLINE ONES BY FAN-IN. They split into two kinds and only one is
+# worth touching:
+#
+#   Owned sub-object -- a config child belonging to exactly one parent (a
+#     database's audit policy, a storage account's management policy). One fetch
+#     per parent is the floor and GetOrCompute already memoizes it there, so
+#     nothing repeats. Leave it alone.
+#
+#   Shared resource -- a subnet, a public IP, a firewall policy, a disk.
+#     Several resources point at it, so it is fetched once per referrer with
+#     nothing deduplicating them. This is the backlog.
+#
+# Tell them apart by counting references to the target type:
+#
+#   rg -c '"<target.mql.name>"' providers/<name>/resources/*.go | grep -v _test
+#
+# In azure the split is roughly 30 owned sub-objects to 12 shared targets, so
+# the real backlog is small and specific. Do not report the raw INLINE count as
+# though all of it were work.
+
+/^func \(a \*mql[A-Za-z0-9]+\) [a-z][A-Za-z0-9]*\(\) \(\*mql[A-Za-z0-9]+, error\) \{/ {
+  inFunc = 1
+  sig = $0
+  start = FNR
+  body = ""
+  next
+}
+
+inFunc && /^}/ {
+  client = (body ~ /New[A-Za-z]*Client\(/)
+  newres = (body ~ /NewResource\(/)
+
+  if (newres)      bucket = "VIA-NEW"
+  else if (client) bucket = "INLINE"
+  else             bucket = "NO-IO"
+
+  printf "%s\t%s:%d\t%s\n", bucket, FILENAME, start, sig
+  inFunc = 0
+  next
+}
+
+inFunc { body = body "\n" $0 }

--- a/.claude/skills/provider-api-call-dedup/classify-inits.awk
+++ b/.claude/skills/provider-api-call-dedup/classify-inits.awk
@@ -13,6 +13,15 @@
 #              migration -- costs one call per asset of that type.
 #   API+LIST   does both; read it by hand, it is usually a partial migration.
 #
+# BLIND SPOT: this reads init functions only. A typed-reference accessor that
+# builds a client and fetches inline never calls NewResource, never enters an
+# init, and so does not appear here at all -- in azure that is ~110 accessors
+# against 169 NewResource call sites. An audit that runs only this script will
+# look complete while missing that half. Count them separately:
+#
+#   rg -n "^func \(a \*mql\w+\) \w+\(\) \(\*mql\w+, error\) \{" -A 25 \
+#      providers/<name>/resources/*.go | rg -c "New\w+Client\("
+#
 # The buckets are a triage heuristic, not a verdict: confirm by reading the
 # function before migrating it. In particular, an API-CALL init that is not a
 # discovery target is reached through typed accessors rather than once per

--- a/.claude/skills/provider-api-call-dedup/classify-inits.awk
+++ b/.claude/skills/provider-api-call-dedup/classify-inits.awk
@@ -15,12 +15,11 @@
 #
 # BLIND SPOT: this reads init functions only. A typed-reference accessor that
 # builds a client and fetches inline never calls NewResource, never enters an
-# init, and so does not appear here at all -- in azure that is ~110 accessors
-# against 169 NewResource call sites. An audit that runs only this script will
-# look complete while missing that half. Count them separately:
-#
-#   rg -n "^func \(a \*mql\w+\) \w+\(\) \(\*mql\w+, error\) \{" -A 25 \
-#      providers/<name>/resources/*.go | rg -c "New\w+Client\("
+# init, and so does not appear here at all -- in azure that is 43 accessors
+# against 126 that go through NewResource. An audit that runs only this script
+# will look complete while missing them. Enumerate them with the companion
+# script, classify-accessors.awk, and split the result by fan-in: most are
+# owned sub-objects with exactly one parent and nothing to dedupe.
 #
 # The buckets are a triage heuristic, not a verdict: confirm by reading the
 # function before migrating it. In particular, an API-CALL init that is not a

--- a/providers/azure/resources/apimanagement.go
+++ b/providers/azure/resources/apimanagement.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	apim "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement/v3"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -340,25 +339,14 @@ func (a *mqlAzureSubscriptionApiManagementServiceService) publicIpAddress() (*mq
 		a.PublicIpAddress.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	azureId, err := ParseResourceID(a.cachePublicIpAddressId)
+
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceIpAddress,
+		map[string]*llx.RawData{"id": llx.StringData(a.cachePublicIpAddressId)})
 	if err != nil {
 		return nil, err
 	}
-	ipName, err := azureId.Component("publicIPAddresses")
-	if err != nil {
-		return nil, err
-	}
-	client, err := network.NewPublicIPAddressesClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Get(ctx, azureId.ResourceGroup, ipName, nil)
-	if err != nil {
-		return nil, err
-	}
-	return azureIpToMql(a.MqlRuntime, resp.PublicIPAddress)
+	return res.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
 }

--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -265,6 +265,13 @@ func initAzureSubscriptionContainerAppServiceManagedEnvironment(runtime *plugin.
 		return nil, nil, err
 	}
 
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionContainerAppServiceManagedEnvironment, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := apps.NewManagedEnvironmentsClient(resourceID.SubscriptionID, conn.Token(), acaClientOptions(conn))
 	if err != nil {
 		return nil, nil, err

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.34.2",
-  "generated_at": "2026-08-14T17:27:51+03:00",
+  "generated_at": "2026-08-14T18:25:29+03:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.ApiManagement/service/apis/policies/read",
@@ -1594,12 +1594,6 @@
       "service": "Microsoft.Network",
       "action": "Get",
       "source_file": "network.go"
-    },
-    {
-      "permission": "Microsoft.Network/publicIPAddresses/read",
-      "service": "Microsoft.Network",
-      "action": "Get",
-      "source_file": "apimanagement.go"
     },
     {
       "permission": "Microsoft.Network/publicIPAddresses/read",

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -1356,6 +1356,13 @@ func initAzureSubscriptionComputeServiceDisk(runtime *plugin.Runtime, args map[s
 		return nil, nil, err
 	}
 
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionComputeServiceDisk, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := compute.NewDisksClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -1397,6 +1404,13 @@ func initAzureSubscriptionComputeServiceDiskEncryptionSet(runtime *plugin.Runtim
 	desName, err := resourceID.Component("diskEncryptionSets")
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionComputeServiceDiskEncryptionSet, id); cached != nil {
+		return args, cached, nil
 	}
 
 	client, err := compute.NewDiskEncryptionSetsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -620,7 +620,6 @@ func diskToMql(runtime *plugin.Runtime, disk compute.Disk) (*mqlAzureSubscriptio
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) osDisk() (*mqlAzureSubscriptionComputeServiceDisk, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	propertiesDict := a.Properties.Data
 	data, err := json.Marshal(propertiesDict)
 	if err != nil {
@@ -641,31 +640,15 @@ func (a *mqlAzureSubscriptionComputeServiceVm) osDisk() (*mqlAzureSubscriptionCo
 		return nil, nil
 	}
 
-	resourceID, err := ParseResourceID(*properties.StorageProfile.OSDisk.ManagedDisk.ID)
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionComputeServiceDisk,
+		map[string]*llx.RawData{"id": llx.StringData(*properties.StorageProfile.OSDisk.ManagedDisk.ID)})
 	if err != nil {
 		return nil, err
 	}
-
-	diskName, err := resourceID.Component("disks")
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := context.Background()
-	token := conn.Token()
-
-	client, err := compute.NewDisksClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	disk, err := client.Get(ctx, resourceID.ResourceGroup, diskName, &compute.DisksClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return diskToMql(a.MqlRuntime, disk.Disk)
+	return res.(*mqlAzureSubscriptionComputeServiceDisk), nil
 }
 
 func (a *mqlAzureSubscriptionComputeServiceVm) dataDisks() ([]any, error) {

--- a/providers/azure/resources/init_from_list.go
+++ b/providers/azure/resources/init_from_list.go
@@ -117,6 +117,31 @@ func initFromServiceList[S azureListService](
 	return nil, nil, fmt.Errorf("%s with id %q not found", resourceName, id)
 }
 
+// cachedResource returns a resource already in this runtime's cache, or nil.
+//
+// NewResource consults the cache only *after* the init has returned, so an init
+// that fetches unconditionally pays for a resource the runtime is holding and
+// then has its result discarded in favour of the cached one. Calling this first
+// makes a reference cost one fetch for the whole scan rather than one per
+// reference.
+//
+// Reach for this when there is no list to resolve from -- otherwise prefer
+// lookupInServiceList, which answers for resources nothing has fetched yet as
+// well. The two compose: check the cache, then the list, then fetch.
+//
+// The lookup is exact, because that is how the runtime keys the cache. A
+// reference whose casing differs from the stored resource's own id misses and
+// falls through to the fetch, which is what happens today anyway.
+func cachedResource(runtime *plugin.Runtime, resourceName, id string) plugin.Resource {
+	if id == "" || runtime == nil || runtime.Resources == nil {
+		return nil
+	}
+	if res, ok := runtime.Resources.Get(resourceName + "\x00" + id); ok {
+		return res
+	}
+	return nil
+}
+
 // lookupInServiceList finds a resource by ARM id in the list its parent service
 // has already fetched, and returns nil when it is not there.
 //

--- a/providers/azure/resources/init_from_list_test.go
+++ b/providers/azure/resources/init_from_list_test.go
@@ -217,3 +217,38 @@ func TestLookupInServiceList(t *testing.T) {
 		assert.Nil(t, lookupInServiceList(runtime, ResourceAzureSubscriptionComputeService, computeSvcList, "not-an-arm-id"))
 	})
 }
+
+const testSubnetID = "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-1/subnets/default"
+
+// The requirement: a referenced resource is fetched once for the scan, and
+// every consecutive reference is answered from the cache.
+//
+// NewResource consults the cache only after the init returns, so an init that
+// fetches unconditionally pays per reference and then has its result discarded.
+// Reaching the cached instance without building a client is what proves the
+// second reference is free -- the fake connection here has no usable
+// credential, so a fetch would fail rather than succeed quietly.
+func TestCachedResource_SecondReferenceIsFree(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+
+	// stand in for what the first reference left behind
+	first, err := CreateResource(runtime, ResourceAzureSubscriptionNetworkServiceSubnet,
+		map[string]*llx.RawData{"id": llx.StringData(testSubnetID)})
+	require.NoError(t, err)
+
+	args, res, err := initAzureSubscriptionNetworkServiceSubnet(runtime,
+		map[string]*llx.RawData{"id": llx.StringData(testSubnetID)})
+
+	require.NoError(t, err)
+	require.NotNil(t, res, "the cached subnet must be returned, not refetched")
+	assert.Same(t, first, res)
+	assert.NotNil(t, args)
+}
+
+// A reference to something nothing has fetched yet must still fall through to
+// the fetch rather than reporting it absent.
+func TestCachedResource_MissFallsThrough(t *testing.T) {
+	runtime := runtimeForAsset(t, nil)
+	assert.Nil(t, cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceSubnet, testSubnetID))
+	assert.Nil(t, cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceSubnet, ""))
+}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1045,9 +1045,6 @@ func nestedResourceIDs(props any, key string) []string {
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceFirewall) policy() (*mqlAzureSubscriptionNetworkServiceFirewallPolicy, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
 	// A firewall using classic rule collections has no policy attached; that
 	// is the normal state, not an error.
 	strId := nestedResourceID(a.Properties.Data, "firewallPolicy")
@@ -1055,34 +1052,19 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewall) policy() (*mqlAzureSubscrip
 		a.Policy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	{
-		azureId, err := ParseResourceID(strId)
-		if err != nil {
-			return nil, err
-		}
-		client, err := network.NewFirewallPoliciesClient(azureId.SubscriptionID, token, &arm.ClientOptions{
-			ClientOptions: conn.ClientOptions(),
-		})
-		if err != nil {
-			return nil, err
-		}
-		policyName, err := azureId.Component("firewallPolicies")
-		if err != nil {
-			return nil, err
-		}
-		fwp, err := client.Get(ctx, azureId.ResourceGroup, policyName, &network.FirewallPoliciesClientGetOptions{})
-		if err != nil {
-			return nil, err
-		}
 
-		return azureFirewallPolicyToMql(a.MqlRuntime, fwp.FirewallPolicy)
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceFirewallPolicy,
+		map[string]*llx.RawData{"id": llx.StringData(strId)})
+	if err != nil {
+		return nil, err
 	}
+	return res.(*mqlAzureSubscriptionNetworkServiceFirewallPolicy), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceFirewallIpConfig) publicIpAddress() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
 	// Management-only and forced-tunneling ip configurations carry no public
 	// IP; report null rather than failing the field.
 	strId := nestedResourceID(a.Properties.Data, "publicIPAddress")
@@ -1090,34 +1072,19 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewallIpConfig) publicIpAddress() (
 		a.PublicIpAddress.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	{
-		azureId, err := ParseResourceID(strId)
-		if err != nil {
-			return nil, err
-		}
-		client, err := network.NewPublicIPAddressesClient(azureId.SubscriptionID, token, &arm.ClientOptions{
-			ClientOptions: conn.ClientOptions(),
-		})
-		if err != nil {
-			return nil, err
-		}
-		ipAddressName, err := azureId.Component("publicIPAddresses")
-		if err != nil {
-			return nil, err
-		}
-		ipAddress, err := client.Get(ctx, azureId.ResourceGroup, ipAddressName, &network.PublicIPAddressesClientGetOptions{})
-		if err != nil {
-			return nil, err
-		}
 
-		return azureIpToMql(a.MqlRuntime, ipAddress.PublicIPAddress)
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceIpAddress,
+		map[string]*llx.RawData{"id": llx.StringData(strId)})
+	if err != nil {
+		return nil, err
 	}
+	return res.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayIpConfig) publicIpAddress() (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
 	// Management-only and forced-tunneling ip configurations carry no public
 	// IP; report null rather than failing the field.
 	strId := nestedResourceID(a.Properties.Data, "publicIPAddress")
@@ -1125,65 +1092,34 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkGatewayIpConfig) public
 		a.PublicIpAddress.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	{
-		azureId, err := ParseResourceID(strId)
-		if err != nil {
-			return nil, err
-		}
-		client, err := network.NewPublicIPAddressesClient(azureId.SubscriptionID, token, &arm.ClientOptions{
-			ClientOptions: conn.ClientOptions(),
-		})
-		if err != nil {
-			return nil, err
-		}
-		ipAddressName, err := azureId.Component("publicIPAddresses")
-		if err != nil {
-			return nil, err
-		}
-		ipAddress, err := client.Get(ctx, azureId.ResourceGroup, ipAddressName, &network.PublicIPAddressesClientGetOptions{})
-		if err != nil {
-			return nil, err
-		}
 
-		return azureIpToMql(a.MqlRuntime, ipAddress.PublicIPAddress)
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceIpAddress,
+		map[string]*llx.RawData{"id": llx.StringData(strId)})
+	if err != nil {
+		return nil, err
 	}
+	return res.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceFirewallIpConfig) subnet() (*mqlAzureSubscriptionNetworkServiceSubnet, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
 	strId := nestedResourceID(a.Properties.Data, "subnet")
 	if strId == "" {
 		a.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	{
-		azureId, err := ParseResourceID(strId)
-		if err != nil {
-			return nil, err
-		}
-		client, err := network.NewSubnetsClient(azureId.SubscriptionID, token, &arm.ClientOptions{
-			ClientOptions: conn.ClientOptions(),
-		})
-		if err != nil {
-			return nil, err
-		}
-		vnName, err := azureId.Component("virtualNetworks")
-		if err != nil {
-			return nil, err
-		}
-		subnetName, err := azureId.Component("subnets")
-		if err != nil {
-			return nil, err
-		}
-		subnet, err := client.Get(ctx, azureId.ResourceGroup, vnName, subnetName, &network.SubnetsClientGetOptions{})
-		if err != nil {
-			return nil, err
-		}
 
-		return azureSubnetToMql(a.MqlRuntime, subnet.Subnet)
+	// Resolved through the subnet's own init rather than fetched here, so a
+	// subnet several resources sit on is fetched once for the scan instead of
+	// once per resource pointing at it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceSubnet,
+		map[string]*llx.RawData{"id": llx.StringData(strId)})
+	if err != nil {
+		return nil, err
 	}
+	return res.(*mqlAzureSubscriptionNetworkServiceSubnet), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkService) firewallPolicies() ([]any, error) {
@@ -1315,28 +1251,16 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetwork) defaultNatGateway() (
 		a.DefaultNatGateway.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	resourceID, err := ParseResourceID(*a.cacheDefaultNatGatewayId)
+
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceNatGateway,
+		map[string]*llx.RawData{"id": llx.StringData(*a.cacheDefaultNatGatewayId)})
 	if err != nil {
 		return nil, err
 	}
-	natGatewayName, err := resourceID.Component("natGateways")
-	if err != nil {
-		return nil, err
-	}
-	client, err := network.NewNatGatewaysClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	natGatewayRes, err := client.Get(ctx, resourceID.ResourceGroup, natGatewayName, &network.NatGatewaysClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return azureNatGatewayToMql(a.MqlRuntime, natGatewayRes.NatGateway)
+	return res.(*mqlAzureSubscriptionNetworkServiceNatGateway), nil
 }
 
 // flowLogs resolves the flow logs that target this virtual network. Returns an
@@ -1560,6 +1484,13 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualNetworkPeering) remoteVirtualN
 	if a.RemoteVirtualNetworkId.Data == "" {
 		a.RemoteVirtualNetwork.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+
+	// Answer a repeated reference from the cache; the fetch below stays,
+	// because a peer often lives in another subscription, which this subscription's vnet
+	// list cannot answer for.
+	if cached := cachedResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceVirtualNetwork, a.RemoteVirtualNetworkId.Data); cached != nil {
+		return cached.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -2806,6 +2737,12 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationGateway) policy() (*mqlAzu
 		a.Policy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
+
+	// Answer a repeated reference from the cache; the fetch below stays,
+	// because this resource has no init to route through.
+	if cached := cachedResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceApplicationFirewallPolicy, strId); cached != nil {
+		return cached.(*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy), nil
+	}
 	azureId, err := ParseResourceID(strId)
 	if err != nil {
 		return nil, err
@@ -3105,14 +3042,6 @@ func (a *mqlAzureSubscriptionNetworkServiceNatGateway) subnets() ([]any, error) 
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceSubnet) natGateway() (*mqlAzureSubscriptionNetworkServiceNatGateway, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	id := a.Id.Data
-	azureId, err := ParseResourceID(id)
-	if err != nil {
-		return nil, err
-	}
 	// NAT gateways are opt-in, so the overwhelming majority of subnets have
 	// none. That is a null, not an error.
 	natGatewayId := nestedResourceID(a.Properties.Data, "natGateway")
@@ -3120,29 +3049,16 @@ func (a *mqlAzureSubscriptionNetworkServiceSubnet) natGateway() (*mqlAzureSubscr
 		a.NatGateway.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	resourceID, err := ParseResourceID(natGatewayId)
+
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceNatGateway,
+		map[string]*llx.RawData{"id": llx.StringData(natGatewayId)})
 	if err != nil {
 		return nil, err
 	}
-	natGatewayName, err := resourceID.Component("natGateways")
-	if err != nil {
-		return nil, err
-	}
-	client, err := network.NewNatGatewaysClient(azureId.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	natGatewayRes, err := client.Get(ctx, resourceID.ResourceGroup, natGatewayName, &network.NatGatewaysClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	mqlNatGateway, err := azureNatGatewayToMql(a.MqlRuntime, natGatewayRes.NatGateway)
-	if err != nil {
-		return nil, err
-	}
-	return mqlNatGateway, nil
+	return res.(*mqlAzureSubscriptionNetworkServiceNatGateway), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceSubnet) ipConfigurations() ([]any, error) {
@@ -3188,9 +3104,6 @@ func (a *mqlAzureSubscriptionNetworkServiceSubnet) ipConfigurations() ([]any, er
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) basePolicy() (*mqlAzureSubscriptionNetworkServiceFirewallPolicy, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
 	// Only child policies have a base policy; a standalone or root policy
 	// legitimately has none.
 	basePolicyId := nestedResourceID(a.Properties.Data, "basePolicy")
@@ -3198,25 +3111,16 @@ func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) basePolicy() (*mqlAzu
 		a.BasePolicy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	resourceID, err := ParseResourceID(basePolicyId)
+
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceFirewallPolicy,
+		map[string]*llx.RawData{"id": llx.StringData(basePolicyId)})
 	if err != nil {
 		return nil, err
 	}
-	client, err := network.NewFirewallPoliciesClient(resourceID.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	basePolicyName, err := resourceID.Component("firewallPolicies")
-	if err != nil {
-		return nil, err
-	}
-	basePolicyRes, err := client.Get(ctx, resourceID.ResourceGroup, basePolicyName, &network.FirewallPoliciesClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return azureFirewallPolicyToMql(a.MqlRuntime, basePolicyRes.FirewallPolicy)
+	return res.(*mqlAzureSubscriptionNetworkServiceFirewallPolicy), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceFirewallPolicy) childPolicies() ([]any, error) {
@@ -4205,28 +4109,16 @@ func (a *mqlAzureSubscriptionNetworkServiceApplicationGatewayFrontendIpConfig) p
 		a.PublicIpAddress.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
-	ctx := context.Background()
-	token := conn.Token()
-	azureId, err := ParseResourceID(a.PublicIpAddressId.Data)
+
+	// Resolved through the target's own init rather than fetched here, so a
+	// resource several things point at is fetched once for the scan instead
+	// of once per reference to it.
+	res, err := NewResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceIpAddress,
+		map[string]*llx.RawData{"id": llx.StringData(a.PublicIpAddressId.Data)})
 	if err != nil {
 		return nil, err
 	}
-	client, err := network.NewPublicIPAddressesClient(azureId.SubscriptionID, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	ipAddressName, err := azureId.Component("publicIPAddresses")
-	if err != nil {
-		return nil, err
-	}
-	ipAddress, err := client.Get(ctx, azureId.ResourceGroup, ipAddressName, &network.PublicIPAddressesClientGetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return azureIpToMql(a.MqlRuntime, ipAddress.PublicIPAddress)
+	return res.(*mqlAzureSubscriptionNetworkServiceIpAddress), nil
 }
 
 // frontendIpConfigFields extracts the displayable fields from an application
@@ -4794,7 +4686,11 @@ func initAzureSubscriptionNetworkServiceSubnet(runtime *plugin.Runtime, args map
 	}
 	resp, err := client.Get(context.Background(), azureId.ResourceGroup, vnName, subnetName, &network.SubnetsClientGetOptions{})
 	if err != nil {
-		return args, nil, nil
+		// Not `return args, nil, nil`: that has the runtime build a subnet from
+		// the id alone, every other field unset rather than null, which reaches
+		// the client as an untyped null with nothing naming the cause. Callers
+		// resolving a subnet reference through here need the failure reported.
+		return nil, nil, err
 	}
 
 	mqlSubnet, err := azureSubnetToMql(runtime, resp.Subnet)

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2225,6 +2225,13 @@ func initAzureSubscriptionNetworkServicePrivateEndpoint(runtime *plugin.Runtime,
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServicePrivateEndpoint, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewPrivateEndpointsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -2537,6 +2544,13 @@ func initAzureSubscriptionNetworkServicePrivateLinkService(runtime *plugin.Runti
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServicePrivateLinkService, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewPrivateLinkServicesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -4688,6 +4702,13 @@ func initAzureSubscriptionNetworkServiceNatGateway(runtime *plugin.Runtime, args
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceNatGateway, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewNatGatewaysClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -4758,6 +4779,13 @@ func initAzureSubscriptionNetworkServiceSubnet(runtime *plugin.Runtime, args map
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceSubnet, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewSubnetsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -6409,6 +6437,13 @@ func initAzureSubscriptionNetworkServiceLocalNetworkGateway(runtime *plugin.Runt
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceLocalNetworkGateway, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewLocalNetworkGatewaysClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network_avnm.go
+++ b/providers/azure/resources/network_avnm.go
@@ -309,6 +309,13 @@ func initAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup(runtime *plug
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewGroupsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network_expansion.go
+++ b/providers/azure/resources/network_expansion.go
@@ -469,6 +469,13 @@ func initAzureSubscriptionNetworkServiceVirtualWan(runtime *plugin.Runtime, args
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceVirtualWan, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewVirtualWansClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -823,6 +830,13 @@ func initAzureSubscriptionNetworkServiceFirewallPolicy(runtime *plugin.Runtime, 
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceFirewallPolicy, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewFirewallPoliciesClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -870,6 +884,13 @@ func initAzureSubscriptionNetworkServiceExpressRouteCircuit(runtime *plugin.Runt
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceExpressRouteCircuit, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewExpressRouteCircuitsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -1514,6 +1535,13 @@ func initAzureSubscriptionNetworkServiceVirtualHub(runtime *plugin.Runtime, args
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceVirtualHub, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewVirtualHubsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -1554,6 +1582,13 @@ func initAzureSubscriptionNetworkServiceVpnSite(runtime *plugin.Runtime, args ma
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceVpnSite, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewVPNSitesClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network_ip_prefixes.go
+++ b/providers/azure/resources/network_ip_prefixes.go
@@ -250,6 +250,13 @@ func initAzureSubscriptionNetworkServiceCustomIpPrefix(runtime *plugin.Runtime, 
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceCustomIpPrefix, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewCustomIPPrefixesClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -414,6 +421,13 @@ func initAzureSubscriptionNetworkServicePublicIpPrefix(runtime *plugin.Runtime, 
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServicePublicIpPrefix, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewPublicIPPrefixesClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
@@ -456,6 +470,13 @@ func initAzureSubscriptionNetworkServiceIpAllocation(runtime *plugin.Runtime, ar
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceIpAllocation, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewIPAllocationsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network_ipgroup.go
+++ b/providers/azure/resources/network_ipgroup.go
@@ -177,6 +177,13 @@ func initAzureSubscriptionNetworkServiceIpGroup(runtime *plugin.Runtime, args ma
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceIpGroup, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewIPGroupsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network_nic_ipconfig.go
+++ b/providers/azure/resources/network_nic_ipconfig.go
@@ -214,6 +214,13 @@ func initAzureSubscriptionNetworkServiceAppSecurityGroup(runtime *plugin.Runtime
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceAppSecurityGroup, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewApplicationSecurityGroupsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})

--- a/providers/azure/resources/network_virtual_appliances.go
+++ b/providers/azure/resources/network_virtual_appliances.go
@@ -296,6 +296,13 @@ func initAzureSubscriptionNetworkServiceVirtualNetworkTap(runtime *plugin.Runtim
 	if err != nil {
 		return nil, nil, err
 	}
+	// Already fetched by an earlier reference: NewResource consults the
+	// cache only after this init returns, so without this the same target is
+	// re-fetched once per reference and the result thrown away.
+	if cached := cachedResource(runtime, ResourceAzureSubscriptionNetworkServiceVirtualNetworkTap, id); cached != nil {
+		return args, cached, nil
+	}
+
 	client, err := network.NewVirtualNetworkTapsClient(azureId.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})


### PR DESCRIPTION
Follow-up to #9848 and #9850. Third and last shape of the same root cause.

## The gap

`NewResource` consults the resource cache only *after* the init has returned — and it has to, because the cache key is the resolved resource's `MqlID()`, which for a resource whose identity is computed during init is not knowable beforehand. So an init that fetches unconditionally pays for a resource the runtime is already holding, then has its result discarded in favour of the cached one.

Two caches already exist, and neither covers this:

| Layer | Covers |
|---|---|
| `GetData` cache check (`plugin/service.go`) | The client asking for a field on a resource id already in the cache |
| `GetOrCompute` (`plugin/runtime.go`) | A field memoized on the **referring instance** — `nicA.subnet` computes once however often it is read |

What neither covers is a **new referring instance resolving a reference for the first time**. Thirty NICs on four subnets means thirty separate `Subnet` fields, thirty `NewResource` calls, thirty inits, thirty fetches — for four subnets.

## The change

Where the caller already supplies the id — which reference resolution always does — the key *is* known up front, so the init can look it up before spending a call. That is all `cachedResource` does.

Applied to **20 reference inits**, including `networkService.subnet`, which has the highest fan-in of any of them at 12 referring files and no service-level list to resolve from instead. That is the one #9850 explicitly deferred; this closes it.

Skipped: ten inits with no clean id-then-client shape, and `initAzureSubscription`, which resolves the connection's own subscription and already memoizes on `mqlAzure.sub`.

## Not measured live — stated plainly

Every reference path that routes through `NewResource` (`subnet`, `natGateway`, `privateEndpoint`, `appSecurityGroup`) is null or absent in the test subscription. The one reference with data there, `vm.osDisk`, turns out to **bypass the init entirely** — it builds a `DisksClient` and fetches in the accessor body.

I confirmed that by A/B against a build with `cachedResource` neutered: identical call counts, because the probe never reached the changed code. So the live evidence here is only that nothing regressed — NSG→interfaces unchanged at 9 calls, discovered asset set still identical to main. The behaviour itself is covered by unit tests.

## A category this cannot reach

The `osDisk` bypass is real, but smaller and far more specific than my first pass suggested. Properly enumerated, azure has **43** accessors that resolve a typed reference by building a client inline, against 126 that go through `NewResource`. *(An earlier revision of this description said ~110 — that counted client-construction lines in a fixed window and over-counted. Corrected.)*

Most of the 43 are not worth touching. Roughly 30 are **owned sub-objects** with exactly one parent — the SQL audit / threat-protection / retention policies, storage account config, web auth settings, Defender plans. One fetch per parent is the floor, and `GetOrCompute` already memoizes it on that parent, so nothing repeats.

The actual backlog is the ~12 pointing at **shared** resources, where fan-in produces repeats:

| accessor | target | other referring places |
|---|---|---|
| `firewallIpConfig.subnet()` | subnet | 13 |
| `peering.remoteVirtualNetwork()` | virtual network | 5 |
| `publicIpAddress()` ×4 — apimanagement, firewall, vnet gateway, app gateway | public IP | 4 |
| `subnet.natGateway()`, `vnet.defaultNatGateway()` | NAT gateway | 2 |
| `firewall.policy()`, `firewallPolicy.basePolicy()`, `appGateway.policy()` | firewall / WAF policy | 2 |
| `vm.osDisk()` | disk | 2 |

And it is **azure-only**: the same enumeration reports zero inline accessors for gcp, aws and k8s, which resolve references through `NewResource` throughout.

## Skill update

`provider-api-call-dedup` gains what this turned up:

- **The classifier's blind spot**, in the script header and in Phase 2 — it reads `init` functions only, so inline-fetching accessors never appear, and an audit run from the script alone reads as complete while missing that half. Now with the grep to count them and an instruction to report the number.
- **A table of the three cache layers** and the gap none of them covers.
- **Cache-first as a third fix shape** alongside from-list, with the rule that asset inits error on a miss while reference inits must fall through — getting that backwards turns documented graceful degradation into failed queries.
- **A fourth measurement trap**: when a neutered build and the real one produce identical counts, suspect the probe, not the fix.

## Checks

`go test ./...`, `go vet`, `gofmt` clean on a fresh `main` base. Permission set unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)