### PR TITLE
🐛 os: accept every valid character in a pacman package name

### DIFF
--- a/providers/os/resources/packages/pacman_packages.go
+++ b/providers/os/resources/packages/pacman_packages.go
@@ -29,10 +29,29 @@ const (
 	PacmanLocalDB = "/var/lib/pacman/local"
 )
 
-var PACMAN_REGEX = regexp.MustCompile(`^([\w-]*)\s([\w\d-+.:]+)$`)
+// PACMAN_REGEX splits one line of `pacman -Q`, which prints "<name> <version>".
+//
+// The name class used to be `[\w-]`, which is letters, digits, `_` and `-`.
+// pkgname also allows `.`, `+`, `@` -- so `db5.3`, `libstdc++` and `libc++`
+// did not match, and a line that does not match is appended nowhere. The
+// package left the inventory with no error and no count discrepancy, which is
+// the one outcome a vulnerability scan cannot recover from: an absent package
+// is an unreported CVE. On a stock `archlinux:base-devel` container that is 2
+// of 170 packages.
+//
+// The version is deliberately matched as a run of non-space rather than by
+// enumerating characters. It is `[epoch:]pkgver-pkgrel`, and pkgver alone can
+// carry `.` `_` `+` `~` and VCS suffixes (`0.3.2.r13.g553691a-1`); enumerating
+// that set is what broke the name in the first place. The name keeps a
+// character class because `pacman -Q` output has no other structure to anchor
+// on -- pacman prints its own diagnostics on the same stream ("warning:
+// database file for 'core' does not exist") and those must not parse as
+// packages. pkgname is a set makepkg actually enforces, unlike the version.
+var PACMAN_REGEX = regexp.MustCompile(`^([A-Za-z0-9@._+][A-Za-z0-9@._+-]*)\s(\S+)$`)
 
 func ParsePacmanPackages(pf *inventory.Platform, input io.Reader) []Package {
 	pkgs := []Package{}
+	dropped := 0
 	scanner := bufio.NewScanner(input)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -47,9 +66,32 @@ func ParsePacmanPackages(pf *inventory.Platform, input io.Reader) []Package {
 				FilesAvailable: PkgFilesAsync,
 				PUrl:           purl.NewPackageURL(pf, purl.TypeAlpm, name, version).String(),
 			})
+		} else if strings.TrimSpace(line) != "" && !isPacmanDiagnostic(line) {
+			// A line we cannot parse is a package we do not report. Count it,
+			// so the next drift in this format shows up as a warning instead of
+			// a quietly shorter package list.
+			dropped++
+			log.Debug().Str("line", line).Msg("mql[pacman]> could not parse package line")
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		log.Warn().Err(err).Msg("mql[pacman]> package list was truncated while scanning")
+	}
+	if dropped > 0 {
+		log.Warn().Int("dropped", dropped).Int("parsed", len(pkgs)).
+			Msg("mql[pacman]> some package lines could not be parsed, packages are missing from the inventory")
+	}
 	return pkgs
+}
+
+// isPacmanDiagnostic reports whether a line is pacman talking about itself
+// rather than a package. pacman emits these on hosts whose sync databases are
+// missing, and they turn up in the same stream we parse -- counting them as
+// lost packages would warn on every scan of a perfectly healthy host.
+func isPacmanDiagnostic(line string) bool {
+	return strings.HasPrefix(line, "warning:") ||
+		strings.HasPrefix(line, "error:") ||
+		strings.HasPrefix(line, "::")
 }
 
 // Arch, Manjaro

--- a/providers/os/resources/packages/pacman_packages_charset_test.go
+++ b/providers/os/resources/packages/pacman_packages_charset_test.go
@@ -1,0 +1,151 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/resources/packages"
+)
+
+var pacmanCharsetPlatform = &inventory.Platform{
+	Name:   "arch",
+	Arch:   "x86_64",
+	Family: []string{"arch", "linux", "unix", "os"},
+	Labels: map[string]string{"distro-id": "arch"},
+}
+
+// A package the regex cannot match is dropped from the inventory with no error,
+// and an absent package is exactly what a vulnerability scan cannot report on.
+// The name class used to be `[\w-]`, so every pkgname containing one of the
+// other characters pkgname allows -- `.`, `+`, `@` -- went missing.
+func TestParsePacmanPackages_NameCharacters(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantName    string
+		wantVersion string
+	}{
+		{
+			// stock archlinux:base-devel ships both of these
+			name:     "dot in the name",
+			line:     "db5.3 5.3.28-5",
+			wantName: "db5.3", wantVersion: "5.3.28-5",
+		},
+		{
+			name:     "trailing plus signs",
+			line:     "libstdc++ 16.1.1+r595+g171d15ac6959-1",
+			wantName: "libstdc++", wantVersion: "16.1.1+r595+g171d15ac6959-1",
+		},
+		{
+			name:     "plus signs after a hyphen",
+			line:     "lib32-libstdc++5 3.3.6-8",
+			wantName: "lib32-libstdc++5", wantVersion: "3.3.6-8",
+		},
+		{
+			name:     "leading digit",
+			line:     "0ad 0.0.26-11",
+			wantName: "0ad", wantVersion: "0.0.26-11",
+		},
+		{
+			name:     "digits then hyphen",
+			line:     "2048-qt 0.1.6-8",
+			wantName: "2048-qt", wantVersion: "0.1.6-8",
+		},
+		{
+			name:     "dot and hyphen together",
+			line:     "python3.11-pip 23.2.1-1",
+			wantName: "python3.11-pip", wantVersion: "23.2.1-1",
+		},
+		{
+			name:     "at sign",
+			line:     "gcc@11 11.4.0-1",
+			wantName: "gcc@11", wantVersion: "11.4.0-1",
+		},
+		{
+			name:     "underscore",
+			line:     "sdl2_image 2.8.2-1",
+			wantName: "sdl2_image", wantVersion: "2.8.2-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pkgs := packages.ParsePacmanPackages(pacmanCharsetPlatform, strings.NewReader(tc.line+"\n"))
+			require.Len(t, pkgs, 1, "package was dropped by PACMAN_REGEX")
+			assert.Equal(t, tc.wantName, pkgs[0].Name)
+			assert.Equal(t, tc.wantVersion, pkgs[0].Version)
+			assert.NotEmpty(t, pkgs[0].PUrl)
+		})
+	}
+}
+
+// pkgver carries characters the old class did not enumerate either, and a
+// version is matched as a run of non-space precisely so this set never has to
+// be guessed at again.
+func TestParsePacmanPackages_VersionCharacters(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantVersion string
+	}{
+		{name: "epoch", line: "zlib 1:1.2.11-2", wantVersion: "1:1.2.11-2"},
+		{name: "vcs snapshot", line: "xfce4-pulseaudio-plugin 0.3.2.r13.g553691a-1", wantVersion: "0.3.2.r13.g553691a-1"},
+		{name: "plus separated build", line: "usbmuxd 1.1.0+28+g46bdf3e-1", wantVersion: "1.1.0+28+g46bdf3e-1"},
+		{name: "tilde pre-release", line: "foo 1.0~beta1-1", wantVersion: "1.0~beta1-1"},
+		{name: "pkgrel with a dot", line: "qpdfview 0.4.17beta1-4.1", wantVersion: "0.4.17beta1-4.1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pkgs := packages.ParsePacmanPackages(pacmanCharsetPlatform, strings.NewReader(tc.line+"\n"))
+			require.Len(t, pkgs, 1, "package was dropped by PACMAN_REGEX")
+			assert.Equal(t, tc.wantVersion, pkgs[0].Version)
+		})
+	}
+}
+
+// Widening the name class must not turn pacman's own output into packages.
+// pacman writes these on any host whose sync databases are missing, on the
+// same stream we parse.
+func TestParsePacmanPackages_RejectsNonPackageLines(t *testing.T) {
+	noise := strings.Join([]string{
+		"",
+		"   ",
+		"warning: database file for 'core' does not exist (use '-Sy' to download)",
+		"error: you cannot perform this operation unless you are root.",
+		":: Synchronizing package databases...",
+		"error: failed to synchronize all databases (failed to retrieve some files)",
+		"-rw-r--r-- 1 root root 0 Jan 1 00:00 file",
+	}, "\n")
+
+	pkgs := packages.ParsePacmanPackages(pacmanCharsetPlatform, strings.NewReader(noise+"\n"))
+	assert.Empty(t, pkgs, "non-package lines must not be parsed as packages")
+}
+
+// A realistic listing: every line survives, in order, alongside the diagnostics
+// pacman interleaves with it.
+func TestParsePacmanPackages_RealisticListing(t *testing.T) {
+	listing := `warning: database file for 'core' does not exist (use '-Sy' to download)
+acl 2.3.2-1
+db5.3 5.3.28-5
+gcc-libs 14.2.1+r134+gab884fffe3fc-1
+libstdc++ 16.1.1+r595+g171d15ac6959-1
+sdl2_image 2.8.2-1
+zlib 1:1.3.1-2
+`
+
+	pkgs := packages.ParsePacmanPackages(pacmanCharsetPlatform, strings.NewReader(listing))
+	require.Len(t, pkgs, 6, "every package in the listing must be parsed")
+
+	var names []string
+	for _, p := range pkgs {
+		names = append(names, p.Name)
+	}
+	assert.Equal(t, []string{"acl", "db5.3", "gcc-libs", "libstdc++", "sdl2_image", "zlib"}, names)
+}


### PR DESCRIPTION
## Problem

`PACMAN_REGEX` enumerated the characters a pkgname may contain:

```go
^([\w-]*)\s([\w\d-+.:]+)$
```

`[\w-]` is letters, digits, `_` and `-`. pkgname also allows `.`, `+` and `@`. `ParsePacmanPackages` has no else branch and no log, so a line that doesn't match is simply never appended — the package vanishes from the inventory with no error and no count discrepancy.

Measured against real `pacman -Q` output:

| image | packages | matched by the old regex | lost |
|---|---|---|---|
| `archlinux:latest` | 137 | 136 | `libstdc++` |
| `archlinux:base-devel` | 170 | 168 | `db5.3`, `libstdc++` |

So on any Arch or Manjaro host, `libstdc++`, `libc++`, `db5.3`, `lib32-libstdc++5` and every other dotted or plus-suffixed package is absent, and every CVE against them goes unreported. The version class was too narrow for the same reason — it had no `~`.

Only the `pacman -Q` path is affected. The `/var/lib/pacman/local/*/desc` fallback reads `%NAME%` directly, so the two collection paths disagree about what is installed on the same host.

## Fix

Rather than widen the enumerations one character at a time, match the real invariant where there is one.

```go
^([A-Za-z0-9@._+][A-Za-z0-9@._+-]*)\s(\S+)$
```

**The version is a run of non-space.** It's `[epoch:]pkgver-pkgrel` and contains no whitespace; pkgver alone carries `.` `_` `+` `~` and VCS suffixes like `0.3.2.r13.g553691a-1`. Enumerating that set is precisely what broke the name, so it isn't enumerated.

**The name keeps a character class**, deliberately. `pacman -Q` output has no `__`-style structure to anchor on, and pacman prints its own diagnostics into the same stream (`warning: database file for 'core' does not exist` — there's an existing test for exactly this), so something has to distinguish a package line from prose. pkgname is a set makepkg actually enforces, unlike the version, and it excludes `:` — which is what rejects `warning:` / `error:` lines.

Silent loss is the failure mode this change is about, so it also stops being silent: unparseable lines are counted and the total is reported at warn, with per-line detail at debug. pacman's own diagnostics are excluded from the count — a host with missing sync databases shouldn't warn on every scan. A scanner error, which truncates the list, logs at warn too.

## Tests

`pacman_packages_charset_test.go` — 4 tests, 20 cases. 6 of the new lines fail against the original regex:

- **name characters** (8): `db5.3`, `libstdc++`, `lib32-libstdc++5`, `python3.11-pip`, `gcc@11`, leading digits (`0ad`, `2048-qt`), underscore
- **version characters** (5): epoch, VCS snapshot, `+`-separated build metadata, `~` pre-release, pkgrel with a dot
- **negative** (1): blank lines, `warning:` / `error:` output, `::` progress lines and `ls`-style noise must not parse as packages — widening the name class must not make pacman's own output look like an inventory
- **realistic listing** (1): a listing interleaved with a warning survives intact and in order

All pre-existing pacman tests pass unchanged, including `TestPacmanWithWarningsParser` and the desc-file fallback tests.

## Found by

Reviewing #9441, which fixes the identical bug in `RPM_REGEX`. Same enumeration, same missing else branch, same silent drop.
