### PR TITLE
🐛 openai: cap the read of the undocumented /v1/me response

### DIFF
--- a/providers/openai/connection/connection.go
+++ b/providers/openai/connection/connection.go
@@ -168,6 +168,12 @@ func fetchAccountInfo(baseURL string, token string) (*accountInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A capped read hands json.Unmarshal a truncated document, which fails with
+	// a generic syntax error that reads like the endpoint returned garbage. Say
+	// which of the two actually happened.
+	if len(body) >= maxAccountInfoBody {
+		return nil, fmt.Errorf("/v1/me response exceeded the %d byte limit", maxAccountInfoBody)
+	}
 
 	var result struct {
 		Orgs struct {

--- a/providers/openai/connection/connection.go
+++ b/providers/openai/connection/connection.go
@@ -27,6 +27,8 @@ const (
 	BaseURLOption      = "base-url"
 
 	PlatformIdPrefix = "//platformid.api.mondoo.app/runtime/openai"
+
+	maxAccountInfoBody = 1 << 20
 )
 
 type OpenaiConnection struct {
@@ -159,7 +161,10 @@ func fetchAccountInfo(baseURL string, token string) (*accountInfo, error) {
 		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// /v1/me is undocumented and answers with a short account record. Cap the
+	// read so a wrong or misbehaving endpoint cannot make connect-time org
+	// detection allocate without limit.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAccountInfoBody))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/openai/connection/connection_test.go
+++ b/providers/openai/connection/connection_test.go
@@ -4,8 +4,10 @@
 package connection
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,4 +70,23 @@ func TestFetchAccountInfo(t *testing.T) {
 			assert.Equal(t, tc.wantName, info.OrgName)
 		})
 	}
+}
+
+// /v1/me is undocumented, so its response size is not a contract we control.
+// A body past the cap must stop the read rather than let connect-time org
+// detection allocate whatever the endpoint sends.
+func TestFetchAccountInfoCapsTheBody(t *testing.T) {
+	padding := strings.Repeat("x", maxAccountInfoBody)
+	body := `{"orgs":{"data":[{"id":"org-abc","name":"` + padding + `","is_default":true}]}}`
+	require.Greater(t, len(body), maxAccountInfoBody, "the test body has to exceed the cap to exercise it")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	info, err := fetchAccountInfo(srv.URL, "sk-test")
+	assert.Error(t, err, "the read stopped at the cap, so the truncated JSON must not parse")
+	assert.Nil(t, info)
 }

--- a/providers/openai/connection/connection_test.go
+++ b/providers/openai/connection/connection_test.go
@@ -87,6 +87,8 @@ func TestFetchAccountInfoCapsTheBody(t *testing.T) {
 	defer srv.Close()
 
 	info, err := fetchAccountInfo(srv.URL, "sk-test")
-	assert.Error(t, err, "the read stopped at the cap, so the truncated JSON must not parse")
+	require.Error(t, err, "the read stopped at the cap")
+	assert.Contains(t, err.Error(), "exceeded the 1048576 byte limit",
+		"a capped read has to name itself: the truncated JSON would otherwise fail with a generic syntax error that reads like a malformed response")
 	assert.Nil(t, info)
 }


### PR DESCRIPTION
Found during a memory pass over the eight AI providers.

`fetchAccountInfo` runs at connect time to detect the organization, and it was the **only** `io.ReadAll` across those providers with no `io.LimitReader` in front of it:

| provider | cap |
|---|---|
| claude | 10 MB |
| vllm | 1 MB (`/version`), 4 MB (`/v1/models`) |
| huggingface, mistral | error bodies capped |
| **openai `/v1/me`** | **none** |

`/v1/me` is undocumented, so its response size is not a contract we control. A wrong base URL or a misbehaving endpoint could make connect-time org detection allocate whatever it was sent.

### What an average run saves

**Nothing, and that is the point.** A healthy `/v1/me` answers with a few hundred bytes, so this changes neither bytes nor time on a normal scan.

What it changes is the tail: the worst case goes from *unbounded* — the provider allocates until the response ends or the process dies — to a hard 1 MB, on a call that happens once per connection before any query runs. This is a bound, not an optimization.

### Tests

`TestFetchAccountInfoCapsTheBody` serves a body past the cap and asserts the truncated JSON does not parse. It fails without the `LimitReader`. The existing `TestFetchAccountInfo` cases (single org, default-org preference, first-org fallback) pass unchanged.

`go build ./... && go test ./...` green in `providers/openai`.

### Review follow-up

A capped read handed `json.Unmarshal` a truncated document, so it failed with a generic syntax error indistinguishable from an endpoint returning garbage. The read now reports the cap by name, and the test asserts that message rather than merely asserting some error.

The caller discards this error (`if info, err := ...; err == nil`) because org detection is best-effort — `/v1/me` legitimately refuses many tokens — so the clearer message is for debugging rather than operator-visible output. Logging it would print on a large share of healthy scans.
