### PR TITLE
⚡ os: split dpkg control fields without a regexp

### DIFF
--- a/providers/os/resources/packages/dpkg_packages.go
+++ b/providers/os/resources/packages/dpkg_packages.go
@@ -5,6 +5,7 @@ package packages
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -24,10 +25,36 @@ const (
 )
 
 var (
-	DPKG_REGEX = regexp.MustCompile(`^(.+):\s(.+)$`)
 	// e.g. source with version: samba (2:4.17.12+dfsg-0+deb12u1)
 	DPKG_ORIGIN_REGEX = regexp.MustCompile(`^\s*([^\(]*)(?:\((.*)\))?\s*$`)
 )
+
+// isDpkgFieldSpace reports whether c belongs to the regexp `\s` class. Go
+// defines that class as [\t\n\f\r ].
+func isDpkgFieldSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r'
+}
+
+// dpkgControlField splits a dpkg control line into its field name and value.
+// It returns the same key and value as the regexp `^(.+):\s(.+)$`. The greedy
+// first group binds that regexp to the last colon followed by a whitespace
+// character. At least one byte must precede the colon, and at least one byte
+// must follow the whitespace.
+//
+// The colon and the whitespace bytes are ASCII, so they never appear inside a
+// multi-byte UTF-8 sequence. A byte scan therefore finds the same split point
+// as a rune scan. The caller passes one line from a bufio.Scanner, so the input
+// carries no newline.
+//
+// The returned slices alias line. The caller must copy what it keeps.
+func dpkgControlField(line []byte) (key []byte, value []byte, ok bool) {
+	for i := len(line) - 3; i >= 1; i-- {
+		if line[i] == ':' && isDpkgFieldSpace(line[i+1]) {
+			return line[:i], line[i+2:], true
+		}
+	}
+	return nil, nil, false
+}
 
 // ParseDpkgPackages parses the dpkg database content located in /var/lib/dpkg/status
 func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, error) {
@@ -55,9 +82,10 @@ func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, erro
 	scanner := bufio.NewScanner(input)
 	pkg := Package{Format: DpkgPkgFormat}
 	state := STATE_RESET
-	var key string
 	for scanner.Scan() {
-		line := scanner.Text()
+		// Bytes avoids one string allocation per line. Every field we keep is
+		// copied into the package below, so nothing aliases the scanner buffer.
+		line := scanner.Bytes()
 
 		// reset package definition once we reach a newline
 		if len(line) == 0 {
@@ -68,30 +96,28 @@ func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, erro
 			}
 		}
 
-		m := DPKG_REGEX.FindStringSubmatch(line)
-		key = ""
-		if m != nil {
-			key = m[1]
+		key, value, ok := dpkgControlField(line)
+		if ok {
 			state = STATE_RESET
 		}
 		switch {
-		case key == "Package":
-			pkg.Name = strings.TrimSpace(m[2])
-		case key == "Version":
-			pkg.Version = strings.TrimSpace(m[2])
-		case key == "Architecture":
-			pkg.Arch = strings.TrimSpace(m[2])
-		case key == "Status":
-			pkg.Status = strings.TrimSpace(m[2])
-		case key == "Source":
-			pkg.Origin = strings.TrimSpace(m[2])
+		case string(key) == "Package":
+			pkg.Name = string(bytes.TrimSpace(value))
+		case string(key) == "Version":
+			pkg.Version = string(bytes.TrimSpace(value))
+		case string(key) == "Architecture":
+			pkg.Arch = string(bytes.TrimSpace(value))
+		case string(key) == "Status":
+			pkg.Status = string(bytes.TrimSpace(value))
+		case string(key) == "Source":
+			pkg.Origin = string(bytes.TrimSpace(value))
 		// description supports multi-line statements, start desc
-		case key == "Description":
-			pkg.Description = strings.TrimSpace(m[2])
+		case string(key) == "Description":
+			pkg.Description = string(bytes.TrimSpace(value))
 			state = STATE_DESC
 		// next desc line, append to previous one
 		case state == STATE_DESC:
-			pkg.Description += "\n" + strings.TrimSpace(line)
+			pkg.Description += "\n" + string(bytes.TrimSpace(line))
 		}
 	}
 

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -4,6 +4,8 @@
 package packages
 
 import (
+	"bytes"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -214,4 +216,86 @@ See /usr/share/common-licenses/GPL-2 for the full license text.
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, "missing"))
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, ""))
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(nil, "bash"))
+}
+
+func TestDpkgControlField(t *testing.T) {
+	// The previous implementation used the regexp `^(.+):\s(.+)$`. The greedy
+	// first group binds it to the last colon that is followed by whitespace.
+	tests := []struct {
+		line  string
+		key   string
+		value string
+		ok    bool
+	}{
+		{"Package: bash", "Package", "bash", true},
+		// the epoch colon has no whitespace after it, so it is not a split point
+		{"Version: 2:5.2-2ubuntu1", "Version", "2:5.2-2ubuntu1", true},
+		{"Depends: libc6 (>= 2.34), libtinfo6", "Depends", "libc6 (>= 2.34), libtinfo6", true},
+		{"Description: the GNU shell: a thing", "Description: the GNU shell", "a thing", true},
+		{"Field:\tvalue", "Field", "value", true},
+		{"Field:  padded", "Field", " padded", true},
+		// no whitespace after the colon
+		{"a:b", "", "", false},
+		// nothing after the whitespace
+		{"a: ", "", "", false},
+		// nothing before the colon
+		{": b", "", "", false},
+		// continuation lines carry no field
+		{" /etc/bash.bashrc 1234", "", "", false},
+		{"Conffiles:", "", "", false},
+		{"", "", "", false},
+		// multi-byte runes around the split point
+		{"Maintainer: Ubuntu Developers <foo@example.org>", "Maintainer", "Ubuntu Developers <foo@example.org>", true},
+		{"Nameé: valué", "Nameé", "valué", true},
+	}
+	for _, test := range tests {
+		key, value, ok := dpkgControlField([]byte(test.line))
+		assert.Equal(t, test.ok, ok, "match for %q", test.line)
+		assert.Equal(t, test.key, string(key), "key for %q", test.line)
+		assert.Equal(t, test.value, string(value), "value for %q", test.line)
+	}
+}
+
+// dpkgBenchStatus builds a status stream in the shape of /var/lib/dpkg/status.
+func dpkgBenchStatus(pkgCount int) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < pkgCount; i++ {
+		name := "package-" + strconv.Itoa(i)
+		buf.WriteString("Package: " + name + "\n")
+		buf.WriteString("Status: install ok installed\n")
+		buf.WriteString("Priority: optional\n")
+		buf.WriteString("Section: utils\n")
+		buf.WriteString("Installed-Size: " + strconv.Itoa(100+i) + "\n")
+		buf.WriteString("Maintainer: Ubuntu Developers <foo@example.org>\n")
+		buf.WriteString("Architecture: amd64\n")
+		buf.WriteString("Source: " + name + "-src\n")
+		buf.WriteString("Version: 1." + strconv.Itoa(i) + "-2ubuntu1\n")
+		buf.WriteString("Depends: libc6 (>= 2.34), libtinfo6 (>= 6), libselinux1 (>= 3.1)\n")
+		buf.WriteString("Description: short summary for " + name + "\n")
+		for j := 0; j < 6; j++ {
+			buf.WriteString(" continuation line " + strconv.Itoa(j) + " of the long description\n")
+		}
+		buf.WriteString("Original-Maintainer: Debian Developers <bar@example.org>\n")
+		buf.WriteString("Homepage: https://example.org/" + name + "\n")
+		buf.WriteString("\n")
+	}
+	return buf.Bytes()
+}
+
+func BenchmarkParseDpkgPackages(b *testing.B) {
+	data := dpkgBenchStatus(1600)
+	pf := &inventory.Platform{Name: "ubuntu", Version: "24.04", Arch: "amd64"}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pkgs, err := ParseDpkgPackages(pf, bytes.NewReader(data))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(pkgs) != 1600 {
+			b.Fatalf("expected 1600 packages, got %d", len(pkgs))
+		}
+	}
 }


### PR DESCRIPTION
## What allocates

`ParseDpkgPackages` reads `/var/lib/dpkg/status`. That file holds about 37000 lines and 1631 packages on a normal Ubuntu 24.04 host. The parser ran the regexp `^(.+):\s(.+)$` on every line. Each `FindStringSubmatch` call allocated a submatch slice plus backtracking state. A heap profile of the parse put `regexp.FindStringSubmatch` at 19.9% of allocated bytes, and `bufio.Scanner.Text` at 11.2%, once the CPE regexp cost from #9856 is taken out.

`scanner.Text` allocated one string per line. The parser keeps at most seven fields per package, so most of those line strings were garbage.

## What changed

`dpkgControlField` replaces the regexp with a backwards byte scan. The greedy first group binds the regexp to the last colon that is followed by a whitespace character, so the scan walks backwards and returns at that point. The colon and the `\s` bytes are ASCII, so they never appear inside a multi-byte UTF-8 sequence, and a byte scan finds the same split point as a rune scan.

The loop now reads `scanner.Bytes`. Every field the package keeps is copied with an explicit string conversion, so nothing aliases the scanner buffer.

`DPKG_REGEX` has no remaining user and is removed.

## Numbers

In-repo benchmark, 1600 synthetic packages in the shape of a real status file:

```
go test ./providers/os/resources/packages/ -run xxx -bench 'BenchmarkParseDpkgPackages$' -benchmem -count=6
```

| | before | after | change |
| --- | --- | --- | --- |
| B/op | 28719436 | 25046591 | -12.8% |
| allocs/op | 414549 | 352089 | -15.1% |
| ns/op | 60668386 | 32527603 | -46.4% |

Same benchmark against a real 1.65 MB `/var/lib/dpkg/status` with 1631 packages:

| | before | after | change |
| --- | --- | --- | --- |
| B/op | 34141261 | 27707335 | -18.8% |
| allocs/op | 436917 | 363187 | -16.9% |
| ns/op | 96956175 | 35202926 | -63.7% |

Stacked on top of #9856, which removes the CPE regexp compile that dominates the rest of this path, the same real-file parse goes from 18825318 to 12892407 B/op, a further -31.5%.

## Correctness

A differential test parsed the real 1.65 MB status file with the old and the new implementation. All 1631 packages compared equal with `reflect.DeepEqual`.

A differential fuzz run compared `dpkgControlField` against the old regexp over 400000 random inputs. The alphabet covered letters, colons, every byte in the `\s` class, multi-byte runes and invalid UTF-8. Inputs carry no newline, because the caller passes lines from a `bufio.Scanner`. All inputs agreed on both the match decision and the two submatches.

`TestDpkgControlField` pins the semantics, including the greedy last-colon case and a version string whose epoch colon has no following whitespace.

`go test ./providers/os/resources/packages/` passes.