### PR TITLE
🐛 os: resolve eLxr inside the debian family so packages can be enumerated

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -448,6 +448,20 @@ var kdeneon = &PlatformResolver{
 	},
 }
 
+// elxr is a Debian derivative (os-release carries ID=elxr, ID_LIKE=debian).
+// It ships dpkg/apt, so it has to resolve inside the debian family for the
+// package manager and the debian-specific resources to be selected.
+var elxr = &PlatformResolver{
+	Name:     "elxr",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "elxr" {
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 // rhel PlatformResolver only detects redhat and no derivatives
 var rhel = &PlatformResolver{
 	Name:     "redhat",
@@ -1252,7 +1266,7 @@ var redhatFamily = &PlatformResolver{
 var debianFamily = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: true,
-	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin, parrot, cumulus, gardenlinux, tails, kdeneon},
+	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin, parrot, cumulus, gardenlinux, tails, kdeneon, elxr},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		return true, nil
 	},

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1250,6 +1250,17 @@ func TestGardenLinuxDetector_1877(t *testing.T) {
 	assert.Equal(t, "1877.9", di.Version, "os version should be identified")
 }
 
+func TestElxrDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-elxr-12.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "elxr", di.Name, "os name should be identified")
+	assert.Equal(t, "eLxr 12 (aria)", di.Title, "os title should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
+	assert.Equal(t, "12", di.Version, "os version should be identified")
+}
+
 func TestCachyOSDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-cachyos.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-elxr-12.toml
+++ b/providers/os/detector/testdata/detect-elxr-12.toml
@@ -1,0 +1,27 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.1.0-42-amd64"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="eLxr 12 (aria)"
+NAME="eLxr"
+VARIANT="Edge Edition"
+VARIANT_ID=edge
+VERSION_ID="12"
+VERSION="12 (aria)"
+VERSION_CODENAME=aria
+ID=elxr
+ID_LIKE=debian
+HOME_URL="https://elxr.org"
+SUPPORT_URL="https://elxr.org"
+BUG_REPORT_URL="https://gitlab.com/groups/elxr/-/issues"
+"""
+
+[files."/etc/debian_version"]
+content = "12.13"


### PR DESCRIPTION
### Problem

[eLxr](https://elxr.org) is a Debian derivative. Its `/etc/os-release` says so explicitly:

```
NAME="eLxr"
VERSION="12 (aria)"
ID=elxr
ID_LIKE=debian
```

It ships dpkg and apt like any other Debian derivative. But `debianFamily.Children` has no resolver for it, so detection falls through to the generic Linux resolver:

```
platform=elxr version=12 family=[linux unix os]
```

Package manager selection keys off `IsFamily("debian")`. With `debian` missing from the family, there is no package manager to select, and the `packages` resource fails outright:

```
* could not detect suitable package manager for platform
```

`package("openssh-server").installed` fails identically. On an eLxr host you currently cannot enumerate installed packages, query a single package, or run anything built on top of either — on a system carrying an entirely ordinary dpkg database (283 packages on the stock 12.13.0.0 cloud image).

### Change

Add an `elxr` resolver and register it in `debianFamily.Children`, following the same one-line-name-match pattern already used for the other derivatives (`gardenlinux`, `linuxmint`, `pop`, `elementary`, `zorin`, `kali`, …).

This is unrelated to the existing `windriver` resolver, which matches `wrlinux` — a different product with a different os-release. No existing resolver changes behaviour; `elxr` is appended to the child list and matches only `pf.Name == "elxr"`.

### Verification

Against a stock **eLxr 12.13.0.0 amd64 cloud image**, booted unmodified under Lima/QEMU (x86_64) and scanned over SSH:

| Probe | Before | After |
|---|---|---|
| `asset.platform == "elxr"` | pass | pass |
| `asset.family.contains("linux")` | pass | pass |
| `asset.family.contains("debian")` | **fail** | **pass** |
| `packages.list.length > 0` | **error** | **pass** |
| `package("openssh-server").installed` | **error** | **pass** |

The two `error` rows are both `could not detect suitable package manager for platform`.

Detection before and after:

```
- platform=elxr family=[linux unix os]
+ platform=elxr family=[debian linux unix os]
```

### Tests

- `TestElxrDetector` in `detector_platform_test.go`, alongside the existing per-distro family tests, asserting `family == [debian linux unix os]`.
- `testdata/detect-elxr-12.toml`, a mock built from the real `/etc/os-release` and `uname` output of the image above.
- Full `providers/os/detector` package passes with no other test touched.
