### PR TITLE
🐛 okta: restore the resource set description, and report unreadable risk providers as null

### DIFF
--- a/providers/okta/resources/authorizationServers_test.go
+++ b/providers/okta/resources/authorizationServers_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/okta/okta-sdk-golang/v6/okta"
@@ -12,20 +13,19 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 )
 
-// TestAuthorizationServerJwksNilIsNullNotAnError pins the absence of a nil
+// TestAuthorizationServerJwksNilDoesNotError pins the absence of a nil
 // guard around the jwks conversion.
 //
 // Most authorization servers do not encrypt tokens, so entry.Jwks is nil on the
 // common path. JsonToDict marshals that to the JSON literal `null` and
 // unmarshals it into the result map, which encoding/json treats as a no-op
-// rather than an error: the call returns a nil map and a nil error. The field
-// then reports null, which is the correct reading for a server that has no
-// encryption key set.
+// rather than an error: the call returns a nil map and a nil error. Checked
+// against a live org, the field then reports an empty dict rather than null.
 //
 // Guarding the call would not fix a bug, and coercing the result to an empty
 // map would introduce one: `{}` asserts that a key set was returned and was
 // empty, which is a different claim from there being no key set at all.
-func TestAuthorizationServerJwksNilIsNullNotAnError(t *testing.T) {
+func TestAuthorizationServerJwksNilDoesNotError(t *testing.T) {
 	t.Parallel()
 
 	// The exact type and nilness the mapper sees for a server without
@@ -35,7 +35,7 @@ func TestAuthorizationServerJwksNilIsNullNotAnError(t *testing.T) {
 	dict, err := convert.JsonToDict(absent)
 	require.NoError(t, err,
 		"a server without token encryption must not fail the listing")
-	assert.Nil(t, dict, "an absent key set must read null, not an empty map")
+	assert.Nil(t, dict, "the conversion yields a nil map, which reports as empty")
 
 	// A configured key set still converts.
 	kid, kty := "k1", "RSA"
@@ -47,4 +47,40 @@ func TestAuthorizationServerJwksNilIsNullNotAnError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, dict)
 	assert.Contains(t, dict, "keys")
+}
+
+// TestResourceSetDescriptionIsTypedNotAdditional pins which of the two
+// description fields the SDK types and which it does not.
+//
+// A resource set types `description`, so it must be read off the field. The
+// resources *inside* a set do not, so theirs arrives in AdditionalProperties.
+// Reading a set's description from AdditionalProperties returns empty even
+// though the API sent it, which is how it shipped in #9976 and what a live
+// org caught: the API returned "A resource set managed by Workflows
+// Administrator" while the field read "".
+func TestResourceSetDescriptionIsTypedNotAdditional(t *testing.T) {
+	t.Parallel()
+
+	const wire = `{
+		"id": "WORKFLOWS_IAM_POLICY",
+		"label": "Workflows Resource Set",
+		"description": "A resource set managed by Workflows Administrator"
+	}`
+
+	set := &okta.ResourceSet{}
+	require.NoError(t, json.Unmarshal([]byte(wire), set))
+
+	require.NotNil(t, set.Description,
+		"the SDK types this field; reading it from AdditionalProperties loses it")
+	assert.Equal(t, "A resource set managed by Workflows Administrator",
+		oktaStr(set.Description))
+	assert.NotContains(t, set.AdditionalProperties, "description",
+		"a typed field is consumed by the model and never reaches AdditionalProperties")
+
+	// The resources inside a set are the opposite case.
+	res := &okta.ResourceSetResource{}
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"orn":"orn:okta:workflow:x:contained","description":"carved out"}`), res))
+	assert.Equal(t, "carved out", oktaStrFrom(res.AdditionalProperties["description"]),
+		"this one is untyped, so it only arrives via AdditionalProperties")
 }

--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -1495,7 +1495,7 @@ private okta.authorizationServer @defaults("name status issuer") {
   // Key set used to encrypt tokens
   //
   // The encryption keys as served, each carrying kid, kty, use, status and
-  // the RSA values n and e. Null when the server does not encrypt tokens,
+  // the RSA values n and e. Empty when the server does not encrypt tokens,
   // which is the default and the common case.
   jwks dict
 }

--- a/providers/okta/resources/resourceSets.go
+++ b/providers/okta/resources/resourceSets.go
@@ -124,9 +124,10 @@ func initOktaResourceSet(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 
 func oktaResourceSetArgs(entry *okta.ResourceSet) map[string]*llx.RawData {
 	return map[string]*llx.RawData{
-		"id":          llx.StringData(oktaStr(entry.Id)),
-		"label":       llx.StringData(oktaStr(entry.Label)),
-		"description": llx.StringData(oktaStrFrom(entry.AdditionalProperties["description"])),
+		"id":    llx.StringData(oktaStr(entry.Id)),
+		"label": llx.StringData(oktaStr(entry.Label)),
+		// The resource set types this field, unlike the resources inside it.
+		"description": llx.StringData(oktaStr(entry.Description)),
 		"created":     llx.TimeDataPtr(entry.Created),
 		"lastUpdated": llx.TimeDataPtr(entry.LastUpdated),
 	}

--- a/providers/okta/resources/threatPosture.go
+++ b/providers/okta/resources/threatPosture.go
@@ -133,10 +133,13 @@ func (o *mqlOkta) riskProviders() ([]any, error) {
 	slice, resp, err := conn.ApiExtension().ListRiskProviders(ctx)
 	if err != nil {
 		// The risk providers endpoint is not available on every org edition
-		// and returns 410 Gone (or 404) when the feature is absent; degrade to
-		// an empty result rather than failing the query.
+		// and answers 410 Gone (or 404) when the feature is absent. That is a
+		// list we could not read, not a list we read and found empty, so it
+		// degrades to null: an empty list would assert the org has no risk
+		// providers, and an audit written on that would pass without anything
+		// having been checked.
 		if resp != nil && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone) {
-			return nil, nil
+			return oktaUnreadableList(&o.RiskProviders)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Three fixes found by running the provider against a **live Okta org** after #9976 and #9977 merged. This is the live verification those PRs said was outstanding.

## 1. `okta.resourceSet.description` came back empty — regression from #9976

The API returns a description; the field read `""`.

```
API   → "description": "A resource set managed by Workflows Administrator"
before→ description: ""
after → description: "A resource set managed by Workflows Administrator"
```

**Cause.** The v6 migration moved this read to `AdditionalProperties`. That is correct for the resources *inside* a set — v6 stopped typing `ResourceSetResource.Description` — but wrong for the **set itself**, which types `Description` as a `*string` in *both* v5 and v6.

`resourceSets.go` has two visually identical `"description": llx.StringData(oktaStr(entry.Description)),` lines, and a single-occurrence replace hit the first (the set) instead of the second (the resource). Both spellings compile, so nothing objected: `AdditionalProperties["description"]` on a model that already consumed the key just yields `""`.

Restored to the typed field, and pinned by `TestResourceSetDescriptionIsTypedNotAdditional`, which asserts *which of the two* is typed and which is not — the distinction that was got wrong.

## 2. `okta.riskProviders` reported `[]` for an endpoint that is gone

This org's `/api/v1/risk/providers` answers **HTTP 410 Gone**. The provider degraded that to an empty list.

An empty list asserts *"this org has no risk providers"*, which an audit reads as a clean result. The truth is the endpoint is retired and we cannot see them at all. That is the exact distinction `oktaUnreadableList` exists for, so it now reports **null**:

```
before→ okta.riskProviders: []
after → okta.riskProviders: null
```

The 410 handling predates the v6 work, but the call site moved in #9976 when the generated client was replaced with a hand-rolled one, so the fix belongs with it.

## 3. `jwks` schema comment was wrong — my own review-response change

While answering review on #9977 I changed the comment to say the field is *null* when a server does not encrypt tokens. Against a live org:

```
okta.authorizationServers { jwks jwks == null }
  jwks: {}
  jwks == null: false
```

It reports an **empty dict**, not null. The comment said "empty" before I changed it; it says empty again, and `TestAuthorizationServerJwksNilDoesNotError` no longer claims otherwise in its name or body. The substance of that review exchange is unchanged — `JsonToDict(nil)` still does not error, and the guard is still unnecessary.

## What the live run confirmed as working

Not everything was broken. Validated against real data:

- **Scope splits** — `RoleAssignmentAUserAPI` returned `assignmentType: "USER"` with a `SUPER_ADMIN` role; `UserResourcesAPI` returned real `groups`, `appLinks` and `clients`; `OrgSettingGeneralAPI` returned the org's company name and subdomain. These are the remappings where a wrong sibling compiles and reads the wrong scope, so real output was the only way to check them.
- **The role union flattener** — the `StandardRole` member flattened with every field populated.
- **`ProfileMapping.Properties`** — the riskiest change, since v6 mistypes the map as a single object. Returned all four configured properties with their Okta Expression Language expressions, exactly matching the API's key set.
- **The `GroupProfile` union** — group names resolved through the flattener.
- **`AssignedAppLink`** and `ListUserGroups` without the removed `.Limit()` builder.
- **Tier A fields** — `universalLogoutStatus` returns a real value (`UNSUPPORTED` on this org's apps).

Empty collections were each checked against the raw API rather than assumed: `inlineHooks`, `agentPools`, `email-servers`, `logStreams` and `idps` all genuinely return 0 items on this org, so those `[]` results are correct.

## Not covered

This is a **trial org**, so several paths still have no live coverage: inline hook metadata, hook keys, application and identity-provider JWK fields (`status`/`alg`/`keyOps`/`x5t`), email servers, log streams, agent pools, and the Tier A `disruptedAgents`/`inactiveAgents`/`properties` fields. Those remain argued from the SDK source only.

The `CUSTOM` vs `CUSTOM_ROLE` question is also still open — this org has a custom role defined (`WORKFLOWS_ADMIN`) but not *assigned* to a principal, so no assignment came back to read the discriminator from.

Separately, `/api/v1/api-service-integrations` answers **405** on this org, and `okta.apiServiceIntegrations` returns `[]`. That predates this work and I have not chased it, but it may be the same unreadable-versus-empty problem as #2.

```
cd providers/okta && go build ./... && go test ./... && go vet ./... && gofmt -l .   # clean
```
