### PR TITLE
🐛 ms365: stop ParseCLI panicking on unset flags and bound the workspace page walk

### DIFF
--- a/providers/ms365/provider/provider.go
+++ b/providers/ms365/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
@@ -29,39 +30,49 @@ func Init() *Service {
 	}
 }
 
+// flagBytes safely reads a flag's raw value. Unset flags (including keys the
+// running command never registered) are absent from the map, so a direct
+// lookup yields a nil primitive.
+func flagBytes(flags map[string]*llx.Primitive, key string) []byte {
+	if p, ok := flags[key]; ok && p != nil {
+		return p.Value
+	}
+	return nil
+}
+
 func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error) {
 	flags := req.GetFlags()
 
-	tenantId := flags["tenant-id"]
-	clientId := flags["client-id"]
-	clientSecret := flags["client-secret"]
-	certificatePath := flags["certificate-path"]
-	certificateSecret := flags["certificate-secret"]
-	organization := flags["organization"]
-	sharepointUrl := flags["sharepoint-url"]
-	authMethod := flags["auth-method"]
+	tenantId := flagBytes(flags, "tenant-id")
+	clientId := flagBytes(flags, "client-id")
+	clientSecret := flagBytes(flags, "client-secret")
+	certificatePath := flagBytes(flags, "certificate-path")
+	certificateSecret := flagBytes(flags, "certificate-secret")
+	organization := flagBytes(flags, "organization")
+	sharepointUrl := flagBytes(flags, "sharepoint-url")
+	authMethod := flagBytes(flags, "auth-method")
 
 	opts := map[string]string{}
 	creds := []*vault.Credential{}
 
-	opts[connection.OptionTenantID] = string(tenantId.Value)
-	opts[connection.OptionClientID] = string(clientId.Value)
-	opts[connection.OptionOrganization] = string(organization.Value)
-	opts[connection.OptionSharepointUrl] = string(sharepointUrl.Value)
-	if authMethod != nil && len(authMethod.Value) > 0 {
-		opts[connection.OptionAuthMethod] = string(authMethod.Value)
+	opts[connection.OptionTenantID] = string(tenantId)
+	opts[connection.OptionClientID] = string(clientId)
+	opts[connection.OptionOrganization] = string(organization)
+	opts[connection.OptionSharepointUrl] = string(sharepointUrl)
+	if len(authMethod) > 0 {
+		opts[connection.OptionAuthMethod] = string(authMethod)
 	}
 
-	if len(clientSecret.Value) > 0 {
+	if len(clientSecret) > 0 {
 		creds = append(creds, &vault.Credential{
 			Type:   vault.CredentialType_password,
-			Secret: clientSecret.Value,
+			Secret: clientSecret,
 		})
-	} else if len(certificatePath.Value) > 0 {
+	} else if len(certificatePath) > 0 {
 		creds = append(creds, &vault.Credential{
 			Type:           vault.CredentialType_pkcs12,
-			PrivateKeyPath: string(certificatePath.Value),
-			Password:       string(certificateSecret.Value),
+			PrivateKeyPath: string(certificatePath),
+			Password:       string(certificateSecret),
 		})
 	}
 	config := &inventory.Config{

--- a/providers/ms365/provider/provider_test.go
+++ b/providers/ms365/provider/provider_test.go
@@ -1,0 +1,180 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+	"go.mondoo.com/mql/v13/providers/ms365/connection"
+)
+
+// connOpts returns the Options map from the single connection ParseCLI builds,
+// failing the test if the response shape is unexpected.
+func connOpts(t *testing.T, res *plugin.ParseCLIRes) map[string]string {
+	t.Helper()
+	require.NotNil(t, res)
+	require.NotNil(t, res.Asset)
+	require.Len(t, res.Asset.Connections, 1)
+	return res.Asset.Connections[0].Options
+}
+
+// connCreds returns the credentials from the single connection ParseCLI builds.
+func connCreds(t *testing.T, res *plugin.ParseCLIRes) []*vault.Credential {
+	t.Helper()
+	require.NotNil(t, res)
+	require.NotNil(t, res.Asset)
+	require.Len(t, res.Asset.Connections, 1)
+	return res.Asset.Connections[0].Credentials
+}
+
+// TestParseCLINilFlags is a regression test: the flags map only carries keys the
+// running command actually set, so any flag the user omitted resolves to a nil
+// *llx.Primitive. ParseCLI used to dereference every flag unconditionally, so
+// `mql run ms365 --tenant-id ... --client-id ... --certificate-path ...`
+// panicked on the first flag the user had not passed (`organization`) before
+// reaching any resource.
+func TestParseCLINilFlags(t *testing.T) {
+	s := Init()
+
+	t.Run("empty flags map does not panic", func(t *testing.T) {
+		var res *plugin.ParseCLIRes
+		var err error
+		require.NotPanics(t, func() {
+			res, err = s.ParseCLI(&plugin.ParseCLIReq{
+				Flags: map[string]*llx.Primitive{},
+			})
+		})
+		require.NoError(t, err)
+		opts := connOpts(t, res)
+		// unset flags map to empty strings, not a crash
+		assert.Empty(t, opts[connection.OptionTenantID])
+		assert.Empty(t, opts[connection.OptionClientID])
+		assert.Empty(t, opts[connection.OptionOrganization])
+		assert.Empty(t, opts[connection.OptionSharepointUrl])
+		// an unset auth-method is omitted entirely rather than set to ""
+		assert.NotContains(t, opts, connection.OptionAuthMethod)
+		assert.Empty(t, connCreds(t, res))
+	})
+
+	t.Run("explicitly nil primitives do not panic", func(t *testing.T) {
+		var err error
+		require.NotPanics(t, func() {
+			_, err = s.ParseCLI(&plugin.ParseCLIReq{
+				Flags: map[string]*llx.Primitive{
+					"tenant-id":          nil,
+					"client-id":          nil,
+					"client-secret":      nil,
+					"certificate-path":   nil,
+					"certificate-secret": nil,
+					"organization":       nil,
+					"sharepoint-url":     nil,
+					"auth-method":        nil,
+				},
+			})
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("partial flags: only the auth flags a user typically passes", func(t *testing.T) {
+		var res *plugin.ParseCLIRes
+		var err error
+		require.NotPanics(t, func() {
+			res, err = s.ParseCLI(&plugin.ParseCLIReq{
+				Flags: map[string]*llx.Primitive{
+					"tenant-id":        llx.StringPrimitive("tid"),
+					"client-id":        llx.StringPrimitive("cid"),
+					"certificate-path": llx.StringPrimitive("/tmp/cert.pem"),
+				},
+			})
+		})
+		require.NoError(t, err)
+		opts := connOpts(t, res)
+		assert.Equal(t, "tid", opts[connection.OptionTenantID])
+		assert.Equal(t, "cid", opts[connection.OptionClientID])
+		assert.Empty(t, opts[connection.OptionOrganization])
+
+		creds := connCreds(t, res)
+		require.Len(t, creds, 1)
+		assert.Equal(t, vault.CredentialType_pkcs12, creds[0].Type)
+		assert.Equal(t, "/tmp/cert.pem", creds[0].PrivateKeyPath)
+		assert.Empty(t, creds[0].Password)
+	})
+}
+
+// TestParseCLICredentials pins which credential a given flag combination
+// produces: a client secret wins over a certificate, and neither yields none.
+func TestParseCLICredentials(t *testing.T) {
+	s := Init()
+
+	t.Run("client secret takes precedence over certificate", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Flags: map[string]*llx.Primitive{
+				"client-secret":    llx.StringPrimitive("shhh"),
+				"certificate-path": llx.StringPrimitive("/tmp/cert.pem"),
+			},
+		})
+		require.NoError(t, err)
+		creds := connCreds(t, res)
+		require.Len(t, creds, 1)
+		assert.Equal(t, vault.CredentialType_password, creds[0].Type)
+		assert.Equal(t, []byte("shhh"), creds[0].Secret)
+	})
+
+	t.Run("certificate with passphrase", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Flags: map[string]*llx.Primitive{
+				"certificate-path":   llx.StringPrimitive("/tmp/cert.pfx"),
+				"certificate-secret": llx.StringPrimitive("pass"),
+			},
+		})
+		require.NoError(t, err)
+		creds := connCreds(t, res)
+		require.Len(t, creds, 1)
+		assert.Equal(t, vault.CredentialType_pkcs12, creds[0].Type)
+		assert.Equal(t, "/tmp/cert.pfx", creds[0].PrivateKeyPath)
+		assert.Equal(t, "pass", creds[0].Password)
+	})
+
+	t.Run("no auth flags yields no credentials", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Flags: map[string]*llx.Primitive{
+				"tenant-id": llx.StringPrimitive("tid"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, connCreds(t, res))
+	})
+}
+
+// TestParseCLIAuthMethod pins that auth-method is only forwarded when non-empty,
+// so an unset flag leaves the connection's default probe order intact rather
+// than pinning it to "".
+func TestParseCLIAuthMethod(t *testing.T) {
+	s := Init()
+
+	t.Run("set", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Flags: map[string]*llx.Primitive{
+				"auth-method": llx.StringPrimitive("cli,env"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "cli,env", connOpts(t, res)[connection.OptionAuthMethod])
+	})
+
+	t.Run("empty string is omitted", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Flags: map[string]*llx.Primitive{
+				"auth-method": llx.StringPrimitive(""),
+			},
+		})
+		require.NoError(t, err)
+		assert.NotContains(t, connOpts(t, res), connection.OptionAuthMethod)
+	})
+}

--- a/providers/ms365/resources/powerbi.go
+++ b/providers/ms365/resources/powerbi.go
@@ -363,24 +363,34 @@ func fetchPowerBiWorkspaces(ctx context.Context, token string) (json.RawMessage,
 // fetchPowerBiWorkspacePages walks the admin groups endpoint until a short page
 // signals the end of the collection. The pages are concatenated into a single
 // array so the section decodes like any other.
+//
+// The walk is bounded by powerBiMaxPages for the same reason the continuation
+// walk is: the only termination signal is a page shorter than pageSize, so an
+// endpoint that ignores $skip answers every request with a full page and the
+// loop never ends, appending pageSize workspaces per iteration until the scan
+// is out of memory.
 func fetchPowerBiWorkspacePages(ctx context.Context, token string, baseUrl string, pageSize int) (json.RawMessage, error) {
 	all := []json.RawMessage{}
-	for skip := 0; ; skip += pageSize {
-		url := fmt.Sprintf("%sadmin/groups?$top=%d&$expand=users&$skip=%d", baseUrl, pageSize, skip)
+	for page := 0; ; page++ {
+		if page >= powerBiMaxPages {
+			return nil, fmt.Errorf("power bi admin/groups returned more than %d pages, the endpoint may be ignoring $skip", powerBiMaxPages)
+		}
+
+		url := fmt.Sprintf("%sadmin/groups?$top=%d&$expand=users&$skip=%d", baseUrl, pageSize, page*pageSize)
 		raw, err := powerBiGet(ctx, token, url, "value")
 		if err != nil {
 			return nil, err
 		}
 
-		var page []json.RawMessage
+		var chunk []json.RawMessage
 		if len(raw) > 0 {
-			if err := json.Unmarshal(raw, &page); err != nil {
+			if err := json.Unmarshal(raw, &chunk); err != nil {
 				return nil, err
 			}
 		}
-		all = append(all, page...)
+		all = append(all, chunk...)
 
-		if len(page) < pageSize {
+		if len(chunk) < pageSize {
 			break
 		}
 	}

--- a/providers/ms365/resources/powerbi_test.go
+++ b/providers/ms365/resources/powerbi_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -311,6 +312,36 @@ func TestFetchPowerBiWorkspacePages(t *testing.T) {
 				assert.Equal(t, fmt.Sprintf("ws-%d", i), got[i].Id)
 			}
 		})
+	}
+}
+
+// TestFetchPowerBiWorkspacePagesBoundsAStuckSkip is the counterpart to
+// TestPowerBiGetRejectsRepeatedContinuation: the only signal that ends this
+// walk is a page shorter than the page size, so an endpoint that ignores $skip
+// answers every request with a full page. Unbounded, the loop never returns and
+// appends pageSize workspaces per iteration until the scan is out of memory.
+func TestFetchPowerBiWorkspacePagesBoundsAStuckSkip(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		// a full page every time, regardless of $skip
+		fmt.Fprint(w, `{"value":[{"id":"ws-0"},{"id":"ws-1"}]}`)
+	}))
+	defer srv.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := fetchPowerBiWorkspacePages(context.Background(), "tok", srv.URL+"/", 2)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ignoring $skip")
+		assert.Equal(t, powerBiMaxPages, requests, "must stop at the page bound")
+	case <-time.After(30 * time.Second):
+		t.Fatal("walk did not terminate: a stuck $skip spins forever")
 	}
 }
 


### PR DESCRIPTION
Two defects found while verifying the recent ms365 changes (#9866, #9591) against a live tenant.

## 1. `ParseCLI` panicked on any flag the user did not pass

`ParseCLI` dereferenced every flag unconditionally, but the flags map only
carries keys the running command actually set. So

```
mql run ms365 --tenant-id <id> --client-id <id> --certificate-path <pem>
```

panicked with a nil pointer dereference at `provider.go:49` (`organization`)
before reaching any resource, and printed the command's help text instead of a
result. No flag combination avoided it: supplying `--organization` and
`--sharepoint-url` as well simply moved the panic to `client-secret`, which a
certificate-authenticated user has no reason to pass.

```
x recovered panic in provider method=ParseCLI panic="invalid memory address or nil pointer dereference"
  go.mondoo.com/mql/v13/providers/ms365/provider.(*Service).ParseCLI(...)
      providers/ms365/provider/provider.go:49
x failed to parse cli arguments error="rpc error: code = Internal desc = panic in provider ParseCLI: ..."
```

This is the same defect the azure provider fixed in #8941; ms365 never got the
same treatment. Every flag read now goes through the nil-safe `flagBytes`
helper, matching that fix.

Verified against a live tenant — `mql run ms365 -c 'microsoft.tenantDomainName'`
now returns the tenant domain rather than a panic.

## 2. The Power BI workspace walk never terminates on a stuck `$skip`

`fetchPowerBiWorkspacePages` ends only when a page comes back shorter than the
page size. An endpoint that ignores `$skip` therefore answers every request with
a full page, and the walk loops forever, appending `powerBiWorkspacePageSize`
(5000) workspaces per iteration until the scan is out of memory.

`powerBiGet` already guards the *continuation* walk against exactly this class
of stuck cursor, with both `powerBiMaxPages` and a repeated-link check. The
`$skip` walk added alongside it has neither.

Measured rather than assumed: a test server that ignores `$skip` drew **47,048
requests in three seconds** and was still climbing. The walk is now bounded by
the same `powerBiMaxPages` constant and reports the likely cause.

## Tests

- `providers/ms365/provider/provider_test.go` (new) — regression coverage for
  the nil-flag panic: an empty flags map, explicitly nil primitives, and the
  realistic partial-flag case. Also pins which credential each flag combination
  produces and that an unset `auth-method` is omitted rather than set to `""`.
- `providers/ms365/resources/powerbi_test.go` — `TestFetchPowerBiWorkspacePagesBoundsAStuckSkip`,
  the counterpart to the existing `TestPowerBiGetRejectsRepeatedContinuation`.

`go test ./...` passes in `providers/ms365/`.
