### PR TITLE
⚡ bicep: slice template entries instead of copying them byte by byte

### DIFF
--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -1671,14 +1671,16 @@ func stripOuter(s string, open, close byte) string {
 
 func splitTopLevelEntries(body string) []string {
 	var entries []string
-	var current strings.Builder
 	st := scanState{}
+	// An entry is the contiguous span body[start:end]. Nothing is copied: a
+	// top-level `// …` comment always runs to the newline that terminates the
+	// entry, so no entry content ever follows a comment and dropping one is
+	// just a matter of leaving `end` where it was.
+	start, end := 0, 0
 	flush := func() {
-		s := strings.TrimSpace(current.String())
-		if s != "" {
+		if s := strings.TrimSpace(body[start:end]); s != "" {
 			entries = append(entries, s)
 		}
-		current.Reset()
 	}
 	i := 0
 	for i < len(body) {
@@ -1690,6 +1692,7 @@ func splitTopLevelEntries(body string) []string {
 			if body[i] == '\n' || body[i] == ',' {
 				flush()
 				i++
+				start, end = i, i
 				continue
 			}
 			// Drop `// …` line comments without copying them into the
@@ -1704,10 +1707,10 @@ func splitTopLevelEntries(body string) []string {
 			}
 		}
 		next := st.stepAt(body, i)
-		// Copy the bytes we just walked into the running entry —
-		// escape sequences (`\'`, `\\`, …) are preserved verbatim
-		// because stepAt walks the escape pair as a single step.
-		current.WriteString(body[i:next])
+		// Extend the entry over the bytes we just walked — escape sequences
+		// (`\'`, `\\`, …) are preserved verbatim because stepAt walks the
+		// escape pair as a single step.
+		end = next
 		i = next
 	}
 	flush()

--- a/providers/bicep/resources/parser_alloc_test.go
+++ b/providers/bicep/resources/parser_alloc_test.go
@@ -1,0 +1,138 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// objectBody builds a resource body of `entries` single-line properties, each
+// carrying a trailing comment so the comment-skipping path is exercised too.
+func objectBody(entries int) string {
+	var sb strings.Builder
+	for i := 0; i < entries; i++ {
+		n := strconv.Itoa(i)
+		sb.WriteString("  property" + n + ": 'a moderately long literal value " + n + "' // trailing comment\n")
+	}
+	return sb.String()
+}
+
+var entriesSink []string
+
+// An entry is a contiguous span of the body, so splitting one out must not copy
+// it. This is stated as a ratio rather than a ceiling because the copy is what
+// scales: the previous implementation walked every byte through a
+// strings.Builder and cost ~4 allocations per entry, so tenfold the entries
+// meant tenfold the allocations. Slicing leaves only the result slice's own
+// growth, which is logarithmic.
+func TestSplitTopLevelEntriesDoesNotAllocatePerEntry(t *testing.T) {
+	small := objectBody(200)
+	large := objectBody(2000)
+
+	allocsSmall := testing.AllocsPerRun(50, func() { entriesSink = splitTopLevelEntries(small) })
+	require.Len(t, entriesSink, 200, "the split still returns every entry")
+
+	allocsLarge := testing.AllocsPerRun(50, func() { entriesSink = splitTopLevelEntries(large) })
+	require.Len(t, entriesSink, 2000, "the split still returns every entry")
+
+	assert.Less(t, allocsLarge, allocsSmall*2,
+		"10x the entries allocated %.0fx as much (%.0f -> %.0f): the body is being copied per entry instead of sliced",
+		allocsLarge/allocsSmall, allocsSmall, allocsLarge)
+}
+
+// twoStatementTemplate builds `pairs` single-line params and `pairs` multi-line
+// vars, i.e. 2*pairs statements.
+func twoStatementTemplate(pairs int) string {
+	var sb strings.Builder
+	for i := 0; i < pairs; i++ {
+		n := strconv.Itoa(i)
+		sb.WriteString("param p" + n + " string = 'value" + n + "'\n")
+		sb.WriteString("var v" + n + " = {\n  key: 'value" + n + "'\n  other: 42\n}\n")
+	}
+	return sb.String()
+}
+
+var statementsSink []bicepStatement
+
+// Tokenizing may allocate for a multi-line statement's joined text, but nothing
+// else should scale with the statement count: the statement slice is sized up
+// front from the unindented-line count, and the body scratch slice is reused.
+// Growing the slice by doubling and reallocating the scratch cost ~2.5
+// allocations per statement.
+func TestTokenizeBicepAllocatesAtMostOncePerStatement(t *testing.T) {
+	src := twoStatementTemplate(2500)
+
+	allocs := testing.AllocsPerRun(20, func() { statementsSink = tokenizeBicep(src) })
+	require.Len(t, statementsSink, 5000, "every statement is still tokenized")
+
+	perStatement := allocs / float64(len(statementsSink))
+	assert.LessOrEqual(t, perStatement, 1.0,
+		"tokenizing allocated %.2f times per statement (%.0f total); only a multi-line statement's joined text may allocate",
+		perStatement, allocs)
+}
+
+// The tokenizer sizes its statement slice from the number of unindented lines.
+// That bound only holds if every top-level construct really does start at
+// column 0, so pin it against the fixtures rather than trusting the assumption.
+func TestUnindentedLinesBoundStatementCount(t *testing.T) {
+	files, err := filepath.Glob("testdata/*.bicep")
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	for _, f := range files {
+		t.Run(filepath.Base(f), func(t *testing.T) {
+			content, err := os.ReadFile(f)
+			require.NoError(t, err)
+
+			unindented := 0
+			for _, line := range strings.Split(stripBlockComments(string(content)), "\n") {
+				if line != "" && line[0] != ' ' && line[0] != '\t' {
+					unindented++
+				}
+			}
+
+			statements := tokenizeBicep(stripBlockComments(string(content)))
+			assert.LessOrEqual(t, len(statements), unindented,
+				"a statement started on an indented line, so the preallocation bound is wrong")
+		})
+	}
+}
+
+var parsedSink *parsedBicepFile
+
+// BenchmarkParseBicep parses a template built by repeating the fixtures with
+// per-copy unique symbol names, which approximates a real infrastructure
+// repo's main template (~270 KB, ~10.9k lines) rather than a 30-line sample.
+func BenchmarkParseBicep(b *testing.B) {
+	files, err := filepath.Glob("testdata/*.bicep")
+	require.NoError(b, err)
+
+	var sb strings.Builder
+	for c := 0; c < 40; c++ {
+		n := strconv.Itoa(c)
+		for _, f := range files {
+			content, err := os.ReadFile(f)
+			require.NoError(b, err)
+			s := strings.ReplaceAll(string(content), "param ", "param p"+n+"_")
+			s = strings.ReplaceAll(s, "var ", "var v"+n+"_")
+			sb.WriteString(s)
+			sb.WriteString("\n")
+		}
+	}
+	content := sb.String()
+	b.Logf("input: %d bytes, %d lines", len(content), strings.Count(content, "\n"))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parsedSink = parseBicep(content)
+	}
+}

--- a/providers/bicep/resources/tokenizer.go
+++ b/providers/bicep/resources/tokenizer.go
@@ -51,7 +51,25 @@ var knownKeywords = map[string]string{
 // statements are skipped.
 func tokenizeBicep(content string) []bicepStatement {
 	lines := strings.Split(content, "\n")
-	var statements []bicepStatement
+
+	// Every top-level construct starts at column 0 and its continuation lines
+	// are indented, so the unindented lines are a tight upper bound on the
+	// statement count. Sizing the slice from that one cheap pass beats growing
+	// it by doubling, which reallocates and copies the whole run of statements
+	// a dozen times on a large template.
+	starts := 0
+	for _, line := range lines {
+		if line != "" && line[0] != ' ' && line[0] != '\t' {
+			starts++
+		}
+	}
+	statements := make([]bicepStatement, 0, starts)
+
+	// One scratch slice for every statement's body: reset per statement rather
+	// than reallocated. strings.Join copies what it needs (and returns the
+	// single line unchanged when a statement is one line), so no statement
+	// keeps a reference to this backing array.
+	var bodyLines []string
 
 	i := 0
 	for i < len(lines) {
@@ -117,7 +135,7 @@ func tokenizeBicep(content string) []bicepStatement {
 		// pulling continuation lines until the running depth returns to zero.
 		startLine := i + 1 // 1-based
 		st := scanState{}
-		var bodyLines []string
+		bodyLines = bodyLines[:0]
 
 		bodyLines = append(bodyLines, lines[i])
 		st.feed(lines[i])


### PR DESCRIPTION
Part of a measured memory pass over the six IaC providers. Bicep is the only one of them that hand-rolls its parser, and it was spending two thirds of its allocations copying its own input.

Parsing a 269 KB, 10,880-line template — the fixtures repeated into something the size of a real infrastructure repo's main template:

|  | B/op | allocs/op | ns/op |
|---|---|---|---|
| before | 5,165,594 | 59,886 | 21.5 ms |
| after | 3,683,592 | 22,108 | 18.5 ms |
| | **−28.7%** | **−63.1%** | **−14%** |

50 iterations × 6 runs. `BenchmarkParseBicep` is included so this is reproducible.

### What changed

**`splitTopLevelEntries` slices instead of copying.** It walked every byte of every resource body through a `strings.Builder`, at roughly four allocations per entry — 12.5 MB of a 60 MB allocation profile. An entry is always a contiguous span of the body, so it can be a substring.

```go
// before
var current strings.Builder
current.WriteString(body[i:next])          // every byte of every body
s := strings.TrimSpace(current.String())

// after
start, end := 0, 0
end = next                                 // just extend the span
s := strings.TrimSpace(body[start:end])
```

The case that looks like it forbids this is a dropped `// …` comment, which would leave an entry discontiguous. It cannot happen: the comment scan only fires at top-level depth and runs to the newline, and **a top-level newline terminates the entry**. So a comment is always the last thing in its entry, and dropping it just means leaving `end` where it stood.

**`tokenizeBicep` sizes its statement slice and reuses its scratch.** The slice grew from nil, reallocating and copying the whole run about a dozen times on a large template (8.9 MB of the same profile). Every top-level construct starts at column 0 with indented continuation lines, so one cheap pass counting unindented lines gives a tight upper bound to size it from. The per-statement `bodyLines` scratch is now reset rather than reallocated — safe because `strings.Join` copies what it needs, and returns the single line unchanged for a one-line statement, so no statement retains the backing array.

The per-statement `decorators` slice is deliberately left as-is: the statement keeps it.

### Retention

Entries are now substrings of the input rather than copies, so they share its backing array. That is not a new pattern here — `strings.Split`, used throughout this parser, already returns substrings that share their source.

### Tests

The parser's existing fixture suite passes unchanged. Three tests are added, and the two guards **state the property rather than a threshold**, because in both cases what changed is how the cost scales:

- `TestSplitTopLevelEntriesDoesNotAllocatePerEntry` — tenfold the entries must not mean tenfold the allocations. Against the previous implementation it fails with `10x the entries allocated 10x as much (807 -> 8011): the body is being copied per entry instead of sliced`.
- `TestTokenizeBicepAllocatesAtMostOncePerStatement` — only a multi-line statement's joined text may allocate. Previously `2.50 times per statement`.
- `TestUnindentedLinesBoundStatementCount` — pins the assumption the preallocation rests on (no statement begins on an indented line) against every fixture, so the bound can't silently go wrong.

`gofmt`, `go vet`, and `go test ./...` are clean in `providers/bicep`.
