### PR TITLE
🎉 redfish-13.1.0

### DIFF
--- a/providers/redfish/config/config.go
+++ b/providers/redfish/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "redfish",
 	ID:              "go.mondoo.com/mql/providers/redfish",
-	Version:         "13.0.6",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Bumps the redfish provider from `13.0.6` to `13.1.0`.

Minor rather than patch because the unreleased change adds resources rather than fixing behaviour — #9878 (`🌟 redfish: add BMC security posture resources`) introduces four new resources plus anonymous-connection support:

- `redfish.networkProtocol` — which management protocols the BMC exposes (IPMI, telnet, SSH, …)
- `redfish.certificate` — the controller's TLS certificates and validity window
- `redfish.sessionService` — session service state and timeout
- `redfish.session` — active sessions with their originating client IP

That is the only commit touching `providers/redfish/` since `13.0.6` shipped in #9824.

Version only, one line in `providers/redfish/config/config.go`. The `redfish.lr.versions` stamps from #9878 read `13.0.7`, because `lr versions` derives its stamp by calling `IncPatch()` on whatever is in `config.go` at the time. Those are deliberately left as-is — the same thing happened with tailscale, whose identity-graph feature stamped `13.3.12` and then released as `13.4.0` without rewriting the stamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)