### PR TITLE
⭐ alicloud: discover CLB, Redis, MongoDB, PolarDB and Function Compute assets

### DIFF
--- a/providers/alicloud/README.md
+++ b/providers/alicloud/README.md
@@ -79,6 +79,11 @@ Scanning an account discovers one asset per major service object, each scoped to
 | `vpcs` | VPC networks |
 | `oss-buckets` | OSS buckets |
 | `rds-instances` | RDS instances |
+| `slbs` | Classic Load Balancers |
+| `redis-instances` | ApsaraDB for Redis instances |
+| `mongodb-instances` | ApsaraDB for MongoDB instances |
+| `polardb-clusters` | PolarDB clusters |
+| `fc-functions` | Function Compute functions |
 | `waf` | Web Application Firewall instances |
 | `cloud-firewall` | the account's Cloud Firewall, when provisioned |
 | `auto` / `all` | every target above |
@@ -104,7 +109,7 @@ cnspec scan alicloud --filters tag:Environment=production
 cnspec scan alicloud --filters tag:Team=platform,security --filters exclude:tag:Lifecycle=temporary
 ```
 
-An exclude filter always wins over an include filter. Tag filters apply to the objects that carry tags — ACK clusters, load balancers, VPCs, ECS instances, OSS buckets, and RDS instances. WAF and Cloud Firewall are untagged account-level services, so tag filters do not narrow them.
+An exclude filter always wins over an include filter. Tag filters apply to the objects that carry tags — ACK clusters, load balancers (ALB, NLB, and CLB), VPCs, ECS instances, OSS buckets, RDS/Redis/MongoDB instances, PolarDB clusters, and Function Compute functions. WAF and Cloud Firewall are untagged account-level services, so tag filters do not narrow them.
 
 Tag lookups that cost a separate API call (OSS buckets, RDS instances) are only performed when a tag filter is actually set.
 

--- a/providers/alicloud/connection/platform.go
+++ b/providers/alicloud/connection/platform.go
@@ -10,14 +10,19 @@ import (
 
 const (
 	// Scope options that pin a discovered child connection to a single object.
-	OptionClusterID     = "cluster-id"
-	OptionAlbID         = "alb-id"
-	OptionNlbID         = "nlb-id"
-	OptionVpcID         = "vpc-id"
-	OptionWafInstanceID = "waf-instance-id"
-	OptionCloudFirewall = "cloud-firewall"
-	OptionOssBucket     = "oss-bucket"
-	OptionRdsInstanceID = "rds-instance-id"
+	OptionClusterID         = "cluster-id"
+	OptionAlbID             = "alb-id"
+	OptionNlbID             = "nlb-id"
+	OptionVpcID             = "vpc-id"
+	OptionWafInstanceID     = "waf-instance-id"
+	OptionCloudFirewall     = "cloud-firewall"
+	OptionOssBucket         = "oss-bucket"
+	OptionRdsInstanceID     = "rds-instance-id"
+	OptionSlbID             = "slb-id"
+	OptionRedisInstanceID   = "redis-instance-id"
+	OptionMongodbInstanceID = "mongodb-instance-id"
+	OptionPolardbClusterID  = "polardb-cluster-id"
+	OptionFcFunctionName    = "fc-function-name"
 )
 
 const (
@@ -30,6 +35,11 @@ const (
 	platformIDCloudFirewall = "//platformid.api.mondoo.app/runtime/alicloud/cloudfirewall/"
 	platformIDOssBucket     = "//platformid.api.mondoo.app/runtime/alicloud/oss/bucket/"
 	platformIDRdsInstance   = "//platformid.api.mondoo.app/runtime/alicloud/rds/instance/"
+	platformIDSlb           = "//platformid.api.mondoo.app/runtime/alicloud/slb/loadbalancer/"
+	platformIDRedisInstance = "//platformid.api.mondoo.app/runtime/alicloud/redis/instance/"
+	platformIDMongodb       = "//platformid.api.mondoo.app/runtime/alicloud/mongodb/instance/"
+	platformIDPolardb       = "//platformid.api.mondoo.app/runtime/alicloud/polardb/cluster/"
+	platformIDFcFunction    = "//platformid.api.mondoo.app/runtime/alicloud/fc/function/"
 )
 
 // Platforms is the static catalog of platforms the alicloud provider emits: the
@@ -45,6 +55,11 @@ var Platforms = []*plugin.PlatformInfo{
 	{Name: "alicloud-cloud-firewall", Title: "Alibaba Cloud Cloud Firewall", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-oss-bucket", Title: "Alibaba Cloud OSS Bucket", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-rds-instance", Title: "Alibaba Cloud RDS Instance", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-slb-loadbalancer", Title: "Alibaba Cloud Classic Load Balancer", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-redis-instance", Title: "Alibaba Cloud ApsaraDB for Redis Instance", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-mongodb-instance", Title: "Alibaba Cloud ApsaraDB for MongoDB Instance", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-polardb-cluster", Title: "Alibaba Cloud PolarDB Cluster", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-fc-function", Title: "Alibaba Cloud Function Compute Function", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)
@@ -118,6 +133,41 @@ func NewRdsInstancePlatform(instanceID string) *inventory.Platform {
 		[]string{"technology=alicloud", "kind=rds-instance", "instance=" + instanceID})
 }
 
+// NewSlbPlatform returns the platform for a discovered CLB instance asset.
+func NewSlbPlatform(lbID string) *inventory.Platform {
+	return newPlatform("alicloud-slb-loadbalancer", "",
+		[]string{"technology=alicloud", "kind=slb-loadbalancer", "loadbalancer=" + lbID})
+}
+
+// NewRedisInstancePlatform returns the platform for a discovered ApsaraDB for
+// Redis instance asset.
+func NewRedisInstancePlatform(instanceID string) *inventory.Platform {
+	return newPlatform("alicloud-redis-instance", "",
+		[]string{"technology=alicloud", "kind=redis-instance", "instance=" + instanceID})
+}
+
+// NewMongodbInstancePlatform returns the platform for a discovered ApsaraDB for
+// MongoDB instance asset.
+func NewMongodbInstancePlatform(instanceID string) *inventory.Platform {
+	return newPlatform("alicloud-mongodb-instance", "",
+		[]string{"technology=alicloud", "kind=mongodb-instance", "instance=" + instanceID})
+}
+
+// NewPolardbClusterPlatform returns the platform for a discovered PolarDB
+// cluster asset.
+func NewPolardbClusterPlatform(clusterID string) *inventory.Platform {
+	return newPlatform("alicloud-polardb-cluster", "",
+		[]string{"technology=alicloud", "kind=polardb-cluster", "cluster=" + clusterID})
+}
+
+// NewFcFunctionPlatform returns the platform for a discovered Function Compute
+// function asset. Function names repeat across regions, so the region is part of
+// the identity.
+func NewFcFunctionPlatform(region, functionName string) *inventory.Platform {
+	return newPlatform("alicloud-fc-function", "",
+		[]string{"technology=alicloud", "kind=fc-function", "region=" + region, "function=" + functionName})
+}
+
 func NewAccountIdentifier(accountID string) string       { return platformIDAccount + accountID }
 func NewAckClusterIdentifier(clusterID string) string    { return platformIDAckCluster + clusterID }
 func NewAlbIdentifier(lbID string) string                { return platformIDAlb + lbID }
@@ -127,3 +177,22 @@ func NewWafInstanceIdentifier(instanceID string) string  { return platformIDWafI
 func NewCloudFirewallIdentifier(accountID string) string { return platformIDCloudFirewall + accountID }
 func NewOssBucketIdentifier(bucketName string) string    { return platformIDOssBucket + bucketName }
 func NewRdsInstanceIdentifier(instanceID string) string  { return platformIDRdsInstance + instanceID }
+func NewSlbIdentifier(lbID string) string                { return platformIDSlb + lbID }
+
+func NewRedisInstanceIdentifier(instanceID string) string {
+	return platformIDRedisInstance + instanceID
+}
+
+func NewMongodbInstanceIdentifier(instanceID string) string {
+	return platformIDMongodb + instanceID
+}
+
+func NewPolardbClusterIdentifier(clusterID string) string {
+	return platformIDPolardb + clusterID
+}
+
+// NewFcFunctionIdentifier keys a function by region and name: Function Compute
+// names are unique within a region, not across the account.
+func NewFcFunctionIdentifier(region, functionName string) string {
+	return platformIDFcFunction + region + "/" + functionName
+}

--- a/providers/alicloud/connection/platform_test.go
+++ b/providers/alicloud/connection/platform_test.go
@@ -22,6 +22,13 @@ func TestAlicloudPlatforms(t *testing.T) {
 	assert.True(t, PlatformByName("alicloud-vpc").Consistent(NewVpcPlatform("vpc-abc")))
 	assert.True(t, PlatformByName("alicloud-waf-instance").Consistent(NewWafInstancePlatform("waf-abc")))
 	assert.True(t, PlatformByName("alicloud-cloud-firewall").Consistent(NewCloudFirewallPlatform("1234567890")))
+	assert.True(t, PlatformByName("alicloud-oss-bucket").Consistent(NewOssBucketPlatform("audit-logs")))
+	assert.True(t, PlatformByName("alicloud-rds-instance").Consistent(NewRdsInstancePlatform("rm-abc")))
+	assert.True(t, PlatformByName("alicloud-slb-loadbalancer").Consistent(NewSlbPlatform("lb-abc")))
+	assert.True(t, PlatformByName("alicloud-redis-instance").Consistent(NewRedisInstancePlatform("r-abc")))
+	assert.True(t, PlatformByName("alicloud-mongodb-instance").Consistent(NewMongodbInstancePlatform("dds-abc")))
+	assert.True(t, PlatformByName("alicloud-polardb-cluster").Consistent(NewPolardbClusterPlatform("pc-abc")))
+	assert.True(t, PlatformByName("alicloud-fc-function").Consistent(NewFcFunctionPlatform("cn-hangzhou", "handler")))
 }
 
 // TestAlicloudIdentifiers pins the stable platform-id formats used for asset
@@ -34,4 +41,19 @@ func TestAlicloudIdentifiers(t *testing.T) {
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/vpc/network/vpc-abc", NewVpcIdentifier("vpc-abc"))
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/waf/instance/waf-abc", NewWafInstanceIdentifier("waf-abc"))
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/cloudfirewall/1234567890", NewCloudFirewallIdentifier("1234567890"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/oss/bucket/audit-logs", NewOssBucketIdentifier("audit-logs"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/rds/instance/rm-abc", NewRdsInstanceIdentifier("rm-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/slb/loadbalancer/lb-abc", NewSlbIdentifier("lb-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/redis/instance/r-abc", NewRedisInstanceIdentifier("r-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/mongodb/instance/dds-abc", NewMongodbInstanceIdentifier("dds-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/polardb/cluster/pc-abc", NewPolardbClusterIdentifier("pc-abc"))
+
+	// Function Compute names repeat across regions, so the region is part of the
+	// identity: two functions named "handler" in different regions must not
+	// collapse into one asset.
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/fc/function/cn-hangzhou/handler",
+		NewFcFunctionIdentifier("cn-hangzhou", "handler"))
+	assert.NotEqual(t,
+		NewFcFunctionIdentifier("cn-hangzhou", "handler"),
+		NewFcFunctionIdentifier("ap-southeast-1", "handler"))
 }

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -242,7 +242,7 @@ func init() {
 			Create: createAlicloudSlb,
 		},
 		"alicloud.slb.loadBalancer": {
-			// to override args, implement: initAlicloudSlbLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAlicloudSlbLoadBalancer,
 			Create: createAlicloudSlbLoadBalancer,
 		},
 		"alicloud.slb.listener": {
@@ -262,7 +262,7 @@ func init() {
 			Create: createAlicloudRedis,
 		},
 		"alicloud.redis.instance": {
-			// to override args, implement: initAlicloudRedisInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAlicloudRedisInstance,
 			Create: createAlicloudRedisInstance,
 		},
 		"alicloud.mongodb": {
@@ -270,7 +270,7 @@ func init() {
 			Create: createAlicloudMongodb,
 		},
 		"alicloud.mongodb.instance": {
-			// to override args, implement: initAlicloudMongodbInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAlicloudMongodbInstance,
 			Create: createAlicloudMongodbInstance,
 		},
 		"alicloud.polardb": {
@@ -278,7 +278,7 @@ func init() {
 			Create: createAlicloudPolardb,
 		},
 		"alicloud.polardb.cluster": {
-			// to override args, implement: initAlicloudPolardbCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAlicloudPolardbCluster,
 			Create: createAlicloudPolardbCluster,
 		},
 		"alicloud.vpc.flowLog": {

--- a/providers/alicloud/resources/discovery.go
+++ b/providers/alicloud/resources/discovery.go
@@ -27,6 +27,12 @@ const (
 	DiscoveryCloudFirewall = "cloud-firewall"
 	DiscoveryOssBuckets    = "oss-buckets"
 	DiscoveryRdsInstances  = "rds-instances"
+
+	DiscoverySlbs             = "slbs"
+	DiscoveryRedisInstances   = "redis-instances"
+	DiscoveryMongodbInstances = "mongodb-instances"
+	DiscoveryPolardbClusters  = "polardb-clusters"
+	DiscoveryFcFunctions      = "fc-functions"
 )
 
 // Discover enumerates the major service objects in the account and returns one
@@ -61,6 +67,16 @@ func Discover(runtime *plugin.Runtime, conf *inventory.Config) (*inventory.Inven
 			assets, err = discoverOssBuckets(runtime, conn, conf)
 		case DiscoveryRdsInstances:
 			assets, err = discoverRdsInstances(runtime, conn, conf)
+		case DiscoverySlbs:
+			assets, err = discoverSlbs(runtime, conn, conf)
+		case DiscoveryRedisInstances:
+			assets, err = discoverRedisInstances(runtime, conn, conf)
+		case DiscoveryMongodbInstances:
+			assets, err = discoverMongodbInstances(runtime, conn, conf)
+		case DiscoveryPolardbClusters:
+			assets, err = discoverPolardbClusters(runtime, conn, conf)
+		case DiscoveryFcFunctions:
+			assets, err = discoverFcFunctions(runtime, conn, conf)
 		case DiscoveryAccounts:
 			// the account is already returned as the connected root asset, so it
 			// contributes no discovered child assets
@@ -89,6 +105,11 @@ func handleTargets(targets []string) []string {
 			DiscoveryCloudFirewall,
 			DiscoveryOssBuckets,
 			DiscoveryRdsInstances,
+			DiscoverySlbs,
+			DiscoveryRedisInstances,
+			DiscoveryMongodbInstances,
+			DiscoveryPolardbClusters,
+			DiscoveryFcFunctions,
 		}
 	}
 	return targets
@@ -228,6 +249,122 @@ func discoverRdsInstances(runtime *plugin.Runtime, conn *connection.AlicloudConn
 		assets = append(assets, newChildAsset(conf, conn.ID(), inst.RegionId.Data,
 			connection.NewRdsInstanceIdentifier(id), connection.NewRdsInstancePlatform(id),
 			nameOr(inst.DbInstanceDescription.Data, id), connection.OptionRdsInstanceID, id))
+	}
+	return assets, nil
+}
+
+func discoverSlbs(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.slb", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	lbs, err := res.(*mqlAlicloudSlb).loadBalancers()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(lbs))
+	for _, il := range lbs {
+		lb := il.(*mqlAlicloudSlbLoadBalancer)
+		id := lb.LoadBalancerId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), lb.RegionId.Data,
+			connection.NewSlbIdentifier(id), connection.NewSlbPlatform(id),
+			nameOr(lb.LoadBalancerName.Data, id), connection.OptionSlbID, id))
+	}
+	return assets, nil
+}
+
+func discoverRedisInstances(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.redis", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	instances, err := res.(*mqlAlicloudRedis).instances()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(instances))
+	for _, ii := range instances {
+		inst := ii.(*mqlAlicloudRedisInstance)
+		id := inst.InstanceId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), inst.RegionId.Data,
+			connection.NewRedisInstanceIdentifier(id), connection.NewRedisInstancePlatform(id),
+			nameOr(inst.InstanceName.Data, id), connection.OptionRedisInstanceID, id))
+	}
+	return assets, nil
+}
+
+func discoverMongodbInstances(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.mongodb", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	instances, err := res.(*mqlAlicloudMongodb).instances()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(instances))
+	for _, ii := range instances {
+		inst := ii.(*mqlAlicloudMongodbInstance)
+		id := inst.DbInstanceId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), inst.RegionId.Data,
+			connection.NewMongodbInstanceIdentifier(id), connection.NewMongodbInstancePlatform(id),
+			nameOr(inst.DbInstanceDescription.Data, id), connection.OptionMongodbInstanceID, id))
+	}
+	return assets, nil
+}
+
+func discoverPolardbClusters(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.polardb", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	clusters, err := res.(*mqlAlicloudPolardb).clusters()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(clusters))
+	for _, ic := range clusters {
+		cluster := ic.(*mqlAlicloudPolardbCluster)
+		id := cluster.DbClusterId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), cluster.RegionId.Data,
+			connection.NewPolardbClusterIdentifier(id), connection.NewPolardbClusterPlatform(id),
+			nameOr(cluster.DbClusterDescription.Data, id), connection.OptionPolardbClusterID, id))
+	}
+	return assets, nil
+}
+
+func discoverFcFunctions(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.fc", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	functions, err := res.(*mqlAlicloudFc).functions()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(functions))
+	for _, ifn := range functions {
+		fn := ifn.(*mqlAlicloudFcFunction)
+		name := fn.FunctionName.Data
+		region := fn.RegionId.Data
+		if name == "" || region == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), region,
+			connection.NewFcFunctionIdentifier(region, name), connection.NewFcFunctionPlatform(region, name),
+			name, connection.OptionFcFunctionName, name))
 	}
 	return assets, nil
 }

--- a/providers/alicloud/resources/discovery_test.go
+++ b/providers/alicloud/resources/discovery_test.go
@@ -16,6 +16,8 @@ func TestHandleTargets(t *testing.T) {
 		DiscoveryK8sClusters, DiscoveryAlbs, DiscoveryNlbs,
 		DiscoveryVpcs, DiscoveryWaf, DiscoveryCloudFirewall,
 		DiscoveryOssBuckets, DiscoveryRdsInstances,
+		DiscoverySlbs, DiscoveryRedisInstances, DiscoveryMongodbInstances,
+		DiscoveryPolardbClusters, DiscoveryFcFunctions,
 	}
 
 	assert.ElementsMatch(t, fineGrained, handleTargets([]string{DiscoveryAuto}))

--- a/providers/alicloud/resources/fc.go
+++ b/providers/alicloud/resources/fc.go
@@ -73,6 +73,11 @@ func (r *mqlAlicloudFc) functions() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				// ListFunctions returns tags inline, so the filter costs nothing
+				// beyond the listing already made
+				if filteredOutByTags(conn, mqlFn.Tags.Data) {
+					continue
+				}
 				res = append(res, mqlFn)
 			}
 			if resp.Body.NextToken == nil || *resp.Body.NextToken == "" {
@@ -181,6 +186,9 @@ func initAlicloudFcFunction(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+	// on a discovered function asset, resolve the function the asset is scoped to
+	args = scopedInitArgs(runtime, args, connection.OptionFcFunctionName, "functionName")
+
 	functionName, err := requiredStringArg(args, "functionName", "alicloud.fc.function")
 	if err != nil {
 		return nil, nil, err

--- a/providers/alicloud/resources/mongodb.go
+++ b/providers/alicloud/resources/mongodb.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -94,46 +95,16 @@ func (r *mqlAlicloudMongodb) instances() ([]any, error) {
 				if inst == nil || inst.DBInstanceId == nil {
 					continue
 				}
-				id := tea.StringValue(inst.DBInstanceId)
 
-				mqlInst, err := CreateResource(r.MqlRuntime, "alicloud.mongodb.instance", map[string]*llx.RawData{
-					"__id":                  llx.StringData(id),
-					"dbInstanceId":          llx.StringDataPtr(inst.DBInstanceId),
-					"dbInstanceDescription": llx.StringDataPtr(inst.DBInstanceDescription),
-					"dbInstanceType":        llx.StringDataPtr(inst.DBInstanceType),
-					"dbInstanceClass":       llx.StringDataPtr(inst.DBInstanceClass),
-					"dbInstanceStorage":     llx.IntData(tea.Int32Value(inst.DBInstanceStorage)),
-					"engine":                llx.StringDataPtr(inst.Engine),
-					"engineVersion":         llx.StringDataPtr(inst.EngineVersion),
-					"dbInstanceStatus":      llx.StringDataPtr(inst.DBInstanceStatus),
-					"regionId":              llx.StringDataPtr(inst.RegionId),
-					"zoneId":                llx.StringDataPtr(inst.ZoneId),
-					"secondaryZoneId":       llx.StringDataPtr(inst.SecondaryZoneId),
-					"hiddenZoneId":          llx.StringDataPtr(inst.HiddenZoneId),
-					"networkType":           llx.StringDataPtr(inst.NetworkType),
-					"chargeType":            llx.StringDataPtr(inst.ChargeType),
-					"storageType":           llx.StringDataPtr(inst.StorageType),
-					"replicationFactor":     llx.StringDataPtr(inst.ReplicationFactor),
-					"vpcAuthMode":           llx.StringDataPtr(inst.VpcAuthMode),
-					"backupRetentionPolicy": llx.IntData(tea.Int32Value(inst.BackupRetentionPolicy)),
-					"capacityUnit":          llx.StringDataPtr(inst.CapacityUnit),
-					"kindCode":              llx.StringDataPtr(inst.KindCode),
-					"createTime":            llx.TimeDataPtr(mongodbParseTime(inst.CreationTime)),
-					"expireTime":            llx.TimeDataPtr(mongodbParseTime(inst.ExpireTime)),
-					"destroyTime":           llx.TimeDataPtr(mongodbParseTime(inst.DestroyTime)),
-					"releaseTime":           llx.TimeDataPtr(mongodbParseTime(inst.ReleaseTime)),
-					"lastDowngradeTime":     llx.StringDataPtr(inst.LastDowngradeTime),
-					"lockMode":              llx.StringDataPtr(inst.LockMode),
-					"resourceGroupId":       llx.StringDataPtr(inst.ResourceGroupId),
-					"tags":                  llx.MapData(mongodbTagsToMap(inst.Tags), types.String),
-				})
+				mqlInst, err := newMongodbInstance(r.MqlRuntime, region, inst)
 				if err != nil {
 					return nil, err
 				}
-				m := mqlInst.(*mqlAlicloudMongodbInstance)
-				m.region = region
-				m.cacheRegion = region
-				m.instanceId = id
+				// DescribeDBInstances returns tags inline, so the filter costs
+				// nothing beyond the listing already made
+				if filteredOutByTags(conn, mqlInst.Tags.Data) {
+					continue
+				}
 				res = append(res, mqlInst)
 			}
 
@@ -166,6 +137,104 @@ type mqlAlicloudMongodbInstanceInternal struct {
 	sslOnce sync.Once
 	sslBody *ddsclient.DescribeDBInstanceSSLResponseBody
 	sslErr  error
+}
+
+// newMongodbInstance builds a fully populated alicloud.mongodb.instance from a
+// DescribeDBInstances list item within a region. It is shared by the instances
+// list accessor and the by-id init so both produce identical resources.
+func newMongodbInstance(runtime *plugin.Runtime, region string, inst *ddsclient.DescribeDBInstancesResponseBodyDBInstancesDBInstance) (*mqlAlicloudMongodbInstance, error) {
+	id := tea.StringValue(inst.DBInstanceId)
+	resource, err := CreateResource(runtime, "alicloud.mongodb.instance", map[string]*llx.RawData{
+		"__id":                  llx.StringData(id),
+		"dbInstanceId":          llx.StringDataPtr(inst.DBInstanceId),
+		"dbInstanceDescription": llx.StringDataPtr(inst.DBInstanceDescription),
+		"dbInstanceType":        llx.StringDataPtr(inst.DBInstanceType),
+		"dbInstanceClass":       llx.StringDataPtr(inst.DBInstanceClass),
+		"dbInstanceStorage":     llx.IntData(tea.Int32Value(inst.DBInstanceStorage)),
+		"engine":                llx.StringDataPtr(inst.Engine),
+		"engineVersion":         llx.StringDataPtr(inst.EngineVersion),
+		"dbInstanceStatus":      llx.StringDataPtr(inst.DBInstanceStatus),
+		"regionId":              llx.StringDataPtr(inst.RegionId),
+		"zoneId":                llx.StringDataPtr(inst.ZoneId),
+		"secondaryZoneId":       llx.StringDataPtr(inst.SecondaryZoneId),
+		"hiddenZoneId":          llx.StringDataPtr(inst.HiddenZoneId),
+		"networkType":           llx.StringDataPtr(inst.NetworkType),
+		"chargeType":            llx.StringDataPtr(inst.ChargeType),
+		"storageType":           llx.StringDataPtr(inst.StorageType),
+		"replicationFactor":     llx.StringDataPtr(inst.ReplicationFactor),
+		"vpcAuthMode":           llx.StringDataPtr(inst.VpcAuthMode),
+		"backupRetentionPolicy": llx.IntData(tea.Int32Value(inst.BackupRetentionPolicy)),
+		"capacityUnit":          llx.StringDataPtr(inst.CapacityUnit),
+		"kindCode":              llx.StringDataPtr(inst.KindCode),
+		"createTime":            llx.TimeDataPtr(mongodbParseTime(inst.CreationTime)),
+		"expireTime":            llx.TimeDataPtr(mongodbParseTime(inst.ExpireTime)),
+		"destroyTime":           llx.TimeDataPtr(mongodbParseTime(inst.DestroyTime)),
+		"releaseTime":           llx.TimeDataPtr(mongodbParseTime(inst.ReleaseTime)),
+		"lastDowngradeTime":     llx.StringDataPtr(inst.LastDowngradeTime),
+		"lockMode":              llx.StringDataPtr(inst.LockMode),
+		"resourceGroupId":       llx.StringDataPtr(inst.ResourceGroupId),
+		"tags":                  llx.MapData(mongodbTagsToMap(inst.Tags), types.String),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlInst := resource.(*mqlAlicloudMongodbInstance)
+	mqlInst.region = region
+	mqlInst.cacheRegion = region
+	mqlInst.instanceId = id
+	return mqlInst, nil
+}
+
+// initAlicloudMongodbInstance resolves an ApsaraDB for MongoDB instance by its
+// native DB instance id within a region, reusing an already-listed instance from
+// the resource cache. It also backs the discovered mongodb-instance asset, which
+// scopes the connection to one instance.
+func initAlicloudMongodbInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	// on a discovered MongoDB instance asset, resolve the instance the asset is
+	// scoped to
+	args = scopedInitArgs(runtime, args, connection.OptionMongodbInstanceID, "dbInstanceId")
+
+	instanceID, err := requiredStringArg(args, "dbInstanceId", "alicloud.mongodb.instance")
+	if err != nil {
+		return nil, nil, err
+	}
+	region, err := requiredStringArg(args, "regionId", "alicloud.mongodb.instance")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if x, ok := runtime.Resources.Get("alicloud.mongodb.instance\x00" + instanceID); ok {
+		return nil, x, nil
+	}
+
+	conn := runtime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.MongoDBClient(region)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.DescribeDBInstances(&ddsclient.DescribeDBInstancesRequest{
+		RegionId:     tea.String(region),
+		DBInstanceId: tea.String(instanceID),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp != nil && resp.Body != nil && resp.Body.DBInstances != nil {
+		for _, inst := range resp.Body.DBInstances.DBInstance {
+			if inst == nil || tea.StringValue(inst.DBInstanceId) != instanceID {
+				continue
+			}
+			res, err := newMongodbInstance(runtime, region, inst)
+			if err != nil {
+				return nil, nil, err
+			}
+			return nil, res, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("alicloud.mongodb.instance %q not found in region %q", instanceID, region)
 }
 
 func (r *mqlAlicloudMongodbInstance) id() (string, error) {

--- a/providers/alicloud/resources/polardb.go
+++ b/providers/alicloud/resources/polardb.go
@@ -4,10 +4,12 @@
 package resources
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	polardb "github.com/alibabacloud-go/polardb-20170801/v8/client"
+	tea "github.com/alibabacloud-go/tea/tea"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/alicloud/connection"
@@ -123,50 +125,16 @@ func (r *mqlAlicloudPolardb) clusters() ([]any, error) {
 				if c == nil || c.DBClusterId == nil {
 					continue
 				}
-				id := region + "/" + *c.DBClusterId
-				resource, err := CreateResource(r.MqlRuntime, "alicloud.polardb.cluster", map[string]*llx.RawData{
-					"__id":                 llx.StringData(id),
-					"dbClusterId":          llx.StringDataPtr(c.DBClusterId),
-					"dbClusterDescription": llx.StringDataPtr(c.DBClusterDescription),
-					"dbClusterStatus":      llx.StringDataPtr(c.DBClusterStatus),
-					"dbType":               llx.StringDataPtr(c.DBType),
-					"dbVersion":            llx.StringDataPtr(c.DBVersion),
-					"engine":               llx.StringDataPtr(c.Engine),
-					"category":             llx.StringDataPtr(c.Category),
-					"subCategory":          llx.StringDataPtr(c.SubCategory),
-					"dbNodeClass":          llx.StringDataPtr(c.DBNodeClass),
-					"dbNodeNumber":         llx.IntDataPtr(c.DBNodeNumber),
-					"cpuCores":             llx.StringDataPtr(c.CpuCores),
-					"memorySize":           llx.StringDataPtr(c.MemorySize),
-					"storageUsed":          llx.IntDataPtr(c.StorageUsed),
-					"storageType":          llx.StringDataPtr(c.StorageType),
-					"storagePayType":       llx.StringDataPtr(c.StoragePayType),
-					"storageSpace":         llx.IntDataPtr(c.StorageSpace),
-					"regionId":             llx.StringDataPtr(c.RegionId),
-					"zoneId":               llx.StringDataPtr(c.ZoneId),
-					"payType":              llx.StringDataPtr(c.PayType),
-					"createTime":           llx.TimeDataPtr(polardbParseTime(c.CreateTime)),
-					"expireTime":           llx.TimeDataPtr(polardbParseTime(c.ExpireTime)),
-					"expired":              llx.StringDataPtr(c.Expired),
-					"lockMode":             llx.StringDataPtr(c.LockMode),
-					"deletionLock":         llx.IntDataPtr(c.DeletionLock),
-					"resourceGroupId":      llx.StringDataPtr(c.ResourceGroupId),
-					"serverlessType":       llx.StringDataPtr(c.ServerlessType),
-					"dbClusterNetworkType": llx.StringDataPtr(c.DBClusterNetworkType),
-					"aiType":               llx.StringDataPtr(c.AiType),
-					"hotStandbyCluster":    llx.StringDataPtr(c.HotStandbyCluster),
-					"strictConsistency":    llx.StringDataPtr(c.StrictConsistency),
-					"tags":                 llx.MapData(polardbTagsToMap(c.Tags), types.String),
-					"dbNodes":              llx.ArrayData(polardbNodesToDict(c.DBNodes), types.Dict),
-				})
+
+				cluster, err := newPolardbCluster(r.MqlRuntime, region, c)
 				if err != nil {
 					return nil, err
 				}
-				cluster := resource.(*mqlAlicloudPolardbCluster)
-				cluster.region = region
-				cluster.dbClusterId = *c.DBClusterId
-				cluster.cacheVpcID = polardbStr(c.VpcId)
-				cluster.cacheVswitchID = polardbStr(c.VswitchId)
+				// DescribeDBClusters returns tags inline, so the filter costs
+				// nothing beyond the listing already made
+				if filteredOutByTags(conn, cluster.Tags.Data) {
+					continue
+				}
 				res = append(res, cluster)
 			}
 
@@ -179,6 +147,110 @@ func (r *mqlAlicloudPolardb) clusters() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// newPolardbCluster builds a fully populated alicloud.polardb.cluster from a
+// DescribeDBClusters list item within a region. It is shared by the clusters
+// list accessor and the by-id init so both produce identical resources.
+func newPolardbCluster(runtime *plugin.Runtime, region string, c *polardb.DescribeDBClustersResponseBodyItemsDBCluster) (*mqlAlicloudPolardbCluster, error) {
+	id := region + "/" + tea.StringValue(c.DBClusterId)
+	resource, err := CreateResource(runtime, "alicloud.polardb.cluster", map[string]*llx.RawData{
+		"__id":                 llx.StringData(id),
+		"dbClusterId":          llx.StringDataPtr(c.DBClusterId),
+		"dbClusterDescription": llx.StringDataPtr(c.DBClusterDescription),
+		"dbClusterStatus":      llx.StringDataPtr(c.DBClusterStatus),
+		"dbType":               llx.StringDataPtr(c.DBType),
+		"dbVersion":            llx.StringDataPtr(c.DBVersion),
+		"engine":               llx.StringDataPtr(c.Engine),
+		"category":             llx.StringDataPtr(c.Category),
+		"subCategory":          llx.StringDataPtr(c.SubCategory),
+		"dbNodeClass":          llx.StringDataPtr(c.DBNodeClass),
+		"dbNodeNumber":         llx.IntDataPtr(c.DBNodeNumber),
+		"cpuCores":             llx.StringDataPtr(c.CpuCores),
+		"memorySize":           llx.StringDataPtr(c.MemorySize),
+		"storageUsed":          llx.IntDataPtr(c.StorageUsed),
+		"storageType":          llx.StringDataPtr(c.StorageType),
+		"storagePayType":       llx.StringDataPtr(c.StoragePayType),
+		"storageSpace":         llx.IntDataPtr(c.StorageSpace),
+		"regionId":             llx.StringDataPtr(c.RegionId),
+		"zoneId":               llx.StringDataPtr(c.ZoneId),
+		"payType":              llx.StringDataPtr(c.PayType),
+		"createTime":           llx.TimeDataPtr(polardbParseTime(c.CreateTime)),
+		"expireTime":           llx.TimeDataPtr(polardbParseTime(c.ExpireTime)),
+		"expired":              llx.StringDataPtr(c.Expired),
+		"lockMode":             llx.StringDataPtr(c.LockMode),
+		"deletionLock":         llx.IntDataPtr(c.DeletionLock),
+		"resourceGroupId":      llx.StringDataPtr(c.ResourceGroupId),
+		"serverlessType":       llx.StringDataPtr(c.ServerlessType),
+		"dbClusterNetworkType": llx.StringDataPtr(c.DBClusterNetworkType),
+		"aiType":               llx.StringDataPtr(c.AiType),
+		"hotStandbyCluster":    llx.StringDataPtr(c.HotStandbyCluster),
+		"strictConsistency":    llx.StringDataPtr(c.StrictConsistency),
+		"tags":                 llx.MapData(polardbTagsToMap(c.Tags), types.String),
+		"dbNodes":              llx.ArrayData(polardbNodesToDict(c.DBNodes), types.Dict),
+	})
+	if err != nil {
+		return nil, err
+	}
+	cluster := resource.(*mqlAlicloudPolardbCluster)
+	cluster.region = region
+	cluster.dbClusterId = tea.StringValue(c.DBClusterId)
+	cluster.cacheVpcID = polardbStr(c.VpcId)
+	cluster.cacheVswitchID = polardbStr(c.VswitchId)
+	return cluster, nil
+}
+
+// initAlicloudPolardbCluster resolves a PolarDB cluster by its native cluster id
+// within a region, reusing an already-listed cluster from the resource cache. It
+// also backs the discovered polardb-cluster asset, which scopes the connection
+// to one cluster.
+func initAlicloudPolardbCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	// on a discovered PolarDB cluster asset, resolve the cluster the asset is
+	// scoped to
+	args = scopedInitArgs(runtime, args, connection.OptionPolardbClusterID, "dbClusterId")
+
+	clusterID, err := requiredStringArg(args, "dbClusterId", "alicloud.polardb.cluster")
+	if err != nil {
+		return nil, nil, err
+	}
+	region, err := requiredStringArg(args, "regionId", "alicloud.polardb.cluster")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Matches the cluster __id: region + "/" + dbClusterId.
+	if x, ok := runtime.Resources.Get("alicloud.polardb.cluster\x00" + region + "/" + clusterID); ok {
+		return nil, x, nil
+	}
+
+	conn := runtime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.PolarDBClient(region)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.DescribeDBClusters(&polardb.DescribeDBClustersRequest{
+		RegionId:     tea.String(region),
+		DBClusterIds: tea.String(clusterID),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp != nil && resp.Body != nil && resp.Body.Items != nil {
+		for _, c := range resp.Body.Items.DBCluster {
+			if c == nil || tea.StringValue(c.DBClusterId) != clusterID {
+				continue
+			}
+			res, err := newPolardbCluster(runtime, region, c)
+			if err != nil {
+				return nil, nil, err
+			}
+			return nil, res, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("alicloud.polardb.cluster %q not found in region %q", clusterID, region)
 }
 
 func (r *mqlAlicloudPolardbCluster) id() (string, error) {

--- a/providers/alicloud/resources/redis.go
+++ b/providers/alicloud/resources/redis.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -97,43 +98,15 @@ func (r *mqlAlicloudRedis) instances() ([]any, error) {
 					continue
 				}
 
-				mqlInst, err := CreateResource(r.MqlRuntime, "alicloud.redis.instance", map[string]*llx.RawData{
-					"__id":             llx.StringDataPtr(inst.InstanceId),
-					"instanceId":       llx.StringDataPtr(inst.InstanceId),
-					"instanceName":     llx.StringDataPtr(inst.InstanceName),
-					"instanceStatus":   llx.StringDataPtr(inst.InstanceStatus),
-					"instanceType":     llx.StringDataPtr(inst.InstanceType),
-					"instanceClass":    llx.StringDataPtr(inst.InstanceClass),
-					"architectureType": llx.StringDataPtr(inst.ArchitectureType),
-					"engineVersion":    llx.StringDataPtr(inst.EngineVersion),
-					"regionId":         llx.StringDataPtr(inst.RegionId),
-					"zoneId":           llx.StringDataPtr(inst.ZoneId),
-					"secondaryZoneId":  llx.StringDataPtr(inst.SecondaryZoneId),
-					"networkType":      llx.StringDataPtr(inst.NetworkType),
-					"connectionDomain": llx.StringDataPtr(inst.ConnectionDomain),
-					"port":             llx.IntDataPtr(inst.Port),
-					"privateIp":        llx.StringDataPtr(inst.PrivateIp),
-					"capacity":         llx.IntDataPtr(inst.Capacity),
-					"bandwidth":        llx.IntDataPtr(inst.Bandwidth),
-					"qps":              llx.IntDataPtr(inst.QPS),
-					"connections":      llx.IntDataPtr(inst.Connections),
-					"chargeType":       llx.StringDataPtr(inst.ChargeType),
-					"nodeType":         llx.StringDataPtr(inst.NodeType),
-					"packageType":      llx.StringDataPtr(inst.PackageType),
-					"editionType":      llx.StringDataPtr(inst.EditionType),
-					"resourceGroupId":  llx.StringDataPtr(inst.ResourceGroupId),
-					"createTime":       llx.TimeDataPtr(redisParseTime(inst.CreateTime)),
-					"endTime":          llx.TimeDataPtr(redisParseTime(inst.EndTime)),
-					"tags":             llx.MapData(redisTagsToMap(inst.Tags), types.String),
-				})
+				mqlInst, err := newRedisInstance(r.MqlRuntime, region, inst)
 				if err != nil {
 					return nil, err
 				}
-				resInst := mqlInst.(*mqlAlicloudRedisInstance)
-				resInst.region = region
-				resInst.cacheRegion = region
-				resInst.cacheVpcID = tea.StringValue(inst.VpcId)
-				resInst.cacheVswitchID = tea.StringValue(inst.VSwitchId)
+				// DescribeInstances returns tags inline, so the filter costs
+				// nothing beyond the listing already made
+				if filteredOutByTags(conn, mqlInst.Tags.Data) {
+					continue
+				}
 				res = append(res, mqlInst)
 			}
 
@@ -145,6 +118,102 @@ func (r *mqlAlicloudRedis) instances() ([]any, error) {
 		}
 	}
 	return res, nil
+}
+
+// newRedisInstance builds a fully populated alicloud.redis.instance from a
+// DescribeInstances list item within a region. It is shared by the instances
+// list accessor and the by-id init so both produce identical resources.
+func newRedisInstance(runtime *plugin.Runtime, region string, inst *rkvclient.DescribeInstancesResponseBodyInstancesKVStoreInstance) (*mqlAlicloudRedisInstance, error) {
+	resource, err := CreateResource(runtime, "alicloud.redis.instance", map[string]*llx.RawData{
+		"__id":             llx.StringDataPtr(inst.InstanceId),
+		"instanceId":       llx.StringDataPtr(inst.InstanceId),
+		"instanceName":     llx.StringDataPtr(inst.InstanceName),
+		"instanceStatus":   llx.StringDataPtr(inst.InstanceStatus),
+		"instanceType":     llx.StringDataPtr(inst.InstanceType),
+		"instanceClass":    llx.StringDataPtr(inst.InstanceClass),
+		"architectureType": llx.StringDataPtr(inst.ArchitectureType),
+		"engineVersion":    llx.StringDataPtr(inst.EngineVersion),
+		"regionId":         llx.StringDataPtr(inst.RegionId),
+		"zoneId":           llx.StringDataPtr(inst.ZoneId),
+		"secondaryZoneId":  llx.StringDataPtr(inst.SecondaryZoneId),
+		"networkType":      llx.StringDataPtr(inst.NetworkType),
+		"connectionDomain": llx.StringDataPtr(inst.ConnectionDomain),
+		"port":             llx.IntDataPtr(inst.Port),
+		"privateIp":        llx.StringDataPtr(inst.PrivateIp),
+		"capacity":         llx.IntDataPtr(inst.Capacity),
+		"bandwidth":        llx.IntDataPtr(inst.Bandwidth),
+		"qps":              llx.IntDataPtr(inst.QPS),
+		"connections":      llx.IntDataPtr(inst.Connections),
+		"chargeType":       llx.StringDataPtr(inst.ChargeType),
+		"nodeType":         llx.StringDataPtr(inst.NodeType),
+		"packageType":      llx.StringDataPtr(inst.PackageType),
+		"editionType":      llx.StringDataPtr(inst.EditionType),
+		"resourceGroupId":  llx.StringDataPtr(inst.ResourceGroupId),
+		"createTime":       llx.TimeDataPtr(redisParseTime(inst.CreateTime)),
+		"endTime":          llx.TimeDataPtr(redisParseTime(inst.EndTime)),
+		"tags":             llx.MapData(redisTagsToMap(inst.Tags), types.String),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlInst := resource.(*mqlAlicloudRedisInstance)
+	mqlInst.region = region
+	mqlInst.cacheRegion = region
+	mqlInst.cacheVpcID = tea.StringValue(inst.VpcId)
+	mqlInst.cacheVswitchID = tea.StringValue(inst.VSwitchId)
+	return mqlInst, nil
+}
+
+// initAlicloudRedisInstance resolves an ApsaraDB for Redis instance by its
+// native instance id within a region, reusing an already-listed instance from
+// the resource cache. It also backs the discovered redis-instance asset, which
+// scopes the connection to one instance.
+func initAlicloudRedisInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	// on a discovered Redis instance asset, resolve the instance the asset is
+	// scoped to
+	args = scopedInitArgs(runtime, args, connection.OptionRedisInstanceID, "instanceId")
+
+	instanceID, err := requiredStringArg(args, "instanceId", "alicloud.redis.instance")
+	if err != nil {
+		return nil, nil, err
+	}
+	region, err := requiredStringArg(args, "regionId", "alicloud.redis.instance")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if x, ok := runtime.Resources.Get("alicloud.redis.instance\x00" + instanceID); ok {
+		return nil, x, nil
+	}
+
+	conn := runtime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RedisClient(region)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.DescribeInstances(&rkvclient.DescribeInstancesRequest{
+		RegionId:    tea.String(region),
+		InstanceIds: tea.String(instanceID),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp != nil && resp.Body != nil && resp.Body.Instances != nil {
+		for _, inst := range resp.Body.Instances.KVStoreInstance {
+			if inst == nil || tea.StringValue(inst.InstanceId) != instanceID {
+				continue
+			}
+			res, err := newRedisInstance(runtime, region, inst)
+			if err != nil {
+				return nil, nil, err
+			}
+			return nil, res, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("alicloud.redis.instance %q not found in region %q", instanceID, region)
 }
 
 func (r *mqlAlicloudRedisInstance) id() (string, error) {

--- a/providers/alicloud/resources/slb.go
+++ b/providers/alicloud/resources/slb.go
@@ -129,39 +129,15 @@ func (r *mqlAlicloudSlb) loadBalancers() ([]any, error) {
 					continue
 				}
 
-				resource, err := CreateResource(r.MqlRuntime, "alicloud.slb.loadBalancer", map[string]*llx.RawData{
-					"__id":                         llx.StringDataPtr(lb.LoadBalancerId),
-					"loadBalancerId":               llx.StringDataPtr(lb.LoadBalancerId),
-					"loadBalancerName":             llx.StringDataPtr(lb.LoadBalancerName),
-					"address":                      llx.StringDataPtr(lb.Address),
-					"addressType":                  llx.StringDataPtr(lb.AddressType),
-					"addressIPVersion":             llx.StringDataPtr(lb.AddressIPVersion),
-					"status":                       llx.StringDataPtr(lb.LoadBalancerStatus),
-					"regionId":                     llx.StringDataPtr(lb.RegionId),
-					"masterZoneId":                 llx.StringDataPtr(lb.MasterZoneId),
-					"slaveZoneId":                  llx.StringDataPtr(lb.SlaveZoneId),
-					"networkType":                  llx.StringDataPtr(lb.NetworkType),
-					"internetChargeType":           llx.StringDataPtr(lb.InternetChargeType),
-					"instanceChargeType":           llx.StringDataPtr(lb.InstanceChargeType),
-					"loadBalancerSpec":             llx.StringDataPtr(lb.LoadBalancerSpec),
-					"payType":                      llx.StringDataPtr(lb.PayType),
-					"bandwidth":                    llx.IntDataPtr(lb.Bandwidth),
-					"createTime":                   llx.TimeDataPtr(slbParseTime(lb.CreateTime)),
-					"deleteProtection":             llx.StringDataPtr(lb.DeleteProtection),
-					"modificationProtectionStatus": llx.StringDataPtr(lb.ModificationProtectionStatus),
-					"modificationProtectionReason": llx.StringDataPtr(lb.ModificationProtectionReason),
-					"resourceGroupId":              llx.StringDataPtr(lb.ResourceGroupId),
-					"tags":                         llx.MapData(slbLoadBalancerTags(lb.Tags), types.String),
-				})
+				mqlLb, err := newSlbLoadBalancer(r.MqlRuntime, region, lb)
 				if err != nil {
 					return nil, err
 				}
-
-				mqlLb := resource.(*mqlAlicloudSlbLoadBalancer)
-				mqlLb.region = region
-				mqlLb.cacheRegion = region
-				mqlLb.cacheVpcID = tea.StringValue(lb.VpcId)
-				mqlLb.cacheVswitchID = tea.StringValue(lb.VSwitchId)
+				// DescribeLoadBalancers returns tags inline, so the filter costs
+				// nothing beyond the listing already made
+				if filteredOutByTags(conn, mqlLb.Tags.Data) {
+					continue
+				}
 				res = append(res, mqlLb)
 			}
 
@@ -172,6 +148,97 @@ func (r *mqlAlicloudSlb) loadBalancers() ([]any, error) {
 		}
 	}
 	return res, nil
+}
+
+// newSlbLoadBalancer builds a fully populated alicloud.slb.loadBalancer from a
+// DescribeLoadBalancers list item within a region. It is shared by the
+// loadBalancers list accessor and the by-id init so both produce identical
+// resources.
+func newSlbLoadBalancer(runtime *plugin.Runtime, region string, lb *slbclient.DescribeLoadBalancersResponseBodyLoadBalancersLoadBalancer) (*mqlAlicloudSlbLoadBalancer, error) {
+	resource, err := CreateResource(runtime, "alicloud.slb.loadBalancer", map[string]*llx.RawData{
+		"__id":                         llx.StringDataPtr(lb.LoadBalancerId),
+		"loadBalancerId":               llx.StringDataPtr(lb.LoadBalancerId),
+		"loadBalancerName":             llx.StringDataPtr(lb.LoadBalancerName),
+		"address":                      llx.StringDataPtr(lb.Address),
+		"addressType":                  llx.StringDataPtr(lb.AddressType),
+		"addressIPVersion":             llx.StringDataPtr(lb.AddressIPVersion),
+		"status":                       llx.StringDataPtr(lb.LoadBalancerStatus),
+		"regionId":                     llx.StringDataPtr(lb.RegionId),
+		"masterZoneId":                 llx.StringDataPtr(lb.MasterZoneId),
+		"slaveZoneId":                  llx.StringDataPtr(lb.SlaveZoneId),
+		"networkType":                  llx.StringDataPtr(lb.NetworkType),
+		"internetChargeType":           llx.StringDataPtr(lb.InternetChargeType),
+		"instanceChargeType":           llx.StringDataPtr(lb.InstanceChargeType),
+		"loadBalancerSpec":             llx.StringDataPtr(lb.LoadBalancerSpec),
+		"payType":                      llx.StringDataPtr(lb.PayType),
+		"bandwidth":                    llx.IntDataPtr(lb.Bandwidth),
+		"createTime":                   llx.TimeDataPtr(slbParseTime(lb.CreateTime)),
+		"deleteProtection":             llx.StringDataPtr(lb.DeleteProtection),
+		"modificationProtectionStatus": llx.StringDataPtr(lb.ModificationProtectionStatus),
+		"modificationProtectionReason": llx.StringDataPtr(lb.ModificationProtectionReason),
+		"resourceGroupId":              llx.StringDataPtr(lb.ResourceGroupId),
+		"tags":                         llx.MapData(slbLoadBalancerTags(lb.Tags), types.String),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlLb := resource.(*mqlAlicloudSlbLoadBalancer)
+	mqlLb.region = region
+	mqlLb.cacheRegion = region
+	mqlLb.cacheVpcID = tea.StringValue(lb.VpcId)
+	mqlLb.cacheVswitchID = tea.StringValue(lb.VSwitchId)
+	return mqlLb, nil
+}
+
+// initAlicloudSlbLoadBalancer resolves a CLB instance by its native load
+// balancer id within a region, reusing an already-listed instance from the
+// resource cache. It also backs the discovered slb asset, which scopes the
+// connection to one load balancer.
+func initAlicloudSlbLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	// on a discovered CLB asset, resolve the load balancer the asset is scoped to
+	args = scopedInitArgs(runtime, args, connection.OptionSlbID, "loadBalancerId")
+
+	lbID, err := requiredStringArg(args, "loadBalancerId", "alicloud.slb.loadBalancer")
+	if err != nil {
+		return nil, nil, err
+	}
+	region, err := requiredStringArg(args, "regionId", "alicloud.slb.loadBalancer")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if x, ok := runtime.Resources.Get("alicloud.slb.loadBalancer\x00" + lbID); ok {
+		return nil, x, nil
+	}
+
+	conn := runtime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.SlbClient(region)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.DescribeLoadBalancers(&slbclient.DescribeLoadBalancersRequest{
+		RegionId:       tea.String(region),
+		LoadBalancerId: tea.String(lbID),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp != nil && resp.Body != nil && resp.Body.LoadBalancers != nil {
+		for _, lb := range resp.Body.LoadBalancers.LoadBalancer {
+			if lb == nil || tea.StringValue(lb.LoadBalancerId) != lbID {
+				continue
+			}
+			res, err := newSlbLoadBalancer(runtime, region, lb)
+			if err != nil {
+				return nil, nil, err
+			}
+			return nil, res, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("alicloud.slb.loadBalancer %q not found in region %q", lbID, region)
 }
 
 func (r *mqlAlicloudSlbLoadBalancer) id() (string, error) {


### PR DESCRIPTION
Fine-grained discovery covered ACK, ALB, NLB, VPC, OSS, RDS, WAF and Cloud Firewall. This adds the five services that were listed by MQL but never became scannable assets of their own.

```bash
cnspec scan alicloud --discover slbs,redis-instances,mongodb-instances
cnspec scan alicloud --discover polardb-clusters,fc-functions
```

| Target | Assets |
|---|---|
| `slbs` | Classic Load Balancers |
| `redis-instances` | ApsaraDB for Redis instances |
| `mongodb-instances` | ApsaraDB for MongoDB instances |
| `polardb-clusters` | PolarDB clusters |
| `fc-functions` | Function Compute functions |

All five are also added to the `auto` / `all` expansion.

### Scoped resolution

A discovered child asset pins the object id into the connection scope, so the singular resource has to resolve itself from that scope when it is queried bare on the child asset. Four of the five had no by-id init at all, so this extracts the resource builder out of each lister (`newSlbLoadBalancer`, `newRedisInstance`, `newMongodbInstance`, `newPolardbCluster`) and adds an init that shares it. A side effect worth having: a resource reached by id is now fully populated rather than a husk, matching what the lister produces.

`alicloud.fc.function` already had an init and a shared builder; it only needed the scope wiring.

### Filters

The five listers now consult `conn.Filters`. A discovery target that ignores `--filters` accepts `--filters tag:Environment=production` and silently scans everything. The check lives in the lister rather than in `discovery.go` so a scan and a plain MQL query see the same set — that is the existing convention here, and it is what keeps the two paths consistent.

All five return tags inline in their list response, so the check costs nothing beyond the listing already made. (OSS and RDS gate the lookup on `HasTags()` because their tags cost a separate call; these don't need to.)

### Function Compute identity

Function names are unique within a region, not across the account, so `NewFcFunctionIdentifier` keys on region **and** name. Keying on the name alone would collapse two functions named `handler` in different regions into a single asset. There is a test pinning that. The other four keep their native id as the platform id, matching the existing RDS and ALB targets.

### Tests

`platform_test.go` now covers every constructor and identifier in the catalog, including the ones that predated this change (`oss-bucket`, `rds-instance`) which had entries but no assertions. `discovery_test.go` covers the widened `auto`/`all` expansion.

Not live-verified — no alicloud credentials available.
