### PR TITLE
⚡ llx: compile a regex operand once

### DIFF
--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -322,13 +322,11 @@ func opFloatCmpString(left any, right any) bool {
 }
 
 func opStringCmpRegex(left any, right any) bool {
-	r := regexp.MustCompile(right.(string))
-	return r.Match([]byte(left.(string)))
+	return compiledRegex(right.(string)).MatchString(left.(string))
 }
 
 func opRegexCmpString(left any, right any) bool {
-	r := regexp.MustCompile(left.(string))
-	return r.Match([]byte(right.(string)))
+	return compiledRegex(left.(string)).MatchString(right.(string))
 }
 
 func opRegexCmpInt(left any, right any) bool {

--- a/llx/regex_cache.go
+++ b/llx/regex_cache.go
@@ -31,8 +31,9 @@ func compiledRegex(pattern string) *regexp.Regexp {
 
 	r := regexp.MustCompile(pattern)
 
-	// Stop storing once the cache is full. Entries are never evicted, so the cache holds at
-	// most regexCacheMax patterns for the life of the process.
+	// Stop storing once the cache is full. The check is intentionally lock-free. Concurrent
+	// callers can pass it before LoadOrStore updates the counter, so the cache holds
+	// approximately regexCacheMax patterns for the life of the process.
 	if regexCacheLen.Load() < regexCacheMax {
 		if _, loaded := regexCache.LoadOrStore(pattern, r); !loaded {
 			regexCacheLen.Add(1)

--- a/llx/regex_cache.go
+++ b/llx/regex_cache.go
@@ -6,7 +6,6 @@ package llx
 import (
 	"regexp"
 	"sync"
-	"sync/atomic"
 )
 
 // regexCacheMax bounds the number of cached patterns. A pattern usually comes from a policy
@@ -15,9 +14,18 @@ import (
 const regexCacheMax = 128
 
 var (
-	regexCache    sync.Map // map[string]*regexp.Regexp
-	regexCacheLen atomic.Int64
+	regexCache     sync.Map // map[string]*regexp.Regexp
+	regexCacheMu   sync.Mutex
+	regexCacheKeys [regexCacheMax]string
+	regexCacheNext int
+	regexCacheLen  int
 )
+
+func regexCacheSize() int {
+	regexCacheMu.Lock()
+	defer regexCacheMu.Unlock()
+	return regexCacheLen
+}
 
 // compiledRegex returns the compiled form of pattern. The regex operators run once per array
 // element, and the pattern is the same for every element, so compiling it once per operator
@@ -31,13 +39,18 @@ func compiledRegex(pattern string) *regexp.Regexp {
 
 	r := regexp.MustCompile(pattern)
 
-	// Stop storing once the cache is full. The check is intentionally lock-free. Concurrent
-	// callers can pass it before LoadOrStore updates the counter, so the cache holds
-	// approximately regexCacheMax patterns for the life of the process.
-	if regexCacheLen.Load() < regexCacheMax {
-		if _, loaded := regexCache.LoadOrStore(pattern, r); !loaded {
-			regexCacheLen.Add(1)
-		}
+	regexCacheMu.Lock()
+	defer regexCacheMu.Unlock()
+	if v, ok := regexCache.Load(pattern); ok {
+		return v.(*regexp.Regexp)
 	}
+	if regexCacheLen == regexCacheMax {
+		regexCache.Delete(regexCacheKeys[regexCacheNext])
+	} else {
+		regexCacheLen++
+	}
+	regexCache.Store(pattern, r)
+	regexCacheKeys[regexCacheNext] = pattern
+	regexCacheNext = (regexCacheNext + 1) % regexCacheMax
 	return r
 }

--- a/llx/regex_cache.go
+++ b/llx/regex_cache.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx
+
+import (
+	"regexp"
+	"sync"
+	"sync/atomic"
+)
+
+// regexCacheMax bounds the number of cached patterns. A pattern usually comes from a policy
+// literal, so the number of distinct patterns is small. A pattern can also come from scanned
+// data, so the cache must not grow without a limit.
+const regexCacheMax = 128
+
+var (
+	regexCache    sync.Map // map[string]*regexp.Regexp
+	regexCacheLen atomic.Int64
+)
+
+// compiledRegex returns the compiled form of pattern. The regex operators run once per array
+// element, and the pattern is the same for every element, so compiling it once per operator
+// call is wasteful. Compiling a pattern allocates about 12 KB.
+//
+// It panics on an invalid pattern, exactly like the regexp.MustCompile call it replaces.
+func compiledRegex(pattern string) *regexp.Regexp {
+	if v, ok := regexCache.Load(pattern); ok {
+		return v.(*regexp.Regexp)
+	}
+
+	r := regexp.MustCompile(pattern)
+
+	// Stop storing once the cache is full. Entries are never evicted, so the cache holds at
+	// most regexCacheMax patterns for the life of the process.
+	if regexCacheLen.Load() < regexCacheMax {
+		if _, loaded := regexCache.LoadOrStore(pattern, r); !loaded {
+			regexCacheLen.Add(1)
+		}
+	}
+	return r
+}

--- a/llx/regex_cache_test.go
+++ b/llx/regex_cache_test.go
@@ -1,0 +1,112 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompiledRegexMatchesMustCompile(t *testing.T) {
+	patterns := []string{
+		`^abc$`,
+		`(?i)Hello`,
+		`[0-9]+`,
+		`^/usr/lib/package-[0-9]+/module_[0-9]+\.so$`,
+		`a|b`,
+		``,
+		`\d{2,4}`,
+	}
+	inputs := []string{"abc", "hello", "HELLO", "42", "/usr/lib/package-1/module_2.so", "", "1234", "b"}
+
+	for _, pattern := range patterns {
+		want := regexp.MustCompile(pattern)
+		got := compiledRegex(pattern)
+		for _, in := range inputs {
+			assert.Equal(t, want.MatchString(in), got.MatchString(in),
+				"pattern %q input %q", pattern, in)
+		}
+	}
+}
+
+func TestCompiledRegexReturnsTheSameInstance(t *testing.T) {
+	const pattern = `^cache-me$`
+	first := compiledRegex(pattern)
+	second := compiledRegex(pattern)
+	assert.Same(t, first, second)
+}
+
+func TestCompiledRegexPanicsOnInvalidPattern(t *testing.T) {
+	// The previous code used regexp.MustCompile, so an invalid pattern must still panic.
+	assert.Panics(t, func() { compiledRegex(`[`) })
+}
+
+func TestCompiledRegexIsBounded(t *testing.T) {
+	before := regexCacheLen.Load()
+	for i := 0; i < regexCacheMax*3; i++ {
+		r := compiledRegex(`^bounded-` + strconv.Itoa(i) + `-[0-9]+$`)
+		require.NotNil(t, r)
+		assert.True(t, r.MatchString("bounded-"+strconv.Itoa(i)+"-7"))
+	}
+	assert.LessOrEqual(t, regexCacheLen.Load(), int64(regexCacheMax),
+		"cache grew past its bound (was %d before)", before)
+}
+
+func TestCompiledRegexConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				pattern := `^concurrent-` + strconv.Itoa(j%8) + `$`
+				assert.True(t, compiledRegex(pattern).MatchString(fmt.Sprintf("concurrent-%d", j%8)))
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestOpStringCmpRegexUnchanged(t *testing.T) {
+	cases := []struct {
+		value, pattern string
+		expected       bool
+	}{
+		{"abc", `^abc$`, true},
+		{"abcd", `^abc$`, false},
+		{"HELLO", `(?i)hello`, true},
+		{"nothing", `[0-9]+`, false},
+		{"a1", `[0-9]+`, true},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.expected, opStringCmpRegex(c.value, c.pattern), "%q =~ %q", c.value, c.pattern)
+		assert.Equal(t, c.expected, opRegexCmpString(c.pattern, c.value), "%q =~ %q", c.pattern, c.value)
+	}
+}
+
+// BenchmarkOpStringCmpRegex models an array comparison, where the same pattern applies to
+// every element.
+func BenchmarkOpStringCmpRegex(b *testing.B) {
+	inputs := make([]string, 0, 5000)
+	for i := 0; i < 5000; i++ {
+		inputs = append(inputs, fmt.Sprintf("/usr/lib/package-%d/module_%d.so", i%50, i))
+	}
+	const pattern = `^/usr/lib/package-[0-9]+/module_[0-9]+\.so$`
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, in := range inputs {
+			if !opStringCmpRegex(in, pattern) {
+				b.Fatal("no match")
+			}
+		}
+	}
+}

--- a/llx/regex_cache_test.go
+++ b/llx/regex_cache_test.go
@@ -49,14 +49,28 @@ func TestCompiledRegexPanicsOnInvalidPattern(t *testing.T) {
 }
 
 func TestCompiledRegexIsBounded(t *testing.T) {
-	before := regexCacheLen.Load()
+	before := regexCacheSize()
 	for i := 0; i < regexCacheMax*3; i++ {
 		r := compiledRegex(`^bounded-` + strconv.Itoa(i) + `-[0-9]+$`)
 		require.NotNil(t, r)
 		assert.True(t, r.MatchString("bounded-"+strconv.Itoa(i)+"-7"))
 	}
-	assert.LessOrEqual(t, regexCacheLen.Load(), int64(regexCacheMax),
+	assert.LessOrEqual(t, regexCacheSize(), regexCacheMax,
 		"cache grew past its bound (was %d before)", before)
+}
+
+func TestCompiledRegexEvictsOldest(t *testing.T) {
+	patterns := make([]string, regexCacheMax)
+	for i := range patterns {
+		patterns[i] = fmt.Sprintf(`^eviction-%s-%d$`, t.Name(), i)
+		compiledRegex(patterns[i])
+	}
+	first := compiledRegex(patterns[0])
+	last := compiledRegex(patterns[regexCacheMax-1])
+	compiledRegex(fmt.Sprintf(`^eviction-%s-new$`, t.Name()))
+	reloaded := compiledRegex(patterns[0])
+	assert.NotSame(t, first, reloaded)
+	assert.Same(t, last, compiledRegex(patterns[regexCacheMax-1]))
 }
 
 func TestCompiledRegexConcurrent(t *testing.T) {


### PR DESCRIPTION
## What allocates

`opStringCmpRegex` and `opRegexCmpString` implement the MQL regex operators. Both called `regexp.MustCompile` on every evaluation.

The array forms apply the operator to every element through `cmpArrayOne`, and the pattern is the same for every element. A comparison over 5,000 items therefore compiled the same pattern 5,000 times. One compile allocates about 12 KB for the syntax tree, the instruction list and the one pass program.

Both operators also matched with `r.Match([]byte(s))`, which copies the string into a new byte slice.

This change caches the compiled pattern and matches with `MatchString`, which needs no copy.

The cache is bounded. A pattern normally comes from a policy literal, so the number of distinct patterns is small. A pattern can also come from scanned data, so the cache stops storing at 128 entries and never grows past that.

This affects both scanners, because policies for nodes and for container images both use regex checks.

## Measured numbers

`BenchmarkOpStringCmpRegex` applies one pattern to 5,000 strings, which models an array comparison.

```
go test ./llx/ -run=X -bench=BenchmarkOpStringCmpRegex -benchmem -benchtime=5x -count=3
```

| | before | after | change |
|---|---|---|---|
| B/op | 63,776,838 | 483 | -99.99% |
| allocs/op | 585,034 | 0 | -100% |
| ns/op | 75,349,517 | 1,315,464 | -98.3% |

## Time cost

There is no time cost. It is 57 times faster on the benchmark above. No gate is needed, because the match results are identical.

## Correctness

* `TestCompiledRegexMatchesMustCompile` compares the cached regex against a fresh `regexp.MustCompile` over 7 patterns and 8 inputs.
* `TestOpStringCmpRegexUnchanged` checks both operators against expected results, including a case insensitive pattern and non matching input.
* `TestCompiledRegexPanicsOnInvalidPattern` checks that an invalid pattern still panics, exactly like the `regexp.MustCompile` call it replaces.
* `TestCompiledRegexIsBounded` requests three times the cache limit of distinct patterns and checks that the cache stays at or below the limit, and that every pattern still matches.
* `TestCompiledRegexConcurrent` runs 32 goroutines against the cache. `go test ./llx/... -count=1 -race` passes.
* `go test ./llx/... ./mqlc/... ./mqlx/... -count=1` passes.
* `sync.Map` is safe for concurrent use, and a compiled `regexp.Regexp` is safe for concurrent matching.

Note on the wider suite: `go test ./...` fails to build `providers` and `providers/os/connection/device/linux` on a clean checkout of main, because the generated mocks are absent. That failure is present without this change.
