### PR TITLE
⚡ aws: answer repeated security group, VPC and reference lookups from the cache

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1604,6 +1604,14 @@ func initAwsEc2Networkinterface(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return args, nil, nil
 	}
 
+	// A reference already materialized by an earlier referrer or by the
+	// list that built it. NewResource consults the cache only after this
+	// init returns, so without this the same target is fetched once per
+	// referring resource and the result discarded.
+	if cached := cachedArgByArn(runtime, ResourceAwsEc2Networkinterface, args); cached != nil {
+		return args, cached, nil
+	}
+
 	if args["id"] == nil {
 		return nil, nil, errors.New("id required to fetch aws network interface")
 	}
@@ -1615,6 +1623,17 @@ func initAwsEc2Networkinterface(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 
 	conn := runtime.Connection.(*connection.AwsConnection)
+	// With the id and a region in hand the ARN is derivable, so check before
+	// paying for a lookup -- and before the region fan-out below, which costs
+	// one call per region for a single interface. Callers that pass an id
+	// rather than an ARN miss the check above, which is the case this catches.
+	if region != "" {
+		if cached := cachedByArn(runtime, ResourceAwsEc2Networkinterface,
+			fmt.Sprintf(networkInterfaceArnPattern, region, conn.AccountId(), eniId)); cached != nil {
+			return args, cached, nil
+		}
+	}
+
 	if region == "" {
 		// Region is required for a targeted DescribeNetworkInterfaces lookup, but
 		// it's not encoded in the ENI id itself. Fan out across regions in
@@ -2213,6 +2232,17 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 
 	if region != "" && groupId != "" {
 		conn := runtime.Connection.(*connection.AwsConnection)
+
+		// Check again now that the ARN can be derived. The check above only
+		// fires for a caller that passed one, and the callers that pass an id
+		// instead are the hot path: a policy scan over 160 assets spent 2,862
+		// DescribeSecurityGroups calls on 102 distinct groups, 40% of all its
+		// API traffic, because every reference re-derived the same group.
+		if cached := cachedByArn(runtime, ResourceAwsEc2Securitygroup,
+			NewSecurityGroupArn(region, conn.AccountId(), groupId)); cached != nil {
+			return args, cached, nil
+		}
+
 		svc := conn.Ec2(region)
 		resp, err := svc.DescribeSecurityGroups(context.Background(), &ec2.DescribeSecurityGroupsInput{
 			GroupIds: []string{groupId},
@@ -2559,6 +2589,14 @@ func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		return args, nil, nil
 	}
 
+	// A reference already materialized by an earlier referrer or by the
+	// list that built it. NewResource consults the cache only after this
+	// init returns, so without this the same target is fetched once per
+	// referring resource and the result discarded.
+	if cached := cachedArgByArn(runtime, ResourceAwsEc2Volume, args); cached != nil {
+		return args, cached, nil
+	}
+
 	if len(args) == 0 {
 		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
@@ -2806,6 +2844,14 @@ func buildSnapshotResource(runtime *plugin.Runtime, region, accountID string, sn
 func initAwsEc2Snapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
+	}
+
+	// A reference already materialized by an earlier referrer or by the
+	// list that built it. NewResource consults the cache only after this
+	// init returns, so without this the same target is fetched once per
+	// referring resource and the result discarded.
+	if cached := cachedArgByArn(runtime, ResourceAwsEc2Snapshot, args); cached != nil {
+		return args, cached, nil
 	}
 
 	if len(args) == 0 {

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1095,6 +1095,14 @@ func initAwsIamUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+
+	// A reference already materialized by an earlier referrer or by the
+	// list that built it. NewResource consults the cache only after this
+	// init returns, so without this the same target is fetched once per
+	// referring resource and the result discarded.
+	if cached := cachedArgByArn(runtime, ResourceAwsIamUser, args); cached != nil {
+		return args, cached, nil
+	}
 	// The lookup is name-driven (GetUser); discovery sets the asset name to
 	// the IAM user name.
 	if len(args) == 0 {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1540,6 +1540,15 @@ func initAwsVpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 
 	if region != "" && vpcId != "" {
 		conn := runtime.Connection.(*connection.AwsConnection)
+
+		// Check again now the ARN can be derived. The check above only fires
+		// for a caller that passed one, and callers passing an id instead are
+		// the ones that repeat.
+		if cached := cachedByArn(runtime, ResourceAwsVpc,
+			fmt.Sprintf(vpcArnPattern, region, conn.AccountId(), vpcId)); cached != nil {
+			return args, cached, nil
+		}
+
 		svc := conn.Ec2(region)
 		resp, err := svc.DescribeVpcs(context.Background(), &ec2.DescribeVpcsInput{
 			VpcIds: []string{vpcId},


### PR DESCRIPTION
An init runs before `NewResource` consults the resource cache, so a reference resolved by id rather than ARN re-fetched its target once per referring resource. This derives the ARN first and then checks the cache, for security groups, VPCs and network interfaces, and adds the same ARN check to the volume, snapshot and IAM user inits.

## Measured

Full AWS security policy scan, 160 assets, `--filters regions=us-east-1`:

| operation | before | after |
|---|---|---|
| DescribeSecurityGroups | 2,862 | 1 |
| DescribeVpcs | 9 | 1 |
| **total AWS API calls** | **7,139** | **3,647** |

Of the 3,647 remaining, 83 calls (2.3%) are genuine duplicates; the rest are distinct requests.

## What this does not fix

The remaining 83 duplicates are concurrent resolution, not stale cache reads: several referrers reach the same init before any has populated the cache, so identical parameters go out 6–8 times (`DescribeVolumes` 50 calls / 8 distinct, `GetUser` 31 / 4, `DescribeSnapshots` 9 / 3). A cache-first check cannot catch that by construction — it needs single-flight on the ARN.

Separately, `ListPolicyVersions` + `GetPolicyVersion` account for 3,180 calls (87% of what remains) at 1.0× repetition. Those are not duplicates; `aws.iam.policies` enumerates all 1,590 policies, nearly all AWS-managed, and fetches each document. Reducing that is a separate change with permission and semantics implications.

## Verification worth doing before merge

Every fix here substitutes a cached instance for a targeted lookup. That is only safe if the list-built resource is field-complete relative to the targeted call — worth confirming per resource, particularly for security groups given the 2,862 → 1 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)