### PR TITLE
⚡ os: size the tar extract buffer from the entry header

### DIFF
--- a/providers/os/connection/tar/file.go
+++ b/providers/os/connection/tar/file.go
@@ -5,8 +5,8 @@ package tar
 
 import (
 	"archive/tar"
-	"bufio"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -18,7 +18,7 @@ type File struct {
 	path   string
 	header *tar.Header
 	Fs     *FS
-	reader *bufio.Reader
+	reader io.Reader
 }
 
 func (f *File) Name() string {

--- a/providers/os/connection/tar/fs.go
+++ b/providers/os/connection/tar/fs.go
@@ -5,8 +5,8 @@ package tar
 
 import (
 	"archive/tar"
-	"bufio"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -147,7 +147,7 @@ func (fs *FS) resolveSymlink(header *tar.Header) string {
 	return path
 }
 
-func (fs *FS) open(header *tar.Header) (*bufio.Reader, error) {
+func (fs *FS) open(header *tar.Header) (io.Reader, error) {
 	log.Debug().Str("file", header.Name).Msg("tar> load file content")
 
 	// open tar file

--- a/providers/os/fsutil/stream.go
+++ b/providers/os/fsutil/stream.go
@@ -49,10 +49,13 @@ func StreamFileAsTar(
 	}
 }
 
-func ExtractFileFromTarStream(path string, tarReader io.Reader) (*bufio.Reader, error) {
+// ExtractFileFromTarStream returns the content of path inside the tar stream.
+// The tar header states the exact entry size, so the content goes into a slice
+// of that size. This avoids the repeated buffer growth of bytes.Buffer, which
+// allocates about twice the entry size for large files.
+func ExtractFileFromTarStream(path string, tarReader io.Reader) (io.Reader, error) {
 	log.Debug().Str("path", path).Msg("fsutil> extract file from tar")
-	var fileBuffer bytes.Buffer
-	bufWriter := bufio.NewWriter(&fileBuffer)
+	var content []byte
 
 	// read stream tar, extract on the fly and put it on stdout
 	tr := tar.NewReader(tarReader)
@@ -67,12 +70,20 @@ func ExtractFileFromTarStream(path string, tarReader io.Reader) (*bufio.Reader, 
 		// log.Debug().Msgf("File %s, Size: %d", h.Name, h.Size)
 		if h.Name == path {
 			log.Debug().Str("path", path).Msg("fsutil> found file")
-			if _, err := io.CopyN(bufWriter, tr, h.Size); err != nil {
+			if h.Size <= 0 {
+				continue
+			}
+			chunk := make([]byte, h.Size)
+			if _, err := io.ReadFull(tr, chunk); err != nil {
 				return nil, err
+			}
+			if content == nil {
+				content = chunk
+			} else {
+				content = append(content, chunk...)
 			}
 		}
 	}
 
-	bufWriter.Flush()
-	return bufio.NewReader(&fileBuffer), nil
+	return bytes.NewReader(content), nil
 }

--- a/providers/os/fsutil/stream.go
+++ b/providers/os/fsutil/stream.go
@@ -49,10 +49,20 @@ func StreamFileAsTar(
 	}
 }
 
+// maxTarEntryPrealloc caps the buffer that ExtractFileFromTarStream allocates from the
+// declared entry size. A container image can come from an untrusted registry, and a
+// malformed header can declare a size that its data does not match. Entries above the cap
+// use incremental growth instead, so the header alone cannot drive a huge allocation.
+const maxTarEntryPrealloc = 64 << 20
+
 // ExtractFileFromTarStream returns the content of path inside the tar stream.
-// The tar header states the exact entry size, so the content goes into a slice
-// of that size. This avoids the repeated buffer growth of bytes.Buffer, which
-// allocates about twice the entry size for large files.
+//
+// The tar header states the entry size, so the content goes into a slice of that size.
+// This avoids the repeated growth of a bytes.Buffer, which allocates about twice the entry
+// size. The size is only trusted up to maxTarEntryPrealloc.
+//
+// The loop reads the whole stream and concatenates every entry that carries the path. That
+// keeps the behaviour of the earlier implementation for a tar that repeats a name.
 func ExtractFileFromTarStream(path string, tarReader io.Reader) (io.Reader, error) {
 	log.Debug().Str("path", path).Msg("fsutil> extract file from tar")
 	var content []byte
@@ -70,11 +80,8 @@ func ExtractFileFromTarStream(path string, tarReader io.Reader) (io.Reader, erro
 		// log.Debug().Msgf("File %s, Size: %d", h.Name, h.Size)
 		if h.Name == path {
 			log.Debug().Str("path", path).Msg("fsutil> found file")
-			if h.Size <= 0 {
-				continue
-			}
-			chunk := make([]byte, h.Size)
-			if _, err := io.ReadFull(tr, chunk); err != nil {
+			chunk, err := readTarEntry(tr, h.Size)
+			if err != nil {
 				return nil, err
 			}
 			if content == nil {
@@ -86,4 +93,27 @@ func ExtractFileFromTarStream(path string, tarReader io.Reader) (io.Reader, erro
 	}
 
 	return bytes.NewReader(content), nil
+}
+
+// readTarEntry reads size bytes of the current tar entry. It allocates the exact size when
+// the entry fits the prealloc cap. A larger entry grows a bytes.Buffer instead, so only the
+// data that the reader really delivers is allocated.
+func readTarEntry(tr *tar.Reader, size int64) ([]byte, error) {
+	if size <= 0 {
+		return nil, nil
+	}
+	if size <= maxTarEntryPrealloc {
+		chunk := make([]byte, size)
+		if _, err := io.ReadFull(tr, chunk); err != nil {
+			return nil, err
+		}
+		return chunk, nil
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(maxTarEntryPrealloc)
+	if _, err := io.CopyN(&buf, tr, size); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/providers/os/fsutil/stream_bench_test.go
+++ b/providers/os/fsutil/stream_bench_test.go
@@ -57,6 +57,12 @@ func BenchmarkExtractFileFromTarStream16MB(b *testing.B) {
 	benchmarkExtractFileFromTarStream(b, 500, 16<<20)
 }
 
+// 64 MiB is the largest entry that still uses the exact prealloc path.
+func BenchmarkExtractFileFromTarStream64MB(b *testing.B) {
+	benchmarkExtractFileFromTarStream(b, 200, 64<<20)
+}
+
+// 128 MiB is above maxTarEntryPrealloc, so this uses the incremental growth path.
 func BenchmarkExtractFileFromTarStream128MB(b *testing.B) {
 	benchmarkExtractFileFromTarStream(b, 200, 128<<20)
 }

--- a/providers/os/fsutil/stream_bench_test.go
+++ b/providers/os/fsutil/stream_bench_test.go
@@ -1,0 +1,66 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package fsutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// benchTar builds a tar with n small entries, one entry of targetSize bytes,
+// then n more small entries. This models a flattened container image layer.
+func benchTar(n int, targetSize int) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	write := func(name string, size int) {
+		_ = tw.WriteHeader(&tar.Header{Name: name, Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(size)})
+		if size > 0 {
+			_, _ = tw.Write(make([]byte, size))
+		}
+	}
+	for i := 0; i < n; i++ {
+		write(fmt.Sprintf("usr/share/doc/f-%06d", i), 128)
+	}
+	write("usr/bin/target", targetSize)
+	for i := 0; i < n; i++ {
+		write(fmt.Sprintf("usr/lib/g-%06d", i), 128)
+	}
+	tw.Close()
+	return buf.Bytes()
+}
+
+func benchmarkExtractFileFromTarStream(b *testing.B, entries, size int) {
+	data := benchTar(entries, size)
+	b.ReportAllocs()
+	b.SetBytes(int64(size))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := ExtractFileFromTarStream("usr/bin/target", bytes.NewReader(data))
+		require.NoError(b, err)
+		n, err := io.Copy(io.Discard, r)
+		require.NoError(b, err)
+		require.Equal(b, int64(size), n)
+	}
+}
+
+func BenchmarkExtractFileFromTarStream1MB(b *testing.B) {
+	benchmarkExtractFileFromTarStream(b, 500, 1<<20)
+}
+
+func BenchmarkExtractFileFromTarStream16MB(b *testing.B) {
+	benchmarkExtractFileFromTarStream(b, 500, 16<<20)
+}
+
+func BenchmarkExtractFileFromTarStream128MB(b *testing.B) {
+	benchmarkExtractFileFromTarStream(b, 200, 128<<20)
+}
+
+func BenchmarkExtractFileFromTarStream4KB(b *testing.B) {
+	benchmarkExtractFileFromTarStream(b, 2000, 4096)
+}

--- a/providers/os/fsutil/stream_test.go
+++ b/providers/os/fsutil/stream_test.go
@@ -57,3 +57,63 @@ func TestStreamFileAsTar(t *testing.T) {
 	_, err = tr.Next()
 	assert.Equal(t, io.EOF, err, "archive must terminate with a valid tar trailer")
 }
+
+// TestExtractFileFromTarStreamLyingHeader checks that a header which declares far more data
+// than the entry holds does not drive the allocation. The read must fail instead.
+func TestExtractFileFromTarStreamLyingHeader(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	// Write a small entry, then rewrite its header to claim a huge size.
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "big", Typeflag: tar.TypeReg, Mode: 0o644, Size: 4}))
+	_, err := tw.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	raw := buf.Bytes()
+	// Overwrite the size field of the first header block with 1 TiB in octal.
+	copy(raw[124:136], []byte("20000000000\x00"))
+
+	_, err = ExtractFileFromTarStream("big", bytes.NewReader(raw))
+	require.Error(t, err)
+}
+
+// TestExtractFileFromTarStreamEmptyEntry checks that a zero length match returns an empty
+// reader and no error, the same as a path that is not present at all.
+func TestExtractFileFromTarStreamEmptyEntry(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "empty", Typeflag: tar.TypeReg, Mode: 0o644, Size: 0}))
+	require.NoError(t, tw.Close())
+
+	r, err := ExtractFileFromTarStream("empty", bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	content, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+
+	r, err = ExtractFileFromTarStream("missing", bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	content, err = io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Empty(t, content)
+}
+
+// TestExtractFileFromTarStreamLargeEntry checks the incremental path above the prealloc cap.
+func TestExtractFileFromTarStreamLargeEntry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates more than the prealloc cap")
+	}
+	size := maxTarEntryPrealloc + (1 << 20)
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "large", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(size)}))
+	_, err := tw.Write(make([]byte, size))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	r, err := ExtractFileFromTarStream("large", bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	n, err := io.Copy(io.Discard, r)
+	require.NoError(t, err)
+	assert.Equal(t, int64(size), n)
+}


### PR DESCRIPTION
## What allocates

The container image scanner extracts a file with `ExtractFileFromTarStream`. Every `fs.Open` on a tar or image connection goes through it.

The function copied the tar entry into a `bytes.Buffer` through a `bufio.Writer`. The buffer got no size hint, so it grew by doubling. A file of N bytes therefore allocated about 2N bytes, plus two 4 KiB bufio buffers.

The tar header states the entry size. This change reads the entry into a slice of that size, then returns a `bytes.Reader` over it.

The declared size comes from the header, and a container image can come from an untrusted registry. The size is therefore trusted only up to `maxTarEntryPrealloc`, which is 64 MiB. A larger entry grows a `bytes.Buffer` instead, so a malformed header alone cannot drive the allocation.

## Measured numbers

The benchmark builds a tar with small entries around one target entry, which models a flattened image layer. The old implementation is benchmarked in the same package against the same fixture.

```
go test ./providers/os/fsutil/ -run=X -bench=ExtractFileFromTarStream -benchmem -benchtime=10x -count=5
```

Median of 5 runs:

| entry size | B/op before | B/op after | change |
|---|---|---|---|
| 4 KiB | 1,605,973 | 1,594,916 | -0.7% |
| 1 MiB | 2,507,418 | 1,452,743 | -42.1% |
| 16 MiB | 33,964,915 | 17,178,860 | -49.4% |
| 64 MiB | 134,391,466 | 67,273,786 | -49.9% |
| 128 MiB | 268,607,544 | 201,493,172 | -25.0% |

The 128 MiB entry is above the cap, so it uses the incremental path. It still improves, because the buffer starts at the cap instead of at zero.

Live heap for one 128 MiB extract, measured with `runtime.ReadMemStats` around the call on the version without the cap: bytes allocated during the extract fell from 256.1 MB to 128.1 MB, and the live heap after the extract fell from 449.5 MB to 385.5 MB.

## Time cost

There is no time cost. Median ns/op:

| entry size | before | after |
|---|---|---|
| 4 KiB | 7,005,773 | 6,968,916 |
| 1 MiB | 2,708,559 | 2,197,377 |
| 16 MiB | 9,888,202 | 6,023,807 |
| 64 MiB | 21,718,433 | 15,883,143 |
| 128 MiB | 46,301,599 | 28,719,134 |

It is faster at every size, because it removes one full copy through the `bufio.Writer` and the repeated buffer growth. No gate is needed, because the output bytes are identical.

## Correctness

* `go test ./providers/os/fsutil/... ./providers/os/connection/tar/... -count=1` passes.
* `TestExtractFileFromTarStreamLyingHeader` writes an entry that holds 4 bytes and rewrites the header to declare 1 TiB. The call returns an error, and the allocation stays at the cap.
* `TestExtractFileFromTarStreamEmptyEntry` checks that a zero length match returns an empty reader and a nil error, the same as a path that is absent.
* `TestExtractFileFromTarStreamLargeEntry` covers an entry above the cap.
* A missing path still returns an empty reader and a nil error.
* Repeated entries with the same name still concatenate, as before. The loop reads the whole stream for that reason, and the code now says so.
* `ExtractFileFromTarStream` now returns `io.Reader` instead of `*bufio.Reader`. The only caller is `tar.FS.open`, and `tar.File` only calls `Read`.
