### PR TITLE
🌟 okta: expose what v6 reports about logout, token encryption and admin scope

### DIFF
--- a/providers/okta/resources/agentPools.go
+++ b/providers/okta/resources/agentPools.go
@@ -72,6 +72,8 @@ func newMqlOktaAgentPool(runtime *plugin.Runtime, entry *okta.AgentPool) (any, e
 		"name":              llx.StringData(oktaStr(entry.Name)),
 		"type":              llx.StringData(oktaStr(entry.Type)),
 		"operationalStatus": llx.StringData(oktaStr(entry.OperationalStatus)),
+		"disruptedAgents":   llx.IntDataPtr(oktaInt64(entry.DisruptedAgents)),
+		"inactiveAgents":    llx.IntDataPtr(oktaInt64(entry.InactiveAgents)),
 		"agents":            llx.ArrayData(agents, types.Resource("okta.agentPool.agent")),
 	})
 }

--- a/providers/okta/resources/apiServiceIntegrations.go
+++ b/providers/okta/resources/apiServiceIntegrations.go
@@ -63,6 +63,15 @@ func newMqlOktaApiServiceIntegration(runtime *plugin.Runtime, entry *okta.APISer
 		}
 	}
 
+	// Properties are a name-to-value list on the wire; the name is the key a
+	// query would look the value up by.
+	properties := map[string]any{}
+	if entry.Properties != nil {
+		for key, prop := range *entry.Properties {
+			properties[key] = oktaStr(prop.Value)
+		}
+	}
+
 	return CreateResource(runtime, "okta.apiServiceIntegration", map[string]*llx.RawData{
 		"id":             llx.StringData(oktaStr(entry.Id)),
 		"name":           llx.StringData(oktaStr(entry.Name)),
@@ -71,6 +80,7 @@ func newMqlOktaApiServiceIntegration(runtime *plugin.Runtime, entry *okta.APISer
 		"configGuideUrl": llx.StringData(oktaStr(entry.ConfigGuideUrl)),
 		"createdBy":      llx.StringData(oktaStr(entry.CreatedBy)),
 		"createdAt":      llx.TimeDataPtr(created),
+		"properties":     llx.MapData(properties, types.String),
 	})
 }
 

--- a/providers/okta/resources/applications.go
+++ b/providers/okta/resources/applications.go
@@ -36,6 +36,20 @@ type oktaApplicationRaw struct {
 	Profile     json.RawMessage `json:"profile,omitempty"`
 	Settings    json.RawMessage `json:"settings,omitempty"`
 	Visibility  json.RawMessage `json:"visibility,omitempty"`
+
+	UniversalLogout *oktaUniversalLogoutRaw `json:"universalLogout,omitempty"`
+}
+
+// oktaUniversalLogoutRaw is the application's Universal Logout block. It is
+// absent on applications Okta cannot sign the user out of, which is why the
+// pointer is kept rather than flattened: the whole block missing and every
+// value within it being empty are the same reading, but only one of them is
+// worth telling apart from a value the API declined to report.
+type oktaUniversalLogoutRaw struct {
+	IdentityStack string `json:"identityStack,omitempty"`
+	Protocol      string `json:"protocol,omitempty"`
+	Status        string `json:"status,omitempty"`
+	SupportType   string `json:"supportType,omitempty"`
 }
 
 func oktaApplicationFromUnion(item okta.ListApplications200ResponseInner) (*oktaApplicationRaw, error) {
@@ -164,25 +178,36 @@ func oktaApplicationArgs(entry *oktaApplicationRaw) (map[string]*llx.RawData, er
 		return nil, err
 	}
 
+	// An application without the block reports empty rather than null, which
+	// matches how every other absent string on this resource reads.
+	ul := entry.UniversalLogout
+	if ul == nil {
+		ul = &oktaUniversalLogoutRaw{}
+	}
+
 	visibility, err := convert.JsonToDict(entry.Visibility)
 	if err != nil {
 		return nil, err
 	}
 
 	return map[string]*llx.RawData{
-		"id":          llx.StringData(entry.Id),
-		"name":        llx.StringData(entry.Name),
-		"label":       llx.StringData(entry.Label),
-		"created":     llx.TimeDataPtr(entry.Created),
-		"lastUpdated": llx.TimeDataPtr(entry.LastUpdated),
-		"credentials": llx.DictData(credentials),
-		"features":    llx.ArrayData(convert.SliceAnyToInterface(entry.Features), types.String),
-		"licensing":   llx.DictData(licensing),
-		"profile":     llx.DictData(profile),
-		"settings":    llx.DictData(settings),
-		"signOnMode":  llx.StringData(entry.SignOnMode),
-		"status":      llx.StringData(entry.Status),
-		"visibility":  llx.DictData(visibility),
+		"id":                           llx.StringData(entry.Id),
+		"name":                         llx.StringData(entry.Name),
+		"label":                        llx.StringData(entry.Label),
+		"created":                      llx.TimeDataPtr(entry.Created),
+		"lastUpdated":                  llx.TimeDataPtr(entry.LastUpdated),
+		"credentials":                  llx.DictData(credentials),
+		"features":                     llx.ArrayData(convert.SliceAnyToInterface(entry.Features), types.String),
+		"licensing":                    llx.DictData(licensing),
+		"profile":                      llx.DictData(profile),
+		"settings":                     llx.DictData(settings),
+		"signOnMode":                   llx.StringData(entry.SignOnMode),
+		"status":                       llx.StringData(entry.Status),
+		"visibility":                   llx.DictData(visibility),
+		"universalLogoutStatus":        llx.StringData(ul.Status),
+		"universalLogoutSupportType":   llx.StringData(ul.SupportType),
+		"universalLogoutProtocol":      llx.StringData(ul.Protocol),
+		"universalLogoutIdentityStack": llx.StringData(ul.IdentityStack),
 	}, nil
 }
 

--- a/providers/okta/resources/authorizationServers.go
+++ b/providers/okta/resources/authorizationServers.go
@@ -90,22 +90,32 @@ func newMqlOktaAuthorizationServer(runtime *plugin.Runtime, entry *okta.Authoriz
 		signingNextRotation = s.NextRotation
 	}
 
+	// Jwks is the key set tokens are encrypted against, which is a different
+	// set from the signing keys the server publishes.
+	jwks, err := convert.JsonToDict(entry.Jwks)
+	if err != nil {
+		return nil, err
+	}
+
 	return CreateResource(runtime, "okta.authorizationServer", map[string]*llx.RawData{
-		"id":                  llx.StringData(oktaStr(entry.Id)),
-		"name":                llx.StringData(oktaStr(entry.Name)),
-		"description":         llx.StringData(oktaStr(entry.Description)),
-		"status":              llx.StringData(oktaStr(entry.Status)),
-		"default":             llx.BoolData(defaultValue),
-		"issuer":              llx.StringData(oktaStr(entry.Issuer)),
-		"issuerMode":          llx.StringData(oktaStr(entry.IssuerMode)),
-		"audiences":           llx.ArrayData(convert.SliceAnyToInterface(entry.Audiences), types.String),
-		"signingKid":          llx.StringData(signingKid),
-		"signingRotationMode": llx.StringData(signingRotationMode),
-		"signingLastRotated":  llx.TimeDataPtr(signingLastRotated),
-		"signingNextRotation": llx.TimeDataPtr(signingNextRotation),
-		"signingUse":          llx.StringData(signingUse),
-		"created":             llx.TimeDataPtr(entry.Created),
-		"lastUpdated":         llx.TimeDataPtr(entry.LastUpdated),
+		"id":                                    llx.StringData(oktaStr(entry.Id)),
+		"name":                                  llx.StringData(oktaStr(entry.Name)),
+		"description":                           llx.StringData(oktaStr(entry.Description)),
+		"status":                                llx.StringData(oktaStr(entry.Status)),
+		"default":                               llx.BoolData(defaultValue),
+		"issuer":                                llx.StringData(oktaStr(entry.Issuer)),
+		"issuerMode":                            llx.StringData(oktaStr(entry.IssuerMode)),
+		"accessTokenEncryptedResponseAlgorithm": llx.StringData(oktaStr(entry.AccessTokenEncryptedResponseAlgorithm)),
+		"jwksUri":                               llx.StringData(oktaStr(entry.JwksUri)),
+		"jwks":                                  llx.DictData(jwks),
+		"audiences":                             llx.ArrayData(convert.SliceAnyToInterface(entry.Audiences), types.String),
+		"signingKid":                            llx.StringData(signingKid),
+		"signingRotationMode":                   llx.StringData(signingRotationMode),
+		"signingLastRotated":                    llx.TimeDataPtr(signingLastRotated),
+		"signingNextRotation":                   llx.TimeDataPtr(signingNextRotation),
+		"signingUse":                            llx.StringData(signingUse),
+		"created":                               llx.TimeDataPtr(entry.Created),
+		"lastUpdated":                           llx.TimeDataPtr(entry.LastUpdated),
 	})
 }
 

--- a/providers/okta/resources/authorizationServers_test.go
+++ b/providers/okta/resources/authorizationServers_test.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/v6/okta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+)
+
+// TestAuthorizationServerJwksNilIsNullNotAnError pins the absence of a nil
+// guard around the jwks conversion.
+//
+// Most authorization servers do not encrypt tokens, so entry.Jwks is nil on the
+// common path. JsonToDict marshals that to the JSON literal `null` and
+// unmarshals it into the result map, which encoding/json treats as a no-op
+// rather than an error: the call returns a nil map and a nil error. The field
+// then reports null, which is the correct reading for a server that has no
+// encryption key set.
+//
+// Guarding the call would not fix a bug, and coercing the result to an empty
+// map would introduce one: `{}` asserts that a key set was returned and was
+// empty, which is a different claim from there being no key set at all.
+func TestAuthorizationServerJwksNilIsNullNotAnError(t *testing.T) {
+	t.Parallel()
+
+	// The exact type and nilness the mapper sees for a server without
+	// token encryption configured.
+	var absent *okta.ResourceServerJsonWebKeys
+
+	dict, err := convert.JsonToDict(absent)
+	require.NoError(t, err,
+		"a server without token encryption must not fail the listing")
+	assert.Nil(t, dict, "an absent key set must read null, not an empty map")
+
+	// A configured key set still converts.
+	kid, kty := "k1", "RSA"
+	present := &okta.ResourceServerJsonWebKeys{
+		Keys: []okta.ResourceServerJsonWebKey{{Kid: &kid, Kty: &kty}},
+	}
+
+	dict, err = convert.JsonToDict(present)
+	require.NoError(t, err)
+	require.NotNil(t, dict)
+	assert.Contains(t, dict, "keys")
+}

--- a/providers/okta/resources/decode_test.go
+++ b/providers/okta/resources/decode_test.go
@@ -216,3 +216,44 @@ func TestUserFactorRawDecode(t *testing.T) {
 	assert.Equal(t, "+1 555 0100", f.Profile["phoneNumber"])
 	require.NotNil(t, f.Created)
 }
+
+// TestOktaApplicationRawUniversalLogout pins the Universal Logout decode.
+//
+// These four values decide whether ending an Okta session actually ends the
+// application's session. A mistyped tag would read empty on every app, which
+// is indistinguishable from an app that does not support Universal Logout at
+// all, so the wrong answer would look like a plausible one.
+func TestOktaApplicationRawUniversalLogout(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{
+		"id": "0oa1",
+		"label": "Workspace",
+		"universalLogout": {
+			"status": "ACTIVE",
+			"supportType": "FULL",
+			"protocol": "OIDC_BACKCHANNEL",
+			"identityStack": "google"
+		}
+	}`
+
+	entry := &oktaApplicationRaw{}
+	require.NoError(t, json.Unmarshal([]byte(payload), entry))
+
+	require.NotNil(t, entry.UniversalLogout)
+	assert.Equal(t, "ACTIVE", entry.UniversalLogout.Status)
+	assert.Equal(t, "FULL", entry.UniversalLogout.SupportType)
+	assert.Equal(t, "OIDC_BACKCHANNEL", entry.UniversalLogout.Protocol)
+	assert.Equal(t, "google", entry.UniversalLogout.IdentityStack)
+}
+
+// TestOktaApplicationRawWithoutUniversalLogout covers an application Okta
+// cannot sign the user out of, which omits the block entirely.
+func TestOktaApplicationRawWithoutUniversalLogout(t *testing.T) {
+	t.Parallel()
+
+	entry := &oktaApplicationRaw{}
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"0oa2","label":"Legacy"}`), entry))
+	assert.Nil(t, entry.UniversalLogout,
+		"an absent block must not decode to a populated one")
+}

--- a/providers/okta/resources/helpers.go
+++ b/providers/okta/resources/helpers.go
@@ -39,6 +39,17 @@ func oktaTimeFromUnixMillis(ms *int64) *time.Time {
 	return &t
 }
 
+// oktaInt64 widens an optional 32-bit count to the width llx reports ints at,
+// keeping nil as nil so an unreported count stays null rather than becoming a
+// confident zero.
+func oktaInt64(v *int32) *int64 {
+	if v == nil {
+		return nil
+	}
+	widened := int64(*v)
+	return &widened
+}
+
 // oktaStrFrom reads a string out of a value the SDK collected into
 // AdditionalProperties, yielding "" when the key was absent or held something
 // other than a string. See oktaStringMapFrom for why these reads exist.

--- a/providers/okta/resources/helpers_test.go
+++ b/providers/okta/resources/helpers_test.go
@@ -219,3 +219,22 @@ func TestOktaStringMapFrom(t *testing.T) {
 	assert.Equal(t, "", got["empty"])
 	assert.Equal(t, `{"a":"b"}`, got["nested"])
 }
+
+// TestOktaInt64 covers the widening of an optional count.
+//
+// The nil case is the one worth pinning: an agent pool whose disrupted count
+// the API does not report must leave the field null. A zero would assert that
+// nothing is disrupted, which is the opposite reading and the one a health
+// check would pass on.
+func TestOktaInt64(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, oktaInt64(nil), "an unreported count must stay null")
+
+	for _, n := range []int32{0, 1, 4096} {
+		got := oktaInt64(&n)
+		if assert.NotNil(t, got) {
+			assert.Equal(t, int64(n), *got)
+		}
+	}
+}

--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -765,6 +765,28 @@ private okta.application @defaults("name") {
   // `autoSubmitToolbar`, `appLinks` (per-link enablement), and `hide`
   // (`iOS` and `web` booleans that suppress the app chiclet).
   visibility dict
+  // Whether Universal Logout is in effect for the application
+  //
+  // Universal Logout lets Okta end the application's own sessions when it
+  // ends the user's Okta session. Where it is not in effect, revoking
+  // access in Okta leaves the application's session running until that
+  // session expires on its own, so offboarding and session revocation stop
+  // at the Okta boundary.
+  universalLogoutStatus string
+  // Extent of the application's Universal Logout support
+  //
+  // Distinguishes an application that terminates every session from one
+  // that terminates only some, which is the difference between a logout
+  // that finishes and one that appears to.
+  universalLogoutSupportType string
+  // Protocol Okta uses to signal Universal Logout to the application
+  universalLogoutProtocol string
+  // Shared identity stack behind the application
+  //
+  // Set when the application shares a sign-in stack with other applications
+  // from the same vendor, in which case ending this session can end the
+  // user's sessions in those too.
+  universalLogoutIdentityStack string
   // Signing keys/certificates published for this application (for SAML/OIDC signing)
   signingKeys() []okta.application.key
   // Users assigned to the application
@@ -1279,6 +1301,12 @@ private okta.resourceSet.resource @defaults("orn href") {
   href string
   // Parsed Okta Resource Name (ORN) of the target, when available
   orn string
+  // Resources carved out of this entry
+  //
+  // Okta Resource Names excluded from the grant, which narrow what the
+  // entry actually covers. An entry naming a whole group of resources
+  // grants less than it appears to when this list is not empty.
+  excludedOrns []string
   // Target group, when the resource is a group
   group() okta.group
   // Target application, when the resource is an application
@@ -1452,6 +1480,23 @@ private okta.authorizationServer @defaults("name status issuer") {
   claims() []okta.authorizationServer.claim
   // Published signing keys for access tokens issued by this server
   keys() []okta.authorizationServer.key
+  // Algorithm used to encrypt access tokens
+  //
+  // When set, an access token is signed and then encrypted, so it reaches
+  // the client as a nested JWT. Empty when the server issues signed tokens
+  // that are not encrypted, which is the default.
+  accessTokenEncryptedResponseAlgorithm string
+  // URL of the key set used to encrypt tokens
+  //
+  // References the JSON Web Key Set this server encrypts issued tokens
+  // against. Distinct from keys, which are the signing keys the server
+  // publishes.
+  jwksUri string
+  // Key set used to encrypt tokens
+  //
+  // The encryption keys as served, each carrying kid, kty, use, status and
+  // the RSA values n and e. Empty when the server does not encrypt tokens.
+  jwks dict
 }
 
 // Okta Authorization Server Policy
@@ -1815,6 +1860,11 @@ private okta.apiServiceIntegration @defaults("name type") {
   createdBy string
   // Timestamp when the integration instance was created
   createdAt time
+  // Configuration properties set on the integration instance
+  //
+  // Keyed by property name, holding the value configured for it. Empty when
+  // the integration takes no configuration or none has been set.
+  properties map[string]string
 }
 
 // Okta Attack Protection Settings
@@ -2069,6 +2119,18 @@ private okta.agentPool @defaults("name type operationalStatus") {
   //
   // One of ACTIVE, INACTIVE, DEGRADED, or UNKNOWN.
   operationalStatus string
+  // Number of agents in the pool that are disrupted
+  //
+  // Agents that reached Okta but are not working correctly. A pool serving
+  // authentication or directory sync with disrupted agents is degraded even
+  // while its operationalStatus still reads ACTIVE.
+  disruptedAgents int
+  // Number of agents in the pool that are inactive
+  //
+  // Agents that are not currently connected to Okta. Read alongside
+  // disruptedAgents to tell a pool that lost capacity from one that never
+  // had it.
+  inactiveAgents int
   // Agents enrolled in the pool
   agents []okta.agentPool.agent
 }

--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -1495,7 +1495,8 @@ private okta.authorizationServer @defaults("name status issuer") {
   // Key set used to encrypt tokens
   //
   // The encryption keys as served, each carrying kid, kty, use, status and
-  // the RSA values n and e. Empty when the server does not encrypt tokens.
+  // the RSA values n and e. Null when the server does not encrypt tokens,
+  // which is the default and the common case.
   jwks dict
 }
 

--- a/providers/okta/resources/okta.lr.go
+++ b/providers/okta/resources/okta.lr.go
@@ -953,6 +953,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"okta.application.visibility": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaApplication).GetVisibility()).ToDataRes(types.Dict)
 	},
+	"okta.application.universalLogoutStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaApplication).GetUniversalLogoutStatus()).ToDataRes(types.String)
+	},
+	"okta.application.universalLogoutSupportType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaApplication).GetUniversalLogoutSupportType()).ToDataRes(types.String)
+	},
+	"okta.application.universalLogoutProtocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaApplication).GetUniversalLogoutProtocol()).ToDataRes(types.String)
+	},
+	"okta.application.universalLogoutIdentityStack": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaApplication).GetUniversalLogoutIdentityStack()).ToDataRes(types.String)
+	},
 	"okta.application.signingKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaApplication).GetSigningKeys()).ToDataRes(types.Array(types.Resource("okta.application.key")))
 	},
@@ -1316,6 +1328,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"okta.resourceSet.resource.orn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaResourceSetResource).GetOrn()).ToDataRes(types.String)
 	},
+	"okta.resourceSet.resource.excludedOrns": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaResourceSetResource).GetExcludedOrns()).ToDataRes(types.Array(types.String))
+	},
 	"okta.resourceSet.resource.group": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaResourceSetResource).GetGroup()).ToDataRes(types.Resource("okta.group"))
 	},
@@ -1468,6 +1483,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"okta.authorizationServer.keys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaAuthorizationServer).GetKeys()).ToDataRes(types.Array(types.Resource("okta.authorizationServer.key")))
+	},
+	"okta.authorizationServer.accessTokenEncryptedResponseAlgorithm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaAuthorizationServer).GetAccessTokenEncryptedResponseAlgorithm()).ToDataRes(types.String)
+	},
+	"okta.authorizationServer.jwksUri": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaAuthorizationServer).GetJwksUri()).ToDataRes(types.String)
+	},
+	"okta.authorizationServer.jwks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaAuthorizationServer).GetJwks()).ToDataRes(types.Dict)
 	},
 	"okta.authorizationServer.policy.authorizationServerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaAuthorizationServerPolicy).GetAuthorizationServerId()).ToDataRes(types.String)
@@ -1778,6 +1802,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"okta.apiServiceIntegration.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaApiServiceIntegration).GetCreatedAt()).ToDataRes(types.Time)
 	},
+	"okta.apiServiceIntegration.properties": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaApiServiceIntegration).GetProperties()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"okta.attackProtection.preventBruteForceLockoutFromUnknownDevices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaAttackProtection).GetPreventBruteForceLockoutFromUnknownDevices()).ToDataRes(types.Bool)
 	},
@@ -1945,6 +1972,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"okta.agentPool.operationalStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaAgentPool).GetOperationalStatus()).ToDataRes(types.String)
+	},
+	"okta.agentPool.disruptedAgents": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaAgentPool).GetDisruptedAgents()).ToDataRes(types.Int)
+	},
+	"okta.agentPool.inactiveAgents": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOktaAgentPool).GetInactiveAgents()).ToDataRes(types.Int)
 	},
 	"okta.agentPool.agents": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOktaAgentPool).GetAgents()).ToDataRes(types.Array(types.Resource("okta.agentPool.agent")))
@@ -2884,6 +2917,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOktaApplication).Visibility, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"okta.application.universalLogoutStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaApplication).UniversalLogoutStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"okta.application.universalLogoutSupportType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaApplication).UniversalLogoutSupportType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"okta.application.universalLogoutProtocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaApplication).UniversalLogoutProtocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"okta.application.universalLogoutIdentityStack": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaApplication).UniversalLogoutIdentityStack, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"okta.application.signingKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOktaApplication).SigningKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -3424,6 +3473,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOktaResourceSetResource).Orn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"okta.resourceSet.resource.excludedOrns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaResourceSetResource).ExcludedOrns, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"okta.resourceSet.resource.group": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOktaResourceSetResource).Group, ok = plugin.RawToTValue[*mqlOktaGroup](v.Value, v.Error)
 		return
@@ -3642,6 +3695,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"okta.authorizationServer.keys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOktaAuthorizationServer).Keys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"okta.authorizationServer.accessTokenEncryptedResponseAlgorithm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaAuthorizationServer).AccessTokenEncryptedResponseAlgorithm, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"okta.authorizationServer.jwksUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaAuthorizationServer).JwksUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"okta.authorizationServer.jwks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaAuthorizationServer).Jwks, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"okta.authorizationServer.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4096,6 +4161,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOktaApiServiceIntegration).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"okta.apiServiceIntegration.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaApiServiceIntegration).Properties, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"okta.attackProtection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOktaAttackProtection).__id, ok = v.Value.(string)
 		return
@@ -4354,6 +4423,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"okta.agentPool.operationalStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOktaAgentPool).OperationalStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"okta.agentPool.disruptedAgents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaAgentPool).DisruptedAgents, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"okta.agentPool.inactiveAgents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOktaAgentPool).InactiveAgents, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"okta.agentPool.agents": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6862,25 +6939,29 @@ type mqlOktaApplication struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOktaApplicationInternal it will be used here
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Label              plugin.TValue[string]
-	Created            plugin.TValue[*time.Time]
-	LastUpdated        plugin.TValue[*time.Time]
-	Credentials        plugin.TValue[any]
-	Features           plugin.TValue[[]any]
-	Licensing          plugin.TValue[any]
-	Profile            plugin.TValue[any]
-	Settings           plugin.TValue[any]
-	SignOnMode         plugin.TValue[string]
-	Status             plugin.TValue[string]
-	Visibility         plugin.TValue[any]
-	SigningKeys        plugin.TValue[[]any]
-	AssignedUsers      plugin.TValue[[]any]
-	AssignedGroups     plugin.TValue[[]any]
-	ScopeConsentGrants plugin.TValue[[]any]
-	AdminRoles         plugin.TValue[[]any]
-	Tokens             plugin.TValue[[]any]
+	Id                           plugin.TValue[string]
+	Name                         plugin.TValue[string]
+	Label                        plugin.TValue[string]
+	Created                      plugin.TValue[*time.Time]
+	LastUpdated                  plugin.TValue[*time.Time]
+	Credentials                  plugin.TValue[any]
+	Features                     plugin.TValue[[]any]
+	Licensing                    plugin.TValue[any]
+	Profile                      plugin.TValue[any]
+	Settings                     plugin.TValue[any]
+	SignOnMode                   plugin.TValue[string]
+	Status                       plugin.TValue[string]
+	Visibility                   plugin.TValue[any]
+	UniversalLogoutStatus        plugin.TValue[string]
+	UniversalLogoutSupportType   plugin.TValue[string]
+	UniversalLogoutProtocol      plugin.TValue[string]
+	UniversalLogoutIdentityStack plugin.TValue[string]
+	SigningKeys                  plugin.TValue[[]any]
+	AssignedUsers                plugin.TValue[[]any]
+	AssignedGroups               plugin.TValue[[]any]
+	ScopeConsentGrants           plugin.TValue[[]any]
+	AdminRoles                   plugin.TValue[[]any]
+	Tokens                       plugin.TValue[[]any]
 }
 
 // createOktaApplication creates a new instance of this resource
@@ -6970,6 +7051,22 @@ func (c *mqlOktaApplication) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlOktaApplication) GetVisibility() *plugin.TValue[any] {
 	return &c.Visibility
+}
+
+func (c *mqlOktaApplication) GetUniversalLogoutStatus() *plugin.TValue[string] {
+	return &c.UniversalLogoutStatus
+}
+
+func (c *mqlOktaApplication) GetUniversalLogoutSupportType() *plugin.TValue[string] {
+	return &c.UniversalLogoutSupportType
+}
+
+func (c *mqlOktaApplication) GetUniversalLogoutProtocol() *plugin.TValue[string] {
+	return &c.UniversalLogoutProtocol
+}
+
+func (c *mqlOktaApplication) GetUniversalLogoutIdentityStack() *plugin.TValue[string] {
+	return &c.UniversalLogoutIdentityStack
 }
 
 func (c *mqlOktaApplication) GetSigningKeys() *plugin.TValue[[]any] {
@@ -8266,13 +8363,14 @@ type mqlOktaResourceSetResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOktaResourceSetResourceInternal
-	Id          plugin.TValue[string]
-	Description plugin.TValue[string]
-	Href        plugin.TValue[string]
-	Orn         plugin.TValue[string]
-	Group       plugin.TValue[*mqlOktaGroup]
-	Application plugin.TValue[*mqlOktaApplication]
-	User        plugin.TValue[*mqlOktaUser]
+	Id           plugin.TValue[string]
+	Description  plugin.TValue[string]
+	Href         plugin.TValue[string]
+	Orn          plugin.TValue[string]
+	ExcludedOrns plugin.TValue[[]any]
+	Group        plugin.TValue[*mqlOktaGroup]
+	Application  plugin.TValue[*mqlOktaApplication]
+	User         plugin.TValue[*mqlOktaUser]
 }
 
 // createOktaResourceSetResource creates a new instance of this resource
@@ -8321,6 +8419,10 @@ func (c *mqlOktaResourceSetResource) GetHref() *plugin.TValue[string] {
 
 func (c *mqlOktaResourceSetResource) GetOrn() *plugin.TValue[string] {
 	return &c.Orn
+}
+
+func (c *mqlOktaResourceSetResource) GetExcludedOrns() *plugin.TValue[[]any] {
+	return &c.ExcludedOrns
 }
 
 func (c *mqlOktaResourceSetResource) GetGroup() *plugin.TValue[*mqlOktaGroup] {
@@ -8696,25 +8798,28 @@ type mqlOktaAuthorizationServer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOktaAuthorizationServerInternal it will be used here
-	Id                  plugin.TValue[string]
-	Name                plugin.TValue[string]
-	Description         plugin.TValue[string]
-	Status              plugin.TValue[string]
-	Default             plugin.TValue[bool]
-	Issuer              plugin.TValue[string]
-	IssuerMode          plugin.TValue[string]
-	Audiences           plugin.TValue[[]any]
-	SigningKid          plugin.TValue[string]
-	SigningRotationMode plugin.TValue[string]
-	SigningLastRotated  plugin.TValue[*time.Time]
-	SigningNextRotation plugin.TValue[*time.Time]
-	SigningUse          plugin.TValue[string]
-	Created             plugin.TValue[*time.Time]
-	LastUpdated         plugin.TValue[*time.Time]
-	Policies            plugin.TValue[[]any]
-	Scopes              plugin.TValue[[]any]
-	Claims              plugin.TValue[[]any]
-	Keys                plugin.TValue[[]any]
+	Id                                    plugin.TValue[string]
+	Name                                  plugin.TValue[string]
+	Description                           plugin.TValue[string]
+	Status                                plugin.TValue[string]
+	Default                               plugin.TValue[bool]
+	Issuer                                plugin.TValue[string]
+	IssuerMode                            plugin.TValue[string]
+	Audiences                             plugin.TValue[[]any]
+	SigningKid                            plugin.TValue[string]
+	SigningRotationMode                   plugin.TValue[string]
+	SigningLastRotated                    plugin.TValue[*time.Time]
+	SigningNextRotation                   plugin.TValue[*time.Time]
+	SigningUse                            plugin.TValue[string]
+	Created                               plugin.TValue[*time.Time]
+	LastUpdated                           plugin.TValue[*time.Time]
+	Policies                              plugin.TValue[[]any]
+	Scopes                                plugin.TValue[[]any]
+	Claims                                plugin.TValue[[]any]
+	Keys                                  plugin.TValue[[]any]
+	AccessTokenEncryptedResponseAlgorithm plugin.TValue[string]
+	JwksUri                               plugin.TValue[string]
+	Jwks                                  plugin.TValue[any]
 }
 
 // createOktaAuthorizationServer creates a new instance of this resource
@@ -8876,6 +8981,18 @@ func (c *mqlOktaAuthorizationServer) GetKeys() *plugin.TValue[[]any] {
 
 		return c.keys()
 	})
+}
+
+func (c *mqlOktaAuthorizationServer) GetAccessTokenEncryptedResponseAlgorithm() *plugin.TValue[string] {
+	return &c.AccessTokenEncryptedResponseAlgorithm
+}
+
+func (c *mqlOktaAuthorizationServer) GetJwksUri() *plugin.TValue[string] {
+	return &c.JwksUri
+}
+
+func (c *mqlOktaAuthorizationServer) GetJwks() *plugin.TValue[any] {
+	return &c.Jwks
 }
 
 // mqlOktaAuthorizationServerPolicy for the okta.authorizationServer.policy resource
@@ -9778,6 +9895,7 @@ type mqlOktaApiServiceIntegration struct {
 	ConfigGuideUrl plugin.TValue[string]
 	CreatedBy      plugin.TValue[string]
 	CreatedAt      plugin.TValue[*time.Time]
+	Properties     plugin.TValue[map[string]any]
 }
 
 // createOktaApiServiceIntegration creates a new instance of this resource
@@ -9843,6 +9961,10 @@ func (c *mqlOktaApiServiceIntegration) GetCreatedBy() *plugin.TValue[string] {
 
 func (c *mqlOktaApiServiceIntegration) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+func (c *mqlOktaApiServiceIntegration) GetProperties() *plugin.TValue[map[string]any] {
+	return &c.Properties
 }
 
 // mqlOktaAttackProtection for the okta.attackProtection resource
@@ -10523,6 +10645,8 @@ type mqlOktaAgentPool struct {
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
 	OperationalStatus plugin.TValue[string]
+	DisruptedAgents   plugin.TValue[int64]
+	InactiveAgents    plugin.TValue[int64]
 	Agents            plugin.TValue[[]any]
 }
 
@@ -10577,6 +10701,14 @@ func (c *mqlOktaAgentPool) GetType() *plugin.TValue[string] {
 
 func (c *mqlOktaAgentPool) GetOperationalStatus() *plugin.TValue[string] {
 	return &c.OperationalStatus
+}
+
+func (c *mqlOktaAgentPool) GetDisruptedAgents() *plugin.TValue[int64] {
+	return &c.DisruptedAgents
+}
+
+func (c *mqlOktaAgentPool) GetInactiveAgents() *plugin.TValue[int64] {
+	return &c.InactiveAgents
 }
 
 func (c *mqlOktaAgentPool) GetAgents() *plugin.TValue[[]any] {

--- a/providers/okta/resources/okta.lr.versions
+++ b/providers/okta/resources/okta.lr.versions
@@ -15,7 +15,9 @@ okta.agentPool.agent.updateMessage 13.4.4
 okta.agentPool.agent.updateStatus 13.4.4
 okta.agentPool.agent.version 13.4.4
 okta.agentPool.agents 13.4.4
+okta.agentPool.disruptedAgents 13.5.2
 okta.agentPool.id 13.4.4
+okta.agentPool.inactiveAgents 13.5.2
 okta.agentPool.name 13.4.4
 okta.agentPool.operationalStatus 13.4.4
 okta.agentPool.type 13.4.4
@@ -36,6 +38,7 @@ okta.apiServiceIntegration.createdBy 13.3.2
 okta.apiServiceIntegration.grantedScopes 13.3.2
 okta.apiServiceIntegration.id 13.3.2
 okta.apiServiceIntegration.name 13.3.2
+okta.apiServiceIntegration.properties 13.5.2
 okta.apiServiceIntegration.type 13.3.2
 okta.apiServiceIntegrations 13.3.2
 okta.apiTokens 13.1.6
@@ -99,6 +102,10 @@ okta.application.token.scopes 13.4.4
 okta.application.token.status 13.4.4
 okta.application.token.user 13.4.4
 okta.application.tokens 13.4.4
+okta.application.universalLogoutIdentityStack 13.5.2
+okta.application.universalLogoutProtocol 13.5.2
+okta.application.universalLogoutStatus 13.5.2
+okta.application.universalLogoutSupportType 13.5.2
 okta.application.user 13.3.2
 okta.application.user.created 13.3.2
 okta.application.user.credentials 13.3.2
@@ -131,6 +138,7 @@ okta.authenticator.type 13.1.6
 okta.authenticator.userVerification 13.1.6
 okta.authenticators 13.1.6
 okta.authorizationServer 13.2.6
+okta.authorizationServer.accessTokenEncryptedResponseAlgorithm 13.5.2
 okta.authorizationServer.audiences 13.2.6
 okta.authorizationServer.claim 13.2.6
 okta.authorizationServer.claim.alwaysIncludeInToken 13.2.6
@@ -151,6 +159,8 @@ okta.authorizationServer.description 13.2.6
 okta.authorizationServer.id 13.2.6
 okta.authorizationServer.issuer 13.2.6
 okta.authorizationServer.issuerMode 13.2.6
+okta.authorizationServer.jwks 13.5.2
+okta.authorizationServer.jwksUri 13.5.2
 okta.authorizationServer.key 13.2.6
 okta.authorizationServer.key.alg 13.2.6
 okta.authorizationServer.key.authorizationServerId 13.2.6
@@ -487,6 +497,7 @@ okta.resourceSet.lastUpdated 13.3.2
 okta.resourceSet.resource 13.3.2
 okta.resourceSet.resource.application 13.3.2
 okta.resourceSet.resource.description 13.3.2
+okta.resourceSet.resource.excludedOrns 13.5.2
 okta.resourceSet.resource.group 13.3.2
 okta.resourceSet.resource.href 13.3.2
 okta.resourceSet.resource.id 13.3.2

--- a/providers/okta/resources/resourceSets.go
+++ b/providers/okta/resources/resourceSets.go
@@ -13,6 +13,7 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 type mqlOktaResourceSetResourceInternal struct {
@@ -186,13 +187,24 @@ func newMqlOktaResourceSetResource(runtime *plugin.Runtime, setID string, entry 
 	orn := oktaStr(entry.Orn)
 	targetType, targetID := resolveOktaResourceTarget(orn, href)
 
+	// Exclusions narrow what the entry actually grants. An absent conditions
+	// block means nothing is carved out, which is an empty list rather than a
+	// null: the API answered, and the answer is "none".
+	excluded := []any{}
+	if entry.Conditions != nil && entry.Conditions.Exclude != nil {
+		for _, orn := range entry.Conditions.Exclude.OktaORN {
+			excluded = append(excluded, orn)
+		}
+	}
+
 	resourceID := oktaStr(entry.Id)
 	r, err := CreateResource(runtime, "okta.resourceSet.resource", map[string]*llx.RawData{
-		"__id":        llx.StringData(fmt.Sprintf("%s/%s", setID, resourceID)),
-		"id":          llx.StringData(resourceID),
-		"description": llx.StringData(oktaStrFrom(entry.AdditionalProperties["description"])),
-		"href":        llx.StringData(href),
-		"orn":         llx.StringData(orn),
+		"__id":         llx.StringData(fmt.Sprintf("%s/%s", setID, resourceID)),
+		"id":           llx.StringData(resourceID),
+		"description":  llx.StringData(oktaStrFrom(entry.AdditionalProperties["description"])),
+		"href":         llx.StringData(href),
+		"orn":          llx.StringData(orn),
+		"excludedOrns": llx.ArrayData(excluded, types.String),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Follow-up to #9976, which moved the provider to okta-sdk-golang v6. This exposes the Tier A fields that upgrade unlocked: values the new SDK carries on resources this provider already ships.

**No new API call.** Every value below arrives in a response the provider already fetches, so nothing here adds request volume or rate-limit pressure.

## `okta.application` — Universal Logout

```
universalLogoutStatus         string
universalLogoutSupportType    string
universalLogoutProtocol       string
universalLogoutIdentityStack  string
```

Universal Logout is what lets Okta end an application's *own* session when it ends the user's Okta session. Where it is not in effect, revoking access in Okta leaves the application signed in until its session expires on its own — offboarding and session revocation stop at the Okta boundary, and nothing in the schema said so.

`universalLogoutSupportType` is the one that separates an app terminating *every* session from one terminating only some, which is the difference between a logout that finishes and one that appears to.

The SDK documents no enum values for these, so the comments describe them without claiming a closed set.

## `okta.authorizationServer` — token encryption

```
accessTokenEncryptedResponseAlgorithm  string
jwksUri                                string
jwks                                   dict
```

These describe how issued tokens are **encrypted**, and are a different key set from the signing keys `keys()` already returns — the SDK docs are explicit that `jwksUri` "references a JSON Web Key Set for encrypting JWTs minted by the custom authorization server". Named for encryption rather than folded in with the signing keys, since conflating the two would be actively misleading.

When encryption is off (the default), `accessTokenEncryptedResponseAlgorithm` is empty.

## `okta.resourceSet.resource` — admin scope exclusions

```
excludedOrns  []string
```

Exclusions narrow what an admin grant actually covers. A resource-set entry naming a whole class of resources grants **less** than it appears to when this list is non-empty, so reading the entry without it overstates the scope.

An absent conditions block yields an empty list, not null: the API answered, and the answer is "nothing is carved out".

## `okta.agentPool` — fleet health

```
disruptedAgents  int
inactiveAgents   int
```

A pool can carry disrupted agents while its `operationalStatus` still reads `ACTIVE`, so the status alone does not tell you a pool serving authentication or directory sync is degraded.

An unreported count stays **null** rather than reporting `0`, since zero would assert that nothing is disrupted — the opposite reading, and the one a health check would pass on.

## `okta.apiServiceIntegration` — configured properties

```
properties  map[string]string
```

Keyed by property name. Modelled as a map rather than a list of `{name, value}` objects, per the schema guidance on name/value pair lists, so a query can look a property up directly.

## Version entries

All 11 entries are at **13.5.2** — one patch past the provider's current `13.5.1` in `config/config.go`. `config.go` itself is not bumped; that belongs to the release flow.

## Tests

- `TestOktaApplicationRawUniversalLogout` pins each of the four struct tags. A mistyped tag would read empty on every application, which is indistinguishable from an app that genuinely lacks Universal Logout — a wrong answer that looks like a plausible one.
- `TestOktaApplicationRawWithoutUniversalLogout` covers the absent block.
- `TestOktaInt64` covers the optional count widening, including that nil stays null.

```
cd providers/okta && go build ./... && go test ./... && go vet ./... && gofmt -l .   # all clean
```

Regenerated with `mqlr generate`; `okta.lr.go` and `okta.lr.versions` are in sync.

## Not verified

**Not exercised against a live Okta org** — no credentials here. The decodes are pinned by unit tests against payloads shaped like the documented responses, but no field below has been observed returning real data from an actual tenant. `universalLogout` in particular is only populated for applications Okta has Universal Logout support for, so a live check would be worth doing before writing policy against it.
