### PR TITLE
⚡ aws: answer a repeated reference from the resource cache instead of refetching

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.53.0",
-  "generated_at": "2026-08-12T08:57:16-07:00",
+  "version": "13.53.1",
+  "generated_at": "2026-08-16T17:48:34+02:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2174,6 +2174,14 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return args, nil, nil
 	}
 
+	// Already materialized by an earlier reference or by the list that
+	// built it: NewResource consults the cache only after this init
+	// returns, so without this the same target is fetched once per
+	// referring resource and the result thrown away.
+	if cached := cachedArgByArn(runtime, ResourceAwsEc2Securitygroup, args); cached != nil {
+		return args, cached, nil
+	}
+
 	if len(args) == 0 {
 		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1750,6 +1750,14 @@ func initAwsIamRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return args, nil, nil
 	}
 
+	// Already materialized by an earlier reference or by the list that
+	// built it: NewResource consults the cache only after this init
+	// returns, so without this the same target is fetched once per
+	// referring resource and the result thrown away.
+	if cached := cachedArgByArn(runtime, ResourceAwsIamRole, args); cached != nil {
+		return args, cached, nil
+	}
+
 	if args["arn"] == nil && args["name"] == nil {
 		return nil, nil, errors.New("arn or name required to fetch aws iam role")
 	}

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -875,6 +875,14 @@ func initAwsKmsKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 		return args, nil, nil
 	}
 
+	// Already materialized by an earlier reference or by the list that
+	// built it: NewResource consults the cache only after this init
+	// returns, so without this the same target is fetched once per
+	// referring resource and the result thrown away.
+	if cached := cachedArgByArn(runtime, ResourceAwsKmsKey, args); cached != nil {
+		return args, cached, nil
+	}
+
 	if len(args) == 0 {
 		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1521,6 +1521,14 @@ func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 		return args, nil, nil
 	}
 
+	// Already materialized by an earlier reference or by the list that
+	// built it: NewResource consults the cache only after this init
+	// returns, so without this the same target is fetched once per
+	// referring resource and the result thrown away.
+	if cached := cachedArgByArn(runtime, ResourceAwsVpc, args); cached != nil {
+		return args, cached, nil
+	}
+
 	// Derive region + vpcId for a single targeted DescribeVpcs call instead of
 	// listing every VPC in every region. This also pulls the ARN from the asset
 	// identifier when args are empty.

--- a/providers/aws/resources/init_cache.go
+++ b/providers/aws/resources/init_cache.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// cachedByArn returns a resource already materialized under this ARN, or nil.
+//
+// NewResource runs a resource's init *before* it consults the runtime cache --
+// it has to, because the cache key is the resolved resource's MqlID, which for
+// a resource whose identity is computed during init is not knowable in advance.
+// An init that fetches unconditionally therefore pays once per referring
+// resource and then has its result discarded in favour of the cached instance:
+// four EC2 instances in one VPC cost four DescribeVpcs calls for the one VPC,
+// and the fan-in on aws.iam.role reaches 94 referring call sites.
+//
+// The opening exists for callers that already supply the id. These resources
+// key their __id on the ARN, and typed references pass the ARN, so the cache
+// key is known up front and can be checked before spending a call.
+//
+// Same shape as the checks already in aws_kms.go, aws_vpc.go and aws_ec2.go;
+// this only gives them one name.
+func cachedByArn(runtime *plugin.Runtime, resourceName, arn string) plugin.Resource {
+	if arn == "" || runtime == nil || runtime.Resources == nil {
+		return nil
+	}
+	if res, ok := runtime.Resources.Get(resourceName + "\x00" + arn); ok {
+		return res
+	}
+	return nil
+}
+
+// cachedArgByArn is cachedByArn for the common init shape, reading the ARN out
+// of args itself. Returns nil when there is no usable "arn" argument, which
+// leaves the caller on its existing path.
+func cachedArgByArn(runtime *plugin.Runtime, resourceName string, args map[string]*llx.RawData) plugin.Resource {
+	raw, ok := args["arn"]
+	if !ok || raw == nil {
+		return nil
+	}
+	arn, ok := raw.Value.(string)
+	if !ok {
+		return nil
+	}
+	return cachedByArn(runtime, resourceName, arn)
+}

--- a/providers/aws/resources/init_cache_test.go
+++ b/providers/aws/resources/init_cache_test.go
@@ -1,0 +1,108 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+const testVpcArn = "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-abc123"
+
+func cacheRuntime() *plugin.Runtime {
+	return &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+// A resource an earlier reference already materialized comes back without an
+// API call. NewResource consults the cache only after the init returns, so
+// without this the same VPC is fetched once per referring resource -- four EC2
+// instances in one VPC measured four DescribeVpcs calls for the one VPC.
+func TestCachedByArn_ReturnsTheCachedResource(t *testing.T) {
+	runtime := cacheRuntime()
+
+	vpc, err := CreateResource(runtime, ResourceAwsVpc, map[string]*llx.RawData{
+		"arn": llx.StringData(testVpcArn),
+	})
+	require.NoError(t, err)
+
+	got := cachedByArn(runtime, ResourceAwsVpc, testVpcArn)
+	assert.Same(t, vpc, got)
+}
+
+// A miss returns nil so the caller stays on its existing fetch path.
+func TestCachedByArn_MissFallsThrough(t *testing.T) {
+	runtime := cacheRuntime()
+
+	assert.Nil(t, cachedByArn(runtime, ResourceAwsVpc, testVpcArn))
+	assert.Nil(t, cachedByArn(runtime, ResourceAwsVpc, ""))
+	assert.Nil(t, cachedByArn(nil, ResourceAwsVpc, testVpcArn))
+}
+
+// The lookup must not cross resource types: two resources can share an ARN
+// shape only by accident, and returning the wrong type would panic the caller's
+// assertion.
+func TestCachedByArn_ScopedToTheResourceType(t *testing.T) {
+	runtime := cacheRuntime()
+
+	_, err := CreateResource(runtime, ResourceAwsVpc, map[string]*llx.RawData{
+		"arn": llx.StringData(testVpcArn),
+	})
+	require.NoError(t, err)
+
+	assert.Nil(t, cachedByArn(runtime, ResourceAwsIamRole, testVpcArn),
+		"a vpc must not answer a lookup for an iam role")
+}
+
+func TestCachedArgByArn(t *testing.T) {
+	runtime := cacheRuntime()
+	vpc, err := CreateResource(runtime, ResourceAwsVpc, map[string]*llx.RawData{
+		"arn": llx.StringData(testVpcArn),
+	})
+	require.NoError(t, err)
+
+	t.Run("reads the arn out of args", func(t *testing.T) {
+		got := cachedArgByArn(runtime, ResourceAwsVpc, map[string]*llx.RawData{
+			"arn": llx.StringData(testVpcArn),
+		})
+		assert.Same(t, vpc, got)
+	})
+
+	// Referrers that pass only an id keep their existing path: the cache key is
+	// the ARN, so there is nothing to look up.
+	t.Run("no arn argument is a miss", func(t *testing.T) {
+		assert.Nil(t, cachedArgByArn(runtime, ResourceAwsVpc, map[string]*llx.RawData{
+			"id": llx.StringData("vpc-abc123"),
+		}))
+		assert.Nil(t, cachedArgByArn(runtime, ResourceAwsVpc, map[string]*llx.RawData{}))
+	})
+
+	t.Run("a non-string arn is a miss, not a panic", func(t *testing.T) {
+		assert.Nil(t, cachedArgByArn(runtime, ResourceAwsVpc, map[string]*llx.RawData{
+			"arn": llx.IntData(42),
+		}))
+	})
+}
+
+// The init keeps its fast path: a caller that supplied everything must not be
+// diverted, and a cache miss must leave the existing lookup untouched.
+func TestInitAwsVpc_UsesTheCacheThenFallsThrough(t *testing.T) {
+	runtime := cacheRuntime()
+	vpc, err := CreateResource(runtime, ResourceAwsVpc, map[string]*llx.RawData{
+		"arn": llx.StringData(testVpcArn),
+	})
+	require.NoError(t, err)
+
+	args, res, err := initAwsVpc(runtime, map[string]*llx.RawData{
+		"arn": llx.StringData(testVpcArn),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Same(t, vpc, res, "must return the cached vpc rather than calling DescribeVpcs")
+	assert.NotNil(t, args)
+}


### PR DESCRIPTION
`NewResource` runs a resource's init **before** it consults the runtime cache — and it has to, because the cache key is the resolved resource's `MqlID()`, which for a resource whose identity is computed during init is not knowable in advance. So an init that fetches unconditionally pays once per *referring* resource, then has its result discarded in favour of the cached instance.

Same mechanism as #9851 in azure. The opening is that these resources key their `__id` on the ARN and typed references pass ARNs, so the key **is** known up front and can be checked before spending a call.

## Measured against a live account

```
aws.ec2.instances { vpc { id } }        — 4 instances, 1 VPC

                        before   after
DescribeVpcs               4        1
total aws calls            6        3
vpc ids resolved           4        4      <- identical
```

And where a list has already populated the cache, the references become free outright:

```
aws.iam.roles.length == 76 && aws.lambda.functions.all(role != null)
  -> [ok] true,  with 1 ListRoles and 0 GetRole   (was 2 GetRole)
```

## Scope

Applied to the four highest fan-in inits:

| resource | referring call sites |
|---|---|
| `aws.iam.role` | 94 |
| `aws.kms.key` | 61 |
| `aws.vpc` | 33 |
| `aws.ec2.securitygroup` | 20 |

`aws.vpc.subnet` (37 sites) needed nothing — it **already had** the check. So does `aws.kms.customKeyStore` and four others, in `aws_kms.go`, `aws_vpc.go`, `aws_ec2.go` and `aws_ec2_transitgateway_routes.go`. This is not a new idea in this provider; the helper gives that existing pattern one name and extends it to the inits that were missing it, with the comment from `aws_kms.go` generalised.

A referrer passing only an `id` rather than an `arn` keeps its existing path — the cache key is the ARN, so there is nothing to look up.

## Where this does *not* help, stated plainly

On a bare `mql run` it is close to invisible, because **discovery dominates**: in a measured run, 816 of 817 API calls were discovery and exactly 1 was the query. This change pays when something traverses references across many assets — which is what a policy-driven `cnspec scan` does, and which I have **not** measured. The numbers above come from queries I wrote specifically to exercise the reference path.

That correction is worth recording: my initial static read put reference resolution as the main AWS cost. Measurement said otherwise, and the fan-in counts above describe where references *could* repeat rather than where scan time actually goes.

Two things deliberately **not** touched, having measured them:

- **Region scoping.** `--region` sets the SDK's default region; discovery scope comes from `--filters regions=`. That is a 13x difference on an identical command (817 -> 62 calls), but cross-region is the normal case for real scans, so narrowing it is not a real win.
- **`jobpool` width**, hardcoded to 5 across 341 sites. The one lever that would speed up a *full* scan rather than narrowing it, but picking a value needs wall-clock measurement against throttling behaviour.

## Tests

Nine cases on the helper, no network: returns the cached resource, miss falls through, nil runtime, empty ARN, scoped to the resource type (a vpc must not answer an iam-role lookup), reads the ARN out of args, id-only args are a miss, non-string ARN is a miss rather than a panic, and `initAwsVpc` returns the cached VPC rather than calling DescribeVpcs. The existing `TestInitAwsVpc` suite passes unchanged.

`aws.permissions.json` is regeneration only — version 13.53.0 -> 13.53.1 and timestamp, permission set unchanged (added none, removed none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)