### PR TITLE
⚡ os: split apk database fields without a regexp

### DIFF
--- a/providers/os/resources/packages/apk_packages.go
+++ b/providers/os/resources/packages/apk_packages.go
@@ -24,7 +24,21 @@ const (
 	ApkDbInstalledUsr = "/usr/lib/apk/db/installed"
 )
 
-var APK_REGEX = regexp.MustCompile(`^([A-Za-z]):(.*)$`)
+// apkField splits a line of the apk database into its one letter field key and
+// its value. It returns the same key and value as the regexp
+// `^([A-Za-z]):(.*)$`, which the parser used before.
+//
+// The returned value aliases line, so the caller must copy what it keeps.
+func apkField(line []byte) (key byte, value []byte, ok bool) {
+	if len(line) < 2 || line[1] != ':' {
+		return 0, nil, false
+	}
+	c := line[0]
+	if (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+		return 0, nil, false
+	}
+	return c, line[2:], true
+}
 
 // ParseApkDbPackages parses the database of the apk package manager located in
 // `/lib/apk/db/installed`
@@ -68,9 +82,11 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 
 	scanner := bufio.NewScanner(input)
 	pkg := Package{}
-	var key string
 	for scanner.Scan() {
-		line := scanner.Text()
+		// Bytes avoids one string allocation per line. Most lines of the apk
+		// database list files, and the parser keeps none of them. Every field
+		// it does keep is copied below.
+		line := scanner.Bytes()
 
 		// reset package definition once we reach a newline
 		if len(line) == 0 {
@@ -81,33 +97,28 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 			pkg = Package{}
 		}
 
-		m := APK_REGEX.FindStringSubmatch(line)
-		key = ""
-		if m != nil {
-			key = m[1]
-		}
-
-		// if we short line, we ignore it since this is not a valid line
-		if len(line) < 2 {
+		// a line we cannot split carries no field, so we ignore it
+		key, value, ok := apkField(line)
+		if !ok {
 			continue
 		}
 
 		// Parse the package name or version.
 		switch key {
-		case "P":
-			pkg.Name = m[2] // package name
-		case "V":
-			pkgVersion = m[2] // package version
-		case "A":
-			pkg.Arch = m[2] // architecture
-		case "t":
-			pkgEpoch = m[2] // epoch
-		case "o":
-			pkg.Origin = m[2] // origin
-		case "T":
-			pkg.Description = m[2] // description
-		case "L":
-			pkg.License = m[2] // license (SPDX expression)
+		case 'P':
+			pkg.Name = string(value) // package name
+		case 'V':
+			pkgVersion = string(value) // package version
+		case 'A':
+			pkg.Arch = string(value) // architecture
+		case 't':
+			pkgEpoch = string(value) // epoch
+		case 'o':
+			pkg.Origin = string(value) // origin
+		case 'T':
+			pkg.Description = string(value) // description
+		case 'L':
+			pkg.License = string(value) // license (SPDX expression)
 		}
 	}
 

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -4,6 +4,8 @@
 package packages
 
 import (
+	"bytes"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -190,4 +192,82 @@ func TestApkUpdateParser(t *testing.T) {
 	assert.Equal(t, "ssl_client", update.Name, "pkg name detected")
 	assert.Equal(t, "1.28.4-r0", update.Version, "pkg version detected")
 	assert.Equal(t, "1.28.4-r1", update.Available, "pkg available version detected")
+}
+
+func TestApkField(t *testing.T) {
+	// The parser used the regexp `^([A-Za-z]):(.*)$` before.
+	tests := []struct {
+		line  string
+		key   byte
+		value string
+		ok    bool
+	}{
+		{"P:musl", 'P', "musl", true},
+		{"V:1.2.5-r0", 'V', "1.2.5-r0", true},
+		{"t:1234567890", 't', "1234567890", true},
+		{"L:MIT", 'L', "MIT", true},
+		// an empty value still matches, because the regexp used `.*`
+		{"T:", 'T', "", true},
+		// file lines are fields too, the parser just keeps none of them
+		{"R:libc.musl-x86_64.so.1", 'R', "libc.musl-x86_64.so.1", true},
+		// the key must be exactly one ASCII letter followed by a colon
+		{"PP:musl", 0, "", false},
+		{"1:musl", 0, "", false},
+		{":musl", 0, "", false},
+		{"P", 0, "", false},
+		{"", 0, "", false},
+		{" P:musl", 0, "", false},
+	}
+	for _, test := range tests {
+		key, value, ok := apkField([]byte(test.line))
+		assert.Equal(t, test.ok, ok, "match for %q", test.line)
+		assert.Equal(t, test.key, key, "key for %q", test.line)
+		assert.Equal(t, test.value, string(value), "value for %q", test.line)
+	}
+}
+
+// apkBenchDB builds a database in the shape of /lib/apk/db/installed. Most
+// lines of a real database list directories and files.
+func apkBenchDB(pkgCount int, filesPerPkg int) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < pkgCount; i++ {
+		name := "package-" + strconv.Itoa(i)
+		buf.WriteString("C:Q1eVpkasdfjkl" + strconv.Itoa(i) + "=\n")
+		buf.WriteString("P:" + name + "\n")
+		buf.WriteString("V:1." + strconv.Itoa(i) + ".0-r0\n")
+		buf.WriteString("A:x86_64\n")
+		buf.WriteString("S:" + strconv.Itoa(10000+i) + "\n")
+		buf.WriteString("I:" + strconv.Itoa(40000+i) + "\n")
+		buf.WriteString("T:short description for " + name + "\n")
+		buf.WriteString("U:https://example.org/" + name + "\n")
+		buf.WriteString("L:MIT\n")
+		buf.WriteString("o:" + name + "\n")
+		buf.WriteString("m:Alpine Developers <foo@example.org>\n")
+		buf.WriteString("t:176000000" + strconv.Itoa(i%10) + "\n")
+		buf.WriteString("c:abcdef0123456789abcdef0123456789abcdef01\n")
+		buf.WriteString("D:so:libc.musl-x86_64.so.1 so:libz.so.1\n")
+		buf.WriteString("p:cmd:" + name + "=1.0.0-r0\n")
+		buf.WriteString("F:usr/lib/" + name + "\n")
+		for j := 0; j < filesPerPkg; j++ {
+			buf.WriteString("R:file-" + strconv.Itoa(j) + ".so\n")
+			buf.WriteString("Z:Q1abcdefghijklmnop" + strconv.Itoa(j) + "=\n")
+		}
+		buf.WriteString("\n")
+	}
+	return buf.Bytes()
+}
+
+func BenchmarkParseApkDbPackages(b *testing.B) {
+	data := apkBenchDB(60, 60)
+	pf := &inventory.Platform{Name: "alpine", Version: "3.21", Arch: "x86_64"}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pkgs := ParseApkDbPackages(pf, bytes.NewReader(data))
+		if len(pkgs) != 60 {
+			b.Fatalf("expected 60 packages, got %d", len(pkgs))
+		}
+	}
 }


### PR DESCRIPTION
## What allocates

`ParseApkDbPackages` reads `/lib/apk/db/installed`. It ran the regexp `^([A-Za-z]):(.*)$` on every line.

Most lines of that database are not package metadata. They list the directories and files each package owns, on `F:`, `R:` and `Z:` lines. The parser keeps none of them. Every one of those lines still paid a `FindStringSubmatch` call, a submatch slice, and a `scanner.Text` string.

The parser also kept the submatch strings directly. A submatch aliases the line string, so each field it stored held the whole line alive.

## What changed

`apkField` replaces the regexp with two byte checks. The key of an apk field is exactly one ASCII letter followed by a colon, so no pattern matching is needed.

The loop now reads `scanner.Bytes`. A line the parser discards costs no allocation. Every field it keeps is copied with an explicit string conversion, which also drops the aliasing of the full line.

`APK_REGEX` has no remaining user and is removed.

## Numbers

```
go test ./providers/os/resources/packages/ -run xxx -bench 'ParseApkDbPackages' -benchmem -count=6
```

The benchmark builds a database of 60 packages, each with 60 files, which is the shape of a small Alpine image.

| | before | after | change |
| --- | --- | --- | --- |
| B/op | 1708985 | 629924 | -63.1% |
| allocs/op | 33286 | 9222 | -72.3% |
| ns/op | 6973171 | 1712500 | -75.4% |

The win is larger than on the dpkg parser because the file lines dominate the apk database, and the parser throws all of them away.

## Correctness

A differential test parsed the same database with the old and the new implementation. All 60 packages compared equal with `reflect.DeepEqual`.

`TestApkField` pins the semantics, including an empty value, a file line, a two letter key, a digit key, a missing key and a leading space.

`go test ./providers/os/resources/packages/` passes.