### PR TITLE
🐛 aws: only adopt a scanned asset's ARN when the asset is that resource

### DIFF
--- a/providers/aws/connection/platforms.go
+++ b/providers/aws/connection/platforms.go
@@ -10,63 +10,127 @@ import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 // object type. Each object is an "aws-object" running in the "aws" runtime;
 // the account root is an "api" platform. This is the single source of truth for
 // both the provider config (config.Config.Platforms) and the runtime builder.
+// Platform names, one per discoverable AWS object type plus the account root.
+// Referencing these instead of string literals means a mistyped platform is a
+// compile error rather than a silently unmatched asset: code that gates on the
+// scanned asset's platform (see getAssetIdentifier) fails closed, so a typo
+// would quietly stop asset-scoped resolution for that resource with no error.
+const (
+	PlatformAccount                   = "aws"
+	PlatformS3Bucket                  = "aws-s3-bucket"
+	PlatformCloudtrailTrail           = "aws-cloudtrail-trail"
+	PlatformRdsDbinstance             = "aws-rds-dbinstance"
+	PlatformRdsDbcluster              = "aws-rds-dbcluster"
+	PlatformDynamodbTable             = "aws-dynamodb-table"
+	PlatformDynamodbGlobaltable       = "aws-dynamodb-globaltable"
+	PlatformRedshiftCluster           = "aws-redshift-cluster"
+	PlatformVpc                       = "aws-vpc"
+	PlatformSecurityGroup             = "aws-security-group"
+	PlatformEbsVolume                 = "aws-ebs-volume"
+	PlatformEbsSnapshot               = "aws-ebs-snapshot"
+	PlatformIamUser                   = "aws-iam-user"
+	PlatformIamGroup                  = "aws-iam-group"
+	PlatformCloudwatchLoggroup        = "aws-cloudwatch-loggroup"
+	PlatformLambdaFunction            = "aws-lambda-function"
+	PlatformEcsContainer              = "aws-ecs-container"
+	PlatformEcsInstance               = "aws-ecs-instance"
+	PlatformEfsFilesystem             = "aws-efs-filesystem"
+	PlatformGatewayRestapi            = "aws-gateway-restapi"
+	PlatformElbLoadbalancer           = "aws-elb-loadbalancer"
+	PlatformEsDomain                  = "aws-es-domain"
+	PlatformOpensearchDomain          = "aws-opensearch-domain"
+	PlatformKmsKey                    = "aws-kms-key"
+	PlatformSagemakerNotebookinstance = "aws-sagemaker-notebookinstance"
+	PlatformSagemakerProcessingjob    = "aws-sagemaker-processingjob"
+	PlatformSagemakerTrainingjob      = "aws-sagemaker-trainingjob"
+	PlatformSagemakerDomain           = "aws-sagemaker-domain"
+	PlatformSagemakerModel            = "aws-sagemaker-model"
+	PlatformEc2Instance               = "aws-ec2-instance"
+	PlatformSsmInstance               = "aws-ssm-instance"
+	PlatformEcrImage                  = "aws-ecr-image"
+	PlatformEcrRepository             = "aws-ecr-repository"
+	PlatformEcsTaskdefinition         = "aws-ecs-taskdefinition"
+	PlatformRoute53Hostedzone         = "aws-route53-hostedzone"
+	PlatformMskCluster                = "aws-msk-cluster"
+	PlatformMqBroker                  = "aws-mq-broker"
+	PlatformEksCluster                = "aws-eks-cluster"
+	PlatformSecretsmanagerSecret      = "aws-secretsmanager-secret"
+	PlatformElasticacheCluster        = "aws-elasticache-cluster"
+	PlatformCloudfrontDistribution    = "aws-cloudfront-distribution"
+	PlatformNeptuneCluster            = "aws-neptune-cluster"
+	PlatformEmrCluster                = "aws-emr-cluster"
+	PlatformDocumentdbCluster         = "aws-documentdb-cluster"
+	PlatformMemorydbCluster           = "aws-memorydb-cluster"
+	PlatformCodebuildProject          = "aws-codebuild-project"
+	PlatformCognitoUserpool           = "aws-cognito-userpool"
+	PlatformTransferServer            = "aws-transfer-server"
+	PlatformApigatewayv2Api           = "aws-apigatewayv2-api"
+	PlatformAthenaWorkgroup           = "aws-athena-workgroup"
+	PlatformAppstreamFleet            = "aws-appstream-fleet"
+	PlatformBatchJobdefinition        = "aws-batch-jobdefinition"
+	PlatformDirectoryserviceDirectory = "aws-directoryservice-directory"
+	PlatformDocumentdbInstance        = "aws-documentdb-instance"
+	PlatformSnsTopic                  = "aws-sns-topic"
+	PlatformSqsQueue                  = "aws-sqs-queue"
+)
+
 var Platforms = []*plugin.PlatformInfo{
-	{Name: "aws", Title: "AWS Account", Kind: []string{"api"}, Runtime: []string{"aws"}},
-	{Name: "aws-s3-bucket", Title: "AWS S3 Bucket", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-cloudtrail-trail", Title: "AWS CloudTrail Trail", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-rds-dbinstance", Title: "AWS RDS DB Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-rds-dbcluster", Title: "AWS RDS DB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-dynamodb-table", Title: "AWS DynamoDB Table", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-dynamodb-globaltable", Title: "AWS DynamoDB Global Table", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-redshift-cluster", Title: "AWS Redshift Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-vpc", Title: "AWS VPC", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-security-group", Title: "AWS Security Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ebs-volume", Title: "AWS EBS Volume", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ebs-snapshot", Title: "AWS EBS Snapshot", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-iam-user", Title: "AWS IAM User", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-iam-group", Title: "AWS IAM Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-cloudwatch-loggroup", Title: "AWS CloudWatch Log Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-lambda-function", Title: "AWS Lambda Function", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ecs-container", Title: "AWS ECS Container", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ecs-instance", Title: "AWS ECS Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-efs-filesystem", Title: "AWS EFS Filesystem", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-gateway-restapi", Title: "AWS Gateway REST API", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-elb-loadbalancer", Title: "AWS ELB Load Balancer", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-es-domain", Title: "AWS ES Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-opensearch-domain", Title: "AWS OpenSearch Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-kms-key", Title: "AWS KMS Key", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-sagemaker-notebookinstance", Title: "AWS SageMaker Notebook Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-sagemaker-processingjob", Title: "AWS SageMaker Processing Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-sagemaker-trainingjob", Title: "AWS SageMaker Training Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-sagemaker-domain", Title: "AWS SageMaker Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-sagemaker-model", Title: "AWS SageMaker Model", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ec2-instance", Title: "AWS EC2 Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ssm-instance", Title: "AWS SSM Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ecr-image", Title: "AWS ECR Image", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ecr-repository", Title: "AWS ECR Repository", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-ecs-taskdefinition", Title: "AWS ECS Task Definition", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-route53-hostedzone", Title: "AWS Route 53 Hosted Zone", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-msk-cluster", Title: "AWS MSK Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-mq-broker", Title: "AWS MQ Broker", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-eks-cluster", Title: "AWS EKS Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-secretsmanager-secret", Title: "AWS Secrets Manager Secret", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-elasticache-cluster", Title: "AWS ElastiCache Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-cloudfront-distribution", Title: "AWS CloudFront Distribution", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-neptune-cluster", Title: "AWS Neptune Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-emr-cluster", Title: "AWS EMR Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-documentdb-cluster", Title: "AWS DocumentDB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-memorydb-cluster", Title: "AWS MemoryDB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-codebuild-project", Title: "AWS CodeBuild Project", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-cognito-userpool", Title: "AWS Cognito User Pool", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-transfer-server", Title: "AWS Transfer Family Server", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-apigatewayv2-api", Title: "AWS API Gateway V2 API", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-athena-workgroup", Title: "AWS Athena Workgroup", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-appstream-fleet", Title: "AWS AppStream Fleet", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-batch-jobdefinition", Title: "AWS Batch Job Definition", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-directoryservice-directory", Title: "AWS Directory Service Directory", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-documentdb-instance", Title: "AWS DocumentDB Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-sns-topic", Title: "AWS SNS Topic", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
-	{Name: "aws-sqs-queue", Title: "AWS SQS Queue", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformAccount, Title: "AWS Account", Kind: []string{"api"}, Runtime: []string{"aws"}},
+	{Name: PlatformS3Bucket, Title: "AWS S3 Bucket", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformCloudtrailTrail, Title: "AWS CloudTrail Trail", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformRdsDbinstance, Title: "AWS RDS DB Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformRdsDbcluster, Title: "AWS RDS DB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformDynamodbTable, Title: "AWS DynamoDB Table", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformDynamodbGlobaltable, Title: "AWS DynamoDB Global Table", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformRedshiftCluster, Title: "AWS Redshift Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformVpc, Title: "AWS VPC", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSecurityGroup, Title: "AWS Security Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEbsVolume, Title: "AWS EBS Volume", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEbsSnapshot, Title: "AWS EBS Snapshot", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformIamUser, Title: "AWS IAM User", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformIamGroup, Title: "AWS IAM Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformCloudwatchLoggroup, Title: "AWS CloudWatch Log Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformLambdaFunction, Title: "AWS Lambda Function", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEcsContainer, Title: "AWS ECS Container", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEcsInstance, Title: "AWS ECS Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEfsFilesystem, Title: "AWS EFS Filesystem", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformGatewayRestapi, Title: "AWS Gateway REST API", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformElbLoadbalancer, Title: "AWS ELB Load Balancer", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEsDomain, Title: "AWS ES Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformOpensearchDomain, Title: "AWS OpenSearch Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformKmsKey, Title: "AWS KMS Key", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSagemakerNotebookinstance, Title: "AWS SageMaker Notebook Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSagemakerProcessingjob, Title: "AWS SageMaker Processing Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSagemakerTrainingjob, Title: "AWS SageMaker Training Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSagemakerDomain, Title: "AWS SageMaker Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSagemakerModel, Title: "AWS SageMaker Model", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEc2Instance, Title: "AWS EC2 Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSsmInstance, Title: "AWS SSM Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEcrImage, Title: "AWS ECR Image", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEcrRepository, Title: "AWS ECR Repository", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEcsTaskdefinition, Title: "AWS ECS Task Definition", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformRoute53Hostedzone, Title: "AWS Route 53 Hosted Zone", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformMskCluster, Title: "AWS MSK Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformMqBroker, Title: "AWS MQ Broker", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEksCluster, Title: "AWS EKS Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSecretsmanagerSecret, Title: "AWS Secrets Manager Secret", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformElasticacheCluster, Title: "AWS ElastiCache Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformCloudfrontDistribution, Title: "AWS CloudFront Distribution", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformNeptuneCluster, Title: "AWS Neptune Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformEmrCluster, Title: "AWS EMR Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformDocumentdbCluster, Title: "AWS DocumentDB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformMemorydbCluster, Title: "AWS MemoryDB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformCodebuildProject, Title: "AWS CodeBuild Project", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformCognitoUserpool, Title: "AWS Cognito User Pool", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformTransferServer, Title: "AWS Transfer Family Server", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformApigatewayv2Api, Title: "AWS API Gateway V2 API", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformAthenaWorkgroup, Title: "AWS Athena Workgroup", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformAppstreamFleet, Title: "AWS AppStream Fleet", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformBatchJobdefinition, Title: "AWS Batch Job Definition", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformDirectoryserviceDirectory, Title: "AWS Directory Service Directory", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformDocumentdbInstance, Title: "AWS DocumentDB Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSnsTopic, Title: "AWS SNS Topic", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: PlatformSqsQueue, Title: "AWS SQS Queue", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)

--- a/providers/aws/resources/asset_platform_test.go
+++ b/providers/aws/resources/asset_platform_test.go
@@ -1,0 +1,115 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+const (
+	testSecretArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod-db-AbCdEf"
+	testEc2Arn    = "arn:aws:ec2:us-east-1:123456789012:instance/i-0123456789abcdef0"
+)
+
+// The scanned asset is the resource the caller asked for, so its ARN is adopted.
+func TestGetAssetIdentifier_MatchingPlatform(t *testing.T) {
+	runtime := testAwsIdentifierRuntime(connection.PlatformSecretsmanagerSecret, "prod-db", []string{testSecretArn})
+	assert.Equal(t, testSecretArn, getAssetIdentifier(runtime, connection.PlatformSecretsmanagerSecret))
+}
+
+// The case this guard exists for. cnspec evaluates every policy filter against
+// every asset, so a filter like `aws.secretsmanager.secret.lastChangedDate !=
+// null` reaches this init while an EC2 instance is being scanned. Adopting the
+// instance's ARN made the provider call DescribeSecret with it -- 1,494 such
+// calls in one measured scan, none of which could ever resolve.
+func TestGetAssetIdentifier_ForeignPlatformIsNotAdopted(t *testing.T) {
+	runtime := testAwsIdentifierRuntime(connection.PlatformEc2Instance, "web-01", []string{testEc2Arn})
+	assert.Empty(t, getAssetIdentifier(runtime, connection.PlatformSecretsmanagerSecret),
+		"an EC2 instance's ARN must never be adopted as a secret's ARN")
+}
+
+// An account asset is not any individual resource, so nothing is adopted.
+func TestGetAssetIdentifier_AccountAssetIsNotAResource(t *testing.T) {
+	runtime := testAwsIdentifierRuntime(connection.PlatformAccount, "AWS Account 123456789012",
+		[]string{"//platformid.api.mondoo.app/runtime/aws/accounts/123456789012"})
+	assert.Empty(t, getAssetIdentifier(runtime, connection.PlatformSecretsmanagerSecret))
+}
+
+// An asset with no platform cannot be shown to be the right kind of thing, so
+// it fails closed rather than adopting on the strength of the ARN alone.
+func TestGetAssetIdentifier_MissingPlatformFailsClosed(t *testing.T) {
+	runtime := testAwsIdentifierRuntime("", "prod-db", []string{testSecretArn})
+	assert.Empty(t, getAssetIdentifier(runtime, connection.PlatformSecretsmanagerSecret))
+}
+
+// Guards the one failure this design cannot catch by itself: a platform string
+// spelled wrong matches no asset, which disables asset-scoped resolution for
+// that resource silently -- no error, just a resource that never resolves.
+// Every platform handed to getAssetIdentifier has to exist in the registry.
+func TestEveryPlatformPassedToGetAssetIdentifierIsRegistered(t *testing.T) {
+	registered := map[string]bool{}
+	for _, p := range connection.Platforms {
+		registered[p.Name] = true
+	}
+
+	// connection.PlatformFooBar -> the literal it is declared as
+	constToValue := map[string]string{}
+	platformsSrc, err := os.ReadFile(filepath.Join("..", "connection", "platforms.go"))
+	require.NoError(t, err)
+	for _, m := range regexp.MustCompile(`(Platform[A-Za-z0-9]+)\s*=\s*"([a-z0-9-]+)"`).
+		FindAllStringSubmatch(string(platformsSrc), -1) {
+		constToValue[m[1]] = m[2]
+	}
+	require.NotEmpty(t, constToValue, "no platform constants found")
+
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+	callRe := regexp.MustCompile(`getAssetIdentifier\(runtime,\s*connection\.(Platform[A-Za-z0-9]+)\)`)
+
+	seen := 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		require.NoError(t, err)
+		for _, m := range callRe.FindAllStringSubmatch(string(src), -1) {
+			seen++
+			value, ok := constToValue[m[1]]
+			require.True(t, ok, "%s: connection.%s is not a declared platform constant", f, m[1])
+			assert.True(t, registered[value],
+				"%s: platform %q (connection.%s) is not in connection.Platforms", f, value, m[1])
+		}
+	}
+	assert.NotZero(t, seen, "found no getAssetIdentifier call sites to check")
+}
+
+// Every platform discovery can stamp on an asset must be in the registry, so
+// the constants stay a complete picture of what a scanned asset can be. A
+// platform returned here but missing from the registry would be unmatchable by
+// any init.
+func TestDiscoveryPlatformNamesAreRegistered(t *testing.T) {
+	registered := map[string]bool{}
+	for _, p := range connection.Platforms {
+		registered[p.Name] = true
+	}
+
+	src, err := os.ReadFile("discovery_conversion.go")
+	require.NoError(t, err)
+
+	matches := regexp.MustCompile(`return "(aws-[a-z0-9-]+)"`).FindAllStringSubmatch(string(src), -1)
+	require.NotEmpty(t, matches, "no platform names found in getPlatformName")
+	for _, m := range matches {
+		assert.True(t, registered[m[1]],
+			"getPlatformName returns %q, which is not in connection.Platforms", m[1])
+	}
+}

--- a/providers/aws/resources/asset_platform_test.go
+++ b/providers/aws/resources/asset_platform_test.go
@@ -113,3 +113,17 @@ func TestDiscoveryPlatformNamesAreRegistered(t *testing.T) {
 			"getPlatformName returns %q, which is not in connection.Platforms", m[1])
 	}
 }
+
+// getAssetName is gated the same way, for the same reason: a bare
+// aws.iam.user query on an EBS volume asset used to call GetUser with the
+// volume id as the user name.
+func TestGetAssetName_ForeignPlatformIsNotAdopted(t *testing.T) {
+	runtime := testAwsIdentifierRuntime(connection.PlatformEbsVolume, "vol-0eacce2fc0d0612e3", nil)
+	assert.Empty(t, getAssetName(runtime, connection.PlatformIamUser),
+		"a volume's name must never be adopted as an IAM user name")
+}
+
+func TestGetAssetName_MatchingPlatform(t *testing.T) {
+	runtime := testAwsIdentifierRuntime(connection.PlatformIamUser, "alice", nil)
+	assert.Equal(t, "alice", getAssetName(runtime, connection.PlatformIamUser))
+}

--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -519,12 +519,21 @@ func getAssetIdentifier(runtime *plugin.Runtime, platform string) string {
 // (e.g. IAM GetUser/GetGroup) and whose discovery sets the asset name to the
 // resource's own name; for everything else resolve by ARN via
 // getAssetIdentifier — the asset name is a display name, not a resource key.
-func getAssetName(runtime *plugin.Runtime) string {
+// The platform argument gates the name the same way getAssetIdentifier gates
+// the ARN, and for the same reason: without it a bare aws.iam.user query on an
+// EBS volume asset called GetUser with the volume id as the user name. Of 169
+// distinct names one scan passed to GetUser, 4 were IAM users; the rest were
+// log groups, volume ids and UUIDs belonging to whatever else was scanned.
+func getAssetName(runtime *plugin.Runtime, platform string) string {
 	var a *inventory.Asset
 	if conn, ok := runtime.Connection.(*connection.AwsConnection); ok {
 		a = conn.Asset()
 	}
 	if a == nil {
+		return ""
+	}
+	if a.Platform == nil || a.Platform.Name != platform {
+		// the scanned asset is not this kind of resource, so its name is not ours
 		return ""
 	}
 	return a.Name

--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -478,12 +478,25 @@ const (
 // is a display name (possibly a Name tag), never a resource key, and must not
 // be used for resolution. Callers must only inject a non-empty result into
 // init args — an empty args["arn"] defeats `args["arn"] == nil` guards.
-func getAssetIdentifier(runtime *plugin.Runtime) string {
+// The platform argument is the platform of the resource asking. The scanned
+// asset's platform is the exact discriminator for what kind of thing it is
+// (connection.Platforms holds one entry per discoverable object type), so
+// requiring it here stops an init from adopting the ARN of an unrelated asset.
+// Without that check a bare query -- e.g. the policy filter
+// `aws.secretsmanager.secret.lastChangedDate != null`, which cnspec evaluates
+// against every asset -- made each init fetch the scanned asset's own ARN and
+// call its own API with it. That cost 1,494 DescribeSecret and 504
+// DescribeClusterV2 calls per scan on ARNs that could never resolve.
+func getAssetIdentifier(runtime *plugin.Runtime, platform string) string {
 	var a *inventory.Asset
 	if conn, ok := runtime.Connection.(*connection.AwsConnection); ok {
 		a = conn.Asset()
 	}
 	if a == nil {
+		return ""
+	}
+	if a.Platform == nil || a.Platform.Name != platform {
+		// the scanned asset is not this kind of resource, so its ARN is not ours
 		return ""
 	}
 

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -129,7 +129,7 @@ func initAwsApigatewayRestapi(runtime *plugin.Runtime, args map[string]*llx.RawD
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformGatewayRestapi); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_apigatewayv2.go
+++ b/providers/aws/resources/aws_apigatewayv2.go
@@ -152,7 +152,7 @@ func initAwsApigatewayv2Api(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 	// Resolve a discovered asset (aws-apigatewayv2-api platform) by its ARN.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformApigatewayv2Api); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_appstream.go
+++ b/providers/aws/resources/aws_appstream.go
@@ -209,7 +209,7 @@ func initAwsAppstreamFleet(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 	// Resolve a discovered asset (aws-appstream-fleet platform) by its ARN.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformAppstreamFleet); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_asset_identifier_test.go
+++ b/providers/aws/resources/aws_asset_identifier_test.go
@@ -84,7 +84,7 @@ func TestGetAssetIdentifier(t *testing.T) {
 
 func TestGetAssetName(t *testing.T) {
 	t.Run("returns empty when the connection is not an AwsConnection", func(t *testing.T) {
-		assert.Empty(t, getAssetName(&plugin.Runtime{}))
+		assert.Empty(t, getAssetName(&plugin.Runtime{}, connection.PlatformIamUser))
 	})
 
 	t.Run("returns empty when the connection has no asset", func(t *testing.T) {
@@ -92,10 +92,10 @@ func TestGetAssetName(t *testing.T) {
 			Connection: plugin.NewConnection(1, &inventory.Asset{Connections: []*inventory.Config{{}}}),
 		}
 		// no UpdateAsset call, so conn.Asset() returns nil
-		assert.Empty(t, getAssetName(&plugin.Runtime{Connection: conn}))
+		assert.Empty(t, getAssetName(&plugin.Runtime{Connection: conn}, connection.PlatformIamUser))
 	})
 
 	t.Run("returns the asset name", func(t *testing.T) {
-		assert.Equal(t, "my-user", getAssetName(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "my-user", nil)))
+		assert.Equal(t, "my-user", getAssetName(testAwsIdentifierRuntime(connection.PlatformIamUser, "my-user", nil), connection.PlatformIamUser))
 	})
 }

--- a/providers/aws/resources/aws_asset_identifier_test.go
+++ b/providers/aws/resources/aws_asset_identifier_test.go
@@ -12,11 +12,16 @@ import (
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 )
 
-func testAwsIdentifierRuntime(assetName string, platformIds []string) *plugin.Runtime {
+// platform is the scanned asset's platform; getAssetIdentifier only hands back
+// an ARN when it matches what the caller asked for.
+func testAwsIdentifierRuntime(platform, assetName string, platformIds []string) *plugin.Runtime {
 	asset := &inventory.Asset{
 		Name:        assetName,
 		PlatformIds: platformIds,
 		Connections: []*inventory.Config{{}},
+	}
+	if platform != "" {
+		asset.Platform = &inventory.Platform{Name: platform}
 	}
 	conn := &connection.AwsConnection{
 		Connection: plugin.NewConnection(1, asset),
@@ -29,7 +34,7 @@ func TestGetAssetIdentifier(t *testing.T) {
 	const validArn = "arn:aws:s3:::my-bucket"
 
 	t.Run("returns empty when the connection is not an AwsConnection", func(t *testing.T) {
-		assert.Empty(t, getAssetIdentifier(&plugin.Runtime{}))
+		assert.Empty(t, getAssetIdentifier(&plugin.Runtime{}, connection.PlatformS3Bucket))
 	})
 
 	t.Run("returns empty when the connection has no asset", func(t *testing.T) {
@@ -37,11 +42,11 @@ func TestGetAssetIdentifier(t *testing.T) {
 			Connection: plugin.NewConnection(1, &inventory.Asset{Connections: []*inventory.Config{{}}}),
 		}
 		// no UpdateAsset call, so conn.Asset() returns nil
-		assert.Empty(t, getAssetIdentifier(&plugin.Runtime{Connection: conn}))
+		assert.Empty(t, getAssetIdentifier(&plugin.Runtime{Connection: conn}, connection.PlatformS3Bucket))
 	})
 
 	t.Run("returns the arn for a valid arn:aws: platform ID", func(t *testing.T) {
-		assert.Equal(t, validArn, getAssetIdentifier(testAwsIdentifierRuntime("my-bucket", []string{validArn})))
+		assert.Equal(t, validArn, getAssetIdentifier(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "my-bucket", []string{validArn}), connection.PlatformS3Bucket))
 	})
 
 	t.Run("returns empty when the only arn:aws: platform ID fails to parse", func(t *testing.T) {
@@ -49,31 +54,31 @@ func TestGetAssetIdentifier(t *testing.T) {
 		// ("arn: not enough sections"). Returning it (or an empty string that
 		// callers inject anyway) made inits set args["arn"] = "" and end up
 		// creating blank resources with unset fields.
-		assert.Empty(t, getAssetIdentifier(testAwsIdentifierRuntime("AWS Account 010438491650", []string{"arn:aws:sts::010438491650"})))
+		assert.Empty(t, getAssetIdentifier(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "AWS Account 010438491650", []string{"arn:aws:sts::010438491650"}), connection.PlatformS3Bucket))
 	})
 
 	t.Run("returns empty when no platform ID has the arn:aws: prefix", func(t *testing.T) {
-		assert.Empty(t, getAssetIdentifier(testAwsIdentifierRuntime("some-asset", []string{
+		assert.Empty(t, getAssetIdentifier(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "some-asset", []string{
 			"//platformid.api.mondoo.app/runtime/aws/accounts/010438491650",
 			"not-an-arn",
-		})))
+		}), connection.PlatformS3Bucket))
 	})
 
 	t.Run("returns empty when the asset has no platform IDs", func(t *testing.T) {
-		assert.Empty(t, getAssetIdentifier(testAwsIdentifierRuntime("some-asset", nil)))
+		assert.Empty(t, getAssetIdentifier(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "some-asset", nil), connection.PlatformS3Bucket))
 	})
 
 	t.Run("skips an invalid ARN and keeps the valid one", func(t *testing.T) {
-		assert.Equal(t, validArn, getAssetIdentifier(testAwsIdentifierRuntime("my-bucket", []string{
+		assert.Equal(t, validArn, getAssetIdentifier(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "my-bucket", []string{
 			"arn:aws:sts::010438491650",
 			validArn,
-		})))
+		}), connection.PlatformS3Bucket))
 	})
 
 	t.Run("last valid ARN wins when multiple are present", func(t *testing.T) {
 		first := "arn:aws:s3:::first-bucket"
 		second := "arn:aws:s3:::second-bucket"
-		assert.Equal(t, second, getAssetIdentifier(testAwsIdentifierRuntime("my-bucket", []string{first, second})))
+		assert.Equal(t, second, getAssetIdentifier(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "my-bucket", []string{first, second}), connection.PlatformS3Bucket))
 	})
 }
 
@@ -91,6 +96,6 @@ func TestGetAssetName(t *testing.T) {
 	})
 
 	t.Run("returns the asset name", func(t *testing.T) {
-		assert.Equal(t, "my-user", getAssetName(testAwsIdentifierRuntime("my-user", nil)))
+		assert.Equal(t, "my-user", getAssetName(testAwsIdentifierRuntime(connection.PlatformS3Bucket, "my-user", nil)))
 	})
 }

--- a/providers/aws/resources/aws_athena.go
+++ b/providers/aws/resources/aws_athena.go
@@ -91,7 +91,7 @@ func initAwsAthenaWorkgroup(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformAthenaWorkgroup); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_batch.go
+++ b/providers/aws/resources/aws_batch.go
@@ -614,7 +614,7 @@ func initAwsBatchJobDefinition(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformBatchJobdefinition); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_bedrock.go
+++ b/providers/aws/resources/aws_bedrock.go
@@ -250,12 +250,6 @@ func initAwsBedrockCustomModel(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["modelArn"] = llx.StringData(assetArn)
-		}
-	}
-
 	if args["modelArn"] == nil {
 		return nil, nil, errors.New("modelArn required to fetch bedrock custom model")
 	}
@@ -505,12 +499,6 @@ type mqlAwsBedrockGuardrailInternal struct {
 func initAwsBedrockGuardrail(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
 	}
 
 	var identifier, region string
@@ -1339,12 +1327,6 @@ type mqlAwsBedrockKnowledgeBaseInternal struct {
 func initAwsBedrockKnowledgeBase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
 	}
 
 	var kbId, region string

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -581,7 +581,7 @@ func initAwsCloudfrontDistribution(runtime *plugin.Runtime, args map[string]*llx
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformCloudfrontDistribution); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -51,7 +51,7 @@ func initAwsCloudtrailTrail(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformCloudtrailTrail); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -706,7 +706,7 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformCloudwatchLoggroup); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -113,7 +113,7 @@ func initAwsCodebuildProject(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the project's region and name from the ARN carried on the asset.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformCodebuildProject); assetArn != "" {
 			parsed, err := arn.Parse(assetArn)
 			if err != nil {
 				return nil, nil, err

--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -119,7 +119,7 @@ func initAwsCognitoUserPool(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the pool's region and id from the ARN carried on the asset.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformCognitoUserpool); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_directoryservice.go
+++ b/providers/aws/resources/aws_directoryservice.go
@@ -53,7 +53,7 @@ func initAwsDirectoryserviceDirectory(runtime *plugin.Runtime, args map[string]*
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformDirectoryserviceDirectory); assetArn != "" {
 			if parsed, err := arn.Parse(assetArn); err == nil {
 				args["directoryId"] = llx.StringData(strings.TrimPrefix(parsed.Resource, "directory/"))
 			}

--- a/providers/aws/resources/aws_documentdb.go
+++ b/providers/aws/resources/aws_documentdb.go
@@ -259,7 +259,7 @@ func initAwsDocumentdbCluster(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformDocumentdbCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -736,7 +736,7 @@ func initAwsDocumentdbInstance(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformDocumentdbInstance); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -334,7 +334,7 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformDynamodbTable); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -929,7 +929,7 @@ func initAwsDynamodbGlobaltable(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformDynamodbGlobaltable); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2183,7 +2183,7 @@ func initAwsEc2Securitygroup(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSecurityGroup); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -2560,7 +2560,7 @@ func initAwsEc2Volume(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEbsVolume); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -2709,7 +2709,7 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 
 	log.Debug().Msg("init an ec2 instance")
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEc2Instance); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -2809,7 +2809,7 @@ func initAwsEc2Snapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEbsSnapshot); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -485,7 +485,7 @@ func initAwsEcrImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEcrImage); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -952,7 +952,7 @@ func initAwsEcrRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEcrRepository); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -157,12 +157,6 @@ func initAwsEcsCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch ecs cluster")
 	}
@@ -430,12 +424,6 @@ func (s *mqlAwsEcsTask) id() (string, error) {
 func initAwsEcsTask(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
 	}
 
 	if args["arn"] == nil {
@@ -2096,12 +2084,6 @@ func initAwsEcsService(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch ecs service")
 	}
@@ -2608,7 +2590,7 @@ func initAwsEcsTaskDefinition(runtime *plugin.Runtime, args map[string]*llx.RawD
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEcsTaskdefinition); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -133,7 +133,7 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEfsFilesystem); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -485,7 +485,7 @@ func initAwsEksCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEksCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -690,7 +690,7 @@ func initAwsElasticacheCluster(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformElasticacheCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -450,7 +450,7 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformElbLoadbalancer); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -114,7 +114,7 @@ func initAwsEmrCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEmrCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -429,7 +429,7 @@ func initAwsEsDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformEsDomain); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_fsx.go
+++ b/providers/aws/resources/aws_fsx.go
@@ -125,12 +125,6 @@ func initAwsFsxFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch fsx filesystem")
 	}
@@ -319,12 +313,6 @@ func initAwsFsxCache(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch fsx cache")
 	}
@@ -494,12 +482,6 @@ func (a *mqlAwsFsx) getBackups(conn *connection.AwsConnection) []*jobpool.Job {
 func initAwsFsxBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
-	}
-
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
 	}
 
 	if args["arn"] == nil {

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1098,7 +1098,7 @@ func initAwsIamUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	// The lookup is name-driven (GetUser); discovery sets the asset name to
 	// the IAM user name.
 	if len(args) == 0 {
-		if name := getAssetName(runtime); name != "" {
+		if name := getAssetName(runtime, connection.PlatformIamUser); name != "" {
 			args["name"] = llx.StringData(name)
 		}
 	}
@@ -2056,7 +2056,7 @@ func initAwsIamGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	// The lookup is name-driven (GetGroup); discovery sets the asset name to
 	// the IAM group name.
 	if len(args) == 0 {
-		if name := getAssetName(runtime); name != "" {
+		if name := getAssetName(runtime, connection.PlatformIamGroup); name != "" {
 			args["name"] = llx.StringData(name)
 		}
 	}

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -884,7 +884,7 @@ func initAwsKmsKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformKmsKey); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -316,7 +316,7 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformLambdaFunction); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_memorydb.go
+++ b/providers/aws/resources/aws_memorydb.go
@@ -98,7 +98,7 @@ func initAwsMemorydbCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the cluster's region and name from the ARN carried on the asset.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformMemorydbCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_mq.go
+++ b/providers/aws/resources/aws_mq.go
@@ -693,7 +693,7 @@ func initAwsMqBroker(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformMqBroker); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_msk.go
+++ b/providers/aws/resources/aws_msk.go
@@ -445,7 +445,7 @@ func initAwsMskCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformMskCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_neptune.go
+++ b/providers/aws/resources/aws_neptune.go
@@ -199,7 +199,7 @@ func initAwsNeptuneCluster(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformNeptuneCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_opensearch.go
+++ b/providers/aws/resources/aws_opensearch.go
@@ -115,7 +115,7 @@ func initAwsOpensearchDomain(runtime *plugin.Runtime, args map[string]*llx.RawDa
 
 	// Get asset identifier if no args provided
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformOpensearchDomain); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -541,7 +541,7 @@ func initAwsRdsDbcluster(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformRdsDbcluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -578,7 +578,7 @@ func initAwsRdsDbinstance(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformRdsDbinstance); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_redshift.go
+++ b/providers/aws/resources/aws_redshift.go
@@ -378,7 +378,7 @@ func initAwsRedshiftCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformRedshiftCluster); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_route53.go
+++ b/providers/aws/resources/aws_route53.go
@@ -196,7 +196,7 @@ func initAwsRoute53HostedZone(runtime *plugin.Runtime, args map[string]*llx.RawD
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformRoute53Hostedzone); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -145,7 +145,7 @@ func initAwsS3Bucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformS3Bucket); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -274,7 +274,7 @@ func initAwsSagemakerNotebookinstance(runtime *plugin.Runtime, args map[string]*
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSagemakerNotebookinstance); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -2152,7 +2152,7 @@ func initAwsSagemakerDomain(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSagemakerDomain); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -4552,7 +4552,7 @@ func initAwsSagemakerTrainingjob(runtime *plugin.Runtime, args map[string]*llx.R
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSagemakerTrainingjob); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
@@ -4594,7 +4594,7 @@ func initAwsSagemakerProcessingjob(runtime *plugin.Runtime, args map[string]*llx
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSagemakerProcessingjob); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -71,7 +71,7 @@ func initAwsSagemakerModel(runtime *plugin.Runtime, args map[string]*llx.RawData
 		return args, nil, nil
 	}
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSagemakerModel); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -56,7 +56,7 @@ func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.R
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSecretsmanagerSecret); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_sns.go
+++ b/providers/aws/resources/aws_sns.go
@@ -62,7 +62,7 @@ func initAwsSnsTopic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSnsTopic); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -79,7 +79,7 @@ func initAwsSqsQueue(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSqsQueue); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -311,7 +311,7 @@ func initAwsSsmInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformSsmInstance); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_storagegateway.go
+++ b/providers/aws/resources/aws_storagegateway.go
@@ -125,12 +125,6 @@ func initAwsStoragegatewayGateway(runtime *plugin.Runtime, args map[string]*llx.
 		return args, nil, nil
 	}
 
-	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
-			args["arn"] = llx.StringData(assetArn)
-		}
-	}
-
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch storage gateway")
 	}

--- a/providers/aws/resources/aws_transfer.go
+++ b/providers/aws/resources/aws_transfer.go
@@ -108,7 +108,7 @@ func initAwsTransferServer(runtime *plugin.Runtime, args map[string]*llx.RawData
 	// During a discovered-asset scan the resource is queried with no args; recover
 	// the server's region and id from the ARN carried on the asset.
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformTransferServer); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1491,7 +1491,7 @@ func initAwsVpcSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 // resolution correct. It may populate args["arn"] from the asset identifier.
 func deriveVpcTarget(runtime *plugin.Runtime, args map[string]*llx.RawData) (region, vpcId string) {
 	if len(args) == 0 {
-		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+		if assetArn := getAssetIdentifier(runtime, connection.PlatformVpc); assetArn != "" {
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}

--- a/providers/aws/resources/aws_vpc_init_test.go
+++ b/providers/aws/resources/aws_vpc_init_test.go
@@ -24,6 +24,9 @@ func testAwsRuntime(assetName string, platformIds []string, vpcs []*mqlAwsVpc) *
 		Name:        assetName,
 		PlatformIds: platformIds,
 		Connections: []*inventory.Config{{}},
+		// the asset under test is a VPC; getAssetIdentifier only adopts an
+		// asset's ARN when its platform matches the resource asking
+		Platform: &inventory.Platform{Name: connection.PlatformVpc},
 	}
 
 	conn := &connection.AwsConnection{


### PR DESCRIPTION
## Problem

An init called with no args takes the scanned asset's ARN from `getAssetIdentifier` and calls its own API with it — without ever checking **what kind of asset** it is:

```go
if len(args) == 0 {
    if assetArn := getAssetIdentifier(runtime); assetArn != "" {
        args["arn"] = llx.StringData(assetArn)   // whatever the asset happens to be
    }
}
```

cnspec evaluates every policy filter against every asset, and several filters probe a bare resource rather than checking `asset.platform`:

```
//policy.api.mondoo.app/filter/AdVyvxA8WWw=
  aws.secretsmanager.secret.lastChangedDate != null
```

So while an EC2 instance is being scanned, that filter reaches `initAwsSecretsmanagerSecret`, which adopts the *instance's* ARN and calls `DescribeSecret` on it. The call can only fail, and failures aren't cached, so it is retried once per referrer.

Whether an init actually burns a call depends on how much of the ARN it validates. `initAwsEc2Snapshot` requires `strings.HasPrefix(parsed.Resource, "snapshot/")`, so a foreign ARN is rejected for free. `initAwsSecretsmanagerSecret` parses the ARN only for its **region**, which succeeds for *any* ARN — so it always proceeds to the API.

## Measured impact

One AWS account, 170 assets, `--filters regions=us-east-1`, server policies. Calls made with an ARN belonging to a different service:

| service | wasted calls |
|---|---|
| `secretsmanager` `DescribeSecret` | 1,494 (only 39 of 1,534 were real) |
| `es` `DescribeDomain` | 556 |
| `kafka` `DescribeClusterV2` | 504 |
| **total** | **2,554 of 9,558 — 26.7%** |

They look like this — the OpenSearch API asked for a security group:

```
GET /2015-01-01/es/domain/security-group%2Fsg-0c1d74b10a768997b
{"SecretId":"arn:aws:ec2:us-east-1:…:instance/i-…"}
```

This is also the only thing that got worse under `--parallelism 4`: a serial scan made 9,558 calls, parallel made 10,060, and **the entire +502 was `es`** retrying the same doomed lookups more times (9× per identifier serial, 12× parallel). Every other operation was byte-identical between the two.

## Fix

The asset's platform is the exact discriminator — `connection.Platforms` holds one entry per discoverable object type — so `getAssetIdentifier` now takes the platform of the resource asking:

```go
func getAssetIdentifier(runtime *plugin.Runtime, platform string) string {
	...
	if a.Platform == nil || a.Platform.Name != platform {
		// the scanned asset is not this kind of resource, so its ARN is not ours
		return ""
	}
```

Chosen over parsing the ARN because it is an exact match rather than a prefix heuristic, and it sidesteps two traps: AWS uses both separators (`secret:name` but `key/id`), and this provider emits a synthetic `arn:aws:vpc:` service that doesn't exist in AWS, so an ARN-shaped guard written from the AWS docs would break VPC scans.

The required parameter is the forcing function — all **61 call sites** had to declare a platform, so the **47 latent** inits are fixed too, not just the three reachable today.

Ten inits whose resource is never a standalone asset (bedrock ×3, ecs cluster/service/task, fsx ×3, storagegateway) could only ever have adopted a foreign ARN; their adoption is removed and they now report the missing id.

Platform names become exported constants used by the registry itself, so a typo is a compile error rather than a silent failure — a mistyped platform matches no asset and would quietly stop asset-scoped resolution for that one resource, with no error to notice.

## Tests

- `getAssetIdentifier` adopts on a matching platform, refuses a foreign one, refuses an account asset, and fails closed when the asset has no platform
- every platform passed to `getAssetIdentifier` is a declared constant present in `connection.Platforms`
- every platform `getPlatformName` can return is in `connection.Platforms`

`go build`, `go vet`, full `go test ./...` green. `gofmt` clean. `aws.permissions.json` unchanged (1025 permissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)