### PR TITLE
🐛 os: find the Apache config when the server is not a distribution package

### DIFF
--- a/providers/os/resources/apache2.go
+++ b/providers/os/resources/apache2.go
@@ -27,15 +27,23 @@ func (s *mqlApache2) id() (string, error) {
 	return "apache2", nil
 }
 
-// apacheVersionBinaries lists the well-known binary paths for the Apache httpd
-// server. The version string (e.g. "Apache/2.4.62") is embedded as a constant in
-// the binary, so we can extract it by reading the file directly — no command
-// execution required.
-var apacheVersionBinaries = []string{
+// apacheBinaries lists the well-known binary paths for the Apache httpd
+// server. Both the version string (e.g. "Apache/2.4.62") and the compiled-in
+// configuration layout are embedded as constants in the binary, so we can
+// extract them by reading the file directly — no command execution required,
+// which keeps this working on image and filesystem scans.
+var apacheBinaries = []string{
 	"/usr/sbin/apache2",
 	"/usr/sbin/httpd",
 	"/usr/local/sbin/httpd",
 	"/usr/local/bin/httpd",
+	// A source build defaults to --prefix=/usr/local/apache2 and keeps its
+	// binary, configuration and content under it. The upstream httpd container
+	// image is built this way.
+	"/usr/local/apache2/bin/httpd",
+	// Homebrew, on Apple Silicon and Intel respectively.
+	"/opt/homebrew/bin/httpd",
+	"/usr/local/opt/httpd/bin/httpd",
 }
 
 // apacheVersionCommands are tried as a fallback when the binary cannot be read.
@@ -49,7 +57,7 @@ func (s *mqlApache2) version() (string, error) {
 
 	// Prefer file-based detection: scan the httpd binary for the embedded
 	// "Apache/x.y.z" version string without loading the full binary into memory.
-	for _, bin := range apacheVersionBinaries {
+	for _, bin := range apacheBinaries {
 		if v := scanBinaryForTag(afs, bin, apacheVersionTag); v != "" {
 			return v, nil
 		}
@@ -101,6 +109,110 @@ func scanBinaryForTag(fs *afero.Afero, path string, tag []byte) string {
 // dot-separated numeric version (e.g. "2.4.62").
 func isApacheVersionByte(b byte) bool {
 	return b == '.' || (b >= '0' && b <= '9')
+}
+
+// The server's compiled-in layout. `httpd -V` prints these two values, but they
+// are plain string constants in the binary, so reading the file gives the same
+// answer on an asset we cannot run commands on.
+var (
+	apacheRootTag       = []byte(`-D HTTPD_ROOT="`)
+	apacheConfigFileTag = []byte(`-D SERVER_CONFIG_FILE="`)
+)
+
+// isNotDoubleQuote terminates a scan at the closing quote of a `-D NAME="value"`
+// literal.
+func isNotDoubleQuote(b byte) bool { return b != '"' }
+
+// maxApacheLayoutValue bounds how far a scan will run looking for that closing
+// quote, so a spurious tag match cannot walk the rest of a binary.
+const maxApacheLayoutValue = 512
+
+// apacheLayout is where a particular build of httpd keeps its configuration.
+type apacheLayout struct {
+	// root is HTTPD_ROOT, the directory relative paths resolve against.
+	root string
+	// conf is SERVER_CONFIG_FILE. Every vendor build observed states it
+	// relative to root, but an absolute value is legal and is honoured.
+	conf string
+}
+
+// confPath returns the absolute path of the main configuration file, or "" when
+// the layout is too incomplete to name one.
+func (l apacheLayout) confPath() string {
+	if l.conf == "" {
+		return ""
+	}
+	if filepath.IsAbs(l.conf) {
+		return l.conf
+	}
+	if l.root == "" {
+		return ""
+	}
+	return filepath.Join(l.root, l.conf)
+}
+
+// apacheLayoutFromBinary reads the layout out of an httpd binary.
+func apacheLayoutFromBinary(fs *afero.Afero, path string) apacheLayout {
+	return apacheLayout{
+		root: scanBinaryForQuotedTag(fs, path, apacheRootTag),
+		conf: scanBinaryForQuotedTag(fs, path, apacheConfigFileTag),
+	}
+}
+
+// scanBinaryForQuotedTag returns the value of a `-D NAME="value"` literal.
+func scanBinaryForQuotedTag(fs *afero.Afero, path string, tag []byte) string {
+	f, err := fs.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	// The overlap has to cover the tag plus the longest value we are willing to
+	// read, so a literal straddling two chunks is not truncated.
+	return scanReaderForTag(f, tag, len(tag)+maxApacheLayoutValue, isNotDoubleQuote)
+}
+
+var (
+	reApacheRoot       = regexp.MustCompile(`-D HTTPD_ROOT="([^"]*)"`)
+	reApacheConfigFile = regexp.MustCompile(`-D SERVER_CONFIG_FILE="([^"]*)"`)
+)
+
+// apacheLayoutFromCommand asks the server itself. This is the last resort: it
+// covers a build whose binary sits somewhere apacheBinaries does not list, and
+// it only works on an asset we can run commands on.
+func apacheLayoutFromCommand(conn shared.Connection) apacheLayout {
+	for _, bin := range apacheVersionCommands {
+		cmd, err := conn.RunCommand(bin + " -V")
+		if err != nil || cmd.ExitStatus != 0 {
+			continue
+		}
+		data, err := io.ReadAll(cmd.Stdout)
+		if err != nil {
+			continue
+		}
+		var layout apacheLayout
+		if m := reApacheRoot.FindSubmatch(data); m != nil {
+			layout.root = string(m[1])
+		}
+		if m := reApacheConfigFile.FindSubmatch(data); m != nil {
+			layout.conf = string(m[1])
+		}
+		if layout.confPath() != "" {
+			return layout
+		}
+	}
+	return apacheLayout{}
+}
+
+// apacheDiscoverLayout finds where the installed server keeps its
+// configuration, preferring the binary over running anything.
+func apacheDiscoverLayout(conn shared.Connection, afs *afero.Afero) apacheLayout {
+	for _, bin := range apacheBinaries {
+		if layout := apacheLayoutFromBinary(afs, bin); layout.confPath() != "" {
+			return layout
+		}
+	}
+	return apacheLayoutFromCommand(conn)
 }
 
 // scanReaderForTag streams r in chunks, looking for tag followed by a run of
@@ -165,8 +277,13 @@ func scanReaderForTag(r io.Reader, tag []byte, overlap int, isVersionByte func(b
 }
 
 type mqlApache2ConfInternal struct {
-	lock       sync.Mutex
+	lock sync.Mutex
+	// serverRoot comes from the config's own ServerRoot directive and wins.
 	serverRoot string
+	// binaryServerRoot is the server's compiled-in HTTPD_ROOT, discovered while
+	// locating the config file. It is only consulted when the config does not
+	// state a ServerRoot, and is written once by file() before any parsing.
+	binaryServerRoot string
 }
 
 // apacheConfByFamily maps platform families (and a few standalone platform
@@ -343,6 +460,28 @@ func (s *mqlApache2Conf) file() (*mqlFile, error) {
 		}
 	}
 
+	// Nothing at a packaged location. Ask the installed server where it keeps
+	// its configuration: a source build with a custom --prefix puts everything
+	// under that prefix, which no vendor path list can anticipate. The vendor
+	// paths are still tried first, so a packaged install is unaffected by this.
+	if layout := apacheDiscoverLayout(conn, afs); layout.confPath() != "" {
+		path := layout.confPath()
+		if ok, _ := afs.Exists(path); ok {
+			// Relative Include paths resolve against HTTPD_ROOT. The platform
+			// default would be wrong for a custom prefix, and the config's own
+			// ServerRoot directive (which takes precedence) is not read yet.
+			s.binaryServerRoot = layout.root
+
+			f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+				"path": llx.StringData(path),
+			})
+			if err != nil {
+				return nil, err
+			}
+			return f.(*mqlFile), nil
+		}
+	}
+
 	// No config file found anywhere — Apache likely isn't installed. Mark the
 	// field as set+null so downstream field accessors (params, modules, ...)
 	// return empty data instead of bubbling up "file does not exist" errors.
@@ -355,9 +494,13 @@ var reApacheGlob = regexp.MustCompile(`[*?\[]`)
 func (s *mqlApache2Conf) expandGlob(pattern string) ([]string, error) {
 	conn := s.MqlRuntime.Connection.(shared.Connection)
 
-	// Resolve relative paths against ServerRoot (prefer config value, fall back to platform default)
+	// Resolve relative paths against ServerRoot: the directive in the config
+	// wins, then the server's compiled-in HTTPD_ROOT, then the platform default.
 	if !filepath.IsAbs(pattern) {
 		serverRoot := s.serverRoot
+		if serverRoot == "" {
+			serverRoot = s.binaryServerRoot
+		}
 		if serverRoot == "" {
 			serverRoot = apacheServerRoot(conn)
 		}

--- a/providers/os/resources/apache2_layout_test.go
+++ b/providers/os/resources/apache2_layout_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package resources

--- a/providers/os/resources/apache2_layout_test.go
+++ b/providers/os/resources/apache2_layout_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The three literals below are copied verbatim out of real httpd binaries, so
+// these tests fail if a vendor ever stops embedding them in this shape.
+const (
+	sourceBuildLayout = ` -D HTTPD_ROOT="/usr/local/apache2"` + "\x00" +
+		` -D SERVER_CONFIG_FILE="conf/httpd.conf"` + "\x00"
+	redhatLayout = ` -D HTTPD_ROOT="/etc/httpd"` + "\x00" +
+		` -D SERVER_CONFIG_FILE="conf/httpd.conf"` + "\x00"
+	debianLayout = ` -D HTTPD_ROOT="/etc/apache2"` + "\x00" +
+		` -D SERVER_CONFIG_FILE="apache2.conf"` + "\x00"
+)
+
+func writeApacheBinary(t *testing.T, path string, data []byte) *afero.Afero {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, path, data, 0o755))
+	return &afero.Afero{Fs: fs}
+}
+
+func TestApacheLayoutFromBinary(t *testing.T) {
+	t.Run("source build under a custom prefix", func(t *testing.T) {
+		afs := writeApacheBinary(t, "/usr/local/apache2/bin/httpd", []byte("\x7fELF\x00"+sourceBuildLayout))
+		layout := apacheLayoutFromBinary(afs, "/usr/local/apache2/bin/httpd")
+		assert.Equal(t, "/usr/local/apache2", layout.root)
+		assert.Equal(t, "conf/httpd.conf", layout.conf)
+		assert.Equal(t, "/usr/local/apache2/conf/httpd.conf", layout.confPath())
+	})
+
+	t.Run("redhat package", func(t *testing.T) {
+		afs := writeApacheBinary(t, "/usr/sbin/httpd", []byte(redhatLayout))
+		assert.Equal(t, "/etc/httpd/conf/httpd.conf", apacheLayoutFromBinary(afs, "/usr/sbin/httpd").confPath())
+	})
+
+	t.Run("debian package", func(t *testing.T) {
+		afs := writeApacheBinary(t, "/usr/sbin/apache2", []byte(debianLayout))
+		assert.Equal(t, "/etc/apache2/apache2.conf", apacheLayoutFromBinary(afs, "/usr/sbin/apache2").confPath())
+	})
+
+	t.Run("binary does not exist", func(t *testing.T) {
+		afs := &afero.Afero{Fs: afero.NewMemMapFs()}
+		assert.Equal(t, "", apacheLayoutFromBinary(afs, "/usr/sbin/httpd").confPath())
+	})
+
+	t.Run("a binary without the literals yields nothing", func(t *testing.T) {
+		afs := writeApacheBinary(t, "/usr/sbin/httpd", []byte("\x7fELF just some bytes"))
+		layout := apacheLayoutFromBinary(afs, "/usr/sbin/httpd")
+		assert.Equal(t, "", layout.root)
+		assert.Equal(t, "", layout.confPath())
+	})
+
+	// The scanner reads in 64 KiB chunks. A literal landing across that seam is
+	// the case a naive implementation truncates, so place one there deliberately.
+	t.Run("literal spanning a chunk boundary", func(t *testing.T) {
+		var buf bytes.Buffer
+		buf.WriteString(strings.Repeat("\x00", 64*1024-20))
+		buf.WriteString(sourceBuildLayout)
+		afs := writeApacheBinary(t, "/usr/sbin/httpd", buf.Bytes())
+		assert.Equal(t, "/usr/local/apache2/conf/httpd.conf", apacheLayoutFromBinary(afs, "/usr/sbin/httpd").confPath())
+	})
+}
+
+func TestApacheLayoutConfPath(t *testing.T) {
+	t.Run("an absolute SERVER_CONFIG_FILE ignores the root", func(t *testing.T) {
+		layout := apacheLayout{root: "/etc/httpd", conf: "/etc/custom/httpd.conf"}
+		assert.Equal(t, "/etc/custom/httpd.conf", layout.confPath())
+	})
+
+	t.Run("a relative config with no root names nothing", func(t *testing.T) {
+		assert.Equal(t, "", apacheLayout{conf: "conf/httpd.conf"}.confPath())
+	})
+
+	t.Run("a root with no config names nothing", func(t *testing.T) {
+		assert.Equal(t, "", apacheLayout{root: "/usr/local/apache2"}.confPath())
+	})
+
+	t.Run("the zero layout names nothing", func(t *testing.T) {
+		assert.Equal(t, "", apacheLayout{}.confPath())
+	})
+}
+
+// The upstream httpd container image installs to /usr/local/apache2, which no
+// packaged path covers. Guard that it is reachable, and that the packaged paths
+// this replaces are all still listed.
+func TestApacheBinariesCoverKnownInstallations(t *testing.T) {
+	for _, want := range []string{
+		"/usr/sbin/apache2",            // debian, ubuntu
+		"/usr/sbin/httpd",              // rhel, fedora, suse
+		"/usr/local/apache2/bin/httpd", // source build default prefix
+	} {
+		assert.Contains(t, apacheBinaries, want)
+	}
+}


### PR DESCRIPTION
## Problem

`apache2.conf` finds the configuration by trying a fixed list of packaged paths — `/etc/apache2/apache2.conf`, `/etc/httpd/conf/httpd.conf` and three siblings. A server built from source lives under its `--prefix` instead, so none of them match:

```
apache2.conf.file.path: null
apache2.conf.params:    {}
```

Every configuration check then errors rather than reporting anything about the server. The **upstream `httpd` container image is exactly this case** — it installs to `/usr/local/apache2` — so auditing an Apache container built on the official image returns nothing at all. Same for any `./configure --prefix=…` install and for Homebrew.

## Fix

The server already knows the answer. `HTTPD_ROOT` and `SERVER_CONFIG_FILE` are compiled in — that is what `httpd -V` prints — and they are plain string constants in the binary:

```
$ strings /usr/local/apache2/bin/httpd | grep -E '^ -D (HTTPD_ROOT|SERVER_CONFIG)'
 -D HTTPD_ROOT="/usr/local/apache2"
 -D SERVER_CONFIG_FILE="conf/httpd.conf"
```

So they can be read straight from the file. That matters because it keeps discovery working on **image and filesystem scans**, where nothing can be executed — and it is the same technique the resource already uses to read the version, reusing `scanReaderForTag` unchanged.

Ordering is deliberate: **the packaged paths are still tried first**, so a distribution install resolves exactly as before and pays nothing for the new work. Discovery only runs when all of them miss, and falls back to `httpd -V` for a binary in a location the list doesn't cover.

Two things come along:

- **Relative `Include` paths resolve against the discovered `HTTPD_ROOT`** when the config states no `ServerRoot` of its own. They previously resolved against the platform default, which is the wrong directory for a custom prefix. The config's own `ServerRoot` still wins over both.
- **`/usr/local/apache2/bin/httpd` and the two Homebrew prefixes join the binary list**, which fixes `apache2.version` on those installations for scans that cannot run commands.

## Verified on running containers

| Asset | `apache2.conf.file.path` | `version` | config files |
|---|---|---|---|
| `httpd:2.4` (source build) | `/usr/local/apache2/conf/httpd.conf` — **was `null`** | `2.4.68` — **was empty** | 2 |
| `rockylinux:9` + `httpd` | `/etc/httpd/conf/httpd.conf` | `2.4.62` | 19 |
| `ubuntu:24.04` + `apache2` | `/etc/apache2/apache2.conf` | `2.4.58` | 38 |
| no Apache installed | `null`, `params` `{}` | — | — |

The last two rows are the regression check: unchanged, including the graceful not-installed behaviour.

I also checked the `ServerRoot` fallback specifically, since the happy path hides it — the upstream image's config *does* declare `ServerRoot`, so the new code would never be exercised. Commenting it out and adding a relative `IncludeOptional conf/probe/*.conf`:

```
apache2.conf.params["RelativeIncludeProbe"]: "7"
apache2.conf.files.map: [
  "/usr/local/apache2/conf/httpd.conf",
  "/usr/local/apache2/conf/extra/proxy-html.conf",
  "/usr/local/apache2/conf/probe/zz.conf",
]
```

Before the change that include resolved against `/etc/apache2` — the platform default for the Debian-based image — and found nothing.

## Tests

`apache2_layout_test.go` covers the parsing and the path arithmetic. The literals in it are copied verbatim from real httpd binaries (source build, RHEL, Debian), so the tests fail if a vendor stops embedding them in this shape. Cases: the three vendor layouts, an absolute `SERVER_CONFIG_FILE`, each half-empty layout, a missing binary, a binary without the literals, and a literal placed deliberately across the scanner's 64 KiB chunk seam — the case a naive implementation truncates.

All pre-existing `providers/os/resources` and `providers/os/resources/apache2` tests still pass.

## Found by

Auditing Apache hardening guidance against a container built on the official image, where every check errored instead of reporting.