### PR TITLE
⭐ aws: resolve a WorkSpace's bundle to a typed reference

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -23190,7 +23190,12 @@ aws.workspaces @defaults("directories") {
   ipGroups() []aws.workspaces.ipGroup
   // List of workspace images across all enabled regions
   images() []aws.workspaces.image
-  // List of workspace bundles across all enabled regions
+  // List of account-owned workspace bundles across all enabled regions
+  //
+  // AWS answers DescribeWorkspaceBundles with the caller's own bundles unless
+  // an owner is named, so the public AMAZON bundles are absent from this list.
+  // To reach the bundle behind a specific WorkSpace whatever its owner, use
+  // `aws.workspaces.workspace.bundle`.
   bundles() []aws.workspaces.bundle
 }
 
@@ -23467,6 +23472,12 @@ private aws.workspaces.workspace @defaults("workspaceId userName state region") 
   computerName string
   // Bundle ID used to create the workspace
   bundleId string
+  // Bundle the WorkSpace was created from
+  //
+  // Resolved by ID, so it is answered for AMAZON-provided bundles as well as
+  // account-owned ones. Use `bundle.owner` to tell the two apart; the
+  // account-wide `aws.workspaces.bundles` list holds only the latter.
+  bundle() aws.workspaces.bundle
   // Subnet ID
   //
   // Deprecated in favor of `subnet`.

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -3895,7 +3895,7 @@ func init() {
 			Create: createAwsWorkspacesImage,
 		},
 		"aws.workspaces.bundle": {
-			// to override args, implement: initAwsWorkspacesBundle(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsWorkspacesBundle,
 			Create: createAwsWorkspacesBundle,
 		},
 		"aws.workspaces.ipGroup": {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -28850,6 +28850,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.workspaces.workspace.bundleId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetBundleId()).ToDataRes(types.String)
 	},
+	"aws.workspaces.workspace.bundle": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWorkspacesWorkspace).GetBundle()).ToDataRes(types.Resource("aws.workspaces.bundle"))
+	},
 	"aws.workspaces.workspace.subnetId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetSubnetId()).ToDataRes(types.String)
 	},
@@ -71700,6 +71703,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.workspaces.workspace.bundleId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWorkspacesWorkspace).BundleId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.workspaces.workspace.bundle": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWorkspacesWorkspace).Bundle, ok = plugin.RawToTValue[*mqlAwsWorkspacesBundle](v.Value, v.Error)
 		return
 	},
 	"aws.workspaces.workspace.subnetId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -173036,6 +173043,7 @@ type mqlAwsWorkspacesWorkspace struct {
 	IpAddress                        plugin.TValue[string]
 	ComputerName                     plugin.TValue[string]
 	BundleId                         plugin.TValue[string]
+	Bundle                           plugin.TValue[*mqlAwsWorkspacesBundle]
 	SubnetId                         plugin.TValue[string]
 	Subnet                           plugin.TValue[*mqlAwsVpcSubnet]
 	State                            plugin.TValue[string]
@@ -173117,6 +173125,22 @@ func (c *mqlAwsWorkspacesWorkspace) GetComputerName() *plugin.TValue[string] {
 
 func (c *mqlAwsWorkspacesWorkspace) GetBundleId() *plugin.TValue[string] {
 	return &c.BundleId
+}
+
+func (c *mqlAwsWorkspacesWorkspace) GetBundle() *plugin.TValue[*mqlAwsWorkspacesBundle] {
+	return plugin.GetOrCompute[*mqlAwsWorkspacesBundle](&c.Bundle, func() (*mqlAwsWorkspacesBundle, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.workspaces.workspace", c.__id, "bundle")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsWorkspacesBundle), nil
+			}
+		}
+
+		return c.bundle()
+	})
 }
 
 func (c *mqlAwsWorkspacesWorkspace) GetSubnetId() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -11434,6 +11434,7 @@ aws.workspaces.ipGroup.userRules 11.16.1
 aws.workspaces.ipGroups 11.16.1
 aws.workspaces.workspace 11.16.1
 aws.workspaces.workspace.arn 13.44.1
+aws.workspaces.workspace.bundle 13.53.2
 aws.workspaces.workspace.bundleId 11.16.1
 aws.workspaces.workspace.computerName 11.16.1
 aws.workspaces.workspace.connectionState 11.16.1

--- a/providers/aws/resources/aws_workspaces.go
+++ b/providers/aws/resources/aws_workspaces.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -664,6 +665,69 @@ func (a *mqlAwsWorkspacesBundle) id() (string, error) {
 	return "aws.workspaces.bundle/" + a.Region.Data + "/" + a.BundleId.Data, nil
 }
 
+// parseWorkspacesBundleRef reads the region and bundle ID a bundle reference was
+// created with. Both are required: DescribeWorkspaceBundles with neither a
+// bundle ID nor an owner answers with every bundle the account owns, so falling
+// through on a partial reference would bind an arbitrary bundle.
+func parseWorkspacesBundleRef(args map[string]*llx.RawData) (string, string, error) {
+	var region, bundleId string
+	if r := args["region"]; r != nil {
+		if s, ok := r.Value.(string); ok {
+			region = s
+		}
+	}
+	if b := args["bundleId"]; b != nil {
+		if s, ok := b.Value.(string); ok {
+			bundleId = s
+		}
+	}
+	if region == "" || bundleId == "" {
+		return "", "", errors.New("bundleId + region required to fetch aws workspaces bundle")
+	}
+	return region, bundleId, nil
+}
+
+// initAwsWorkspacesBundle fetches a single bundle by ID.
+//
+// Filtering by bundle ID reaches AMAZON-provided bundles as well as
+// account-owned ones, which an unfiltered DescribeWorkspaceBundles does not:
+// AWS answers that with the caller's own bundles unless an owner is named.
+func initAwsWorkspacesBundle(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	region, bundleId, err := parseWorkspacesBundleRef(args)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Workspaces(region)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	resp, err := svc.DescribeWorkspaceBundles(ctx, &workspaces.DescribeWorkspaceBundlesInput{
+		BundleIds: []string{bundleId},
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+			log.Debug().Str("region", region).Msg("error accessing region for AWS WorkSpaces bundles API")
+			return args, nil, nil
+		}
+		return nil, nil, err
+	}
+	// a bundle deleted after the WorkSpace was built no longer resolves
+	if len(resp.Bundles) == 0 {
+		return args, nil, nil
+	}
+
+	mqlBundle, err := newMqlAwsWorkspacesBundle(runtime, region, resp.Bundles[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, mqlBundle, nil
+}
+
 // ---- IP Groups ----
 
 func (a *mqlAwsWorkspaces) ipGroups() ([]any, error) {
@@ -786,6 +850,22 @@ func (a *mqlAwsWorkspacesDirectory) subnets() ([]any, error) {
 		res = append(res, mqlSubnet)
 	}
 	return res, nil
+}
+
+func (a *mqlAwsWorkspacesWorkspace) bundle() (*mqlAwsWorkspacesBundle, error) {
+	bundleId := a.BundleId.Data
+	if bundleId == "" {
+		a.Bundle.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "aws.workspaces.bundle", map[string]*llx.RawData{
+		"bundleId": llx.StringData(bundleId),
+		"region":   llx.StringData(a.Region.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsWorkspacesBundle), nil
 }
 
 func (a *mqlAwsWorkspacesWorkspace) subnet() (*mqlAwsVpcSubnet, error) {

--- a/providers/aws/resources/aws_workspaces.go
+++ b/providers/aws/resources/aws_workspaces.go
@@ -665,6 +665,15 @@ func (a *mqlAwsWorkspacesBundle) id() (string, error) {
 	return "aws.workspaces.bundle/" + a.Region.Data + "/" + a.BundleId.Data, nil
 }
 
+// errWorkspacesBundleUnresolved marks a bundle reference that names no readable
+// bundle. Returning it beats handing back a half-populated resource: a resource
+// built from the reference args alone leaves every other field *unset*, and an
+// unset field encodes to a primitive with no type, which llx logs as malformed
+// before coercing it to null (see plugin.TValue.ToDataRes and
+// llx.Primitive.RawData). Callers that would rather have a null bundle than an
+// error convert it back at the accessor.
+var errWorkspacesBundleUnresolved = errors.New("aws workspaces bundle unresolved")
+
 // parseWorkspacesBundleRef reads the region and bundle ID a bundle reference was
 // created with. Both are required: DescribeWorkspaceBundles with neither a
 // bundle ID nor an owner answers with every bundle the account owns, so falling
@@ -712,13 +721,13 @@ func initAwsWorkspacesBundle(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	if err != nil {
 		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 			log.Debug().Str("region", region).Msg("error accessing region for AWS WorkSpaces bundles API")
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("%w: %q in %s is not readable", errWorkspacesBundleUnresolved, bundleId, region)
 		}
 		return nil, nil, err
 	}
 	// a bundle deleted after the WorkSpace was built no longer resolves
 	if len(resp.Bundles) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("%w: %q not found in %s", errWorkspacesBundleUnresolved, bundleId, region)
 	}
 
 	mqlBundle, err := newMqlAwsWorkspacesBundle(runtime, region, resp.Bundles[0])
@@ -863,6 +872,14 @@ func (a *mqlAwsWorkspacesWorkspace) bundle() (*mqlAwsWorkspacesBundle, error) {
 		"region":   llx.StringData(a.Region.Data),
 	})
 	if err != nil {
+		// a bundle that names nothing readable is this WorkSpace having no
+		// bundle to report, not a failure: one deleted or unreadable bundle
+		// must not take down a fleet-wide query
+		if errors.Is(err, errWorkspacesBundleUnresolved) {
+			log.Debug().Str("bundleId", bundleId).Str("region", a.Region.Data).Msg("workspaces>bundle>unresolved")
+			a.Bundle.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return res.(*mqlAwsWorkspacesBundle), nil

--- a/providers/aws/resources/aws_workspaces_test.go
+++ b/providers/aws/resources/aws_workspaces_test.go
@@ -9,6 +9,8 @@ import (
 	workspacestypes "github.com/aws/aws-sdk-go-v2/service/workspaces/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 // ===== client properties are absent =====
@@ -80,4 +82,47 @@ func TestDirectoryClientPropertiesDisabled(t *testing.T) {
 	policy, err := d.clientExperiencePolicy()
 	require.NoError(t, err)
 	assert.Equal(t, "", policy)
+}
+
+// ===== bundle reference =====
+
+// A WorkSpace with no bundle ID reports a null bundle rather than an error, so
+// a fleet-wide query is not lost to one desktop whose bundle cannot be named.
+func TestWorkspaceBundleAbsent(t *testing.T) {
+	w := &mqlAwsWorkspacesWorkspace{}
+
+	bundle, err := w.bundle()
+	require.NoError(t, err)
+	assert.Nil(t, bundle)
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, w.Bundle.State)
+}
+
+// ===== bundle init arguments =====
+
+// A bundle is fetched by ID within a region, both of which the init function
+// reads off the args the reference was created with.
+func TestParseWorkspacesBundleRef(t *testing.T) {
+	region, bundleId, err := parseWorkspacesBundleRef(map[string]*llx.RawData{
+		"bundleId": llx.StringData("wsb-ccc333fff"),
+		"region":   llx.StringData("us-east-1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1", region)
+	assert.Equal(t, "wsb-ccc333fff", bundleId)
+}
+
+// Without both halves of the reference there is nothing to look up. The init
+// function has to say so rather than fall through to DescribeWorkspaceBundles
+// with an empty filter, which answers with every bundle the account owns and
+// would bind an arbitrary one to the WorkSpace.
+func TestParseWorkspacesBundleRefIncomplete(t *testing.T) {
+	_, _, err := parseWorkspacesBundleRef(map[string]*llx.RawData{
+		"bundleId": llx.StringData("wsb-ccc333fff"),
+	})
+	require.Error(t, err)
+
+	_, _, err = parseWorkspacesBundleRef(map[string]*llx.RawData{
+		"region": llx.StringData("us-east-1"),
+	})
+	require.Error(t, err)
 }

--- a/providers/aws/resources/aws_workspaces_test.go
+++ b/providers/aws/resources/aws_workspaces_test.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	workspacestypes "github.com/aws/aws-sdk-go-v2/service/workspaces/types"
@@ -125,4 +127,16 @@ func TestParseWorkspacesBundleRefIncomplete(t *testing.T) {
 		"region": llx.StringData("us-east-1"),
 	})
 	require.Error(t, err)
+}
+
+// ===== unresolvable bundles =====
+
+// A bundle that cannot be named — deleted after the WorkSpace was built, or in a
+// region the caller cannot read — is reported as a null bundle. Any other
+// failure is a real error and must not be swallowed into a null.
+func TestWorkspacesBundleUnresolvedClassification(t *testing.T) {
+	notFound := fmt.Errorf("%w: id %q in %s", errWorkspacesBundleUnresolved, "wsb-ccc333fff", "us-east-1")
+	assert.True(t, errors.Is(notFound, errWorkspacesBundleUnresolved))
+
+	assert.False(t, errors.Is(errors.New("connection reset by peer"), errWorkspacesBundleUnresolved))
 }


### PR DESCRIPTION
### Problem

`aws.workspaces.bundles` calls `DescribeWorkspaceBundles` with no `Owner`, and [AWS answers that with the bundles the calling account owns](https://docs.aws.amazon.com/workspaces/latest/api/API_DescribeWorkspaceBundles.html) — the public AMAZON bundles are absent:

> To describe the bundles provided by Amazon Web Services, specify `AMAZON`. To describe the bundles that belong to your account, don't specify a value.

So there is currently no way to ask what bundle a given WorkSpace was built from. Most fleets run on AMAZON bundles, and those never appear in the list.

For a compliance check that is worse than a missing convenience — it is a silent false negative. Pairing a WorkSpace with its bundle today means filtering the list by `bundleId`:

```coffee
# wrong: empty for any WorkSpace on a public bundle, and .all() is
# vacuously true on an empty list — so it passes on the bad case
aws.workspaces.instances.all(
  aws.workspaces.bundles.where(bundleId == _.bundleId).all(owner != "AMAZON")
)
```

This blocks CIS AWS End User Compute Services **2.12** ("Restrict WorkSpaces Bundle options to organization approved versions"), which is exactly the control that needs to distinguish an org-approved custom bundle from a public one.

### Change

Add `aws.workspaces.workspace.bundle`, resolved by bundle ID. Filtering `DescribeWorkspaceBundles` by `BundleIds` reaches AMAZON-provided and account-owned bundles alike, so the check becomes honest — and an unresolvable bundle (deleted after the WorkSpace was built) surfaces as `null` rather than an empty set:

```coffee
aws.workspaces.instances.all(bundle.owner != "AMAZON")
```

It follows the existing lazy-reference pattern in this provider — `workspace.subnet`, `appstream.fleet.image` — with an `initAwsWorkspacesBundle` that fetches on demand.

`bundles()` keeps its current semantics. Adding a second `Owner: "AMAZON"` pass would pull hundreds of public bundles per region across every enabled region for data nobody queries, and would change the meaning of an existing field. Its doc comment, which claimed to list all bundles, is corrected instead.

### Tests

`go test ./resources/` in `providers/aws` — full suite green. New cases cover the null path when a WorkSpace has no bundle ID, and the reference parsing, including the partial-reference case: without both halves, `DescribeWorkspaceBundles` would fall through to an unfiltered call that returns every account bundle and bind an arbitrary one.

Not exercised against a live account — that needs a fleet with WorkSpaces on both a custom and a public bundle. Worth a manual check before the release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)