### PR TITLE
🧹 providers: refresh slack and dropbox SDK dependencies

### DIFF
--- a/providers/dropbox/go.mod
+++ b/providers/dropbox/go.mod
@@ -6,7 +6,7 @@ go 1.26.5
 
 require (
 	github.com/cockroachdb/errors v1.14.0
-	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.5.0
+	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0
 	go.mondoo.com/mql/v13 v13.0.0-00010101000000-000000000000
 )
 

--- a/providers/dropbox/go.sum
+++ b/providers/dropbox/go.sum
@@ -128,8 +128,8 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.5.0 h1:so0Hhjd4FhCKwTuwpuyD7IdTCJkYCDWlTi9BSdPWjjU=
-github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.5.0/go.mod h1:gDXhl0OElhzYoDsYWHr1RXjpxjGeLzEvjYzH7sZV73k=
+github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0 h1:LWwNAeoGaMbNkbaa/0wlNc01SeT0JtISyTZOr4iLeXU=
+github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0/go.mod h1:gDXhl0OElhzYoDsYWHr1RXjpxjGeLzEvjYzH7sZV73k=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=

--- a/providers/slack/go.mod
+++ b/providers/slack/go.mod
@@ -7,7 +7,7 @@ go 1.26.5
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/rs/zerolog v1.35.1
-	github.com/slack-go/slack v0.27.0
+	github.com/slack-go/slack v0.29.0
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.32.2
 )

--- a/providers/slack/go.sum
+++ b/providers/slack/go.sum
@@ -390,8 +390,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
-github.com/slack-go/slack v0.27.0 h1:VWOpUzOK6UAPCCQlFxl79jhv8a/b+GOSJMnWziDJ8B8=
-github.com/slack-go/slack v0.27.0/go.mod h1:UEe+jmo9WLlwHB04qsOrTDvqM7Aa4rQL3O5wF3n0hx4=
+github.com/slack-go/slack v0.29.0 h1:ohhMNgp9DmPKiLhH/pNZV4NxhOXKgNy0SH8FzVHNerI=
+github.com/slack-go/slack v0.29.0/go.mod h1:UEe+jmo9WLlwHB04qsOrTDvqM7Aa4rQL3O5wF3n0hx4=
 github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTCzfY=
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=


### PR DESCRIPTION
Dependency-only refresh for the two providers whose SDK bump needed no code change at all.

| Provider | Module | From | To |
|---|---|---|---|
| slack | `github.com/slack-go/slack` | v0.27.0 | v0.29.0 |
| dropbox | `github.com/dropbox/dropbox-sdk-go-unofficial/v6` | v6.5.0 | v6.6.0 |

Each provider is its own Go module, so **each was built and tested separately**:

```
cd providers/slack   && go build ./... && go test ./... && gofmt -l .   # clean
cd providers/dropbox && go build ./... && go test ./... && gofmt -l .   # clean
```

## Why these are safe

**slack v0.28.0 / v0.29.0** are additive: a `Channels` field for sharing an uploaded file with multiple conversations, container block support, the full message object on `chat.postMessage` responses, and a fix for parsing top-level action tokens. None is a read path this provider uses. Worth noting explicitly because slack-go is pre-1.0 and therefore carries no semver promise — a minor genuinely can break, so the release notes were read rather than assumed.

**dropbox v6.6.0** is the one that deserved a second look, because a *minor* release on a community-maintained fork:

- **removed the entire `filedownload` package**, replacing it with `filetransfer`; and
- **added `public_logged_in_only`** to the `team_log` MediaHub shared-link audience enum.

This provider imports only `dropbox`, `team`, `team_common` and `team_policies`, so neither reaches it. Had we imported `filedownload`, a minor bump would have broken the build.

No shipped MQL field changes type, shape, or meaning in either provider.

## go mod tidy side effects, deliberately excluded

`go mod tidy` on **`main`** — with no bump at all — already reclassifies `github.com/rs/zerolog` from indirect to direct in `providers/dropbox/go.mod` and drops a stale `github.com/endobit/oui` entry from both `go.sum` files. That drift is not a consequence of these bumps, and folding it in would make the diff read as though it were.

`go.mod` and `go.sum` here therefore carry **only** the version bump for each provider. The pre-existing untidiness is left for a clean-up of its own.

## Not verified

Neither provider was exercised against a live Slack workspace or Dropbox team — no credentials here. These claims rest on the compiler, the unit tests in-repo, and the upstream changelogs and commit diffs, not on an actual API response.
