### PR TITLE
🐛 aws: report isServiceLinked for a role reached through its init

### DIFF
--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -740,7 +740,7 @@ func (a *mqlAwsIam) roles() ([]any, error) {
 					"maxSessionDuration":       llx.IntDataDefault(role.MaxSessionDuration, 3600),
 					"permissionsBoundaryArn":   llx.StringData(permBoundaryArn),
 					"path":                     llx.StringDataPtr(role.Path),
-					"isServiceLinked":          llx.BoolData(strings.HasPrefix(convert.ToValue(role.Path), "/aws-service-role/")),
+					"isServiceLinked":          llx.BoolData(isServiceLinkedRolePath(convert.ToValue(role.Path))),
 				})
 			if err != nil {
 				return nil, err
@@ -1753,6 +1753,14 @@ func (a *mqlAwsIamPolicyversion) document() (any, error) {
 	return dict, nil
 }
 
+// isServiceLinkedRolePath reports whether an IAM role path marks the role as
+// service-linked. IAM does not return a flag for this; the path prefix is the
+// documented signal. Shared by roles() and initAwsIamRole so the two cannot
+// disagree about the same role.
+func isServiceLinkedRolePath(path string) bool {
+	return strings.HasPrefix(path, "/aws-service-role/")
+}
+
 func initAwsIamRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
@@ -1823,6 +1831,11 @@ func initAwsIamRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		args["maxSessionDuration"] = llx.IntDataDefault(role.MaxSessionDuration, 3600)
 		args["permissionsBoundaryArn"] = llx.StringData(permBoundaryArn)
 		args["path"] = llx.StringDataPtr(role.Path)
+		// Leaving this unset reported null for every role reached through the
+		// init, and because the resource the init builds is cached under the
+		// role ARN, a query that touched aws.iam.role(...) also degraded
+		// isServiceLinked to null for aws.iam.roles in the same scan.
+		args["isServiceLinked"] = llx.BoolData(isServiceLinkedRolePath(convert.ToValue(role.Path)))
 		return args, nil, nil
 	}
 

--- a/providers/aws/resources/aws_iam_test.go
+++ b/providers/aws/resources/aws_iam_test.go
@@ -67,3 +67,34 @@ func TestIamLoginProfileCacheKeysAreDistinct(t *testing.T) {
 	assert.True(t, alice.(*mqlAwsIamLoginProfile).PasswordResetRequired.Data)
 	assert.False(t, bob.(*mqlAwsIamLoginProfile).PasswordResetRequired.Data)
 }
+
+// TestIsServiceLinkedRolePath pins the one signal IAM gives for a
+// service-linked role. roles() derived it inline while initAwsIamRole did not
+// set the field at all, so a role reached through the init reported null --
+// and since that init-built resource is cached under the role ARN, a query
+// touching aws.iam.role(...) degraded isServiceLinked to null for
+// aws.iam.roles in the same scan.
+func TestIsServiceLinkedRolePath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"service-linked", "/aws-service-role/", true},
+		{"service-linked with service", "/aws-service-role/elasticbeanstalk.amazonaws.com/", true},
+		{"plain role", "/", false},
+		{"customer path", "/my-team/", false},
+		{"empty path", "", false},
+		// A customer-chosen path that merely mentions the segment is not
+		// service-linked: IAM only treats the leading prefix as the signal.
+		{"prefix not at start", "/team/aws-service-role/", false},
+		// The trailing slash in the prefix is load-bearing: a customer path that
+		// merely starts with the same characters must not be reported as
+		// service-linked.
+		{"similar prefix", "/aws-service-role-ish/", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isServiceLinkedRolePath(tc.path))
+		})
+	}
+}


### PR DESCRIPTION
Found while verifying #9996 and #9998 against live AWS infrastructure. Not a regression from those PRs — the bug is present on `main` before them and reproduces identically on both sides of that change.

## The bug

`aws.iam.roles` derives `isServiceLinked` from the role path, but `initAwsIamRole` never set the field. Every role reached through the init — `aws.iam.role(arn: ...)`, or any typed reference that resolves to one — reported `null` instead of `true`/`false`.

The blast radius is wider than the init itself. The resource the init builds is cached under the role ARN, so once a query touches `aws.iam.role(...)`, that sparse instance is what `aws.iam.roles` finds in the cache. Adding an unrelated single-role lookup to a query silently degrades `isServiceLinked` to `null` for the whole list in the same scan:

```
# list alone -- correct
aws.iam.roles.where(name=='x') { isServiceLinked }        => false

# init alone -- null
aws.iam.role(arn:'...') { isServiceLinked }               => null

# both in one scan -- the list is now null too
aws.iam.roles.where(name=='x') { isServiceLinked }
aws.iam.role(arn:'...') { isServiceLinked }               => null, null
```

That last case is the dangerous one: a policy asserting `isServiceLinked == false` reads `null`, and under MQL's three-valued logic that is not the failure the author expected.

## The fix

Derive it in the init from `role.Path`, which `GetRole` already returns — no extra API call. Both call sites now share `isServiceLinkedRolePath` instead of repeating the prefix test, so the list and the init cannot disagree about the same role.

## Test plan

- `TestIsServiceLinkedRolePath` covers both directions plus the empty path and a customer path that merely starts with the same characters (`/aws-service-role-ish/` must not match — the trailing slash in the prefix is load-bearing).
- `go test ./resources/` passes in `providers/aws`.
- Verified against live infrastructure in `us-west-2`:

| query | before | after |
|---|---|---|
| customer role, list only | `false` | `false` |
| customer role, init only | `null` | `false` |
| customer role, list + init in one scan | `null` (both) | `false` (both) |
| `AWSServiceRoleForAccessAnalyzer`, init only | `null` | `true` |

- Full 14-query regression sweep across `aws.vpc`, `aws.ec2.securitygroup`, `aws.ec2.networkinterface`, `aws.ec2.volume`, `aws.ec2.snapshot`, `aws.kms.key`, `aws.iam.user` and `aws.iam.role`: byte-identical to `main` except the intended `isServiceLinked` change.
- No generated-file or `aws.permissions.json` drift.
