### PR TITLE
🧹 skills: probe SDK deps for the providers shipped since the table was written

### DIFF
--- a/.claude/skills/update-provider-deps/probe.py
+++ b/.claude/skills/update-provider-deps/probe.py
@@ -63,11 +63,15 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 #
 # Only providers that vendor a real platform SDK are listed. Providers that talk to their
 # API over hand-rolled HTTP (vercel, netlify, neon, nextdns, proxmox, clickhousecloud,
-# mistral, huggingface, vllm, grafana, iru) have nothing to probe. Deliberately out of
-# scope: DB drivers (mysqldb, postgresdb, redisdb, mssql, cassandra, clickhousedb),
-# network/hardware (arista, mikrotik, redfish, ipmi, opcua, nmap) and IaC tooling
-# (terraform, helm, kustomize, cloudformation, ansible) — pass their go.mod in
-# single-file mode if you ever want them.
+# mistral, huggingface, vllm, grafana, iru, artifactory, bitwarden, jumpcloud, keycloak,
+# zoom) have nothing to probe. Deliberately out of scope: DB drivers (mysqldb, postgresdb,
+# redisdb, mssql, cassandra, clickhousedb), network and hardware protocol clients (arista,
+# mikrotik, redfish, ipmi, opcua, nmap, activedirectory) and IaC tooling (terraform, helm,
+# kustomize, cloudformation, ansible) — pass their go.mod in single-file mode if you ever
+# want them.
+#
+# equinix vendors github.com/packethost/packngo but the provider is queued for removal
+# (PR #9734), so it is left out rather than wired up.
 #
 # nutanix is EXCLUDED ON PURPOSE — do not add it back. Its SDK version is dictated by the
 # Prism Central release the customer runs, not by what is newest: the v4.1+ clients request
@@ -101,9 +105,13 @@ PROVIDER_PREFIXES = {
     "ms365":          ("github.com/microsoftgraph/", "github.com/microsoft/kiota", "github.com/Azure/"),
     "google-workspace": ("google.golang.org/api",),
     "okta":           ("github.com/okta/okta-sdk-golang",),
+    "auth0":          ("github.com/auth0/go-auth0",),
     "jamf":           ("github.com/deploymenttheory/go-api-sdk-jamfpro",),
     "atlassian":      ("github.com/ctreminiom/go-atlassian",),
     "slack":          ("github.com/slack-go/slack",),
+    # community-maintained, not published by Dropbox: read the repo's commit history
+    # before treating a quiet release feed as "current".
+    "dropbox":        ("github.com/dropbox/dropbox-sdk-go-unofficial",),
 
     # --- devops / SCM SaaS ---
     "github":         ("github.com/google/go-github/", "github.com/bradleyfalzon/ghinstallation"),


### PR DESCRIPTION
The `update-provider-deps` skill resolves providers from a hardcoded `PROVIDER_PREFIXES` table in `probe.py`. A provider absent from that table isn't reported as unknown — it simply never appears in the `UP`/`OK`/`BETA` output. So "are our SDKs current?" answers *yes* for a provider the probe has never looked at.

Seven providers landed on `main` after that table was last touched: `artifactory`, `auth0`, `bitwarden`, `dropbox`, `jumpcloud`, `keycloak`, `zoom`. Two of them vendor a real SDK and were going unprobed.

## Wired up

| Provider | Module | Found by the probe |
|---|---|---|
| `auth0` | `github.com/auth0/go-auth0` | `v1.46.0` → **`v3.2.0`** |
| `dropbox` | `github.com/dropbox/dropbox-sdk-go-unofficial` | `v6.5.0` → `v6.6.0` |

`auth0` is two majors behind. That is precisely the case `go get path@latest` cannot find, since it only searches within the current major and never discovers that the dep now lives at `path/v3` — the reason `probe.py` exists.

**Neither bump is applied in this PR.** Both cross a major boundary or want the Phase 2 changelog read first; this change only makes them visible.

`dropbox-sdk-go-unofficial` is community-maintained rather than vendor-published, so it carries an inline note: a quiet release feed there is not evidence of currency the way it is for a vendor SDK.

## Recorded as deliberately out of scope

The remaining five have no SDK to probe, and the comment block now says so, so the next run doesn't re-derive it from scratch:

- `artifactory`, `bitwarden`, `jumpcloud`, `keycloak`, `zoom` — hand-rolled `net/http` in `connection/client.go`, zero third-party deps in `go.mod`.

Two older gaps the same sweep surfaced:

- `activedirectory` (April) vendors `go-ldap/v3`, `gokrb5/v8` and `jfjallid/go-smb` — protocol clients, filed with arista/mikrotik/redfish/ipmi/opcua/nmap.
- `equinix` vendors `packethost/packngo`, but the provider is queued for removal in #9734, so it's noted rather than wired up.

## Verification

```
$ python3 .claude/skills/update-provider-deps/probe.py --provider=auth0,dropbox

===== auth0 (./providers/auth0/go.mod) =====
UP   github.com/auth0/go-auth0@v1.46.0 -> github.com/auth0/go-auth0/v3@v3.2.0
# 1 upgradeable, 0 beta-only.

===== dropbox (./providers/dropbox/go.mod) =====
UP   github.com/dropbox/dropbox-sdk-go-unofficial/v6@v6.5.0 -> .../v6@v6.6.0
# 1 upgradeable, 0 beta-only.
```

Coverage was checked by listing every direct, non-infrastructure dependency across all `providers/*/go.mod` and diffing that against the table plus the exclusion comment. No provider is unaccounted for as of this commit.

**Not verified:** no dependency was upgraded and no provider was rebuilt, so nothing here rests on a green build of an SDK bump. This is a change to the skill's provider table only.

## Follow-up worth considering

The failure mode is an *absence*, so it recurs silently every time a provider ships. A `--list` check that walks `providers/*/go.mod` and warns about any directory named in neither the table nor an explicit exclusion set would turn this from a periodic manual sweep into a one-line signal. Left out here to keep the change to what was asked.
