### PR TITLE
🐛 skills: fix enumdrift false positives, and the databricks drift it then found

### DIFF
--- a/.claude/skills/update-provider-deps/SKILL.md
+++ b/.claude/skills/update-provider-deps/SKILL.md
@@ -163,11 +163,21 @@ silently loses a value costs them rows they should have matched.
 python3 $P/enumdrift.py providers/databricks/resources/databricks.lr "$NEW"
 ```
 
-It pairs each enumerating comment with the SDK const block whose values overlap most, and
-reports what the SDK has that the comment omits. Treat every hit as a candidate, not a
-verdict — confirm the paired enum is the one the field carries, and that the omission
-isn't deliberate (a comment may list only the values we map). Fix the genuine ones in the
-same PR; they are cheap and they are documentation the user relies on.
+It pairs each enumerating comment with the SDK const block whose values it quotes, and
+reports what the SDK has that the comment omits. Only comments that claim completeness
+("One of A, B, or C") are reported; ones phrased as examples ("such as A or B") are
+allowed to be partial and are counted separately.
+
+Treat every hit as a candidate, not a verdict — confirm the paired enum is the one the
+field carries, and that the omission isn't deliberate. Fix the genuine ones in the same
+PR; they are cheap, and they are documentation a policy author relies on when deciding
+which `where()` clauses to write.
+
+**A clean run is not always a clean bill of health.** The check needs the SDK to declare
+typed string constants. Azure, Databricks, GCP and Nutanix do; several OpenAPI-generated
+SDKs — go-github, okta, the Atlas SDK — type every enum field as a plain string, and the
+tool will tell you it has nothing to compare against. For those, enumerated values have to
+be checked against the vendor's API docs by hand, or left alone.
 
 ## Phase 6 — Propose additions, then stop
 

--- a/.claude/skills/update-provider-deps/enumdrift.py
+++ b/.claude/skills/update-provider-deps/enumdrift.py
@@ -13,11 +13,30 @@ list silently becomes wrong, and a policy that enumerates the documented values
 starts missing rows it should match.
 
 The check is a *comparison aid*, not a linter. It pairs each enumerated comment
-with the SDK constant blocks whose values overlap, then reports what the SDK has
+with the SDK constant block whose values it quotes, then reports what the SDK has
 that the comment does not. Read the pairs before editing: a comment can list a
 deliberate subset (the values we actually map), and the matcher can pair the
 wrong constant block when several enums share vocabulary. Both are for a human
 to judge, which is why the output is a report rather than a diff to apply.
+
+Only comments that *claim* completeness are reported. "One of A, B, or C" is a
+promise and a missing value breaks it; "such as A or B" is explicitly an example
+and is allowed to be partial forever. Without that distinction the handful of
+real defects drown in every field that happens to give an example. Pass
+--include-illustrative to see the example-phrased ones too, which is worth doing
+when deciding whether one of them ought to become exhaustive.
+
+Matching is case-sensitive on purpose. Enum values carry their case (`gitHub`,
+not `GITHUB`), so an exact match is good evidence the comment is quoting that
+constant rather than coincidentally sharing a word -- and a discriminator whose
+values this provider invents itself will not pair with an unrelated SDK enum.
+
+Scope limit worth knowing up front: this only works on SDKs that declare typed
+string constants. Azure, Databricks, GCP and Nutanix do; several
+OpenAPI-generated ones -- go-github, okta, the Atlas SDK -- type every enum field
+as a plain string, and there is nothing to compare against. The tool says so
+rather than reporting a clean run, because "0 drifted" and "nothing to check"
+mean very different things.
 
 Typical use, after extracting both SDK versions with modfetch.sh:
 
@@ -37,21 +56,38 @@ import sys
 #   such as A or B            (A, B, or C)
 # Captured loosely, then split on separators, because the goal is to notice a
 # missing value rather than to parse English.
+# Two kinds of enumerating clause, and the difference decides whether a missing value
+# is a defect at all. "One of A, B, or C" claims completeness, so a value the SDK has
+# and the comment lacks is drift a policy author can be misled by. "such as A or B" is
+# explicitly illustrative and is allowed to be partial forever. Reporting both as drift
+# buries the handful of real defects under every field that gives an example.
+EXHAUSTIVE_LEAD = r"one of|either|values? are|valid values|possible values"
+ILLUSTRATIVE_LEAD = r"such as|for example|e\.g\.|including|includes|include"
+
 ENUM_PROSE_RE = re.compile(
-    r"(?:one of|such as|either|values?(?:\s+are)?:?)\s+(?P<body>[^.]*)", re.IGNORECASE
+    rf"(?P<lead>{EXHAUSTIVE_LEAD}|{ILLUSTRATIVE_LEAD}):?\s+(?P<body>[^.]*)", re.IGNORECASE
 )
+EXHAUSTIVE_RE = re.compile(rf"^({EXHAUSTIVE_LEAD})$", re.IGNORECASE)
 
 # A candidate value inside that prose: BAREWORD, "quoted", or `backticked`.
 # Enum values in these APIs are overwhelmingly single tokens.
 VALUE_RE = re.compile(r'[`"]?([A-Za-z][A-Za-z0-9_.-]{1,60})[`"]?')
 
-# Words that show up inside an enumeration but are not values.
+# Connective words that appear inside an enumeration but are not values. Matched
+# against the all-lowercase form only, never case-insensitively, because several of
+# these also ship as real constants in SCREAMING_CASE. Filtering "none" without regard
+# to case hid a genuine NONE from the Databricks access-mode comment and reported the
+# comment as missing a value it already documented.
 STOPWORDS = {
     "one", "of", "or", "and", "either", "such", "as", "the", "a", "an", "is", "are",
     "value", "values", "for", "to", "in", "on", "when", "which", "that", "this",
     "empty", "null", "unset", "none", "other", "others", "kinds", "etc", "example",
     "instance", "default", "defaults", "set", "not", "it", "its", "be", "by", "with",
+    "include", "includes", "including", "disables", "enables", "means", "only",
 }
+
+# A `.lr` field declaration: `name type`, `name() type`, either with @tags between.
+FIELD_DECL_RE = re.compile(r"^\s*([a-z][A-Za-z0-9_]*)\s*(?:\(\))?\s*(?:@[^\s]+\s*)*(?:[\[\]A-Za-z]|map)")
 
 # type X string  +  const XFoo X = "FOO" / `FOO`
 GO_CONST_RE = re.compile(
@@ -70,46 +106,36 @@ def lr_fields_with_enums(lr_path: str):
         if s.startswith("//"):
             buf.append(s.lstrip("/").strip())
             continue
-        # A field declaration is `name type` or `name() type`, possibly with tags.
-        m = re.match(r"^([a-z][A-Za-z0-9_]*)\s*(?:\(\))?\s*(?:@[^\s]+\s*)*([\[\]A-Za-z]|map)", s)
+        m = FIELD_DECL_RE.match(s)
         if m and buf:
             comment = " ".join(buf)
-            vals = extract_enum_values(comment)
-            if vals:
-                out.append((m.group(1), i + 1, vals, comment))
+            cands, exhaustive = extract_candidates(comment)
+            if cands:
+                out.append((m.group(1), i + 1, cands, exhaustive, comment))
         if not s.startswith("//"):
             buf = []
     return out
 
 
-def looks_like_enum_token(v: str) -> bool:
-    """Distinguish an API value from an English word caught by the same regex.
+def extract_candidates(comment: str):
+    """Pull every plausible value token out of an enumerating doc comment.
 
-    The enumerating clause runs on into prose ("One of A, B, or C, which disables
-    the Unity Catalog") and a naive split swallows "disables", "Unity", "Catalog"
-    as values. Real values in these SDKs are SCREAMING_SNAKE, camelCase, or
-    hyphen/underscore-joined; a bare English word, capitalized or not, is not one.
+    Deliberately permissive. An earlier version tried to tell values from prose by
+    their shape -- SCREAMING_CASE or camelCase in, bare lowercase words out -- and
+    threw away real values in the process: `anthropic`, `cohere`, `openai` and `palm`
+    are all genuine Databricks constants and all look exactly like English words.
+
+    Rather than guess, this hands everything to the matcher and lets the SDK decide.
+    A token that is really prose will not appear in any constant block, so it drops
+    out on its own; a lowercase token that is really a value gets matched. The only
+    filtering here is of connectives that would otherwise pad the candidate set.
     """
-    if "_" in v or "-" in v or "." in v:
-        return True
-    if v.isupper() and len(v) > 1:
-        return True
-    # camelCase / PascalCase with an internal capital: gitHub, bitbucketCloud.
-    return any(c.isupper() for c in v[1:])
-
-
-def extract_enum_values(comment: str):
-    """Pull the enumerated values out of a doc comment, or return an empty set."""
     m = ENUM_PROSE_RE.search(comment)
     if not m:
-        return set()
-    body = m.group("body")
-    vals = set()
-    for cand in VALUE_RE.findall(body):
-        if cand.lower() in STOPWORDS or not looks_like_enum_token(cand):
-            continue
-        vals.add(cand)
-    return vals if len(vals) >= 2 else set()
+        return set(), False
+    cands = {c for c in VALUE_RE.findall(m.group("body")) if c not in STOPWORDS}
+    exhaustive = bool(EXHAUSTIVE_RE.match(m.group("lead").strip()))
+    return (cands, exhaustive) if len(cands) >= 2 else (set(), False)
 
 
 def sdk_const_groups(sdk_dir: str):
@@ -129,26 +155,30 @@ def sdk_const_groups(sdk_dir: str):
     return {k: v for k, v in groups.items() if len(v) >= 2}
 
 
-def best_match(values, groups):
-    """Pick the SDK enum whose values overlap the comment's most.
+def best_match(candidates, groups):
+    """Pick the SDK enum that best explains the comment's tokens.
 
-    Scored on two axes. Coverage (how much of the comment the enum accounts for)
-    decides, because a comment may deliberately list a subset. Tightness (how
-    little of the enum is left over) breaks ties, which matters more than it
-    sounds: unrelated enums share vocabulary -- USER, GROUP and SERVICE_PRINCIPAL
-    appear in half a dozen types -- so several will cover a short comment
-    perfectly and the tightest fit is the likeliest one.
+    Matching is case-SENSITIVE, which does real work here. Enum values carry their
+    case (`gitHub`, not `GITHUB`), so an exact match is strong evidence the comment is
+    quoting that constant. It also keeps provider-invented vocabulary from pairing with
+    an unrelated SDK enum: a discriminator whose values this provider defines itself in
+    snake_case will not match an SDK enum spelling them in SCREAMING_CASE, and so is
+    correctly left alone instead of being reported as drifted.
+
+    Ranked on the number of values matched first, since that is what makes an enum a
+    plausible explanation at all, then on tightness of fit, because unrelated enums
+    share vocabulary -- USER, GROUP and SERVICE_PRINCIPAL appear in half a dozen types
+    -- and the enum with least left over is the likeliest one.
     """
-    best, best_score = None, (0.0, 0.0)
-    lowered = {v.lower() for v in values}
+    best, best_score, best_hits = None, (0, 0.0), set()
     for type_name, sdk_vals in groups.items():
-        hit = len(lowered & {v.lower() for v in sdk_vals})
-        if not hit:
+        hits = candidates & sdk_vals
+        if len(hits) < 2:
             continue
-        score = (hit / len(lowered), hit / len(sdk_vals))
+        score = (len(hits), len(hits) / len(sdk_vals))
         if score > best_score:
-            best, best_score = type_name, score
-    return best, best_score[0]
+            best, best_score, best_hits = type_name, score, hits
+    return best, best_hits
 
 
 def main():
@@ -157,46 +187,77 @@ def main():
     ap.add_argument("sdk_dir")
     ap.add_argument("--field", help="only report this field name")
     ap.add_argument(
-        "--min-overlap",
-        type=float,
-        default=0.5,
-        help="fraction of the comment's values an SDK enum must cover to be paired (default: 0.5)",
+        "--include-illustrative",
+        action="store_true",
+        help="also report comments phrased as examples (\"such as A or B\"), which are "
+        "allowed to be partial. Useful when deciding whether one should become exhaustive.",
+    )
+    ap.add_argument(
+        "--min-values",
+        type=int,
+        default=2,
+        help="how many of an SDK enum's values a comment must quote exactly before the two "
+        "are considered the same enum (default: 2)",
     )
     args = ap.parse_args()
 
     fields = lr_fields_with_enums(args.lr_file)
+    if not fields:
+        print(f"no .lr fields with enumerated values found in {args.lr_file}", file=sys.stderr)
+        return
     if args.field:
         fields = [f for f in fields if f[0] == args.field]
-    if not fields:
-        print("no .lr fields with enumerated values found", file=sys.stderr)
-        return
+        if not fields:
+            # Distinguish "that field has no enumerated comment" from "that field does
+            # not exist here", which otherwise reads the same and sends you looking in
+            # the wrong place.
+            exists = any(
+                (m := FIELD_DECL_RE.match(line)) and m.group(1) == args.field
+                for line in open(args.lr_file, encoding="utf-8", errors="replace")
+            )
+            why = "does not enumerate values in its comment" if exists else f"is not declared in {args.lr_file}"
+            print(f"{args.field} {why}", file=sys.stderr)
+            return
 
     groups = sdk_const_groups(args.sdk_dir)
     if not groups:
-        print(f"no Go string-const enums found under {args.sdk_dir}", file=sys.stderr)
+        # Not a failure, and not a clean bill of health either. Plenty of SDKs --
+        # most OpenAPI-generated ones, including go-github, okta and atlas -- model
+        # every enum as a plain string with no constants to compare against. Say so,
+        # so nobody reads silence as "the comments were checked and were fine".
+        print(
+            f"no Go string-const enums declared in {args.sdk_dir}.\n"
+            "This SDK types its enum fields as plain strings, so there is nothing to compare\n"
+            "comments against here. Verify enumerated values against the vendor's API docs\n"
+            "instead; this check cannot cover them.",
+            file=sys.stderr,
+        )
         return
 
-    drifted, checked, unpaired = 0, 0, 0
-    for field, line, values, comment in fields:
-        match, score = best_match(values, groups)
-        if not match or score < args.min_overlap:
+    drifted, checked, unpaired, illustrative = 0, 0, 0, 0
+    for field, line, candidates, exhaustive, comment in fields:
+        match, hits = best_match(candidates, groups)
+        if not match or len(hits) < args.min_values:
             unpaired += 1
             continue
         checked += 1
         sdk_vals = groups[match]
-        lowered = {v.lower() for v in values}
-        missing = sorted(v for v in sdk_vals if v.lower() not in lowered)
+        missing = sorted(sdk_vals - hits)
         if not missing:
             continue
+        if not exhaustive and not args.include_illustrative:
+            illustrative += 1
+            continue
         drifted += 1
-        print(f"\n{args.lr_file}:{line}  {field}")
-        print(f"  comment lists : {', '.join(sorted(values))}")
-        print(f"  SDK enum      : {match} ({int(score * 100)}% overlap)")
-        print(f"  SDK also has  : {', '.join(missing)}")
+        kind = "" if exhaustive else "  [illustrative: allowed to be partial]"
+        print(f"\n{args.lr_file}:{line}  {field}{kind}")
+        print(f"  comment quotes: {', '.join(sorted(hits))}")
+        print(f"  SDK enum      : {match} ({len(hits)}/{len(sdk_vals)} values documented)")
+        print(f"  not documented: {', '.join(missing)}")
 
     print(
-        f"\n# {checked} enumerated field(s) paired with an SDK enum, {drifted} with values "
-        f"the comment omits, {unpaired} unpaired (no confident match).",
+        f"\n# {checked} enumerated field(s) paired with an SDK enum, {drifted} reported, "
+        f"{illustrative} skipped as illustrative, {unpaired} unpaired (no confident match).",
         file=sys.stderr,
     )
     if drifted:

--- a/providers/databricks/resources/databricks.lr
+++ b/providers/databricks/resources/databricks.lr
@@ -916,18 +916,18 @@ databricks.connection @defaults("name connectionType credentialType owner") {
   fullName string
   // External system the connection reaches
   //
-  // One of BIGQUERY, CONFLUENCE, DATABRICKS, GITHUB, GLUE, HIVE_METASTORE,
-  // HTTP, HUBSPOT, JDBC, META_MARKETING, MYSQL, ORACLE, OUTLOOK, POSTGRESQL,
-  // POWER_BI, REDSHIFT, SALESFORCE, SALESFORCE_DATA_CLOUD, SERVICENOW,
-  // SMARTSHEET, SNOWFLAKE, SQLDW, SQLSERVER, TERADATA, WORKDAY_RAAS, ZENDESK,
-  // or UNKNOWN_CONNECTION_TYPE.
+  // One of BIGQUERY, CONFLUENCE, DATABRICKS, DYNAMICS365, GA4_RAW_DATA,
+  // GITHUB, GLUE, HIVE_METASTORE, HTTP, HUBSPOT, JDBC, META_MARKETING, MYSQL,
+  // NETSUITE, ORACLE, OUTLOOK, POSTGRESQL, POWER_BI, REDSHIFT, SALESFORCE,
+  // SALESFORCE_DATA_CLOUD, SERVICENOW, SMARTSHEET, SNOWFLAKE, SQLDW,
+  // SQLSERVER, TERADATA, WORKDAY_RAAS, ZENDESK, or UNKNOWN_CONNECTION_TYPE.
   connectionType string
   // Kind of credential the connection authenticates with
   //
   // One of ANY_STATIC_CREDENTIAL, BEARER_TOKEN, EDGEGRID_AKAMAI,
-  // OAUTH_ACCESS_TOKEN, OAUTH_MTLS, OAUTH_REFRESH_TOKEN,
-  // OAUTH_RESOURCE_OWNER_PASSWORD, OIDC_TOKEN, PEM_PRIVATE_KEY,
-  // SERVICE_CREDENTIAL, SSWS_TOKEN, USERNAME_PASSWORD, or
+  // OAUTH_ACCESS_TOKEN, OAUTH_M2M, OAUTH_MTLS, OAUTH_REFRESH_TOKEN,
+  // OAUTH_RESOURCE_OWNER_PASSWORD, OAUTH_U2M, OAUTH_U2M_MAPPING, OIDC_TOKEN,
+  // PEM_PRIVATE_KEY, SERVICE_CREDENTIAL, SSWS_TOKEN, USERNAME_PASSWORD, or
   // UNKNOWN_CREDENTIAL_TYPE.
   credentialType string
   // URL of the external system, when the connection type carries one
@@ -1615,7 +1615,7 @@ private databricks.job.trigger @defaults("triggerType pauseStatus") {
   periodicInterval int
   // Unit of the periodic interval
   //
-  // One of DAYS, HOURS, or MINUTES. Empty for other kinds.
+  // One of DAYS, HOURS, MINUTES, or WEEKS. Empty for other kinds.
   periodicUnit string
   // URL a file arrival trigger monitors, empty for other kinds
   //


### PR DESCRIPTION
## What

Fixes accuracy bugs in the `enumdrift.py` check added in #9911, and fixes the three real `.lr` drifts it found once it was trustworthy.

Running it for real on databricks surfaced bugs in the check before it surfaced anything about the schema — **3 of its first 6 hits were wrong, and all 3 were the tool's fault.**

## The tool bugs

**Stopwords matched case-insensitively.** The connective `none` also suppressed the enum value `NONE`, so the access-mode comment was reported as missing a value it already documented. Stopwords now match the lowercase form only — several of them (`NONE`, `DEFAULT`, `SET`, `OTHER`) ship as real constants in SCREAMING_CASE.

**Values were filtered by shape.** The theory was that an API value looks like `SCREAMING_SNAKE` or `camelCase` and an English word does not. Databricks names its model providers `anthropic`, `cohere`, `openai`, `palm` — all discarded, so a comment correctly listing all nine was reported as listing three.

The shape filter is gone. Candidates now go to the matcher permissively and **the SDK decides**: a token that is really prose appears in no constant block and drops out by itself. That is both more accurate and less code than trying to tell values from English.

**Matching is now case-sensitive.** A discriminator this provider defines *itself* in snake_case was pairing with an unrelated SDK enum spelling similar values in SCREAMING_CASE. Exact case is also better evidence a comment is quoting a constant rather than sharing a word by coincidence.

## The bigger change: completeness vs examples

`One of A, B, or C` is a promise — a policy author reads it to decide which `where()` clauses to write, so a missing value costs them matches. `such as A or B` is explicitly partial and always will be.

Treating both as drift buried the real defects. **Databricks went from 13 hits to 3**, and the 12 now skipped are all correct as written (`gitProvider`, `state`, and the 51-value `Privilege` list are all giving examples on purpose). `--include-illustrative` shows them when you want to decide whether one *should* become exhaustive.

## The real drift

| Field | Missing |
|---|---|
| `databricks.connection.connectionType` | `DYNAMICS365`, `GA4_RAW_DATA`, `NETSUITE` |
| `databricks.connection.credentialType` | `OAUTH_M2M`, `OAUTH_U2M`, `OAUTH_U2M_MAPPING` |
| `databricks.job.trigger.periodicUnit` | `WEEKS` |

All three claim to enumerate. The first two feed straight from `c.ConnectionType` / `c.CredentialType`, so the constants are exactly the field's domain. The third omitted `WEEKS` in the same commit that added the field (#9907) — which is a fair illustration of why the check exists.

Comment-only changes, so no codegen diff; `go build` and `go test` pass in `providers/databricks`.

## One honest limitation, now stated out loud

The check needs the SDK to declare typed string constants. Azure, Databricks, GCP and Nutanix do. **go-github, okta and the Atlas SDK type every enum as a plain string** — there is nothing to compare against, and the tool previously said `no Go string-const enums found`, which reads like a clean run.

It now says so explicitly and points at the vendor's API docs instead. "0 drifted" and "nothing to check" mean very different things, and the difference decides whether a comment has actually been verified.

The same caveat is now in the skill's Phase 5.
