### PR TITLE
🐛 os: read the apk database past a 64KB line (re-land of #9945)

### DIFF
--- a/providers/os/resources/packages/apk_packages.go
+++ b/providers/os/resources/packages/apk_packages.go
@@ -24,6 +24,11 @@ const (
 	ApkDbInstalledUsr = "/usr/lib/apk/db/installed"
 )
 
+// apkMaxLine caps how long a single line of the apk database may be. The
+// dependency and provides lines of a metapackage are the long ones, and they
+// grow with the number of packages a distribution ships.
+const apkMaxLine = 4 * 1024 * 1024
+
 // apkField splits a line of the apk database into its one letter field key and
 // its value. It returns the same key and value as the regexp
 // `^([A-Za-z]):(.*)$`, which the parser used before.
@@ -81,6 +86,10 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 	}
 
 	scanner := bufio.NewScanner(input)
+	// A line longer than the 64KB default ends the scan, and the packages that
+	// follow it are lost without a word. Raise the cap so a long dependency
+	// line cannot shorten the package list.
+	scanner.Buffer(nil, apkMaxLine)
 	pkg := Package{}
 	for scanner.Scan() {
 		// Bytes avoids one string allocation per line. Most lines of the apk
@@ -122,8 +131,17 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 		}
 	}
 
+	// a read that stopped early leaves the package list short, so say so
+	if err := scanner.Err(); err != nil {
+		log.Error().Err(err).Msg("could not read the apk database to its end, the package list is incomplete")
+	}
+
 	// if the last line is not an empty line we have things in flight, lets check it
-	add(pkg)
+	// a database that ends with an empty line has nothing left, and reporting
+	// that empty package as ignored only reads like data loss
+	if pkg.Name != "" {
+		add(pkg)
+	}
 	return pkgs
 }
 

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -6,6 +6,7 @@ package packages
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -255,6 +256,42 @@ func apkBenchDB(pkgCount int, filesPerPkg int) []byte {
 		buf.WriteString("\n")
 	}
 	return buf.Bytes()
+}
+
+func TestApkLongLineDoesNotTruncate(t *testing.T) {
+	pf := &inventory.Platform{Name: "alpine", Version: "3.21", Arch: "x86_64"}
+
+	// a dependency line well past the 64KB default of bufio.Scanner
+	var buf bytes.Buffer
+	buf.WriteString("P:first\nV:1.0.0-r0\nA:x86_64\n\n")
+	buf.WriteString("P:huge\nV:2.0.0-r0\nA:x86_64\n")
+	buf.WriteString("D:" + strings.Repeat("so:libfoo.so.1 ", 6000) + "\n\n")
+	buf.WriteString("P:last\nV:3.0.0-r0\nA:x86_64\n\n")
+
+	pkgs := ParseApkDbPackages(pf, bytes.NewReader(buf.Bytes()))
+
+	names := make([]string, len(pkgs))
+	for i := range pkgs {
+		names[i] = pkgs[i].Name
+	}
+	// without a raised scanner limit the scan stops at the long line and the
+	// packages behind it are lost
+	assert.Equal(t, []string{"first", "huge", "last"}, names)
+}
+
+func TestApkLastPackage(t *testing.T) {
+	pf := &inventory.Platform{Name: "alpine", Version: "3.21", Arch: "x86_64"}
+	db := "P:first\nV:1.0.0-r0\nA:x86_64\n\nP:last\nV:2.0.0-r0\nA:x86_64\n"
+
+	// a database whose last package has no trailing empty line
+	pkgs := ParseApkDbPackages(pf, bytes.NewReader([]byte(db)))
+	assert.Len(t, pkgs, 2)
+	assert.Equal(t, "last", pkgs[1].Name)
+
+	// and one that ends the last package with an empty line
+	pkgs = ParseApkDbPackages(pf, bytes.NewReader([]byte(db+"\n")))
+	assert.Len(t, pkgs, 2)
+	assert.Equal(t, "last", pkgs[1].Name)
 }
 
 func BenchmarkParseApkDbPackages(b *testing.B) {


### PR DESCRIPTION
Re-lands #9945, which merged into the wrong branch and never reached `main`.

## What happened

#9945 was stacked on #9879, an external contribution we could not push to. To keep its diff reviewable it was based on `stack/9879-base`, a mirror of #9879's head, with a note in the body to retarget it to `main` once #9879 landed. It was merged before that retarget happened, so its commit went to `stack/9879-base` and stopped there. #9879 itself was squash-merged, so the mirror branch shares no commit with `main` and nothing pulled the fix across.

The result: `main` has the parser rewrite from #9879 but not the scanner fix, and `git log main` gives no sign that anything is missing.

Verified on current `main` (`c345dec67`):

```
$ git show origin/main:providers/os/resources/packages/apk_packages.go | grep -c scanner.Buffer
0
```

This PR is that commit cherry-picked onto `main`. The content is unchanged from what was reviewed and approved on #9945.

## What it fixes, again

`ParseApkDbPackages` scans `/lib/apk/db/installed` with a default `bufio.Scanner`. A line longer than 64KB ends the scan, and nothing checks `scanner.Err()`, so every package behind that line is dropped and the caller is told nothing — a short package list reads as a clean asset rather than a failed read.

`scanner.Buffer(nil, apkMaxLine)` raises the cap to 4MB, at no cost (757,093 vs 757,075 B/op, identical allocs). A read that still stops early now logs an error. The trailing `add(pkg)` is guarded so a database ending in an empty line no longer logs `ignored apk package since information is missing` once per healthy asset.

Tests: `TestApkLongLineDoesNotTruncate` (fails without the fix — `expected [first huge last]`, `actual [first huge]`) and `TestApkLastPackage`. `go test ./resources/packages/` passes on current `main`.

## Follow-up

`stack/9879-base` should be deleted once this merges — it now holds one commit that exists nowhere else, which is the trap that caused this. A stacked PR against a mirror branch needs the retarget to happen *before* the merge button, or it needs to just target `main` and carry the extra commit in its diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)