### PR TITLE
🧹 ci: bump stale action pins and group codeql-action for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,14 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      # codeql-action/init and codeql-action/analyze run as a pair within a single
+      # workflow and must resolve to the same release. Ungrouped, Dependabot opens a
+      # separate PR per sub-action, so each PR bumps only one half and CodeQL fails
+      # with "Loaded a configuration file for version X, but running version Y".
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: docker
     directory: /
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,7 +75,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,4 +87,4 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -109,7 +109,7 @@ jobs:
       # These packages have been installed on the self-hosted runner using ansible from the private repo
 
       - name: Azure login
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID}}

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -154,7 +154,7 @@ jobs:
       # These packages have been installed on the self-hosted runner using ansible from the private repo
 
       - name: Azure login
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.TSIGN_AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.TSIGN_AZURE_TENANT_ID}}

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
+      - uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/xgrep.yaml
+++ b/.github/workflows/xgrep.yaml
@@ -33,7 +33,7 @@ jobs:
           fail-on: "off" # report-only for now; surface findings without blocking PRs
       - name: Upload SARIF results
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif
           category: xgrep


### PR DESCRIPTION
## What

Audited all **28** SHA-pinned actions in `.github/` against their latest releases. **25 were already current**; three were behind:

| action | pinned | now |
|---|---|---|
| `github/codeql-action/init` | `d1ba80a1` v4.37.5 | `ff2f1c62` **v4.37.7** |
| `github/codeql-action/analyze` | `d1ba80a1` v4.37.5 | `ff2f1c62` **v4.37.7** |
| `github/codeql-action/upload-sarif` | `e4fba868` v4.37.3 | `ff2f1c62` **v4.37.7** |
| `azure/login` ×2 | `532459ea` v3.0.0 | `f5d393ae` **v3.0.1** |
| `crate-ci/typos` | `bee27e3a` v1.48.0 | `8a48f81b` **v1.49.0** |

All three target SHAs are the ones cnspec already runs in CI, so they're proven in an equivalent pipeline.

## Why codeql-action drifted, and the fix

Its sub-actions were pinned to **two different releases** — `init`/`analyze` on v4.37.5, `upload-sarif` on v4.37.3. That's the signature of ungrouped Dependabot updates: it opens a separate PR per sub-action, and each PR bumps only the ones it names, so the halves wander apart.

That matters because `init` and `analyze` must resolve to the same release, or CodeQL fails with:

```
Loaded a configuration file for version X, but running version Y
```

cnspec already guards this with a `codeql-action` group in its Dependabot config. This PR adds the same group here, so the pins move together from now on and this doesn't silently re-drift.

## One thing deliberately left alone

`tcort/github-action-markdown-link-check` looks stale through the API but isn't. It's pinned to `e047c5b3`, which is the **v1.1.3** tag (2026-07-28) — published without a GitHub release object, so `releases/latest` reports the older **v1.1.2** (2025-11-19). "Bumping" it would have been an 8-month downgrade. Latest-release and latest-tag are not the same thing.

## Verification

- Every new SHA resolved from its release tag via the GitHub API, not copied by hand.
- All six touched YAML files parse cleanly.
- Diff is 14 lines: 8 in `dependabot.yml`, 6 pin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)