### PR TITLE
⚡ claude: build resource ids by concatenation instead of Sprintf

### DIFF
--- a/providers/claude/resources/claude_beta.go
+++ b/providers/claude/resources/claude_beta.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"go.mondoo.com/mql/v13/llx"
@@ -122,7 +123,7 @@ func agentSkills(runtime *plugin.Runtime, agentID string, skills []anthropic.Bet
 	res := make([]interface{}, 0, len(skills))
 	for _, s := range skills {
 		mqlSkill, err := CreateResource(runtime, "claude.agent.skill", map[string]*llx.RawData{
-			"__id":    llx.StringData(fmt.Sprintf("%s/skill/%s/%s", agentID, s.SkillID, s.Version)),
+			"__id":    llx.StringData(agentID + "/skill/" + s.SkillID + "/" + s.Version),
 			"source":  llx.StringData(s.Type),
 			"version": llx.StringData(s.Version),
 		})
@@ -206,7 +207,7 @@ func agentTools(runtime *plugin.Runtime, agentID string, entries []anthropic.Bet
 			}
 
 			mqlTool, err := CreateResource(runtime, "claude.agent.customTool", map[string]*llx.RawData{
-				"__id":        llx.StringData(fmt.Sprintf("%s/customTool/%s", agentID, tool.Name)),
+				"__id":        llx.StringData(agentID + "/customTool/" + tool.Name),
 				"name":        llx.StringData(tool.Name),
 				"description": llx.StringData(tool.Description),
 				"inputSchema": llx.DictData(inputSchema),
@@ -240,10 +241,12 @@ type toolsetSpec struct {
 }
 
 func newToolset(runtime *plugin.Runtime, agentID string, toolsetIndex int, spec toolsetSpec) (plugin.Resource, error) {
+	toolsetID := agentID + "/toolset/" + strconv.Itoa(toolsetIndex)
+
 	tools := make([]interface{}, 0, len(spec.tools))
 	for _, tool := range spec.tools {
 		mqlTool, err := CreateResource(runtime, "claude.agent.toolset.tool", map[string]*llx.RawData{
-			"__id":             llx.StringData(fmt.Sprintf("%s/toolset/%d/%s", agentID, toolsetIndex, tool.name)),
+			"__id":             llx.StringData(toolsetID + "/" + tool.name),
 			"name":             llx.StringData(tool.name),
 			"enabled":          llx.BoolData(tool.enabled),
 			"permissionPolicy": llx.StringData(tool.permissionPolicy),
@@ -255,7 +258,7 @@ func newToolset(runtime *plugin.Runtime, agentID string, toolsetIndex int, spec 
 	}
 
 	return CreateResource(runtime, "claude.agent.toolset", map[string]*llx.RawData{
-		"__id":                    llx.StringData(fmt.Sprintf("%s/toolset/%d", agentID, toolsetIndex)),
+		"__id":                    llx.StringData(toolsetID),
 		"type":                    llx.StringData(spec.toolsetType),
 		"mcpServerName":           llx.StringData(spec.mcpServerName),
 		"defaultEnabled":          llx.BoolData(spec.defaultEnabled),

--- a/providers/claude/resources/claude_organization.go
+++ b/providers/claude/resources/claude_organization.go
@@ -267,7 +267,7 @@ func convertRateLimits(runtime *plugin.Runtime, limits []connection.AdminRateLim
 		}
 
 		mqlLimit, err := CreateResource(runtime, "claude.organization.rateLimit", map[string]*llx.RawData{
-			"__id":                  llx.StringData(fmt.Sprintf("%s/ratelimit/%s", prefix, l.GroupType)),
+			"__id":                  llx.StringData(prefix + "/ratelimit/" + l.GroupType),
 			"groupType":             llx.StringData(l.GroupType),
 			"models":                llx.ArrayData(models, types.String),
 			"requestsPerMinute":     llx.IntData(l.LimitValue("requests_per_minute")),
@@ -406,7 +406,7 @@ func (r *mqlClaudeOrganization) usageReport() ([]interface{}, error) {
 
 		for _, result := range b.Results {
 			mqlEntry, err := CreateResource(r.MqlRuntime, "claude.organization.usageEntry", map[string]*llx.RawData{
-				"__id":                 llx.StringData(fmt.Sprintf("usage/%s/%s/%s/%s", b.StartingAt, result.Model, result.WorkspaceID, result.ServiceTier)),
+				"__id":                 llx.StringData("usage/" + b.StartingAt + "/" + result.Model + "/" + result.WorkspaceID + "/" + result.ServiceTier),
 				"startingAt":           llx.TimeData(startingAt),
 				"endingAt":             llx.TimeData(endingAt),
 				"model":                llx.StringData(result.Model),
@@ -471,7 +471,7 @@ func (r *mqlClaudeOrganization) costReport() ([]interface{}, error) {
 
 		for _, result := range b.Results {
 			mqlEntry, err := CreateResource(r.MqlRuntime, "claude.organization.costEntry", map[string]*llx.RawData{
-				"__id":        llx.StringData(fmt.Sprintf("cost/%s/%s/%s/%s", b.StartingAt, result.CostType, result.Model, result.WorkspaceID)),
+				"__id":        llx.StringData("cost/" + b.StartingAt + "/" + result.CostType + "/" + result.Model + "/" + result.WorkspaceID),
 				"startingAt":  llx.TimeData(startingAt),
 				"endingAt":    llx.TimeData(endingAt),
 				"amount":      llx.StringData(result.Amount),

--- a/providers/claude/resources/claude_workspace.go
+++ b/providers/claude/resources/claude_workspace.go
@@ -151,7 +151,7 @@ func parseFamily(id string) string {
 	if !ok {
 		return ""
 	}
-	for _, seg := range strings.Split(rest, "-") {
+	for seg := range strings.SplitSeq(rest, "-") {
 		if seg == "" || (seg[0] >= '0' && seg[0] <= '9') {
 			continue
 		}


### PR DESCRIPTION
Part of a measured memory pass over the eight AI providers.

Seven `__id` sites sat inside per-item loops, and every one boxed its arguments into an `any` before formatting. On a four-segment id:

| | B/op | allocs/op | ns/op |
|---|---|---|---|
| before | 168 | 5 | 199 |
| after | 96 | 1 | 160 |

The rest of the file already concatenates (`m.WorkspaceID + "/" + m.UserID` two functions away).

`newToolset` now builds its id once and reuses it for the toolset and each of its tools, instead of formatting per tool. `parseFamily` also walks the model id with `SplitSeq` rather than splitting it into a slice to read one segment.

### What an average run saves

72 B and 4 allocations per id, so the saving is however many ids a scan builds. For a mid-size org querying the full organization surface:

| source | ids |
|---|---|
| usage report (7 daily buckets × ~4 models × ~3 workspaces) | ~85 |
| cost report (7 buckets × ~3 workspaces × ~2 cost types) | ~40 |
| rate limits (org + per workspace) | ~15 |
| agents (~15 agents × skills, toolsets, tools, custom tools) | ~195 |
| **total** | **~335** |

**~24 KB, ~1,300 fewer allocations, ~15 µs per scan.** The usage and cost reports are the part that scales: they are the only endpoints here whose cardinality grows with the org's activity rather than its configuration, so a large org with many workspaces and models pays a multiple of this.

### Correctness

Every id is byte-identical to what the format string produced, and **the compiler checks that for us**: `%s` accepts a non-string operand silently, `+` does not compile. `TestParseFamily`'s table covers the family parsing unchanged.

`go build ./... && go test ./...` green in `providers/claude`.

### Not in this PR

`connection/admin.go` reads the whole response body before unmarshalling, which looks like an obvious streaming-decoder candidate. Measured, it is not: a `json.Decoder` is **worse** at both sizes (28 KB payload 87 KB → 111 KB; 3.73 MB payload 18.6 MB → 19.4 MB, alloc counts within 0.05%), because the decoder refills its own scratch buffer and re-slices tokens out of it. Left alone deliberately.
