### PR TITLE
🎉 oci-13.20.0, mysqldb-13.1.0, mssql-13.1.0, ms365-13.12.0, mongodbatlas-13.4.0, mongo-13.1.0, k8s-13.10.0, gcp-13.36.0, databricks-13.3.0, cloudflare-13.8.0, azure-13.35.0

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.34.4",
+	Version:   "13.35.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.7.1",
+	Version:         "13.8.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/databricks/config/config.go
+++ b/providers/databricks/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "databricks",
 	ID:        "go.mondoo.com/mql/providers/databricks",
-	Version:   "13.2.1",
+	Version:   "13.3.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.35.1",
+	Version: "13.36.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.9.1",
+	Version:         "13.10.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mongo/config/config.go
+++ b/providers/mongo/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mongo",
 	ID:              "go.mondoo.com/mql/v13/providers/mongo",
-	Version:         "13.0.2",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mongodbatlas/config/config.go
+++ b/providers/mongodbatlas/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "mongodbatlas",
 	ID:        "go.mondoo.com/mql/providers/mongodbatlas",
-	Version:   "13.3.0",
+	Version:   "13.4.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.11.1",
+	Version:         "13.12.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mssql/config/config.go
+++ b/providers/mssql/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mssql",
 	ID:              "go.mondoo.com/mql/v13/providers/mssql",
-	Version:         "13.0.2",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mysqldb/config/config.go
+++ b/providers/mysqldb/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mysqldb",
 	ID:              "go.mondoo.com/mql/v13/providers/mysqldb",
-	Version:         "13.0.2",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.19.0",
+	Version:         "13.20.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### oci (13.20.0)
- 🐛 oci: ask for the identity domain attributes we were already asking for (#9973)
- 🌟 oci: expose who outside the tenancy can reach the data inside it (#9969)
- 🌟 oci: expose the registry an image policy is checked against (#9970)
- 🌟 oci: expose where multi-factor authentication is actually enforced (#9968)
- 🌟 oci: expose who is allowed to mount a file system (#9967)

### mysqldb (13.1.0)
- db providers: auto discovery returns the server, not every database (#9846)

### mssql (13.1.0)
- db providers: auto discovery returns the server, not every database (#9846)

### ms365 (13.12.0)
- 🧹 ms365: fetch Exchange Online over REST, keep PowerShell as fallback (#9594)
- 🧹 ms365: upgrade github.com/Azure/azure-sdk-for-go/sdk/azcore to v1.23.0 (#9920)

### mongodbatlas (13.4.0)
- ⭐ mongodbatlas: upgrade the SDK and expose Remote MCP and backup configuration (#9908)

### mongo (13.1.0)
- db providers: auto discovery returns the server, not every database (#9846)

### k8s (13.10.0)
- 🐛 os: read the PKCS#12 keystores keytool has written since JDK 9 (#9989)
- ✨ k8s: model dynamic resource allocation (DRA) objects (#9933)

### gcp (13.36.0)
- 🐛 os: read the PKCS#12 keystores keytool has written since JDK 9 (#9989)
- 🧹 gcp: upgrade google.golang.org/api to v0.293.0 (#9921)

### databricks (13.3.0)
- 🐛 skills: fix enumdrift false positives, and the databricks drift it then found (#9912)
- ⭐ databricks: upgrade the SDK and expose job trigger configuration (#9907)

### cloudflare (13.8.0)
- ⭐ cloudflare: upgrade to cloudflare-go v7 and expose the AI surface (#9909)

### azure (13.35.0)
- 🐛 os: read the PKCS#12 keystores keytool has written since JDK 9 (#9989)
- ⭐ azure: expose Arc machine identity protection, clone detection, and hardware inventory (#9925)
- 🧹 azure: upgrade armhybridcompute to v3 and correct the Arc agent status values (#9913)
