### PR TITLE
🐛 oci: ask for the identity domain attributes we were already asking for

### DIFF
--- a/providers/oci/connection/clients.go
+++ b/providers/oci/connection/clients.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/aidocument"
@@ -217,8 +218,43 @@ func (c *OciConnection) IdentityDomainsClient(endpoint string) (*identitydomains
 		if err != nil {
 			return nil, err
 		}
+		client.Interceptor = collapseScimAttributeSets
 		return &client, nil
 	})
+}
+
+// collapseScimAttributeSets rewrites a repeated attributeSets query parameter
+// into the single comma-delimited value the SCIM service expects.
+//
+// The SDK tags the parameter collectionFormat:"multi", so asking for two
+// attribute sets goes out as `attributeSets=default&attributeSets=request`. The
+// identity domains service honors only the first of those and drops the rest,
+// and it reports nothing about having done so: the response is a well-formed
+// listing that is simply missing every attribute the second set would have
+// carried. Asking for the request set alongside the default one therefore
+// returned the default set alone, so a user's last login and MFA enrollment
+// date came back null, a group's members came back empty, and a sign-on
+// policy's rules came back empty - each reading as a fact about the tenancy
+// rather than as an unasked-for attribute.
+//
+// Joining the values with a comma is the form the service documents, and it
+// returns the union: a strict superset of the default listing. This runs as a
+// request interceptor because the SDK applies it before signing, so the
+// rewritten query is the one that gets signed.
+func collapseScimAttributeSets(req *http.Request) error {
+	if req == nil || req.URL == nil {
+		return nil
+	}
+
+	query := req.URL.Query()
+	sets := query["attributeSets"]
+	if len(sets) < 2 {
+		return nil
+	}
+
+	query.Set("attributeSets", strings.Join(sets, ","))
+	req.URL.RawQuery = query.Encode()
+	return nil
 }
 
 // --- Core (compute, networking, block storage) ------------------------------

--- a/providers/oci/connection/scim_attributesets_test.go
+++ b/providers/oci/connection/scim_attributesets_test.go
@@ -1,0 +1,160 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identitydomains"
+)
+
+// requestFor builds the request an interceptor would receive for a raw query.
+func requestFor(t *testing.T, rawQuery string) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "https://idcs.example.com/admin/v1/Users?"+rawQuery, nil)
+	if err != nil {
+		t.Fatalf("building the request: %v", err)
+	}
+	return req
+}
+
+// TestCollapseScimAttributeSetsJoinsRepeatedValues pins the fix itself.
+//
+// The identity domains service reads only the first of a repeated
+// attributeSets parameter, so the two-value form the SDK emits has to become
+// one comma-delimited value before the request is signed.
+func TestCollapseScimAttributeSetsJoinsRepeatedValues(t *testing.T) {
+	req := requestFor(t, "attributeSets=default&attributeSets=request&count=200")
+
+	if err := collapseScimAttributeSets(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := req.URL.Query()["attributeSets"]
+	if len(got) != 1 {
+		t.Fatalf("attributeSets stayed repeated as %v; the service would honor only the first", got)
+	}
+	if got[0] != "default,request" {
+		t.Errorf("attributeSets = %q, want %q", got[0], "default,request")
+	}
+
+	// The rest of the query has to survive: dropping count would silently
+	// change the page size the pagination loop is built around.
+	if count := req.URL.Query().Get("count"); count != "200" {
+		t.Errorf("count = %q, want %q", count, "200")
+	}
+}
+
+// TestCollapseScimAttributeSetsPreservesOrder keeps `default` ahead of
+// `request`. The service resolves a repeated parameter to whichever value comes
+// first, so an order flip is exactly the failure this guards against and it
+// would not show up as an error.
+func TestCollapseScimAttributeSetsPreservesOrder(t *testing.T) {
+	req := requestFor(t, "attributeSets=default&attributeSets=request")
+
+	if err := collapseScimAttributeSets(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := req.URL.Query().Get("attributeSets"); got != "default,request" {
+		t.Errorf("attributeSets = %q, want the values joined in the order they were sent", got)
+	}
+}
+
+// TestCollapseScimAttributeSetsLeavesOtherRequestsAlone covers the cases the
+// interceptor must not touch: it runs on every identity domains call, not only
+// the listings that ask for two attribute sets.
+func TestCollapseScimAttributeSetsLeavesOtherRequestsAlone(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		rawQuery string
+	}{
+		{"no attributeSets at all", "count=200&startIndex=1"},
+		{"a single attributeSets value", "attributeSets=default&count=200"},
+		{"an empty query", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := requestFor(t, test.rawQuery)
+			before := req.URL.RawQuery
+
+			if err := collapseScimAttributeSets(req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if req.URL.RawQuery != before {
+				t.Errorf("query rewritten to %q, want it left as %q", req.URL.RawQuery, before)
+			}
+		})
+	}
+}
+
+// TestCollapseScimAttributeSetsSurvivesAnEmptyRequest guards the interceptor
+// against a nil request or URL rather than panicking inside the SDK's call
+// path, where a panic would take down the whole scan rather than one field.
+func TestCollapseScimAttributeSetsSurvivesAnEmptyRequest(t *testing.T) {
+	if err := collapseScimAttributeSets(nil); err != nil {
+		t.Errorf("nil request returned %v, want no error", err)
+	}
+	if err := collapseScimAttributeSets(&http.Request{}); err != nil {
+		t.Errorf("request without a URL returned %v, want no error", err)
+	}
+}
+
+// TestScimListingEmitsRepeatedAttributeSets is the reason the interceptor
+// exists, pinned against the SDK rather than against our own assumption.
+//
+// The request struct tags attributeSets collectionFormat:"multi". If a future
+// SDK switched it to a comma-joined value this test fails, which is the signal
+// to delete the interceptor rather than to keep a rewrite that has become a
+// no-op.
+func TestScimListingEmitsRepeatedAttributeSets(t *testing.T) {
+	request := identitydomains.ListUsersRequest{
+		Count: common.Int(200),
+		AttributeSets: []identitydomains.AttributeSetsEnum{
+			identitydomains.AttributeSetsDefault,
+			identitydomains.AttributeSetsRequest,
+		},
+	}
+
+	httpRequest, err := common.MakeDefaultHTTPRequestWithTaggedStruct(
+		http.MethodGet, "/admin/v1/Users", request)
+	if err != nil {
+		t.Fatalf("building the SDK request: %v", err)
+	}
+
+	values, err := url.ParseQuery(httpRequest.URL.RawQuery)
+	if err != nil {
+		t.Fatalf("parsing the SDK query: %v", err)
+	}
+
+	if got := values["attributeSets"]; len(got) != 2 {
+		t.Fatalf("the SDK emitted attributeSets as %v; the interceptor is written for the repeated form", got)
+	}
+}
+
+// TestIdentityDomainsClientInstallsTheInterceptor makes the wiring explicit:
+// the rewrite only takes effect if the client carries it, and a client built
+// without it fails silently by returning listings that are missing attributes.
+func TestIdentityDomainsClientInstallsTheInterceptor(t *testing.T) {
+	conn := testConnection(t)
+
+	client, err := conn.IdentityDomainsClient("https://idcs.example.com")
+	if err != nil {
+		t.Fatalf("building the identity domains client: %v", err)
+	}
+	if client.Interceptor == nil {
+		t.Fatal("the identity domains client has no interceptor; repeated attributeSets would reach the service unjoined")
+	}
+
+	req := requestFor(t, "attributeSets=default&attributeSets=request")
+	if err := client.Interceptor(req); err != nil {
+		t.Fatalf("the installed interceptor returned %v", err)
+	}
+	if got := req.URL.Query().Get("attributeSets"); got != "default,request" {
+		t.Errorf("the installed interceptor produced %q, want %q", got, "default,request")
+	}
+}

--- a/providers/oci/resources/identitydomains_signon.go
+++ b/providers/oci/resources/identitydomains_signon.go
@@ -210,14 +210,18 @@ func (o *mqlOciIdentityDomain) rules() ([]any, error) {
 		conditionGroupType, conditionGroupName, conditionID := ociRuleConditionGroup(rule.ConditionGroup)
 
 		mqlRule, err := CreateResource(o.MqlRuntime, "oci.identity.domain.rule", map[string]*llx.RawData{
-			"__id":                llx.StringData(o.Id.Data + "/rule/" + stringValue(rule.Id)),
-			"id":                  llx.StringDataPtr(rule.Id),
-			"ocid":                llx.StringDataPtr(rule.Ocid),
-			"name":                llx.StringDataPtr(rule.Name),
-			"description":         llx.StringDataPtr(rule.Description),
-			"policyType":          llx.StringData(policyType),
-			"active":              llx.BoolData(boolValue(rule.Active)),
-			"locked":              llx.BoolData(boolValue(rule.Locked)),
+			"__id":        llx.StringData(o.Id.Data + "/rule/" + stringValue(rule.Id)),
+			"id":          llx.StringDataPtr(rule.Id),
+			"ocid":        llx.StringDataPtr(rule.Ocid),
+			"name":        llx.StringDataPtr(rule.Name),
+			"description": llx.StringDataPtr(rule.Description),
+			"policyType":  llx.StringData(policyType),
+			// Null rather than false when the service omits the flag: it does
+			// not report `active` or `locked` for the rules it ships with, and
+			// answering false there would state that the rule requiring
+			// multi-factor authentication is switched off.
+			"active":              llx.BoolDataPtr(rule.Active),
+			"locked":              llx.BoolDataPtr(rule.Locked),
 			"conditionExpression": llx.StringDataPtr(rule.Condition),
 			"conditionGroupType":  llx.StringData(conditionGroupType),
 			"conditionGroupName":  llx.StringData(conditionGroupName),


### PR DESCRIPTION
Found while live-verifying the OCI PRs merged since `oci-13.19.0` (#9967, #9968, #9969, #9970) against a real tenancy.

## What is wrong

The identity domain SCIM listings ask for two attribute sets:

```go
AttributeSets: []identitydomains.AttributeSetsEnum{
    identitydomains.AttributeSetsDefault,
    identitydomains.AttributeSetsRequest,
}
```

The SDK tags that field `collectionFormat:"multi"`, so it goes out as `attributeSets=default&attributeSets=request`. The service honors **only the first value** and silently drops the rest — the response is a well-formed listing that is simply missing everything the second set would have carried.

Measured against a live domain:

| query form | `rules` | `active` |
|---|---|---|
| `attributeSets=default,request` (comma) | ✅ set | ✅ true |
| `attributeSets=default&attributeSets=request` (repeated) | ❌ null | true |
| `attributeSets=request&attributeSets=default` (repeated) | set | ❌ null |

## Why it matters

The dropped attributes are the security-relevant ones, and an absent attribute is indistinguishable from a real negative:

| field | reported | actual |
|---|---|---|
| `user.mfaEnabledOn` | `null` | 2026-04-13 |
| `user.lastSuccessfulLogin` | `null` (reads as "never signed in") | 2026-08-08 |
| `user.previousSuccessfulLogin` | `null` | 2026-04-13 |
| `user.lastFailedLogin` | `null` | 2026-04-13 |
| `user.groups` | `[]` | 1 membership |
| `group.memberCount` | `0` | 1 for `Administrators` |
| `policy.rules` | `[]` | the policy's ordered rules |

`policy.rules` being empty means #9968 shipped without the thing it set out to expose: no sign-on policy appeared to require anything, including the two rules that require MFA.

## The fix

A request interceptor joins the repeated values into the single comma-delimited form the service documents. The SDK applies interceptors before signing, so the rewritten query is the one that gets signed.

Naming attributes individually via the `attributes` parameter was the other candidate and is a **trap** — despite the SDK doc saying the two union. Diffing attribute-by-attribute against a live domain, it drops nine default attributes including the `canUse*` capabilities and `isFederatedUser`, both of which the mapper reads. The comma form is a strict superset: loses nothing, gains 19.

Also: rule `active`/`locked` become `null` instead of `false` when the service omits them, which it does for the rules a domain ships with under every parameter combination. Answering `false` states that the rule requiring MFA is switched off.

## Verification

Live OCI tenancy, before and after the same binary change.

Before — `oci.identity.domains { policies { name rules { name } } }` returned `rules: []` on all five policies.

After:

```
name: "Security Policy for OCI Console"
rules: [
  { name: "MFA for administrators", returns[authenticationFactor]: "IDP+2FA" }
  { name: "MFA for all users",      returns[authenticationFactor]: "IDP+2FA" }
]
```

Order matches the API's `sequence` (admin = 1, all-users = 2). All six user/group fields above now return their real values.

## Tests

`providers/oci/connection/scim_attributesets_test.go` — the join, order preservation, the untouched cases (no/single `attributeSets`, empty query), nil-safety, that the client actually installs the interceptor, and a test pinned against the **SDK** asserting it still emits the repeated form (if a future SDK switches to comma-joining, that test fails, which is the signal to delete the interceptor rather than keep a dead rewrite).
