### PR TITLE
📄 skills: split update-provider-deps output into per-provider and combined PRs

### DIFF
--- a/.claude/skills/update-provider-deps/SKILL.md
+++ b/.claude/skills/update-provider-deps/SKILL.md
@@ -22,9 +22,33 @@ P=.claude/skills/update-provider-deps
 
 ## Phase 0 — Scope
 
-Work in a worktree, and **one provider per branch and PR**. Bumps across providers are
-independent, they get reviewed by different people, and a single failing migration
-shouldn't hold up four clean ones.
+Work in worktrees. How the run splits into PRs depends on **what each provider's diff
+touches**, not on how many providers the run spans:
+
+- **A provider whose diff touches anything beyond `go.mod`/`go.sum` gets its own worktree,
+  branch, and PR.** That means the Phase 6 schema additions the user picked, the code edits
+  a major-version migration forces, and `.lr` enum-drift fixes. **Bundle that provider's SDK
+  bump into the same PR** — the bump is what unlocked the fields, and splitting them makes
+  a reviewer reconstruct the connection from two places.
+- **Everything else goes in one combined PR**, covering every provider whose entire diff is
+  a dependency bump with no code change at all.
+
+The test is what the review actually costs: reading logic and judging a schema decision, or
+confirming a green build. The first needs a domain reviewer and a thread of its own; the
+second needs a glance — and N of them need N glances plus N context switches for no added
+safety. Review cost per PR is close to constant regardless of diff size, so a run that opens
+eleven PRs where nine are a one-line `go.mod` bump saying the same thing has spent most of
+its review budget on ceremony.
+
+**A failing bump leaves the combined PR rather than sinking it.** If one provider in the
+combined set won't build, pull it out and give it its own PR — by definition it now has a
+code change. The combined PR should only ever hold changes that cannot fail in interesting
+ways.
+
+**Sequencing consequence: do not open the combined PR until the Phase 6 selections are in.**
+A provider moves out of the combined PR the moment the user picks a field on it, and you
+cannot know that before Phase 6. Apply and verify everything first, decide the split last.
+Opening PRs as each provider goes green feels like progress and forces a rewrite.
 
 Pick the providers with the user. `python3 $P/probe.py --list` shows every known provider
 and the module prefixes it scans. For a provider that isn't in that table (a DB driver, a
@@ -205,21 +229,43 @@ criteria.
 Present the list, ask which numbers they want, and wait. The user picks — that's the point
 of the phase.
 
+Their answer also settles the PR split from Phase 0: every provider they pick a field on
+leaves the combined PR and gets its own. A provider they pick nothing on stays in the
+combined PR unless its bump already needed a code edit.
+
 ## Phase 7 — Implement the selection, verify, PR
 
 For each chosen item, follow `references/schema-additions.md`: `.lr` entry, `.lr.versions`
 at the provider's current version plus a patch, regenerate, map the field, and handle the
 null-versus-zero question honestly.
 
-Verify before claiming anything:
+Verify before claiming anything, and verify **per provider** — including every provider
+riding in the combined PR, which is a set of independent modules rather than one build:
 
 ```bash
 cd providers/<name> && go build ./... && go test ./... && gofmt -l .
 ```
 
-Then commit and open a PR. Say plainly in the PR what was **not** verified — none of this
-can be checked against live infrastructure without credentials, and a reviewer needs to
-know which claims rest on the compiler and which on an actual API response.
+Then open PRs in the two shapes Phase 0 set out.
+
+**Per-provider PRs.** One for each provider whose diff has a code change. The body carries
+the SDK bump and the schema work together, and should state which breaking changes in the
+new version did *not* reach a shipped field, and why. That is the reasoning a reviewer would
+otherwise have to redo from the changelog.
+
+**The combined PR.** One PR for all the pure bumps, titled for the sweep rather than for any
+one provider (`🧹 providers: refresh SDK dependencies`). Its body needs:
+
+- a table of every provider and module bumped, with from/to versions, so the change is
+  readable without expanding `go.sum`;
+- confirmation that each provider was built and tested **separately**;
+- an explicit note on any `go mod tidy` side effect that rode along. An unrelated indirect
+  dependency dropped because `main` was untidy is not a consequence of the bump, and it
+  reads as one unless you say so.
+
+Say plainly in every PR what was **not** verified — none of this can be checked against live
+infrastructure without credentials, and a reviewer needs to know which claims rest on the
+compiler and which on an actual API response.
 
 Provider versions in `config/config.go` are **not** bumped here; that's the release flow.
 

--- a/.claude/skills/update-provider-deps/references/breaking-changes.md
+++ b/.claude/skills/update-provider-deps/references/breaking-changes.md
@@ -76,7 +76,10 @@ A method that still exists but is marked `// Deprecated:` is a judgment call, no
 Take the replacement when it is shaped the same. Leave the deprecated call when adopting
 the replacement would change the MQL schema — for example when a singleton getter is
 replaced by a list-plus-get pair, turning one resource into a collection. That is a schema
-change that deserves its own PR and its own review, not a rider on a dependency bump.
+change nobody chose in this run, so it belongs in a PR of its own rather than being absorbed
+into the migration. (This is not in tension with bundling the Phase 6 additions into the
+provider's PR: those were picked deliberately and reviewed as part of the upgrade. This one
+would arrive unannounced, as a side effect of a call-site edit.)
 
 Either way, leave a comment at the call site saying which it is and why, so the next
 upgrade doesn't have to re-derive the reasoning.

--- a/.claude/skills/update-provider-deps/references/proposal-format.md
+++ b/.claude/skills/update-provider-deps/references/proposal-format.md
@@ -98,3 +98,8 @@ waiting — the point of the phase is that the choice is theirs.
 Confirm the selection back in one line, then implement per `schema-additions.md`. If a
 chosen item turns out to be unbuildable once you're in the code, say so and stop rather
 than substituting something else.
+
+The selection also decides the PR split (Phase 0). Each provider the user picks a field on
+gets its own PR carrying both the schema work and that provider's SDK bump; the providers
+nobody picked stay in the single combined dependency PR. This is why the combined PR cannot
+be opened before the user answers.


### PR DESCRIPTION
The skill told the agent to open **one PR per provider**. A full run today produced **11 PRs, nine of which were a one-line `go.mod` bump** with near-identical bodies (#9914–#9923). That is most of a review budget spent on ceremony, and it also splits the schema additions an upgrade unlocks away from the bump that unlocked them.

## The new rule

The split is now decided by **what each provider's diff touches**, not by how many providers the run spans.

| Diff touches | Goes in |
|---|---|
| Anything beyond `go.mod`/`go.sum` — Phase 6 schema additions, major-migration code edits, `.lr` enum-drift fixes | **Its own PR**, carrying that provider's SDK bump too |
| `go.mod` / `go.sum` only, no code change | **One combined PR** |

The discriminator is what the review actually costs: reading logic and judging a schema decision, versus confirming a green build. The first needs a domain reviewer and a thread of its own. The second needs a glance — and N of them need N glances plus N context switches for no added safety, because review cost per PR is close to constant regardless of diff size.

**Bundling the bump with the schema work is the other half of the change.** The bump is *why* the fields became available; splitting them makes a reviewer reconstruct that connection from two places.

## What is preserved

The old rationale for splitting — one failing migration shouldn't hold up four clean ones — still holds. It's now stated as a rule about the combined PR: a provider that won't build **leaves** the combined PR and gets its own, which by definition it now needs anyway. The combined PR only ever holds changes that cannot fail in interesting ways.

## The sequencing trap this creates

Worth calling out, because the new rule makes an ordering mistake possible that the old one didn't:

> **Do not open the combined PR until the Phase 6 selections are in.**

A provider moves out of the combined PR the moment the user picks a field on it, and you cannot know that before Phase 6. Opening PRs as each provider goes green feels like progress and forces a rewrite. This is recorded in Phase 0, restated at the end of Phase 6, and repeated in `proposal-format.md`.

## Phase 7

Rewritten around the two PR shapes:

- **Per-provider PR** — body carries the bump and the schema work together, and states which breaking changes did *not* reach a shipped field, and why. That's reasoning a reviewer would otherwise redo from the changelog.
- **Combined PR** — titled for the sweep (`🧹 providers: refresh SDK dependencies`), and its body needs a from/to table for every module, confirmation each provider was built and tested **separately** (it's a set of independent Go modules, not one build), and an explicit note on any `go mod tidy` side effect that rode along. That last one is from today's run: #9922 dropped an unrelated indirect dependency because `main` was untidy, which reads as a consequence of the bump unless you say otherwise.

## Reference files

- `breaking-changes.md` drew a line against schema changes riding on a dependency bump. That needed distinguishing from the Phase 6 additions, which now deliberately do ride along — the difference is whether the user chose it or it arrived unannounced as a side effect of a call-site edit.
- `proposal-format.md` gains the note that the user's selection is what decides the split.

## Verification

Documentation only — no code, no scripts changed. Diff was read rendered rather than trusted, per the skill's own warning about bulk-edit artifacts.
