### PR TITLE
⚡ os: share one string between the tar file map key and the header name

### DIFF
--- a/providers/os/connection/tar/connection.go
+++ b/providers/os/connection/tar/connection.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -149,6 +150,13 @@ func (c *Connection) Load(stream io.Reader) error {
 		}
 
 		path := Abs(h.Name)
+
+		// The map key holds the entry name with a leading separator, so the name is stored
+		// twice. Point the header name at the tail of the key when the bytes are the same.
+		// Both strings then share one backing array, and the header keeps its exact value.
+		if strings.HasSuffix(path, h.Name) {
+			h.Name = path[len(path)-len(h.Name):]
+		}
 		c.fs.FileMap[path] = h
 	}
 	log.Debug().Int("files", len(c.fs.FileMap)).Msg("tar> successfully loaded")

--- a/providers/os/connection/tar/load_test.go
+++ b/providers/os/connection/tar/load_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tar
+
+import (
+	archivetar "archive/tar"
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// imageTarBytes builds a tar whose entry names look like a flattened container image.
+func imageTarBytes(t testing.TB, n int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := archivetar.NewWriter(&buf)
+	dirs := []string{"usr/share/doc", "usr/lib/python3.11/site-packages", "usr/bin", "etc", "var/lib/dpkg/info"}
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("%s/package-%06d/module_%d.py", dirs[i%len(dirs)], i/7, i)
+		require.NoError(t, tw.WriteHeader(&archivetar.Header{
+			Name: name, Typeflag: archivetar.TypeReg, Mode: 0o644, Uname: "root", Gname: "root",
+		}))
+	}
+	require.NoError(t, tw.Close())
+	return buf.Bytes()
+}
+
+// TestLoadKeepsHeaderNames checks that sharing the backing array of the map key does not
+// change the value of Header.Name. fs.open matches that name against the tar stream.
+func TestLoadKeepsHeaderNames(t *testing.T) {
+	names := []string{
+		"usr/bin/ls",
+		"./etc/hosts",
+		"/var/log/syslog",
+		"usr//share/doc",
+		"opt/app/../app/config.yaml",
+		"srv/data/",
+	}
+
+	var buf bytes.Buffer
+	tw := archivetar.NewWriter(&buf)
+	for _, name := range names {
+		typ := byte(archivetar.TypeReg)
+		if strings.HasSuffix(name, "/") {
+			typ = archivetar.TypeDir
+		}
+		require.NoError(t, tw.WriteHeader(&archivetar.Header{Name: name, Typeflag: typ, Mode: 0o644}))
+	}
+	require.NoError(t, tw.Close())
+
+	// Read the names back the way archive/tar reports them, so the expectation does not
+	// depend on how the writer normalizes them.
+	expected := map[string]string{}
+	tr := archivetar.NewReader(bytes.NewReader(buf.Bytes()))
+	for {
+		h, err := tr.Next()
+		if err != nil {
+			break
+		}
+		expected[Abs(h.Name)] = h.Name
+	}
+	require.NotEmpty(t, expected)
+
+	c := &Connection{fs: NewFs("")}
+	require.NoError(t, c.Load(bytes.NewReader(buf.Bytes())))
+
+	require.Len(t, c.fs.FileMap, len(expected))
+	for path, want := range expected {
+		h, ok := c.fs.FileMap[path]
+		require.True(t, ok, "missing entry for %q", path)
+		assert.Equal(t, want, h.Name, "header name changed for %q", path)
+	}
+}
+
+// BenchmarkLoad loads a 50000 entry image tar. It also reports the heap that the file map
+// holds after the load, as retained-B/entry.
+func BenchmarkLoad(b *testing.B) {
+	const entries = 50000
+	data := imageTarBytes(b, entries)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var c *Connection
+	for i := 0; i < b.N; i++ {
+		c = &Connection{fs: NewFs("")}
+		require.NoError(b, c.Load(bytes.NewReader(data)))
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	var withMap runtime.MemStats
+	runtime.ReadMemStats(&withMap)
+	held := withMap.HeapAlloc
+	c.fs.FileMap = nil
+	runtime.GC()
+	var withoutMap runtime.MemStats
+	runtime.ReadMemStats(&withoutMap)
+	b.ReportMetric(float64(held-withoutMap.HeapAlloc)/float64(entries), "retained-B/entry")
+}


### PR DESCRIPTION
## What allocates

The container image scanner flattens the image to a tar, then `tar.Connection.Load` indexes every entry in `FS.FileMap`. That map lives for the whole scan, so its size is retained heap, not garbage.

The map key is `Abs(h.Name)`, which is the entry name with a leading separator. The header keeps its own copy of the name. The map therefore holds the name twice, in two separate string allocations.

This change points `Header.Name` at the tail of the key when the bytes are the same. Both strings then share one backing array, and the second copy becomes garbage.

`fs.open` matches `Header.Name` against the names in the tar stream, so the value must stay exactly as `archive/tar` reported it. The change only moves where the bytes live.

## Measured numbers

```
go test ./providers/os/connection/tar/ -run=X -bench=BenchmarkLoad -benchmem -benchtime=20x -count=3
```

`BenchmarkLoad` loads a 50,000 entry image tar. It reports `retained-B/entry`, which is the heap the file map holds after the load, measured by dropping the map and comparing `HeapAlloc`.

| | before | after | change |
|---|---|---|---|
| retained-B/entry | 388.4 | 337.4 | -13.1% |
| ns/op | 116,136,721 | 116,336,880 | +0.2% |
| B/op | 33,648,232 | 33,650,119 | no change |
| allocs/op | 900,289 | 900,290 | no change |

For a 100,000 file image the retained file map goes from about 38.9 MB to about 33.7 MB, so about 5.2 MB less held for the whole scan.

`B/op` does not change, and that is expected. `archive/tar` still allocates the name. The change stops the map from holding it, so it becomes collectable instead of retained.

## Time cost

There is no measurable time cost. The added work is one `strings.HasSuffix` per entry, and the 0.2% difference above is inside the run to run spread. No gate is needed, because the map contents are unchanged.

## Correctness

* `TestLoadKeepsHeaderNames` loads a tar with names that exercise every shape where the key and the name differ: a plain relative name, `./etc/hosts`, an absolute `/var/log/syslog`, a double separator, an inner `..` element, and a directory with a trailing separator. It compares every stored `Header.Name` against the name that `archive/tar` reports for the same entry, so the expectation does not depend on how the writer normalizes names.
* `go test ./providers/os/connection/tar/... -count=1` passes.
