### PR TITLE
🎉 okta-13.6.0

### DIFF
--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "okta",
 	ID:              "go.mondoo.com/cnquery/v9/providers/okta",
-	Version:         "13.5.1",
+	Version:         "13.6.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### okta (13.6.0)
- 🐛 okta: restore the resource set description, and report unreadable risk providers as null (#9978)
- 🌟 okta: expose what v6 reports about logout, token encryption and admin scope (#9977)
- 🧹 okta: move to okta-sdk-golang v6 (#9976)