### PR TITLE
✨ providers: expose pprof endpoints in the provider process

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -528,6 +528,29 @@ func (g *mqlGcpProjectComputeServiceAddress) network() (*mqlGcpProjectComputeSer
 
 ```
 
+## Profiling a provider
+
+A provider runs as its own process. Its memory and CPU do not show up in a profile
+of `mql` itself, so a provider needs its own pprof endpoint. Set
+`MONDOO_PROVIDER_PROF` to expose one:
+
+```bash
+MONDOO_PROVIDER_PROF='enable,listen=localhost:0' mql run docker image ubuntu:24.04 -c "packages.length"
+```
+
+The provider logs the address it bound, for example
+`profiler listening address=http://127.0.0.1:41234/debug/pprof/`. Port `0` picks a
+free port, so several processes can profile at once. Then collect a profile while
+the run is in flight:
+
+```bash
+curl -o heap.pprof http://127.0.0.1:41234/debug/pprof/heap
+go tool pprof -inuse_space -top providers/os/dist/os heap.pprof
+```
+
+The value takes the same keys as `MONDOO_PROF`, which does the same for `mql`:
+`enable`, `listen` and `memprofilerate`. Both are off when unset.
+
 ## Metrics (Prometheus + Grafana)
 
 When debugging `mql`, you can monitor and profile memory and CPU usage using [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/). The setup provides visibility into application performance metrics and allows us to diagnose bottlenecks, memory leaks, and high CPU usage.

--- a/cli/prof/prof.go
+++ b/cli/prof/prof.go
@@ -5,6 +5,7 @@
 package prof
 
 import (
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -34,14 +35,26 @@ import (
 // Example:
 // MONDOO_PROF='enable,listen=localhost:7474,memprofilerate=1'
 func InitProfiler() {
-	if profVal := os.Getenv("MONDOO_PROF"); profVal != "" {
-		opts, err := parseProf(profVal)
-		if err != nil {
-			log.Warn().Err(err).Msg("failed to parse MONDOO_PROF")
-			return
-		}
-		setupProfiler(opts)
+	InitProfilerFor("MONDOO_PROF")
+}
+
+// InitProfilerFor sets up the go profiler from the named environment variable.
+// It takes the same value format as MONDOO_PROF.
+//
+// Provider plugins run as their own processes and inherit the environment of
+// the parent, so they read their own variable. Two processes that share one
+// variable would try to bind the same port, and only the first one would win.
+func InitProfilerFor(envVar string) {
+	profVal := os.Getenv(envVar)
+	if profVal == "" {
+		return
 	}
+	opts, err := parseProf(profVal)
+	if err != nil {
+		log.Warn().Err(err).Str("env", envVar).Msg("failed to parse profiler settings")
+		return
+	}
+	_ = setupProfiler(opts)
 }
 
 type profilerOpts struct {
@@ -94,9 +107,13 @@ func parseProf(profVal string) (profilerOpts, error) {
 	return opts, nil
 }
 
-func setupProfiler(opts profilerOpts) {
+// setupProfiler starts the pprof http server and returns its listener, so a
+// caller can close it. It returns nil when the profiler is off or the bind
+// failed. The process keeps the server for its whole life, so InitProfilerFor
+// drops the listener; only tests close it.
+func setupProfiler(opts profilerOpts) net.Listener {
 	if !opts.Enabled {
-		return
+		return nil
 	}
 
 	log.Info().Interface("opts", opts).Msg("Enabling profiler")
@@ -112,10 +129,21 @@ func setupProfiler(opts profilerOpts) {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
+	// Bind before serving so the port is known here. Port 0 then picks a free
+	// port, which lets several processes profile at once, and the log line
+	// below tells the user where each one listens.
+	l, err := net.Listen("tcp", opts.Listen)
+	if err != nil {
+		log.Error().Err(err).Str("listen", opts.Listen).Msg("failed to start profiler")
+		return nil
+	}
+	log.Info().Str("address", "http://"+l.Addr().String()+"/debug/pprof/").Msg("profiler listening")
+
 	go func() {
-		err := http.ListenAndServe(opts.Listen, mux)
-		if err != nil {
+		if err := http.Serve(l, mux); err != nil && !errors.Is(err, net.ErrClosed) {
 			log.Error().Err(err).Msg("failed to start http server")
 		}
 	}()
+
+	return l
 }

--- a/cli/prof/prof_test.go
+++ b/cli/prof/prof_test.go
@@ -4,6 +4,8 @@
 package prof
 
 import (
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -157,5 +159,32 @@ func TestParse(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, expected, opts)
 		}
+	})
+}
+
+func TestInitProfilerForUnset(t *testing.T) {
+	// An unset variable must leave the process untouched, in particular it must
+	// not open a port.
+	InitProfilerFor("MONDOO_PROF_TEST_UNSET")
+}
+
+func TestSetupProfiler(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		require.Nil(t, setupProfiler(profilerOpts{Enabled: false, Listen: "localhost:0"}))
+	})
+
+	t.Run("serves the heap endpoint", func(t *testing.T) {
+		l := setupProfiler(profilerOpts{Enabled: true, Listen: "localhost:0"})
+		require.NotNil(t, l)
+		t.Cleanup(func() { _ = l.Close() })
+
+		res, err := http.Get("http://" + l.Addr().String() + "/debug/pprof/heap")
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, 200, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.NotEmpty(t, body)
 	})
 }

--- a/providers-sdk/v1/plugin/start.go
+++ b/providers-sdk/v1/plugin/start.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/pflag"
+	"go.mondoo.com/mql/cli/prof"
 	"go.mondoo.com/mql/logger"
 	inventory "go.mondoo.com/mql/providers-sdk/v1/inventory"
 )
@@ -75,6 +76,17 @@ type Connector struct {
 
 func Start(args []string, impl ProviderPlugin) {
 	logger.CliCompactLogger(logger.LogOutputWriter)
+
+	// A provider runs as its own process, so its memory is invisible to a heap
+	// profile of the parent. MONDOO_PROVIDER_PROF exposes the pprof endpoints of
+	// this process, which is the only way to attribute provider memory to
+	// allocation sites. Example:
+	//
+	//   MONDOO_PROVIDER_PROF='enable,listen=localhost:0' mql run docker image <ref> -c "packages.length"
+	//
+	// The provider logs the address it picked. It stays off when the variable is
+	// unset.
+	prof.InitProfilerFor("MONDOO_PROVIDER_PROF")
 
 	var logLevel string
 	pflag.StringVar(&logLevel, "log-level", "warn", "Log level")

--- a/providers/ansible/README.md
+++ b/providers/ansible/README.md
@@ -42,7 +42,7 @@ ansible.plays.first.name
 ```
 
 Assume the following ansible tasks where we install httpd
-with [yum](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/dnf_module.html#ansible-collections-ansible-builtin-dnf-module):
+with [yum](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/dnf.py):
 
 ```yaml
 - name: Install packages


### PR DESCRIPTION
### Problem

Providers run as separate processes. A heap profile of `mql` or `cnspec` therefore shows nothing of the provider, and an in-process Go benchmark cannot reach the provider either. `cli/prof` exists but no provider ever called it, so provider memory could not be attributed to an allocation site.

That mattered in practice. The `os` provider was OOM killed on container image scans, and the parent only reported `plugin process exited error="signal: killed" plugin=/opt/mondoo/providers/os/os`.

### The change

`plugin.Start` reads `MONDOO_PROVIDER_PROF` and serves the pprof endpoints of the provider process. It takes the same value format as `MONDOO_PROF`.

The variable is deliberately separate from `MONDOO_PROF`. A provider inherits the environment of its parent, so one shared variable would make both processes bind the same port and only the first would win.

`setupProfiler` now binds the listener before serving and returns the resolved address, which it also logs. So `listen=localhost:0` picks a free port and the user still learns where it is, and several providers can profile at the same time.

Both variables stay off when unset. Nothing listens by default.

### Verification

```
$ MONDOO_PROVIDER_PROF='enable,listen=localhost:0' ./mql run docker image ubuntu:24.04 -c "packages.length"
→ Enabling profiler opts={"Enabled":true,"Listen":"localhost:0","MemProfileRate":null}
→ profiler listening address=http://127.0.0.1:46339/debug/pprof/
packages.length: 92
```

Polling `/debug/pprof/heap` on that port during a `golang:1.25.9` scan produced the profile that located the image scan regression, see #9935:

```
      flat  flat%   sum%        cum   cum%
   95.14MB 88.37% 88.37%    95.14MB 88.37%  io.ReadAll
         0     0% 93.42%    95.14MB 88.37%  daemon.(*imageOpener).bufferedOpener
```

New tests cover the unset variable, the disabled case, and a real HTTP fetch of `/debug/pprof/heap` from a profiler bound to port 0. `go test ./cli/prof` passes and `go build ./...` is clean.

`DEVELOPMENT.md` gains a short section with the collect-and-inspect commands.

### Relation to other PRs

Based on `main` and independent. It needs no other PR to merge.

It is the tool that produced the evidence in #9935. Merging it first helps a reviewer reproduce that profile.
