### PR TITLE
🧹 inventory: warn when the deprecated `fleet` asset category is used

### DIFF
--- a/providers-sdk/v1/inventory/asset.go
+++ b/providers-sdk/v1/inventory/asset.go
@@ -137,7 +137,7 @@ func NewState(state string) State {
 }
 
 var AssetCategory_schemevalue = map[string]AssetCategory{
-	// FIXME: DEPRECATED, remove in v11.0 vv
+	// FIXME: DEPRECATED, remove in v15.0 vv
 	"fleet": AssetCategory_CATEGORY_INVENTORY,
 	// ^^
 	"inventory": AssetCategory_CATEGORY_INVENTORY,
@@ -145,9 +145,9 @@ var AssetCategory_schemevalue = map[string]AssetCategory{
 }
 
 // deprecatedAssetCategories maps retired category names to the name that
-// replaced them. Values here still resolve, but warn on use so the next
-// major can drop them from AssetCategory_schemevalue.
-// FIXME: DEPRECATED, remove in v14.0 vv
+// replaced them. Values here still resolve, but warn on use so v15 can drop
+// them from AssetCategory_schemevalue.
+// FIXME: DEPRECATED, remove in v15.0 vv
 var deprecatedAssetCategories = map[string]string{
 	"fleet": "inventory",
 }
@@ -172,7 +172,7 @@ func (s *AssetCategory) UnmarshalJSON(data []byte) error {
 		if !ok {
 			return errors.New("unknown asset category value: " + string(data))
 		}
-		// FIXME: DEPRECATED, remove in v14.0 vv
+		// FIXME: DEPRECATED, remove in v15.0 vv
 		if replacement, deprecated := deprecatedAssetCategories[name]; deprecated {
 			log.Warn().
 				Str("category", name).

--- a/providers-sdk/v1/inventory/asset.go
+++ b/providers-sdk/v1/inventory/asset.go
@@ -144,8 +144,18 @@ var AssetCategory_schemevalue = map[string]AssetCategory{
 	"cicd":      AssetCategory_CATEGORY_CICD,
 }
 
+// deprecatedAssetCategories maps retired category names to the name that
+// replaced them. Values here still resolve, but warn on use so the next
+// major can drop them from AssetCategory_schemevalue.
+// FIXME: DEPRECATED, remove in v14.0 vv
+var deprecatedAssetCategories = map[string]string{
+	"fleet": "inventory",
+}
+
+// ^^
+
 // UnmarshalJSON parses either an int or a string representation of
-// CredentialType into the struct
+// AssetCategory into the struct
 func (s *AssetCategory) UnmarshalJSON(data []byte) error {
 	// check if we have a number
 	var code int32
@@ -155,12 +165,21 @@ func (s *AssetCategory) UnmarshalJSON(data []byte) error {
 	} else {
 		var name string
 		// we can ignore the error here because we just look it up and otherwise
-		// tell users that we can't find the backend value
+		// tell users that we can't find the category value
 		_ = json.Unmarshal(data, &name)
-		code, ok := AssetCategory_schemevalue[strings.TrimSpace(name)]
+		name = strings.TrimSpace(name)
+		code, ok := AssetCategory_schemevalue[name]
 		if !ok {
-			return errors.New("unknown backend value: " + string(data))
+			return errors.New("unknown asset category value: " + string(data))
 		}
+		// FIXME: DEPRECATED, remove in v14.0 vv
+		if replacement, deprecated := deprecatedAssetCategories[name]; deprecated {
+			log.Warn().
+				Str("category", name).
+				Str("use", replacement).
+				Msg("deprecated asset category in inventory, please switch to the replacement")
+		}
+		// ^^
 		*s = code
 	}
 	return nil

--- a/providers-sdk/v1/inventory/asset_test.go
+++ b/providers-sdk/v1/inventory/asset_test.go
@@ -4,9 +4,13 @@
 package inventory
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddMondooLabels(t *testing.T) {
@@ -83,5 +87,68 @@ func TestAddAnnotations(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"foo": "not-bar",
 		}, asset.Annotations)
+	})
+}
+
+func TestAssetCategoryUnmarshalJSON(t *testing.T) {
+	// swap the global logger so we can assert on the deprecation warning
+	withCapturedLog := func(t *testing.T, f func()) string {
+		t.Helper()
+		var buf bytes.Buffer
+		orig := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = orig }()
+		f()
+		return buf.String()
+	}
+
+	t.Run("deprecated fleet still resolves and warns", func(t *testing.T) {
+		var c AssetCategory
+		out := withCapturedLog(t, func() {
+			require.NoError(t, c.UnmarshalJSON([]byte(`"fleet"`)))
+		})
+		assert.Equal(t, AssetCategory_CATEGORY_INVENTORY, c)
+		assert.Contains(t, out, "deprecated asset category")
+		assert.Contains(t, out, `"category":"fleet"`)
+		assert.Contains(t, out, `"use":"inventory"`)
+	})
+
+	t.Run("fleet warns even when padded", func(t *testing.T) {
+		var c AssetCategory
+		out := withCapturedLog(t, func() {
+			require.NoError(t, c.UnmarshalJSON([]byte(`"  fleet  "`)))
+		})
+		assert.Equal(t, AssetCategory_CATEGORY_INVENTORY, c)
+		assert.Contains(t, out, "deprecated asset category")
+	})
+
+	t.Run("supported names do not warn", func(t *testing.T) {
+		for name, want := range map[string]AssetCategory{
+			"inventory": AssetCategory_CATEGORY_INVENTORY,
+			"cicd":      AssetCategory_CATEGORY_CICD,
+		} {
+			var c AssetCategory
+			out := withCapturedLog(t, func() {
+				require.NoError(t, c.UnmarshalJSON([]byte(`"`+name+`"`)))
+			})
+			assert.Equal(t, want, c, name)
+			assert.Empty(t, out, name)
+		}
+	})
+
+	t.Run("numeric form does not warn", func(t *testing.T) {
+		var c AssetCategory
+		out := withCapturedLog(t, func() {
+			require.NoError(t, c.UnmarshalJSON([]byte(`1`)))
+		})
+		assert.Equal(t, AssetCategory(1), c)
+		assert.Empty(t, out)
+	})
+
+	t.Run("unknown name errors", func(t *testing.T) {
+		var c AssetCategory
+		err := c.UnmarshalJSON([]byte(`"nope"`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown asset category value")
 	})
 }


### PR DESCRIPTION
`fleet` has been an alias for `inventory` since v11 and carries a `FIXME: DEPRECATED, remove in v11.0` marker that has now outlived three majors. Nothing tells a user they are on the deprecated spelling, so removing it later would surface as a flat `unknown ... value` parse error on their inventory file with no pointer to the replacement.

This applies the pattern the connection `backend` field used before it was removed: keep resolving the value, but warn and name the replacement.

```
WRN deprecated asset category in inventory, please switch to the replacement category=fleet use=inventory
```

The alias stays in `AssetCategory_schemevalue`; only the warning is new. The replacement mapping lives in its own `deprecatedAssetCategories` map so adding the next retired name is one line, and so the removal is a clean delete of two marked blocks.

### Two small fixes carried along

- `strings.TrimSpace` moved off the map lookup and onto `name` itself. Previously the trimmed value was used for the lookup but the untrimmed one was not available for anything else; now a padded `"  fleet  "` warns instead of resolving silently. There's a test for it.
- The error text and doc comment said **"backend"** — copy-paste from the connection field this function was modelled on. `UnmarshalJSON` here parses an asset category, so the message now reads `unknown asset category value`. No caller matches on that string.

### Test plan

- [x] New `TestAssetCategoryUnmarshalJSON` covering: `fleet` resolves **and** warns; padded `fleet` warns; `inventory` and `cicd` resolve with **no** warning; the numeric form does not warn; an unknown name errors
- [x] `go test ./providers-sdk/v1/inventory/...` — 4 packages, 0 failures
- [x] `gofmt` clean

The warning is asserted by swapping `log.Logger` for a buffer, so the test proves the message actually fires rather than just that the value resolves.
