### PR TITLE
🧹 azure: upgrade armhybridcompute to v3 and correct the Arc agent status values

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor/v2 v2.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault/v2 v2.0.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.4.0
@@ -143,7 +143,6 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/endobit/oui v0.7.0 // indirect
 	github.com/facebookincubator/nvdtools v0.1.5 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -106,8 +106,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0/go.mod h1:TSH7DcFItwAufy0Lz+Ft2cyopExCpxbOxI5SkH4dRNo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor/v2 v2.0.0 h1:hllt77imY438iao+x/FatjViqGMq9JUuCrlq6+sLxgk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor/v2 v2.0.0/go.mod h1:oSOL1euXyQO4Cp3x4cr3G40q3NCd80zn46XNEfac2CU=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0 h1:VvSZmyJEBvdzQXbs1Ued+iaapfSze5+rawR0EFFzyVw=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0/go.mod h1:6BoXNi4OfvyyIdP4vl4fEGt8CWHFFDMHgiUtNLHl1/0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v3 v3.0.0 h1:7iqUZadRKfVTzDpFCeV6SwSm5XoaFzlryy3P2rqIWcQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v3 v3.0.0/go.mod h1:3EoBUWN+rvHUbeUiiPQ7uyoqEConIHGqUkQxbSpD2TQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.2.0 h1:+lnLQhKh3cgSOIOVH61UZ3s/l9d+bAZp5d/spt1+7UI=
@@ -380,8 +380,6 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/endobit/oui v0.7.0 h1:6/aPQPEA+HcCW+pvZcYBVa0EVcj1uOS9c7XJS33uyCg=
-github.com/endobit/oui v0.7.0/go.mod h1:Y40Y6pCm9rVd6L1OITp7WJp7+F3cSIfaYqohHvMreZs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -744,8 +744,8 @@ private azure.subscription.computeService.vm.imageReference @defaults("publisher
 //
 // Azure Arc-enabled server (Microsoft.HybridCompute/machines), an
 // on-premises or other-cloud machine projected into Azure for
-// management. Surfaces the agent status (Connected, Disconnected,
-// Expired), agent version, OS name and version, last status check,
+// management. Surfaces the agent status (AwaitingConnection, Connected,
+// Disconnected, Error), agent version, OS name and version, last status check,
 // machine identity, attached extensions, private link scope, and the
 // `cloudMetadata` describing the underlying environment when the
 // machine is hosted on AWS, GCP, VMware, or another cloud.
@@ -760,7 +760,9 @@ azure.subscription.computeService.hybridMachine @defaults("name location osName 
   tags map[string]string
   // ARM resource type (Microsoft.HybridCompute/machines)
   type string
-  // Connection status of the Arc agent. Possible values: "Connected", "Disconnected", "Error"
+  // Connection status of the Arc agent
+  //
+  // One of AwaitingConnection, Connected, Disconnected, or Error.
   status string
   // Last time the Arc agent reported in
   lastStatusChange time

--- a/providers/azure/resources/hybridcompute.go
+++ b/providers/azure/resources/hybridcompute.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	hybridcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2"
+	hybridcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v3"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"


### PR DESCRIPTION
Bumps `armhybridcompute` from **v2.0.0 to v3.0.0**.

## Breaking changes in v3, and why none of them reach a shipped field

| v3 breaking change | Impact here |
|---|---|
| `Machine.Identity` retyped `*Identity` → `*ManagedServiceIdentity` | None. `hybridMachine` has no `identity` field. |
| Struct `Identity` removed | None. Never referenced. |
| `MachinesClient.Delete` → `BeginDelete` (LRO) | None. mql is read-only. |

The `properties` dict is built from `convert.JsonToDict(m.Properties)`, and `Identity` lives on `Machine`, not on `Machine.Properties` — so the retype does not change the dict's shape either.

The struct diff shows **no field removed or retyped on `MachineProperties`**, so every mapped field keeps its source. The only code change is the import path.

## Two doc errors found while checking enum drift

Both predate this bump; found by diffing the `.lr` comments against the v3 `StatusTypes` enum.

1. The resource description listed **`Expired`** as an agent status. That value does not exist in `StatusTypes` and never has.
2. The `status` field documented three of four values, omitting **`AwaitingConnection`**.

Both now match `StatusTypes` exactly: `AwaitingConnection`, `Connected`, `Disconnected`, `Error`.

This one has real consequences for policy authors: a policy filtering `status` against the documented set would silently miss machines that have been onboarded but have not yet connected — exactly the population you would want an Arc onboarding audit to flag.

The `status` comment also moves to the two-part doc form, per the `.lr` convention for enumerated values.

## Not changed

`azure.permissions.json` — the bump adds and removes no API calls, so the manifest is byte-identical apart from build-stamp churn.

## Verification

- `go build ./...` — clean
- `go test ./...` — all packages pass
- `gofmt -l .` — clean
- `mqlr generate` — no codegen diff (comment-only `.lr` change)

**Not verified against live Azure infrastructure.** The claims above rest on the v2→v3 struct diff and on the provider build and unit tests, not on an API response from a real Arc-enabled server.
