### PR TITLE
⚡ llx: share the entrypoint and callback tables of a block

### DIFF
--- a/exec/blockexec_bench_test.go
+++ b/exec/blockexec_bench_test.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package exec_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/v13/exec"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/mqlc"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+)
+
+// arrayLiteralQuery builds `[0,1,...,n-1]` followed by tail.
+func arrayLiteralQuery(n int, tail string) string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(strconv.Itoa(i))
+	}
+	sb.WriteString("]")
+	sb.WriteString(tail)
+	return sb.String()
+}
+
+func benchmarkArrayQuery(b *testing.B, n int, tail string) {
+	runtime := testutils.LinuxMock()
+	query := arrayLiteralQuery(n, tail)
+
+	bundle, err := mqlc.Compile(query, nil, mqlc.NewConfig(runtime.Schema(), testutils.Features))
+	if err != nil {
+		b.Fatal(err)
+	}
+	var props map[string]*llx.Primitive
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := exec.ExecuteCode(runtime, bundle, props, testutils.Features)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(res) == 0 {
+			b.Fatal("no results")
+		}
+	}
+}
+
+// BenchmarkWhereBlock runs one block executor per array element. It measures
+// the cost the executor pays per element of a filtered array.
+func BenchmarkWhereBlock(b *testing.B) {
+	benchmarkArrayQuery(b, 5000, ".where(_ >= 0)")
+}
+
+// BenchmarkNoBlock is the same array without a block, as a reference point.
+func BenchmarkNoBlock(b *testing.B) {
+	benchmarkArrayQuery(b, 5000, ".length")
+}

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -128,6 +128,9 @@ type MQLExecutorV2 struct {
 	lock           sync.Mutex
 	blockExecutors []*blockExecutor
 	unregistered   bool
+
+	blockPointsLock sync.Mutex
+	blockPoints     map[uint64]*blockPoints
 }
 
 func (c *blockExecutor) watcherUID(ref uint64) string {
@@ -165,6 +168,7 @@ func NewExecutorV2(code *CodeV2, runtime Runtime, props map[string]*Primitive, c
 		code:           code,
 		props:          props,
 		blockExecutors: []*blockExecutor{},
+		blockPoints:    map[uint64]*blockPoints{},
 	}
 
 	exec, err := res._newBlockExecutor(1<<32, callback, nil)
@@ -184,13 +188,16 @@ func (c *MQLExecutorV2) _newBlockExecutor(blockRef uint64, callback ResultCallba
 		return nil, errors.New("cannot find block " + strconv.FormatUint(blockRef, 10))
 	}
 
-	callbackPoints := map[uint64]string{}
+	points, err := c.pointsForBlock(blockRef, block)
+	if err != nil {
+		return nil, err
+	}
 
 	res := &blockExecutor{
 		id:             uuid.Must(uuid.NewV4()).String() + "/" + strconv.FormatUint(blockRef>>32, 10),
 		blockRef:       blockRef,
 		callback:       callback,
-		callbackPoints: callbackPoints,
+		callbackPoints: points.callbackPoints,
 		cache:          newCache(),
 		stepTracker:    newCache(),
 		calls: &Calls{
@@ -201,7 +208,35 @@ func (c *MQLExecutorV2) _newBlockExecutor(blockRef uint64, callback ResultCallba
 		ctx:         c,
 		parent:      parent,
 		watcherIds:  &types.StringSet{},
-		entrypoints: map[uint64]struct{}{},
+		entrypoints: points.entrypoints,
+	}
+
+	return res, nil
+}
+
+// blockPoints holds the entrypoint and callback lookup tables of one block.
+// Both derive from the block and from the code checksums, which never change
+// while the executor runs. Both are read-only after this constructor returns.
+type blockPoints struct {
+	entrypoints    map[uint64]struct{}
+	callbackPoints map[uint64]string
+}
+
+// pointsForBlock returns the lookup tables of a block. An array or map block
+// runs one block executor per element, so a query over a large array asked for
+// the same two tables thousands of times. The tables are equal for every
+// executor of the same block, so they are built once and shared.
+func (c *MQLExecutorV2) pointsForBlock(blockRef uint64, block *Block) (*blockPoints, error) {
+	c.blockPointsLock.Lock()
+	defer c.blockPointsLock.Unlock()
+
+	if points, ok := c.blockPoints[blockRef]; ok {
+		return points, nil
+	}
+
+	points := &blockPoints{
+		entrypoints:    make(map[uint64]struct{}, len(block.Entrypoints)),
+		callbackPoints: make(map[uint64]string, len(block.Entrypoints)+len(block.Datapoints)),
 	}
 
 	for _, ref := range block.Entrypoints {
@@ -212,8 +247,8 @@ func (c *MQLExecutorV2) _newBlockExecutor(blockRef uint64, callback ResultCallba
 		if ref < 1 {
 			return nil, errors.New("llx.executor> cannot execute with invalid ref number in entrypoint")
 		}
-		res.entrypoints[ref] = struct{}{}
-		res.callbackPoints[ref] = id
+		points.entrypoints[ref] = struct{}{}
+		points.callbackPoints[ref] = id
 	}
 
 	for _, ref := range block.Datapoints {
@@ -224,14 +259,15 @@ func (c *MQLExecutorV2) _newBlockExecutor(blockRef uint64, callback ResultCallba
 		if ref < 1 {
 			return nil, errors.New("llx.executor> cannot execute with invalid ref number in datapoint")
 		}
-		res.callbackPoints[ref] = id
+		points.callbackPoints[ref] = id
 	}
 
-	if len(res.callbackPoints) == 0 {
+	if len(points.callbackPoints) == 0 {
 		panic("no callback points")
 	}
 
-	return res, nil
+	c.blockPoints[blockRef] = points
+	return points, nil
 }
 
 // NoRun returns error for all callbacks and don't run code

--- a/llx/llx.go
+++ b/llx/llx.go
@@ -129,7 +129,7 @@ type MQLExecutorV2 struct {
 	blockExecutors []*blockExecutor
 	unregistered   bool
 
-	blockPointsLock sync.Mutex
+	blockPointsLock sync.RWMutex
 	blockPoints     map[uint64]*blockPoints
 }
 
@@ -226,15 +226,19 @@ type blockPoints struct {
 // runs one block executor per element, so a query over a large array asked for
 // the same two tables thousands of times. The tables are equal for every
 // executor of the same block, so they are built once and shared.
+// The lock only covers the map lookup and the map write. The tables are built
+// outside it. Two executors that reach a block at the same time may both build
+// the tables, and the first result stored wins. The tables are equal either
+// way, because they derive from the same immutable code.
 func (c *MQLExecutorV2) pointsForBlock(blockRef uint64, block *Block) (*blockPoints, error) {
-	c.blockPointsLock.Lock()
-	defer c.blockPointsLock.Unlock()
-
-	if points, ok := c.blockPoints[blockRef]; ok {
+	c.blockPointsLock.RLock()
+	points, ok := c.blockPoints[blockRef]
+	c.blockPointsLock.RUnlock()
+	if ok {
 		return points, nil
 	}
 
-	points := &blockPoints{
+	points = &blockPoints{
 		entrypoints:    make(map[uint64]struct{}, len(block.Entrypoints)),
 		callbackPoints: make(map[uint64]string, len(block.Entrypoints)+len(block.Datapoints)),
 	}
@@ -266,6 +270,12 @@ func (c *MQLExecutorV2) pointsForBlock(blockRef uint64, block *Block) (*blockPoi
 		panic("no callback points")
 	}
 
+	c.blockPointsLock.Lock()
+	defer c.blockPointsLock.Unlock()
+
+	if existing, ok := c.blockPoints[blockRef]; ok {
+		return existing, nil
+	}
 	c.blockPoints[blockRef] = points
 	return points, nil
 }


### PR DESCRIPTION
## What allocates

An array or map block runs one block executor per element. `packages.where(...)` over 1631 packages creates 1631 block executors, and `files.find(...).where(...)` creates one per file.

Each executor built its own `entrypoints` map and its own `callbackPoints` map in `_newBlockExecutor`. Both derive from `block.Entrypoints`, `block.Datapoints` and `code.Checksums`, which do not change while the executor runs. Every executor of the same block therefore built the same two maps.

A heap profile of a `where` over 5000 elements put `_newBlockExecutor` at the top with 25.8% of allocated bytes. The two maps were 48.5 MB of its 94.5 MB, split between the map headers and the bucket growth on first insert:

```
    3.50MB     3.50MB    187:	callbackPoints := map[uint64]string{}
    3.50MB     3.50MB    204:		entrypoints: map[uint64]struct{}{},
   15.50MB    15.50MB    215:		res.entrypoints[ref] = struct{}{}
   26.01MB    26.01MB    216:		res.callbackPoints[ref] = id
```

## What changed

`pointsForBlock` builds the two tables once per block reference and returns the same `blockPoints` to every executor of that block. Both maps get a capacity hint, so the bucket growth during construction goes away too.

Both maps are read-only once the constructor returns. The only writes were the three lines in `_newBlockExecutor` shown above. Every other use is a lookup or a range, in `llx.go`, `builtin.go`, `builtin_array.go` and `builtin_resource.go`.

The order of the checks and the panic on an empty callback table are unchanged. A block whose tables fail to build is not cached, so the error repeats for the next executor of that block.

## Numbers

```
go test ./exec/ -run xxx -bench 'BenchmarkWhereBlock|BenchmarkNoBlock' -benchmem -benchtime 50x -count=5
```

`BenchmarkWhereBlock`, 5000 elements through a block:

| | before | after | change |
| --- | --- | --- | --- |
| B/op | 11499421 | 9259356 | -19.5% |
| allocs/op | 180038 | 160043 | -11.1% |

`BenchmarkNoBlock` is the same array without a block. It stays at 375222 B/op and 9991 allocs/op, which confirms the change only touches the block executor path.

Run time is unchanged. The spread between repeated runs on my machine is larger than the difference between the two versions, so I make no claim on time. A CPU profile puts the new lock at 0.21% of samples.

## Correctness

`go test ./llx/... ./mqlc/... ./exec/...` passes.

`go test -race ./llx/... ./exec/...` passes. The race detector matters here because the tables are now shared across the executors of one block, and block executors run concurrently. The build is guarded by a mutex, and the maps are never written after the constructor returns.