### PR TITLE
⚡ github: take license and a deploy key's repository from records already in hand

### DIFF
--- a/providers/github/resources/github_prefetch_test.go
+++ b/providers/github/resources/github_prefetch_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// bare runtime with a real resource cache. Neither builder under test reaches
+// for the connection, so nothing here talks to GitHub.
+func prefetchRuntime() *plugin.Runtime {
+	return &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+func testRepo(license *github.License) *github.Repository {
+	id := int64(1)
+	name := "example"
+	return &github.Repository{ID: &id, Name: &name, License: license}
+}
+
+// Every repository record carries its license, so setting the field means
+// GetOrCompute short-circuits and the license() resolver -- one
+// Repositories.License call per repository -- never runs.
+func TestNewMqlGithubRepository_SetsLicenseFromTheRecord(t *testing.T) {
+	runtime := prefetchRuntime()
+	key, name, spdx := "mit", "MIT License", "MIT"
+
+	repo, err := newMqlGithubRepository(runtime, testRepo(&github.License{
+		Key: &key, Name: &name, SPDXID: &spdx,
+	}))
+	require.NoError(t, err)
+
+	require.True(t, repo.License.IsSet(), "a set field is what stops the resolver running")
+	require.NotNil(t, repo.License.Data)
+	assert.Equal(t, "MIT", repo.License.Data.SpdxId.Data)
+	assert.Equal(t, "MIT License", repo.License.Data.Name.Data)
+}
+
+// The common case, and the one that makes this worth doing: a repository with
+// no license reports null straight from the record. Leaving it unset would
+// still spend a Repositories.License call each, only to learn there is none --
+// on the org measured, 190 of 225 repositories.
+func TestNewMqlGithubRepository_AbsentLicenseIsNull(t *testing.T) {
+	runtime := prefetchRuntime()
+
+	repo, err := newMqlGithubRepository(runtime, testRepo(nil))
+	require.NoError(t, err)
+
+	require.True(t, repo.License.IsSet(), "set, so the resolver does not run")
+	assert.True(t, repo.License.State&plugin.StateIsNull != 0, "and explicitly null")
+	assert.Nil(t, repo.License.Data)
+}
+
+// CreateResource hands back the already-cached instance for a repository some
+// other listing has built, so a second record must not overwrite what the
+// first one resolved.
+func TestNewMqlGithubRepository_FirstLicenseWins(t *testing.T) {
+	runtime := prefetchRuntime()
+	key, name, spdx := "mit", "MIT License", "MIT"
+
+	first, err := newMqlGithubRepository(runtime, testRepo(&github.License{
+		Key: &key, Name: &name, SPDXID: &spdx,
+	}))
+	require.NoError(t, err)
+
+	otherKey, otherName, otherSpdx := "apache-2.0", "Apache License 2.0", "Apache-2.0"
+	second, err := newMqlGithubRepository(runtime, testRepo(&github.License{
+		Key: &otherKey, Name: &otherName, SPDXID: &otherSpdx,
+	}))
+	require.NoError(t, err)
+
+	assert.Same(t, first, second, "same id, so the cached instance comes back")
+	assert.Equal(t, "MIT", second.License.Data.SpdxId.Data)
+}
+
+// The repository a deploy key was read from is the resource the caller is
+// already standing on. Handing it over means repository() -- one
+// Repositories.Get per key, repeated for every key on the same repository --
+// never runs.
+func TestNewMqlDeployKey_TakesTheRepositoryFromItsCaller(t *testing.T) {
+	runtime := prefetchRuntime()
+
+	repo, err := newMqlGithubRepository(runtime, testRepo(nil))
+	require.NoError(t, err)
+
+	id := int64(7)
+	title := "deploy"
+	dk, err := newMqlDeployKey(runtime, &github.Key{ID: &id, Title: &title}, repo, "acme", "example")
+	require.NoError(t, err)
+
+	require.True(t, dk.Repository.IsSet())
+	assert.Same(t, repo, dk.Repository.Data, "must hand back the caller's repository, not refetch it")
+}
+
+// A caller without the repository keeps the old behaviour: the field stays
+// unset so repository() can fetch it.
+func TestNewMqlDeployKey_WithoutARepositoryFallsBack(t *testing.T) {
+	runtime := prefetchRuntime()
+
+	id := int64(8)
+	dk, err := newMqlDeployKey(runtime, &github.Key{ID: &id}, nil, "acme", "example")
+	require.NoError(t, err)
+
+	assert.False(t, dk.Repository.IsSet(), "unset leaves the resolver free to fetch")
+	assert.Equal(t, "acme", dk.cacheRepoOwner)
+	assert.Equal(t, "example", dk.cacheRepoName)
+}
+
+// No repository and no owner/name is a genuine empty state, and must still be
+// reported as null rather than left for a resolver that cannot answer.
+func TestNewMqlDeployKey_NoRepositoryReferenceIsNull(t *testing.T) {
+	runtime := prefetchRuntime()
+
+	id := int64(9)
+	dk, err := newMqlDeployKey(runtime, &github.Key{ID: &id}, nil, "", "")
+	require.NoError(t, err)
+
+	assert.True(t, dk.Repository.IsSet())
+	assert.True(t, dk.Repository.State&plugin.StateIsNull != 0, "should be explicitly null")
+	assert.Nil(t, dk.Repository.Data)
+}

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -141,6 +141,34 @@ func newMqlGithubRepository(runtime *plugin.Runtime, repo *github.Repository) (*
 	}
 	r := res.(*mqlGithubRepository)
 	r.mqlGithubRepositoryInternal.findSpecialFilesOnceFunc = sync.OnceValue[error](r.findSpecialFiles)
+
+	// Every repository record already carries its license, so set the field
+	// here and the resolver never runs -- it was costing one
+	// Repositories.License call per repository for data that arrived with the
+	// repository itself.
+	//
+	// Null included, which is what makes this worth doing: a repository with no
+	// license is the common case, and leaving those unset would still spend a
+	// call each to learn nothing. Every endpoint feeding this returns one of
+	// GitHub's repository representations, and repository, full-repository and
+	// minimal-repository all define license as present-but-nullable, so a nil
+	// here means the repository has no license rather than that the listing
+	// omitted it.
+	//
+	// First writer wins: CreateResource hands back the already-cached instance
+	// for a repository some other listing has built, and a second record must
+	// not overwrite what the first one recorded.
+	if !r.License.IsSet() {
+		if repo.License == nil {
+			r.License = plugin.TValue[*mqlGithubLicense]{State: plugin.StateIsSet | plugin.StateIsNull}
+		} else {
+			license, err := newMqlGithubLicense(runtime, repo.License)
+			if err != nil {
+				return nil, err
+			}
+			r.License = plugin.TValue[*mqlGithubLicense]{Data: license, State: plugin.StateIsSet}
+		}
+	}
 	return r, nil
 }
 
@@ -333,8 +361,11 @@ func (g *mqlGithubRepository) license() (*mqlGithubLicense, error) {
 		return nil, nil
 	}
 
-	license := repoLicense.License
-	res, err := CreateResource(g.MqlRuntime, "github.license", map[string]*llx.RawData{
+	return newMqlGithubLicense(g.MqlRuntime, repoLicense.License)
+}
+
+func newMqlGithubLicense(runtime *plugin.Runtime, license *github.License) (*mqlGithubLicense, error) {
+	res, err := CreateResource(runtime, "github.license", map[string]*llx.RawData{
 		"key":    llx.StringData(license.GetKey()),
 		"name":   llx.StringData(license.GetName()),
 		"url":    llx.StringData(license.GetURL()),

--- a/providers/github/resources/github_security.go
+++ b/providers/github/resources/github_security.go
@@ -843,7 +843,12 @@ func keyAgeInDays(createdAt *github.Timestamp) int64 {
 	return int64(time.Since(createdAt.Time).Hours() / 24)
 }
 
-func newMqlDeployKey(runtime *plugin.Runtime, k *github.Key, repoOwner, repoName string) (*mqlGithubDeployKey, error) {
+// newMqlDeployKey builds a deploy key. repo is the repository the key was read
+// from, when the caller has it; passing it sets the key's repository field
+// outright, so repository() -- one Repositories.Get per key, for a repository
+// the scan is already holding, repeated for every key on the same one -- never
+// runs. A caller without the repository passes nil and keeps that fallback.
+func newMqlDeployKey(runtime *plugin.Runtime, k *github.Key, repo *mqlGithubRepository, repoOwner, repoName string) (*mqlGithubDeployKey, error) {
 	var idVal int64
 	if k.ID != nil {
 		idVal = *k.ID
@@ -868,7 +873,10 @@ func newMqlDeployKey(runtime *plugin.Runtime, k *github.Key, repoOwner, repoName
 	if k.AddedBy != nil {
 		dk.cacheAddedByLogin = *k.AddedBy
 	}
-	if repoOwner == "" || repoName == "" {
+	switch {
+	case repo != nil:
+		dk.Repository = plugin.TValue[*mqlGithubRepository]{Data: repo, State: plugin.StateIsSet}
+	case repoOwner == "" || repoName == "":
 		dk.Repository.State = plugin.StateIsSet | plugin.StateIsNull
 	}
 	return dk, nil
@@ -931,7 +939,7 @@ func (g *mqlGithubRepository) deployKeys() ([]any, error) {
 
 	res := make([]any, 0, len(allKeys))
 	for _, k := range allKeys {
-		dk, err := newMqlDeployKey(g.MqlRuntime, k, ownerLogin, repoName)
+		dk, err := newMqlDeployKey(g.MqlRuntime, k, g, ownerLogin, repoName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Two accessors were fetching data that had already arrived with the resource referencing it. Found by running the `provider-api-call-dedup` audit against github; the provider is otherwise in good shape (zero API-calling inits, parent-connection sharing already in place).

Both are fixed the same way, and it is simpler than it first looks: **set the field at construction.** `GetOrCompute` returns early when the field `IsSet()`, so the resolver never runs. No caches, no flags, no change to either resolver — they just stop being called.

## Measured

The provider has no per-call API log of its own, so I added one temporarily and removed it (`connection.go` is untouched in this diff).

```
github.organization.repositories { name license { spdxId } }   — mondoohq, 225 repos

                        before   after
total github api calls     197        7
/license calls             190        0
repos resolved             450      450   <- identical
licenses resolved           70       70   <- identical
```

**28x fewer calls, byte-identical output.**

## 1. License

`license()` spent one `Repositories.License` call per repository. Every GitHub repository representation — `repository`, `full-repository` and `minimal-repository` alike — carries `license` as a present-but-nullable field, so the org, user and fork listings that build these resources already had the answer.

**Null matters as much as the value here.** My first version set the field only when the record had a license, so a nil could not be mistaken for "this listing does not populate the field". The measurement showed that leaves most of the win behind: 190 of the 225 repositories have no license, and each still spent a call to learn that. Setting null too is what took it from 190 to 0.

I verified against the live API before doing that — org, user and fork listings all return `license` as a key even when its value is null (`has_license_key: true`).

## 2. Deploy keys

`deployKeys()` is a method on `*mqlGithubRepository`, so the repository a key belongs to *is* the receiver. `newMqlDeployKey` now takes it and sets the field, and `repository()` — one `Repositories.Get` per key, repeated for every key on the same repository — no longer runs. Callers without a repository pass nil and keep that fallback.

## Coverage and its limits

Six unit tests, no network: license set from the record, absent-license-is-null, first-writer-wins when `CreateResource` returns an already-cached instance, deploy key takes the caller's repository, falls back without one, and null when there is no reference at all.

Two things a reviewer should know rather than assume:

- **The deploy key change is not measured live.** No repository this token can read has any deploy keys. Unit tests only.
- **`Teams.ListTeamReposByID` is unverified.** Every listing I could check returns `license` even when null, but the one team I can read has no repositories. If that endpoint turned out to omit the field, a licensed repository would report null — a wrong compliance answer rather than an error. It is a one-line revert (drop the null branch) if it ever surfaces.

## Worth a follow-up, not in scope here

This provider has no API-call logging. Azure has `apiTracePolicy`; a github equivalent would make this kind of work measurable without patching the provider first. Happy to send that separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)