### PR TITLE
⚡ os: compile the CPE regexps once, not once per package

### DIFF
--- a/providers/os/resources/cpe/pkg2cpe.go
+++ b/providers/os/resources/cpe/pkg2cpe.go
@@ -11,6 +11,9 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
+// epochRegex matches a version that carries an epoch, e.g. `1:2.3.4`.
+var epochRegex = regexp.MustCompile(`^\d+:(.*)$`)
+
 func NewPackage2Cpe(vendor, name, version, release, arch string) ([]string, error) {
 	cpes := []string{}
 	vendor = strings.ToLower(vendor)
@@ -21,7 +24,6 @@ func NewPackage2Cpe(vendor, name, version, release, arch string) ([]string, erro
 
 	// Remove epoch when present; otherwise WFNize will only use the epoch as
 	// the version.
-	epochRegex := regexp.MustCompile(`^\d+:(.*)$`)
 	if matches := epochRegex.FindStringSubmatch(version); len(matches) > 1 {
 		version = matches[1]
 	}

--- a/providers/os/resources/cpe/pkg2cpe_test.go
+++ b/providers/os/resources/cpe/pkg2cpe_test.go
@@ -55,3 +55,13 @@ func TestPkg2Gen(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkNewPackage2Cpe(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := NewPackage2Cpe("", "openssl", "1774381254:3.5.4-r0", "", "x86_64")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/providers/os/resources/cpe/platforms.go
+++ b/providers/os/resources/cpe/platforms.go
@@ -12,6 +12,9 @@ import (
 	"go.mondoo.com/mql/v13/utils/stringx"
 )
 
+// amznLegacyVersion matches the Amazon Linux 1 version scheme.
+var amznLegacyVersion = regexp.MustCompile(`^(2017|2018)\.`)
+
 type platformCPEEntry struct {
 	Platform    string
 	CPEBuilder  func(platform, version string, workstation bool) (string, error)
@@ -36,10 +39,9 @@ var platformCPES = []platformCPEEntry{
 	{
 		Platform: "amazonlinux",
 		CPEBuilder: func(platform, version string, workstation bool) (string, error) {
-			amzn1 := regexp.MustCompile(`^(2017|2018)\.`)
 			product := ""
 
-			if amzn1.MatchString(version) {
+			if amznLegacyVersion.MatchString(version) {
 				product = "linux"
 			} else if version == "2" {
 				product = "linux_2"


### PR DESCRIPTION
## What allocates

`cpe.NewPackage2Cpe` compiles `^\d+:(.*)$` **inside the function body**, so every package of every ecosystem pays for a regexp compile just to strip an epoch off a version string.

Twenty call sites reach it: the apk, dpkg, rpm and Windows package parsers, plus the npm, python, java, golang, rust, php, dart, swift, haskell, terraform and dotnet language parsers. Every package of every scanned asset goes through it.

This is the same shape #9861 fixed in the parsers; this one was missed because it sits in `resources/cpe`.

## How it was found

Profiling what remains after #9879 lands, on a real 435KB apk database pulled out of an Alpine container:

```
go tool pprof -sample_index=alloc_objects
  46.65% cum  cpe.NewPackage2Cpe
  ~19%         regexp/syntax.(*parser).newRegexp, regexp.makeOnePass, mergeRuneSets, newQueue
```

95% of the allocations left in an apk scan are in the per-package `add()`, not in parsing. The regexp compile is the part we control.

## Numbers

`BenchmarkNewPackage2Cpe`, per call:

| | before | after | change |
| --- | --- | --- | --- |
| ns/op | 5890 | 2165 | -63.2% |
| B/op | 4795 | 336 | -93.0% |
| allocs/op | 77 | 21 | -72.7% |

Parsing that same real apk database, on top of #9879:

| | #9879 | + this | change |
| --- | --- | --- | --- |
| ns/op | 866,022 | 658,782 | -23.9% |
| B/op | 757,075 | 424,110 | -44.0% |
| allocs/op | 11,206 | 7,027 | -37.3% |

The remaining cost is `strings.NewReplacer` inside `nvdtools/wfn`, which is vendored.

## Correctness

The generated CPEs do not change. `go test ./resources/...` passes in `providers/os`, and a scan of a live `nginx:alpine` container returns byte-identical package output (71 packages, 28,011 bytes of JSON) against a provider built from `main`.

`platforms.go` compiled the Amazon Linux version regexp inside a CPE builder closure. That one is cold, once per platform rather than once per package, and is hoisted for consistency.

## Related

Found while reviewing #9879. Independent of it: different file, no overlap. #9879 makes the parser cheap; this makes what the parser calls cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)