### PR TITLE
🐛 azure: report a vault child's real region and stop claiming it is untagged

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -12772,9 +12772,17 @@ private azure.subscription.recoveryServicesService.vault.backupPolicy @defaults(
   // Backup policy name
   name string
   // Backup policy location
+  //
+  // Azure Resource Manager does not carry a location on a backup policy, so
+  // this reports the region of the vault the policy belongs to.
   location string
   // Backup policy tags
-  tags map[string]string
+  //
+  // Deprecated in favor of the vault's tags. Azure Resource Manager does not
+  // support tags on a backup policy: a tag written against the policy resource
+  // ID is stored on the vault instead, and a create that sets tags has them
+  // stripped, so this field is always null.
+  tags @maturity("deprecated") map[string]string
   // Resource type
   type string
   // Backup policy properties
@@ -12794,9 +12802,17 @@ private azure.subscription.recoveryServicesService.vault.protectedItem @defaults
   // Protected item name
   name string
   // Protected item location
+  //
+  // Azure Resource Manager does not carry a location on a protected item, so
+  // this reports the region of the vault the item belongs to.
   location string
   // Protected item tags
-  tags map[string]string
+  //
+  // Deprecated in favor of the vault's tags, or the tags of the protected
+  // resource itself. Azure Resource Manager does not support tags on a
+  // protected item: a tag written against the item resource ID is stored on
+  // the vault instead, so this field is always null.
+  tags @maturity("deprecated") map[string]string
   // Resource type
   type string
   // Protected item properties

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -729,6 +729,37 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVaultBackupConfig) id() (str
 	return a.Id.Data, nil
 }
 
+// vaultChildLocationAndTags answers the location and tags for a child of a
+// recovery services vault.
+//
+// Backup policies and protected items are ARM proxy resources: the API omits
+// location and tags from both the list and the get response, and a PUT that
+// sets either has them stripped from the stored resource. Azure applies a tag
+// written against a policy's resource ID to the vault instead.
+//
+// The child still lives in the vault's region, so fall back to that rather
+// than reporting an unknown location. Tags stay null: an empty map asserts the
+// resource carries no tags, and that is a claim the API never made, so a
+// policy requiring a tag would fail on every policy in the tenant while a
+// policy exempting by tag would exempt none of them.
+func vaultChildLocationAndTags(vaultLocation *plugin.TValue[string], location *string, tags map[string]*string) (*llx.RawData, *llx.RawData) {
+	locationData := llx.NilData
+	switch {
+	case location != nil && *location != "":
+		locationData = llx.StringDataPtr(location)
+	case vaultLocation != nil && vaultLocation.Error == nil &&
+		vaultLocation.State&plugin.StateIsNull == 0 && vaultLocation.Data != "":
+		locationData = llx.StringData(vaultLocation.Data)
+	}
+
+	tagsData := llx.NilData
+	if len(tags) > 0 {
+		tagsData = llx.MapData(convert.PtrMapStrToInterface(tags), types.String)
+	}
+
+	return locationData, tagsData
+}
+
 // backupPolicies fetches all backup policies in the vault.
 func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) backupPolicies() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
@@ -769,12 +800,14 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) backupPolicies() ([]a
 				return nil, err
 			}
 
+			location, tags := vaultChildLocationAndTags(a.GetLocation(), policy.Location, policy.Tags)
+
 			mqlPolicy, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionRecoveryServicesServiceVaultBackupPolicy,
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(policy.ID),
 					"name":       llx.StringDataPtr(policy.Name),
-					"location":   llx.StringDataPtr(policy.Location),
-					"tags":       llx.MapData(convert.PtrMapStrToInterface(policy.Tags), types.String),
+					"location":   location,
+					"tags":       tags,
 					"type":       llx.StringDataPtr(policy.Type),
 					"properties": llx.DictData(properties),
 				})
@@ -831,12 +864,14 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceVault) protectedItems() ([]a
 				return nil, err
 			}
 
+			location, tags := vaultChildLocationAndTags(a.GetLocation(), item.Location, item.Tags)
+
 			mqlItem, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionRecoveryServicesServiceVaultProtectedItem,
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(item.ID),
 					"name":       llx.StringDataPtr(item.Name),
-					"location":   llx.StringDataPtr(item.Location),
-					"tags":       llx.MapData(convert.PtrMapStrToInterface(item.Tags), types.String),
+					"location":   location,
+					"tags":       tags,
 					"type":       llx.StringDataPtr(item.Type),
 					"properties": llx.DictData(properties),
 				})

--- a/providers/azure/resources/recoveryservices_test.go
+++ b/providers/azure/resources/recoveryservices_test.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func vaultLocationTValue(location string) *plugin.TValue[string] {
+	return &plugin.TValue[string]{Data: location, State: plugin.StateIsSet}
+}
+
+func TestVaultChildLocationAndTags(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+
+	t.Run("falls back to the vault region when ARM omits location", func(t *testing.T) {
+		location, _ := vaultChildLocationAndTags(vaultLocationTValue("westus2"), nil, nil)
+		require.Equal(t, types.String, location.Type)
+		assert.Equal(t, "westus2", location.Value)
+	})
+
+	t.Run("prefers a location the API did return", func(t *testing.T) {
+		location, _ := vaultChildLocationAndTags(vaultLocationTValue("westus2"), ptr("eastus"), nil)
+		assert.Equal(t, "eastus", location.Value)
+	})
+
+	t.Run("an empty API location is not a location", func(t *testing.T) {
+		location, _ := vaultChildLocationAndTags(vaultLocationTValue("westus2"), ptr(""), nil)
+		assert.Equal(t, "westus2", location.Value)
+	})
+
+	t.Run("null location when neither the API nor the vault has one", func(t *testing.T) {
+		location, _ := vaultChildLocationAndTags(vaultLocationTValue(""), nil, nil)
+		assert.Same(t, llx.NilData, location)
+	})
+
+	t.Run("a vault whose location errored does not become a location", func(t *testing.T) {
+		vault := &plugin.TValue[string]{Data: "westus2", State: plugin.StateIsSet, Error: errors.New("boom")}
+		location, _ := vaultChildLocationAndTags(vault, nil, nil)
+		assert.Same(t, llx.NilData, location)
+	})
+
+	t.Run("a null vault location does not become a location", func(t *testing.T) {
+		vault := &plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+		location, _ := vaultChildLocationAndTags(vault, nil, nil)
+		assert.Same(t, llx.NilData, location)
+	})
+
+	t.Run("a nil vault value is tolerated", func(t *testing.T) {
+		location, _ := vaultChildLocationAndTags(nil, nil, nil)
+		assert.Same(t, llx.NilData, location)
+	})
+}
+
+// The regression this guards: an empty map asserts "this resource carries no
+// tags". ARM never returns tags for these proxy resources, so that assertion
+// would make a tag-required policy fail on every policy in the tenant and a
+// tag-exempting policy exempt none of them. Null says "no tag data", which is
+// what is actually true.
+func TestVaultChildTagsAreNullNotEmpty(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+
+	t.Run("nil tag map is null, not an empty map", func(t *testing.T) {
+		_, tags := vaultChildLocationAndTags(vaultLocationTValue("westus2"), nil, nil)
+		assert.Same(t, llx.NilData, tags)
+	})
+
+	t.Run("empty tag map is null, not an empty map", func(t *testing.T) {
+		_, tags := vaultChildLocationAndTags(vaultLocationTValue("westus2"), nil, map[string]*string{})
+		assert.Same(t, llx.NilData, tags)
+	})
+
+	t.Run("tags are reported when the API does return them", func(t *testing.T) {
+		_, tags := vaultChildLocationAndTags(vaultLocationTValue("westus2"), nil, map[string]*string{
+			"owner": ptr("platform"),
+		})
+		require.NotSame(t, llx.NilData, tags)
+		assert.Equal(t, map[string]any{"owner": "platform"}, tags.Value)
+	})
+}


### PR DESCRIPTION
## What

`azure.subscription.recoveryServicesService.vault.backupPolicy` and `.protectedItem` mapped `location` and `tags` straight from the ARM envelope. Azure never carries either on those resources, so `location` was permanently `null` and `tags` permanently `{}`.

Found while verifying the last 72 hours of merged PRs against live Azure.

## Why it matters

`tags: {}` is an assertion — it says *this resource carries no tags*. Since Azure never returns tags here, an audit requiring a tag on backup policies failed on every policy in the tenant, and one exempting resources by tag exempted none of them. That is exactly the false assertion #9826 removed from 33 AWS tag accessors in the same release window.

## Evidence (live Azure, api-version 2023-02-01)

Backup policies and protected items are ARM **proxy** resources under the vault:

```
# GET a backup policy — no location, no tags key at all
keys: ['id', 'name', 'properties', 'type']

# Write a tag against the POLICY resource id...
az tag update --resource-id .../vaults/V/backupPolicies/DefaultPolicy --operation merge --tags probe=yes
# ...and ARM stores it on the VAULT instead:
  id: .../vaults/V/providers/Microsoft.Resources/tags/default
  vault tags: {'probe': 'yes'}
  policy tags: ABSENT

# PUT a new policy with location + tags explicitly in the body — both stripped:
keys returned: ['id', 'name', 'properties', 'type']
tags     -> ABSENT
location -> ABSENT
```

## The change

Both listers run on the vault, so the vault's region is already in hand.

- **`location`** — fall back to the vault's region. A policy or protected item genuinely lives there; this makes the field useful instead of always-null. An API-supplied location still wins if one ever appears.
- **`tags`** — `llx.NilData` instead of `llx.MapData(nil, ...)`. The latter wraps a *typed* nil map, which is non-nil as an interface, so `RawToTValue` sets `StateIsSet` and it renders `{}`; `NilData` produces a genuine null.
- **`tags` marked `@maturity("deprecated")`** on both resources — Azure has no tag concept for them, so the field can never hold data. Descriptions point at the vault's tags (or the protected resource's own tags).

`.lr.versions` is unchanged, per the convention that deprecation does not bump a field's version.

## Verification

Before → after, same vault:

| Field | Before | After |
|---|---|---|
| `backupPolicy.location` | `null` | `"westus2"` |
| `backupPolicy.tags` | `{}` | `null` |
| `protectedItem.location` | `null` | `"westus2"` |
| `protectedItem.tags` | `{}` | `null` |

Confirmed against a live vault with 4 backup policies and 1 protected VM.

`recoveryservices_test.go` adds table tests for the pure-Go helper: the vault fallback, an API location winning, an empty API location, and the vault-errored / vault-null / nil-vault paths; plus nil-map and empty-map both yielding null while real tags still pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
