### PR TITLE
🎉 os-13.40.7

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.40.6",
+	Version: "13.40.7",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.40.7)
- 🐛 os: accept every valid character in a pacman package name (#9868)
- 🐛 os: accept every valid character in an rpm package name (#9441)