### PR TITLE
📄 skills: add new-resource, and point CLAUDE.md at the skills it ships

### DIFF
--- a/.claude/skills/new-provider/SKILL.md
+++ b/.claude/skills/new-provider/SKILL.md
@@ -75,6 +75,7 @@ Show the user:
    make providers/build/<provider-id> && make providers/install/<provider-id>
    mql shell <provider-id>
    ```
+4. That the work from here on is resource development, and the **`new-resource`** skill covers it: grounding the schema in a real artifact, the traps that fire at codegen, and verifying each field against a live target.
 
 ## Important Reminders
 

--- a/.claude/skills/new-resource/SKILL.md
+++ b/.claude/skills/new-resource/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: new-resource
+description: Add or change a resource in an existing mql provider — schema, codegen, implementation, tests, and verification against a real target. Use when the user wants to add a resource or fields to a provider (e.g. "add a bind9 resource", "expose the tomcat connectors", "add a resource for named.conf", "model the postfix config"), or when a resource returns null, empty, or wrong values and the cause is the schema rather than the API call.
+argument-hint: "<provider>/<resource> (e.g. os/bind9, aws/aws.ec2.instance)"
+---
+
+# Add a resource to an mql provider
+
+**CLAUDE.md is the rulebook** — doc-comment format, the typed-reference gate, `CreateResource` vs `NewResource`, `.lr.versions`, the sub-resource bar. Read it and follow it. This skill is the part that rulebooks do not carry: the traps that bite *even when you know the rule*, the commands that catch them mechanically, and the verification that proves the resource against a real target rather than against your reading of it.
+
+Work through it in order. Every step ends in something you can run.
+
+## 1. Ground the schema in a real artifact before writing it
+
+Never design from documentation alone. Get the real thing first:
+
+```bash
+docker run -d --name src ubuntu:24.04 sleep 3600
+docker exec src sh -c 'apt-get update -qq && apt-get install -y -qq <package>'
+docker exec src sh -c 'cat /etc/<config>; ls /etc/<dir>/'
+```
+
+Read the distribution's actual layout. Debian splits configuration across fragments that the entry point includes; Red Hat usually does not. A schema designed from upstream docs models a file that no distribution ships.
+
+**Validate every fixture with the format's own tool.** `named-checkconf`, `nginx -t`, `apachectl configtest`, `sshd -T`, `postfix check`. This is not politeness — it is what stops you pinning invented syntax as expected behavior:
+
+> `named-checkconf` rejected two hand-written bind9 fixtures ("all zones must be in views", and a `recursion`/`allow-recursion` conflict). Both would have shipped as tests asserting configurations that BIND refuses to load.
+
+## 2. Decide the shape, then check it against the identity dimensions
+
+Follow CLAUDE.md's sub-resource bar (clear id, or nested typed refs — otherwise flatten). Then answer one more question the rulebook does not ask:
+
+**Along which dimensions can this thing repeat?** Write them down and build `__id` from all of them.
+
+Configuration formats nest, and the same name legitimately appears in two scopes:
+
+| resource | dimensions | id must carry |
+|---|---|---|
+| `bind9.zone` | view, class, name | all three |
+| `bind9.key` | view, name | both — two views may declare the same key name |
+| `nginx.conf.server` | serverName, listen | both |
+
+A missed dimension is not a cosmetic bug. `CreateResource` returns the **cached first instance** for a repeated id, so the second declaration silently reports the first one's values:
+
+> `bind9.keys` reported both keys as `hmac-sha256` when the internet-facing view actually used `hmac-md5`. `bind9.keys.none(algorithm == "hmac-md5")` **passed** on a server using MD5 — the failure direction that matters.
+
+Test it directly: two entries with the same name in different scopes, and assert the ids are distinct.
+
+## 3. Traps that bite even though they are documented
+
+Each of these is in CLAUDE.md. Each still gets walked into, because the failure looks like a bug in your Go code rather than a naming rule. Match the fingerprint:
+
+| symptom | cause | fix |
+|---|---|---|
+| every field of a sub-resource reads `null`, plus `provider returned no data and no error for a field` with an empty `id=` | a field named `x` on a resource named `<parent>.x` — same dotted path, and the field loses | rename the resource, or flatten the block onto the parent |
+| `is not a list type` | a list field whose path equals its element resource type | plural field over singular element resource (`zones` → `bind9.zone`) |
+| `undefined: mql<Name>Internal` | an `Internal` struct added or removed after codegen | run `./mqlr generate` a second time |
+| a generated accessor collides with an internal cache field | both named `directory` | prefix the cache field (`baseDir`, `cachePath`) |
+
+**The init argument form is positional, not named.** This is not in CLAUDE.md and the `nginx.conf` doc comment gets it wrong:
+
+```
+bind9(path: "/etc/named.conf")   # failed to compile: resource bind9 does not have a field named path
+bind9("/etc/named.conf")         # works
+```
+
+Write the positional form in the resource's doc comment, and use it for local verification.
+
+## 4. Build and test without clobbering the installed provider
+
+`PROVIDERS_PATH` replaces the provider search path entirely, so a build under test never touches `~/.config/mondoo/providers`:
+
+```bash
+make providers/build/<provider>
+mkdir -p /tmp/pd/<provider> && cp providers/<provider>/dist/<provider>* /tmp/pd/<provider>/
+PROVIDERS_PATH=/tmp/pd mql run <connection> -c "<query>"
+```
+
+Two builds in two directories give you an **A/B against `main`**, which is how you show a change is additive:
+
+```bash
+PROVIDERS_PATH=/tmp/pd-main mql run docker container c -c "$Q" -j > main.json
+PROVIDERS_PATH=/tmp/pd-pr   mql run docker container c -c "$Q" -j > pr.json
+cmp -s main.json pr.json && echo IDENTICAL
+```
+
+Build the baseline from the **current** `origin/main`. A stale baseline attributes someone else's merged change to your PR — or hides yours.
+
+## 5. Verify against a real target, field by field
+
+Automated tests do not prove a resource; they prove the parser. Run every new field against the real thing and read the values, then check these four, which are where resources actually fail:
+
+- **The absent case.** On a host without the software, the check must **fail**, never pass vacuously. `mql run docker container <plain-ubuntu> -c '<resource>.<field> == false'` should error or report false. A resource that returns null and a check that reads null as satisfied is worse than no resource.
+- **Null over invented values.** A field with no value in the file reports null or a documented zero — not a default you made up. If you *do* report an effective default (BIND recursion is on when unset), say so in the field's doc comment and pick the direction that fails safe.
+- **Secrets.** If the format carries key material, sweep for it: `mql run ... -j | grep -c '<the secret>'` must be 0. Then state the guarantee precisely — "this field carries no secret" is true; "the secret is not exposed" is false while `file.content` exists.
+- **Composability.** `<resource>.files { permissions { ... } }` — permission and ownership checks should reach every file that contributed, not just the entry point.
+
+## 6. Before the PR
+
+```bash
+gofmt -l <changed .go files>
+./mqlr generate providers/<p>/resources/<p>.lr --dist providers/<p>/resources
+go build ./... && go test ./resources/...
+git diff --stat providers/<p>/resources/<p>.lr.versions    # new entries at version+1
+git diff -U0 -- '*.lr' | grep '^+' | grep -c "—"          # em dashes: check your lines, not the file
+```
+
+Check the diff, not the whole file: `os.lr` already carries 38 em dashes from before the rule, so grepping the file reports a problem you did not create.
+
+Then write the PR body around what you **ran**, not what you wrote: the queries, the values they returned, and the cases that failed before the fix. A table of observed results is worth more than a description of the schema, and it is what lets a reviewer disagree with you about something real.
+
+## Reference implementations
+
+- **Brace-block config with includes:** `providers/os/resources/bind9/` + `bind9.go`, or `nginx/` + `nginx.go`. Include expansion, cycle detection, partial-parse survival.
+- **Key/value config:** `providers/os/resources/sshd.go`.
+- **Cloud API listing:** any `providers/aws/resources/aws_*.go` — different shape, same schema rules.
+
+## Where this skill stops
+
+This is the **build** path: design a resource, generate it, implement it, prove it against a real target.
+
+- Auditing resources that already shipped — nil handling, pagination truncation, `__id` collisions across a whole provider — is the **`provider-bug-review`** skill. It reads code looking for defects; this one builds and verifies. If you are asking "what is wrong with the okta provider", you want that skill, not this one.
+- Proving a PR against provisioned cloud infrastructure is **`provider-verification`**.
+- Bootstrapping a provider that does not exist yet is **`new-provider`**, which hands off to this skill at its Step 7.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,27 @@ This directory contains information to help Claude AI assistants understand and 
 *   **cnspec**: The security scanning tool built *on top* of mql. It implements **policy assertions**, vulnerability checks, **scanning** (`scan`), and **SBOM generation** (`sbom`).
 *   **Rule of Thumb:** For resource development (adding fields, new assets), you only need to work within **mql**.
 
+## 1.5 Skills
+
+This repo ships skills for its recurring tasks. They carry the procedure — the commands to run and the traps that bite — while this file carries the rules. Invoke the skill when the task matches; don't reconstruct the steps from scratch.
+
+| skill | use when |
+|---|---|
+| `new-resource` | adding or changing a resource or field in an existing provider, or a resource returns null/empty and the schema is the suspect |
+| `new-provider` | bootstrapping a provider that does not exist yet (hands off to `new-resource`) |
+| `provider-verification` | proving a PR or commit range against provisioned cloud infrastructure |
+| `provider-bug-review` | auditing a shipped provider by reading code: nil handling, pagination, `__id` collisions |
+| `provider-api-call-dedup` | a scan is slow, times out, or trips rate limits |
+| `provider-release` | bumping provider versions and preparing a release |
+| `update-provider-deps` | upgrading vendored SDKs and finding what the new version unlocks |
+| `staged-discovery` | adding staged/phased discovery to a provider |
+| `check-querypack-deprecations` | checking `content/` query packs against deprecated resources or fields |
+
 ## 2. Resource Development Guide
 
-The primary task in this repo is adding or modifying resources. Follow this lifecycle:
+The primary task in this repo is adding or modifying resources. Follow this lifecycle.
+
+**Use the `new-resource` skill for this.** It covers the parts this guide does not: grounding the schema in a real artifact, the identity dimensions an `__id` has to carry, testing a build without clobbering the installed provider, and verifying field by field against a live target.
 
 ### Step 1: Definition (`.lr` schema)
 Resources are defined in `.lr` files (e.g., `providers/aws/resources/aws.lr`). This acts as the GraphQL-like schema.
@@ -134,6 +152,8 @@ This is a manual gate, not a build-time one — there is no linter that catches 
 
 ### Step 2: Code Generation
 **Crucial:** You must generate Go interfaces after modifying `.lr` files.
+
+Two naming traps fire at this step and look like Go bugs rather than schema mistakes (a field whose every value reads null, a list that is not a list). The `new-resource` skill indexes them by symptom.
 ```bash
 # Generate all code (slow)
 make mql/generate
@@ -344,6 +364,8 @@ Put decode tests in `resources/decode_test.go` and client tests in `connection/c
 
 ### Step 4: Verification (Interactive)
 Automated tests are rare for MQL resources (thin wrappers). **Interactive testing is standard**, and it complements rather than replaces the unit tests in Step 3.6.
+
+To test a build without overwriting your installed provider, and to A/B a change against `main`, see the `PROVIDERS_PATH` recipe in the `new-resource` skill. For proving a PR against provisioned cloud infrastructure, use `provider-verification`.
 
 1.  **Install**: `make mql/install` (one-time, or when changing mql core).
 2.  **Provider**: `make providers/build/<provider> && make providers/install/<provider>` (after each provider change).
@@ -661,7 +683,7 @@ Key directories for user-facing functionality:
 
 ## 7. Pre-PR Checklist
 
-When work appears complete, present this checklist to the user for local verification:
+When work appears complete, present this checklist to the user for local verification. For a resource change, the `new-resource` skill adds the checks specific to one: the absent-host case, invented defaults, and secret sweeps.
 
 ### Essential Checks (Run These)
 ```bash


### PR DESCRIPTION
Adding or changing a resource is what CLAUDE.md calls "the primary task in this repo", and it was the one task without a skill. The eight existing ones all work at provider level — scaffold, audit, release, bump deps, verify against infrastructure. `new-provider` stops exactly where resource work starts: its Step 7 is literally "the key files they should edit next".

CLAUDE.md also referenced **none** of them. `grep -ci skill CLAUDE.md` returned 0, so nine skills existed and nothing in the always-loaded context pointed at any of them.

## The split

**CLAUDE.md keeps the rules. The skill carries the procedure.** It does not restate the doc-comment format, the typed-reference gate or the `.lr.versions` rule — it references them. Measured before writing it:

| in the skill | mentions in CLAUDE.md |
|---|---|
| `PROVIDERS_PATH` isolation, A/B against main | 0 |
| positional init form | 0 |
| validating fixtures with the format's own tool | 0 |
| the vacuous-pass check | 0 |
| identity dimensions, "cached first instance" collisions | 0 |
| husk pitfall, list-type error, `Internal` regen, `__id` | already covered — referenced, not restated |

## What it adds

Each item is something no rule prevented while building the bind9 resource in #9982:

- **Ground the schema in a real artifact, and validate every fixture with the format's own tool.** `named-checkconf` rejected two hand-written fixtures that would otherwise have shipped as tests asserting configurations BIND refuses to load.
- **Enumerate the dimensions a thing repeats along before building `__id`.** A missing view dimension collided two TSIG keys, and the survivor reported the *stronger* algorithm — so `none(algorithm == "hmac-md5")` passed on a server using MD5.
- **A symptom index** for traps that are documented and still get walked into, because each looks like a Go bug rather than a naming rule. The husk pitfall is in CLAUDE.md and I shipped one anyway.
- **`PROVIDERS_PATH`**, which appears nowhere in the repo docs: it replaces the provider search path, so a build under test never touches the installed provider, and two directories give an A/B against `main`.
- **The init form is positional.** `bind9(path: "...")` does not compile; `nginx.conf`'s own doc comment states it wrongly.
- **Verification that fails safe:** on a host without the software the check must fail, not pass vacuously.

Plus an explicit boundary — this is the build path; `provider-bug-review` is the audit path for shipped code, `provider-verification` the live-infra one — cross-linked rather than duplicated.

## CLAUDE.md

A `## 1.5 Skills` table of all nine with one-line triggers, and three inline pointers: at Step 2 (codegen traps), Step 4 (the `PROVIDERS_PATH` recipe), and the pre-PR checklist. **No rules moved** out of the always-loaded file — moving a rule into an on-demand skill would make it invisible unless the skill happened to load.

`new-provider` Step 7 gains one line handing off to the new skill.

## Verified

Skills have no test suite, so I exercised the parts that can be:

- **Frontmatter parses** and `name` matches the directory for all nine skills; field set matches `staged-discovery`.
- **Both claims re-run against a live build.** `bind9(path: "...")` → `does not have a field named path`; the positional form reads the file.
- **One check was wrong in the first draft and is fixed.** `grep -c "—" os.lr` returns **38** — the file predates the no-em-dash rule — so a skill telling you to grep the file reports a problem you did not create. It now checks the diff: `git diff -U0 -- '*.lr' | grep '^+' | grep -c "—"`, which returns 0 here and still catches a new one.
- **No duplication drift:** the skill references CLAUDE.md four times rather than restating it.

What I could not test from here: that the skill triggers on a real request phrasing, which needs a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)