### PR TITLE
🐛 os: read the apk database past a 64KB line

### DIFF
--- a/providers/os/resources/packages/apk_packages.go
+++ b/providers/os/resources/packages/apk_packages.go
@@ -24,6 +24,11 @@ const (
 	ApkDbInstalledUsr = "/usr/lib/apk/db/installed"
 )
 
+// apkMaxLine caps how long a single line of the apk database may be. The
+// dependency and provides lines of a metapackage are the long ones, and they
+// grow with the number of packages a distribution ships.
+const apkMaxLine = 4 * 1024 * 1024
+
 // apkField splits a line of the apk database into its one letter field key and
 // its value. It returns the same key and value as the regexp
 // `^([A-Za-z]):(.*)$`, which the parser used before.
@@ -81,6 +86,10 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 	}
 
 	scanner := bufio.NewScanner(input)
+	// A line longer than the 64KB default ends the scan, and the packages that
+	// follow it are lost without a word. Raise the cap so a long dependency
+	// line cannot shorten the package list.
+	scanner.Buffer(nil, apkMaxLine)
 	pkg := Package{}
 	for scanner.Scan() {
 		// Bytes avoids one string allocation per line. Most lines of the apk
@@ -122,8 +131,17 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 		}
 	}
 
+	// a read that stopped early leaves the package list short, so say so
+	if err := scanner.Err(); err != nil {
+		log.Error().Err(err).Msg("could not read the apk database to its end, the package list is incomplete")
+	}
+
 	// if the last line is not an empty line we have things in flight, lets check it
-	add(pkg)
+	// a database that ends with an empty line has nothing left, and reporting
+	// that empty package as ignored only reads like data loss
+	if pkg.Name != "" {
+		add(pkg)
+	}
 	return pkgs
 }
 

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -6,6 +6,7 @@ package packages
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -255,6 +256,42 @@ func apkBenchDB(pkgCount int, filesPerPkg int) []byte {
 		buf.WriteString("\n")
 	}
 	return buf.Bytes()
+}
+
+func TestApkLongLineDoesNotTruncate(t *testing.T) {
+	pf := &inventory.Platform{Name: "alpine", Version: "3.21", Arch: "x86_64"}
+
+	// a dependency line well past the 64KB default of bufio.Scanner
+	var buf bytes.Buffer
+	buf.WriteString("P:first\nV:1.0.0-r0\nA:x86_64\n\n")
+	buf.WriteString("P:huge\nV:2.0.0-r0\nA:x86_64\n")
+	buf.WriteString("D:" + strings.Repeat("so:libfoo.so.1 ", 6000) + "\n\n")
+	buf.WriteString("P:last\nV:3.0.0-r0\nA:x86_64\n\n")
+
+	pkgs := ParseApkDbPackages(pf, bytes.NewReader(buf.Bytes()))
+
+	names := make([]string, len(pkgs))
+	for i := range pkgs {
+		names[i] = pkgs[i].Name
+	}
+	// without a raised scanner limit the scan stops at the long line and the
+	// packages behind it are lost
+	assert.Equal(t, []string{"first", "huge", "last"}, names)
+}
+
+func TestApkLastPackage(t *testing.T) {
+	pf := &inventory.Platform{Name: "alpine", Version: "3.21", Arch: "x86_64"}
+	db := "P:first\nV:1.0.0-r0\nA:x86_64\n\nP:last\nV:2.0.0-r0\nA:x86_64\n"
+
+	// a database whose last package has no trailing empty line
+	pkgs := ParseApkDbPackages(pf, bytes.NewReader([]byte(db)))
+	assert.Len(t, pkgs, 2)
+	assert.Equal(t, "last", pkgs[1].Name)
+
+	// and one that ends the last package with an empty line
+	pkgs = ParseApkDbPackages(pf, bytes.NewReader([]byte(db+"\n")))
+	assert.Len(t, pkgs, 2)
+	assert.Equal(t, "last", pkgs[1].Name)
 }
 
 func BenchmarkParseApkDbPackages(b *testing.B) {


### PR DESCRIPTION
> **Stacked on #9879.** Base is `stack/9879-base`, a mirror of that PR's head (`ba8d170d4`), so the diff here is only this change. Retarget to `main` once #9879 merges. #9879 is an external contribution, so this could not be pushed onto its branch.

## What is lost

`ParseApkDbPackages` scans `/lib/apk/db/installed` with a default `bufio.Scanner`. A line longer than 64KB ends the scan, and the parser never looks at `scanner.Err()`. Every package behind the long line is dropped, and the caller is told nothing — a short package list reads as a clean asset, not as a failed read.

Demonstrated with a database whose middle package carries a 90KB dependency line:

```
parsed 2 of 3 packages: [first huge]     <- "last" is gone, no error
```

The dependency and provides lines of a metapackage are the long ones, and they grow with the number of packages a distribution ships. Today's images stay well inside the limit — the longest line across eleven Alpine, Wolfi, and language base images is 674 bytes — so this is latent rather than something users hit now. It is worth closing because the failure is silent and the result is a package list that looks complete.

## What changed

`scanner.Buffer(nil, apkMaxLine)` raises the cap to 4MB. Passing a **nil** initial buffer matters: the scanner keeps growing on demand, so the change costs nothing.

| | without | with |
| --- | --- | --- |
| B/op | 757,075 | 757,093 |
| allocs/op | 11,206 | 11,206 |

(A `make([]byte, 0, 64*1024)` initial buffer, the more obvious form, costs +61KB per parse for no benefit.)

A read that still stops early now logs an error, so an incomplete package list is attributable rather than silent.

The trailing `add(pkg)` is also guarded. A database that ends with an empty line has nothing left in flight, so that call only ever logged `ignored apk package since information is missing` — once per parse of every healthy Alpine asset. Measured on `nginx:alpine`: 71 packages, 1 such line before, 0 after. It also takes the zerolog call out of the measured loop in #9879's new benchmark.

## Tests

- `TestApkLongLineDoesNotTruncate` — the three-package database above. Fails without the fix (`expected: [first huge last]`, `actual: [first huge]`).
- `TestApkLastPackage` — a database whose last package has no trailing empty line still yields that package, which is what the `pkg.Name != ""` guard must not break.

`go test ./resources/packages/` passes. Verified against live containers: a scan of `nginx:alpine` returns byte-identical package output against a provider built from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)