### PR TITLE
🧹 os: stop TestToOSProcessDoesNotScaleWithPathDepth flaking

### DIFF
--- a/providers/os/resources/processes/unixps_executable_test.go
+++ b/providers/os/resources/processes/unixps_executable_test.go
@@ -94,9 +94,21 @@ func TestToOSProcessDoesNotScaleWithPathDepth(t *testing.T) {
 	shallowBytes := allocatedBytes(1000, func() { processSink = shallow.ToOSProcess() })
 	deepBytes := allocatedBytes(1000, func() { processSink = deep.ToOSProcess() })
 
-	assert.Equal(t, shallowBytes, deepBytes,
-		"memory grew with path depth (%d -> %d bytes over 1000 calls), so the path is still being split",
-		shallowBytes, deepBytes)
+	// Compared with a tolerance, not for equality. TotalAlloc is a process-wide
+	// counter, so anything else allocating between the two reads moves it --
+	// which made this fail intermittently, in both directions, by 16 bytes over
+	// 1000 calls.
+	//
+	// The tolerance is far below what a regression costs. Measured on the same
+	// inputs: taking the last segment allocates 0 bytes either way, while
+	// splitting allocates 32,000 for the shallow path and 176,000 for the deep
+	// one -- a difference of 144,000. Anything between the 16 bytes of noise and
+	// those 144,000 works; 8 KiB is ~500x the noise and ~1/17th of the signal.
+	const tolerance = 8 << 10
+
+	assert.InDelta(t, shallowBytes, deepBytes, tolerance,
+		"memory scaled with path depth (%d bytes shallow vs %d deep over 1000 calls), "+
+			"so the path is being split into a slice again", shallowBytes, deepBytes)
 }
 
 // processSink keeps the results reachable so the allocations are not optimized


### PR DESCRIPTION
`TestToOSProcessDoesNotScaleWithPathDepth` compares two heap measurements for **exact equality**. `TotalAlloc` is a process-wide counter, so anything else allocating between the two reads moves it — and running the whole package is enough to do that.

It fails intermittently in **both directions** by 16 bytes over 1000 calls, which also makes the failure message wrong half the time:

```
memory grew with path depth (296016 -> 296000 bytes over 1000 calls)
```

That is a *decrease*, reported as growth. Whichever value happens to land first becomes "expected".

## Reproduced on `main` before touching anything

| | full package | test alone |
|---|---|---|
| `origin/main`, untouched | 5 pass, **1 fail** | 15 pass, 0 fail |

Isolation was hiding it, which is why it only ever shows up in CI.

## The tolerance is measured, not picked

I measured what a regression actually costs, on the same inputs the test uses:

| implementation | shallow | deep | delta |
|---|---|---|---|
| `LastIndexByte` (current) | 0 | 0 | **0** |
| `strings.Split` (the regression) | 32,000 | 176,000 | **144,000** |

Noise is **16 bytes**; signal is **144,000 bytes** — a ratio of 9,000:1. The 8 KiB tolerance sits ~500× above the noise and ~1/17th below the signal, so the test gets stable without getting permissive. Both numbers are in the comment so the next person does not have to re-derive them.

## Verified both directions

- **Stable:** 10 consecutive full-package runs, 0 failures.
- **Still catches what it exists to catch:** reintroducing the `strings.Split` regression fails the test, now with a message that describes what happened —
  ```
  memory scaled with path depth (328000 bytes shallow vs 472000 deep over 1000 calls),
  so the path is being split into a slice again
  ```

Worth fixing now rather than later: it will fail intermittently on **every** PR touching the `os` provider until it is, and it already cost a re-run on #9990.