### PR TITLE
📄 docs: document the mock generation step before go test

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,6 +66,34 @@ make providers/mqlr
 ```
 To quickly install the changed provider plugin run `make providers/build/aws && make providers/install/aws`.
 
+## Run the tests
+
+Some tests use mocks that `mockgen` writes. The generated files are not committed. A fresh clone therefore cannot build
+the tests of `providers` and of `providers/os/connection/device/linux`. `go test ./...` stops with
+`undefined: NewMockProviderPlugin` and `undefined: snapshot.MockVolumeMounter`.
+
+Generate the mocks once after you clone:
+
+```bash
+make test/generate
+```
+
+The target installs `mockgen` and then runs `go generate ./providers/...`. It writes four files:
+
+- `providers/mock_coordinator.go`
+- `providers/mock_plugin_interface.go`
+- `providers/mock_schema.go`
+- `providers/os/connection/snapshot/mock_volumemounter.go`
+
+Run the target again after you change one of the interfaces that these files mock. Every CI test job runs it before the
+tests.
+
+After that step `go test ./...` builds. To run the core suite the way CI does, use:
+
+```bash
+make test/go
+```
+
 ## Debug providers
 
 `mql` uses a plugin mechanism. Each provider has its own go modules. This ensures that dependencies are only used on


### PR DESCRIPTION
## The problem

On a fresh clone of the default branch, `go test ./...` fails to build two packages:

```
# go.mondoo.com/mql/v13/providers
vet: providers/coordinator_test.go:29:17: undefined: NewMockProviderPlugin
# go.mondoo.com/mql/v13/providers/os/connection/device/linux
vet: providers/os/connection/device/linux/device_manager_test.go:16:26: undefined: snapshot.MockVolumeMounter
```

## Root cause

This is not a broken build. It is a missing instruction.

The mocks are generated, not committed. `.gitignore` has held these four paths since #3308 in February 2024:

```
providers/mock_coordinator.go
providers/mock_plugin_interface.go
providers/mock_schema.go
providers/os/connection/snapshot/mock_volumemounter.go
```

Four `go:generate mockgen` directives produce them, in `providers/coordinator.go` and in `providers/os/connection/snapshot/volumemounter.go`. `make test/generate` runs `go generate ./providers/...` and installs `mockgen` first. Three CI workflows call `make test/generate` before their test jobs, so CI is unaffected.

The gap is the developer flow. `DEVELOPMENT.md` had no test section at all, and named neither `make test/generate` nor `mockgen`. A new contributor meets an `undefined` error with no documented remedy.

## The fix

A "Run the tests" section in `DEVELOPMENT.md`. It names the failure, gives the one command that fixes it, lists the four generated files, and says when to run the command again.

I did not commit the generated files. Whether to track them instead of generating them reverses a deliberate choice from #3308, so that is a maintainer decision, not one to make in a docs change.

## Verification

`make test/generate` was run on a clean checkout of the default branch. It installed `mockgen` v0.6.0 and wrote all four files.

`go vet ./...` then reported no build error in any package. `go vet` type-checks test files, so this covers the test build across the repository.

One pre-existing `go vet` finding remains, unrelated to mocks and untouched here: `providers/runtime.go:852:2: unreachable code`.