### PR TITLE
🐛 oci: list 33 more resource types from every compartment, not just the root

### DIFF
--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -27,7 +27,7 @@ func (o *mqlOciApigateway) id() (string, error) {
 func (o *mqlOciApigateway) gateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci api gateways with region %s", region)
 
@@ -226,7 +226,7 @@ func (o *mqlOciApigatewayGateway) hasResponseCache() (bool, error) {
 func (o *mqlOciApigateway) deployments() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci api gateway deployments with region %s", region)
 
@@ -596,7 +596,7 @@ func (o *mqlOciApigatewayDeployment) hasDynamicAuthentication() (bool, error) {
 func (o *mqlOciApigateway) certificates() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci api gateway certificates with region %s", region)
 

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -23,7 +23,7 @@ func (o *mqlOciBastion) id() (string, error) {
 func (o *mqlOciBastion) bastions() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci bastion with region %s", region)
 

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -205,7 +205,7 @@ func initOciCertificatesCertificateAuthority(runtime *plugin.Runtime, args map[s
 func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci certificate authorities with region %s", region)
 
@@ -358,7 +358,7 @@ func initOciCertificatesCaBundle(runtime *plugin.Runtime, args map[string]*llx.R
 func (o *mqlOciCertificates) caBundles() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci CA bundles with region %s", region)
 

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -66,7 +66,7 @@ func (o *mqlOciContainerInstances) id() (string, error) {
 func (o *mqlOciContainerInstances) instances() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci container instances with region %s", region)
 

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -26,7 +26,7 @@ func (o *mqlOciDatabase) id() (string, error) {
 func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci DB systems with region %s", region)
 
@@ -140,7 +140,7 @@ func (o *mqlOciDatabaseDbSystem) subnet() (*mqlOciNetworkSubnet, error) {
 func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci autonomous databases with region %s", region)
 
@@ -298,7 +298,7 @@ func (o *mqlOciDatabaseAutonomousDatabase) subnet() (*mqlOciNetworkSubnet, error
 func (o *mqlOciDatabase) backups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci database backups with region %s", region)
 
@@ -416,7 +416,7 @@ func (o *mqlOciDatabaseBackup) kmsVault() (*mqlOciKmsVault, error) {
 func (o *mqlOciDatabase) autonomousDatabaseBackups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci autonomous database backups with region %s", region)
 

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -23,7 +23,7 @@ func (o *mqlOciFunctions) id() (string, error) {
 func (o *mqlOciFunctions) applications() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci functions with region %s", region)
 

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -30,7 +30,7 @@ func (o *mqlOciAiAgents) id() (string, error) {
 func (o *mqlOciAiAgents) agents() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci generative ai agents with region %s", region)
 
@@ -127,7 +127,7 @@ func (o *mqlOciAiAgentsAgent) compartment() (*mqlOciCompartment, error) {
 func (o *mqlOciAiAgents) agentEndpoints() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
@@ -248,7 +248,7 @@ func (o *mqlOciAiAgentsEndpoint) agent() (*mqlOciAiAgentsAgent, error) {
 func (o *mqlOciAiAgents) knowledgeBases() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
@@ -335,7 +335,7 @@ func (o *mqlOciAiAgentsKnowledgeBase) compartment() (*mqlOciCompartment, error) 
 func (o *mqlOciAiAgents) dataSources() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {
@@ -443,7 +443,7 @@ func (o *mqlOciAiAgentsDataSource) knowledgeBase() (*mqlOciAiAgentsKnowledgeBase
 func (o *mqlOciAiAgents) tools() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			svc, err := conn.GenerativeAiAgentClient(region)
 			if err != nil {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -933,7 +933,7 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci internet gateways with region %s", region)
 
@@ -1014,7 +1014,7 @@ func (o *mqlOciNetworkInternetGateway) vcn() (*mqlOciNetworkVcn, error) {
 func (o *mqlOciNetwork) natGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci NAT gateways with region %s", region)
 
@@ -1257,7 +1257,7 @@ func (o *mqlOciNetworkSubnet) routeTable() (*mqlOciNetworkRouteTable, error) {
 func (o *mqlOciNetwork) publicIps() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci public ips with region %s", region)
 

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -24,7 +24,7 @@ func (o *mqlOciNetworkFirewall) id() (string, error) {
 func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci network firewall with region %s", region)
 
@@ -145,7 +145,7 @@ func (o *mqlOciNetworkFirewallFirewall) policy() (*mqlOciNetworkFirewallPolicy, 
 func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci network firewall policies with region %s", region)
 

--- a/providers/oci/resources/ociscope.go
+++ b/providers/oci/resources/ociscope.go
@@ -36,8 +36,23 @@ const (
 	//
 	// This is what the older listers did implicitly. It is correct for a
 	// genuinely tenancy-wide API, and wrong for anything a customer can place in
-	// a child compartment - which is most things. Sites carrying this scope are
-	// the migration list.
+	// a child compartment - which is most things.
+	//
+	// The bulk migration is done. What still carries this scope is one of three
+	// things, and only the last is a defect:
+	//
+	//   - the request sets a compartmentIdInSubtree flag itself, so one call
+	//     from the root already covers the tree (Cloud Guard, Data Safe,
+	//     Logging, Monitoring);
+	//   - the service really is tenancy-scoped (Zero Trust Packet Routing);
+	//   - the lister ignores the compartment it is handed and asks about
+	//     conn.TenantID() instead. Those cannot simply be re-scoped: under the
+	//     compartment scope they would ask the root once per compartment and,
+	//     since ociJoinCompartmentJobs concatenates without deduplicating,
+	//     return the root's resources N times while still never reading a child
+	//     compartment. Fixing one means threading the compartmentID argument
+	//     through first. TestCompartmentScopedListersUseTheirCompartment fails
+	//     the build if one is re-scoped without that.
 	ociScopeTenancyRoot ociScope = iota
 
 	// ociScopeAllCompartments walks the tenancy root plus every active

--- a/providers/oci/resources/ociscope_guard_test.go
+++ b/providers/oci/resources/ociscope_guard_test.go
@@ -1,0 +1,108 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A lister fanned out over every compartment must ask each one about itself.
+//
+// ociCollect hands its lister the compartment to query. A lister that ignores
+// that argument and passes conn.TenantID() instead asks the root the same
+// question once per compartment, and ociJoinCompartmentJobs concatenates the
+// answers without deduplicating - so the root's resources are returned N times
+// while every child compartment is still never looked at. That is strictly
+// worse than the root-only scope it replaced, and nothing about it fails: it
+// compiles, it returns data, and the data looks plausible.
+//
+// The compiler cannot see this because the argument is simply unused, which Go
+// permits for function parameters. So it is checked here, by parsing the
+// package and walking the lambda passed to each ociCollect call.
+//
+// Sites that are still deliberately root-scoped are not covered, and do not
+// need to be: asking the root about the root is what they mean. This test is
+// what stops one of them being flipped to the compartment scope without the
+// hardcoded tenancy id being removed at the same time.
+func TestCompartmentScopedListersUseTheirCompartment(t *testing.T) {
+	fset := gotoken.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+
+	var checked int
+	for _, pkg := range pkgs {
+		for name, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				ident, ok := call.Fun.(*ast.Ident)
+				if !ok || ident.Name != "ociCollect" || len(call.Args) < 3 {
+					return true
+				}
+				scope, ok := call.Args[1].(*ast.Ident)
+				if !ok || scope.Name != "ociScopeAllCompartments" {
+					return true
+				}
+				lambda, ok := call.Args[2].(*ast.FuncLit)
+				if !ok {
+					return true
+				}
+
+				checked++
+				pos := fset.Position(call.Pos())
+				where := filepath.Base(name) + ":" + strconv.Itoa(pos.Line)
+
+				if callsTenantID(lambda.Body) {
+					t.Errorf("%s: this lister runs under ociScopeAllCompartments but calls "+
+						"conn.TenantID() in its body. It will ask the tenancy root once per "+
+						"compartment and return the root's resources N times, while every child "+
+						"compartment goes unread. Use the compartmentID argument ociCollect "+
+						"passes in.", where)
+				}
+				return true
+			})
+		}
+	}
+
+	// A filter that matched nothing would let this test pass while checking
+	// nothing at all, which is the failure mode the guard itself is guarding
+	// against.
+	require.Greater(t, checked, 20,
+		"expected to find the compartment-scoped listers; the AST match is probably broken")
+	t.Logf("checked %d compartment-scoped listers", checked)
+}
+
+// callsTenantID reports whether the body contains a call to TenantID().
+func callsTenantID(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name == "TenantID" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -25,7 +25,7 @@ func (o *mqlOciOke) id() (string, error) {
 func (o *mqlOciOke) clusters() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci oke with region %s", region)
 

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -24,7 +24,7 @@ func (o *mqlOciRedis) id() (string, error) {
 func (o *mqlOciRedis) clusters() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci redis cluster with region %s", region)
 

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -26,7 +26,7 @@ type mqlOciNetworkDrgInternal struct {
 
 func (o *mqlOciNetwork) drgs() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			regionKey := region
 			log.Debug().Msgf("calling oci DRGs with region %s", regionKey)
@@ -388,7 +388,7 @@ type mqlOciNetworkLocalPeeringGatewayInternal struct {
 
 func (o *mqlOciNetwork) localPeeringGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			regionKey := region
 			log.Debug().Msgf("calling oci local peering gateways with region %s", regionKey)
@@ -537,7 +537,7 @@ type mqlOciNetworkServiceGatewayInternal struct {
 
 func (o *mqlOciNetwork) serviceGateways() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			regionKey := region
 			log.Debug().Msgf("calling oci service gateways with region %s", regionKey)

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -22,7 +22,7 @@ import (
 
 func (o *mqlOciNetwork) cpes() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			regionKey := region
 			log.Debug().Msgf("calling oci CPEs with region %s", regionKey)
@@ -122,7 +122,7 @@ type mqlOciNetworkIpsecConnectionInternal struct {
 
 func (o *mqlOciNetwork) ipsecConnections() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			regionKey := region
 			log.Debug().Msgf("calling oci IPSec connections with region %s", regionKey)
@@ -621,7 +621,7 @@ type crossConnectMapping struct {
 
 func (o *mqlOciNetwork) virtualCircuits() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			regionKey := region
 			log.Debug().Msgf("calling oci virtual circuits with region %s", regionKey)
@@ -758,7 +758,7 @@ func (o *mqlOciNetworkVirtualCircuit) drg() (*mqlOciNetworkDrg, error) {
 
 func (o *mqlOciNetwork) crossConnects() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			regionKey := region
 			log.Debug().Msgf("calling oci cross-connects with region %s", regionKey)

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -24,7 +24,7 @@ func (o *mqlOciWaf) id() (string, error) {
 func (o *mqlOciWaf) firewalls() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci WAF firewalls with region %s", region)
 
@@ -128,7 +128,7 @@ func (o *mqlOciWafFirewall) loadBalancer() (*mqlOciLoadBalancerLoadBalancer, err
 func (o *mqlOciWaf) policies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	return ociCollect(o.MqlRuntime, ociScopeTenancyRoot,
+	return ociCollect(o.MqlRuntime, ociScopeAllCompartments,
 		func(ctx context.Context, region string, compartmentID string) ([]any, error) {
 			log.Debug().Msgf("calling oci WAF policies with region %s", region)
 


### PR DESCRIPTION
Closes **F1** from the OCI coverage audit — the largest correctness gap left in the provider — for 33 of the 41 affected listers. The other 8 are addressed below: 3 are correct as they are, and 5 are deliberately deferred with a build-time guard added to stop them being "fixed" the wrong way.

## The bug

Most OCI list APIs answer for exactly one compartment and offer no `compartmentIdInSubtree` flag. A lister scoped to the tenancy root therefore sees only what sits *directly* in the root — and a tenancy that organises resources into child compartments, which is the normal way to run OCI, got an **empty list**. An empty list reads as a passing audit rather than as a scan that never looked.

## What moved (33)

| Area | Resources |
|---|---|
| API Gateway | gateways, deployments, certificates |
| Security | bastions, certificate authorities, CA bundles, network firewalls + policies, WAFs + policies |
| Compute/containers | container instances |
| Database | DB systems, autonomous databases, backups, autonomous DB backups |
| Serverless / AI | function applications, the 5 generative AI agent resources |
| Network | internet gateways, NAT gateways, public IPs |
| Connectivity | DRGs, local peering gateways, service gateways, CPEs, IPSec connections, virtual circuits, cross connects |
| Platform | OKE clusters, Redis clusters |

## What deliberately stayed on the root (8)

**Correct as-is (3)** — these already cover the tree:
- `logging.logGroups` sets `IsCompartmentIdInSubtree`
- `monitoring.alarms` sets `CompartmentIdInSubtree`
- `zpr.policies` — Zero Trust Packet Routing is genuinely tenancy-scoped

I checked all 41 request types against the SDK; **only** logging and monitoring have a subtree option at all.

**Deferred (5)** — `compute.images`, `compute.blockVolumes`, `compute.bootVolumes`, `events.rules`, `filestorage.fileSystems`.

These ignore the compartment `ociCollect` hands them and pass `conn.TenantID()` instead. **Re-scoping them without fixing that would be worse than leaving them alone:** they'd ask the root once per compartment and, since `ociJoinCompartmentJobs` concatenates without deduplicating (`ociDedupeByID` is only wired into `dns.go`), return the root's resources N times while *still* never reading a child compartment.

`compute.images` needs one thing more: `ListImages` returns the Oracle platform image catalogue from every compartment, so fanning out would multiply ~100 platform images by the compartment count. That one needs `ociDedupeByID` on the result.

These want their own change with real review attention, not a rushed rider on a mechanical one.

## The guard test

The compiler can't catch the deferred bug — an unused function parameter is legal Go — so `TestCompartmentScopedListersUseTheirCompartment` parses the package and walks the lambda passed to each `ociCollect` call, failing if one running under `ociScopeAllCompartments` calls `TenantID()`.

It covers **60** listers (27 pre-existing + the 33 here) and refuses to pass if the AST match finds fewer than 20, so it can't silently degrade into checking nothing. Confirmed it actually fires by re-scoping `events.go` and watching it fail with the file, line and an explanation — then reverted.

The five deferred sites stay root-scoped, so they sit outside the guard's scope today. That's the point: the guard is what will stop them being flipped later without the fix.

## Risk

This changes what 33 already-shipped resources return, which is why it was deferred originally. Two things have changed since: `ociScopeAllCompartments` and its error policy are now well-established (a per-compartment 403 is tolerated and counted, all-denied is an error), and `--filters compartments=` shipped in #9957 as the escape hatch for request volume on large tenancies.

## Testing

`go build`, `go vet`, `gofmt -l` and the full suite are green. No schema changes, so no codegen.

**Not verified against a real multi-compartment tenancy.** The verification tenancy is Always-Free with a single region, and several of these services can't be provisioned there at all. Specifically unproven: that a child-compartment resource now actually appears, the `ListImages` duplication claim above (documented OCI behaviour, not something I could confirm from the SDK source), and the request-volume impact at scale. Stating that rather than implying coverage this doesn't have.
