### PR TITLE
⚡ os: size the tar read buffer from the entry header

### DIFF
--- a/providers/os/fsutil/read_tarfile.go
+++ b/providers/os/fsutil/read_tarfile.go
@@ -5,20 +5,31 @@ package fsutil
 
 import (
 	"archive/tar"
-	"bufio"
 	"bytes"
 	"io"
 )
 
+// ReadFileFromTarStream returns the content of every entry in the tar stream,
+// concatenated in the order the entries appear.
+//
+// The tar header states the size of an entry, so the buffer is grown to that
+// size before the copy. Without it the buffer doubles as it fills, which
+// allocates about twice the content and copies the content on every step.
+//
 // TODO: check size of file to ensure we do not crash the process
 func ReadFileFromTarStream(r io.Reader) ([]byte, error) {
+	// A container image can come from an untrusted registry, and a malformed
+	// header can declare a size that the data does not match. Above this cap
+	// the buffer grows on demand instead, so the header alone cannot drive a
+	// huge allocation.
+	const maxHeaderPrealloc = 64 << 20
+
 	var fileBuffer bytes.Buffer
-	fileWriter := bufio.NewWriter(&fileBuffer)
 
 	// read stream tar, extract on the fly and put it on stdout
 	tr := tar.NewReader(r)
 	for {
-		_, err := tr.Next()
+		hdr, err := tr.Next()
 		if err == io.EOF {
 			break
 		}
@@ -26,11 +37,14 @@ func ReadFileFromTarStream(r io.Reader) ([]byte, error) {
 			return nil, err
 		}
 
-		if _, err := io.Copy(fileWriter, tr); err != nil {
+		if hdr.Size > 0 && hdr.Size <= maxHeaderPrealloc {
+			fileBuffer.Grow(int(hdr.Size))
+		}
+
+		if _, err := io.Copy(&fileBuffer, tr); err != nil {
 			return nil, err
 		}
 	}
-	fileWriter.Flush()
 
 	return fileBuffer.Bytes(), nil
 }

--- a/providers/os/fsutil/read_tarfile_test.go
+++ b/providers/os/fsutil/read_tarfile_test.go
@@ -1,0 +1,99 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package fsutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tarStreamWith builds a tar stream that holds one entry per content item.
+func tarStreamWith(tb testing.TB, contents ...[]byte) []byte {
+	tb.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for i, content := range contents {
+		hdr := &tar.Header{
+			Name:     "file" + string(rune('a'+i)),
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		require.NoError(tb, tw.WriteHeader(hdr))
+		_, err := tw.Write(content)
+		require.NoError(tb, err)
+	}
+	require.NoError(tb, tw.Close())
+	return buf.Bytes()
+}
+
+func TestReadFileFromTarStream(t *testing.T) {
+	t.Run("single entry", func(t *testing.T) {
+		content := []byte("hello world")
+		data, err := ReadFileFromTarStream(bytes.NewReader(tarStreamWith(t, content)))
+		require.NoError(t, err)
+		assert.Equal(t, content, data)
+	})
+
+	t.Run("entries are concatenated", func(t *testing.T) {
+		data, err := ReadFileFromTarStream(bytes.NewReader(
+			tarStreamWith(t, []byte("abc"), []byte("def"), []byte("ghi"))))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("abcdefghi"), data)
+	})
+
+	t.Run("empty entry", func(t *testing.T) {
+		data, err := ReadFileFromTarStream(bytes.NewReader(tarStreamWith(t, []byte{})))
+		require.NoError(t, err)
+		assert.Empty(t, data)
+	})
+
+	t.Run("empty stream", func(t *testing.T) {
+		data, err := ReadFileFromTarStream(bytes.NewReader(tarStreamWith(t)))
+		require.NoError(t, err)
+		assert.Empty(t, data)
+	})
+
+	t.Run("large entry", func(t *testing.T) {
+		content := bytes.Repeat([]byte("0123456789"), 200000)
+		data, err := ReadFileFromTarStream(bytes.NewReader(tarStreamWith(t, content)))
+		require.NoError(t, err)
+		assert.Equal(t, content, data)
+	})
+
+	t.Run("not a tar stream", func(t *testing.T) {
+		_, err := ReadFileFromTarStream(bytes.NewReader([]byte("this is not a tar")))
+		assert.Error(t, err)
+	})
+}
+
+func benchmarkReadFileFromTarStream(b *testing.B, size int) {
+	stream := tarStreamWith(b, bytes.Repeat([]byte("a"), size))
+
+	b.ReportAllocs()
+	b.SetBytes(int64(size))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		data, err := ReadFileFromTarStream(bytes.NewReader(stream))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(data) != size {
+			b.Fatalf("expected %d bytes, got %d", size, len(data))
+		}
+	}
+}
+
+func BenchmarkReadFileFromTarStream1MB(b *testing.B) {
+	benchmarkReadFileFromTarStream(b, 1<<20)
+}
+
+func BenchmarkReadFileFromTarStream8MB(b *testing.B) {
+	benchmarkReadFileFromTarStream(b, 8<<20)
+}


### PR DESCRIPTION
## What allocates

`ReadFileFromTarStream` reads a file out of a container through the docker connection. It copied the entry into a `bytes.Buffer` that started empty.

An empty `bytes.Buffer` doubles its capacity as it fills. Reading an 8 MB entry therefore allocated about 16 MB across a chain of ever larger buffers, and copied the content again on every growth step.

A `bufio.Writer` sat between the copy and the buffer. Writing to a `bytes.Buffer` through a `bufio.Writer` adds a second copy of every byte and no benefit.

## What changed

The tar header states the size of the entry, so the buffer is grown to that size before the copy. The content then lands in one allocation.

The declared size is trusted up to a 64 MB cap. A container image can come from an untrusted registry, and a malformed header can declare a size that its data does not match. Above the cap the buffer grows on demand, as before, so the header alone cannot drive a huge allocation. This matches the cap that #9864 uses for the same reason in the sibling function.

The `bufio.Writer` is removed.

The function still reads every entry and concatenates the content, so the result is unchanged for a stream that carries more than one entry.

## Numbers

```
go test ./providers/os/fsutil/ -run xxx -bench 'ReadFileFromTarStream' -benchmem -count=4
```

`BenchmarkReadFileFromTarStream1MB`:

| | before | after | change |
| --- | --- | --- | --- |
| B/op | 2105778 | 1051469 | -50.1% |
| allocs/op | 33 | 19 | -42.4% |
| ns/op | 739605 | 302048 | -59.2% |

`BenchmarkReadFileFromTarStream8MB`:

| | before | after | change |
| --- | --- | --- | --- |
| B/op | 16788667 | 8392310 | -50.0% |
| allocs/op | 38 | 20 | -47.4% |
| ns/op | 5258914 | 2251613 | -57.2% |

The buffer now holds the content once instead of twice, which is the 50% the numbers show.

## Correctness

The function had no test, so this adds `TestReadFileFromTarStream`. It covers a single entry, several entries concatenated, an empty entry, an empty stream, a 2 MB entry, and input that is not a tar stream.

The tests were run against the old implementation as well, and they pass there too. They therefore describe the behaviour of the function, not the shape of the new code.

`go test ./providers/os/fsutil/...` passes. `golangci-lint run ./providers/os/fsutil/...` reports no issue. The docker connection, which is the only caller, still builds.
