### PR TITLE
🎉 alicloud-13.5.0

### DIFF
--- a/providers/alicloud/config/config.go
+++ b/providers/alicloud/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "alicloud",
 	ID:              "go.mondoo.com/mql/providers/alicloud",
-	Version:         "13.4.0",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Bumps `providers/alicloud` from **13.4.0 → 13.5.0**. One line in `config/config.go`; no other changes.

**Minor rather than patch** — this release adds two services, four discovery targets, and a set of resources that change the answers existing queries already give.

## What's in it (9 PRs since 13.4.0)

**New services**
- #9955 — Container Registry: instances, namespaces, repositories, replication rules, scan rules
- #9956 — Elasticsearch: clusters, public/Kibana endpoints, address lists

**New discovery targets** — `slbs`, `redis-instances`, `mongodb-instances`, `polardb-clusters`, `fc-functions` (#9954), `acr-instances` (#9955), `es-clusters` (#9956)

**Coverage**
- #9953 — Cloud Config audit plane: evaluation results, compliance packs, aggregators, typed delivery channels; plus SLS project policy and `isPublic`
- #9960 — load balancer backends: ALB/NLB server-group members, CLB vServer groups and backend servers, with typed `ecsInstance` refs
- #9962 — twelve OSS bucket controls: `policyAllowsPublicAccess`, TLS floor, object lock, CORS, referer, website, replication
- #9910 — ten service SDK upgrades and new RDS capabilities

**Changes existing answers** — worth calling out for anyone with alicloud policies in flight:
- #9958 — a security group rule scoped to a prefix list carries no `sourceCidrIp`, so `0.0.0.0/0` audits were walking past it. `alicloud.ecs.prefixList` plus `sourcePrefixList`/`destPrefixList` refs close that. Network ACL rules and route entries also move from `[]dict` to typed resources (the dicts stay, deprecated).
- #9964 — **OSS was unauthenticated under two of the four documented auth methods.** The shared credentials file and ECS instance-role auth reached every service except OSS, so every OSS field on every bucket failed with a misleading "access key is empty". Found by live verification against a real account.

## Verification

Partially verified live against a real Alibaba account earlier today. Confirmed working: prefix lists and their typed refs (including the empty-`sourceCidrIp` case that motivated #9958), typed network ACL entries, typed routes, and `resourceGroup` refs. The #9964 fix was verified live before merge.

Not exercised, for account reasons rather than code reasons: OSS (disabled account-wide), CLB backends (shared spec discontinued, performance spec returned 500), and the ACR/Elasticsearch/Config/SLS listers (account has none of those resources). Those return clean empties today; their decode paths remain unproven.

## Notes

- `.lr.versions` entries added since 13.4.0 sit at `13.4.1` and ship in `13.5.0`. That matches the existing pattern — entries at `13.2.5` and `13.3.2` shipped in `13.3.0` and `13.4.0` respectively.
- Generated with `providers-sdk/v1/util/version`. Its `--commit` step could not run inside a git worktree, so the commit was made by hand; it is authored under my own identity rather than the release bot's, which is what CLA requires for a human-pushed commit.
