### PR TITLE
📄 skills: fix classify-accessors.awk reporting zero for most providers

### DIFF
--- a/.claude/skills/provider-api-call-dedup/SKILL.md
+++ b/.claude/skills/provider-api-call-dedup/SKILL.md
@@ -182,8 +182,23 @@ client and fetches inline is invisible to it.** Such an accessor never calls
 in Phase 4 — while an audit that only ran the classifier will read as complete.
 
 Enumerate them properly rather than grepping for client construction in a
-window — that over-counts badly. In azure a real enumeration gives **43** inline
-accessors against 126 that go through `NewResource`.
+window — that over-counts badly. And **do not pin the receiver name**: providers
+use `a`, `g`, `k`, `o`, `r`, `m`, `c`, `p`, `i`. Pinning one silently reports
+zero for every provider that picked another letter.
+
+Real counts, receiver-agnostic:
+
+| provider | INLINE | BOTH | VIA-NEW |
+|---|---|---|---|
+| aws | 41 | 6 | 550 |
+| azure | 38 | 0 | 136 |
+| github | 16 | 1 | 5 |
+| ms365 | 14 | 0 | 11 |
+| gcp | 10 | 0 | 71 |
+| okta | 1 | 0 | 4 |
+| k8s | **0** | 0 | 23 |
+
+k8s at zero is the shape to aim for. Everything else has some.
 
 ```bash
 awk -f .claude/skills/provider-api-call-dedup/classify-accessors.awk \
@@ -198,9 +213,8 @@ accessor falls into one of two kinds:
 | **Owned sub-object** | A config child belonging to exactly one parent — a database's audit policy, a storage account's management policy, a site's auth settings | **No.** One fetch per parent is the floor, and `GetOrCompute` already memoizes it on that parent. Nothing repeats |
 | **Shared resource** | A subnet, a public IP, a firewall policy, a disk — something several resources point at | **Yes.** Fan-in means repeats, and nothing dedupes them |
 
-In azure that split is roughly 30 owned sub-objects (all the SQL policies,
-storage config, web auth settings, Defender plans) against ~12 shared targets.
-So the backlog is small and specific, not half the provider. Measure fan-in per
+In azure that split is roughly 30 owned sub-objects against ~12 shared targets,
+so the backlog is small and specific, not half the provider. Measure fan-in per
 target before proposing anything:
 
 ```bash

--- a/.claude/skills/provider-api-call-dedup/classify-accessors.awk
+++ b/.claude/skills/provider-api-call-dedup/classify-accessors.awk
@@ -12,18 +12,28 @@
 #
 # This one reads the accessors instead: functions shaped
 #
-#   func (a *mqlFoo) bar() (*mqlBaz, error)
+#   func (x *mqlFoo) bar() (*mqlBaz, error)
 #
 # i.e. returning a single resource, which is what a typed reference looks like.
+# The receiver name is deliberately not pinned -- providers use a, g, k, o, r,
+# m, c, p, i and more, and pinning it silently reports zero for every provider
+# that picked a different letter.
 #
 # Output: <bucket>\t<file>:<line>\t<signature>
 #
-#   INLINE   builds a client and fetches; never calls NewResource. Not reachable
-#            from init-level work. Triage by fan-in before doing anything (see
-#            below).
+#   INLINE   reaches the API itself; never calls NewResource. Not reachable
+#            from init-level work. Triage by fan-in before doing anything.
 #   VIA-NEW  calls NewResource, so it routes through the target's init and the
 #            init-level fixes apply.
+#   BOTH     does both -- typically a cache or list check with a fetch as the
+#            fallback, which is usually correct. Read it before touching it;
+#            bucketing these as VIA-NEW would hide a live fetch.
 #   NO-IO    reads what it already has. Fine.
+#
+# A ZERO IS A RESULT TO CHECK, NOT TO TRUST. If a provider reports no INLINE and
+# no VIA-NEW at all, suspect the patterns below before believing it: confirm the
+# provider's accessors actually match the signature shape, and that it obtains
+# clients in one of the ways detected here.
 #
 # TRIAGE THE INLINE ONES BY FAN-IN. They split into two kinds and only one is
 # worth touching:
@@ -45,25 +55,49 @@
 # the real backlog is small and specific. Do not report the raw INLINE count as
 # though all of it were work.
 
-/^func \(a \*mql[A-Za-z0-9]+\) [a-z][A-Za-z0-9]*\(\) \(\*mql[A-Za-z0-9]+, error\) \{/ {
-  inFunc = 1
-  sig = $0
-  start = FNR
-  body = ""
-  next
+BEGIN {
+    # An SDK operation always takes a context; an MQL list getter takes no
+    # arguments. Requiring the context is what keeps svc.GetBackupVaults() on
+    # an MQL resource from reading as an SDK call -- gcp names MQL resources
+    # `svc`, aws names SDK clients `svc`.
+    #
+    # Connection methods that are NOT API calls -- they hand back credentials,
+    # config or identity the connection already holds. Without scrubbing these,
+    # the conn.<Service>( pattern that catches the aws style (conn.Ec2(region))
+    # also matches conn.Token(), conn.Regions(), conn.Asset() and friends, and
+    # every accessor looks like it reaches the API.
+    notAPI = "Asset|Runtime|Context|Token|ClientOptions|Credentials|Config|Conf|" \
+             "SubId|AccountId|OrganizationID|Regions|Region|BasePlatformId|" \
+             "PlatformId|Name|Filters|Options|ID|Id|Provider|Upstream|Hash"
+}
+
+/^func \([a-z][a-zA-Z0-9]* \*mql[A-Za-z0-9]+\) [a-z][A-Za-z0-9]*\(\) \(\*mql[A-Za-z0-9]+, error\) \{/ {
+    inFunc = 1
+    sig = $0
+    start = FNR
+    body = ""
+    next
 }
 
 inFunc && /^}/ {
-  client = (body ~ /New[A-Za-z]*Client\(/)
-  newres = (body ~ /NewResource\(/)
+    scrubbed = body
+    gsub("conn\\.(" notAPI ")\\(", "", scrubbed)
 
-  if (newres)      bucket = "VIA-NEW"
-  else if (client) bucket = "INLINE"
-  else             bucket = "NO-IO"
+    client = (scrubbed ~ /New[A-Za-z]*Client\(/) ||     # azure, gcp, some aws
+             (scrubbed ~ /conn\.Client\(\)/) ||         # github, okta, gcp
+             (scrubbed ~ /conn\.[A-Z][A-Za-z]*\(/) ||   # aws: conn.Ec2(region)
+             (scrubbed ~ /svc\.[A-Z][A-Za-z]*\((ctx|context\.)/) || # aws sdk ops
+             (scrubbed ~ /client\.[A-Z][A-Za-z]*\(ctx/) # gcp sdk operations
+    newres = (scrubbed ~ /NewResource\(/)
 
-  printf "%s\t%s:%d\t%s\n", bucket, FILENAME, start, sig
-  inFunc = 0
-  next
+    if (newres && client) bucket = "BOTH"
+    else if (newres)      bucket = "VIA-NEW"
+    else if (client)      bucket = "INLINE"
+    else                  bucket = "NO-IO"
+
+    printf "%s\t%s:%d\t%s\n", bucket, FILENAME, start, sig
+    inFunc = 0
+    next
 }
 
 inFunc { body = body "\n" $0 }

--- a/.claude/skills/provider-api-call-dedup/classify-inits.awk
+++ b/.claude/skills/provider-api-call-dedup/classify-inits.awk
@@ -15,9 +15,9 @@
 #
 # BLIND SPOT: this reads init functions only. A typed-reference accessor that
 # builds a client and fetches inline never calls NewResource, never enters an
-# init, and so does not appear here at all -- in azure that is 43 accessors
-# against 126 that go through NewResource. An audit that runs only this script
-# will look complete while missing them. Enumerate them with the companion
+# init, and so does not appear here at all. An audit that runs only this script
+# will look complete while missing them: aws has 41 such accessors, azure 38,
+# github 16, ms365 14, gcp 10, k8s none. Enumerate them with the companion
 # script, classify-accessors.awk, and split the result by fan-in: most are
 # owned sub-objects with exactly one parent and nothing to dedupe.
 #


### PR DESCRIPTION
The accessor matcher pinned the receiver name to `a`. Providers use a, g, k, o, r, m, c, p and i, so the script silently reported zero inline accessors for github (177 of 177 use `g`) and under-reported gcp, k8s and okta. A zero from a detector reads as a clean bill of health, which is the worst way for it to fail.

Client detection was wrong too, matching only New*Client( and so missing github's conn.Client() and aws's conn.Ec2(region) entirely.

Real counts, receiver-agnostic: aws 41 inline accessors, azure 38, github 16, ms365 14, gcp 10, okta 1, k8s none. k8s at zero is genuine and is the shape to aim for. This also corrects the claim in #9853 that the pattern was azure-only.

Validating the fix caught two further problems. A gcp false positive: the svc.<Op>( pattern that catches aws SDK calls also matched svc.GetBackupVaults() on an MQL resource, because gcp names MQL resources `svc` where clients `svc`. Requiring a context argument separates them, since SDK operations take one and MQL getters take none. And an accessor doing both a and a NewResource was filed as VIA-NEW, hiding the fetch; those now get a BOTH bucket, mirroring API+LIST in the init classifier.

Every remaining INLINE result across azure, aws, ms365 and githu carry actual client or API evidence: none without. The header now says a zero is a result to check rather than trust.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.co