### PR TITLE
⚡ os: compile the CPE patterns once (duplicate of #9856)

### DIFF
--- a/providers/os/resources/cpe/pkg2cpe.go
+++ b/providers/os/resources/cpe/pkg2cpe.go
@@ -11,6 +11,10 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
+// epochRegex matches a leading epoch such as "2:" in "2:4.17.12". NewPackage2Cpe runs once
+// per package, so the pattern is compiled once here and not on every call.
+var epochRegex = regexp.MustCompile(`^\d+:(.*)$`)
+
 func NewPackage2Cpe(vendor, name, version, release, arch string) ([]string, error) {
 	cpes := []string{}
 	vendor = strings.ToLower(vendor)
@@ -21,21 +25,25 @@ func NewPackage2Cpe(vendor, name, version, release, arch string) ([]string, erro
 
 	// Remove epoch when present; otherwise WFNize will only use the epoch as
 	// the version.
-	epochRegex := regexp.MustCompile(`^\d+:(.*)$`)
 	if matches := epochRegex.FindStringSubmatch(version); len(matches) > 1 {
 		version = matches[1]
 	}
 
 	var err error
-	for n, addr := range map[string]*string{
-		"vendor":  &vendor,
-		"name":    &name,
-		"version": &version,
-		"release": &release,
-		"arch":    &arch,
+	// A fixed array avoids building a map on every call, and it reports the same field
+	// first when more than one field fails.
+	for _, field := range [...]struct {
+		name string
+		addr *string
+	}{
+		{"vendor", &vendor},
+		{"name", &name},
+		{"version", &version},
+		{"release", &release},
+		{"arch", &arch},
 	} {
-		if *addr, err = wfn.WFNize(*addr); err != nil {
-			return cpes, fmt.Errorf("couldn't wfnize %s %q: %v", n, *addr, err)
+		if *field.addr, err = wfn.WFNize(*field.addr); err != nil {
+			return cpes, fmt.Errorf("couldn't wfnize %s %q: %v", field.name, *field.addr, err)
 		}
 	}
 

--- a/providers/os/resources/cpe/pkg2cpe_bench_test.go
+++ b/providers/os/resources/cpe/pkg2cpe_bench_test.go
@@ -1,0 +1,38 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cpe
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkNewPackage2Cpe models a package listing. Every package parser calls
+// NewPackage2Cpe at least once per package, so this runs on every OS scan.
+func BenchmarkNewPackage2Cpe(b *testing.B) {
+	type pkg struct{ name, version, epoch, arch string }
+	pkgs := make([]pkg, 0, 2000)
+	for i := 0; i < 2000; i++ {
+		pkgs = append(pkgs, pkg{
+			name:    fmt.Sprintf("libexample-%d", i),
+			version: fmt.Sprintf("1.%d.%d-3ubuntu2", i%20, i%7),
+			epoch:   "",
+			arch:    "amd64",
+		})
+	}
+	// A quarter of the versions carry an epoch, which exercises the epoch pattern.
+	for i := 0; i < len(pkgs); i += 4 {
+		pkgs[i].version = "2:" + pkgs[i].version
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, p := range pkgs {
+			if _, err := NewPackage2Cpe(p.name, p.name, p.version, p.epoch, p.arch); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/providers/os/resources/cpe/platforms.go
+++ b/providers/os/resources/cpe/platforms.go
@@ -12,6 +12,10 @@ import (
 	"go.mondoo.com/mql/v13/utils/stringx"
 )
 
+// amazonLinux1Regex matches the Amazon Linux 1 version scheme. The pattern is compiled
+// once here and not on every CPE build.
+var amazonLinux1Regex = regexp.MustCompile(`^(2017|2018)\.`)
+
 type platformCPEEntry struct {
 	Platform    string
 	CPEBuilder  func(platform, version string, workstation bool) (string, error)
@@ -36,10 +40,9 @@ var platformCPES = []platformCPEEntry{
 	{
 		Platform: "amazonlinux",
 		CPEBuilder: func(platform, version string, workstation bool) (string, error) {
-			amzn1 := regexp.MustCompile(`^(2017|2018)\.`)
 			product := ""
 
-			if amzn1.MatchString(version) {
+			if amazonLinux1Regex.MatchString(version) {
 				product = "linux"
 			} else if version == "2" {
 				product = "linux_2"


### PR DESCRIPTION
> **This duplicates #9856 and should be closed in favour of it.** #9856 was opened first and makes the same two changes to `pkg2cpe.go`, the hoisted epoch pattern and the map to array replacement. The only part not covered there is the Amazon Linux pattern in `platforms.go`, which runs once per asset and shows no measurable gain on its own. The measurements below are kept because they quantify the win that #9856 delivers.

## What allocates

`cpe.NewPackage2Cpe` compiled its epoch pattern with `regexp.MustCompile` on every call.

Every package parser calls it at least once per package. `dpkg` calls it twice per package, `rpm` three times. So a scan compiled the same pattern thousands of times, and each compile allocates the parsed syntax tree, the instruction list and the one pass program.

A heap profile of parsing a real 1.65 MB `/var/lib/dpkg/status` file shows the size of this:

```
go tool pprof -sample_index=alloc_space -peek=regexp.MustCompile
...
   284.59MB 99.30% | go.mondoo.com/mql/v13/providers/os/resources/cpe.NewPackage2Cpe
         0     0%     286.60MB 41.82% | regexp.MustCompile
```

Regex compilation was 41.5% of all bytes allocated during the parse, and `NewPackage2Cpe` was the source of 99.3% of it.

This change moves the pattern to a package variable. It does the same for the Amazon Linux pattern in the platform CPE builder. It also replaces the per-call field map with a fixed array, which removes one map allocation per call.

This affects both scanners. The node scanner and the container image scanner both enumerate OS packages.

## Measured numbers

`BenchmarkNewPackage2Cpe` builds 2,000 packages, a quarter of them with an epoch, and converts them all.

```
go test ./providers/os/resources/cpe/ -run=X -bench=BenchmarkNewPackage2Cpe -benchmem -count=5
```

Median of 5 runs:

| | before | after | change |
|---|---|---|---|
| B/op | 9,919,410 | 999,980 | -89.9% |
| allocs/op | 160,513 | 48,501 | -69.8% |
| ns/op | 11,186,128 | 3,069,684 | -72.6% |

End to end on a real dpkg database, parsing `/var/lib/dpkg/status` (1,652,556 bytes, about 2,200 packages) with `ParseDpkgPackages`:

```
go test ./providers/os/resources/packages/ -run=X -bench=BenchmarkParseDpkgPackages -benchmem -benchtime=20x -count=5
```

| | before | after | change |
|---|---|---|---|
| B/op | 34,024,748 | 18,892,934 | -44.5% |
| allocs/op | 436,916 | 254,149 | -41.8% |
| ns/op | 84,200,674 | 59,449,658 | -29.4% |

The dpkg benchmark reads the host package database, so it is not committed. The committed benchmark is the portable one in the `cpe` package.

## Time cost

There is no time cost. It is faster in both benchmarks. No gate is needed, because the returned CPEs are identical.

## Correctness

* `go test ./providers/os/resources/cpe/... ./providers/os/resources/packages/... ./providers/os/resources/languages/... -count=1` passes.
* The patterns are unchanged, only their compile site moves.
* The field loop changes from a map to a fixed array. The set of fields and the checks are the same. Map iteration order is random, so the previous code could name any failing field when more than one field failed. The array always reports vendor, name, version, release, arch in that order, so the error is now deterministic.
