### PR TITLE
⚡ os: short circuit the file find matcher

### DIFF
--- a/providers/os/fsutil/find_files.go
+++ b/providers/os/fsutil/find_files.go
@@ -67,12 +67,17 @@ func (m findFilesMatcher) DepthReached(p string) bool {
 	return depth > *m.depth
 }
 
+// Match reports whether a walked path passes every filter.
+//
+// The three tests are ordered by cost, and they short circuit. matchesType
+// reads the mode the walk already carries. matchesRegex runs the pattern.
+// matchesPerm stats the path, and matchesType stats a symlink as well, so both
+// can cost a syscall per path. A path that fails an earlier test never pays for
+// a later one.
+//
+// All three are pure, so the result does not depend on how many of them run.
 func (m findFilesMatcher) Match(path string, t fs.FileMode) bool {
-	matchesType := m.matchesType(path, t)
-	matchesRegex := m.matchesRegex(path)
-	matchesPerm := m.matchesPerm(path)
-
-	return matchesType && matchesRegex && matchesPerm
+	return m.matchesType(path, t) && m.matchesRegex(path) && m.matchesPerm(path)
 }
 
 func (m findFilesMatcher) matchesRegex(path string) bool {

--- a/providers/os/fsutil/find_files_bench_test.go
+++ b/providers/os/fsutil/find_files_bench_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// benchTree builds a directory tree on disk, the shape a node scan walks.
+func benchTree(tb testing.TB, dirs, filesPerDir int) string {
+	root := tb.TempDir()
+	for d := 0; d < dirs; d++ {
+		dir := filepath.Join(root, "dir"+strconv.Itoa(d))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			tb.Fatal(err)
+		}
+		for f := 0; f < filesPerDir; f++ {
+			name := filepath.Join(dir, "file"+strconv.Itoa(f)+".conf")
+			if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
+				tb.Fatal(err)
+			}
+		}
+	}
+	return root
+}
+
+func benchmarkFindFiles(b *testing.B, typ string, rx string, perm *uint32) {
+	root := benchTree(b, 200, 50)
+	iofs := os.DirFS(root)
+
+	var r *regexp.Regexp
+	if rx != "" {
+		r = regexp.MustCompile(rx)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := FindFiles(iofs, ".", r, typ, perm, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFindFilesType has no permission filter, so no path is stat-ed.
+func BenchmarkFindFilesType(b *testing.B) {
+	benchmarkFindFiles(b, "f", "", nil)
+}
+
+// BenchmarkFindFilesRegex has no permission filter and a pattern that matches
+// nothing.
+func BenchmarkFindFilesRegex(b *testing.B) {
+	benchmarkFindFiles(b, "f", `.*\.nomatch$`, nil)
+}
+
+// BenchmarkFindFilesPerm sets a permission filter next to a pattern that
+// matches nothing. The permission test stats a path, so it is the expensive
+// one, and the pattern already decides the result.
+func BenchmarkFindFilesPerm(b *testing.B) {
+	p := uint32(0o600)
+	benchmarkFindFiles(b, "f", `.*\.nomatch$`, &p)
+}


### PR DESCRIPTION
## What allocates

`FindFiles` powers `files.find`, and it backs the filesystem and the mounted disk connections. It walks a tree and asks `Match` about every path.

`Match` evaluated all three tests and combined the results afterwards:

```go
matchesType := m.matchesType(path, t)
matchesRegex := m.matchesRegex(path)
matchesPerm := m.matchesPerm(path)

return matchesType && matchesRegex && matchesPerm
```

`matchesPerm` calls `fs.Stat`. `matchesType` calls `fs.Stat` too when the entry is a symlink and a non-link type is wanted. So a walk with a permission filter paid a syscall for every path, even for the paths the type or the pattern had already excluded.

A heap profile of a walk over 10000 files with a permission filter put `os.statNolog` at 48.9% of allocated bytes.

## What changed

The three tests now short circuit, in the cost order they already had. `matchesType` reads the mode the walk carries, `matchesRegex` runs the pattern, and `matchesPerm` stats the path.

All three are pure predicates. They read the path, the walk mode and the matcher fields, and they hold no state. The result is therefore the same however many of them run. Short circuiting only removes work, so no case gets slower and no behaviour changes. No feature gate is needed.

## Numbers

```
go test ./providers/os/fsutil/ -run xxx -bench 'BenchmarkFindFiles' -benchmem -benchtime 10x -count=3
```

The tree holds 200 directories with 50 files each.

`BenchmarkFindFilesPerm` sets a permission filter next to a pattern that matches nothing:

| | before | after | change |
| --- | --- | --- | --- |
| B/op | 5067495 | 1578195 | -68.9% |
| allocs/op | 64047 | 33429 | -47.8% |
| ns/op | 47632780 | 12473787 | -73.8% |

The other two benchmarks are controls. Neither sets a permission filter, so neither can gain, and both stay flat:

| benchmark | before B/op | after B/op |
| --- | --- | --- |
| `BenchmarkFindFilesType` | 2210963 | 2208535 |
| `BenchmarkFindFilesRegex` | 1576962 | 1577465 |

## Correctness

`go test ./providers/os/fsutil/...` passes. That covers `TestFindFilesMatcher`, `TestFindFiles` and the unix permission test, which exercise the type, pattern and permission filters and their combinations.

`go test ./providers/os/resources/ -run 'Find|Files'` passes.

`golangci-lint run ./providers/os/fsutil/...` reports no issue.