### PR TITLE
🐛 alicloud: let OSS use the same credential as every other service

### DIFF
--- a/providers/alicloud/connection/clients.go
+++ b/providers/alicloud/connection/clients.go
@@ -4,6 +4,7 @@
 package connection
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -34,10 +35,12 @@ import (
 	slbclient "github.com/alibabacloud-go/slb-20140515/v4/client"
 	slsclient "github.com/alibabacloud-go/sls-20201230/v6/client"
 	stsclient "github.com/alibabacloud-go/sts-20150401/v2/client"
+	tea "github.com/alibabacloud-go/tea/tea"
 	vpcclient "github.com/alibabacloud-go/vpc-20160428/v7/client"
 	wafclient "github.com/alibabacloud-go/waf-openapi-20211001/v7/client"
 	oss "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
 	osscred "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss/credentials"
+	credential "github.com/aliyun/credentials-go/credentials"
 )
 
 // endpoint builds the public Alibaba Cloud service endpoint for a region. A few
@@ -256,21 +259,46 @@ func (c *AlicloudConnection) PolarDBClient(region string) (*polardbclient.Client
 	return client.(*polardbclient.Client), nil
 }
 
-// OssClient returns an Object Storage Service client for a region. OSS uses its
-// own SDK and credential provider type, so it is built from the retained static
-// credential (falling back to the OSS environment credential provider when no
-// static credential was supplied).
+// darabonbaOssCredentials adapts the Darabonba credential every other service
+// client uses to the credential provider type the OSS SDK expects.
+//
+// It exists because those two SDKs resolve credentials independently. Without
+// the adapter OSS can only see a static access key, so the two credential
+// sources that never produce one, the shared credentials file and an ECS
+// instance RAM role, reach every service except OSS. The failure is silent and
+// misleading: OSS reports "access key id or access key secret is empty" on an
+// account whose credentials are working everywhere else.
+type darabonbaOssCredentials struct {
+	cred credential.Credential
+}
+
+// GetCredentials resolves the current credential on every call rather than
+// caching it, so a session token that the Darabonba credential refreshes (an
+// assumed RAM role, an instance role) stays valid for OSS too.
+func (p *darabonbaOssCredentials) GetCredentials(ctx context.Context) (osscred.Credentials, error) {
+	model, err := p.cred.GetCredential()
+	if err != nil {
+		return osscred.Credentials{}, err
+	}
+	if model == nil {
+		return osscred.Credentials{}, errors.New("alicloud: no credential available for OSS")
+	}
+	return osscred.Credentials{
+		AccessKeyID:     tea.StringValue(model.AccessKeyId),
+		AccessKeySecret: tea.StringValue(model.AccessKeySecret),
+		SecurityToken:   tea.StringValue(model.SecurityToken),
+	}, nil
+}
+
+// OssClient returns an Object Storage Service client for a region. OSS ships its
+// own SDK with its own credential provider type, so the shared Darabonba
+// credential is adapted rather than rebuilt, which keeps all four documented
+// auth methods working for OSS exactly as they do for every other service.
 func (c *AlicloudConnection) OssClient(region string) (*oss.Client, error) {
 	client, err := c.cachedClient("oss/"+region, func() (any, error) {
-		var provider osscred.CredentialsProvider
-		if c.accessKeyID != "" && c.accessKeySecret != "" {
-			provider = osscred.NewStaticCredentialsProvider(c.accessKeyID, c.accessKeySecret, c.securityToken)
-		} else {
-			provider = osscred.NewEnvironmentVariableCredentialsProvider()
-		}
 		cfg := oss.LoadDefaultConfig().
 			WithRegion(region).
-			WithCredentialsProvider(provider)
+			WithCredentialsProvider(&darabonbaOssCredentials{cred: c.cred})
 		return oss.NewClient(cfg), nil
 	})
 	if err != nil {

--- a/providers/alicloud/connection/oss_credentials_test.go
+++ b/providers/alicloud/connection/oss_credentials_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	tea "github.com/alibabacloud-go/tea/tea"
+	credential "github.com/aliyun/credentials-go/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCredential is a credential.Credential whose GetCredential result is
+// controlled by the test.
+type fakeCredential struct {
+	credential.Credential
+	model *credential.CredentialModel
+	err   error
+	calls int
+}
+
+func (f *fakeCredential) GetCredential() (*credential.CredentialModel, error) {
+	f.calls++
+	return f.model, f.err
+}
+
+// TestDarabonbaOssCredentials covers the adapter that lets OSS see the same
+// credential every other service client uses. Without it OSS only ever saw a
+// static access key, so the shared credentials file and an ECS instance RAM role
+// reached every service except OSS, and OSS reported the key as empty on an
+// account whose credentials were working everywhere else.
+func TestDarabonbaOssCredentials(t *testing.T) {
+	t.Run("an access key pair is passed through", func(t *testing.T) {
+		p := &darabonbaOssCredentials{cred: &fakeCredential{
+			model: &credential.CredentialModel{
+				AccessKeyId:     tea.String("akid"),
+				AccessKeySecret: tea.String("aksecret"),
+			},
+		}}
+		creds, err := p.GetCredentials(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "akid", creds.AccessKeyID)
+		assert.Equal(t, "aksecret", creds.AccessKeySecret)
+		assert.Equal(t, "", creds.SecurityToken)
+	})
+
+	t.Run("a session token is carried too", func(t *testing.T) {
+		p := &darabonbaOssCredentials{cred: &fakeCredential{
+			model: &credential.CredentialModel{
+				AccessKeyId:     tea.String("akid"),
+				AccessKeySecret: tea.String("aksecret"),
+				SecurityToken:   tea.String("token"),
+			},
+		}}
+		creds, err := p.GetCredentials(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "token", creds.SecurityToken)
+	})
+
+	t.Run("a resolution error surfaces rather than yielding empty credentials", func(t *testing.T) {
+		p := &darabonbaOssCredentials{cred: &fakeCredential{err: errors.New("no credential source")}}
+		_, err := p.GetCredentials(context.Background())
+		assert.Error(t, err)
+	})
+
+	t.Run("a nil model is an error, not a silent empty key", func(t *testing.T) {
+		// This is the shape the old code failed on: empty strings reached the
+		// OSS SDK and surfaced as "access key id or access key secret is empty",
+		// which reads like a configuration mistake rather than a resolution one.
+		p := &darabonbaOssCredentials{cred: &fakeCredential{model: nil}}
+		_, err := p.GetCredentials(context.Background())
+		assert.Error(t, err)
+	})
+
+	t.Run("the credential is resolved on every call so a refreshed token is seen", func(t *testing.T) {
+		f := &fakeCredential{model: &credential.CredentialModel{
+			AccessKeyId:     tea.String("akid"),
+			AccessKeySecret: tea.String("aksecret"),
+		}}
+		p := &darabonbaOssCredentials{cred: f}
+		_, err := p.GetCredentials(context.Background())
+		require.NoError(t, err)
+		_, err = p.GetCredentials(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 2, f.calls, "caching would pin an expired session token")
+	})
+}


### PR DESCRIPTION
Found by running the provider against a real Alibaba Cloud account. `alicloud.oss.buckets` failed with **"access key id or access key secret is empty"** while every other service authenticated fine on the same credentials.

### Cause

OSS ships its own SDK with its own credential provider type. `OssClient` built one from the retained static access key, falling back to the OSS SDK's own environment-variable provider:

```go
if c.accessKeyID != "" && c.accessKeySecret != "" {
    provider = osscred.NewStaticCredentialsProvider(...)
} else {
    provider = osscred.NewEnvironmentVariableCredentialsProvider()
}
```

Every other client is built from `c.cred`, the Darabonba credential — and the existing comment on that field even said so: *"the Darabonba credential used by every service client except OSS."*

The two SDKs resolve credentials independently, so the two sources that never produce a static access key reached every service **except** OSS:

- the shared credentials file, `~/.alibabacloud/credentials`
- an ECS instance RAM role

Both are documented in the provider README as supported auth methods (3 and 4 of 4). With either of them, **every OSS field on every bucket failed** — `isPublic`, `blockPublicAccess`, `acl`, `policy`, and all twelve controls added in #9962 — and the message pointed at a missing key rather than at the resolution path that actually broke.

### Fix

Adapt `c.cred` to the OSS provider interface rather than rebuilding a credential, so all four documented auth methods behave the same for OSS as for everything else. The adapter resolves on every call rather than caching, so a session token the Darabonba credential refreshes (assumed RAM role, instance role) stays valid for OSS too.

### Verified live

Against a real account, with only `~/.alibabacloud/credentials` present and **no** environment variables set:

| | `alicloud.oss.buckets` |
|---|---|
| before | `operation error ListBuckets: access key id or access key secret is empty!` |
| after | a genuine service response from OSS |

The credential now reaches the service. (That account separately has OSS disabled at the account level, which is why the response is a service-side refusal rather than a bucket list — unrelated to this bug, and it is exactly the distinction the old code made impossible to see.)

### Tests

`oss_credentials_test.go` covers pass-through of an access key pair, a session token, a resolution error surfacing rather than yielding empty credentials, a nil model being an error rather than a silent empty key, and that the credential is resolved on every call so a refreshed token is seen.
