### PR TITLE
🎉 oci-13.19.0

### DIFF
--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.18.1",
+	Version:         "13.19.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Releases the OCI provider as **13.19.0**. Single-line change to `providers/oci/config/config.go`.

Minor rather than patch because #9957 grew the resource surface — new resources and new fields, no breaking changes.

## What's in it

| PR | |
|---|---|
| ✨ #9957 | Zero Trust Packet Routing, discovery filters, network firewall policy lists |
| 🐛 #9959 | 33 more resource types listed from every compartment, not just the tenancy root |
| 🐛 #9961 | ephemeral public IPs, which were silently missing |
| ⚡ #9838 | compartment references resolved from the cached tenancy tree |

**New resources:** `oci.zpr.policy`, `oci.zpr.configuration`, `oci.securityAttributes.{namespace,attribute,applied}`, and nine `oci.networkFirewall.policy` sub-resources (address lists, URL lists, services, service lists, applications, application groups, mapped secrets, NAT rules, tunnel inspection rules).

**New CLI surface:** `--filters` with `regions`, `compartments`, `tag:` and their `exclude:` forms.

**Behaviour changes worth calling out for release notes:**

- 33 listers now walk the compartment tree instead of the tenancy root, so a tenancy that organises resources into child compartments will start seeing results where it previously got empty lists. Region and compartment filters also narrow plain MQL queries, not just discovery.
- `oci.network.exposure` gains `zprEnforced`, `securityAttributes` and `zprPolicies()`. `internetReachable` keeps its existing meaning — nothing shipped changed semantics.

## Verification

The three code PRs were verified against a live OCI tenancy before this bump: child-compartment listing proven with a before/after (root-scoped → `[]`, all-compartments → both resources), the full filter matrix exercised, and the ephemeral public IP bug reproduced and confirmed fixed. Infrastructure was torn down afterwards.

Not verified live, for tenancy-entitlement reasons rather than code ones: the ZPR/security-attribute *data* paths (service returns 404 — not enabled) and the network firewall lists (`premium-nfw-max-count = 0`). The ZPR *absent* path — which is what most tenancies hit — is verified.

## Note on `.lr.versions`

Entries added by #9957 are marked `13.18.2`, the next patch after the then-current 13.18.1. Since this releases 13.19.0 instead, those markers name a version that never shipped. Harmless — any 13.19.0 build has the fields, and the convention is that entries are never rewritten — but flagging it rather than leaving it to be noticed later.
