### PR TITLE
🎉 alicloud-13.4.0, mongodbatlas-13.3.0, ms365-13.11.0, neon-13.1.0, netlify-13.1.0, nutanix-13.4.0, ollama-13.1.2, openstack-13.9.0, snowflake-13.6.0, stackit-13.7.0, tailscale-13.4.0

### DIFF
--- a/providers/alicloud/config/config.go
+++ b/providers/alicloud/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "alicloud",
 	ID:              "go.mondoo.com/mql/providers/alicloud",
-	Version:         "13.3.1",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/mongodbatlas/config/config.go
+++ b/providers/mongodbatlas/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "mongodbatlas",
 	ID:        "go.mondoo.com/mql/providers/mongodbatlas",
-	Version:   "13.2.1",
+	Version:   "13.3.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.10.3",
+	Version:         "13.11.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/neon/config/config.go
+++ b/providers/neon/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "neon",
 	ID:              "go.mondoo.com/mql/providers/neon",
-	Version:         "13.0.0",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/netlify/config/config.go
+++ b/providers/netlify/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "netlify",
 	ID:              "go.mondoo.com/mql/providers/netlify",
-	Version:         "13.0.0",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nutanix",
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
-	Version:         "13.3.3",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ollama/config/config.go
+++ b/providers/ollama/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ollama",
 	ID:              "go.mondoo.com/mql/providers/ollama",
-	Version:         "13.1.1",
+	Version:         "13.1.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.8.1",
+	Version:         "13.9.0",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.5.1",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -16,7 +16,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.6.1",
+	Version:         "13.7.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.3.11",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Releases 11 providers. Only `config/config.go` `Version` strings change (11 files, 11 lines).

Ten providers take a minor bump because each one adds schema (new resources, new fields, or new cross-resource references); `ollama` takes a patch because its change is a bug fix plus a deprecation, with no new schema.

| Provider | From | To | Bump |
| --- | --- | --- | --- |
| alicloud | 13.3.1 | 13.4.0 | minor |
| mongodbatlas | 13.2.1 | 13.3.0 | minor |
| ms365 | 13.10.3 | 13.11.0 | minor |
| neon | 13.0.0 | 13.1.0 | minor |
| netlify | 13.0.0 | 13.1.0 | minor |
| nutanix | 13.3.3 | 13.4.0 | minor |
| ollama | 13.1.1 | 13.1.2 | patch |
| openstack | 13.8.1 | 13.9.0 | minor |
| snowflake | 13.5.1 | 13.6.0 | minor |
| stackit | 13.6.1 | 13.7.0 | minor |
| tailscale | 13.3.11 | 13.4.0 | minor |

## What's new

### alicloud 13.4.0

- **Resource groups are queryable** (#9829). `resourceGroupId` was carried by 27 resources across ECS, VPC, OSS, RDS, Redis, MongoDB, PolarDB, SLB/ALB/NLB, ACK, FC, NAS, CEN, Log Service and Auto Scaling but resolved to nothing, so the ownership boundary most Alibaba Cloud accounts are organized around could only be read as an opaque `rg-` string. Adds `alicloud.resourceManager.resourceGroup` and a `resourceGroup` reference on every resource reporting a group id, so an audit can select or exclude an environment by name:
  ```
  alicloud.oss.buckets.where(resourceGroup.name == "sandbox" && isPublic)
  ```
- **13 dangling reference gaps closed** across ECS, ACK, SLS, NAS and FC (#9830). Each field named another modeled resource but resolved only to a string, in most cases while a sibling resource already had the reference. Adds `ecs.instance.keyPair`, `ecs.securitygroup.vpc`, `cs.nodePool.cluster`, `cs.nodePool.image`, `log.logstore.project`, `vpc.flowLog.project`, `nas.mountTarget.fileSystem`, `fc.trigger.function`, `ram.accessKey.user`, `resourceManager.folder.parentFolder` and others.

### mongodbatlas 13.3.0

- **Project references no longer cost a `GetProject` each** (#9833). `NewResource` runs the target's init before the runtime cache is consulted, so resolving a project per role assignment issued one API call per reference. Both project accessors now go through `orgProjectsByID`, the memo already on the root resource, keeping the direct fetch as a fallback for a project the organization listing does not cover.

### ms365 13.11.0

- **Three SharePoint tenant sharing settings added to `tenantConfig`** (#9866). `ms365.sharepointonline.tenantConfig` replaced the deprecated `spoTenant` dict, but these never made it across, so checks for them were stuck on the deprecated field: `enableAzureADB2BIntegration` (whether guest sharing runs through Entra B2B rather than SharePoint's one-time-passcode flow), `oneDriveSharingCapability` (the OneDrive external-sharing cap, independent of `sharingCapability`), and `whoCanShareAuthenticatedGuestAllowList` (the security groups allowed to share with guests). All three are already in the `Get-PnPTenant` payload the resource decodes, so there is no extra API call.
- **Power BI is fetched over REST instead of PowerShell** (#9591). `microsoft.powerbi` shelled out to `pwsh` running the `MicrosoftPowerBIMgmt` module, but every section of that script was already an `Invoke-PowerBIRestMethod`/`Invoke-RestMethod` call, so the module was only acting as an HTTP client for a token we already acquire in Go. The five admin endpoints are now called directly.

### neon 13.1.0

- **Null project back-refs, an organization N+1, and a data race fixed** (#9837). `project.organization` resolved through `NewResource`, re-reading an organization the root had already fetched once per project. `projectByID` resolved only against the root project list, which is collected per organization, so a personal project — which belongs to no organization — made `branch.project` and `endpoint.project` report null.

### netlify 13.1.0

- **References resolve through the cached lists; env vars degrade on 403** (#9835). `netlify.site.account`, `netlify.site.deployKey` and `netlify.dnsZone.site` each resolved with `NewResource`, making them an API call per record — including a full paged `GET /accounts` walk per site. Each now scans the list the root already fetched, the idiom `netlify.envVar.updatedBy` and `netlify.deployKey.sites` already use, with the original call kept as a load-bearing fallback for records naming something outside the connection's scope.

### nutanix 13.4.0

- **Four reference ids the list responses already carry are now resolved** (#9841). The image, VPC and storage-container list responses already returned these values and the mapping code dropped them; no new API surface is involved. Adds `nutanix.image.clusters` (clusters holding a copy of the image), `nutanix.image.owner` (the IAM user), `nutanix.network.vpc.externalSubnets` (a VPC's egress path and NAT posture in one query), and `nutanix.storage.container.affinityHost` (the host an RF-1 container is pinned to).

### ollama 13.1.2

- **An unlisted running model reports null instead of failing the field** (#9834). `runningModel.model` resolved through `NewResource`, and `initOllamaModel` errors when `/api/tags` does not list the name — so a model that `/api/ps` reports but `/api/tags` does not (loaded then deleted, or cloud-resident) failed the whole field rather than reporting absence. The not-found case now returns a sentinel the accessor classifies with `errors.Is`, setting `StateIsSet|StateIsNull`; every other error, including a transport failure, still propagates.
- `ollama.model.model` is a byte-identical duplicate of `ollama.model.name` and is now marked deprecated. No schema is added, hence the patch bump.

### openstack 13.9.0

- **HA/DVR router ports and secret-valued Octavia TLS refs resolve** (#9836). Two silent false negatives where a field read as "nothing configured" while something was. `openstack.port.router` matched the owner on a `network:router` prefix, missing `network:ha_router_replicated_interface` — the `device_owner` Neutron gives every router interface replicated onto a compute or network node under DVR or HA, i.e. most production OpenStack — so a query walking ports to their routers silently skipped them. Octavia TLS refs pointing at a bare Barbican secret rather than a container are also resolved now.

### snowflake 13.6.0

- **Databases, schemas and warehouses are indexed account-wide** (#9840). Every reference to one of these cost a live SQL round trip, because `NewResource` runs the init before the cache is consulted: `snowflake.account.tables { database { owner } }` on a 2,000-table account issued 2,000 `SHOW DATABASES LIKE` statements. Account-level name indexes — in the shape `roleIndex` and `userIndex` already use — memoize one account-wide statement on the singleton account resource together with its error, turning those 2,000 statements into 1.

### stackit 13.7.0

- **Volume encryption keys and IAM role bindings resolve to their resources** (#9842). `stackit.volume.encryptionKey` resolves the customer-managed key wrapping a volume's data-encryption key to `stackit.kms.key`, and `encryptionKeyVersionRef` resolves the pinned generation to `stackit.kms.key.version`; `encryptionKeyId` is deprecated in favor of the reference. `stackit.iam.member.roleDetails` resolves a binding's role name to the `stackit.iam.role` catalog entry carrying its permissions, with the raw `role` field retained since it is the binding's own key half.

### tailscale 13.4.0

- **The identity graph is traversable** (#9839). The provider previously had no cross-resource references at all — every accessor was a root-to-child list, and three raw strings naming a `tailscale.user` the provider already models left the join to the reader. Adds `tailscale.device.owner`, `tailscale.authKey.user`, `tailscale.webhook.creator`, `tailscale.user.devices` and `tailscale.user.authKeys`.

## How this was generated

`providers-sdk/v1/util/version/version.go update <providers> --increment=minor|patch`, run without `--commit` so the branch, commit message and description are authored here rather than by the versioning bot.
