### PR TITLE
🧹 weaviate: point at the role in the list instead of copying it

### DIFF
--- a/providers/weaviate/resources/rbac.go
+++ b/providers/weaviate/resources/rbac.go
@@ -25,10 +25,12 @@ func (r *mqlWeaviateInstance) roles() ([]any, error) {
 	}
 
 	serverID := conn.ServerID()
-	list := []any{}
+	list := make([]any, 0, len(roles))
 	for i := range roles {
-		role := roles[i]
-		mqlRole, err := newWeaviateRole(r.MqlRuntime, serverID, &role)
+		// &roles[i], not the address of a loop copy: a Role carries twelve
+		// permission slices, and every one of them becomes a retained resource
+		// anyway, so copying each before taking its address buys nothing.
+		mqlRole, err := newWeaviateRole(r.MqlRuntime, serverID, &roles[i])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Part of a measured memory pass over the eight AI providers.

`roles()` copied a whole `rbac.Role` into a loop variable and then took the address of that copy, so every role paid for a struct copy plus the heap allocation that escaping it forces. `unsafe.Sizeof(rbac.Role{})` is **304 bytes** — a name plus twelve permission slice headers — which lands in the 320 B size class.

Every role becomes a retained resource holding that pointer anyway (`cacheRole`), so `&roles[i]` keeps exactly as much alive with none of the copying.

### What an average run saves

320 B per role, once per `weaviate.instance.roles` query. A cluster with RBAC on carries the ~8 built-in roles plus whatever the team defined — call it 15 roles:

**~4.8 KB and well under a microsecond per scan**, plus a handful of slice growths avoided by preallocating the result from the role count.

This is a small, unambiguous cleanup rather than a performance fix — the copy was buying nothing, since the pointer outlives the loop either way.

`go build ./... && go test ./...` green in `providers/weaviate`.

### Considered and dropped

Preallocating `flattenPermissions`' result looked adjacent, but the capacity is the total number of *actions* across twelve domain slices, not the number of groups — counting it correctly needs twelve more loops for a slice that holds tens of entries. Not worth the code.
