### PR TITLE
🐛 aws: drop deprecated clusterArn from ecs.service @defaults

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -9102,7 +9102,7 @@ private aws.ecs.taskDefinition @defaults("arn family revision") {
 // registrations, capacity provider strategy, and placement constraints and
 // strategy. Whether ECS Exec is permitted on the tasks is reported by
 // enableExecuteCommand.
-private aws.ecs.service @defaults("arn name clusterArn status") {
+private aws.ecs.service @defaults("arn name launchType status") {
   // ARN of the ECS service
   arn string
   // Name of the ECS service


### PR DESCRIPTION
`aws.ecs.service` lists the deprecated `clusterArn` field in its `@defaults`. Default fields are compiled into every query that materializes the resource, so any query touching `services` fetches the deprecated field whether or not it references it.

That makes cnspec's `query-deprecated-symbol` lint **unfixable from content**. Even a query as bare as

```coffee
aws.ecs.clusters.all(services.length > 0)
```

is reported as using `aws.ecs.service.clusterArn`, because the datapoint is added by the defaults expansion rather than by the query author.

### Where this shows up

In cnspec, `mondoo-aws-security-ecs-service-not-internet-reachable` warns even though its mql never mentions `clusterArn`:

```
query-deprecated-symbol  warning  mondoo-aws-security.mql.yaml  57030
  query 'mondoo-aws-security-ecs-service-not-internet-reachable'
  uses deprecated field 'aws.ecs.service.clusterArn'
```

### The change

Replaces `clusterArn` with `launchType` in the defaults.

The cluster association is not lost: an ECS service ARN is `arn:aws:ecs:<region>:<acct>:service/<cluster>/<service>`, so the parent cluster is already carried by the `arn` default. `launchType` adds the compute model the ARN does not express.

`launchType` is empty for a service that uses a capacity provider strategy instead of a launch type — happy to swap it for `runningCount` or to just drop to `arn name status` if reviewers prefer an always-populated field.

The non-deprecated replacement `cluster()` is resource-typed, so it is deliberately not put in defaults.

This is the same shape as #9831, which did the equivalent fix for `azure.subscription.frontDoorService.profile.securityPolicy.wafPolicyId`.

### Verification

Built and installed the provider locally, then linted a probe bundle whose only ECS query is a bare `.length` — the warning is gone, and `mondoo-aws-security.mql.yaml` no longer reports any `ecs.service.clusterArn` warning.

`providers/aws/resources/aws.resources.json` is gitignored and regenerated at build time; `aws.lr.go` is unchanged, since `@defaults` does not reach the generated Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)