### PR TITLE
🎉 azure-13.34.4, ms365-13.11.1

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.34.3",
+	Version:   "13.34.4",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.11.0",
+	Version:         "13.11.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Patch release for the `azure` and `ms365` providers.

## azure 13.34.3 → 13.34.4

- 🐛 report a vault child's real region and stop claiming it is untagged (#9888) — `recoveryServicesService.vault.backupPolicy` and `.protectedItem` reported `location: null` and `tags: {}` unconditionally. `tags: {}` asserted the resource carried no tags, so a policy requiring a tag failed on every backup policy in a tenant. `location` now falls back to the vault's region and `tags` is null, with the field deprecated since ARM has no tag concept for these proxy resources.
- 🐛 drop deprecated `wafPolicyId` from `securityPolicy` @defaults (#9831)

## ms365 13.11.0 → 13.11.1

- 🐛 stop `ParseCLI` panicking on unset flags and bound the workspace page walk (#9887)

---

Version bumps generated with `providers-sdk/v1/util/version`. Only `config.go` `Version` fields change; no schema or `.lr.versions` changes are part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
