### PR TITLE
⚡ os: take the process executable name without splitting the whole path

### DIFF
--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -61,11 +61,19 @@ func (p ProcessEntry) ToOSProcess() *OSProcess {
 		executablePath = args[0]
 	}
 
-	executablePathParts := strings.Split(executablePath, "/")
+	// Take the last path segment without splitting the whole path first, which
+	// allocated a slice of every segment per process just to read one of them.
+	// Deliberately not path.Base: it maps "" to "." and "/usr/bin/" to "bin",
+	// where this reports "" for both.
+	executable := executablePath
+	if i := strings.LastIndexByte(executablePath, '/'); i >= 0 {
+		executable = executablePath[i+1:]
+	}
+
 	return &OSProcess{
 		Pid:        p.Pid,
 		Command:    p.Command,
-		Executable: executablePathParts[len(executablePathParts)-1],
+		Executable: executable,
 		State:      "",
 	}
 }

--- a/providers/os/resources/processes/unixps_executable_test.go
+++ b/providers/os/resources/processes/unixps_executable_test.go
@@ -1,0 +1,115 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package processes
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ToOSProcess derives Executable from the last path segment of the command's
+// first word. The edge cases matter more than the happy path: the obvious
+// "cleanup" here is path.Base, which reports "." for an empty path and "bin"
+// for "/usr/bin/", where this reports "" for both.
+func TestProcessEntryToOSProcess(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		executable string
+	}{
+		{
+			name:       "absolute path with flags",
+			command:    "/usr/lib/systemd/systemd --switched-root --system --deserialize 31",
+			executable: "systemd",
+		},
+		{
+			name:       "bare name, no path",
+			command:    "sshd",
+			executable: "sshd",
+		},
+		{
+			name:       "relative path",
+			command:    "./bin/agent --config /etc/agent.yaml",
+			executable: "agent",
+		},
+		{
+			name:       "quoted path containing a space",
+			command:    `"/opt/my app/bin/worker" --verbose`,
+			executable: "worker",
+		},
+		{
+			name:       "empty command",
+			command:    "",
+			executable: "",
+		},
+		{
+			name:       "trailing slash yields an empty executable, not the parent dir",
+			command:    "/usr/bin/",
+			executable: "",
+		},
+		{
+			name:       "root yields an empty executable, not a slash",
+			command:    "/",
+			executable: "",
+		},
+		{
+			name:       "unbalanced quoting leaves the executable empty",
+			command:    `/usr/bin/foo "unterminated`,
+			executable: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := ProcessEntry{Pid: 42, Command: test.command}
+			got := p.ToOSProcess()
+
+			assert.Equal(t, test.executable, got.Executable)
+			assert.Equal(t, int64(42), got.Pid)
+			// Command is passed through untouched regardless of how it parses.
+			assert.Equal(t, test.command, got.Command)
+		})
+	}
+}
+
+// Deriving the executable must not allocate a slice of every path segment, so
+// the memory ToOSProcess uses must not grow with how deep the path is. Two
+// commands of identical length that differ only in separator count isolate
+// that: splitting allocates a slice proportional to the segment count, taking
+// the last segment allocates nothing at all.
+//
+// This measures bytes rather than allocation counts on purpose -- strings.Split
+// allocates one slice whatever the depth, so a count-based check cannot tell
+// the two implementations apart.
+func TestToOSProcessDoesNotScaleWithPathDepth(t *testing.T) {
+	shallow := ProcessEntry{Pid: 1, Command: "/usrxlibxsystemdxbinxlibxexecxoptxvarxrunxsystemd --system"}
+	deep := ProcessEntry{Pid: 1, Command: "/usr/lib/systemd/bin/lib/exec/opt/var/run/systemd --system"}
+
+	// same byte length, so any difference comes from the separators alone
+	assert.Equal(t, len(shallow.Command), len(deep.Command), "test inputs must be the same length")
+
+	shallowBytes := allocatedBytes(1000, func() { processSink = shallow.ToOSProcess() })
+	deepBytes := allocatedBytes(1000, func() { processSink = deep.ToOSProcess() })
+
+	assert.Equal(t, shallowBytes, deepBytes,
+		"memory grew with path depth (%d -> %d bytes over 1000 calls), so the path is still being split",
+		shallowBytes, deepBytes)
+}
+
+// processSink keeps the results reachable so the allocations are not optimized
+// away while measuring.
+var processSink *OSProcess
+
+func allocatedBytes(n int, f func()) uint64 {
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for i := 0; i < n; i++ {
+		f()
+	}
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}


### PR DESCRIPTION
## What

`ToOSProcess` derived `Executable` by running `strings.Split` over the command's first word and keeping the last element — allocating a slice of **every** path segment, per process, to read one of them.

```go
executablePathParts := strings.Split(executablePath, "/")
... Executable: executablePathParts[len(executablePathParts)-1]
```

Replaced with `strings.LastIndexByte` and a slice, which allocates nothing (a substring shares the original backing array).

## Not `path.Base`

The obvious cleanup is `path.Base`, and it is wrong here:

| input | current / this PR | `path.Base` |
|---|---|---|
| `""` | `""` | `"."` |
| `"/usr/bin/"` | `""` | `"bin"` |
| `"/"` | `""` | `"/"` |

`Executable` is user-visible on the `processes` resource, so that would be a silent data change. The table test pins all three.

## Numbers

300 processes, three runs each:

| | B/op | allocs/op |
|---|---|---|
| before | 170,113 / 170,121 / 170,121 | 3,890 |
| after | **153,312 / 153,313 / 153,314** | **3,590** |

**−9.9% bytes**, and exactly one allocation per process.

## Tests

`ToOSProcess` had no test at all, so this adds one. The table covers the `path.Base` divergences above plus unbalanced quoting and a quoted path containing a space — and **passes unchanged against the old implementation**, which is what makes it a parity check rather than a description of the new code.

The companion test asserts the memory used does not grow with path depth, comparing two commands of **identical byte length** that differ only in how many separators they contain:

```
--- FAIL: TestToOSProcessDoesNotScaleWithPathDepth
    Messages: memory grew with path depth (328000 -> 472000 bytes over 1000 calls),
              so the path is still being split
```

It measures **bytes rather than allocation counts** on purpose. My first attempt compared `testing.AllocsPerRun` and passed on both implementations — `strings.Split` allocates one slice whatever the depth, so a count-based check cannot tell them apart. It also uses `runtime.MemStats` over a fixed loop rather than `testing.Benchmark`, which cut the test from 3.5s to 0.00s.

## Left alone

`shellquote.Split` still parses the entire command line to take `args[0]`, and that is the larger allocation in this function. Changing it means reimplementing shell quoting, which is not worth the risk in a PR about a path split.

## Testing

```
go test ./providers/os/resources/processes/
```

passes. `gofmt` clean, `go build ./providers/os/...` clean.

## Context

From the os provider memory audit. Related: #9854, #9856, #9858, #9859.
