### PR TITLE
⭐ github: upgrade to go-github v90 and expose stacked pull requests

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/rs/zerolog"

--- a/providers/github/connection/connection_test.go
+++ b/providers/github/connection/connection_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/cockroachdb/errors v1.14.0
 	github.com/gobwas/glob v0.2.3
-	github.com/google/go-github/v89 v89.0.0
+	github.com/google/go-github/v90 v90.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/rs/zerolog v1.35.1
@@ -81,7 +81,6 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/endobit/oui v0.7.0 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -242,8 +242,6 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/endobit/oui v0.7.0 h1:6/aPQPEA+HcCW+pvZcYBVa0EVcj1uOS9c7XJS33uyCg=
-github.com/endobit/oui v0.7.0/go.mod h1:Y40Y6pCm9rVd6L1OITp7WJp7+F3cSIfaYqohHvMreZs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -384,8 +382,8 @@ github.com/google/go-containerregistry v0.21.7 h1:/vPFuVXDjtFREsVArW+0h1CIl5urnO
 github.com/google/go-containerregistry v0.21.7/go.mod h1:kjSbt7/zMsKLWfnHrIvKvhXHUw91jbe9DNjPPJ32gXE=
 github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
 github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
-github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
-github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
+github.com/google/go-github/v90 v90.0.0 h1:EnX9HvTfqvuJbUSWu1/jLrYH6JJLMz0w0qfQVbTxPzE=
+github.com/google/go-github/v90 v90.0.0/go.mod h1:pLzt1FZURZyoTHT5/Z1UQY3b9fYyrbXH6aj7X+qgID4=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/discovery_iac_test.go
+++ b/providers/github/resources/discovery_iac_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/github/resources/git.go
+++ b/providers/github/resources/git.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )

--- a/providers/github/resources/github.go
+++ b/providers/github/resources/github.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -1839,6 +1839,28 @@ private github.mergeRequest @defaults("id state") {
   mergedAt time
   // User who merged the pull request
   mergedBy github.user
+  // Identifier of the stack this pull request belongs to
+  //
+  // A stack is an ordered chain of pull requests that split one change into
+  // reviewable steps, each targeting the one below it and the whole chain
+  // targeting a single base branch. Null when the pull request is not part
+  // of a stack.
+  stackId int
+  // Number of the stack this pull request belongs to
+  stackNumber int
+  // Count of pull requests in the stack
+  stackSize int
+  // Position of this pull request within the stack
+  //
+  // Counts from 1 at the bottom of the stack, the pull request closest to
+  // the base branch. Every entry above it builds on the ones below, so a
+  // change merged out of order reaches the base branch without the review
+  // recorded against its predecessors.
+  stackPosition int
+  // Branch the whole stack targets
+  stackBaseBranch string
+  // Commit SHA the whole stack targets
+  stackBaseSha string
 }
 
 // GitHub pull request review

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -2081,6 +2081,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.mergeRequest.mergedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubMergeRequest).GetMergedBy()).ToDataRes(types.Resource("github.user"))
 	},
+	"github.mergeRequest.stackId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubMergeRequest).GetStackId()).ToDataRes(types.Int)
+	},
+	"github.mergeRequest.stackNumber": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubMergeRequest).GetStackNumber()).ToDataRes(types.Int)
+	},
+	"github.mergeRequest.stackSize": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubMergeRequest).GetStackSize()).ToDataRes(types.Int)
+	},
+	"github.mergeRequest.stackPosition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubMergeRequest).GetStackPosition()).ToDataRes(types.Int)
+	},
+	"github.mergeRequest.stackBaseBranch": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubMergeRequest).GetStackBaseBranch()).ToDataRes(types.String)
+	},
+	"github.mergeRequest.stackBaseSha": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubMergeRequest).GetStackBaseSha()).ToDataRes(types.String)
+	},
 	"github.review.url": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubReview).GetUrl()).ToDataRes(types.String)
 	},
@@ -5112,6 +5130,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.mergeRequest.mergedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubMergeRequest).MergedBy, ok = plugin.RawToTValue[*mqlGithubUser](v.Value, v.Error)
+		return
+	},
+	"github.mergeRequest.stackId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubMergeRequest).StackId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"github.mergeRequest.stackNumber": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubMergeRequest).StackNumber, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"github.mergeRequest.stackSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubMergeRequest).StackSize, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"github.mergeRequest.stackPosition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubMergeRequest).StackPosition, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"github.mergeRequest.stackBaseBranch": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubMergeRequest).StackBaseBranch, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"github.mergeRequest.stackBaseSha": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubMergeRequest).StackBaseSha, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"github.review.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11925,6 +11967,12 @@ type mqlGithubMergeRequest struct {
 	Merged             plugin.TValue[bool]
 	MergedAt           plugin.TValue[*time.Time]
 	MergedBy           plugin.TValue[*mqlGithubUser]
+	StackId            plugin.TValue[int64]
+	StackNumber        plugin.TValue[int64]
+	StackSize          plugin.TValue[int64]
+	StackPosition      plugin.TValue[int64]
+	StackBaseBranch    plugin.TValue[string]
+	StackBaseSha       plugin.TValue[string]
 }
 
 // createGithubMergeRequest creates a new instance of this resource
@@ -12062,6 +12110,30 @@ func (c *mqlGithubMergeRequest) GetMergedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlGithubMergeRequest) GetMergedBy() *plugin.TValue[*mqlGithubUser] {
 	return &c.MergedBy
+}
+
+func (c *mqlGithubMergeRequest) GetStackId() *plugin.TValue[int64] {
+	return &c.StackId
+}
+
+func (c *mqlGithubMergeRequest) GetStackNumber() *plugin.TValue[int64] {
+	return &c.StackNumber
+}
+
+func (c *mqlGithubMergeRequest) GetStackSize() *plugin.TValue[int64] {
+	return &c.StackSize
+}
+
+func (c *mqlGithubMergeRequest) GetStackPosition() *plugin.TValue[int64] {
+	return &c.StackPosition
+}
+
+func (c *mqlGithubMergeRequest) GetStackBaseBranch() *plugin.TValue[string] {
+	return &c.StackBaseBranch
+}
+
+func (c *mqlGithubMergeRequest) GetStackBaseSha() *plugin.TValue[string] {
+	return &c.StackBaseSha
 }
 
 // mqlGithubReview for the github.review resource

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -291,6 +291,12 @@ github.mergeRequest.repoName 9.0.0
 github.mergeRequest.repoOwnerLogin 13.7.6
 github.mergeRequest.requestedReviewers 13.1.1
 github.mergeRequest.reviews 9.0.0
+github.mergeRequest.stackBaseBranch 13.8.3
+github.mergeRequest.stackBaseSha 13.8.3
+github.mergeRequest.stackId 13.8.3
+github.mergeRequest.stackNumber 13.8.3
+github.mergeRequest.stackPosition 13.8.3
+github.mergeRequest.stackSize 13.8.3
 github.mergeRequest.state 9.0.0
 github.mergeRequest.title 9.0.0
 github.mergeRequest.updatedAt 13.1.1

--- a/providers/github/resources/github_access.go
+++ b/providers/github/resources/github_access.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_access_test.go
+++ b/providers/github/resources/github_access_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/providers/github/resources/github_actions_governance.go
+++ b/providers/github/resources/github_actions_governance.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_actions_secrets.go
+++ b/providers/github/resources/github_actions_secrets.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"fmt"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_audit.go
+++ b/providers/github/resources/github_audit.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/github/resources/github_copilot.go
+++ b/providers/github/resources/github_copilot.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_environments.go
+++ b/providers/github/resources/github_environments.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_package.go
+++ b/providers/github/resources/github_package.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_prefetch_test.go
+++ b/providers/github/resources/github_prefetch_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"path"
 	"strconv"
@@ -14,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"
@@ -377,6 +378,40 @@ func newMqlGithubLicense(runtime *plugin.Runtime, license *github.License) (*mql
 	return res.(*mqlGithubLicense), nil
 }
 
+// pullRequestStackFields maps a pull request's stacked-pull-request membership.
+//
+// Every field stays null when the pull request is not part of a stack, and the
+// base fields stay null independently of the counters. Reporting zeros instead
+// would read as a real stack of size 0 at position 0 to any policy comparing
+// the numbers, which is worse than reporting nothing.
+func pullRequestStackFields(pr *github.PullRequest) map[string]*llx.RawData {
+	fields := map[string]*llx.RawData{
+		"stackId":         llx.NilData,
+		"stackNumber":     llx.NilData,
+		"stackSize":       llx.NilData,
+		"stackPosition":   llx.NilData,
+		"stackBaseBranch": llx.NilData,
+		"stackBaseSha":    llx.NilData,
+	}
+
+	stack := pr.GetStack()
+	if stack == nil {
+		return fields
+	}
+
+	fields["stackId"] = llx.IntDataPtr(stack.ID)
+	fields["stackNumber"] = llx.IntDataPtr(stack.Number)
+	fields["stackSize"] = llx.IntDataPtr(stack.Size)
+	fields["stackPosition"] = llx.IntDataPtr(stack.Position)
+
+	if base := stack.Base; base != nil {
+		fields["stackBaseBranch"] = llx.StringData(base.Ref)
+		fields["stackBaseSha"] = llx.StringData(base.SHA)
+	}
+
+	return fields
+}
+
 func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 	ownerLogin, repoName, err := repoOwnerAndName(g)
@@ -469,7 +504,7 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 			mergedBy = r
 		}
 
-		r, err := CreateResource(g.MqlRuntime, "github.mergeRequest", map[string]*llx.RawData{
+		args := map[string]*llx.RawData{
 			"id":                 llx.IntDataPtr(pr.ID),
 			"repoOwnerLogin":     llx.StringData(ownerLogin),
 			"number":             llx.IntData(int64(pr.GetNumber())),
@@ -487,7 +522,10 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 			"merged":             llx.BoolDataPtr(pr.Merged),
 			"mergedAt":           llx.TimeDataPtr(githubTimestamp(pr.MergedAt)),
 			"mergedBy":           llx.AnyData(mergedBy),
-		})
+		}
+		maps.Copy(args, pullRequestStackFields(pr))
+
+		r, err := CreateResource(g.MqlRuntime, "github.mergeRequest", args)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/github/resources/github_repo_test.go
+++ b/providers/github/resources/github_repo_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/github/resources/github_runners.go
+++ b/providers/github/resources/github_runners.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_runners_test.go
+++ b/providers/github/resources/github_runners_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/providers/github/resources/github_security.go
+++ b/providers/github/resources/github_security.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/github/resources/github_security_test.go
+++ b/providers/github/resources/github_security_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/github/resources/github_stack_test.go
+++ b/providers/github/resources/github_stack_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v90/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestPullRequestStackFields(t *testing.T) {
+	stackKeys := []string{
+		"stackId", "stackNumber", "stackSize", "stackPosition",
+		"stackBaseBranch", "stackBaseSha",
+	}
+
+	t.Run("pull request outside a stack reports null, not zero", func(t *testing.T) {
+		fields := pullRequestStackFields(&github.PullRequest{})
+
+		require.Len(t, fields, len(stackKeys))
+		for _, k := range stackKeys {
+			assert.Equal(t, llx.NilData, fields[k], "%s must be null when the PR is not stacked", k)
+		}
+	})
+
+	t.Run("stacked pull request reports its position", func(t *testing.T) {
+		fields := pullRequestStackFields(&github.PullRequest{
+			Stack: &github.PullRequestStack{
+				ID:       github.Ptr(int64(4210)),
+				Number:   github.Ptr(7),
+				Size:     github.Ptr(3),
+				Position: github.Ptr(2),
+				Base: &github.PullRequestStackBase{
+					Ref: "main",
+					SHA: "8e1f0c0a4d2b6f9c3a5e7d1b0f2c4a6e8d0b2f4a",
+				},
+			},
+		})
+
+		assert.Equal(t, int64(4210), fields["stackId"].Value)
+		assert.Equal(t, int64(7), fields["stackNumber"].Value)
+		assert.Equal(t, int64(3), fields["stackSize"].Value)
+		assert.Equal(t, int64(2), fields["stackPosition"].Value)
+		assert.Equal(t, "main", fields["stackBaseBranch"].Value)
+		assert.Equal(t, "8e1f0c0a4d2b6f9c3a5e7d1b0f2c4a6e8d0b2f4a", fields["stackBaseSha"].Value)
+	})
+
+	// The bottom of a stack is position 1, so a policy asserting "reviewed in
+	// order" must be able to tell position 1 from an unstacked PR. That only
+	// works if the unstacked case is null rather than 0.
+	t.Run("bottom of the stack is position 1", func(t *testing.T) {
+		fields := pullRequestStackFields(&github.PullRequest{
+			Stack: &github.PullRequestStack{Position: github.Ptr(1), Size: github.Ptr(2)},
+		})
+
+		assert.Equal(t, int64(1), fields["stackPosition"].Value)
+		assert.NotEqual(t, llx.NilData, fields["stackPosition"])
+	})
+
+	t.Run("missing base leaves only the base fields null", func(t *testing.T) {
+		fields := pullRequestStackFields(&github.PullRequest{
+			Stack: &github.PullRequestStack{ID: github.Ptr(int64(9)), Size: github.Ptr(2)},
+		})
+
+		assert.Equal(t, int64(9), fields["stackId"].Value)
+		assert.Equal(t, llx.NilData, fields["stackBaseBranch"])
+		assert.Equal(t, llx.NilData, fields["stackBaseSha"])
+	})
+
+	// An absent counter inside a present stack must not silently become 0.
+	t.Run("absent counters inside a present stack stay null", func(t *testing.T) {
+		fields := pullRequestStackFields(&github.PullRequest{
+			Stack: &github.PullRequestStack{ID: github.Ptr(int64(11))},
+		})
+
+		assert.Nil(t, fields["stackSize"].Value)
+		assert.Nil(t, fields["stackPosition"].Value)
+	})
+}

--- a/providers/github/resources/github_team.go
+++ b/providers/github/resources/github_team.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers/github/connection"
 )

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/logger"

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v90/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"


### PR DESCRIPTION
## What

Upgrades the github provider to `go-github` v90 and exposes GitHub's stacked pull requests on `github.mergeRequest`.

## The bump

v90 lives at a new module path, so every import moves from `v89` to `v90`. **No other source change was required.** All twelve of v90's breaking changes are on write APIs — `CreateLabel`, `DismissReview`, `UploadSarif`, `CreatePullRequest`, and so on — and this provider only reads.

`go mod tidy` also drops `github.com/endobit/oui`, an indirect no longer in the build graph. That is pre-existing drift on main, not a consequence of this bump: neither go-github v89 nor v90 references it.

## The new fields

v90 adds `PullRequest.Stack`. A stack is an ordered chain of pull requests that splits one change into reviewable steps, each targeting the one below it while the whole chain targets a single base branch.

| Field | Meaning |
|---|---|
| `stackId` | Identifier of the stack |
| `stackNumber` | Number of the stack |
| `stackSize` | Count of pull requests in the stack |
| `stackPosition` | Position within the stack, counting from 1 at the bottom |
| `stackBaseBranch` | Branch the whole stack targets |
| `stackBaseSha` | Commit SHA the whole stack targets |

```
github.repositories.where(name == "mql") {
  openMergeRequests.where(stackSize != null) { number stackPosition stackSize stackBaseBranch }
}
```

## Two modelling decisions

**Flattened, not a sub-resource.** A stack is shared by every pull request in it, so a `github.mergeRequest.stack` sub-resource keyed on the stack ID would cache a single instance across all members — and `position` is per pull request, not per stack, so that instance would report one member's position for all of them. Flat fields avoid the collision.

**Null, not zero, outside a stack.** A pull request that is not stacked reports null on all six fields. Size 0 at position 0 would read as a real stack to any policy comparing the numbers, and position 1 is a legitimate value (the bottom of the stack), so the two cases have to stay distinguishable. `stackBaseBranch` / `stackBaseSha` are null independently of the counters, since the base can be absent while the counters are present.

## Not included

`stackBaseBranch` is a raw branch name rather than a typed `github.branch` accessor. The repository-level precedent (`defaultBranchName` + `defaultBranch()`) costs one `GetBranch` per repository; the equivalent here would be one per pull request, and this provider already runs into GitHub's secondary rate limits. Worth doing as a lazy accessor later, but not bundled into a dependency bump.

## Testing

- `go build ./...` and `go test ./...` pass in `providers/github`.
- New `github_stack_test.go` covers the unstacked case, a fully-populated stack, position 1 at the bottom, a stack with a missing base, and absent counters inside a present stack.
- Not exercised against a live stacked pull request — the feature needs a repository with stacks enabled.
