### PR TITLE
⭐ mongodbatlas: upgrade the SDK and expose Remote MCP and backup configuration

### DIFF
--- a/providers/mongodbatlas/connection/connection.go
+++ b/providers/mongodbatlas/connection/connection.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 const (
@@ -134,7 +134,7 @@ func (c *MongoDBAtlasConnection) EnsureOrgID(ctx context.Context) (string, error
 	if c.orgID != "" {
 		return c.orgID, nil
 	}
-	orgs, _, err := c.client.OrganizationsApi.ListOrganizations(ctx).Execute()
+	orgs, _, err := c.client.OrganizationsAPI.ListOrgs(ctx).Execute()
 	if err != nil {
 		return "", err
 	}

--- a/providers/mongodbatlas/go.mod
+++ b/providers/mongodbatlas/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 require (
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.32.2
-	go.mongodb.org/atlas-sdk/v20250312006 v20250312006.1.0
+	go.mongodb.org/atlas-sdk/v20250312023 v20250312023.1.0
 )
 
 require (

--- a/providers/mongodbatlas/go.sum
+++ b/providers/mongodbatlas/go.sum
@@ -134,8 +134,6 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/endobit/oui v0.7.0 h1:6/aPQPEA+HcCW+pvZcYBVa0EVcj1uOS9c7XJS33uyCg=
-github.com/endobit/oui v0.7.0/go.mod h1:Y40Y6pCm9rVd6L1OITp7WJp7+F3cSIfaYqohHvMreZs=
 github.com/facebookincubator/nvdtools v0.1.5 h1:jbmDT1nd6+k+rlvKhnkgMokrCAzHoASWE5LtHbX2qFQ=
 github.com/facebookincubator/nvdtools v0.1.5/go.mod h1:Kh55SAWnjckS96TBSrXI99KrEKH4iB0OJby3N8GRJO4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -432,8 +430,8 @@ go.mondoo.com/mondoo-go v0.0.0-20260808001139-ef2a665833b7 h1:4XvjK+Hng0qCDb2i4L
 go.mondoo.com/mondoo-go v0.0.0-20260808001139-ef2a665833b7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
-go.mongodb.org/atlas-sdk/v20250312006 v20250312006.1.0 h1:PcVxslw4G7/I9SbUi5y81i4YZnL1dKRnGpeHVyNSTh4=
-go.mongodb.org/atlas-sdk/v20250312006 v20250312006.1.0/go.mod h1:UZYSaCimjGs3j+wMwgHSKUSIvoJXzmy/xrer0t5TLgo=
+go.mongodb.org/atlas-sdk/v20250312023 v20250312023.1.0 h1:7IIFoyOZvTp5CdS0FxXA2Nkb672/VrZxjsCbuUGWPk8=
+go.mongodb.org/atlas-sdk/v20250312023 v20250312023.1.0/go.mod h1:ZOQisJgGQ+iDbdSwgVU0ClrUlqUSpffW9pVX06+c7nc=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 h1:LMuyCAyfalSjDyjdC65nK6N0zoTT63+E/u95X0JovZI=

--- a/providers/mongodbatlas/resources/access_lists.go
+++ b/providers/mongodbatlas/resources/access_lists.go
@@ -9,7 +9,7 @@ import (
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 // apiAccessListEntry is the normalized form of an access list entry. Atlas
@@ -92,8 +92,8 @@ func (r *mqlMongodbatlasApiKey) accessList() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, httpResp, err := client.ProgrammaticAPIKeysApi.
-			ListApiKeyAccessListsEntries(ctx, oid, r.cacheApiKeyID).
+		resp, httpResp, err := client.ProgrammaticAPIKeysAPI.
+			ListOrgAccessEntries(ctx, oid, r.cacheApiKeyID).
 			ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			// An empty access list is precisely the finding this accessor
@@ -135,8 +135,8 @@ func (r *mqlMongodbatlasServiceAccount) accessList() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, httpResp, err := client.ServiceAccountsApi.
-			ListServiceAccountAccessList(ctx, oid, clientID).
+		resp, httpResp, err := client.ServiceAccountsAPI.
+			ListOrgAccessList(ctx, oid, clientID).
 			ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			if isAccessDenied(httpResp) {
@@ -176,8 +176,8 @@ func (r *mqlMongodbatlasServiceAccount) projects() ([]any, error) {
 
 	groupIDs := []string{}
 	for page := 1; ; page++ {
-		resp, httpResp, err := client.ServiceAccountsApi.
-			ListServiceAccountProjects(ctx, oid, clientID).
+		resp, httpResp, err := client.ServiceAccountsAPI.
+			GetServiceAccountGroups(ctx, oid, clientID).
 			ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			// A denied read establishes nothing about the account's reach, so

--- a/providers/mongodbatlas/resources/access_lists_test.go
+++ b/providers/mongodbatlas/resources/access_lists_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 func TestApiKeyAccessEntry(t *testing.T) {

--- a/providers/mongodbatlas/resources/backup.go
+++ b/providers/mongodbatlas/resources/backup.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 type mqlMongodbatlasBackupScheduleConfigInternal struct {
@@ -38,7 +38,7 @@ func (r *mqlMongodbatlasCluster) backupSchedule() (*mqlMongodbatlasBackupSchedul
 		return nil, err
 	}
 
-	schedule, httpResp, err := atlasClient(r.MqlRuntime).CloudBackupsApi.
+	schedule, httpResp, err := atlasClient(r.MqlRuntime).CloudBackupsAPI.
 		GetBackupSchedule(context.Background(), pid, r.Name.Data).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
@@ -163,7 +163,7 @@ func (r *mqlMongodbatlas) snapshotExportBuckets() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, httpResp, err := client.CloudBackupsApi.ListExportBuckets(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, httpResp, err := client.CloudBackupsAPI.ListExportBuckets(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			// An export bucket is a path for backup data to leave Atlas, so an
 			// empty list is read as "no such path exists". A credential without
@@ -192,13 +192,14 @@ func (r *mqlMongodbatlas) snapshotExportBuckets() ([]any, error) {
 
 func newMqlMongodbatlasSnapshotExportBucket(runtime *plugin.Runtime, pid string, b admin.DiskBackupSnapshotExportBucketResponse) (*mqlMongodbatlasSnapshotExportBucket, error) {
 	res, err := CreateResource(runtime, "mongodbatlas.snapshotExportBucket", map[string]*llx.RawData{
-		"__id":          llx.StringData("mongodbatlas.snapshotExportBucket/" + pid + "/" + b.GetId()),
-		"id":            llx.StringData(b.GetId()),
-		"bucketName":    llx.StringData(b.GetBucketName()),
-		"cloudProvider": llx.StringData(b.GetCloudProvider()),
-		"region":        llx.StringDataPtr(b.Region),
-		"serviceUrl":    llx.StringDataPtr(b.ServiceUrl),
-		"tenantId":      llx.StringDataPtr(b.TenantId),
+		"__id":                     llx.StringData("mongodbatlas.snapshotExportBucket/" + pid + "/" + b.GetId()),
+		"id":                       llx.StringData(b.GetId()),
+		"bucketName":               llx.StringData(b.GetBucketName()),
+		"cloudProvider":            llx.StringData(b.GetCloudProvider()),
+		"region":                   llx.StringDataPtr(b.Region),
+		"serviceUrl":               llx.StringDataPtr(b.ServiceUrl),
+		"tenantId":                 llx.StringDataPtr(b.TenantId),
+		"requirePrivateNetworking": llx.BoolData(b.GetRequirePrivateNetworking()),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/mongodbatlas/resources/backup_compliance.go
+++ b/providers/mongodbatlas/resources/backup_compliance.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 func (r *mqlMongodbatlas) backupCompliancePolicy() (*mqlMongodbatlasBackupComplianceConfig, error) {
@@ -18,7 +18,7 @@ func (r *mqlMongodbatlas) backupCompliancePolicy() (*mqlMongodbatlasBackupCompli
 	if err != nil {
 		return nil, err
 	}
-	settings, httpResp, err := atlasClient(r.MqlRuntime).CloudBackupsApi.GetDataProtectionSettings(context.Background(), pid).Execute()
+	settings, httpResp, err := atlasClient(r.MqlRuntime).CloudBackupsAPI.GetCompliancePolicy(context.Background(), pid).Execute()
 	if err != nil {
 		// The Backup Compliance Policy is a feature-gated guardrail that is not
 		// configured on every project; degrade to null rather than failing the

--- a/providers/mongodbatlas/resources/cluster.go
+++ b/providers/mongodbatlas/resources/cluster.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 // newMqlMongodbatlasCluster maps a cluster to its resource, shared by the
@@ -98,6 +98,7 @@ func newMqlMongodbatlasCluster(runtime *plugin.Runtime, pid string, c admin.Clus
 		"clusterType":                      llx.StringData(c.GetClusterType()),
 		"stateName":                        llx.StringData(c.GetStateName()),
 		"backupEnabled":                    llx.BoolData(c.GetBackupEnabled()),
+		"retainBackups":                    llx.BoolData(c.GetRetainBackups()),
 		"pitEnabled":                       llx.BoolData(c.GetPitEnabled()),
 		"encryptionAtRestProvider":         llx.StringData(c.GetEncryptionAtRestProvider()),
 		"minimumEnabledTlsProtocol":        llx.StringData(tlsMin),
@@ -150,7 +151,7 @@ func initMongodbatlasCluster(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	if err != nil {
 		return nil, nil, err
 	}
-	c, _, err := atlasClient(runtime).ClustersApi.GetCluster(context.Background(), pid, name).Execute()
+	c, _, err := atlasClient(runtime).ClustersAPI.GetCluster(context.Background(), pid, name).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -191,7 +192,7 @@ func (r *mqlMongodbatlas) clusters() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.ClustersApi.ListClusters(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.ClustersAPI.ListClusters(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/converters_test.go
+++ b/providers/mongodbatlas/resources/converters_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 func TestIsAccessDenied(t *testing.T) {

--- a/providers/mongodbatlas/resources/custom_roles.go
+++ b/providers/mongodbatlas/resources/custom_roles.go
@@ -19,7 +19,7 @@ func (r *mqlMongodbatlas) customDatabaseRoles() ([]any, error) {
 	ctx := context.Background()
 
 	// ListCustomDatabaseRoles returns the full set in one call (no pagination).
-	roles, _, err := client.CustomDatabaseRolesApi.ListCustomDatabaseRoles(ctx, pid).Execute()
+	roles, _, err := client.CustomDatabaseRolesAPI.ListCustomDbRoles(ctx, pid).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/mongodbatlas/resources/dbusers.go
+++ b/providers/mongodbatlas/resources/dbusers.go
@@ -24,7 +24,7 @@ func (r *mqlMongodbatlas) databaseUsers() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.DatabaseUsersApi.ListDatabaseUsers(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.DatabaseUsersAPI.ListDatabaseUsers(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/discovery.go
+++ b/providers/mongodbatlas/resources/discovery.go
@@ -28,7 +28,7 @@ func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inven
 	ctx := context.Background()
 
 	for page := 1; ; page++ {
-		resp, _, err := client.ProjectsApi.ListProjects(ctx).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.ProjectsAPI.ListGroups(ctx).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return in, err
 		}

--- a/providers/mongodbatlas/resources/federation.go
+++ b/providers/mongodbatlas/resources/federation.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 type mqlMongodbatlasFederationConfigInternal struct {
@@ -22,7 +22,7 @@ func (r *mqlMongodbatlas) federationSettings() (*mqlMongodbatlasFederationConfig
 	if err != nil {
 		return nil, err
 	}
-	fs, httpResp, err := atlasClient(r.MqlRuntime).FederatedAuthenticationApi.GetFederationSettings(context.Background(), oid).Execute()
+	fs, httpResp, err := atlasClient(r.MqlRuntime).FederatedAuthenticationAPI.GetFederationSettings(context.Background(), oid).Execute()
 	if err != nil {
 		// An organization without federation configured returns 404, and a
 		// credential without org-owner access returns 401/403; both degrade to
@@ -87,7 +87,7 @@ func (r *mqlMongodbatlasFederationConfig) identityProvider() (*mqlMongodbatlasId
 		return nil, nil
 	}
 	fedID := r.Id.Data
-	idp, httpResp, err := atlasClient(r.MqlRuntime).FederatedAuthenticationApi.GetIdentityProvider(context.Background(), fedID, r.cacheIdpID).Execute()
+	idp, httpResp, err := atlasClient(r.MqlRuntime).FederatedAuthenticationAPI.GetIdentityProvider(context.Background(), fedID, r.cacheIdpID).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			r.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
@@ -105,7 +105,7 @@ func (r *mqlMongodbatlasFederationConfig) identityProviders() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.FederatedAuthenticationApi.ListIdentityProviders(ctx, fedID).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.FederatedAuthenticationAPI.ListIdentityProviders(ctx, fedID).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/flex.go
+++ b/providers/mongodbatlas/resources/flex.go
@@ -25,7 +25,7 @@ func (r *mqlMongodbatlas) flexClusters() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, httpResp, err := client.FlexClustersApi.ListFlexClusters(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, httpResp, err := client.FlexClustersAPI.ListFlexClusters(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			// Flex deployments are invisible in the clusters listing, so this
 			// call is the only thing that reports them. A credential that may

--- a/providers/mongodbatlas/resources/log_export.go
+++ b/providers/mongodbatlas/resources/log_export.go
@@ -21,7 +21,12 @@ func (r *mqlMongodbatlas) pushBasedLogExport() (*mqlMongodbatlasPushBasedLogConf
 	if err != nil {
 		return nil, err
 	}
-	cfg, httpResp, err := atlasClient(r.MqlRuntime).PushBasedLogExportApi.GetPushBasedLogConfiguration(context.Background(), pid).Execute()
+	// GetLogExport is deprecated in favor of ListGroupLogIntegrations plus
+	// GetGroupLogIntegration, which model a project as holding several named
+	// integrations rather than one configuration. Adopting that would turn this
+	// singleton resource into a list, a schema change this upgrade does not
+	// carry; the deprecated call keeps reporting the same configuration.
+	cfg, httpResp, err := atlasClient(r.MqlRuntime).PushBasedLogExportAPI.GetLogExport(context.Background(), pid).Execute()
 	if err != nil {
 		// Push-based log export is an optional feature that is not configured on
 		// every project; degrade to null rather than failing the scan when it is

--- a/providers/mongodbatlas/resources/mcp.go
+++ b/providers/mongodbatlas/resources/mcp.go
@@ -1,0 +1,212 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"net/http"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/types"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+)
+
+// mcpUnavailable reports whether the endpoint answered in a way that means
+// Remote MCP is off or unreadable, rather than that no configurations exist.
+// The distinction matters: an empty list is the claim "no agent can reach this
+// deployment", which a denied read has not established.
+func mcpUnavailable(resp *http.Response) bool {
+	return isAccessDenied(resp) || (resp != nil && resp.StatusCode == http.StatusNotFound)
+}
+
+type mqlMongodbatlasMcpConfigurationInternal struct {
+	cacheClientID string
+}
+
+const (
+	mcpScopeOrganization = "ORGANIZATION"
+	mcpScopeProject      = "PROJECT"
+)
+
+// mcpConfigFields is the shape shared by the organization and project responses.
+// The two SDK types are structurally identical but unrelated, so the lists are
+// normalized onto this before the resource is built.
+type mcpConfigFields struct {
+	id             string
+	name           string
+	scope          string
+	roles          []string
+	clientID       string
+	egressClientID string
+	ipAccessList   []admin.ServiceAccountIPAccessListEntry
+}
+
+func newMqlMongodbatlasMcpConfiguration(runtime *plugin.Runtime, parent string, c mcpConfigFields) (*mqlMongodbatlasMcpConfiguration, error) {
+	entries := []any{}
+	for i := range c.ipAccessList {
+		entry, err := newMqlMongodbatlasApiAccessListEntry(runtime, "mcp/"+c.id, serviceAccountAccessEntry(c.ipAccessList[i]))
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+
+	res, err := CreateResource(runtime, "mongodbatlas.mcpConfiguration", map[string]*llx.RawData{
+		// The id is unique per scope, not globally, so the cache key carries the
+		// organization or project it was read from.
+		"__id":           llx.StringData("mongodbatlas.mcpConfiguration/" + parent + "/" + c.id),
+		"id":             llx.StringData(c.id),
+		"name":           llx.StringData(c.name),
+		"scope":          llx.StringData(c.scope),
+		"roles":          llx.ArrayData(strSlice(c.roles), types.String),
+		"clientId":       llx.StringData(c.clientID),
+		"egressClientId": llx.StringData(c.egressClientID),
+		"ipAccessList":   llx.ArrayData(entries, types.Resource("mongodbatlas.apiAccessListEntry")),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	mqlCfg := res.(*mqlMongodbatlasMcpConfiguration)
+	mqlCfg.cacheClientID = c.clientID
+	return mqlCfg, nil
+}
+
+// mcpConfigurations reports the Remote MCP configurations defined at the
+// organization. Each one is a standing path into every project beneath it, so
+// an organization with configurations nobody remembers creating is the finding.
+func (r *mqlMongodbatlas) mcpConfigurations() ([]any, error) {
+	oid, err := orgID(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+
+	out := []any{}
+	for page := 1; ; page++ {
+		resp, httpResp, err := atlasClient(r.MqlRuntime).RemoteMCPConfigurationsAPI.
+			ListOrgMcpConfigs(ctx, oid).
+			ItemsPerPage(pageSize).PageNum(page).Execute()
+		if err != nil {
+			// Remote MCP is not enabled on every organization, and a credential
+			// that cannot read it has established nothing about which
+			// configurations exist. Render null rather than an empty list, which
+			// would assert there are none.
+			if mcpUnavailable(httpResp) {
+				r.McpConfigurations.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		results := resp.GetResults()
+		for i := range results {
+			c := results[i]
+			cfg, err := newMqlMongodbatlasMcpConfiguration(r.MqlRuntime, "org/"+oid, mcpConfigFields{
+				id:             c.GetMcpConfigId(),
+				name:           c.GetMcpConfigName(),
+				scope:          mcpScopeOrganization,
+				roles:          c.GetRoles(),
+				clientID:       c.GetClientId(),
+				egressClientID: c.GetEgressClientId(),
+				ipAccessList:   c.GetIpAccessList(),
+			})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, cfg)
+		}
+
+		if len(results) < pageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// projectMcpConfigurations reports the Remote MCP configurations defined on the
+// project. A project can carry its own independently of the organization, so
+// both lists have to be read to see every agent path into the data.
+func (r *mqlMongodbatlas) projectMcpConfigurations() ([]any, error) {
+	pid, err := projectID(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+
+	out := []any{}
+	for page := 1; ; page++ {
+		resp, httpResp, err := atlasClient(r.MqlRuntime).RemoteMCPConfigurationsAPI.
+			ListGroupMcpConfigs(ctx, pid).
+			ItemsPerPage(pageSize).PageNum(page).Execute()
+		if err != nil {
+			if mcpUnavailable(httpResp) {
+				r.ProjectMcpConfigurations.State = plugin.StateIsSet | plugin.StateIsNull
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		results := resp.GetResults()
+		for i := range results {
+			c := results[i]
+			cfg, err := newMqlMongodbatlasMcpConfiguration(r.MqlRuntime, "group/"+pid, mcpConfigFields{
+				id:             c.GetMcpConfigId(),
+				name:           c.GetMcpConfigName(),
+				scope:          mcpScopeProject,
+				roles:          c.GetRoles(),
+				clientID:       c.GetClientId(),
+				egressClientID: c.GetEgressClientId(),
+				ipAccessList:   c.GetIpAccessList(),
+			})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, cfg)
+		}
+
+		if len(results) < pageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// serviceAccount resolves the account the MCP client authenticates as by
+// scanning the organization's service account list, which is fetched once and
+// cached, rather than looking the account up per configuration.
+func (r *mqlMongodbatlasMcpConfiguration) serviceAccount() (*mqlMongodbatlasServiceAccount, error) {
+	if r.cacheClientID == "" {
+		r.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	atlas, err := CreateResource(r.MqlRuntime, "mongodbatlas", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+
+	accounts := atlas.(*mqlMongodbatlas).GetServiceAccounts()
+	if accounts.Error != nil {
+		return nil, accounts.Error
+	}
+
+	for _, a := range accounts.Data {
+		sa, ok := a.(*mqlMongodbatlasServiceAccount)
+		if !ok {
+			continue
+		}
+		if sa.ClientId.Data == r.cacheClientID {
+			return sa, nil
+		}
+	}
+
+	// The MCP service account is not always visible in the organization list,
+	// for instance when the credential reads MCP but not service accounts.
+	// Report null rather than an error so the rest of the configuration still
+	// renders.
+	r.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}

--- a/providers/mongodbatlas/resources/mcp_test.go
+++ b/providers/mongodbatlas/resources/mcp_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+)
+
+func TestMcpUnavailable(t *testing.T) {
+	// The stakes: when this returns true the accessor renders null, and when it
+	// returns false the error propagates. What it must never do is let a
+	// transport failure through as "feature not enabled", because the caller
+	// turns that into a null field and an audit passes on data never read.
+	tests := []struct {
+		name string
+		resp *http.Response
+		want bool
+	}{
+		{"nil response is a transport error, not a feature answer", nil, false},
+		{"403 means the credential cannot read MCP", &http.Response{StatusCode: http.StatusForbidden}, true},
+		{"401 means the credential cannot read MCP", &http.Response{StatusCode: http.StatusUnauthorized}, true},
+		{"404 means Remote MCP is not enabled", &http.Response{StatusCode: http.StatusNotFound}, true},
+		{"200 is not an unavailable answer", &http.Response{StatusCode: http.StatusOK}, false},
+		{"500 is a server fault the caller must see", &http.Response{StatusCode: http.StatusInternalServerError}, false},
+		{"429 is throttling the caller must see", &http.Response{StatusCode: http.StatusTooManyRequests}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, mcpUnavailable(tc.resp))
+		})
+	}
+}
+
+func TestServiceAccountAccessEntryMapsMcpIpAccessList(t *testing.T) {
+	// The MCP configuration reuses the service account access list shape. If a
+	// tag drifts, the source restriction reads as empty, which is exactly the
+	// finding the field exists to report.
+	created := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	lastUsed := time.Date(2026, 4, 2, 9, 30, 0, 0, time.UTC)
+
+	got := serviceAccountAccessEntry(admin.ServiceAccountIPAccessListEntry{
+		CidrBlock:       admin.PtrString("10.0.0.0/8"),
+		IpAddress:       admin.PtrString("10.1.2.3"),
+		CreatedAt:       &created,
+		LastUsedAt:      &lastUsed,
+		LastUsedAddress: admin.PtrString("10.1.2.3"),
+		RequestCount:    admin.PtrInt(42),
+	})
+
+	assert.Equal(t, "10.0.0.0/8", got.cidrBlock)
+	assert.Equal(t, "10.1.2.3", got.ipAddress)
+	assert.Equal(t, "10.1.2.3", got.lastUsedAddress)
+	assert.Equal(t, int64(42), got.requestCount)
+	assert.Equal(t, &created, got.created)
+	assert.Equal(t, &lastUsed, got.lastUsed)
+}
+
+func TestServiceAccountAccessEntryHandlesAbsentValues(t *testing.T) {
+	// An entry restricted by CIDR carries no ipAddress and has never been used.
+	// Those must stay empty and null rather than becoming a zero timestamp,
+	// which would report 1 January year 1 as a real last-used date.
+	got := serviceAccountAccessEntry(admin.ServiceAccountIPAccessListEntry{
+		CidrBlock: admin.PtrString("192.168.0.0/16"),
+	})
+
+	assert.Equal(t, "192.168.0.0/16", got.cidrBlock)
+	assert.Empty(t, got.ipAddress)
+	assert.Zero(t, got.requestCount)
+	assert.Nil(t, got.created)
+	assert.Nil(t, got.lastUsed)
+}

--- a/providers/mongodbatlas/resources/mongodbatlas.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.go
@@ -13,7 +13,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/mongodbatlas/connection"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 type mqlMongodbatlasInternal struct {
@@ -98,7 +98,7 @@ func (r *mqlMongodbatlas) fetchOrgSettings() (*admin.OrganizationSettings, error
 	if err != nil {
 		return nil, err
 	}
-	settings, httpResp, err := atlasClient(r.MqlRuntime).OrganizationsApi.GetOrganizationSettings(context.Background(), oid).Execute()
+	settings, httpResp, err := atlasClient(r.MqlRuntime).OrganizationsAPI.GetOrgSettings(context.Background(), oid).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			// Degrade: leave orgSettings nil and mark done. Each dependent
@@ -122,7 +122,7 @@ func (r *mqlMongodbatlas) organizationName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	org, httpResp, err := atlasClient(r.MqlRuntime).OrganizationsApi.GetOrganization(context.Background(), oid).Execute()
+	org, httpResp, err := atlasClient(r.MqlRuntime).OrganizationsAPI.GetOrg(context.Background(), oid).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			r.OrganizationName.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/mongodbatlas/resources/mongodbatlas.lr
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr
@@ -45,6 +45,17 @@ mongodbatlas {
   apiKeys() []mongodbatlas.apiKey
   // Service accounts in the organization
   serviceAccounts() []mongodbatlas.serviceAccount
+  // Remote MCP configurations defined at the organization
+  //
+  // Each configuration lets an MCP client reach Atlas with organization-wide
+  // roles, so this is the organization's inventory of agent access.
+  mcpConfigurations() []mongodbatlas.mcpConfiguration
+  // Remote MCP configurations defined on the project
+  //
+  // The project-scoped equivalent of the organization list. A project can carry
+  // its own configurations independently of the organization, so both have to
+  // be read to see every path an agent has into the data.
+  projectMcpConfigurations() []mongodbatlas.mcpConfiguration
   // Organization resource policies (Atlas Resource Policies)
   resourcePolicies() []mongodbatlas.resourcePolicy
   // Clusters in the project
@@ -254,6 +265,48 @@ mongodbatlas.serviceAccount @defaults("name clientId") {
   projects() []mongodbatlas.project
 }
 
+// MongoDB Atlas Remote MCP configuration
+//
+// A configuration that exposes Atlas through the Remote MCP endpoint, which is
+// how an MCP client such as an AI agent reads and acts on the deployment. Each
+// configuration authenticates as a service account and carries the roles that
+// account holds plus the addresses it may connect from, so it is a standing
+// non-human path into the data that outlives any individual session. Reports
+// the roles granted, the service account behind the configuration, and the
+// source restriction, which is the control that keeps the endpoint from being
+// reachable by anyone holding the credentials. Configurations exist at both
+// organization and project scope and the scope field says which this one is.
+// Keyed by id.
+mongodbatlas.mcpConfiguration @defaults("name scope") {
+  // Configuration id
+  id string
+  // Human-readable name identifying the configuration
+  name string
+  // Scope the configuration is defined at, ORGANIZATION or PROJECT
+  //
+  // An organization-scoped configuration grants organization roles and reaches
+  // every project beneath it; a project-scoped one is confined to its project.
+  scope string
+  // Roles the configuration grants
+  //
+  // Organization roles for an organization-scoped configuration and project
+  // roles for a project-scoped one. These are the permissions an MCP client
+  // acts with once it connects.
+  roles []string
+  // OAuth client id of the service account the MCP client authenticates as
+  clientId string
+  // OAuth client id of the egress service account MongoDB Atlas manages
+  egressClientId string
+  // Service account the MCP client authenticates as
+  serviceAccount() mongodbatlas.serviceAccount
+  // Addresses the MCP client may connect from
+  //
+  // Empty when the configuration carries no source restriction, which leaves
+  // the endpoint reachable from anywhere the Atlas API is, for anyone holding
+  // the service account credentials.
+  ipAccessList []mongodbatlas.apiAccessListEntry
+}
+
 // MongoDB Atlas cluster
 //
 // A database cluster (deployment) in the project, keyed by name. Covers the
@@ -282,6 +335,12 @@ mongodbatlas.cluster @defaults("name mongoDBMajorVersion encryptionAtRestProvide
   stateName string
   // Whether cloud backup is enabled
   backupEnabled bool
+  // Whether snapshots survive the cluster being deleted
+  //
+  // When false, deleting the cluster destroys its backups with it, so a
+  // deletion leaves nothing to restore from. Independent of backupEnabled,
+  // which only reports that backups are being taken.
+  retainBackups bool
   // Whether continuous point-in-time recovery is enabled
   pitEnabled bool
   // Encryption-at-rest provider (NONE, AWS, AZURE, or GCP)
@@ -471,6 +530,12 @@ mongodbatlas.snapshotExportBucket @defaults("bucketName cloudProvider") {
   serviceUrl string
   // Azure tenant id that owns the storage account, null for an AWS bucket
   tenantId string
+  // Whether snapshot export traffic is confined to private networking
+  //
+  // When false, exported snapshots travel to the bucket over the public
+  // internet, so backup data leaves Atlas across a path the project does not
+  // control.
+  requirePrivateNetworking bool
   // Cloud provider access role Atlas assumes to write snapshots to the bucket
   cloudProviderAccessRole() mongodbatlas.cloudProviderAccessRole
 }

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.go
@@ -25,6 +25,7 @@ const (
 	ResourceMongodbatlasApiKeyRoleAssignment    string = "mongodbatlas.apiKey.roleAssignment"
 	ResourceMongodbatlasApiAccessListEntry      string = "mongodbatlas.apiAccessListEntry"
 	ResourceMongodbatlasServiceAccount          string = "mongodbatlas.serviceAccount"
+	ResourceMongodbatlasMcpConfiguration        string = "mongodbatlas.mcpConfiguration"
 	ResourceMongodbatlasCluster                 string = "mongodbatlas.cluster"
 	ResourceMongodbatlasBackupScheduleConfig    string = "mongodbatlas.backupScheduleConfig"
 	ResourceMongodbatlasFlexCluster             string = "mongodbatlas.flexCluster"
@@ -85,6 +86,10 @@ func init() {
 		"mongodbatlas.serviceAccount": {
 			// to override args, implement: initMongodbatlasServiceAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMongodbatlasServiceAccount,
+		},
+		"mongodbatlas.mcpConfiguration": {
+			// to override args, implement: initMongodbatlasMcpConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMongodbatlasMcpConfiguration,
 		},
 		"mongodbatlas.cluster": {
 			Init:   initMongodbatlasCluster,
@@ -275,6 +280,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.serviceAccounts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlas).GetServiceAccounts()).ToDataRes(types.Array(types.Resource("mongodbatlas.serviceAccount")))
 	},
+	"mongodbatlas.mcpConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlas).GetMcpConfigurations()).ToDataRes(types.Array(types.Resource("mongodbatlas.mcpConfiguration")))
+	},
+	"mongodbatlas.projectMcpConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlas).GetProjectMcpConfigurations()).ToDataRes(types.Array(types.Resource("mongodbatlas.mcpConfiguration")))
+	},
 	"mongodbatlas.resourcePolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlas).GetResourcePolicies()).ToDataRes(types.Array(types.Resource("mongodbatlas.resourcePolicy")))
 	},
@@ -455,6 +466,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.serviceAccount.projects": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasServiceAccount).GetProjects()).ToDataRes(types.Array(types.Resource("mongodbatlas.project")))
 	},
+	"mongodbatlas.mcpConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetId()).ToDataRes(types.String)
+	},
+	"mongodbatlas.mcpConfiguration.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetName()).ToDataRes(types.String)
+	},
+	"mongodbatlas.mcpConfiguration.scope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetScope()).ToDataRes(types.String)
+	},
+	"mongodbatlas.mcpConfiguration.roles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetRoles()).ToDataRes(types.Array(types.String))
+	},
+	"mongodbatlas.mcpConfiguration.clientId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetClientId()).ToDataRes(types.String)
+	},
+	"mongodbatlas.mcpConfiguration.egressClientId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetEgressClientId()).ToDataRes(types.String)
+	},
+	"mongodbatlas.mcpConfiguration.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetServiceAccount()).ToDataRes(types.Resource("mongodbatlas.serviceAccount"))
+	},
+	"mongodbatlas.mcpConfiguration.ipAccessList": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasMcpConfiguration).GetIpAccessList()).ToDataRes(types.Array(types.Resource("mongodbatlas.apiAccessListEntry")))
+	},
 	"mongodbatlas.cluster.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasCluster).GetId()).ToDataRes(types.String)
 	},
@@ -475,6 +510,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mongodbatlas.cluster.backupEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasCluster).GetBackupEnabled()).ToDataRes(types.Bool)
+	},
+	"mongodbatlas.cluster.retainBackups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasCluster).GetRetainBackups()).ToDataRes(types.Bool)
 	},
 	"mongodbatlas.cluster.pitEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasCluster).GetPitEnabled()).ToDataRes(types.Bool)
@@ -655,6 +693,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mongodbatlas.snapshotExportBucket.tenantId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasSnapshotExportBucket).GetTenantId()).ToDataRes(types.String)
+	},
+	"mongodbatlas.snapshotExportBucket.requirePrivateNetworking": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSnapshotExportBucket).GetRequirePrivateNetworking()).ToDataRes(types.Bool)
 	},
 	"mongodbatlas.snapshotExportBucket.cloudProviderAccessRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasSnapshotExportBucket).GetCloudProviderAccessRole()).ToDataRes(types.Resource("mongodbatlas.cloudProviderAccessRole"))
@@ -1082,6 +1123,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlas).ServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"mongodbatlas.mcpConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlas).McpConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.projectMcpConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlas).ProjectMcpConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"mongodbatlas.resourcePolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlas).ResourcePolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1354,6 +1403,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlasServiceAccount).Projects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"mongodbatlas.mcpConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).__id, ok = v.Value.(string)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.roles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).Roles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.clientId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).ClientId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.egressClientId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).EgressClientId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).ServiceAccount, ok = plugin.RawToTValue[*mqlMongodbatlasServiceAccount](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.mcpConfiguration.ipAccessList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasMcpConfiguration).IpAccessList, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"mongodbatlas.cluster.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasCluster).__id, ok = v.Value.(string)
 		return
@@ -1384,6 +1469,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongodbatlas.cluster.backupEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasCluster).BackupEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.cluster.retainBackups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasCluster).RetainBackups, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.cluster.pitEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1636,6 +1725,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongodbatlas.snapshotExportBucket.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasSnapshotExportBucket).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.snapshotExportBucket.requirePrivateNetworking": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSnapshotExportBucket).RequirePrivateNetworking, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.snapshotExportBucket.cloudProviderAccessRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2213,6 +2306,8 @@ type mqlMongodbatlas struct {
 	Teams                                  plugin.TValue[[]any]
 	ApiKeys                                plugin.TValue[[]any]
 	ServiceAccounts                        plugin.TValue[[]any]
+	McpConfigurations                      plugin.TValue[[]any]
+	ProjectMcpConfigurations               plugin.TValue[[]any]
 	ResourcePolicies                       plugin.TValue[[]any]
 	Clusters                               plugin.TValue[[]any]
 	FlexClusters                           plugin.TValue[[]any]
@@ -2399,6 +2494,38 @@ func (c *mqlMongodbatlas) GetServiceAccounts() *plugin.TValue[[]any] {
 		}
 
 		return c.serviceAccounts()
+	})
+}
+
+func (c *mqlMongodbatlas) GetMcpConfigurations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.McpConfigurations, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas", c.__id, "mcpConfigurations")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.mcpConfigurations()
+	})
+}
+
+func (c *mqlMongodbatlas) GetProjectMcpConfigurations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ProjectMcpConfigurations, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas", c.__id, "projectMcpConfigurations")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.projectMcpConfigurations()
 	})
 }
 
@@ -3298,6 +3425,97 @@ func (c *mqlMongodbatlasServiceAccount) GetProjects() *plugin.TValue[[]any] {
 	})
 }
 
+// mqlMongodbatlasMcpConfiguration for the mongodbatlas.mcpConfiguration resource
+type mqlMongodbatlasMcpConfiguration struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlMongodbatlasMcpConfigurationInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Scope          plugin.TValue[string]
+	Roles          plugin.TValue[[]any]
+	ClientId       plugin.TValue[string]
+	EgressClientId plugin.TValue[string]
+	ServiceAccount plugin.TValue[*mqlMongodbatlasServiceAccount]
+	IpAccessList   plugin.TValue[[]any]
+}
+
+// createMongodbatlasMcpConfiguration creates a new instance of this resource
+func createMongodbatlasMcpConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMongodbatlasMcpConfiguration{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("mongodbatlas.mcpConfiguration", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) MqlName() string {
+	return "mongodbatlas.mcpConfiguration"
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetScope() *plugin.TValue[string] {
+	return &c.Scope
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetRoles() *plugin.TValue[[]any] {
+	return &c.Roles
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetClientId() *plugin.TValue[string] {
+	return &c.ClientId
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetEgressClientId() *plugin.TValue[string] {
+	return &c.EgressClientId
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetServiceAccount() *plugin.TValue[*mqlMongodbatlasServiceAccount] {
+	return plugin.GetOrCompute[*mqlMongodbatlasServiceAccount](&c.ServiceAccount, func() (*mqlMongodbatlasServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.mcpConfiguration", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMongodbatlasServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
+}
+
+func (c *mqlMongodbatlasMcpConfiguration) GetIpAccessList() *plugin.TValue[[]any] {
+	return &c.IpAccessList
+}
+
 // mqlMongodbatlasCluster for the mongodbatlas.cluster resource
 type mqlMongodbatlasCluster struct {
 	MqlRuntime *plugin.Runtime
@@ -3310,6 +3528,7 @@ type mqlMongodbatlasCluster struct {
 	ClusterType                               plugin.TValue[string]
 	StateName                                 plugin.TValue[string]
 	BackupEnabled                             plugin.TValue[bool]
+	RetainBackups                             plugin.TValue[bool]
 	PitEnabled                                plugin.TValue[bool]
 	EncryptionAtRestProvider                  plugin.TValue[string]
 	MinimumEnabledTlsProtocol                 plugin.TValue[string]
@@ -3398,6 +3617,10 @@ func (c *mqlMongodbatlasCluster) GetStateName() *plugin.TValue[string] {
 
 func (c *mqlMongodbatlasCluster) GetBackupEnabled() *plugin.TValue[bool] {
 	return &c.BackupEnabled
+}
+
+func (c *mqlMongodbatlasCluster) GetRetainBackups() *plugin.TValue[bool] {
+	return &c.RetainBackups
 }
 
 func (c *mqlMongodbatlasCluster) GetPitEnabled() *plugin.TValue[bool] {
@@ -3761,13 +3984,14 @@ type mqlMongodbatlasSnapshotExportBucket struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlMongodbatlasSnapshotExportBucketInternal
-	Id                      plugin.TValue[string]
-	BucketName              plugin.TValue[string]
-	CloudProvider           plugin.TValue[string]
-	Region                  plugin.TValue[string]
-	ServiceUrl              plugin.TValue[string]
-	TenantId                plugin.TValue[string]
-	CloudProviderAccessRole plugin.TValue[*mqlMongodbatlasCloudProviderAccessRole]
+	Id                       plugin.TValue[string]
+	BucketName               plugin.TValue[string]
+	CloudProvider            plugin.TValue[string]
+	Region                   plugin.TValue[string]
+	ServiceUrl               plugin.TValue[string]
+	TenantId                 plugin.TValue[string]
+	RequirePrivateNetworking plugin.TValue[bool]
+	CloudProviderAccessRole  plugin.TValue[*mqlMongodbatlasCloudProviderAccessRole]
 }
 
 // createMongodbatlasSnapshotExportBucket creates a new instance of this resource
@@ -3824,6 +4048,10 @@ func (c *mqlMongodbatlasSnapshotExportBucket) GetServiceUrl() *plugin.TValue[str
 
 func (c *mqlMongodbatlasSnapshotExportBucket) GetTenantId() *plugin.TValue[string] {
 	return &c.TenantId
+}
+
+func (c *mqlMongodbatlasSnapshotExportBucket) GetRequirePrivateNetworking() *plugin.TValue[bool] {
+	return &c.RequirePrivateNetworking
 }
 
 func (c *mqlMongodbatlasSnapshotExportBucket) GetCloudProviderAccessRole() *plugin.TValue[*mqlMongodbatlasCloudProviderAccessRole] {

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.versions
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.versions
@@ -87,6 +87,7 @@ mongodbatlas.cluster.privateSrvConnectionString 13.1.4
 mongodbatlas.cluster.redactClientLogData 13.0.0
 mongodbatlas.cluster.regionConfigs 13.0.0
 mongodbatlas.cluster.replicaSetScalingStrategy 13.1.4
+mongodbatlas.cluster.retainBackups 13.3.1
 mongodbatlas.cluster.rootCertType 13.0.0
 mongodbatlas.cluster.searchIndexes 13.0.1
 mongodbatlas.cluster.standardSrvConnectionString 13.1.4
@@ -173,6 +174,16 @@ mongodbatlas.identityProvider.updatedAt 13.0.1
 mongodbatlas.identityProvider.userClaim 13.0.1
 mongodbatlas.ipAccessList 13.0.0
 mongodbatlas.maxServiceAccountSecretValidityInHours 13.0.0
+mongodbatlas.mcpConfiguration 13.3.1
+mongodbatlas.mcpConfiguration.clientId 13.3.1
+mongodbatlas.mcpConfiguration.egressClientId 13.3.1
+mongodbatlas.mcpConfiguration.id 13.3.1
+mongodbatlas.mcpConfiguration.ipAccessList 13.3.1
+mongodbatlas.mcpConfiguration.name 13.3.1
+mongodbatlas.mcpConfiguration.roles 13.3.1
+mongodbatlas.mcpConfiguration.scope 13.3.1
+mongodbatlas.mcpConfiguration.serviceAccount 13.3.1
+mongodbatlas.mcpConfigurations 13.3.1
 mongodbatlas.multiFactorAuthRequired 13.0.0
 mongodbatlas.networkAccessEntry 13.0.0
 mongodbatlas.networkAccessEntry.awsSecurityGroup 13.0.0
@@ -232,6 +243,7 @@ mongodbatlas.projectConfig.isExtendedStorageSizesEnabled 13.0.0
 mongodbatlas.projectConfig.isPerformanceAdvisorEnabled 13.0.0
 mongodbatlas.projectConfig.isRealtimePerformancePanelEnabled 13.0.0
 mongodbatlas.projectConfig.isSchemaAdvisorEnabled 13.0.0
+mongodbatlas.projectMcpConfigurations 13.3.1
 mongodbatlas.projectSettings 13.0.0
 mongodbatlas.projects 13.0.0
 mongodbatlas.pushBasedLogConfig 13.0.1
@@ -279,6 +291,7 @@ mongodbatlas.snapshotExportBucket.cloudProvider 13.1.4
 mongodbatlas.snapshotExportBucket.cloudProviderAccessRole 13.1.4
 mongodbatlas.snapshotExportBucket.id 13.1.4
 mongodbatlas.snapshotExportBucket.region 13.1.4
+mongodbatlas.snapshotExportBucket.requirePrivateNetworking 13.3.1
 mongodbatlas.snapshotExportBucket.serviceUrl 13.1.4
 mongodbatlas.snapshotExportBucket.tenantId 13.1.4
 mongodbatlas.snapshotExportBuckets 13.1.4

--- a/providers/mongodbatlas/resources/network.go
+++ b/providers/mongodbatlas/resources/network.go
@@ -44,7 +44,7 @@ func (r *mqlMongodbatlas) ipAccessList() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.ProjectIPAccessListApi.ListProjectIpAccessLists(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.ProjectIPAccessListAPI.ListAccessListEntries(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +88,7 @@ func (r *mqlMongodbatlas) privateEndpoints() ([]any, error) {
 
 	out := []any{}
 	for _, provider := range []string{"AWS", "AZURE", "GCP"} {
-		services, httpResp, err := client.PrivateEndpointServicesApi.ListPrivateEndpointServices(ctx, pid, provider).Execute()
+		services, httpResp, err := client.PrivateEndpointServicesAPI.ListPrivateEndpointService(ctx, pid, provider).Execute()
 		if err != nil {
 			// A provider without any configured private endpoint service returns
 			// 404; skip it, but surface auth, throttling, and other real errors.
@@ -127,7 +127,7 @@ func (r *mqlMongodbatlas) networkPeerings() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.NetworkPeeringApi.ListPeeringConnections(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.NetworkPeeringAPI.ListGroupPeers(ctx, pid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +171,7 @@ func (r *mqlMongodbatlas) cloudProviderAccessRoles() ([]any, error) {
 	client := atlasClient(r.MqlRuntime)
 	ctx := context.Background()
 
-	roles, _, err := client.CloudProviderAccessApi.ListCloudProviderAccessRoles(ctx, pid).Execute()
+	roles, _, err := client.CloudProviderAccessAPI.ListCloudProviderAccess(ctx, pid).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (r *mqlMongodbatlas) cloudProviderAccessRoles() ([]any, error) {
 // roles on each call; the only caller today is pushBasedLogConfig, of which
 // there is at most one per project, so the list call is bounded to one per scan.
 func resolveCloudProviderAccessRole(runtime *plugin.Runtime, pid, roleID string) (*mqlMongodbatlasCloudProviderAccessRole, error) {
-	roles, _, err := atlasClient(runtime).CloudProviderAccessApi.ListCloudProviderAccessRoles(context.Background(), pid).Execute()
+	roles, _, err := atlasClient(runtime).CloudProviderAccessAPI.ListCloudProviderAccess(context.Background(), pid).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 // pageSize is the per-request page size used for the SDK's manual pagination.
@@ -58,7 +58,7 @@ func initMongodbatlasProject(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	if id == "" {
 		return nil, nil, fmt.Errorf("mongodbatlas.project requires a non-empty id")
 	}
-	p, _, err := atlasClient(runtime).ProjectsApi.GetProject(context.Background(), id).Execute()
+	p, _, err := atlasClient(runtime).ProjectsAPI.GetGroup(context.Background(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,7 +75,7 @@ func (r *mqlMongodbatlas) projects() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.ProjectsApi.ListProjects(ctx).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.ProjectsAPI.ListGroups(ctx).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func (r *mqlMongodbatlas) orgUsers() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.MongoDBCloudUsersApi.ListOrganizationUsers(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.MongoDBCloudUsersAPI.ListOrgUsers(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -257,7 +257,7 @@ func (r *mqlMongodbatlas) orgTeamsByID() (map[string]admin.TeamResponse, error) 
 
 		m := map[string]admin.TeamResponse{}
 		for page := 1; ; page++ {
-			resp, httpResp, err := client.TeamsApi.ListOrganizationTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
+			resp, httpResp, err := client.TeamsAPI.ListOrgTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
 			if err != nil {
 				// A project-scoped credential without org privilege cannot list
 				// teams; record the denial rather than failing every user's
@@ -327,7 +327,7 @@ func (r *mqlMongodbatlas) teams() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.TeamsApi.ListOrganizationTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.TeamsAPI.ListOrgTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (r *mqlMongodbatlasTeam) users() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.MongoDBCloudUsersApi.ListTeamUsers(ctx, oid, r.Id.Data).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.MongoDBCloudUsersAPI.ListTeamUsers(ctx, oid, r.Id.Data).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -398,7 +398,7 @@ func (r *mqlMongodbatlas) apiKeys() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.ProgrammaticAPIKeysApi.ListApiKeys(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.ProgrammaticAPIKeysAPI.ListOrgApiKeys(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -481,7 +481,7 @@ func (r *mqlMongodbatlas) serviceAccounts() ([]any, error) {
 
 	out := []any{}
 	for page := 1; ; page++ {
-		resp, _, err := client.ServiceAccountsApi.ListServiceAccounts(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
+		resp, _, err := client.ServiceAccountsAPI.ListOrgServiceAccounts(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
 		if err != nil {
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/resource_policies.go
+++ b/providers/mongodbatlas/resources/resource_policies.go
@@ -17,7 +17,7 @@ func (r *mqlMongodbatlas) resourcePolicies() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	policies, httpResp, err := atlasClient(r.MqlRuntime).ResourcePoliciesApi.ListOrgResourcePolicies(context.Background(), oid).Execute()
+	policies, httpResp, err := atlasClient(r.MqlRuntime).ResourcePoliciesAPI.ListOrgResourcePolicies(context.Background(), oid).Execute()
 	if err != nil {
 		// Resource policies are the org-wide guardrails, so an empty list says
 		// "nothing constrains this organization". A credential without access

--- a/providers/mongodbatlas/resources/search.go
+++ b/providers/mongodbatlas/resources/search.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/types"
-	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 // searchIndexes lists the Atlas Search and Atlas Vector Search indexes defined
@@ -25,8 +25,8 @@ func (c *mqlMongodbatlasCluster) searchIndexes() ([]any, error) {
 	}
 	name := c.Name.Data
 
-	indexes, httpResp, err := atlasClient(c.MqlRuntime).AtlasSearchApi.
-		ListAtlasSearchIndexesCluster(context.Background(), pid, name).Execute()
+	indexes, httpResp, err := atlasClient(c.MqlRuntime).AtlasSearchAPI.
+		ListClusterSearchIndexes(context.Background(), pid, name).Execute()
 	if err != nil {
 		// A credential that may not read the endpoint has not established
 		// anything about the cluster's indexes, so the field renders null. An

--- a/providers/mongodbatlas/resources/settings.go
+++ b/providers/mongodbatlas/resources/settings.go
@@ -23,7 +23,7 @@ func (r *mqlMongodbatlas) projectSettings() (*mqlMongodbatlasProjectConfig, erro
 	if err != nil {
 		return nil, err
 	}
-	s, _, err := atlasClient(r.MqlRuntime).ProjectsApi.GetProjectSettings(context.Background(), pid).Execute()
+	s, _, err := atlasClient(r.MqlRuntime).ProjectsAPI.GetGroupSettings(context.Background(), pid).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (r *mqlMongodbatlas) auditing() (*mqlMongodbatlasAuditConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	a, httpResp, err := atlasClient(r.MqlRuntime).AuditingApi.GetAuditingConfiguration(context.Background(), pid).Execute()
+	a, httpResp, err := atlasClient(r.MqlRuntime).AuditingAPI.GetGroupAuditLog(context.Background(), pid).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			r.Auditing.State = plugin.StateIsSet | plugin.StateIsNull
@@ -74,7 +74,7 @@ func (r *mqlMongodbatlas) encryptionAtRest() (*mqlMongodbatlasEncryptionConfig, 
 	if err != nil {
 		return nil, err
 	}
-	e, httpResp, err := atlasClient(r.MqlRuntime).EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), pid).Execute()
+	e, httpResp, err := atlasClient(r.MqlRuntime).EncryptionAtRestUsingCustomerKeyManagementAPI.GetEncryptionAtRest(context.Background(), pid).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			r.EncryptionAtRest.State = plugin.StateIsSet | plugin.StateIsNull


### PR DESCRIPTION
## What

Upgrades the mongodbatlas provider from `atlas-sdk` **v20250312006 → v20250312023** (17 majors), then exposes the Remote MCP configurations and the backup fields that bump unlocks.

## The upgrade is not a rename

Atlas versions its major by date stamp and revs it on most releases, so the provider drifted 17 majors without anything flagging it.

Every service accessor renames `Api` → `API`, which is a sed. But the SDK also **re-scoped its methods around groups and organizations**, and 21 calls needed real replacements:

| Was | Now |
|---|---|
| `ListProjects` | `ListGroups` |
| `GetProject` / `GetProjectSettings` | `GetGroup` / `GetGroupSettings` |
| `ListOrganizationUsers` / `ListOrganizationTeams` | `ListOrgUsers` / `ListOrgTeams` |
| `ListApiKeys` | `ListOrgApiKeys` (also `ListGroupApiKeys` exists) |
| `ListServiceAccounts` | `ListOrgServiceAccounts` |
| `ListServiceAccountProjects` | `GetServiceAccountGroups` |
| `GetDataProtectionSettings` | `GetCompliancePolicy` |
| `ListCustomDatabaseRoles` | `ListCustomDbRoles` |
| `ListPeeringConnections` | `ListGroupPeers` |
| `ListProjectIpAccessLists` | `ListAccessListEntries` |
| `GetAuditingConfiguration` | `GetGroupAuditLog` |
| …and 10 more | |

The `Org`/`Group` splits are the dangerous ones: both overloads take `(ctx, string)`, so picking the wrong scope **compiles cleanly** and silently reads the wrong thing. Each call site was checked against the id variable it passes (`oid` vs `pid`) rather than trusted to the compiler.

## Remote MCP configurations

The headline addition. A Remote MCP configuration exposes Atlas through the MCP endpoint, authenticating as a service account that carries roles and an optional source restriction — a standing, non-human path into the data that outlives any session.

```
mongodbatlas.mcpConfigurations.where(ipAccessList.length == 0) { name roles clientId }
mongodbatlas.projectMcpConfigurations { name scope roles serviceAccount { name } }
```

Both scopes are read: a project can carry configurations independently of its organization, so reading one list misses half the exposure. The `scope` field distinguishes them.

`serviceAccount()` resolves through the organization's **cached service account list**, not a lookup per configuration, so N configurations cost one extra call rather than N.

An organization where Remote MCP is not enabled, or a credential that cannot read it, renders **null** rather than an empty list — an empty list is the claim "no agent can reach this deployment", which a denied read has not established.

## Backup configuration

| Resource | Field | Reports |
|---|---|---|
| `mongodbatlas.cluster` | `retainBackups` | Whether snapshots survive the cluster being deleted. Independent of `backupEnabled`: a cluster can be backed up and still lose everything on delete. |
| `mongodbatlas.snapshotExportBucket` | `requirePrivateNetworking` | Whether exported backup data crosses the public internet on its way out of Atlas. |

## A deprecation left alone

`PushBasedLogExportAPI.GetLogExport` is now deprecated upstream in favour of `ListGroupLogIntegrations` + `GetGroupLogIntegration`, which model a project as holding several *named* integrations rather than one configuration. Adopting that turns `mongodbatlas.pushBasedLogConfig` from a singleton into a list — a schema change that deserves its own PR. The deprecated call is kept with a comment explaining why.

## Testing

- `go build ./...` and `go test ./...` pass in `providers/mongodbatlas`.
- New `mcp_test.go` covers the `mcpUnavailable` classifier (403/401/404 → unavailable; nil response, 500, 429 → propagate, so a transport failure can never render as "no agents configured") and the IP-access-list mapping including the absent-value case.
- **Not verified against a live Atlas org** — no account credentials available here. The MCP accessors in particular should be checked against an org with Remote MCP enabled before release.
