### PR TITLE
🐛 os: read a dpkg field name up to its first colon

### DIFF
--- a/providers/os/resources/packages/dpkg_packages.go
+++ b/providers/os/resources/packages/dpkg_packages.go
@@ -35,11 +35,13 @@ func isDpkgFieldSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r'
 }
 
-// dpkgControlField splits a dpkg control line into its field name and value.
-// It returns the same key and value as the regexp `^(.+):\s(.+)$`. The greedy
-// first group binds that regexp to the last colon followed by a whitespace
-// character. At least one byte must precede the colon, and at least one byte
-// must follow the whitespace.
+// dpkgControlField splits a dpkg control line into its field name and value,
+// following the Debian control file format: a field name carries neither space
+// nor colon, so the first colon ends it, and a line that starts with a space or
+// a tab is a continuation of the field above it rather than a field of its own.
+//
+// At least one byte must precede the colon, and at least one byte must follow
+// the whitespace that separates the name from the value.
 //
 // The colon and the whitespace bytes are ASCII, so they never appear inside a
 // multi-byte UTF-8 sequence. A byte scan therefore finds the same split point
@@ -48,12 +50,15 @@ func isDpkgFieldSpace(c byte) bool {
 //
 // The returned slices alias line. The caller must copy what it keeps.
 func dpkgControlField(line []byte) (key []byte, value []byte, ok bool) {
-	for i := len(line) - 3; i >= 1; i-- {
-		if line[i] == ':' && isDpkgFieldSpace(line[i+1]) {
-			return line[:i], line[i+2:], true
-		}
+	// a continuation line belongs to the field above it
+	if len(line) == 0 || line[0] == ' ' || line[0] == '\t' {
+		return nil, nil, false
 	}
-	return nil, nil, false
+	i := bytes.IndexByte(line, ':')
+	if i < 1 || i+2 > len(line)-1 || !isDpkgFieldSpace(line[i+1]) {
+		return nil, nil, false
+	}
+	return line[:i], line[i+2:], true
 }
 
 // ParseDpkgPackages parses the dpkg database content located in /var/lib/dpkg/status

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -218,9 +218,53 @@ See /usr/share/common-licenses/GPL-2 for the full license text.
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(nil, "bash"))
 }
 
+// Both shapes that used to cost a package its description, in the form they
+// appear on a real host: libc6 carries a colon in its summary, and
+// gpg-wks-client carries one in a continuation line.
+func TestDpkgParserDescriptionWithColons(t *testing.T) {
+	pf := &inventory.Platform{Name: "ubuntu", Version: "24.04", Arch: "amd64"}
+
+	status := `Package: libc6
+Status: install ok installed
+Architecture: amd64
+Version: 2.39-0ubuntu8.6
+Description: GNU C Library: Shared libraries
+ Contains the standard libraries that are used by nearly all programs on
+ the system. This package includes shared versions of the standard C library
+ and the standard math library, as well as many others.
+
+Package: gpg-wks-client
+Status: install ok installed
+Architecture: amd64
+Version: 2.4.4-2ubuntu17
+Description: GNU privacy guard - Web Key Service client
+ GnuPG is GNU's tool for secure communication and data storage.
+ For more information see: https://wiki.gnupg.org/WKS
+ It is a tool to provide digital encryption.
+`
+
+	pkgs, err := ParseDpkgPackages(pf, bytes.NewReader([]byte(status)))
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+
+	// The summary keeps the colon that used to be read as the separator, and
+	// the continuation lines that used to be dropped with it are still here.
+	assert.Equal(t, `GNU C Library: Shared libraries
+Contains the standard libraries that are used by nearly all programs on
+the system. This package includes shared versions of the standard C library
+and the standard math library, as well as many others.`, pkgs[0].Description)
+
+	// A continuation line is a continuation whatever it contains, so the
+	// description does not end at the colon in the middle of it.
+	assert.Equal(t, `GNU privacy guard - Web Key Service client
+GnuPG is GNU's tool for secure communication and data storage.
+For more information see: https://wiki.gnupg.org/WKS
+It is a tool to provide digital encryption.`, pkgs[1].Description)
+}
+
 func TestDpkgControlField(t *testing.T) {
-	// The previous implementation used the regexp `^(.+):\s(.+)$`. The greedy
-	// first group binds it to the last colon that is followed by whitespace.
+	// A field name carries neither space nor colon, so the first colon ends it,
+	// and a line starting with a space or a tab continues the field above it.
 	tests := []struct {
 		line  string
 		key   string
@@ -231,7 +275,11 @@ func TestDpkgControlField(t *testing.T) {
 		// the epoch colon has no whitespace after it, so it is not a split point
 		{"Version: 2:5.2-2ubuntu1", "Version", "2:5.2-2ubuntu1", true},
 		{"Depends: libc6 (>= 2.34), libtinfo6", "Depends", "libc6 (>= 2.34), libtinfo6", true},
-		{"Description: the GNU shell: a thing", "Description: the GNU shell", "a thing", true},
+		// A colon inside the value is part of the value. Reading the last one
+		// as the separator is what used to leave every package whose summary
+		// carries a colon -- libc6 among them -- with no description at all.
+		{"Description: the GNU shell: a thing", "Description", "the GNU shell: a thing", true},
+		{"Description: GNU C Library: Shared libraries", "Description", "GNU C Library: Shared libraries", true},
 		{"Field:\tvalue", "Field", "value", true},
 		{"Field:  padded", "Field", " padded", true},
 		// no whitespace after the colon
@@ -240,8 +288,10 @@ func TestDpkgControlField(t *testing.T) {
 		{"a: ", "", "", false},
 		// nothing before the colon
 		{": b", "", "", false},
-		// continuation lines carry no field
+		// continuation lines carry no field, whatever they contain
 		{" /etc/bash.bashrc 1234", "", "", false},
+		{" For more information see: https://wiki.gnupg.org/WKS", "", "", false},
+		{"\tindented continuation: with a colon", "", "", false},
 		{"Conffiles:", "", "", false},
 		{"", "", "", false},
 		// multi-byte runes around the split point


### PR DESCRIPTION
> Rebased onto `main` now that #9873 has merged. The stack is gone: this is one commit against `main`, touching only the split function and its tests.
## The bug

`libc6` reports no description at all, on every Debian and Ubuntu host. Against a live `debian:12` container, current `main`:

```
packages.where(name == "libc6") { name description }
  name: "libc6"
  description: ""
```

Its status entry:

```
Description: GNU C Library: Shared libraries
 Contains the standard libraries that are used by nearly all programs on
 the system. This package includes shared versions of the standard C library
 and the standard math library, as well as many others.
```

The parser splits a control line on the **last** colon followed by whitespace — the greedy first group of `^(.+):\s(.+)$`, which #9873 ports faithfully as a backwards scan. So the field name comes out as `Description: GNU C Library`, matches no case, `state` never becomes `STATE_DESC`, and the summary plus every continuation line under it is discarded.

A colon in a *continuation* line ends a description the same way. `gpg-wks-client` stops at `For more information see: https://wiki.gnupg.org/WKS`.

## The fix is smaller than what it replaces

Debian's control format is simpler than the pattern that was matching it: a field name carries neither space nor colon, so the first colon ends it, and a line beginning with a space or tab continues the field above it.

```go
// a continuation line belongs to the field above it
if len(line) == 0 || line[0] == ' ' || line[0] == '\t' {
	return nil, nil, false
}
i := bytes.IndexByte(line, ':')
if i < 1 || i+2 > len(line)-1 || !isDpkgFieldSpace(line[i+1]) {
	return nil, nil, false
}
return line[:i], line[i+2:], true
```

One forward `IndexByte` instead of a backwards scan, so it does not give back what #9873 gained.

## Impact, measured

Against `/var/lib/dpkg/status` taken from five real images:

| image | packages | empty descriptions | descriptions corrected |
| --- | --- | --- | --- |
| debian:12 | 88 | 2 → 0 | 5 |
| debian:13 | 78 | 2 → 0 | 5 |
| ubuntu:22.04 | 101 | 2 → 0 | 6 |
| ubuntu:24.04 | 92 | 2 → 0 | 6 |
| ubuntu + build tools | 259 | 5 → 0 | 20 |

**No other field changes on any package** — name, version, arch, status, origin and purl are identical throughout.

Confirmed end to end against a live `debian:12` container, provider built from this branch against one built from `main`:

```
every field except description: IDENTICAL byte-for-byte (88 packages)
descriptions: 5 of 88 changed, empty 2 -> 0
  bsdutils:    108 chars -> 243
  libc-bin:      0 chars -> 422
  libc6:         0 chars -> 234
  libhogweed6: 128 chars -> 821
  libnettle8:  139 chars -> 847
```

## Tests

- `TestDpkgParserDescriptionWithColons` — both shapes in the form they appear on a real host: a colon in the summary (`libc6`) and a colon in a continuation line (`gpg-wks-client`). Fails against the greedy split.
- `TestDpkgControlField` gains the `Description: GNU C Library: Shared libraries` case, a continuation line carrying a colon, and a tab-indented one. One case from #9873 flips — the one that pinned the greedy behavior, which is the bug being fixed.

`go test ./resources/packages/` passes in `providers/os`.

## Not included

Two hygiene items from the #9873 review, both already fixed for the apk parser in #9946, left out to keep this change to one behavior: `scanner.Err()` is never checked even though `ParseDpkgPackages` already returns an `error`, and the trailing `add(pkg)` logs `ignored deb packages since information is missing` once per parse of every healthy host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
