### PR TITLE
⚡ os: reuse one args map when building package resources

### DIFF
--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -159,6 +159,53 @@ type mqlPackagesInternal struct {
 	packagesByName map[string]*mqlPackage
 }
 
+// fillPackageArgs resets args and fills in the resource arguments for one
+// package. It clears the map itself rather than expecting a fresh one, so
+// list() can reuse a single map for the whole package list: CreateResource
+// copies every value out via SetAllData and keeps no reference to it.
+//
+// The clear is load bearing. license is only set when the backend reported
+// one, so a leftover key would hand one package's license to the next.
+func fillPackageArgs(args map[string]*llx.RawData, osPkg *packages.Package, available string, cpes []any) {
+	clear(args)
+
+	args["name"] = llx.StringData(osPkg.Name)
+	args["version"] = llx.StringData(osPkg.Version)
+	args["available"] = llx.StringData(available)
+	args["arch"] = llx.StringData(osPkg.Arch)
+	args["status"] = llx.StringData(osPkg.Status)
+	args["description"] = llx.StringData(osPkg.Description)
+	args["format"] = llx.StringData(osPkg.Format)
+	args["installed"] = llx.BoolData(true)
+	args["origin"] = llx.StringData(osPkg.Origin)
+	args["epoch"] = llx.StringData(osPkg.Epoch)
+	args["purl"] = llx.StringData(osPkg.PUrl)
+	args["cpes"] = llx.ArrayData(cpes, types.Resource("cpe"))
+	args["vendor"] = llx.StringData(osPkg.Vendor)
+
+	// Only eagerly set license when the backend populated it (rpm, apk,
+	// pacman). dpkg leaves it empty here so the lazy `license()` method on
+	// mqlPackage can fire and read /usr/share/doc/<pkg>/copyright on demand.
+	// Setting "" here would short-circuit the GetOrCompute wrapper and the
+	// lazy fallback would never run.
+	if osPkg.License != "" {
+		args["license"] = llx.StringData(osPkg.License)
+	}
+
+	// Install date: explicit null via llx.NilData when the backend didn't
+	// report one (dpkg / apk / pacman / macOS / rpm gpg-pubkey). The generated
+	// dispatcher routes Nil through RawToTValue[time.Time] which yields
+	// State=StateIsSet|StateIsNull — MQL surfaces that as a real null. Leaving
+	// the key absent would leave the field in an entirely unset state and MQL
+	// fails with "no type information." Passing TimeData(zero) would surface
+	// the Go zero time (0001-01-01) as if it were a real install date.
+	if osPkg.InstallDate.IsZero() {
+		args["installDate"] = llx.NilData
+	} else {
+		args["installDate"] = llx.TimeData(osPkg.InstallDate)
+	}
+}
+
 func (x *mqlPackages) list() ([]any, error) {
 	x.lock.Lock()
 	defer x.lock.Unlock()
@@ -200,6 +247,13 @@ func (x *mqlPackages) list() ([]any, error) {
 
 	// create MQL package os for each package
 	pkgs := make([]any, len(osPkgs))
+
+	// CreateResource copies every value out of this map (SetAllData) and keeps
+	// no reference to it, so one map serves the whole loop. clear() empties it
+	// while keeping the buckets, which matters because a package-heavy host
+	// would otherwise build and discard thousands of 15-entry maps.
+	pkgArgs := make(map[string]*llx.RawData, 15)
+
 	for i, osPkg := range osPkgs {
 		// check if we found a newer version
 		available := ""
@@ -220,44 +274,8 @@ func (x *mqlPackages) list() ([]any, error) {
 			cpes = append(cpes, cpe)
 		}
 
-		pkgArgs := map[string]*llx.RawData{
-			"name":        llx.StringData(osPkg.Name),
-			"version":     llx.StringData(osPkg.Version),
-			"available":   llx.StringData(available),
-			"arch":        llx.StringData(osPkg.Arch),
-			"status":      llx.StringData(osPkg.Status),
-			"description": llx.StringData(osPkg.Description),
-			"format":      llx.StringData(osPkg.Format),
-			"installed":   llx.BoolData(true),
-			"origin":      llx.StringData(osPkg.Origin),
-			"epoch":       llx.StringData(osPkg.Epoch),
-			"purl":        llx.StringData(osPkg.PUrl),
-			"cpes":        llx.ArrayData(cpes, types.Resource("cpe")),
-			"vendor":      llx.StringData(osPkg.Vendor),
-		}
-		// Only eagerly set license when the backend populated it (rpm,
-		// apk, pacman). dpkg leaves it empty here so the lazy `license()`
-		// method on mqlPackage can fire and read
-		// /usr/share/doc/<pkg>/copyright on demand. Setting "" here
-		// would short-circuit the GetOrCompute wrapper and the lazy
-		// fallback would never run.
-		if osPkg.License != "" {
-			pkgArgs["license"] = llx.StringData(osPkg.License)
-		}
-		// Install date: explicit null via llx.NilData when the backend
-		// didn't report one (dpkg / apk / pacman / macOS / rpm
-		// gpg-pubkey). The generated dispatcher routes Nil through
-		// RawToTValue[time.Time] which yields State=StateIsSet|
-		// StateIsNull — MQL surfaces that as a real null. Leaving the
-		// key absent from pkgArgs would leave the field in an entirely
-		// unset state and MQL fails with "no type information."
-		// Passing TimeData(zero) would surface the Go zero time
-		// (0001-01-01) as if it were a real install date.
-		if osPkg.InstallDate.IsZero() {
-			pkgArgs["installDate"] = llx.NilData
-		} else {
-			pkgArgs["installDate"] = llx.TimeData(osPkg.InstallDate)
-		}
+		fillPackageArgs(pkgArgs, &osPkg, available, cpes)
+
 		pkg, err := CreateResource(x.MqlRuntime, "package", pkgArgs)
 		if err != nil {
 			return nil, err

--- a/providers/os/resources/packages_internal_test.go
+++ b/providers/os/resources/packages_internal_test.go
@@ -1,0 +1,118 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/resources/packages"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// list() reuses one args map for every package, so fillPackageArgs has to
+// leave no trace of the previous one. license is the field that exposes this:
+// it is only set when the backend reported one, so without the clear a package
+// that has no license inherits whichever license came before it.
+func TestFillPackageArgsDoesNotLeakBetweenPackages(t *testing.T) {
+	args := make(map[string]*llx.RawData, 15)
+	installed := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	withLicense := packages.Package{
+		Name: "openssl", Version: "3.0.11", Arch: "x86_64", Format: "rpm",
+		License: "Apache-2.0", InstallDate: installed,
+	}
+	withoutLicense := packages.Package{
+		Name: "libfoo", Version: "1.2.3", Arch: "amd64", Format: "deb",
+	}
+
+	fillPackageArgs(args, &withLicense, "", nil)
+	require.Contains(t, args, "license")
+	assert.Equal(t, "Apache-2.0", args["license"].Value)
+	require.IsType(t, &time.Time{}, args["installDate"].Value)
+	assert.Equal(t, installed, *args["installDate"].Value.(*time.Time))
+
+	fillPackageArgs(args, &withoutLicense, "", nil)
+	assert.NotContains(t, args, "license",
+		"license leaked from the previous package")
+	assert.Equal(t, llx.NilData.Value, args["installDate"].Value,
+		"installDate leaked from the previous package")
+	assert.Equal(t, "libfoo", args["name"].Value)
+	assert.Equal(t, "deb", args["format"].Value)
+}
+
+func TestFillPackageArgs(t *testing.T) {
+	args := make(map[string]*llx.RawData, 15)
+
+	pkg := packages.Package{
+		Name:        "openssl",
+		Version:     "3.0.11-1",
+		Arch:        "x86_64",
+		Status:      "install ok installed",
+		Description: "TLS toolkit",
+		Format:      "rpm",
+		Origin:      "openssl-src",
+		Epoch:       "1",
+		PUrl:        "pkg:rpm/redhat/openssl@3.0.11-1?arch=x86_64",
+		Vendor:      "Red Hat",
+	}
+	fillPackageArgs(args, &pkg, "3.0.12-1", nil)
+
+	assert.Equal(t, "openssl", args["name"].Value)
+	assert.Equal(t, "3.0.11-1", args["version"].Value)
+	assert.Equal(t, "3.0.12-1", args["available"].Value)
+	assert.Equal(t, "x86_64", args["arch"].Value)
+	assert.Equal(t, "install ok installed", args["status"].Value)
+	assert.Equal(t, "TLS toolkit", args["description"].Value)
+	assert.Equal(t, "rpm", args["format"].Value)
+	assert.Equal(t, true, args["installed"].Value)
+	assert.Equal(t, "openssl-src", args["origin"].Value)
+	assert.Equal(t, "1", args["epoch"].Value)
+	assert.Equal(t, "pkg:rpm/redhat/openssl@3.0.11-1?arch=x86_64", args["purl"].Value)
+	assert.Equal(t, "Red Hat", args["vendor"].Value)
+
+	// An absent install date must stay a real null rather than becoming the Go
+	// zero time, which would report 0001-01-01 as a genuine install date.
+	assert.Equal(t, llx.NilData.Value, args["installDate"].Value)
+
+	// dpkg reports no license inline; the key must stay absent so the lazy
+	// license() accessor still runs.
+	assert.NotContains(t, args, "license")
+}
+
+// The reuse is only sound because CreateResource copies every value out and
+// keeps no reference to the map. If it ever retained one, every package would
+// collapse onto the last package's values.
+func TestCreateResourceDoesNotRetainArgs(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	args := make(map[string]*llx.RawData, 15)
+
+	pkgs := []packages.Package{
+		{Name: "alpha", Version: "1.0", Arch: "amd64", Format: "deb", License: "MIT"},
+		{Name: "beta", Version: "2.0", Arch: "amd64", Format: "deb"},
+		{Name: "gamma", Version: "3.0", Arch: "amd64", Format: "deb", License: "GPL-2.0"},
+	}
+
+	created := make([]*mqlPackage, 0, len(pkgs))
+	for i := range pkgs {
+		fillPackageArgs(args, &pkgs[i], "", nil)
+		res, err := CreateResource(runtime, "package", args)
+		require.NoError(t, err)
+		created = append(created, res.(*mqlPackage))
+	}
+
+	for i, got := range created {
+		assert.Equal(t, pkgs[i].Name, got.Name.Data, "package %d name", i)
+		assert.Equal(t, pkgs[i].Version, got.Version.Data, "package %d version", i)
+	}
+
+	// beta has no license of its own and must not have picked up alpha's.
+	assert.Equal(t, "MIT", created[0].License.Data)
+	assert.Empty(t, created[1].License.Data, "beta inherited a license")
+	assert.Equal(t, "GPL-2.0", created[2].License.Data)
+}


### PR DESCRIPTION
## What

`packages.list()` built a fresh 15-entry `map[string]*llx.RawData` for **every package** and handed it to `CreateResource`, which copies every value out via `SetAllData` and keeps no reference to it. On a package-heavy host that is thousands of maps allocated and discarded for nothing.

This hoists one map out of the loop and `clear()`s it per package — `clear` empties a map while keeping its buckets, which is the whole point.

## Numbers

Measured over 2,000 packages driving the real `CreateResource` against a real `plugin.Runtime`:

| | allocated | allocations |
|---|---|---|
| before | 4,596,051 B | 66,660 |
| after | **3,589,109 B** | **58,665** |

**−22% bytes, −12% allocations** — about 500 B and 4 allocations per package. Wall time is unchanged to within noise (3.70 ms → 3.61 ms).

One correction to my own earlier estimate: I'd guessed ~900 B per package from bucket sizing. Measured, it is ~500 B. Still worth having, but the number in the audit was high.

## The risk, and what guards it

Reusing a map across iterations is only safe if nothing is left behind, and `license` is exactly the field that exposes it — it is only set when the backend reported one, so a leftover key hands one package's license to the next. That is a silent data-correctness bug, not a crash.

So the arg building moves into `fillPackageArgs`, which owns the `clear()` itself rather than trusting the caller to remember. That also gives the invariant a real seam: the tests exercise the production function, not a copy of it.

Both new tests fail if the `clear()` is removed:

```
--- FAIL: TestFillPackageArgsDoesNotLeakBetweenPackages
    Messages: license leaked from the previous package
--- FAIL: TestCreateResourceDoesNotRetainArgs
    Error:    Should be empty, but was MIT
    Messages: beta inherited a license
```

`TestCreateResourceDoesNotRetainArgs` also pins the assumption the whole change rests on — that `CreateResource` copies out and retains nothing. If that ever stops being true, every package would collapse onto the last one's values, and this test says so directly.

## Testing

```
go test ./providers/os/resources/
```

passes. `go build ./providers/os/...` clean.

## Context

From the os provider memory audit. This one is GC pressure on package-heavy assets rather than resident baseline — it does not move RSS, it moves how much garbage a scan makes. Companion PRs: #9854 (OUI table, −2.51 MB live heap) and #9856 (CPE regexp, −54% on package parsing).
