### PR TITLE
🧹 ci: refresh the embedded OUI table weekly

### DIFF
--- a/.github/workflows/update-oui-table.yaml
+++ b/.github/workflows/update-oui-table.yaml
@@ -1,0 +1,126 @@
+name: Update the IEEE OUI table
+
+# The os provider embeds the IEEE MA-L registry to name the vendor that owns a
+# MAC address on network.interfaces. Vendors register new prefixes constantly,
+# so the checked-in table goes stale on its own. This regenerates it from the
+# published registry once a week and opens a pull request when it moved.
+
+on:
+  schedule:
+    - cron: "33 8 * * 1" # every monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  OUI_DIR: providers/os/id/networki/oui
+  OUI_CSV_URL: https://standards-oui.ieee.org/oui/oui.csv
+
+jobs:
+  update-oui-table:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # https://github.com/peter-evans/create-pull-request/issues/48
+      # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
+      # tl;dr:
+      # The GITHUB_TOKEN is limited when creating PRs from a workflow
+      # because of that we use a ssh key for which the limitations do not apply
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ssh-key: ${{ secrets.CNQUERY_DEPLOY_KEY_PRIV }}
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ">=${{ env.golang-version }}"
+          check-latest: true
+          cache: false
+
+      - name: Download the IEEE registry
+        run: |
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 30 --max-time 300 \
+            --output "${OUI_DIR}/oui.csv" "${OUI_CSV_URL}"
+
+          # The registry host answers cloud IPs with error pages and
+          # interstitials often enough that an unchecked download would
+          # regenerate a near-empty table and open a pull request deleting
+          # every vendor the provider knows. A stale table beats a wrong one,
+          # so anything that does not look like the registry fails the run.
+          size=$(wc -c < "${OUI_DIR}/oui.csv")
+          if [ "${size}" -lt 1000000 ]; then
+            echo "::error::${OUI_CSV_URL} returned ${size} bytes, the registry is several MB"
+            exit 1
+          fi
+          if ! head -n 1 "${OUI_DIR}/oui.csv" | grep -q '^Registry,Assignment'; then
+            echo "::error::${OUI_CSV_URL} did not return the registry CSV, it starts with: $(head -c 120 "${OUI_DIR}/oui.csv")"
+            exit 1
+          fi
+
+      - name: Regenerate the table
+        working-directory: providers/os/id/networki/oui
+        run: |
+          go run ./gen -csv oui.csv -out oui.bin -summary "${RUNNER_TEMP}/oui-summary.md"
+
+          # The pull request action stages everything in the tree, and the
+          # registry export is not something this repository tracks.
+          rm oui.csv
+
+      # oui.bin is embedded rather than parsed, so a table that encoded wrong
+      # would surface as silently missing vendors during a scan. The committed
+      # suite walks every assignment and has to pass before this is proposed.
+      - name: Test the regenerated table
+        working-directory: providers/os
+        run: go test ./id/networki/oui/...
+
+      # The table is a binary blob, so review would otherwise see nothing but
+      # "Binary file changed".
+      - name: Compose the pull request body
+        run: |
+          {
+            echo "\`${OUI_DIR}/oui.bin\` regenerated from the IEEE MA-L registry."
+            echo
+            cat "${RUNNER_TEMP}/oui-summary.md"
+            echo
+            echo "Source: <${OUI_CSV_URL}>, fetched $(date -u +%Y-%m-%d)."
+            echo "Built by \`${OUI_DIR}/gen\`, no hand edits."
+            echo "Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > "${RUNNER_TEMP}/pr-body.md"
+
+      - name: Prepare title and branch name
+        id: branch
+        run: |
+          BRANCH_NAME="version/oui_update_$(date +%Y%m%d)"
+          COMMIT_MSG="🧹 os: refresh the IEEE OUI table $(date +%Y%m%d)"
+          echo "COMMIT_TITLE=${COMMIT_MSG}" >> $GITHUB_OUTPUT
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+
+      # We have to use this extensions, because `gh pr create` does not support the ssh key case.
+      # It is also a no-op when the regenerated table is byte-identical to the
+      # committed one, which is what keeps a quiet week from opening a PR.
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: main
+          labels: dependencies
+          committer: "Mondoo Tools <tools@mondoo.com>"
+          commit-message: ${{ steps.branch.outputs.COMMIT_TITLE }}
+          author: "Mondoo Tools <tools@mondoo.com>"
+          title: ${{ steps.branch.outputs.COMMIT_TITLE }}
+          branch: ${{ steps.branch.outputs.BRANCH_NAME }}
+          body-path: ${{ runner.temp }}/pr-body.md
+
+      - name: PR infos
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ providers/mock_schema.go
 providers-sdk/*/testutils/mockprovider/resources/*.resources.json
 !providers/core/resources/*.resources.json
 providers/os/connection/snapshot/mock_volumemounter.go
+# the IEEE registry export the embedded OUI table is generated from
+providers/os/id/networki/oui/oui.csv
 !providers-sdk/v1/mqlr
 settings.local.json
 *.lr.manifest.json

--- a/providers/os/id/networki/oui/gen/main.go
+++ b/providers/os/id/networki/oui/gen/main.go
@@ -14,14 +14,22 @@
 // Usage:
 //
 //	go run ./gen -csv oui.csv -out oui.bin
+//
+// The encoded table is a binary blob, so a refresh shows up in review as
+// "Binary file changed" and nothing else. -summary writes a Markdown account
+// of what moved between the table already on disk and the one being written:
+//
+//	go run ./gen -csv oui.csv -out oui.bin -summary summary.md
 package main
 
 import (
 	"bytes"
 	"encoding/binary"
 	"encoding/csv"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"regexp"
 	"sort"
@@ -32,6 +40,7 @@ import (
 func main() {
 	csvPath := flag.String("csv", "", "path to the IEEE oui.csv registry export")
 	outPath := flag.String("out", "oui.bin", "path to write the encoded table to")
+	summaryPath := flag.String("summary", "", "path to write a Markdown summary of the change to")
 	flag.Parse()
 
 	if *csvPath == "" {
@@ -39,7 +48,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(*csvPath, *outPath); err != nil {
+	if err := run(*csvPath, *outPath, *summaryPath); err != nil {
 		fmt.Fprintln(os.Stderr, "gen:", err)
 		os.Exit(1)
 	}
@@ -50,7 +59,22 @@ type entry struct {
 	vendor string
 }
 
-func run(csvPath, outPath string) error {
+func run(csvPath, outPath, summaryPath string) error {
+	// Read the table being replaced before it is overwritten, so the summary
+	// can say what the refresh actually changed.
+	var before []entry
+	if summaryPath != "" {
+		old, err := os.ReadFile(outPath)
+		switch {
+		case err == nil:
+			if before, err = readTable(old); err != nil {
+				return fmt.Errorf("read existing %s: %w", outPath, err)
+			}
+		case !errors.Is(err, fs.ErrNotExist):
+			return err
+		}
+	}
+
 	f, err := os.Open(csvPath)
 	if err != nil {
 		return err
@@ -146,6 +170,12 @@ func run(csvPath, outPath string) error {
 
 	fmt.Printf("wrote %s: %d assignments, %d distinct vendors, %d bytes\n",
 		outPath, len(entries), len(offsets), out.Len())
+
+	if summaryPath != "" {
+		if err := os.WriteFile(summaryPath, []byte(summarize(before, entries)), 0o644); err != nil {
+			return fmt.Errorf("write summary: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -153,6 +183,7 @@ func run(csvPath, outPath string) error {
 const (
 	magic      = "MQOUIv1\x00"
 	recordSize = 8
+	headerSize = len(magic) + 4
 )
 
 // The IEEE registry records legal entity names, so most of them carry a

--- a/providers/os/id/networki/oui/gen/main_test.go
+++ b/providers/os/id/networki/oui/gen/main_test.go
@@ -1,0 +1,133 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const csvHeader = "Registry,Assignment,Organization Name,Organization Address\n"
+
+func writeCSV(t *testing.T, rows string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "oui.csv")
+	require.NoError(t, os.WriteFile(path, []byte(csvHeader+rows), 0o600))
+	return path
+}
+
+// vendor is user-visible on network.interfaces, so these are the strings the
+// provider has returned since before the table was embedded. They belong here
+// rather than against the shipped table, where the IEEE renaming an
+// organization would fail an assertion that is really about suffix handling.
+func TestSimplifyName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ltd", "Nokia Shanghai Bell Co.,Ltd", "Nokia Shanghai Bell"},
+		{"inc", "Cisco Systems Inc", "Cisco Systems"},
+		{"inc with a period", "Apple Inc.", "Apple"},
+		{"incorporated", "Belkin International Incorporated", "Belkin International"},
+		{"llc", "Amazon Technologies LLC", "Amazon Technologies"},
+		{"limited", "Arm Limited", "Arm"},
+		{"corporation", "XEROX CORPORATION", "XEROX"},
+		{"corp", "Intel Corp.", "Intel"},
+		{"company", "Hewlett Packard Company", "Hewlett Packard"},
+		{"gmbh", "Sennheiser electronic GmbH", "Sennheiser electronic"},
+
+		// A name without a corporate suffix survives whole, including one that
+		// merely ends in a word the patterns do not cover.
+		{"kept whole", "Extreme Networks Headquarters", "Extreme Networks Headquarters"},
+		{"kept whole, no suffix at all", "Espressif", "Espressif"},
+
+		// The patterns run in a fixed order and each runs once, so a name
+		// carrying two suffixes loses them outermost first.
+		{"stacked suffixes", "Nokia Shanghai Bell Co., Ltd.", "Nokia Shanghai Bell"},
+
+		// Only a trailing suffix is a suffix.
+		{"suffix word in the middle", "Inc Networks Systems", "Inc Networks Systems"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, simplifyName(test.in))
+		})
+	}
+}
+
+func TestRunWritesSummaryAgainstTheExistingTable(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "oui.bin")
+	summaryPath := filepath.Join(dir, "summary.md")
+
+	require.NoError(t, run(writeCSV(t, "MA-L,000000,XEROX CORPORATION,\n"), binPath, ""))
+
+	// A second pass over a registry that gained an assignment overwrites the
+	// table, and the summary has to describe the table it replaced.
+	refreshed := writeCSV(t, "MA-L,000000,XEROX CORPORATION,\nMA-L,00000C,Cisco Systems Inc,\n")
+	require.NoError(t, run(refreshed, binPath, summaryPath))
+
+	summary, err := os.ReadFile(summaryPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(summary), "**1 → 2 assignments** (1 added, 0 removed, 0 renamed)")
+	assert.Contains(t, string(summary), "| `00:00:0C` | Cisco Systems |")
+
+	data, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	got, err := readTable(data)
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+}
+
+// Nothing generates into a checkout without a table, but a missing file is not
+// a reason to fail the run.
+func TestRunSummarizesAMissingTableAsInitial(t *testing.T) {
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+
+	require.NoError(t, run(
+		writeCSV(t, "MA-L,000000,XEROX CORPORATION,\n"),
+		filepath.Join(dir, "oui.bin"),
+		summaryPath,
+	))
+
+	summary, err := os.ReadFile(summaryPath)
+	require.NoError(t, err)
+	assert.Equal(t, "Initial table: **1 assignments**.\n", string(summary))
+}
+
+// Pointing -summary at a table this generator did not write means the file was
+// swapped or corrupted, which is worth failing over rather than describing as
+// tens of thousands of additions.
+func TestRunRejectsAnUnreadableExistingTable(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "oui.bin")
+	require.NoError(t, os.WriteFile(binPath, []byte("not an oui table"), 0o600))
+
+	err := run(
+		writeCSV(t, "MA-L,000000,XEROX CORPORATION,\n"),
+		binPath,
+		filepath.Join(dir, "summary.md"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong magic")
+}
+
+// The header guard is what keeps an error page or an unrelated CSV from being
+// encoded into a table that reports every vendor as gone.
+func TestRunRejectsANonRegistryCSV(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oui.csv")
+	require.NoError(t, os.WriteFile(path, []byte("a,b,c\n1,2,3\n"), 0o600))
+
+	err := run(path, filepath.Join(t.TempDir(), "oui.bin"), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is this the IEEE oui.csv?")
+}

--- a/providers/os/id/networki/oui/gen/main_test.go
+++ b/providers/os/id/networki/oui/gen/main_test.go
@@ -121,6 +121,22 @@ func TestRunRejectsAnUnreadableExistingTable(t *testing.T) {
 	assert.Contains(t, err.Error(), "wrong magic")
 }
 
+// An organization whose whole legal name is a corporate suffix simplifies to
+// nothing. Such a row has to be dropped rather than written: readTable rejects
+// a zero-length name, so emitting one would produce a table this generator
+// cannot read back.
+func TestRunDropsRowsThatSimplifyToNothing(t *testing.T) {
+	binPath := filepath.Join(t.TempDir(), "oui.bin")
+	require.NoError(t, run(writeCSV(t, "MA-L,000000,XEROX CORPORATION,\nMA-L,00000C,Co.,\n"), binPath, ""))
+
+	data, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+
+	got, err := readTable(data)
+	require.NoError(t, err)
+	assert.Equal(t, []entry{{oui: 0x000000, vendor: "XEROX"}}, got)
+}
+
 // The header guard is what keeps an error page or an unrelated CSV from being
 // encoded into a table that reports every vendor as gone.
 func TestRunRejectsANonRegistryCSV(t *testing.T) {

--- a/providers/os/id/networki/oui/gen/summary.go
+++ b/providers/os/id/networki/oui/gen/summary.go
@@ -1,0 +1,171 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// readTable decodes a table written by run. The reader in oui.go keeps its
+// decoding unexported and bound to the one blob it embeds at build time, so
+// comparing the table on disk against a fresh one needs a decoder here.
+func readTable(data []byte) ([]entry, error) {
+	if len(data) < headerSize || string(data[:len(magic)]) != magic {
+		return nil, errors.New("wrong magic, this is not an encoded OUI table")
+	}
+
+	n := int(binary.LittleEndian.Uint32(data[len(magic):headerSize]))
+	blobStart := headerSize + n*recordSize
+	if blobStart > len(data) {
+		return nil, fmt.Errorf("table claims %d assignments but is only %d bytes", n, len(data))
+	}
+
+	entries := make([]entry, 0, n)
+	for i := range n {
+		rec := headerSize + i*recordSize
+		off := blobStart + int(binary.LittleEndian.Uint32(data[rec+3:rec+7]))
+		end := off + int(data[rec+7])
+		if end > len(data) {
+			return nil, fmt.Errorf("assignment %d names bytes %d:%d, past the end of the blob", i, off, end)
+		}
+
+		entries = append(entries, entry{
+			oui:    uint32(data[rec])<<16 | uint32(data[rec+1])<<8 | uint32(data[rec+2]),
+			vendor: string(data[off:end]),
+		})
+	}
+
+	// The writer sorts, and diffTables walks both sides in lockstep. Sorting a
+	// table that is already sorted costs nothing and keeps a hand-mangled file
+	// from turning into a summary that reads plausibly and says the wrong thing.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].oui < entries[j].oui })
+	return entries, nil
+}
+
+// change is one assignment that differs between two tables. from is empty for
+// an addition, to is empty for a removal, and both are set for a rename.
+type change struct {
+	oui  uint32
+	from string
+	to   string
+}
+
+type tableDiff struct {
+	added   []change
+	removed []change
+	renamed []change
+}
+
+func (d tableDiff) empty() bool {
+	return len(d.added) == 0 && len(d.removed) == 0 && len(d.renamed) == 0
+}
+
+// diffTables compares two tables sorted by OUI.
+func diffTables(before, after []entry) tableDiff {
+	var d tableDiff
+
+	i, j := 0, 0
+	for i < len(before) && j < len(after) {
+		switch {
+		case before[i].oui < after[j].oui:
+			d.removed = append(d.removed, change{oui: before[i].oui, from: before[i].vendor})
+			i++
+		case before[i].oui > after[j].oui:
+			d.added = append(d.added, change{oui: after[j].oui, to: after[j].vendor})
+			j++
+		default:
+			if before[i].vendor != after[j].vendor {
+				d.renamed = append(d.renamed, change{
+					oui:  before[i].oui,
+					from: before[i].vendor,
+					to:   after[j].vendor,
+				})
+			}
+			i++
+			j++
+		}
+	}
+	for ; i < len(before); i++ {
+		d.removed = append(d.removed, change{oui: before[i].oui, from: before[i].vendor})
+	}
+	for ; j < len(after); j++ {
+		d.added = append(d.added, change{oui: after[j].oui, to: after[j].vendor})
+	}
+
+	return d
+}
+
+// maxRows bounds each section of the summary. A quiet week moves a handful of
+// assignments, but the registry lands hundreds at once often enough that the
+// summary has to stay readable as a pull request body.
+const maxRows = 25
+
+// summarize describes what changed between the table already on disk and the
+// one just generated. An empty before means there was no table to replace.
+func summarize(before, after []entry) string {
+	var b strings.Builder
+
+	if len(before) == 0 {
+		fmt.Fprintf(&b, "Initial table: **%d assignments**.\n", len(after))
+		return b.String()
+	}
+
+	d := diffTables(before, after)
+	if d.empty() {
+		fmt.Fprintf(&b, "The regenerated table is identical to the one already committed: **%d assignments**, unchanged.\n", len(after))
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "**%d → %d assignments** (%d added, %d removed, %d renamed)\n",
+		len(before), len(after), len(d.added), len(d.removed), len(d.renamed))
+
+	section(&b, "Added", d.added, []string{"OUI", "Vendor"}, func(c change) []string {
+		return []string{"`" + formatOUI(c.oui) + "`", escapeCell(c.to)}
+	})
+	section(&b, "Removed", d.removed, []string{"OUI", "Vendor"}, func(c change) []string {
+		return []string{"`" + formatOUI(c.oui) + "`", escapeCell(c.from)}
+	})
+	section(&b, "Renamed", d.renamed, []string{"OUI", "Before", "After"}, func(c change) []string {
+		return []string{"`" + formatOUI(c.oui) + "`", escapeCell(c.from), escapeCell(c.to)}
+	})
+
+	return b.String()
+}
+
+func section(b *strings.Builder, title string, changes []change, header []string, row func(change) []string) {
+	if len(changes) == 0 {
+		return
+	}
+
+	fmt.Fprintf(b, "\n### %s (%d)\n\n", title, len(changes))
+	fmt.Fprintf(b, "| %s |\n", strings.Join(header, " | "))
+	fmt.Fprintf(b, "|%s\n", strings.Repeat(" --- |", len(header)))
+
+	shown := changes
+	if len(shown) > maxRows {
+		shown = shown[:maxRows]
+	}
+	for _, c := range shown {
+		fmt.Fprintf(b, "| %s |\n", strings.Join(row(c), " | "))
+	}
+
+	if len(changes) > len(shown) {
+		fmt.Fprintf(b, "\n_and %d more._\n", len(changes)-len(shown))
+	}
+}
+
+func formatOUI(oui uint32) string {
+	return fmt.Sprintf("%02X:%02X:%02X", byte(oui>>16), byte(oui>>8), byte(oui))
+}
+
+// escapeCell keeps a vendor name from breaking out of its table cell. The
+// registry records legal entity names, which are free text.
+func escapeCell(s string) string {
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/providers/os/id/networki/oui/gen/summary.go
+++ b/providers/os/id/networki/oui/gen/summary.go
@@ -28,8 +28,17 @@ func readTable(data []byte) ([]entry, error) {
 	entries := make([]entry, 0, n)
 	for i := range n {
 		rec := headerSize + i*recordSize
+		length := int(data[rec+7])
 		off := blobStart + int(binary.LittleEndian.Uint32(data[rec+3:rec+7]))
-		end := off + int(data[rec+7])
+		end := off + length
+
+		// simplifyName can reduce an organization name to nothing, and run
+		// drops those rows rather than writing them, so a length of zero here
+		// means the file was corrupted. Letting it through would report the
+		// assignment as renamed into an empty cell instead of failing.
+		if length == 0 {
+			return nil, fmt.Errorf("assignment %d has an empty vendor name", i)
+		}
 		if end > len(data) {
 			return nil, fmt.Errorf("assignment %d names bytes %d:%d, past the end of the blob", i, off, end)
 		}

--- a/providers/os/id/networki/oui/gen/summary_test.go
+++ b/providers/os/id/networki/oui/gen/summary_test.go
@@ -1,0 +1,237 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Encoding by hand in the test would only duplicate whatever the writer does,
+// so the decoder is checked against tables the writer actually produced.
+func TestReadTableRoundTrip(t *testing.T) {
+	csvPath := writeCSV(t, strings.Join([]string{
+		`MA-L,00000C,Cisco Systems Inc,`,
+		`MA-L,000000,XEROX CORPORATION,`,
+		`MA-L,286FB9,"Nokia Shanghai Bell Co.,Ltd",`,
+
+		// Repeated vendors share one string in the blob, so two records
+		// resolving to the same name exercises the offset table.
+		`MA-L,3C22FB,Apple Inc.,`,
+
+		// Not 24 bits, so not reachable by an OUI lookup and not in the table.
+		`MA-M,0055DA1,Sonic Technology,`,
+	}, "\n")+"\n")
+
+	binPath := filepath.Join(t.TempDir(), "oui.bin")
+	require.NoError(t, run(csvPath, binPath, ""))
+
+	data, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+
+	got, err := readTable(data)
+	require.NoError(t, err)
+	assert.Equal(t, []entry{
+		{oui: 0x000000, vendor: "XEROX"},
+		{oui: 0x00000C, vendor: "Cisco Systems"},
+		{oui: 0x286FB9, vendor: "Nokia Shanghai Bell"},
+		{oui: 0x3C22FB, vendor: "Apple"},
+	}, got)
+}
+
+func TestReadTableRejectsMalformed(t *testing.T) {
+	header := func(count uint32) []byte {
+		b := append([]byte{}, magic...)
+		return binary.LittleEndian.AppendUint32(b, count)
+	}
+
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{"empty", nil, "wrong magic"},
+		{"shorter than the header", []byte("MQOUIv1\x00"), "wrong magic"},
+		{"wrong magic", append([]byte("MQOUIv2\x00"), 0, 0, 0, 0), "wrong magic"},
+		{"records truncated away", header(4), "claims 4 assignments"},
+		{
+			// One well-formed record whose vendor runs off the end of the blob.
+			name:    "vendor past the end of the blob",
+			data:    append(header(1), 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x00, 0xFF),
+			wantErr: "past the end of the blob",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := readTable(test.data)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}
+
+// A table that reached disk out of order would make the lockstep walk in
+// diffTables report churn that never happened.
+func TestReadTableSortsRecords(t *testing.T) {
+	data := append([]byte{}, magic...)
+	data = binary.LittleEndian.AppendUint32(data, 2)
+	data = append(data, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 4) // last, first
+	data = append(data, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 5) // first, last
+	data = append(data, "zzzzaaaaa"...)
+
+	got, err := readTable(data)
+	require.NoError(t, err)
+	assert.Equal(t, []entry{
+		{oui: 0x000000, vendor: "aaaaa"},
+		{oui: 0xFFFFFF, vendor: "zzzz"},
+	}, got)
+}
+
+func TestDiffTables(t *testing.T) {
+	tests := []struct {
+		name   string
+		before []entry
+		after  []entry
+		want   tableDiff
+	}{
+		{
+			name:   "unchanged",
+			before: []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}},
+			after:  []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}},
+			want:   tableDiff{},
+		},
+		{
+			name:   "added in the middle",
+			before: []entry{{oui: 1, vendor: "a"}, {oui: 3, vendor: "c"}},
+			after:  []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}, {oui: 3, vendor: "c"}},
+			want:   tableDiff{added: []change{{oui: 2, to: "b"}}},
+		},
+		{
+			name:   "removed from the middle",
+			before: []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}, {oui: 3, vendor: "c"}},
+			after:  []entry{{oui: 1, vendor: "a"}, {oui: 3, vendor: "c"}},
+			want:   tableDiff{removed: []change{{oui: 2, from: "b"}}},
+		},
+		{
+			name:   "renamed",
+			before: []entry{{oui: 1, vendor: "Nokia Bell"}},
+			after:  []entry{{oui: 1, vendor: "Nokia"}},
+			want:   tableDiff{renamed: []change{{oui: 1, from: "Nokia Bell", to: "Nokia"}}},
+		},
+		{
+			// Whichever side runs out first, the rest of the other side still
+			// has to be reported.
+			name:   "appended past the end of the old table",
+			before: []entry{{oui: 1, vendor: "a"}},
+			after:  []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}, {oui: 3, vendor: "c"}},
+			want:   tableDiff{added: []change{{oui: 2, to: "b"}, {oui: 3, to: "c"}}},
+		},
+		{
+			name:   "dropped past the end of the new table",
+			before: []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}, {oui: 3, vendor: "c"}},
+			after:  []entry{{oui: 1, vendor: "a"}},
+			want:   tableDiff{removed: []change{{oui: 2, from: "b"}, {oui: 3, from: "c"}}},
+		},
+		{
+			name:   "empty new table",
+			before: []entry{{oui: 1, vendor: "a"}},
+			after:  nil,
+			want:   tableDiff{removed: []change{{oui: 1, from: "a"}}},
+		},
+		{
+			name:   "all three at once",
+			before: []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}, {oui: 4, vendor: "d"}},
+			after:  []entry{{oui: 1, vendor: "a"}, {oui: 3, vendor: "c"}, {oui: 4, vendor: "D"}},
+			want: tableDiff{
+				added:   []change{{oui: 3, to: "c"}},
+				removed: []change{{oui: 2, from: "b"}},
+				renamed: []change{{oui: 4, from: "d", to: "D"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := diffTables(test.before, test.after)
+			assert.Equal(t, test.want, got)
+			assert.Equal(t, test.want.empty(), got.empty())
+		})
+	}
+}
+
+func TestSummarizeInitialTable(t *testing.T) {
+	got := summarize(nil, []entry{{oui: 1, vendor: "a"}, {oui: 2, vendor: "b"}})
+	assert.Equal(t, "Initial table: **2 assignments**.\n", got)
+}
+
+func TestSummarizeUnchanged(t *testing.T) {
+	table := []entry{{oui: 1, vendor: "a"}}
+	got := summarize(table, table)
+	assert.Contains(t, got, "identical to the one already committed")
+	assert.NotContains(t, got, "###")
+}
+
+func TestSummarizeReportsEachSection(t *testing.T) {
+	before := []entry{
+		{oui: 0x000000, vendor: "XEROX"},
+		{oui: 0x001B44, vendor: "SanDisk"},
+		{oui: 0x8C1F64, vendor: "Nokia Bell"},
+	}
+	after := []entry{
+		{oui: 0x000000, vendor: "XEROX"},
+		{oui: 0x0CB527, vendor: "Shenzhen Yunlink Technology"},
+		{oui: 0x8C1F64, vendor: "Nokia"},
+	}
+
+	got := summarize(before, after)
+	assert.Contains(t, got, "**3 → 3 assignments** (1 added, 1 removed, 1 renamed)")
+	assert.Contains(t, got, "### Added (1)")
+	assert.Contains(t, got, "| `0C:B5:27` | Shenzhen Yunlink Technology |")
+	assert.Contains(t, got, "### Removed (1)")
+	assert.Contains(t, got, "| `00:1B:44` | SanDisk |")
+	assert.Contains(t, got, "### Renamed (1)")
+	assert.Contains(t, got, "| `8C:1F:64` | Nokia Bell | Nokia |")
+	assert.NotContains(t, got, "more._")
+}
+
+// The registry lands hundreds of assignments in a single week often enough
+// that an uncapped summary would be unusable as a pull request body.
+func TestSummarizeCapsEachSection(t *testing.T) {
+	before := []entry{{oui: 0, vendor: "keep"}}
+	after := []entry{{oui: 0, vendor: "keep"}}
+	for i := 1; i <= maxRows+5; i++ {
+		after = append(after, entry{oui: uint32(i), vendor: fmt.Sprintf("vendor %d", i)})
+	}
+
+	got := summarize(before, after)
+	assert.Contains(t, got, fmt.Sprintf("### Added (%d)", maxRows+5))
+	assert.Contains(t, got, "_and 5 more._")
+	assert.Contains(t, got, "| vendor 1 |")
+	assert.Contains(t, got, fmt.Sprintf("| vendor %d |", maxRows))
+	assert.NotContains(t, got, fmt.Sprintf("| vendor %d |", maxRows+1))
+}
+
+// Organization names are free text out of the registry, so a name carrying a
+// pipe must not tear the table it is rendered into.
+func TestSummarizeEscapesVendorNames(t *testing.T) {
+	got := summarize(
+		[]entry{{oui: 1, vendor: "old"}},
+		[]entry{{oui: 1, vendor: "Pipe | Maker\nInc"}},
+	)
+	assert.Contains(t, got, `| `+"`00:00:01`"+` | old | Pipe \| Maker Inc |`)
+}
+
+func TestFormatOUI(t *testing.T) {
+	assert.Equal(t, "00:00:0C", formatOUI(0x00000C))
+	assert.Equal(t, "FF:FF:FF", formatOUI(0xFFFFFF))
+	assert.Equal(t, "0C:B5:27", formatOUI(0x0CB527))
+}

--- a/providers/os/id/networki/oui/gen/summary_test.go
+++ b/providers/os/id/networki/oui/gen/summary_test.go
@@ -68,6 +68,13 @@ func TestReadTableRejectsMalformed(t *testing.T) {
 			data:    append(header(1), 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x00, 0xFF),
 			wantErr: "past the end of the blob",
 		},
+		{
+			// The writer never emits a zero-length name, so one here is
+			// corruption rather than an assignment with no vendor.
+			name:    "empty vendor name",
+			data:    append(header(1), 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00),
+			wantErr: "empty vendor name",
+		},
 	}
 
 	for _, test := range tests {

--- a/providers/os/id/networki/oui/oui_test.go
+++ b/providers/os/id/networki/oui/oui_test.go
@@ -11,39 +11,54 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/id/networki/oui"
 )
 
-func TestVendor(t *testing.T) {
+// Every spelling of an address resolves off the same first 24 bits, so they
+// all have to agree.
+//
+// The vendor string itself is deliberately not pinned. The IEEE renames
+// organizations in place, so an assertion on a literal name turns any refresh
+// of the embedded table into a build failure: "Extreme Networks Headquarters"
+// became "Extreme Networks" in the registry. The shortening rules that produce
+// these strings are covered against a fixture in gen, where they live.
+func TestVendorAcceptsEveryAddressForm(t *testing.T) {
+	want := oui.Vendor("00000c")
+	require.NotEmpty(t, want, "00:00:0c has been an assigned prefix for decades")
+
+	addrs := []string{
+		"00000C",
+		"00:00:0c",
+		"00:00:0C",
+		"00:00:0c:11:22:33",
+		"00000c112233",
+
+		// Separators are dropped wherever they fall, so a MAC written with
+		// ragged groups still resolves off its first six hex digits.
+		"0:00:00:c:11:22",
+	}
+
+	for _, addr := range addrs {
+		t.Run(addr, func(t *testing.T) {
+			assert.Equal(t, want, oui.Vendor(addr))
+		})
+	}
+}
+
+func TestVendorRejectsMalformedAddresses(t *testing.T) {
 	tests := []struct {
 		name string
 		addr string
-		want string
 	}{
-		{"bare oui", "00000c", "Cisco Systems"},
-		{"bare oui, uppercase", "00000C", "Cisco Systems"},
-		{"colon separated", "00:00:0c", "Cisco Systems"},
-		{"colon separated, uppercase", "00:00:0C", "Cisco Systems"},
-		{"full mac", "00:00:0c:11:22:33", "Cisco Systems"},
-		{"full mac, no separators", "00000c112233", "Cisco Systems"},
-		{"first record in the table", "000000", "XEROX"},
-		{"vendor with a stripped suffix", "286fb9", "Nokia Shanghai Bell"},
-		{"vendor kept whole", "08ea44", "Extreme Networks Headquarters"},
-		{"apple", "3c22fb", "Apple"},
-
-		// Separators are dropped wherever they fall, so a MAC written with
-		// single-digit groups still resolves off its first six hex digits.
-		{"ragged separators", "0:0:0:c:11:22", "NIPPON DEMPA"},
-
-		{"unassigned", "ffffff", ""},
-		{"empty", "", ""},
-		{"too short", "00000", ""},
-		{"too short after separators", "00:00:0", ""},
-		{"not hex", "zzzzzz", ""},
-		{"partially not hex", "00000z", ""},
-		{"dash separated is not hex", "00-00-0c", ""},
+		{"unassigned", "ffffff"},
+		{"empty", ""},
+		{"too short", "00000"},
+		{"too short after separators", "00:00:0"},
+		{"not hex", "zzzzzz"},
+		{"partially not hex", "00000z"},
+		{"dash separated is not hex", "00-00-0c"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, oui.Vendor(test.addr))
+			assert.Empty(t, oui.Vendor(test.addr))
 		})
 	}
 }


### PR DESCRIPTION
## What

#9854 replaced `github.com/endobit/oui` with a table this repository generates and embeds, which means the IEEE MA-L registry is now ours to keep current. Nothing does that today, and nothing signals when it drifts.

It has already drifted. Regenerating against the registry as of today:

```
**39038 → 39941 assignments** (903 added, 0 removed, 140 renamed)
```

`.github/workflows/update-oui-table.yaml` downloads `https://standards-oui.ieee.org/oui/oui.csv` every Monday, regenerates `providers/os/id/networki/oui/oui.bin`, and opens a pull request when the result differs. `create-pull-request` is a no-op on a byte-identical table, so a quiet week is silent.

The workflow is modeled on `update-deps.yaml` step for step, including the `CNQUERY_DEPLOY_KEY_PRIV` deploy key — a pull request pushed with the `GITHUB_TOKEN` does not trigger CI.

## Making a binary diff reviewable

The table is a blob, so review would otherwise see `Binary file changed` and nothing else. `gen` grows a `-summary` flag that decodes the table already on disk before overwriting it and writes a Markdown account of what moved. Both sides are sorted by OUI, so it is one merge pass into three buckets, capped at 25 rows each so a heavy week stays readable:

```markdown
**39038 → 39941 assignments** (903 added, 0 removed, 140 renamed)

### Added (903)

| OUI | Vendor |
| --- | --- |
| `00:3C:B7` | AzureWave Technology |
| `00:61:68` | Nokia |
| `00:66:DC` | Apple |
...

_and 878 more._

### Renamed (140)

| OUI | Before | After |
| --- | --- | --- |
| `00:03:74` | Control Microsystems | Schneider Electric |
| `00:07:CC` | Kaba Benzing | dormakaba Deutschland |
| `00:90:1D` | PEC (NZ) | Gallagher Group |
...
```

That is the real output of a dry run, and it composes into a 71-line pull request body.

## Guards

A refresh that silently goes wrong is worse than no refresh, so two things have to hold before a pull request exists:

- **The download has to look like the registry.** It must be at least a megabyte (the real file is 3.8 MB) and its first line must start with `Registry,Assignment`. The IEEE host answers cloud addresses with error pages and interstitials often enough that an unchecked download would encode a near-empty table and propose deleting every vendor the provider knows. A stale table beats a wrong one, so a failed guard fails the run.
- **The committed suite has to pass on the regenerated table**, before the pull request is opened. `oui.bin` is embedded rather than parsed, so a misencoded table surfaces as silently missing vendors during a scan rather than as an error.

## The first run would have failed

`TestVendor` asserted vendor strings read out of the shipped table, and the registry renames organizations in place:

```
--- FAIL: TestVendor/vendor_kept_whole
    expected: "Extreme Networks Headquarters"
    actual  : "Extreme Networks"
```

That assertion is really about suffix shortening, not about any particular table, so pinning it against live registry data made an unrelated refresh a build failure. The address-parsing cases now assert that every spelling of an address agrees with the bare OUI, without pinning the name, and the shortening rules moved to a CSV-fixture test in `gen` next to `simplifyName` — where they are also covered more thoroughly than before (`llc`/`ltd`/`limited`/`inc`/`incorporated`/`co`/`company`/`corp`/`corporation`/`gmbh`, stacked suffixes, names kept whole, and a suffix word appearing mid-name).

`oui.csv` is gitignored so a local regeneration, which the refresh instructions tell you to do right in that directory, cannot become a 3.8 MB commit.

## This PR does not refresh the table

`oui.bin` is untouched here so the mechanism can be reviewed on its own. The first scheduled run delivers the 903 assignments.

## Testing

New unit tests, all against fixtures rather than the shipped table:

- `readTable` round-trips what the writer produces, including repeated vendors sharing one blob offset and MA-M assignments being excluded; rejects bad magic, a truncated header, a record naming bytes past the end of the blob; and sorts a table that reached disk out of order, which would otherwise make the merge report churn that never happened
- `diffTables` across added / removed / renamed, each side running out first, an empty new table, and all three at once
- `summarize` for the initial, unchanged, and capped cases, and for a vendor name carrying a `|` that would otherwise tear the table it renders into
- `run` writing a summary against an existing table, treating a missing table as initial, refusing a table it did not write, and refusing a CSV that is not the registry
- `simplifyName` across every suffix pattern

```
go test -count=1 ./id/networki/oui/...
ok  go.mondoo.com/mql/v13/providers/os/id/networki/oui
ok  go.mondoo.com/mql/v13/providers/os/id/networki/oui/gen
```

Verified against **both** tables — the committed one and a live regeneration from today's registry (39,941 assignments) — since passing on only one of those is what caused the problem this PR fixes.

Every `run:` block in the workflow was then executed locally against the live registry, in order: download, both guards (3,815,340 bytes, header matched), regenerate, `rm oui.csv`, `go test`, and body composition. In a clean checkout the only file staged for the pull request is `oui.bin`.

The workflow itself can be confirmed with `workflow_dispatch` once merged.
