### PR TITLE
⚡ os: buffer the docker image save to a file, not to memory

### DIFF
--- a/providers/os/connection/container/image/docker.go
+++ b/providers/os/connection/container/image/docker.go
@@ -47,7 +47,17 @@ func LoadImageFromDockerEngine(sha string, disableBuffer bool) (v1.Image, error)
 	if err != nil {
 		return nil, err
 	}
-	opts := []daemon.Option{daemon.WithClient(dc)}
+	// Buffer the `docker save` stream to a temporary file, not to memory.
+	//
+	// daemon.Image defaults to the in-memory opener, which reads the whole save
+	// stream with io.ReadAll and keeps it alive for the lifetime of the image.
+	// That single []byte holds the complete image, so the provider process grows
+	// with the image and the Go heap target doubles it again. A 847 MB image cost
+	// about 2.2 GB of peak RSS, which the container runtime turns into an OOM kill.
+	//
+	// The file-backed opener still runs exactly one `docker save`, so it does not
+	// pay the repeated-save cost of the unbuffered opener.
+	opts := []daemon.Option{daemon.WithClient(dc), daemon.WithFileBufferedOpener()}
 	if disableBuffer {
 		opts = append(opts, daemon.WithUnbufferedOpener())
 	}

--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -284,9 +284,6 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 
 	// This is the image id that is used to pull the image from the registry.
 	log.Debug().Msg("found docker engine image " + labelImageId)
-	if ii.Size > 1024 && !disableInmemoryCache { // > 1GB
-		log.Warn().Int64("size", ii.Size).Msg("Because the image is larger than 1 GB, this task will require a lot of memory. Consider disabling the in-memory cache by adding this flag to the command: `--disable-cache=true`")
-	}
 
 	identifier := containerid.MondooContainerImageID(labelImageId)
 


### PR DESCRIPTION
### What allocates

`LoadImageFromDockerEngine` calls `daemon.Image` without a buffer option, so go-containerregistry uses its default in-memory opener:

```go
func (i *imageOpener) bufferedOpener() (io.ReadCloser, error) {
	i.once.Do(func() {
		i.bytes, i.err = func() ([]byte, error) {
			rc, err := i.saveImage()
			...
			return io.ReadAll(rc)
		}()
	})
	return io.NopCloser(bytes.NewReader(i.bytes)), i.err
}
```

`io.ReadAll` holds the complete `docker save` stream in one `[]byte`. The slice stays alive for the lifetime of the image, so the provider heap carries a full copy of the image while `mutate.Extract` streams the flattened filesystem to a temp file. With `GOGC=100` the heap target then doubles that live set, so peak RSS lands near three times the image size.

A heap profile of the provider process at peak, `golang:1.25.9`:

```
      flat  flat%   sum%        cum   cum%
   95.14MB 88.37% 88.37%    95.14MB 88.37%  io.ReadAll
...
         0     0% 93.42%    95.14MB 88.37%  daemon.(*imageOpener).bufferedOpener
```

The provider runs as a separate process, so this memory is invisible to an in-process benchmark or to a cnspec heap profile. Under a container memory limit the provider is OOM killed and the scan fails with `plugin process exited error="signal: killed" plugin=/opt/mondoo/providers/os/os`.

### The change

Pass `daemon.WithFileBufferedOpener()`. It writes the same save stream to a temporary file and reopens that file per read. It still issues exactly one `docker save`, so it does not pay the repeated-save cost of `WithUnbufferedOpener`, which `--disable-cache=true` selects.

The explicit `--disable-cache=true` behaviour is unchanged: that option is appended after the new one and still selects the unbuffered opener.

### Before and after

Peak RSS of the `os` provider subprocess, sampled from `/proc/<pid>/status` while the scan runs, best of three:

| image | docker size | before | after |
|---|---|---|---|
| `alpine:3` | 8.4 MB | 83 MB | 62 MB |
| `ubuntu:24.04` | 78 MB | 242 MB | 59 MB |
| `t-caas-operator` (internal) | 201 MB | 465 MB | 58 MB |
| `golang:1.25.9` | 847 MB | 2191 MB | 88 MB |

Command:

```
make providers/build/os && make providers/install/os
./mql run docker image golang:1.25.9 -c "packages.length"
```

with a sampler loop over `/proc/[0-9]*/status`, selecting the process whose `exe` link ends in `mondoo/providers/os/os` and keeping the maximum `VmRSS`.

Memory no longer scales with image size. Before the change it was roughly 80 MB plus 2.6x the image size.

Wall time, same runs, best of three: `ubuntu:24.04` 10.37 s before and 9.95 s after, `golang:1.25.9` 27.27 s before and 23.86 s after. The change is not a memory-for-speed trade, so it needs no feature gate.

### Correctness

`mql run docker image <ref> -c "packages.length"` returns the same result before and after on all four images above (`alpine:3` 16, `ubuntu:24.04` 92, `t-caas-operator` 39, `golang:1.25.9` 207). `go build ./providers/os/...` and `go vet` on the two touched packages are clean.

The size warning is removed because the in-memory cost it warned about no longer exists.

### Relation to other PRs

Based on `main` and independent. It needs no other PR to merge.

#9941 adds the provider pprof endpoint that produced the profile quoted above. Merging #9941 first lets a reviewer reproduce that profile, but this change stands on its own.
