### PR TITLE
🎉 proxmox-0.5.0

### DIFF
--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
-	Version:         "0.4.1",
+	Version:         "0.5.0",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### proxmox (0.5.0)
- ⭐ proxmox: resolve node and storage names to typed references on guests, volumes and Ceph daemons (#9843)