### PR TITLE
🐛 os: report a truncated read of the dpkg status file

### DIFF
--- a/providers/os/resources/packages/dpkg_packages.go
+++ b/providers/os/resources/packages/dpkg_packages.go
@@ -24,6 +24,11 @@ const (
 	DpkgPkgFormat = "deb"
 )
 
+// dpkgMaxLine caps how long a single line of a dpkg control stream may be. The
+// Depends and Conffiles lines of a metapackage are the long ones, and they grow
+// with the number of packages a distribution ships.
+const dpkgMaxLine = 4 * 1024 * 1024
+
 var (
 	// e.g. source with version: samba (2:4.17.12+dfsg-0+deb12u1)
 	DPKG_ORIGIN_REGEX = regexp.MustCompile(`^\s*([^\(]*)(?:\((.*)\))?\s*$`)
@@ -85,6 +90,10 @@ func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, erro
 	}
 
 	scanner := bufio.NewScanner(input)
+	// A line longer than the 64KB default ends the scan, and the packages that
+	// follow it are lost. Raise the cap so a long Depends line cannot shorten
+	// the package list.
+	scanner.Buffer(nil, dpkgMaxLine)
 	pkg := Package{Format: DpkgPkgFormat}
 	state := STATE_RESET
 	for scanner.Scan() {
@@ -126,8 +135,19 @@ func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, erro
 		}
 	}
 
+	// A read that stopped early leaves the package list short. Reporting that
+	// as a successful parse would present a partial inventory as a complete
+	// one, so it is an error rather than a shorter answer.
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("could not read the dpkg status stream to its end: %w", err)
+	}
+
 	// if the last line is not an empty line we have things in flight, lets check it
-	add(pkg)
+	// a stream that ends with an empty line has nothing left, and reporting
+	// that empty package as ignored only reads like data loss
+	if pkg.Name != "" {
+		add(pkg)
+	}
 
 	return pkgs, nil
 }
@@ -181,6 +201,7 @@ var DPKG_UPDATE_REGEX = regexp.MustCompile(`^Inst\s([a-zA-Z0-9.\-_]+)\s\[([a-zA-
 func ParseDpkgUpdates(input io.Reader) (map[string]PackageUpdate, error) {
 	pkgs := map[string]PackageUpdate{}
 	scanner := bufio.NewScanner(input)
+	scanner.Buffer(nil, dpkgMaxLine)
 	for scanner.Scan() {
 		line := scanner.Text()
 		m := DPKG_UPDATE_REGEX.FindStringSubmatch(line)
@@ -192,6 +213,11 @@ func ParseDpkgUpdates(input io.Reader) (map[string]PackageUpdate, error) {
 			}
 		}
 	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("could not read the dpkg update list to its end: %w", err)
+	}
+
 	return pkgs, nil
 }
 
@@ -234,7 +260,7 @@ func (dpm *DebPkgManager) List() ([]Package, error) {
 
 		list, err := ParseDpkgPackages(dpm.platform, fi)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse dpkg package list")
+			return nil, fmt.Errorf("could not parse dpkg package list: %w", err)
 		}
 		pkgList = append(pkgList, list...)
 	}
@@ -258,7 +284,7 @@ func (dpm *DebPkgManager) List() ([]Package, error) {
 			fi.Close()
 			if err != nil {
 				log.Debug().Err(err).Str("path", path).Msg("could not parse")
-				return fmt.Errorf("could not parse dpkg package list")
+				return fmt.Errorf("could not parse dpkg package list %q: %w", path, err)
 			}
 
 			log.Debug().Int("pkgs", len(list)).Msg("completed parsing")

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -6,8 +6,11 @@ package packages
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -216,6 +219,84 @@ See /usr/share/common-licenses/GPL-2 for the full license text.
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, "missing"))
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(fs, ""))
 	assert.Equal(t, "", ParseDpkgCopyrightLicense(nil, "bash"))
+}
+
+// A line longer than bufio.Scanner's 64KB default used to end the scan, and
+// every package behind it was dropped while the parser still reported success.
+func TestDpkgLongLineDoesNotTruncate(t *testing.T) {
+	pf := &inventory.Platform{Name: "ubuntu", Version: "24.04", Arch: "amd64"}
+
+	var buf bytes.Buffer
+	buf.WriteString("Package: first\nStatus: install ok installed\nVersion: 1.0\nArchitecture: amd64\n\n")
+	buf.WriteString("Package: huge\nStatus: install ok installed\nVersion: 2.0\nArchitecture: amd64\n")
+	buf.WriteString("Depends: " + strings.Repeat("libfoo (>= 1.0), ", 6000) + "libbar\n\n")
+	buf.WriteString("Package: last\nStatus: install ok installed\nVersion: 3.0\nArchitecture: amd64\n\n")
+
+	pkgs, err := ParseDpkgPackages(pf, bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	names := make([]string, len(pkgs))
+	for i := range pkgs {
+		names[i] = pkgs[i].Name
+	}
+	assert.Equal(t, []string{"first", "huge", "last"}, names)
+}
+
+// Past the raised cap the read still stops, and a short package list must not
+// be handed back as a successful parse.
+func TestDpkgOverlongLineIsAnError(t *testing.T) {
+	pf := &inventory.Platform{Name: "ubuntu", Version: "24.04", Arch: "amd64"}
+
+	var buf bytes.Buffer
+	buf.WriteString("Package: first\nStatus: install ok installed\nVersion: 1.0\nArchitecture: amd64\n\n")
+	buf.WriteString("Package: huge\nDepends: " + strings.Repeat("x", dpkgMaxLine+1) + "\n\n")
+	buf.WriteString("Package: last\nStatus: install ok installed\nVersion: 3.0\nArchitecture: amd64\n\n")
+
+	pkgs, err := ParseDpkgPackages(pf, bytes.NewReader(buf.Bytes()))
+	require.Error(t, err)
+	assert.Nil(t, pkgs, "a partial inventory must not be reported as a complete one")
+	assert.Contains(t, err.Error(), "could not read the dpkg status stream to its end")
+}
+
+// The trailing add() is guarded now, which must not cost the last package of a
+// stream that ends without an empty line.
+func TestDpkgLastPackage(t *testing.T) {
+	pf := &inventory.Platform{Name: "ubuntu", Version: "24.04", Arch: "amd64"}
+	status := "Package: first\nStatus: install ok installed\nVersion: 1.0\nArchitecture: amd64\n\n" +
+		"Package: last\nStatus: install ok installed\nVersion: 2.0\nArchitecture: amd64\n"
+
+	pkgs, err := ParseDpkgPackages(pf, bytes.NewReader([]byte(status)))
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	assert.Equal(t, "last", pkgs[1].Name)
+
+	// and the same stream closed with an empty line
+	pkgs, err = ParseDpkgPackages(pf, bytes.NewReader([]byte(status+"\n")))
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	assert.Equal(t, "last", pkgs[1].Name)
+}
+
+// The trailing add() used to run on an empty package for every stream that
+// ends with an empty line, which is every healthy host, and logged it as
+// ignored. Nothing was lost, but the debug log said otherwise once per parse.
+func TestDpkgNoSpuriousIgnoreLog(t *testing.T) {
+	pf := &inventory.Platform{Name: "ubuntu", Version: "24.04", Arch: "amd64"}
+	status := "Package: first\nStatus: install ok installed\nVersion: 1.0\nArchitecture: amd64\n\n"
+
+	var out bytes.Buffer
+	origLogger, origLevel := log.Logger, zerolog.GlobalLevel()
+	log.Logger = zerolog.New(&out)
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	defer func() {
+		log.Logger = origLogger
+		zerolog.SetGlobalLevel(origLevel)
+	}()
+
+	pkgs, err := ParseDpkgPackages(pf, bytes.NewReader([]byte(status)))
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	assert.NotContains(t, out.String(), "ignored deb packages since information is missing")
 }
 
 // Both shapes that used to cost a package its description, in the form they

--- a/providers/os/resources/packages/dpkg_packages_test.go
+++ b/providers/os/resources/packages/dpkg_packages_test.go
@@ -284,14 +284,16 @@ func TestDpkgNoSpuriousIgnoreLog(t *testing.T) {
 	pf := &inventory.Platform{Name: "ubuntu", Version: "24.04", Arch: "amd64"}
 	status := "Package: first\nStatus: install ok installed\nVersion: 1.0\nArchitecture: amd64\n\n"
 
+	// The parser logs through the process-wide zerolog logger, so observing
+	// what it writes means swapping that logger for the duration of this test.
+	// No test in this package runs in parallel and the parser logs from the
+	// calling goroutine only, so nothing else can read the logger while it is
+	// swapped. If a parallel test is ever added here, this has to move to a
+	// logger passed into the parser rather than the global one.
 	var out bytes.Buffer
-	origLogger, origLevel := log.Logger, zerolog.GlobalLevel()
+	origLogger := log.Logger
 	log.Logger = zerolog.New(&out)
-	zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	defer func() {
-		log.Logger = origLogger
-		zerolog.SetGlobalLevel(origLevel)
-	}()
+	defer func() { log.Logger = origLogger }()
 
 	pkgs, err := ParseDpkgPackages(pf, bytes.NewReader([]byte(status)))
 	require.NoError(t, err)


### PR DESCRIPTION
The dpkg half of what #9946 fixed for apk, and the follow-up promised in #9947. Three things, all in the same parser.

## 1. A truncated read is reported as success

`ParseDpkgPackages` returns an `error` it never sets. It scans `/var/lib/dpkg/status` with a default `bufio.Scanner`, so a line over 64KB ends the scan, the packages behind it are dropped, and the caller receives `nil`:

```
parsed 2 of 3 packages: [first huge]   <- "last" is gone, err == nil
```

A short package list reads as a clean asset — the wrong direction to fail in for something that feeds vulnerability matching.

`scanner.Buffer(nil, dpkgMaxLine)` raises the cap to 4MB. The **nil** initial buffer is what makes it free; the more obvious `make([]byte, 0, 64*1024)` costs an extra 61KB per parse for nothing (measured while doing this for apk). Past the raised cap the read still stops, and `scanner.Err()` now reaches the caller.

The Depends and Conffiles lines of a metapackage are the long ones. The longest line across `debian:12`, `debian:13`, `ubuntu:22.04`, `ubuntu:24.04` and an Ubuntu image with build tools is 3.6KB, so this is latent rather than live — worth closing because the failure is silent and the result looks complete.

`ParseDpkgUpdates` had the same unused error return and the same silent stop, and gets the same treatment.

## 2. The cause was thrown away one frame up

Both call sites wrapped the failure as `fmt.Errorf("could not parse dpkg package list")` — no `%w`, no cause. The new error would have died there. They now wrap it, and the walk over `status.d` names the file it was reading.

## 3. A debug line on every healthy host

A status file ends with an empty line, so the trailing `add(pkg)` always ran on an empty package and logged `ignored deb packages since information is missing`. Nothing was lost, but the log said otherwise, once per parse. It also sits inside the measured loop of the benchmark #9873 added, which is what makes `go test -bench` output unreadable.

Live `debian:12` scan with `--log-level debug`:

```
main:    1 occurrence
this PR: 0
```

## Tests

Each one was checked against a revert rather than just added:

| test | fails without |
| --- | --- |
| `TestDpkgLongLineDoesNotTruncate` | the raised buffer — `[first huge]`, not `[first huge last]` |
| `TestDpkgOverlongLineIsAnError` | the `scanner.Err()` check — `an error is expected but got nil` |
| `TestDpkgNoSpuriousIgnoreLog` | the trailing-add guard |
| `TestDpkgLastPackage` | nothing — it is there so the guard cannot start dropping a real trailing package |

## No output change

Providers built from `main@19cc03e27` and from this branch, both run against a live `debian:12` container: **byte-for-byte identical package output, 88 packages.** `go test ./resources/packages/...` passes in `providers/os`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)