### PR TITLE
🧹 aws: warn when the deprecated `ec2:tag:` discovery filters are used

### DIFF
--- a/providers/aws/connection/filters.go
+++ b/providers/aws/connection/filters.go
@@ -60,7 +60,7 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 		AccountTags:          parseMapOpt(opts, "account-tag:"),
 	}
 
-	// FIXME: DEPRECATED, remove in v14.0 vv
+	// FIXME: DEPRECATED, remove in v15.0 vv
 	// `ec2:tag:` and `ec2:exclude:tag:` were folded into the general `tag:` and
 	// `exclude:tag:` filters. They still apply, but warn, so the removal lands
 	// on users who have already been told rather than silently dropping a
@@ -75,7 +75,7 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 // general replacement, warning that the option is deprecated. The replacement
 // wins on conflict, so a key carrying a different value under each option gets
 // a second warning naming the value being dropped.
-// FIXME: DEPRECATED, remove in v14.0 vv
+// FIXME: DEPRECATED, remove in v15.0 vv
 func mergeDeprecatedTagOpt(deprecated, replacement string, from, into map[string]string) {
 	if len(from) == 0 {
 		return

--- a/providers/aws/connection/filters.go
+++ b/providers/aws/connection/filters.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/filteropts"
 )
 
@@ -59,20 +60,45 @@ func DiscoveryFiltersFromOpts(opts map[string]string) DiscoveryFilters {
 		AccountTags:          parseMapOpt(opts, "account-tag:"),
 	}
 
-	// TODO: backward compatibility, remove in future versions
-	ec2Tags := parseMapOpt(opts, "ec2:tag:")
-	ec2ExcludeTags := parseMapOpt(opts, "ec2:exclude:tag:")
-	for k, v := range ec2Tags {
-		if _, exists := d.General.Tags[k]; !exists {
-			d.General.Tags[k] = v
-		}
-	}
-	for k, v := range ec2ExcludeTags {
-		if _, exists := d.General.ExcludeTags[k]; !exists {
-			d.General.ExcludeTags[k] = v
-		}
-	}
+	// FIXME: DEPRECATED, remove in v14.0 vv
+	// `ec2:tag:` and `ec2:exclude:tag:` were folded into the general `tag:` and
+	// `exclude:tag:` filters. They still apply, but warn, so the removal lands
+	// on users who have already been told rather than silently dropping a
+	// filter they rely on to scope a scan.
+	mergeDeprecatedTagOpt("ec2:tag:", "tag:", parseMapOpt(opts, "ec2:tag:"), d.General.Tags)
+	mergeDeprecatedTagOpt("ec2:exclude:tag:", "exclude:tag:", parseMapOpt(opts, "ec2:exclude:tag:"), d.General.ExcludeTags)
+	// ^^
 	return d
+}
+
+// mergeDeprecatedTagOpt folds a retired `ec2:`-prefixed tag filter into its
+// general replacement, warning that the option is deprecated. The replacement
+// wins on conflict, so a key carrying a different value under each option gets
+// a second warning naming the value being dropped.
+// FIXME: DEPRECATED, remove in v14.0 vv
+func mergeDeprecatedTagOpt(deprecated, replacement string, from, into map[string]string) {
+	if len(from) == 0 {
+		return
+	}
+
+	log.Warn().
+		Str("option", deprecated).
+		Str("use", replacement).
+		Msg("deprecated AWS discovery filter, please switch to the replacement")
+
+	for k, v := range from {
+		if existing, exists := into[k]; exists {
+			if existing != v {
+				log.Warn().
+					Str("option", deprecated+k).
+					Str("ignored", v).
+					Str("using", existing).
+					Msg("filter key set by both the deprecated and the replacement option, the deprecated value is ignored")
+			}
+			continue
+		}
+		into[k] = v
+	}
 }
 
 type GeneralDiscoveryFilters struct {

--- a/providers/aws/connection/filters_test.go
+++ b/providers/aws/connection/filters_test.go
@@ -4,13 +4,83 @@
 package connection
 
 import (
+	"bytes"
 	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
+
+// withCapturedLog swaps the global logger for a buffer so tests can assert on
+// deprecation warnings.
+func withCapturedLog(t *testing.T, f func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() { log.Logger = orig }()
+	f()
+	return buf.String()
+}
+
+func TestDeprecatedEc2TagOpts(t *testing.T) {
+	t.Run("ec2:tag: still applies and warns", func(t *testing.T) {
+		var d DiscoveryFilters
+		out := withCapturedLog(t, func() {
+			d = DiscoveryFiltersFromOpts(map[string]string{"ec2:tag:env": "prod"})
+		})
+		require.Equal(t, map[string]string{"env": "prod"}, d.General.Tags)
+		require.Contains(t, out, "deprecated AWS discovery filter")
+		require.Contains(t, out, `"option":"ec2:tag:"`)
+		require.Contains(t, out, `"use":"tag:"`)
+	})
+
+	t.Run("ec2:exclude:tag: still applies and warns", func(t *testing.T) {
+		var d DiscoveryFilters
+		out := withCapturedLog(t, func() {
+			d = DiscoveryFiltersFromOpts(map[string]string{"ec2:exclude:tag:env": "dev"})
+		})
+		require.Equal(t, map[string]string{"env": "dev"}, d.General.ExcludeTags)
+		require.Contains(t, out, `"option":"ec2:exclude:tag:"`)
+		require.Contains(t, out, `"use":"exclude:tag:"`)
+	})
+
+	t.Run("a key set by both keeps the replacement and warns about the dropped value", func(t *testing.T) {
+		var d DiscoveryFilters
+		out := withCapturedLog(t, func() {
+			d = DiscoveryFiltersFromOpts(map[string]string{
+				"tag:env":     "prod",
+				"ec2:tag:env": "staging",
+			})
+		})
+		require.Equal(t, map[string]string{"env": "prod"}, d.General.Tags)
+		require.Contains(t, out, "the deprecated value is ignored")
+		require.Contains(t, out, `"ignored":"staging"`)
+		require.Contains(t, out, `"using":"prod"`)
+	})
+
+	t.Run("a key set by both with the same value does not warn about a dropped value", func(t *testing.T) {
+		out := withCapturedLog(t, func() {
+			DiscoveryFiltersFromOpts(map[string]string{
+				"tag:env":     "prod",
+				"ec2:tag:env": "prod",
+			})
+		})
+		require.Contains(t, out, "deprecated AWS discovery filter")
+		require.NotContains(t, out, "the deprecated value is ignored")
+	})
+
+	t.Run("no deprecated opts means no warning", func(t *testing.T) {
+		out := withCapturedLog(t, func() {
+			DiscoveryFiltersFromOpts(map[string]string{"tag:env": "prod"})
+		})
+		require.Empty(t, out)
+	})
+}
 
 func TestToServerSideEc2Filters(t *testing.T) {
 	t.Run("correctly converts include and exclude tags to AWS SDK filters", func(t *testing.T) {


### PR DESCRIPTION
`ec2:tag:` and `ec2:exclude:tag:` were folded into the general `tag:` / `exclude:tag:` filters, leaving a `TODO: backward compatibility, remove in future versions` and no signal to anyone still passing the old form.

Removing them quietly is the bad case here: a tag filter exists to *narrow* a scan, so dropping it doesn't fail — it widens discovery to the whole account. That is a bigger bill and a bigger blast radius, arriving with no error to trace it to.

```
WRN deprecated AWS discovery filter, please switch to the replacement option=ec2:tag: use=tag:
```

### The silent case this also fixes

The general filter wins on conflict. If a key was set under both `tag:env` and `ec2:tag:env` with **different** values, the `ec2:` value was discarded with no indication:

```
WRN filter key set by both the deprecated and the replacement option, the deprecated value is ignored option=ec2:tag:env ignored=staging using=prod
```

Identical values on both sides lose nothing, so that stays quiet — the warning fires on actual information loss, not on mere overlap.

### Shape

The include and exclude merges moved into `mergeDeprecatedTagOpt` instead of being duplicated. Both call sites and the helper carry `FIXME: DEPRECATED, remove in v15.0` markers, so the eventual removal is a delete of two marked blocks rather than an untangling.

No behavior change to which filters apply — same precedence, same results, just no longer silent.

### Test plan

- [x] New `TestDeprecatedEc2TagOpts`: `ec2:tag:` applies **and** warns; `ec2:exclude:tag:` applies **and** warns; a conflicting key keeps the replacement and warns about the dropped value; an identical duplicate does **not** warn about a dropped value; no deprecated opts produces no output at all
- [x] `go test ./connection/` in `providers/aws` — passing
- [x] `go mod tidy` clean inside `providers/aws`
- [x] `gofmt` clean

The compat path had zero coverage before this, so the existing `TestDiscoveryFiltersFromOpts` never touched it.