### PR TITLE
⚡ mqlc: skip the unicode transform for printable ASCII labels

### DIFF
--- a/mqlc/compile_bench_test.go
+++ b/mqlc/compile_bench_test.go
@@ -1,0 +1,28 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlc_test
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/v13/mqlc"
+)
+
+func BenchmarkCompileWithLabels(b *testing.B) {
+	queries := []string{
+		"mondoo.version == 'yo'",
+		"packages.list { name version }",
+		"users.list { name uid gid home }",
+		"file('/etc/passwd').permissions.user_readable",
+		"packages.where(name == 'ssh').list { name }",
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, q := range queries {
+			if _, err := mqlc.Compile(q, nil, conf); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/mqlc/compile_bench_test.go
+++ b/mqlc/compile_bench_test.go
@@ -6,7 +6,7 @@ package mqlc_test
 import (
 	"testing"
 
-	"go.mondoo.com/mql/v13/mqlc"
+	"go.mondoo.com/mql/mqlc"
 )
 
 func BenchmarkCompileWithLabels(b *testing.B) {

--- a/mqlc/labels.go
+++ b/mqlc/labels.go
@@ -142,6 +142,17 @@ func isAccessor(s string) bool {
 // Unicode normalization and filtering, see http://blog.golang.org/normalization and
 // http://godoc.org/golang.org/x/text/unicode/norm for more details.
 func stripCtlAndExtFromUnicode(str string) string {
+	// Almost every label is printable ASCII. NFKD leaves printable ASCII
+	// unchanged, because no ASCII rune has a compatibility decomposition, and
+	// the filter below removes nothing from it. So the transform is the
+	// identity here and the string can be returned as it is.
+	//
+	// The transform chain itself costs about 4.6 kB and 5 allocations per call,
+	// which dominates label creation on a large scan.
+	if isPrintableASCII(str) {
+		return str
+	}
+
 	isOk := func(r rune) bool {
 		return r < 32 || r >= 127
 	}
@@ -149,6 +160,18 @@ func stripCtlAndExtFromUnicode(str string) string {
 	t := transform.Chain(norm.NFKD, runes.Remove(runes.Predicate(isOk)))
 	str, _, _ = transform.String(t, str)
 	return str
+}
+
+// isPrintableASCII reports whether every byte of str is a printable ASCII
+// character, that is in the range [32, 127). A multi byte rune always has bytes
+// above 127, so a byte scan is enough and no decoding is needed.
+func isPrintableASCII(str string) bool {
+	for i := 0; i < len(str); i++ {
+		if str[i] < 32 || str[i] >= 127 {
+			return false
+		}
+	}
+	return true
 }
 
 // UpdateLabels for the given code under the schema

--- a/mqlc/labels_internal_test.go
+++ b/mqlc/labels_internal_test.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlc
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// stripViaTransform is the original implementation. It is the reference the fast
+// path must agree with.
+func stripViaTransform(str string) string {
+	isOk := func(r rune) bool {
+		return r < 32 || r >= 127
+	}
+	t := transform.Chain(norm.NFKD, runes.Remove(runes.Predicate(isOk)))
+	str, _, _ = transform.String(t, str)
+	return str
+}
+
+func TestStripCtlAndExtFromUnicode(t *testing.T) {
+	cases := []string{
+		"",
+		"packages.list",
+		"users.list[0].name",
+		`file("/etc/passwd").permissions.user_readable`,
+		" leading and trailing ",
+		"~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./",
+		"tab\there",
+		"newline\nhere",
+		"del\x7fhere",
+		"café",
+		"ﬁle", // ligature, NFKD splits it into "fi"
+		"Ä",   // precomposed, NFKD splits it and the mark is dropped
+		"日本語", // fully removed
+		"mixed café.list",
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, stripViaTransform(c), stripCtlAndExtFromUnicode(c), "input %q", c)
+	}
+}
+
+func TestStripCtlAndExtFromUnicodeRandom(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 2000; i++ {
+		var sb strings.Builder
+		for j := 0; j < 1+r.Intn(20); j++ {
+			sb.WriteRune(rune(r.Intn(0x300)))
+		}
+		in := sb.String()
+		assert.Equal(t, stripViaTransform(in), stripCtlAndExtFromUnicode(in), "input %q", in)
+	}
+}
+
+var benchSink string
+
+func BenchmarkStripCtlAndExtFromUnicode(b *testing.B) {
+	labels := []string{
+		"packages.list",
+		"asset.platform",
+		"users.list[0].name",
+		"aws.ec2.instances",
+		"file(\"/etc/passwd\").permissions.user_readable",
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, l := range labels {
+			benchSink = stripCtlAndExtFromUnicode(l)
+		}
+	}
+}


### PR DESCRIPTION
### What allocates

`createLabel` ends every label with `stripCtlAndExtFromUnicode`, and that function builds a fresh `transform.Chain` per call:

```go
t := transform.Chain(norm.NFKD, runes.Remove(runes.Predicate(isOk)))
str, _, _ = transform.String(t, str)
```

`transform.Chain` allocates the chain, its per-link state and its buffers, and `runes.Remove(runes.Predicate(...))` allocates on top. That is about 4.6 kB and 5 allocations for every label, and a scan creates one label per datapoint per asset.

The chain cannot simply be hoisted to a package variable. A `transform.Transformer` carries state and is not safe for concurrent use, and compiles run concurrently across assets.

### The change

Almost every label is printable ASCII. No ASCII rune has a compatibility decomposition, so `norm.NFKD` is the identity on it, and the filter removes nothing in the range `[32, 127)`. So the whole transform is the identity and the input can be returned as it is. A byte scan detects the case, because any multi byte rune has bytes above 127.

Non ASCII input still takes the original path, unchanged.

### Before and after

```
go test ./mqlc -run XXX -bench . -benchtime 300x -count=3
```

`BenchmarkStripCtlAndExtFromUnicode`, 5 labels per iteration:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 10794 | 22960 | 25 |
| after | 69 | 0 | 0 |

`BenchmarkCompileWithLabels`, a full `mqlc.Compile` of 5 queries per iteration:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 176503 | 159195 | 943 |
| after | 123684 | 61064 | 838 |

So the transform was 62% of the bytes allocated by a compile.

### Correctness

`TestStripCtlAndExtFromUnicode` and `TestStripCtlAndExtFromUnicodeRandom` keep a copy of the original implementation and assert that the new one returns the same string. They cover empty input, control characters, DEL, punctuation, a ligature that NFKD splits, a precomposed accent whose mark is dropped, CJK that is removed entirely, and 2000 random strings over the range `[0, 0x300)`.

`go test ./mqlc` passes.

### Relation to other PRs

Based on `main` and independent. It touches only `mqlc` and shares no file with #9935 or #9941.
