### PR TITLE
🐛 oci: list ephemeral public IPs, which were silently missing

### DIFF
--- a/providers/oci/resources/availabilitydomains_test.go
+++ b/providers/oci/resources/availabilitydomains_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The availability-domain cache exists so a lister running inside the
+// compartment fan-out does not pay one Identity call per compartment for an
+// answer that is the same in all of them. What makes that work is that every
+// caller for a region shares one fetch guard, so these tests are about the map
+// wiring rather than about ociRetryLazy, whose own semantics are covered in
+// ocilazy_test.go.
+
+func TestOciAvailabilityDomainEntryIsSharedPerKey(t *testing.T) {
+	t.Cleanup(resetOciAvailabilityDomainCache)
+	resetOciAvailabilityDomainCache()
+
+	first := ociAvailabilityDomainEntry("1/us-sanjose-1")
+	second := ociAvailabilityDomainEntry("1/us-sanjose-1")
+
+	// Same pointer, so the second caller waits on the first caller's fetch
+	// instead of making its own.
+	assert.Same(t, first, second)
+}
+
+func TestOciAvailabilityDomainEntryIsPerRegionAndConnection(t *testing.T) {
+	t.Cleanup(resetOciAvailabilityDomainCache)
+	resetOciAvailabilityDomainCache()
+
+	sanjose := ociAvailabilityDomainEntry("1/us-sanjose-1")
+	ashburn := ociAvailabilityDomainEntry("1/us-ashburn-1")
+	otherConn := ociAvailabilityDomainEntry("2/us-sanjose-1")
+
+	// A tenancy's domains differ between regions, so regions must not share an
+	// entry - and two connections may be different tenancies entirely.
+	assert.NotSame(t, sanjose, ashburn)
+	assert.NotSame(t, sanjose, otherConn)
+}
+
+func TestOciAvailabilityDomainsFetchesOncePerKey(t *testing.T) {
+	t.Cleanup(resetOciAvailabilityDomainCache)
+	resetOciAvailabilityDomainCache()
+
+	var calls atomic.Int32
+	fetch := func() ([]string, error) {
+		calls.Add(1)
+		return []string{"cIew:US-SANJOSE-1-AD-1"}, nil
+	}
+
+	// Concurrent callers for one region, as the compartment fan-out produces.
+	// Exactly one may reach the API; the rest must observe its result.
+	const concurrency = 24
+	var wg sync.WaitGroup
+	results := make([][]string, concurrency)
+	for i := range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := ociAvailabilityDomainEntry("1/us-sanjose-1").get(fetch)
+			assert.NoError(t, err)
+			results[i] = got
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load(),
+		"the fan-out must cost one Identity call per region, not one per compartment")
+	for i := range results {
+		require.Equal(t, []string{"cIew:US-SANJOSE-1-AD-1"}, results[i])
+	}
+}
+
+func TestOciAvailabilityDomainsDoesNotCacheFailure(t *testing.T) {
+	t.Cleanup(resetOciAvailabilityDomainCache)
+	resetOciAvailabilityDomainCache()
+
+	entry := ociAvailabilityDomainEntry("1/us-sanjose-1")
+
+	_, err := entry.get(func() ([]string, error) {
+		return nil, assert.AnError
+	})
+	require.Error(t, err)
+
+	// A throttled or transient Identity failure must not empty the region for
+	// the rest of the scan - the next caller retries.
+	got, err := entry.get(func() ([]string, error) {
+		return []string{"cIew:US-SANJOSE-1-AD-1"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cIew:US-SANJOSE-1-AD-1"}, got)
+}
+
+func resetOciAvailabilityDomainCache() {
+	ociAvailabilityDomainCacheMu.Lock()
+	defer ociAvailabilityDomainCacheMu.Unlock()
+	ociAvailabilityDomainCache = map[string]*ociRetryLazy[[]string]{}
+}

--- a/providers/oci/resources/conversion.go
+++ b/providers/oci/resources/conversion.go
@@ -6,12 +6,16 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identity"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
+	"go.mondoo.com/mql/v13/providers/oci/connection"
 )
 
 func stringValue(s *string) string {
@@ -224,4 +228,55 @@ func ociRegionServiceUnavailable(err error) bool {
 // to be one.
 func ociRunRegionPool(jobs []*jobpool.Job) ([]any, error) {
 	return ociJoinRegionJobs(jobs, ociScopeTenancyRoot.concurrency())
+}
+
+// ociAvailabilityDomainCache memoizes a region's availability domains.
+//
+// Some OCI APIs are scoped to an availability domain rather than a region, so a
+// lister has to ask which domains exist before it can ask its real question.
+// That answer is the same for every compartment and does not change during a
+// scan, while the listers needing it run inside a compartment fan-out - so
+// without this, one collection costs an Identity call per compartment. Keyed by
+// connection and region because a tenancy's domains differ between regions.
+var (
+	ociAvailabilityDomainCache   = map[string][]string{}
+	ociAvailabilityDomainCacheMu sync.Mutex
+)
+
+// ociAvailabilityDomains returns the names of the availability domains in a
+// region.
+//
+// compartmentID is passed through to the Identity call, which accepts any
+// compartment in the tenancy and answers the same either way; it is not part of
+// the cache key for that reason. A failure is not cached, so a throttled call
+// is retried by the next caller rather than emptying the region for the rest of
+// the scan.
+func ociAvailabilityDomains(ctx context.Context, conn *connection.OciConnection, region, compartmentID string) ([]string, error) {
+	key := fmt.Sprintf("%d/%s", conn.ID(), region)
+
+	ociAvailabilityDomainCacheMu.Lock()
+	defer ociAvailabilityDomainCacheMu.Unlock()
+	if cached, ok := ociAvailabilityDomainCache[key]; ok {
+		return cached, nil
+	}
+
+	client, err := conn.IdentityClientWithRegion(region)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ListAvailabilityDomains(ctx, identity.ListAvailabilityDomainsRequest{
+		CompartmentId: common.String(compartmentID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(resp.Items))
+	for i := range resp.Items {
+		if name := stringValue(resp.Items[i].Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	ociAvailabilityDomainCache[key] = names
+	return names, nil
 }

--- a/providers/oci/resources/conversion.go
+++ b/providers/oci/resources/conversion.go
@@ -238,45 +238,62 @@ func ociRunRegionPool(jobs []*jobpool.Job) ([]any, error) {
 // scan, while the listers needing it run inside a compartment fan-out - so
 // without this, one collection costs an Identity call per compartment. Keyed by
 // connection and region because a tenancy's domains differ between regions.
+// The mutex guards the map only. The fetch itself is serialized by the
+// per-region ociRetryLazy, so a cold cache blocks the callers asking about that
+// one region rather than every caller in the scan - and other regions keep
+// resolving in parallel.
 var (
-	ociAvailabilityDomainCache   = map[string][]string{}
+	ociAvailabilityDomainCache   = map[string]*ociRetryLazy[[]string]{}
 	ociAvailabilityDomainCacheMu sync.Mutex
 )
+
+// ociAvailabilityDomainEntry returns the fetch guard for one cache key,
+// creating it on first use.
+//
+// Separated from the fetch so the lock covers the map access and nothing else.
+// Holding it across the API call would serialize every region in the scan
+// behind whichever one happened to ask first.
+func ociAvailabilityDomainEntry(key string) *ociRetryLazy[[]string] {
+	ociAvailabilityDomainCacheMu.Lock()
+	defer ociAvailabilityDomainCacheMu.Unlock()
+
+	entry, ok := ociAvailabilityDomainCache[key]
+	if !ok {
+		entry = &ociRetryLazy[[]string]{}
+		ociAvailabilityDomainCache[key] = entry
+	}
+	return entry
+}
 
 // ociAvailabilityDomains returns the names of the availability domains in a
 // region.
 //
 // compartmentID is passed through to the Identity call, which accepts any
 // compartment in the tenancy and answers the same either way; it is not part of
-// the cache key for that reason. A failure is not cached, so a throttled call
-// is retried by the next caller rather than emptying the region for the rest of
-// the scan.
+// the cache key for that reason. A failure is not cached - that is
+// ociRetryLazy's policy - so a throttled call is retried by the next caller
+// rather than emptying the region for the rest of the scan.
 func ociAvailabilityDomains(ctx context.Context, conn *connection.OciConnection, region, compartmentID string) ([]string, error) {
-	key := fmt.Sprintf("%d/%s", conn.ID(), region)
+	entry := ociAvailabilityDomainEntry(fmt.Sprintf("%d/%s", conn.ID(), region))
 
-	ociAvailabilityDomainCacheMu.Lock()
-	defer ociAvailabilityDomainCacheMu.Unlock()
-	if cached, ok := ociAvailabilityDomainCache[key]; ok {
-		return cached, nil
-	}
-
-	client, err := conn.IdentityClientWithRegion(region)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.ListAvailabilityDomains(ctx, identity.ListAvailabilityDomainsRequest{
-		CompartmentId: common.String(compartmentID),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	names := make([]string, 0, len(resp.Items))
-	for i := range resp.Items {
-		if name := stringValue(resp.Items[i].Name); name != "" {
-			names = append(names, name)
+	return entry.get(func() ([]string, error) {
+		client, err := conn.IdentityClientWithRegion(region)
+		if err != nil {
+			return nil, err
 		}
-	}
-	ociAvailabilityDomainCache[key] = names
-	return names, nil
+		resp, err := client.ListAvailabilityDomains(ctx, identity.ListAvailabilityDomainsRequest{
+			CompartmentId: common.String(compartmentID),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		names := make([]string, 0, len(resp.Items))
+		for i := range resp.Items {
+			if name := stringValue(resp.Items[i].Name); name != "" {
+				names = append(names, name)
+			}
+		}
+		return names, nil
+	})
 }

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -1266,21 +1266,46 @@ func (o *mqlOciNetwork) publicIps() ([]any, error) {
 				return nil, err
 			}
 
-			// Region-scoped listing covers reserved public IPs (which persist
-			// unattached) and the ephemeral public IPs held by regional
-			// entities such as NAT gateways. The OCI API requires a separate
-			// call per lifetime at REGION scope.
-			publicIps := []core.PublicIp{}
-			for _, lifetime := range []core.ListPublicIpsLifetimeEnum{
-				core.ListPublicIpsLifetimeReserved,
-				core.ListPublicIpsLifetimeEphemeral,
-			} {
-				perLifetime, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.PublicIp, *string, error) {
+			// The two lifetimes live at different scopes, and asking at the
+			// wrong one returns nothing rather than an error.
+			//
+			// Reserved public IPs are regional: they persist unattached, so
+			// they answer at REGION scope. Ephemeral public IPs belong to the
+			// availability domain of the resource holding them - which is
+			// every public IP OCI assigns to an instance by default - and
+			// ListPublicIps only returns those when it is given
+			// AVAILABILITY_DOMAIN scope together with the domain to look in.
+			// Asking for EPHEMERAL at REGION scope, as this did, is accepted
+			// and returns an empty list, so instance public IPs were silently
+			// absent from the collection while reserved ones looked fine.
+			publicIps, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.PublicIp, *string, error) {
+				response, err := svc.ListPublicIps(ctx, core.ListPublicIpsRequest{
+					Scope:         core.ListPublicIpsScopeRegion,
+					CompartmentId: common.String(compartmentID),
+					Lifetime:      core.ListPublicIpsLifetimeReserved,
+					Page:          page,
+				})
+				if err != nil {
+					return nil, nil, err
+				}
+				return response.Items, response.OpcNextPage, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			availabilityDomains, err := ociAvailabilityDomains(ctx, conn, region, compartmentID)
+			if err != nil {
+				return nil, err
+			}
+			for _, availabilityDomain := range availabilityDomains {
+				perDomain, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.PublicIp, *string, error) {
 					response, err := svc.ListPublicIps(ctx, core.ListPublicIpsRequest{
-						Scope:         core.ListPublicIpsScopeRegion,
-						CompartmentId: common.String(compartmentID),
-						Lifetime:      lifetime,
-						Page:          page,
+						Scope:              core.ListPublicIpsScopeAvailabilityDomain,
+						AvailabilityDomain: common.String(availabilityDomain),
+						CompartmentId:      common.String(compartmentID),
+						Lifetime:           core.ListPublicIpsLifetimeEphemeral,
+						Page:               page,
 					})
 					if err != nil {
 						return nil, nil, err
@@ -1290,7 +1315,7 @@ func (o *mqlOciNetwork) publicIps() ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
-				publicIps = append(publicIps, perLifetime...)
+				publicIps = append(publicIps, perDomain...)
 			}
 
 			var res []any

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -1294,9 +1295,27 @@ func (o *mqlOciNetwork) publicIps() ([]any, error) {
 				return nil, err
 			}
 
+			// A failure here fails the collection rather than returning the
+			// reserved IPs alone.
+			//
+			// Continuing would produce a list that is short by exactly the
+			// ephemeral addresses - which is the bug this call was added to
+			// fix, reintroduced with a warning in place of an error. Nothing
+			// downstream can tell a tenancy whose instances have no public IPs
+			// from one whose availability domains could not be listed, and an
+			// authoritative-looking short list is worse than a failure in an
+			// inventory tool; see ociRegionServiceUnavailable, which draws the
+			// same line for throttles and IAM gaps.
+			//
+			// The blast radius is one (region, compartment) job: the join
+			// tolerates a per-compartment denial, and ociRetryLazy does not
+			// cache the failure, so a throttle is retried rather than being
+			// sticky for the rest of the scan.
 			availabilityDomains, err := ociAvailabilityDomains(ctx, conn, region, compartmentID)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf(
+					"oci.network.publicIps: cannot list availability domains in %s, so ephemeral public IPs "+
+						"cannot be read and the result would omit them: %w", region, err)
 			}
 			for _, availabilityDomain := range availabilityDomains {
 				perDomain, err := ociPaginate(ctx, func(ctx context.Context, page *string) ([]core.PublicIp, *string, error) {


### PR DESCRIPTION
Found during live verification of #9957 and #9959 against a real OCI tenancy. **Pre-existing bug**, not introduced by either of those PRs.

## The bug

`oci.network.publicIps` asked for both public IP lifetimes at `REGION` scope:

```go
for _, lifetime := range []core.ListPublicIpsLifetimeEnum{
    core.ListPublicIpsLifetimeReserved,
    core.ListPublicIpsLifetimeEphemeral,
} {
    svc.ListPublicIps(ctx, core.ListPublicIpsRequest{
        Scope: core.ListPublicIpsScopeRegion,   // <- wrong for EPHEMERAL
        ...
```

Reserved public IPs answer at region scope. **Ephemeral ones do not** — they belong to the availability domain of the resource holding them, and `ListPublicIps` only returns them when given `AVAILABILITY_DOMAIN` scope *together with* the domain to look in.

Asking for `EPHEMERAL` at `REGION` scope is **not an error**. The API accepts it and returns an empty list. So the collection looked healthy while omitting every public IP that OCI assigns to an instance by default — which is most of the public IPs in a typical tenancy, and precisely the ones that make an instance reachable from the internet.

## How it surfaced

A verification instance with public IP `64.181.230.26`:

```console
$ mql run oci -c 'oci.network.publicIps { ipAddress lifetime }'
oci.network.publicIps: []                                  # ← the bug

$ oci network public-ip list --scope AVAILABILITY_DOMAIN \
    --availability-domain "cIew:US-SANJOSE-1-AD-1" --lifetime EPHEMERAL
      "ip-address": "64.181.230.26",
      "lifetime": "EPHEMERAL",
```

The same instance reported `exposure.hasPublicIp: true` and `exposure.internetReachable: true`, so the provider clearly *knew* about the address through the VNIC — it just wasn't in the public IP collection.

## The fix

Reserved IPs keep their single region-scoped call. Ephemeral IPs get one call per availability domain in the region.

The domains come from a new `ociAvailabilityDomains` helper in `conversion.go`, memoized per connection and region. That matters: this lister runs inside the compartment fan-out, so without memoization a single collection would cost one Identity call per compartment for an answer that is identical across all of them. A failure is deliberately not cached, so a throttled call is retried by the next caller rather than emptying the region for the rest of the scan.

`filestorage.go` open-codes the same availability-domain lookup and could move onto this helper later; left alone here to keep the fix to one behaviour.

## Testing

`go build`, `go vet`, `gofmt -l` and the full suite are green.

**Verified live** against a real tenancy — the query returned the instance's ephemeral IP after the change and an empty list before it. That before/after against real infrastructure is the actual proof here; there is no new pure Go logic worth a unit test (the helper is one SDK call plus a cache), so I did not add one rather than write a test that asserts nothing.
