### PR TITLE
🧹 ms365: add three SharePoint tenant sharing settings to tenantConfig

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -4589,7 +4589,8 @@ private ms365.sharepointonline.tenantConfig {
   //
   // Empty when every user may share externally. A non-empty list restricts
   // guest sharing to the members of those groups, which is what limiting
-  // external sharing by security group means.
+  // external sharing by security group means. Null, as distinct from empty,
+  // when the tenant does not report the setting.
   whoCanShareAuthenticatedGuestAllowList []string
 }
 

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -4570,6 +4570,27 @@ private ms365.sharepointonline.tenantConfig {
   isUnmanagedSyncClientForTenantRestricted bool
   // Whether downloading files detected as infected is blocked
   disallowInfectedFileDownload bool
+  // Whether SharePoint and OneDrive use Microsoft Entra B2B for guest sharing
+  //
+  // When true, guests are invited through Entra B2B and are subject to its
+  // authentication and lifecycle controls, instead of the one-time-passcode
+  // flow SharePoint uses on its own. Null when the tenant does not report
+  // the setting.
+  enableAzureADB2BIntegration bool
+  // External sharing capability for OneDrive
+  //
+  // One of Disabled, ExistingExternalUserSharingOnly,
+  // ExternalUserSharingOnly, or ExternalUserAndGuestSharing, capping how
+  // broadly OneDrive content can be shared independently of
+  // `sharingCapability`, which caps SharePoint. Null when the tenant does
+  // not report the setting.
+  oneDriveSharingCapability string
+  // Object IDs of the security groups whose members may share with authenticated guests
+  //
+  // Empty when every user may share externally. A non-empty list restricts
+  // guest sharing to the members of those groups, which is what limiting
+  // external sharing by security group means.
+  whoCanShareAuthenticatedGuestAllowList []string
 }
 
 // Microsoft 365 SharePoint Site

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -4987,6 +4987,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.sharepointonline.tenantConfig.disallowInfectedFileDownload": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365SharepointonlineTenantConfig).GetDisallowInfectedFileDownload()).ToDataRes(types.Bool)
 	},
+	"ms365.sharepointonline.tenantConfig.enableAzureADB2BIntegration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365SharepointonlineTenantConfig).GetEnableAzureADB2BIntegration()).ToDataRes(types.Bool)
+	},
+	"ms365.sharepointonline.tenantConfig.oneDriveSharingCapability": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365SharepointonlineTenantConfig).GetOneDriveSharingCapability()).ToDataRes(types.String)
+	},
+	"ms365.sharepointonline.tenantConfig.whoCanShareAuthenticatedGuestAllowList": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMs365SharepointonlineTenantConfig).GetWhoCanShareAuthenticatedGuestAllowList()).ToDataRes(types.Array(types.String))
+	},
 	"ms365.sharepointonline.site.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365SharepointonlineSite).GetUrl()).ToDataRes(types.String)
 	},
@@ -11754,6 +11763,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ms365.sharepointonline.tenantConfig.disallowInfectedFileDownload": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMs365SharepointonlineTenantConfig).DisallowInfectedFileDownload, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ms365.sharepointonline.tenantConfig.enableAzureADB2BIntegration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365SharepointonlineTenantConfig).EnableAzureADB2BIntegration, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ms365.sharepointonline.tenantConfig.oneDriveSharingCapability": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365SharepointonlineTenantConfig).OneDriveSharingCapability, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ms365.sharepointonline.tenantConfig.whoCanShareAuthenticatedGuestAllowList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMs365SharepointonlineTenantConfig).WhoCanShareAuthenticatedGuestAllowList, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"ms365.sharepointonline.site.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28112,6 +28133,9 @@ type mqlMs365SharepointonlineTenantConfig struct {
 	ConditionalAccessPolicy                    plugin.TValue[string]
 	IsUnmanagedSyncClientForTenantRestricted   plugin.TValue[bool]
 	DisallowInfectedFileDownload               plugin.TValue[bool]
+	EnableAzureADB2BIntegration                plugin.TValue[bool]
+	OneDriveSharingCapability                  plugin.TValue[string]
+	WhoCanShareAuthenticatedGuestAllowList     plugin.TValue[[]any]
 }
 
 // createMs365SharepointonlineTenantConfig creates a new instance of this resource
@@ -28228,6 +28252,18 @@ func (c *mqlMs365SharepointonlineTenantConfig) GetIsUnmanagedSyncClientForTenant
 
 func (c *mqlMs365SharepointonlineTenantConfig) GetDisallowInfectedFileDownload() *plugin.TValue[bool] {
 	return &c.DisallowInfectedFileDownload
+}
+
+func (c *mqlMs365SharepointonlineTenantConfig) GetEnableAzureADB2BIntegration() *plugin.TValue[bool] {
+	return &c.EnableAzureADB2BIntegration
+}
+
+func (c *mqlMs365SharepointonlineTenantConfig) GetOneDriveSharingCapability() *plugin.TValue[string] {
+	return &c.OneDriveSharingCapability
+}
+
+func (c *mqlMs365SharepointonlineTenantConfig) GetWhoCanShareAuthenticatedGuestAllowList() *plugin.TValue[[]any] {
+	return &c.WhoCanShareAuthenticatedGuestAllowList
 }
 
 // mqlMs365SharepointonlineSite for the ms365.sharepointonline.site resource

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -1630,11 +1630,13 @@ ms365.sharepointonline.tenantConfig.defaultSharingLinkType 13.2.2
 ms365.sharepointonline.tenantConfig.disallowInfectedFileDownload 13.2.2
 ms365.sharepointonline.tenantConfig.emailAttestationReAuthDays 13.2.2
 ms365.sharepointonline.tenantConfig.emailAttestationRequired 13.2.2
+ms365.sharepointonline.tenantConfig.enableAzureADB2BIntegration 13.10.4
 ms365.sharepointonline.tenantConfig.externalUserExpirationRequired 13.2.2
 ms365.sharepointonline.tenantConfig.externalUserExpireInDays 13.2.2
 ms365.sharepointonline.tenantConfig.isUnmanagedSyncClientForTenantRestricted 13.2.2
 ms365.sharepointonline.tenantConfig.legacyAuthProtocolsEnabled 13.2.2
 ms365.sharepointonline.tenantConfig.notifyOwnersWhenItemsReshared 13.2.2
+ms365.sharepointonline.tenantConfig.oneDriveSharingCapability 13.10.4
 ms365.sharepointonline.tenantConfig.preventExternalUsersFromResharing 13.2.2
 ms365.sharepointonline.tenantConfig.requireAcceptingAccountMatchInvitedAccount 13.2.2
 ms365.sharepointonline.tenantConfig.requireAnonymousLinksExpireInDays 13.2.2
@@ -1645,6 +1647,7 @@ ms365.sharepointonline.tenantConfig.sharingDomainRestrictionMode 13.2.2
 ms365.sharepointonline.tenantConfig.showAllUsersClaim 13.2.2
 ms365.sharepointonline.tenantConfig.showEveryoneClaim 13.2.2
 ms365.sharepointonline.tenantConfig.showEveryoneExceptExternalUsersClaim 13.2.2
+ms365.sharepointonline.tenantConfig.whoCanShareAuthenticatedGuestAllowList 13.10.4
 ms365.sharepointonline.tenantConfiguration 13.2.2
 ms365.teams 9.0.0
 ms365.teams.channel 13.3.1

--- a/providers/ms365/resources/ms365_sharepoint.go
+++ b/providers/ms365/resources/ms365_sharepoint.go
@@ -95,6 +95,18 @@ type SpoSite struct {
 	Status                   string `json:"Status"`
 }
 
+// stringListData keeps a nil slice null instead of turning it into an empty
+// array. convert.SliceAnyToInterface allocates for a nil input, so passing its
+// result straight to llx.ArrayData would report a setting the tenant never
+// returned as an empty list -- e.g. "no security group restricts guest
+// sharing", which is a security answer rather than a missing one.
+func stringListData(v []string) *llx.RawData {
+	if v == nil {
+		return llx.NilData
+	}
+	return llx.ArrayData(convert.SliceAnyToInterface(v), types.String)
+}
+
 func (m *mqlMs365SharepointonlineSite) id() (string, error) {
 	return m.Url.Data, nil
 }
@@ -269,8 +281,8 @@ func (r *mqlMs365Sharepointonline) getSharepointOnlineReport() error {
 				"disallowInfectedFileDownload":               llx.BoolData(tenantConfig.DisallowInfectedFileDownload),
 				"enableAzureADB2BIntegration":                llx.BoolDataPtr(tenantConfig.EnableAzureADB2BIntegration),
 				"oneDriveSharingCapability":                  llx.StringDataPtr(tenantConfig.OneDriveSharingCapability),
-				"whoCanShareAuthenticatedGuestAllowList": llx.ArrayData(
-					convert.SliceAnyToInterface(tenantConfig.WhoCanShareAuthenticatedGuestAllowList), types.String),
+				"whoCanShareAuthenticatedGuestAllowList": stringListData(
+					tenantConfig.WhoCanShareAuthenticatedGuestAllowList),
 			})
 		if mqlTenantConfigErr != nil {
 			r.TenantConfiguration = plugin.TValue[*mqlMs365SharepointonlineTenantConfig]{State: plugin.StateIsSet, Error: mqlTenantConfigErr}

--- a/providers/ms365/resources/ms365_sharepoint.go
+++ b/providers/ms365/resources/ms365_sharepoint.go
@@ -19,6 +19,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/ms365/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 var sharepointReport = `
@@ -74,6 +75,11 @@ type SpoTenantConfig struct {
 	ConditionalAccessPolicy                    string `json:"ConditionalAccessPolicy"`
 	IsUnmanagedSyncClientForTenantRestricted   bool   `json:"IsUnmanagedSyncClientForTenantRestricted"`
 	DisallowInfectedFileDownload               bool   `json:"DisallowInfectedFileDownload"`
+	// pointers so that a tenant which does not report the setting yields null
+	// rather than a zero value that reads as "disabled"
+	EnableAzureADB2BIntegration            *bool    `json:"EnableAzureADB2BIntegration"`
+	OneDriveSharingCapability              *string  `json:"OneDriveSharingCapability"`
+	WhoCanShareAuthenticatedGuestAllowList []string `json:"WhoCanShareAuthenticatedGuestAllowList"`
 }
 
 type SpoSite struct {
@@ -261,6 +267,10 @@ func (r *mqlMs365Sharepointonline) getSharepointOnlineReport() error {
 				"conditionalAccessPolicy":                    llx.StringData(tenantConfig.ConditionalAccessPolicy),
 				"isUnmanagedSyncClientForTenantRestricted":   llx.BoolData(tenantConfig.IsUnmanagedSyncClientForTenantRestricted),
 				"disallowInfectedFileDownload":               llx.BoolData(tenantConfig.DisallowInfectedFileDownload),
+				"enableAzureADB2BIntegration":                llx.BoolDataPtr(tenantConfig.EnableAzureADB2BIntegration),
+				"oneDriveSharingCapability":                  llx.StringDataPtr(tenantConfig.OneDriveSharingCapability),
+				"whoCanShareAuthenticatedGuestAllowList": llx.ArrayData(
+					convert.SliceAnyToInterface(tenantConfig.WhoCanShareAuthenticatedGuestAllowList), types.String),
 			})
 		if mqlTenantConfigErr != nil {
 			r.TenantConfiguration = plugin.TValue[*mqlMs365SharepointonlineTenantConfig]{State: plugin.StateIsSet, Error: mqlTenantConfigErr}

--- a/providers/ms365/resources/ms365_sharepoint_test.go
+++ b/providers/ms365/resources/ms365_sharepoint_test.go
@@ -4,10 +4,66 @@
 package resources
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSpoTenantConfigSharingFields(t *testing.T) {
+	t.Run("reported by the tenant", func(t *testing.T) {
+		cfg := &SpoTenantConfig{}
+		err := json.Unmarshal([]byte(`{
+			"EnableAzureADB2BIntegration": true,
+			"OneDriveSharingCapability": "Disabled",
+			"WhoCanShareAuthenticatedGuestAllowList": ["a1b2c3d4-0000-0000-0000-000000000001"]
+		}`), cfg)
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg.EnableAzureADB2BIntegration)
+		assert.True(t, *cfg.EnableAzureADB2BIntegration)
+		require.NotNil(t, cfg.OneDriveSharingCapability)
+		assert.Equal(t, "Disabled", *cfg.OneDriveSharingCapability)
+		assert.Equal(t, []string{"a1b2c3d4-0000-0000-0000-000000000001"},
+			cfg.WhoCanShareAuthenticatedGuestAllowList)
+	})
+
+	// a tenant that omits the properties must not read as "B2B off, OneDrive
+	// unrestricted" -- the pointers stay nil so the fields resolve to null
+	t.Run("omitted by the tenant", func(t *testing.T) {
+		cfg := &SpoTenantConfig{}
+		err := json.Unmarshal([]byte(`{"SharingCapability": "Disabled"}`), cfg)
+		require.NoError(t, err)
+
+		assert.Nil(t, cfg.EnableAzureADB2BIntegration)
+		assert.Nil(t, cfg.OneDriveSharingCapability)
+		assert.Nil(t, cfg.WhoCanShareAuthenticatedGuestAllowList)
+	})
+
+	t.Run("reported as null", func(t *testing.T) {
+		cfg := &SpoTenantConfig{}
+		err := json.Unmarshal([]byte(`{
+			"EnableAzureADB2BIntegration": null,
+			"OneDriveSharingCapability": null,
+			"WhoCanShareAuthenticatedGuestAllowList": null
+		}`), cfg)
+		require.NoError(t, err)
+
+		assert.Nil(t, cfg.EnableAzureADB2BIntegration)
+		assert.Nil(t, cfg.OneDriveSharingCapability)
+		assert.Nil(t, cfg.WhoCanShareAuthenticatedGuestAllowList)
+	})
+
+	// no security group restricts guest sharing
+	t.Run("empty allow list", func(t *testing.T) {
+		cfg := &SpoTenantConfig{}
+		err := json.Unmarshal([]byte(`{"WhoCanShareAuthenticatedGuestAllowList": []}`), cfg)
+		require.NoError(t, err)
+
+		assert.Empty(t, cfg.WhoCanShareAuthenticatedGuestAllowList)
+	})
+}
 
 func TestExtractSharepointTenant(t *testing.T) {
 	tests := []struct {

--- a/providers/ms365/resources/ms365_sharepoint_test.go
+++ b/providers/ms365/resources/ms365_sharepoint_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func TestSpoTenantConfigSharingFields(t *testing.T) {
@@ -62,6 +64,26 @@ func TestSpoTenantConfigSharingFields(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Empty(t, cfg.WhoCanShareAuthenticatedGuestAllowList)
+	})
+}
+
+func TestStringListData(t *testing.T) {
+	// the distinction that matters: a tenant that never reported the setting
+	// must not read as one that reported no groups
+	t.Run("nil is null", func(t *testing.T) {
+		assert.Equal(t, llx.NilData, stringListData(nil))
+	})
+
+	t.Run("empty is an empty array", func(t *testing.T) {
+		got := stringListData([]string{})
+		assert.Equal(t, types.Array(types.String), got.Type)
+		assert.Equal(t, []any{}, got.Value)
+	})
+
+	t.Run("values are preserved", func(t *testing.T) {
+		got := stringListData([]string{"group-a", "group-b"})
+		assert.Equal(t, types.Array(types.String), got.Type)
+		assert.Equal(t, []any{"group-a", "group-b"}, got.Value)
 	})
 }
 


### PR DESCRIPTION
Adds three fields to `ms365.sharepointonline.tenantConfig`:

| Field | Type | Why |
|---|---|---|
| `enableAzureADB2BIntegration` | bool | Guest sharing runs through Entra B2B instead of SharePoint's one-time-passcode flow — CIS M365 7.2.2 |
| `oneDriveSharingCapability` | string | OneDrive's external-sharing cap, independent of `sharingCapability`, which caps SharePoint — CIS M365 7.2.4 |
| `whoCanShareAuthenticatedGuestAllowList` | []string | Object IDs of the security groups permitted to share with guests — CIS M365 7.2.8 |

## Why

`tenantConfig` (via `tenantConfiguration()`) is the typed replacement for the deprecated `spoTenant` dict, but these three settings were never carried over. Checks that need them are still pinned to `spoTenant` and cannot be migrated off the deprecated field — see mondoohq/cnspec-enterprise-policies for the three CIS Microsoft 365 checks blocked on exactly these names.

All three are properties of PnP's [`SPOTenant` model](https://github.com/pnp/powershell/blob/dev/src/Commands/Model/SPOTenant.cs) (`EnableAzureADB2BIntegration`, `OneDriveSharingCapability`, `WhoCanShareAuthenticatedGuestAllowList`), which is what `Get-PnPTenant` returns — so they are already inside the payload `ms365_sharepoint.go` decodes. No extra API call, no new permission.

## Nullability

The two scalars are `*bool` / `*string` in `SpoTenantConfig` and are emitted with `llx.BoolDataPtr` / `llx.StringDataPtr`, so a tenant that does not report them resolves to **null** rather than `false` / `""`. That distinction matters here: a zero value would read as "B2B integration is off" and "OneDrive sharing is unset", which is a wrong answer for a compliance check rather than a missing one. (`OneDriveSharingCapability` is a nullable enum on the PnP side, and the report script already runs `ConvertTo-Json -EnumsAsStrings`.)

The allow list is a plain `[]string`; empty means no security group restricts guest sharing.

## Test plan

- `go test ./resources/` in `providers/ms365` — passes, including a new `TestSpoTenantConfigSharingFields` covering the four decode cases: properties present, omitted, explicitly null, and an empty allow list.
- `make providers/build/ms365` — regenerates `ms365.lr.go` / `ms365.lr.versions` (new fields land at 13.10.4) and compiles the provider.
- `go vet ./resources/` — clean for the touched files; the two `users.go` warnings are pre-existing.
- `gofmt -l` — clean.

Not exercised against a live tenant; the decode path is covered by the unit test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)