### PR TITLE
⚡ os: add a fast path to the tar Abs helper

### DIFF
--- a/providers/os/connection/tar/path.go
+++ b/providers/os/connection/tar/path.go
@@ -14,7 +14,34 @@ import (
 
 // docker images only use relative paths, we need to make them absolute here
 func Abs(path string) string {
+	// Most tar entries are already clean relative paths such as "usr/bin/ls". Such a path
+	// only needs a leading separator, which is one allocation. The join and Clean pair below
+	// needs three, because it builds the joined string, then a Clean buffer, then the result.
+	if isCleanRelative(path) {
+		return "/" + path
+	}
 	return join("/", path)
+}
+
+// isCleanRelative reports whether path is a relative path that Clean leaves unchanged.
+// Such a path is not empty, starts and ends with a name character, and holds no empty,
+// "." or ".." element.
+func isCleanRelative(path string) bool {
+	if path == "" || path[0] == Separator || path[len(path)-1] == Separator {
+		return false
+	}
+	start := 0
+	for i := 0; i <= len(path); i++ {
+		if i < len(path) && path[i] != Separator {
+			continue
+		}
+		switch path[start:i] {
+		case "", ".", "..":
+			return false
+		}
+		start = i + 1
+	}
+	return true
 }
 
 const (

--- a/providers/os/connection/tar/path_test.go
+++ b/providers/os/connection/tar/path_test.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tar
+
+import (
+	archivetar "archive/tar"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// absSlow is the implementation Abs used before the fast path was added. The tests
+// compare Abs against it, so the fast path must return the same string.
+func absSlow(path string) string {
+	return join("/", path)
+}
+
+var absCases = []string{
+	"",
+	".",
+	"..",
+	"/",
+	"//",
+	"usr",
+	"usr/bin/ls",
+	"/usr/bin/ls",
+	"./usr/bin/ls",
+	"usr//bin/ls",
+	"usr/bin/",
+	"usr/./bin/ls",
+	"usr/../bin/ls",
+	"../etc/passwd",
+	"etc/",
+	"/etc",
+	"a/b/c/d/e/f/g",
+	"var/lib/dpkg/info/base-files.list",
+	"...",
+	"a/.../b",
+	".hidden/file",
+	"a/..b/c",
+	"a/b../c",
+}
+
+func TestAbsMatchesJoinAndClean(t *testing.T) {
+	for _, path := range absCases {
+		t.Run(path, func(t *testing.T) {
+			assert.Equal(t, absSlow(path), Abs(path))
+		})
+	}
+}
+
+func FuzzAbsMatchesJoinAndClean(f *testing.F) {
+	for _, path := range absCases {
+		f.Add(path)
+	}
+	f.Fuzz(func(t *testing.T, path string) {
+		assert.Equal(t, absSlow(path), Abs(path))
+	})
+}
+
+func BenchmarkAbs(b *testing.B) {
+	paths := []string{
+		"usr/bin/ls",
+		"usr/share/doc/package-000123/module_1.py",
+		"etc/ssl/certs/ca-certificates.crt",
+		"/var/lib/dpkg/info/base-files.list",
+		"usr/lib/python3.11/site-packages/pip/_vendor/urllib3/util/ssl_.py",
+		"./opt/app/config.yaml",
+		"var/log/",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Abs(paths[i%len(paths)])
+	}
+}
+
+// buildImageTar writes a tar whose entry names look like a flattened container image.
+func buildImageTar(b *testing.B, n int) string {
+	b.Helper()
+	p := filepath.Join(b.TempDir(), "image.tar")
+	f, err := os.Create(p)
+	require.NoError(b, err)
+	tw := archivetar.NewWriter(f)
+	dirs := []string{"usr/share/doc", "usr/lib/python3.11/site-packages", "usr/bin", "etc", "var/lib/dpkg/info"}
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("%s/package-%06d/module_%d.py", dirs[i%len(dirs)], i/7, i)
+		require.NoError(b, tw.WriteHeader(&archivetar.Header{
+			Name: name, Typeflag: archivetar.TypeReg, Mode: 0o644, Uname: "root", Gname: "root",
+		}))
+	}
+	require.NoError(b, tw.Close())
+	require.NoError(b, f.Close())
+	return p
+}
+
+// BenchmarkLoadImageTar loads a 50000 entry image tar, which calls Abs once per entry.
+func BenchmarkLoadImageTar(b *testing.B) {
+	p := buildImageTar(b, 50000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := &Connection{fs: NewFs(p)}
+		require.NoError(b, c.LoadFile(p))
+	}
+}


### PR DESCRIPTION
## What allocates

The container image scanner flattens the image to a tar, then indexes it. `tar.Connection.Load` calls `Abs` once for every entry, to turn the relative entry name into the map key of `FS.FileMap`.

`Abs` called `join("/", path)`, which calls `strings.Join` and then `Clean`. That is three allocations per entry:

1. the joined string `"//usr/bin/ls"`,
2. the `lazybuf` byte buffer inside `Clean`,
3. the result string built from that buffer.

Most tar entries are already clean relative paths such as `usr/bin/ls`. Such a path only needs a leading separator, which is one allocation. This change adds that fast path and keeps `join` and `Clean` for every other shape.

## Measured numbers

`Abs` over a mixed path list, `go test ./providers/os/connection/tar/ -run=X -bench=BenchmarkAbs -benchmem -count=5`:

| | before | after | change |
|---|---|---|---|
| B/op | 118 | 64 | -45.8% |
| allocs/op | 3 | 1 | -66.7% |
| ns/op | 167.6 | 104.1 | -37.9% |

Loading a 50,000 entry image tar, `go test ./providers/os/connection/tar/ -run=X -bench=Load -benchmem -benchtime=20x -count=3`:

| | before | after | change |
|---|---|---|---|
| B/op | 33,689,435 | 27,999,881 | -16.9% |
| allocs/op | 900,302 | 800,302 | -11.1% |
| ns/op | 195,544,088 | 183,072,904 | -6.4% |

That is 100,000 fewer allocations for 50,000 entries, which is the two saved allocations per entry.

## Time cost

There is no time cost. The fast path is faster at both scales. No gate is needed, because the returned string is identical.

## Correctness

* `TestAbsMatchesJoinAndClean` compares `Abs` against the previous `join("/", path)` implementation over 23 path shapes, including `""`, `"/"`, `"//"`, `"."`, `".."`, trailing slashes, double slashes, inner `.` and `..` elements, and names such as `"..b"` and `"..."` that only look like dot elements.
* `FuzzAbsMatchesJoinAndClean` compares the two implementations on fuzzed input. `go test ./providers/os/connection/tar/ -run=XXX -fuzz=FuzzAbsMatchesJoinAndClean -fuzztime=45s` ran 936,488 executions with no mismatch.
* `go test ./providers/os/connection/tar/... ./providers/os/fsutil/... -count=1` passes.
