### PR TITLE
⚡ os: stop allocating an empty qualifiers map for every rpm package

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -151,10 +151,20 @@ func newRpmPackage(pf *inventory.Platform, name, version, arch, epoch, vendor, d
 	cpesWithoutEpochAndArch, _ := cpe.NewPackage2Cpe(vendor, name, version, "", "")
 	cpes = append(cpes, cpesWithoutEpoch...)
 	cpes = append(cpes, cpesWithoutEpochAndArch...)
-	qualifiers := map[string]string{}
-	if modularity != "" && modularity != "(none)" {
-		qualifiers["rpmmod"] = modularity
+	// Only packages from a module stream carry a qualifier. Allocating an empty
+	// map for every other package, and threading it through a WithQualifiers
+	// closure, was pure overhead: the purl renderer builds its own map when
+	// there is nothing to hand it.
+	purlModifiers := []purl.Modifier{
+		purl.WithArch(arch),
+		purl.WithEpoch(epoch),
 	}
+	if modularity != "" && modularity != "(none)" {
+		purlModifiers = append(purlModifiers, purl.WithQualifiers(map[string]string{
+			"rpmmod": modularity,
+		}))
+	}
+
 	pkg := Package{
 		Name:        name,
 		Version:     version,
@@ -165,11 +175,7 @@ func newRpmPackage(pf *inventory.Platform, name, version, arch, epoch, vendor, d
 		CPEs:        cpes,
 		Vendor:      vendor,
 		License:     license,
-		PUrl: purl.NewPackageURL(pf, purl.TypeRPM, name, version,
-			purl.WithArch(arch),
-			purl.WithEpoch(epoch),
-			purl.WithQualifiers(qualifiers),
-		).String(),
+		PUrl:        purl.NewPackageURL(pf, purl.TypeRPM, name, version, purlModifiers...).String(),
 	}
 	if installTime > 0 {
 		pkg.InstallDate = time.Unix(installTime, 0).UTC()


### PR DESCRIPTION
## What

`newRpmPackage` allocated a `map[string]string` for **every** package and threaded it through a `WithQualifiers` closure — but only packages from a module stream ever put anything in it. Every other package built an empty map to say "nothing" and paid for the closure that carried it.

This builds the modifier list without the qualifiers entry unless there is a modularity label to record.

## Numbers, and an honest correction

Synthetic 2,000-package `rpm -qa` parse, three runs each:

| | B/op |
|---|---|
| before | 31,334,921 / 31,356,618 / 31,374,709 |
| after | **30,687,415 / 30,625,693 / 30,764,088** |

**≈ −663 KB, −2.1%**, with no overlap between the two sets.

Worth being precise about what this does and does not do, because my own audit note oversold it: **the allocation count is unchanged** (440,207 → 440,181, inside the noise). `purl.String()` already allocates its own map when handed none, so the map does not disappear — it moves. What actually goes away is the closure and one element of the variadic slice. Wall time is unchanged.

So: a real, reproducible byte reduction, not the clean "one less allocation per package" I originally wrote down.

## Behavior

`purl.String()` handles a nil `Qualifiers` by building its own map, so the rendered purl is byte-identical either way. I confirmed that directly before making the change, then relied on the existing suite:

- `rpm_packages_test.go` already asserts modular packages render `...&rpmmod=php:7.4:8100020241212065510:eb0869e2` in the purl
- and that non-modular packages carry no `rpmmod` qualifier

Both branches were already pinned, which is why this PR adds no new tests — the coverage that matters already existed.

## Testing

```
go test ./providers/os/resources/packages/ ./providers/os/resources/purl/
```

passes. `gofmt` clean, `go build ./providers/os/...` clean.

## Context

From the os provider memory audit. Related: #9854 (OUI table), #9856 (CPE regexp), #9858 (package args map). The larger win in this same code path is the purl renderer — `packageurl-go` v0.1.5 rebuilds a trie-backed `strings.Replacer` on every `percentEncode`, which is most of the ~15 KB per package still visible above. Separate PR.
