### PR TITLE
🧹 run the generated-files check when go.mod changes

### DIFF
--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -1,6 +1,12 @@
 name: Generated Code Test
 
 ## Only trigger tests if source is changing
+##
+## go.mod and go.sum count as source here: the protoc plugins come from the
+## `tool` directive, so bumping google.golang.org/protobuf changes what the
+## generated files look like. Without them a dependency bump lands green and the
+## next push that happens to touch a .go file inherits the failure, which is how
+## mondoohq/cnspec#3336 happened.
 on:
   # Run on PRs so the arc-runner job can be skipped while the PR is a draft
   # (see the `if` guard below); ready_for_review re-triggers it.
@@ -10,6 +16,8 @@ on:
       - "**.proto"
       - "**.lr"
       - "**.go"
+      - "go.mod"
+      - "go.sum"
   # Still validate merges to main.
   push:
     branches: [main]
@@ -17,6 +25,8 @@ on:
       - "**.proto"
       - "**.lr"
       - "**.go"
+      - "go.mod"
+      - "go.sum"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The protoc plugins come from the `tool` directive in `go.mod`, so the version of `google.golang.org/protobuf` decides what every generated file contains — down to the header the generator stamps. `Generated Code Test` did not watch `go.mod` or `go.sum`:

```yaml
paths:
  - "**.proto"
  - "**.lr"
  - "**.go"
```

So a bump of that module lands green, and the failure appears later, on whichever unrelated branch next pushes a `.go` file.

## This is not hypothetical

It happened in cnspec today. Dependabot moved `google.golang.org/protobuf` from a pseudo-version to the released `v1.36.12`, which changed the stamp from `protoc-gen-go v1.36.11-devel` to `v1.36.12` in four generated files. The check never ran on that PR — it touched only `go.mod` and `go.sum` — and it surfaced on a Windows-metadata branch that contains no Go code at all, which had merely rebased onto the new `main`. Fix and full write-up: mondoohq/cnspec#3336.

## State of this repo

**Currently in sync**, so this is prevention rather than a fix. The four files the generate step covers carry the `-devel` stamp that this repo's pinned pseudo-version produces, and `generated-files` is green on recent PRs. The other 14 committed `.pb.go` files carry `v1.36.11` but are not regenerated by the make target, so they do not enter into the check.

When dependabot bumps `google.golang.org/protobuf` here — the pin is still `v1.36.12-0.20260120151049-f2248ac996af` — the same thing would happen without this change.

## Scope

Both trigger blocks (`pull_request` and `push`) get `go.mod` and `go.sum`. Provider modules are deliberately left out: their dependencies do not feed the generators, and `**.go` already covers provider source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)