### PR TITLE
⚡ os: hoist static regexps out of function bodies

### DIFF
--- a/providers/os/id/awsebs/unix_ebs.go
+++ b/providers/os/id/awsebs/unix_ebs.go
@@ -14,6 +14,12 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/id/hostname"
 )
 
+// Compiled once: applied to every line of the metadata and lsblk output.
+var (
+	ipv4PublicRE = regexp.MustCompile(`meta-data/network/interfaces/macs/([0-9a-f:]+)/ipv4-associations/([0-9.]+)`)
+	ipRegex      = regexp.MustCompile(`\|\s+(\w+)\s+\|\s+True\s+\|\s+([^\s]+)\s+\|\s+([^\s]+)\s+\|[^\|]+\|\s+([^\s]+)\s+\|`)
+)
+
 func (m *ebsMetadata) unixMetadata() (any, error) {
 	mdata := map[string]any{}
 
@@ -67,7 +73,6 @@ func (m *ebsMetadata) getUnixNetworkInterfaces() (any, bool) {
 		//
 		// 'http://169.254.169.254:80/2021-03-23/meta-data/network/interfaces/macs/0a:ff:ed:34:f3:6d/ipv4-associations/54.146.163.122'
 		//
-		ipv4PublicRE := regexp.MustCompile(`meta-data/network/interfaces/macs/([0-9a-f:]+)/ipv4-associations/([0-9.]+)`)
 		for _, line := range strings.Split(string(cloudInitLog), "\n") {
 			if matches := ipv4PublicRE.FindStringSubmatch(line); len(matches) == 3 {
 				// check if we have already detected that MAC address
@@ -117,7 +122,6 @@ func (m *ebsMetadata) getUnixNetworkInterfaces() (any, bool) {
 		// ci-info: |   2   |    local    |    ::   |    enX0   |   U   |
 		// ci-info: |   3   |  multicast  |    ::   |    enX0   |   U   |
 		// ci-info: +-------+-------------+---------+-----------+-------+
-		ipRegex := regexp.MustCompile(`\|\s+(\w+)\s+\|\s+True\s+\|\s+([^\s]+)\s+\|\s+([^\s]+)\s+\|[^\|]+\|\s+([^\s]+)\s+\|`)
 		for _, line := range strings.Split(string(cloudInitOutputLog), "\n") {
 			matches := ipRegex.FindStringSubmatch(line)
 			if len(matches) == 5 {

--- a/providers/os/id/awsec2/id.go
+++ b/providers/os/id/awsec2/id.go
@@ -10,6 +10,9 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Compiled once: applied to each platform id being parsed.
+var awsec2 = regexp.MustCompile(`^\/\/platformid.api.mondoo.app\/runtime\/aws\/ec2\/v1\/accounts\/(.*)\/regions\/(.*)\/instances\/(.*)$`)
+
 // aws://ec2/v1/accounts/{account}/regions/{region}/instances/{instanceid}
 func MondooInstanceID(account string, region string, instanceid string) string {
 	return "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/" + account + "/regions/" + region + "/instances/" + instanceid
@@ -113,7 +116,6 @@ func IsValidMondooAccountId(path string) bool {
 
 func ParseEc2PlatformID(uri string) *MondooInstanceId {
 	// aws://ec2/v1/accounts/{account}/regions/{region}/instances/{instanceid}
-	awsec2 := regexp.MustCompile(`^\/\/platformid.api.mondoo.app\/runtime\/aws\/ec2\/v1\/accounts\/(.*)\/regions\/(.*)\/instances\/(.*)$`)
 	m := awsec2.FindStringSubmatch(uri)
 	if len(m) == 0 {
 		return nil

--- a/providers/os/id/metadata/crawler.go
+++ b/providers/os/id/metadata/crawler.go
@@ -12,6 +12,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Compiled once: applied to every value the crawler classifies.
+var sshKeyPattern = regexp.MustCompile(`(?:^|[:\s])(?:ssh-(?:rsa|dss|ed25519)|ecdsa-sha2-nistp(?:256|384|521)|ssh-ecdsa)\s+[A-Za-z0-9+/=]`)
+
 const maxDepth = 50
 
 // recursive is the interface passed to `Crawl` to fetch all metadata from an instance
@@ -187,8 +190,6 @@ func detectMultilineString(data string) bool {
 	if len(data) > 50 {
 		prefix = data[:50]
 	}
-
-	sshKeyPattern := regexp.MustCompile(`(?:^|[:\s])(?:ssh-(?:rsa|dss|ed25519)|ecdsa-sha2-nistp(?:256|384|521)|ssh-ecdsa)\s+[A-Za-z0-9+/=]`)
 
 	switch {
 	case strings.Contains(prefix, "#!/bin/bash"):

--- a/providers/os/id/networki/darwin_n.go
+++ b/providers/os/id/networki/darwin_n.go
@@ -17,6 +17,9 @@ import (
 	"howett.net/plist"
 )
 
+// Compiled once: this is matched against every line of ifconfig output.
+var darwinFlagsRegex = regexp.MustCompile(`flags=([0-9]+)<([^>]+)>`)
+
 // detectDarwinInterfaces detects network interfaces on Darwin.
 func (n *neti) detectDarwinInterfaces() ([]Interface, error) {
 	detectors := []func() ([]Interface, error){
@@ -252,7 +255,7 @@ func (n *neti) getMacIfconfigInterfaces() (interfaces []Interface, err error) {
 
 			// Match flags
 			if strings.Contains(line, "flags=") {
-				flagsMatch := regexp.MustCompile(`flags=([0-9]+)<([^>]+)>`).FindStringSubmatch(line)
+				flagsMatch := darwinFlagsRegex.FindStringSubmatch(line)
 				if len(flagsMatch) > 2 {
 					currentInterface.Flags = strings.Split(flagsMatch[2], ",")
 				}

--- a/providers/os/id/networki/linux_n.go
+++ b/providers/os/id/networki/linux_n.go
@@ -17,6 +17,14 @@ import (
 	"github.com/spf13/afero"
 )
 
+// Compiled once: these are matched against every line of `ip addr` output.
+var (
+	interfaceRegex = regexp.MustCompile(`^\d+: ([^:]+): <([^>]+)> mtu (\d+)`)
+	macRegex       = regexp.MustCompile(`link/ether ([0-9a-fA-F:]+) `)
+	ipRegex        = regexp.MustCompile(`inet ([0-9\.]+)/([0-9]+)`)
+	ip6Regex       = regexp.MustCompile(`inet6 ([0-9a-fA-F:]+)/([0-9]+) scope (global|link|host)`)
+)
+
 // detectLinuxInterfaces detects network interfaces on Linux.
 func (n *neti) detectLinuxInterfaces() ([]Interface, error) {
 	var errs []error
@@ -246,12 +254,8 @@ func (n *neti) getLinuxCmdInterfaces() ([]Interface, error) {
 	}
 
 	var (
-		interfaces     = []Interface{}
-		scanner        = bufio.NewScanner(strings.NewReader(string(output)))
-		interfaceRegex = regexp.MustCompile(`^\d+: ([^:]+): <([^>]+)> mtu (\d+)`)
-		macRegex       = regexp.MustCompile(`link/ether ([0-9a-fA-F:]+) `)
-		ipRegex        = regexp.MustCompile(`inet ([0-9\.]+)/([0-9]+)`)
-		ip6Regex       = regexp.MustCompile(`inet6 ([0-9a-fA-F:]+)/([0-9]+) scope (global|link|host)`)
+		interfaces = []Interface{}
+		scanner    = bufio.NewScanner(strings.NewReader(string(output)))
 		// TODO @afiune we could add additional information to the interface struct like
 		//  * `altname` (alternative name)
 		//  * `metric` (priority or cost of a network interface)

--- a/providers/os/id/networki/windows_n.go
+++ b/providers/os/id/networki/windows_n.go
@@ -13,6 +13,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Compiled once: the header pattern is matched against every line of ipconfig
+// output, and the suffix pattern against every address it reports.
+var (
+	interfaceHeaderRegex = regexp.MustCompile(`^(Ethernet|Wireless|Bluetooth|VPN|Local Area Connection|Wi-Fi|Cellular|Tunnel) adapter (.+):$`)
+	ipSuffixRegex        = regexp.MustCompile(`\(.*?\)$`)
+)
+
 // detectWindowsInterfaces detects network interfaces on Windows.
 func (n *neti) detectWindowsInterfaces() ([]Interface, error) {
 	var errs []error
@@ -164,10 +171,9 @@ func (n *neti) getWindowsIpconfigCmdInterfaces() (interfaces []Interface, err er
 	}
 
 	var (
-		ips                  []IPAddress
-		gateways             []string
-		currentInterface     *Interface
-		interfaceHeaderRegex = regexp.MustCompile(`^(Ethernet|Wireless|Bluetooth|VPN|Local Area Connection|Wi-Fi|Cellular|Tunnel) adapter (.+):$`)
+		ips              []IPAddress
+		gateways         []string
+		currentInterface *Interface
 	)
 
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
@@ -238,8 +244,7 @@ func lastField(fields []string) string {
 }
 
 func cleanIPString(ip string) string {
-	re := regexp.MustCompile(`\(.*?\)$`)
-	return strings.TrimSpace(re.ReplaceAllString(ip, ""))
+	return strings.TrimSpace(ipSuffixRegex.ReplaceAllString(ip, ""))
 }
 
 func updateWindowsNetInterface(currentInterface *Interface, ips []IPAddress, gateways []string) {

--- a/providers/os/resources/kernel/modules.go
+++ b/providers/os/resources/kernel/modules.go
@@ -11,10 +11,18 @@ import (
 	"strings"
 )
 
+// Compiled once: each of these is matched against every line of its command's
+// output.
+var (
+	lsmodEntry       = regexp.MustCompile(`^(\S+)\s+(\S+)\s+(\S+)\s*(\S*)$`)
+	procModulesEntry = regexp.MustCompile(`^(\S+)\s(\S+)\s(\S+)\s(.*)$`)
+	kldstatEntry     = regexp.MustCompile(`^\s+(\S+)\s+(\S+)\s+(\S+)\s*(\S*)\s*(\S*)$`)
+	kextstatEntry    = regexp.MustCompile(`^\s+(\S+)\s+(\S+)\s+(\S+)\s*(\S*)\s*(\S*)\s*(\S*)`)
+	genkexEntry      = regexp.MustCompile(`^\s*(\S+)\s+(\S+)\s+(\S+)\s*$`)
+)
+
 func ParseLsmod(r io.Reader) []*KernelModule {
 	res := []*KernelModule{}
-
-	lsmodEntry := regexp.MustCompile(`^(\S+)\s+(\S+)\s+(\S+)\s*(\S*)$`)
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -39,8 +47,6 @@ func ParseLsmod(r io.Reader) []*KernelModule {
 func ParseLinuxProcModules(r io.Reader) []*KernelModule {
 	res := []*KernelModule{}
 
-	procModulesEntry := regexp.MustCompile(`^(\S+)\s(\S+)\s(\S+)\s(.*)$`)
-
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -60,12 +66,10 @@ func ParseLinuxProcModules(r io.Reader) []*KernelModule {
 func ParseKldstat(r io.Reader) []*KernelModule {
 	res := []*KernelModule{}
 
-	lsmodEntry := regexp.MustCompile(`^\s+(\S+)\s+(\S+)\s+(\S+)\s*(\S*)\s*(\S*)$`)
-
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
-		m := lsmodEntry.FindStringSubmatch(line)
+		m := kldstatEntry.FindStringSubmatch(line)
 		if len(m) == 6 {
 			res = append(res, &KernelModule{
 				Name:   strings.TrimSpace(m[5]),
@@ -81,12 +85,10 @@ func ParseKldstat(r io.Reader) []*KernelModule {
 func ParseKextstat(r io.Reader) []*KernelModule {
 	res := []*KernelModule{}
 
-	lsmodEntry := regexp.MustCompile(`^\s+(\S+)\s+(\S+)\s+(\S+)\s*(\S*)\s*(\S*)\s*(\S*)`)
-
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
-		m := lsmodEntry.FindStringSubmatch(line)
+		m := kextstatEntry.FindStringSubmatch(line)
 		if len(m) == 7 {
 			res = append(res, &KernelModule{
 				Name:   strings.TrimSpace(m[6]),
@@ -108,8 +110,6 @@ func ParseGenkex(stdout io.Reader) ([]*KernelModule, error) {
 	// f10009d5b06d8000     d000 /usr/lib/drivers/bpf
 	// f10009d5b06a2000    36000 /usr/lib/drivers/autofs.ext
 	// f10009d5b0685000    1d000 /usr/lib/drivers/ahafs.ext
-
-	genkexEntry := regexp.MustCompile(`^\s*(\S+)\s+(\S+)\s+(\S+)\s*$`)
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Scan()

--- a/providers/os/resources/kubelet_flags.go
+++ b/providers/os/resources/kubelet_flags.go
@@ -11,6 +11,9 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 )
 
+// Compiled once: applied to each eviction threshold flag.
+var evictionRegex = regexp.MustCompile(`^(.+)[<>=]+([\d]+[A-Za-z%]*)$`)
+
 // mergeFlagsIntoConfig adds flags to the kubelet config
 // It does not take care of deprecated flags
 // The flags are not just kubelet specific, but can also be global flags
@@ -86,8 +89,6 @@ func parseKeyValueListFlag(s string) map[string]string {
 // The list of flags is taken from
 // https://github.com/kubernetes/kubernetes/blob/release-1.25/cmd/kubelet/app/options/options.go
 func mergeDeprecatedFlagsIntoConfig(kubeletConfig map[string]any, flags map[string]any) error {
-	evictionRegex := regexp.MustCompile(`^(.+)[<>=]+([\d]+[A-Za-z%]*)$`)
-
 	if _, ok := flags["enable-server"]; ok {
 		kubeletConfig["enableServer"] = flags["enable-server"]
 	}

--- a/providers/os/resources/languages/javascript/yarnlock/extractor.go
+++ b/providers/os/resources/languages/javascript/yarnlock/extractor.go
@@ -16,6 +16,9 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// Compiled once: matched against every line of a yarn.lock file.
+var kv = regexp.MustCompile(`^(\s+)(\S+)\s+(.+?)\s*$`)
+
 // yarnLockBom wraps a parsed yarnLock with file evidence.
 type yarnLockBom struct {
 	packages yarnLock
@@ -42,7 +45,6 @@ func (p *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
 	// "url"`) OR unquoted (`integrity sha512-…`). Rewrite both forms to
 	// `key: "value"`; pass through blank lines, comments, and mapping headers
 	// (spec lines / `dependencies:` that already end in ":") untouched.
-	kv := regexp.MustCompile(`^(\s+)(\S+)\s+(.+?)\s*$`)
 	scanner := bufio.NewScanner(r)
 	// yarn.lock integrity/resolved lines can be long; grow the scanner buffer.
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)

--- a/providers/os/resources/languages/ocaml/opam/extractor.go
+++ b/providers/os/resources/languages/ocaml/opam/extractor.go
@@ -16,6 +16,9 @@ import (
 	"go.mondoo.com/mql/v13/sbom"
 )
 
+// Compiled once: applied to every opam file parsed.
+var dependsHeader = regexp.MustCompile(`(?m)^depends:`)
+
 var (
 	_ languages.Extractor = (*Extractor)(nil)
 	_ languages.Bom       = (*opamFile)(nil)
@@ -87,7 +90,7 @@ func parseOpam(content string) *opamFile {
 // counting skips over quoted strings so a `[` or `]` byte inside a string
 // literal does not throw off the depth.
 func dependsBlock(content string) (string, bool) {
-	idx := regexp.MustCompile(`(?m)^depends:`).FindStringIndex(content)
+	idx := dependsHeader.FindStringIndex(content)
 	if idx == nil {
 		return "", false
 	}

--- a/providers/os/resources/logindefs/logindefs.go
+++ b/providers/os/resources/logindefs/logindefs.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 )
 
+// ignore line if it starts with a comment, allow trailing comments though.
+// Compiled once: matched against every line of login.defs.
+var logindefEntry = regexp.MustCompile(`^\s*([^#]\S+)\s+(\S+)\s*(?:#.*)?$`)
+
 func Parse(r io.Reader) map[string]string {
 	res := map[string]string{}
-
-	// ignore line if it starts with a comment, allow trailing comments though
-	logindefEntry := regexp.MustCompile(`^\s*([^#]\S+)\s+(\S+)\s*(?:#.*)?$`)
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {

--- a/providers/os/resources/mount/mount.go
+++ b/providers/os/resources/mount/mount.go
@@ -13,15 +13,21 @@ import (
 	"github.com/spf13/afero"
 )
 
+// Compiled once: each of these is matched against every line of its command's
+// output.
+var (
+	linuxMountEntry     = regexp.MustCompile(`^(\S+)\son\s(\S+)\stype\s(\S+)\s\((\S+)\)$`)
+	unixMountEntry      = regexp.MustCompile(`^(\S+)\son\s(\S+)\s\((.*)\)$`)
+	linuxProcMountEntry = regexp.MustCompile(`^(\S+)\s(\S+)\s(\S+)\s(\S+)\s0\s0$`)
+)
+
 func ParseLinuxMountCmd(r io.Reader) []MountPoint {
 	res := []MountPoint{}
-
-	mountEntry := regexp.MustCompile(`^(\S+)\son\s(\S+)\stype\s(\S+)\s\((\S+)\)$`)
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
-		m := mountEntry.FindStringSubmatch(line)
+		m := linuxMountEntry.FindStringSubmatch(line)
 		if len(m) == 5 {
 			res = append(res, MountPoint{
 				Device:     strings.TrimSpace(m[1]),
@@ -38,12 +44,10 @@ func ParseLinuxMountCmd(r io.Reader) []MountPoint {
 // NOTE: we do not handle `map auto_home` on macos
 func ParseUnixMountCmd(r io.Reader) []MountPoint {
 	res := []MountPoint{}
-	mountEntry := regexp.MustCompile(`^(\S+)\son\s(\S+)\s\((.*)\)$`)
-
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
-		m := mountEntry.FindStringSubmatch(line)
+		m := unixMountEntry.FindStringSubmatch(line)
 		if len(m) == 4 {
 			opts := strings.TrimSpace(m[3])
 			fstype := ""
@@ -68,12 +72,10 @@ func ParseUnixMountCmd(r io.Reader) []MountPoint {
 func ParseLinuxProcMount(r io.Reader) []MountPoint {
 	res := []MountPoint{}
 
-	procMountEntry := regexp.MustCompile(`^(\S+)\s(\S+)\s(\S+)\s(\S+)\s0\s0$`)
-
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
-		m := procMountEntry.FindStringSubmatch(line)
+		m := linuxProcMountEntry.FindStringSubmatch(line)
 		if len(m) == 5 {
 			res = append(res, MountPoint{
 				Device:     strings.TrimSpace(m[1]),

--- a/providers/os/resources/networkinterface/interface.go
+++ b/providers/os/resources/networkinterface/interface.go
@@ -22,6 +22,9 @@ import (
 
 var errNoSuchInterface = errors.New("no such network interface")
 
+// Compiled once: matched against every line of `ip addr` output.
+var ipaddrParse = regexp.MustCompile(`^(\d+):\s([\w\d\./\:]+)\s*(inet|inet6)\s([\w\d\./\:]+)\s(.*)$`)
+
 // mimics https://go.dev/src/net/interface.go to provide a similar api
 type Interface struct {
 	Index          int              // positive integer that starts at one, zero is never used
@@ -150,7 +153,6 @@ func (i *LinuxInterfaceHandler) ParseIpAddr(r io.Reader) ([]Interface, error) {
 	interfaces := map[string]Interface{}
 
 	scanner := bufio.NewScanner(r)
-	ipaddrParse := regexp.MustCompile(`^(\d+):\s([\w\d\./\:]+)\s*(inet|inet6)\s([\w\d\./\:]+)\s(.*)$`)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -28,6 +28,9 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/resources/purl"
 )
 
+// Compiled once: reused for each root the appx search walks.
+var appxManifestPattern = regexp.MustCompile(".*/[Aa]ppx[Mm]anifest.xml")
+
 // ProcessorArchitecture Enum
 // https://learn.microsoft.com/en-us/uwp/api/windows.system.processorarchitecture
 // https://learn.microsoft.com/en-us/dotnet/api/system.reflection.processorarchitecture?redirectedfrom=MSDN&view=netframework-4.8
@@ -602,7 +605,7 @@ func (w *WinPkgManager) getFsAppxPackages() ([]Package, error) {
 	}
 	appxPaths := map[string]struct{}{}
 	for p, depth := range paths {
-		res, err := fsSearch.Find(p, regexp.MustCompile(".*/[Aa]ppx[Mm]anifest.xml"), "f", nil, &depth)
+		res, err := fsSearch.Find(p, appxManifestPattern, "f", nil, &depth)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## What

Twenty static patterns across 14 files were compiled **inside** the functions that used them. Compiling a regexp builds a syntax tree, a program, and a one-pass table — so each of these rebuilt the same pattern on every call and threw it away.

## Numbers

Measured on `ParseLinuxMountCmd` over a 10-entry mount table, which is representative of these parsers:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 22,147 | 25,370 | 215 |
| after | **12,863** | **12,553** | **67** |

**−50% bytes, −69% allocations, 1.7× faster.** Compiling the three patterns cost more than parsing the entire mount table did.

The worst site was `id/networki/darwin_n.go`, which compiled its `flags=…` pattern **for every line** of ifconfig output rather than once:

```go
if strings.Contains(line, "flags=") {
    flagsMatch := regexp.MustCompile(`flags=([0-9]+)<([^>]+)>`).FindStringSubmatch(line)
```

Most of the rest are once per parse — which, on a provider process that serves many assets, is once per asset rather than once per process.

## Deliberately left compiled in place

Three of the sites my audit flagged should **not** be hoisted, and are untouched:

- **`resources/files.go:125,130`** builds its pattern from user input — the `name` and `regex` arguments of `files.find`. There is nothing static to hoist.
- **`id/metadata/crawler.go:155`** likewise compiles a caller-supplied pattern.
- **`resources/cpe/pkg2cpe.go:24`** is the same change already in flight as #9856, so it is excluded here to avoid a conflict.

One more that looks like a hit but is not: `languages/elixir/mixlock/extractor.go` already declares `mixLockPattern` at package level. My detection script mis-tracked brace state around a preceding `var` block and reported it as a false positive.

## Verifying nothing was missed

```sh
find providers/os -name '*.go' -not -name '*_test.go' -print0 |
  xargs -0 awk '/^func /{f=1} /^}/{f=0} f && /regexp\.(Must)?Compile/ {print FILENAME":"FNR": "$0}'
```

After this PR that reports only the four exclusions above.

## Behavior

Unchanged — same patterns, same call sites, only the compile moves. Every touched package's existing tests pass:

```
go test ./providers/os/resources/... ./providers/os/id/...
```

`gofmt` clean, `go build ./providers/os/...` clean. (`go vet` reports two pre-existing unkeyed-field warnings in `connection/` and the known `connection/device/linux` mockgen gap, none of them in files this PR touches.)

## Context

From the os provider memory audit. Related: #9854, #9856, #9858, #9859, #9860.
