### PR TITLE
⭐ gcp: effectiveTags across the taggable resource set

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -771,7 +771,59 @@ func extractGCPPermissions(root string) []PermissionDetail {
 		details = append(details, extractGCPgRPCCalls(f, gcpImports, fileName)...)
 	}
 
-	return details
+	return expandGCPPermissions(details)
+}
+
+// expandGCPPermissions rewrites any derived permission that stands for a set of
+// real ones. See gcpPermissionExpansions for why a single call site can require
+// more than one permission.
+func expandGCPPermissions(details []PermissionDetail) []PermissionDetail {
+	out := make([]PermissionDetail, 0, len(details))
+	for _, d := range details {
+		expanded, ok := gcpPermissionExpansions[d.Permission]
+		if !ok {
+			out = append(out, d)
+			continue
+		}
+		for _, perm := range expanded {
+			e := d
+			e.Permission = perm
+			e.overridden = true
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// gcpPermissionExpansions maps a derived permission onto the full set of IAM
+// permissions the call actually requires.
+//
+// cloudresourcemanager's effectiveTags.list is authorized against the *target*
+// resource's own permission rather than a resourcemanager one: the API docs
+// state it "utilizes the existing resource-specific <resource>.listEffectiveTags
+// IAM permission". The auto-derived "resourcemanager.effectiveTags.list" is not
+// a real permission, and because one call site in effective_tags.go serves every
+// taggable resource, it maps to one permission per resource type rather than to
+// a single replacement. This is the same trap already documented for
+// EffectiveTagBindingCollections.Get in gcpPermissionOverrides.
+var gcpPermissionExpansions = map[string][]string{
+	"resourcemanager.effectiveTags.list": {
+		"bigquery.datasets.listEffectiveTags",
+		"bigquery.tables.listEffectiveTags",
+		"cloudsql.instances.listEffectiveTags",
+		"compute.disks.listEffectiveTags",
+		"compute.firewalls.listEffectiveTags",
+		"compute.instances.listEffectiveTags",
+		"compute.networks.listEffectiveTags",
+		"compute.subnetworks.listEffectiveTags",
+		"compute.vpnGateways.listEffectiveTags",
+		"compute.vpnTunnels.listEffectiveTags",
+		"container.clusters.listEffectiveTags",
+		"dns.managedZones.listEffectiveTags",
+		"run.services.listEffectiveTags",
+		"secretmanager.secrets.listEffectiveTags",
+		"storage.buckets.listEffectiveTags",
+	},
 }
 
 // gcpImportInfo holds information about a GCP import.

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -59,6 +59,7 @@ type mqlGcpProjectComputeServiceSslPolicyInternal struct {
 type mqlGcpProjectComputeServiceSubnetworkInternal struct {
 	cacheNetworkUrl string
 	cacheRegionUrl  string
+	cacheSelfLink   string
 }
 
 func initGcpProjectComputeService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -776,6 +777,13 @@ type mqlGcpProjectComputeServiceInstanceInternal struct {
 	cacheServiceAccountEmails []string
 }
 
+func (g *mqlGcpProjectComputeServiceInstance) effectiveTags() ([]any, error) {
+	if g.SelfLink.Error != nil {
+		return nil, g.SelfLink.Error
+	}
+	return effectiveTagsForResource(g.MqlRuntime, computeSelfLinkToResourceName(g.SelfLink.Data))
+}
+
 func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeServiceZone, runtime *plugin.Runtime, instance *compute.Instance) (*mqlGcpProjectComputeServiceInstance, error) {
 	metadata := map[string]string{}
 	if instance.Metadata != nil {
@@ -1165,6 +1173,11 @@ type mqlGcpProjectComputeServiceDiskInternal struct {
 	cacheSourceSnapshotUrl string
 	cacheStoragePoolUrl    string
 	cacheKmsKeyName        string
+	cacheSelfLink          string
+}
+
+func (g *mqlGcpProjectComputeServiceDisk) effectiveTags() ([]any, error) {
+	return effectiveTagsForResource(g.MqlRuntime, computeSelfLinkToResourceName(g.cacheSelfLink))
 }
 
 func (g *mqlGcpProjectComputeServiceDisk) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {
@@ -1469,6 +1482,7 @@ func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 				mqlD.cacheSourceImageUrl = disk.SourceImage
 				mqlD.cacheSourceSnapshotUrl = disk.SourceSnapshot
 				mqlD.cacheStoragePoolUrl = disk.StoragePool
+				mqlD.cacheSelfLink = disk.SelfLink
 				if disk.DiskEncryptionKey != nil {
 					mqlD.cacheKmsKeyName = disk.DiskEncryptionKey.KmsKeyName
 				}
@@ -1484,6 +1498,11 @@ func (g *mqlGcpProjectComputeService) disks() ([]any, error) {
 
 type mqlGcpProjectComputeServiceFirewallInternal struct {
 	cacheNetworkUrl string
+	cacheSelfLink   string
+}
+
+func (g *mqlGcpProjectComputeServiceFirewall) effectiveTags() ([]any, error) {
+	return effectiveTagsForResource(g.MqlRuntime, computeSelfLinkToResourceName(g.cacheSelfLink))
 }
 
 func (g *mqlGcpProjectComputeServiceFirewall) network() (*mqlGcpProjectComputeServiceNetwork, error) {
@@ -1683,6 +1702,7 @@ func (g *mqlGcpProjectComputeService) firewalls() ([]any, error) {
 			}
 			mqlFw := mqlFirewall.(*mqlGcpProjectComputeServiceFirewall)
 			mqlFw.cacheNetworkUrl = firewall.Network
+			mqlFw.cacheSelfLink = firewall.SelfLink
 			res = append(res, mqlFirewall)
 		}
 		return nil
@@ -2067,6 +2087,11 @@ func (g *mqlGcpProjectComputeService) images() ([]any, error) {
 
 type mqlGcpProjectComputeServiceNetworkInternal struct {
 	cachePeerings []*compute.NetworkPeering
+	cacheSelfLink string
+}
+
+func (g *mqlGcpProjectComputeServiceNetwork) effectiveTags() ([]any, error) {
+	return effectiveTagsForResource(g.MqlRuntime, computeSelfLinkToResourceName(g.cacheSelfLink))
 }
 
 func (g *mqlGcpProjectComputeServiceNetwork) id() (string, error) {
@@ -2296,7 +2321,9 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 	if err != nil {
 		return nil, nil, err
 	}
-	return args, mqlNetwork.(*mqlGcpProjectComputeServiceNetwork), nil
+	mqlNet := mqlNetwork.(*mqlGcpProjectComputeServiceNetwork)
+	mqlNet.cacheSelfLink = network.SelfLink
+	return args, mqlNet, nil
 }
 
 func (g *mqlGcpProjectComputeService) networks() ([]any, error) {
@@ -2359,6 +2386,7 @@ func (g *mqlGcpProjectComputeService) networks() ([]any, error) {
 			}
 			mqlNet := mqlNetwork.(*mqlGcpProjectComputeServiceNetwork)
 			mqlNet.cachePeerings = network.Peerings
+			mqlNet.cacheSelfLink = network.SelfLink
 			res = append(res, mqlNetwork)
 		}
 		return nil
@@ -2633,7 +2661,12 @@ func newMqlSubnetwork(projectId string, runtime *plugin.Runtime, subnetwork *com
 	mqlSubnet := res.(*mqlGcpProjectComputeServiceSubnetwork)
 	mqlSubnet.cacheRegionUrl = subnetwork.GetRegion()
 	mqlSubnet.cacheNetworkUrl = subnetwork.GetNetwork()
+	mqlSubnet.cacheSelfLink = subnetwork.GetSelfLink()
 	return res, nil
+}
+
+func (g *mqlGcpProjectComputeServiceSubnetwork) effectiveTags() ([]any, error) {
+	return effectiveTagsForResource(g.MqlRuntime, computeSelfLinkToResourceName(g.cacheSelfLink))
 }
 
 func (g *mqlGcpProjectComputeService) subnetworks() ([]any, error) {
@@ -3934,6 +3967,18 @@ func (g *mqlGcpProjectComputeServiceVpnGateway) id() (string, error) {
 type mqlGcpProjectComputeServiceVpnGatewayInternal struct {
 	cacheNetworkUrl string
 	cacheRegionUrl  string
+	cacheSelfLink   string
+}
+
+func (g *mqlGcpProjectComputeServiceVpnGateway) effectiveTags() ([]any, error) {
+	return effectiveTagsForResource(g.MqlRuntime, computeSelfLinkToResourceName(g.cacheSelfLink))
+}
+
+func (g *mqlGcpProjectComputeServiceVpnTunnel) effectiveTags() ([]any, error) {
+	if g.SelfLink.Error != nil {
+		return nil, g.SelfLink.Error
+	}
+	return effectiveTagsForResource(g.MqlRuntime, computeSelfLinkToResourceName(g.SelfLink.Data))
 }
 
 func (g *mqlGcpProjectComputeServiceVpnGateway) network() (*mqlGcpProjectComputeServiceNetwork, error) {
@@ -4004,9 +4049,10 @@ func (g *mqlGcpProjectComputeService) vpnGateways() ([]any, error) {
 				if err != nil {
 					return err
 				}
-				mqlRef := mqlGw.(*mqlGcpProjectComputeServiceVpnGateway)
-				mqlRef.cacheRegionUrl = gw.Region
-				mqlGw.(*mqlGcpProjectComputeServiceVpnGateway).cacheNetworkUrl = gw.Network
+				mqlGwRes := mqlGw.(*mqlGcpProjectComputeServiceVpnGateway)
+				mqlGwRes.cacheRegionUrl = gw.Region
+				mqlGwRes.cacheNetworkUrl = gw.Network
+				mqlGwRes.cacheSelfLink = gw.SelfLink
 				res = append(res, mqlGw)
 			}
 		}

--- a/providers/gcp/resources/effective_tags.go
+++ b/providers/gcp/resources/effective_tags.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
-	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers/gcp/connection"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/gcp/connection"
 	"google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"

--- a/providers/gcp/resources/effective_tags.go
+++ b/providers/gcp/resources/effective_tags.go
@@ -1,0 +1,234 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/gcp/connection"
+	"google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// computeSelfLinkPrefixes are the Compute Engine API roots a selfLink can carry.
+// The v1 form is what the API returns today; the beta form is accepted so a
+// resource fetched through a beta client still resolves.
+var computeSelfLinkPrefixes = []string{
+	"https://www.googleapis.com/compute/v1/",
+	"https://www.googleapis.com/compute/beta/",
+	"https://compute.googleapis.com/compute/v1/",
+	"https://compute.googleapis.com/compute/beta/",
+}
+
+// computeSelfLinkToResourceName converts a Compute Engine selfLink into the full
+// resource name the Resource Manager tag APIs expect.
+//
+//	https://www.googleapis.com/compute/v1/projects/p/zones/z/instances/i
+//	//compute.googleapis.com/projects/p/zones/z/instances/i
+//
+// It returns "" for an empty or unrecognized selfLink, which callers treat as
+// "cannot resolve" rather than as a resource name.
+func computeSelfLinkToResourceName(selfLink string) string {
+	if selfLink == "" {
+		return ""
+	}
+	for _, prefix := range computeSelfLinkPrefixes {
+		if path, ok := strings.CutPrefix(selfLink, prefix); ok {
+			if path == "" {
+				return ""
+			}
+			return "//compute.googleapis.com/" + path
+		}
+	}
+	return ""
+}
+
+// effectiveTagsForResource returns every Resource Manager tag value that applies
+// to fullResourceName, including values inherited from the enclosing project,
+// folder, or organization.
+//
+// A resource the caller cannot read tags for, or one that has never been bound
+// to a tag, yields an empty list rather than an error. That matches the
+// behaviour of the older gcp.project.storageService.bucket.tags field, so the
+// two report the same thing on the same bucket.
+func effectiveTagsForResource(runtime *plugin.Runtime, fullResourceName string) ([]any, error) {
+	if fullResourceName == "" {
+		return []any{}, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, errors.New("effective tags require a GCP connection")
+	}
+
+	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	svc, err := cloudresourcemanager.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []*cloudresourcemanager.EffectiveTag
+	err = svc.EffectiveTags.List().Parent(fullResourceName).Context(ctx).
+		Pages(ctx, func(page *cloudresourcemanager.ListEffectiveTagsResponse) error {
+			tags = append(tags, page.EffectiveTags...)
+			return nil
+		})
+	if err != nil {
+		var gerr *googleapi.Error
+		if errors.As(err, &gerr) {
+			switch gerr.Code {
+			case 403:
+				log.Warn().Str("resource", fullResourceName).
+					Msg("not permitted to list effective tags, reporting none")
+				return []any{}, nil
+			case 404:
+				log.Debug().Str("resource", fullResourceName).
+					Msg("no effective tag bindings for resource")
+				return []any{}, nil
+			}
+		}
+		return nil, err
+	}
+
+	return effectiveTagsToMql(runtime, fullResourceName, tags)
+}
+
+// stringFields reads the string fields an effective-tag resource name is built
+// from, surfacing the first error any of them carries. It reports ok=false when
+// a field is empty, since a resource name assembled from a blank segment names
+// something other than the resource in hand.
+func stringFields(fields ...*plugin.TValue[string]) ([]string, bool, error) {
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f.Error != nil {
+			return nil, false, f.Error
+		}
+		if f.Data == "" {
+			return nil, false, nil
+		}
+		out = append(out, f.Data)
+	}
+	return out, true, nil
+}
+
+func (g *mqlGcpProjectSqlServiceInstance) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.ProjectId, &g.Name)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//sqladmin.googleapis.com/projects/%s/instances/%s", p[0], p[1]))
+}
+
+func (g *mqlGcpProjectGkeServiceCluster) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.ProjectId, &g.Location, &g.Name)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", p[0], p[1], p[2]))
+}
+
+func (g *mqlGcpProjectCloudRunServiceService) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.ProjectId, &g.Region, &g.Name)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//run.googleapis.com/projects/%s/locations/%s/services/%s", p[0], p[1], p[2]))
+}
+
+func (g *mqlGcpProjectBigqueryServiceDataset) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.ProjectId, &g.Id)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//bigquery.googleapis.com/projects/%s/datasets/%s", p[0], p[1]))
+}
+
+func (g *mqlGcpProjectBigqueryServiceTable) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.ProjectId, &g.DatasetId, &g.Id)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//bigquery.googleapis.com/projects/%s/datasets/%s/tables/%s", p[0], p[1], p[2]))
+}
+
+func (g *mqlGcpProjectSecretmanagerServiceSecret) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.ProjectId, &g.Name)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//secretmanager.googleapis.com/projects/%s/secrets/%s", p[0], p[1]))
+}
+
+func (g *mqlGcpProjectDnsServiceManagedzone) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.ProjectId, &g.Name)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//dns.googleapis.com/projects/%s/managedZones/%s", p[0], p[1]))
+}
+
+// effectiveTags on a bucket uses the projects/_ wildcard, which is the
+// documented resource-name form for Cloud Storage.
+func (g *mqlGcpProjectStorageServiceBucket) effectiveTags() ([]any, error) {
+	p, ok, err := stringFields(&g.Name)
+	if err != nil || !ok {
+		return []any{}, err
+	}
+	return effectiveTagsForResource(g.MqlRuntime,
+		fmt.Sprintf("//storage.googleapis.com/projects/_/buckets/%s", p[0]))
+}
+
+// effectiveTagCacheKey builds the cache key for one effective tag.
+//
+// The key is qualified by fullResourceName because the same tag value
+// legitimately applies to many resources at once, and an inherited value
+// applies to every resource beneath its parent. Keying on the tag value alone
+// would collapse every resource's copy onto whichever one was created first, so
+// a fleet-wide query would report one resource's tags for all of them.
+func effectiveTagCacheKey(fullResourceName, tagValue string) string {
+	return fullResourceName + "/" + tagValue
+}
+
+// effectiveTagsToMql maps the API records onto gcp.effectiveTag resources.
+func effectiveTagsToMql(runtime *plugin.Runtime, fullResourceName string, tags []*cloudresourcemanager.EffectiveTag) ([]any, error) {
+	res := make([]any, 0, len(tags))
+	for _, tag := range tags {
+		if tag == nil {
+			continue
+		}
+		mqlTag, err := CreateResource(runtime, "gcp.effectiveTag", map[string]*llx.RawData{
+			"__id":               llx.StringData(effectiveTagCacheKey(fullResourceName, tag.TagValue)),
+			"tagKey":             llx.StringData(tag.TagKey),
+			"tagValue":           llx.StringData(tag.TagValue),
+			"namespacedTagKey":   llx.StringData(tag.NamespacedTagKey),
+			"namespacedTagValue": llx.StringData(tag.NamespacedTagValue),
+			"inherited":          llx.BoolData(tag.Inherited),
+			"tagKeyParent":       llx.StringData(tag.TagKeyParentName),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlTag)
+	}
+	return res, nil
+}

--- a/providers/gcp/resources/effective_tags_test.go
+++ b/providers/gcp/resources/effective_tags_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
 func TestComputeSelfLinkToResourceName(t *testing.T) {

--- a/providers/gcp/resources/effective_tags_test.go
+++ b/providers/gcp/resources/effective_tags_test.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestComputeSelfLinkToResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		selfLink string
+		want     string
+	}{
+		{
+			name:     "zonal instance",
+			selfLink: "https://www.googleapis.com/compute/v1/projects/p1/zones/us-central1-a/instances/vm1",
+			want:     "//compute.googleapis.com/projects/p1/zones/us-central1-a/instances/vm1",
+		},
+		{
+			name:     "regional disk",
+			selfLink: "https://www.googleapis.com/compute/v1/projects/p1/regions/us-central1/disks/d1",
+			want:     "//compute.googleapis.com/projects/p1/regions/us-central1/disks/d1",
+		},
+		{
+			name:     "global network",
+			selfLink: "https://www.googleapis.com/compute/v1/projects/p1/global/networks/default",
+			want:     "//compute.googleapis.com/projects/p1/global/networks/default",
+		},
+		{
+			name:     "global firewall",
+			selfLink: "https://www.googleapis.com/compute/v1/projects/p1/global/firewalls/allow-ssh",
+			want:     "//compute.googleapis.com/projects/p1/global/firewalls/allow-ssh",
+		},
+		{
+			name:     "compute.googleapis.com host form",
+			selfLink: "https://compute.googleapis.com/compute/v1/projects/p1/zones/z1/instances/vm1",
+			want:     "//compute.googleapis.com/projects/p1/zones/z1/instances/vm1",
+		},
+		{
+			name:     "beta api version",
+			selfLink: "https://www.googleapis.com/compute/beta/projects/p1/zones/z1/instances/vm1",
+			want:     "//compute.googleapis.com/projects/p1/zones/z1/instances/vm1",
+		},
+		{
+			// A resource created before the field was cached reports no selfLink.
+			// It must resolve to "" so the caller reports no tags rather than
+			// querying a malformed resource name.
+			name:     "empty selfLink",
+			selfLink: "",
+			want:     "",
+		},
+		{
+			name:     "prefix present but no path",
+			selfLink: "https://www.googleapis.com/compute/v1/",
+			want:     "",
+		},
+		{
+			name:     "unrecognized host",
+			selfLink: "https://example.com/compute/v1/projects/p1/zones/z1/instances/vm1",
+			want:     "",
+		},
+		{
+			// A non-compute self link must not be rewritten as a compute one.
+			name:     "different service url",
+			selfLink: "https://storage.googleapis.com/storage/v1/b/bucket1",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, computeSelfLinkToResourceName(tt.selfLink))
+		})
+	}
+}
+
+// The cache key must stay distinct per resource. An inherited tag value applies
+// to every resource under its parent, so keying on the tag value alone would
+// make the first resource's tag list stand in for all of them.
+func TestEffectiveTagCacheKeyIsPerResource(t *testing.T) {
+	vm1 := "//compute.googleapis.com/projects/p1/zones/z1/instances/vm1"
+	vm2 := "//compute.googleapis.com/projects/p1/zones/z1/instances/vm2"
+	sharedValue := "tagValues/456"
+
+	k1 := effectiveTagCacheKey(vm1, sharedValue)
+	k2 := effectiveTagCacheKey(vm2, sharedValue)
+
+	assert.NotEqual(t, k1, k2, "same tag value on two resources must not share a cache key")
+	assert.Equal(t, vm1+"/"+sharedValue, k1)
+}
+
+func TestEffectiveTagCacheKeyDistinguishesValues(t *testing.T) {
+	vm := "//compute.googleapis.com/projects/p1/zones/z1/instances/vm1"
+
+	assert.NotEqual(t,
+		effectiveTagCacheKey(vm, "tagValues/1"),
+		effectiveTagCacheKey(vm, "tagValues/2"),
+		"two tag values on one resource must not share a cache key")
+}
+
+func TestStringFields(t *testing.T) {
+	set := func(s string) plugin.TValue[string] {
+		return plugin.TValue[string]{Data: s, State: plugin.StateIsSet}
+	}
+
+	t.Run("all present", func(t *testing.T) {
+		p := set("project1")
+		n := set("instance1")
+		got, ok, err := stringFields(&p, &n)
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, []string{"project1", "instance1"}, got)
+	})
+
+	t.Run("empty field reports not ok", func(t *testing.T) {
+		p := set("project1")
+		n := set("")
+		got, ok, err := stringFields(&p, &n)
+		require.NoError(t, err)
+		assert.False(t, ok, "an empty segment must not build a resource name")
+		assert.Nil(t, got)
+	})
+
+	t.Run("field error propagates", func(t *testing.T) {
+		p := set("project1")
+		n := plugin.TValue[string]{Error: assert.AnError, State: plugin.StateIsSet}
+		_, ok, err := stringFields(&p, &n)
+		assert.Error(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("error wins over later empty field", func(t *testing.T) {
+		p := plugin.TValue[string]{Error: assert.AnError, State: plugin.StateIsSet}
+		n := set("")
+		_, _, err := stringFields(&p, &n)
+		assert.Error(t, err, "a read failure must not be reported as a missing value")
+	})
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1172,6 +1172,41 @@ private gcp.project.tagBinding @defaults("tagValueNamespacedName resource") {
   resource string
 }
 
+// Google Cloud Resource Manager effective tag
+//
+// Resource Manager tag value that applies to a resource, whether it is bound
+// to the resource directly or reaches it from the project, folder, or
+// organization above it. The `inherited` field separates the two, so an audit
+// can tell a resource that was deliberately tagged from one that only sits
+// beneath a tagged parent. Tags drive conditional IAM grants and organization
+// policy enforcement, so the effective set is what decides whether those rules
+// reach a given resource. The `namespacedTagValue` field carries the readable
+// key and value path, for example `123456789/environment/production`.
+private gcp.effectiveTag @defaults("namespacedTagValue inherited") {
+  // Permanent ID of the tag key (tagKeys/123)
+  tagKey string
+  // Permanent ID of the tag value (tagValues/456)
+  tagValue string
+  // Namespaced name of the tag key
+  //
+  // Formatted as `{organizationId}/{shortName}` or `{projectId}/{shortName}`,
+  // for example `123456789/environment`.
+  namespacedTagKey string
+  // Namespaced name of the tag value
+  //
+  // Formatted as `{organizationId}/{keyShortName}/{valueShortName}`, for
+  // example `123456789/environment/production`.
+  namespacedTagValue string
+  // Whether the tag value reaches this resource through the resource hierarchy
+  //
+  // True when the value is set on an ancestor project, folder, or organization
+  // and applies by inheritance. False when it is bound to this resource
+  // directly.
+  inherited bool
+  // Parent of the tag key, as organizations/{organizationId} or projects/{projectNumber}
+  tagKeyParent string
+}
+
 // Google Cloud service API
 //
 // Single Google Cloud service API, such as compute.googleapis.com or
@@ -1906,6 +1941,12 @@ gcp.project.computeService.instance @defaults("name id") {
   // discarded when the instance stops, so the local SSD contents cannot be
   // recovered afterwards.
   localSsdEncryptionMode string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Compute instance internet-exposure breakdown
@@ -2325,6 +2366,12 @@ private gcp.project.computeService.disk @defaults("name") {
   // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
   // when the resource carries no management signal.
   managedBy() string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud (GCP) Compute attached disk
@@ -2621,6 +2668,12 @@ private gcp.project.computeService.firewall @defaults("name") {
   logConfigMetadata string
   // Network resource for this firewall rule
   network() gcp.project.computeService.network
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud VPC network
@@ -2687,6 +2740,12 @@ gcp.project.computeService.network @defaults("name") {
   firewallPolicyRef() gcp.project.computeService.firewallPolicy
   // URL of the network profile applied to this network
   networkProfile string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud VPC subnetwork
@@ -2774,6 +2833,12 @@ gcp.project.computeService.subnetwork @defaults("name") {
   // Keys: `internalIpv6Utilization` and `externalIpv6Utilization`, each with
   // the assigned and free address counts for that family.
   utilizationDetails dict
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud (GCP) Compute VPC network partitioning log configuration
@@ -3247,6 +3312,12 @@ private gcp.project.storageService.bucket @defaults("id") {
   // `softDeletePolicy` which configures object-level soft-delete retention.
   // Null on live buckets.
   softDeleteTime time
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Legacy access control entry on a Cloud Storage bucket
@@ -3582,6 +3653,12 @@ private gcp.project.sqlService.instance @defaults("name") {
   // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
   // when the resource carries no management signal.
   managedBy() string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // External primary server a Cloud SQL instance replicates from
@@ -4157,6 +4234,12 @@ private gcp.project.bigqueryService.dataset @defaults("id name") {
   // in the form `projects/{project_id}/locations/{location_id}/connections/{connection_id}`.
   // Null for datasets stored natively in BigQuery.
   externalDatasetReference dict
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud (GCP) BigQuery dataset access entry
@@ -4304,6 +4387,12 @@ private gcp.project.bigqueryService.table @defaults("id") {
   foreignKeys []gcp.project.bigqueryService.table.foreignKey
   // Storage and connection settings for a BigLake managed table
   bigLakeConfiguration gcp.project.bigqueryService.table.bigLakeConfig
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // BigLake configuration of a BigQuery table
@@ -4700,6 +4789,12 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
   // when the resource carries no management signal.
   managedBy() string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud DNS zone signing key
@@ -5192,6 +5287,12 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   nodePoolAutoConfig dict
   // Node auto-provisioning settings, and the defaults applied to the nodes it creates
   nodeAutoprovisioning gcp.project.gkeService.cluster.nodeAutoprovisioningConfig
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Node auto-provisioning settings of a GKE cluster
@@ -8870,6 +8971,12 @@ private gcp.project.cloudRunService.service @defaults("name") {
   urls []string
   // Source build the service was deployed from, when Cloud Run built the image itself
   buildConfig gcp.project.cloudRunService.service.buildSettings
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Source build behind a Cloud Run service
@@ -9732,6 +9839,12 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
   // when the resource carries no management signal.
   managedBy() string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud (GCP) Secret Manager secret version
@@ -11173,8 +11286,19 @@ private gcp.project.computeService.vpnGateway @defaults("name") {
   region() gcp.project.computeService.region
   // VPN interfaces associated with this VPN gateway
   vpnInterfaces []dict
-  // Resource manager tags bound to this VPN gateway
-  resourceManagerTags map[string]string
+  // Resource Manager tags supplied when this VPN gateway was created
+  //
+  // Deprecated in favor of effectiveTags, which also covers tag values
+  // inherited from the project, folder, or organization. This field reports
+  // only the tags passed at creation time, so a check written against it
+  // passes on a gateway that carries the tag by inheritance.
+  resourceManagerTags @maturity("deprecated") map[string]string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud (GCP) Compute VPN tunnel
@@ -11226,10 +11350,21 @@ private gcp.project.computeService.vpnTunnel @defaults("name status") {
   vpnGateway() gcp.project.computeService.vpnGateway
   // Interface ID of the VPN gateway
   vpnGatewayInterface int
-  // Resource manager tags bound to this VPN tunnel
-  resourceManagerTags map[string]string
+  // Resource Manager tags supplied when this VPN tunnel was created
+  //
+  // Deprecated in favor of effectiveTags, which also covers tag values
+  // inherited from the project, folder, or organization. This field reports
+  // only the tags passed at creation time, so a check written against it
+  // passes on a tunnel that carries the tag by inheritance.
+  resourceManagerTags @maturity("deprecated") map[string]string
   // Server-defined self-link URL for the VPN tunnel
   selfLink string
+  // Resource Manager tags that apply to the resource, including inherited ones
+  //
+  // Covers both tag values bound to the resource directly and those set on an
+  // ancestor project, folder, or organization. Each entry reports which of the
+  // two it is through its `inherited` field.
+  effectiveTags() []gcp.effectiveTag
 }
 
 // Google Cloud (GCP) Compute storage pool

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -44,6 +44,7 @@ const (
 	ResourceGcpProject                                                                 string = "gcp.project"
 	ResourceGcpProjectLien                                                             string = "gcp.project.lien"
 	ResourceGcpProjectTagBinding                                                       string = "gcp.project.tagBinding"
+	ResourceGcpEffectiveTag                                                            string = "gcp.effectiveTag"
 	ResourceGcpService                                                                 string = "gcp.service"
 	ResourceGcpRecommendation                                                          string = "gcp.recommendation"
 	ResourceGcpInsight                                                                 string = "gcp.insight"
@@ -659,6 +660,10 @@ func init() {
 		"gcp.project.tagBinding": {
 			// to override args, implement: initGcpProjectTagBinding(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createGcpProjectTagBinding,
+		},
+		"gcp.effectiveTag": {
+			// to override args, implement: initGcpEffectiveTag(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpEffectiveTag,
 		},
 		"gcp.service": {
 			Init:   initGcpService,
@@ -3848,6 +3853,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.tagBinding.resource": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectTagBinding).GetResource()).ToDataRes(types.String)
 	},
+	"gcp.effectiveTag.tagKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpEffectiveTag).GetTagKey()).ToDataRes(types.String)
+	},
+	"gcp.effectiveTag.tagValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpEffectiveTag).GetTagValue()).ToDataRes(types.String)
+	},
+	"gcp.effectiveTag.namespacedTagKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpEffectiveTag).GetNamespacedTagKey()).ToDataRes(types.String)
+	},
+	"gcp.effectiveTag.namespacedTagValue": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpEffectiveTag).GetNamespacedTagValue()).ToDataRes(types.String)
+	},
+	"gcp.effectiveTag.inherited": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpEffectiveTag).GetInherited()).ToDataRes(types.Bool)
+	},
+	"gcp.effectiveTag.tagKeyParent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpEffectiveTag).GetTagKeyParent()).ToDataRes(types.String)
+	},
 	"gcp.service.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpService).GetProjectId()).ToDataRes(types.String)
 	},
@@ -4550,6 +4573,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.localSsdEncryptionMode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstance).GetLocalSsdEncryptionMode()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.instance.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstance).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
+	},
 	"gcp.project.computeService.instance.exposure.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetInternetReachable()).ToDataRes(types.Bool)
 	},
@@ -4883,6 +4909,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.disk.managedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceDisk).GetManagedBy()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.disk.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceDisk).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
+	},
 	"gcp.project.computeService.attachedDisk.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceAttachedDisk).GetId()).ToDataRes(types.String)
 	},
@@ -5186,6 +5215,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.firewall.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceFirewall).GetNetwork()).ToDataRes(types.Resource("gcp.project.computeService.network"))
 	},
+	"gcp.project.computeService.firewall.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceFirewall).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
+	},
 	"gcp.project.computeService.network.legacy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetLegacy()).ToDataRes(types.Bool)
 	},
@@ -5251,6 +5283,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceNetwork).GetNetworkProfile()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.network.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceNetwork).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.computeService.subnetwork.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetId()).ToDataRes(types.String)
@@ -5341,6 +5376,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.subnetwork.utilizationDetails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetUtilizationDetails()).ToDataRes(types.Dict)
+	},
+	"gcp.project.computeService.subnetwork.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceSubnetwork).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.computeService.subnetwork.logConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceSubnetworkLogConfig).GetId()).ToDataRes(types.String)
@@ -5795,6 +5833,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.storageService.bucket.softDeleteTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucket).GetSoftDeleteTime()).ToDataRes(types.Time)
 	},
+	"gcp.project.storageService.bucket.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectStorageServiceBucket).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
+	},
 	"gcp.project.storageService.bucket.accessControl.entity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectStorageServiceBucketAccessControl).GetEntity()).ToDataRes(types.String)
 	},
@@ -6073,6 +6114,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.sqlService.instance.managedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstance).GetManagedBy()).ToDataRes(types.String)
+	},
+	"gcp.project.sqlService.instance.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstance).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.sqlService.instance.onPremisesConfiguration.hostPort": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration).GetHostPort()).ToDataRes(types.String)
@@ -6593,6 +6637,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.bigqueryService.dataset.externalDatasetReference": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetExternalDatasetReference()).ToDataRes(types.Dict)
 	},
+	"gcp.project.bigqueryService.dataset.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceDataset).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
+	},
 	"gcp.project.bigqueryService.dataset.accessEntry.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceDatasetAccessEntry).GetId()).ToDataRes(types.String)
 	},
@@ -6730,6 +6777,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTable).GetBigLakeConfiguration()).ToDataRes(types.Resource("gcp.project.bigqueryService.table.bigLakeConfig"))
+	},
+	"gcp.project.bigqueryService.table.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceTable).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfig.storageUri": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig).GetStorageUri()).ToDataRes(types.String)
@@ -7045,6 +7095,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.dnsService.managedzone.managedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetManagedBy()).ToDataRes(types.String)
+	},
+	"gcp.project.dnsService.managedzone.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDnsServiceManagedzone).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.dnsService.managedzone.dnsKey.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDnsServiceManagedzoneDnsKey).GetId()).ToDataRes(types.String)
@@ -7444,6 +7497,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.gkeService.cluster.nodeAutoprovisioning": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceCluster).GetNodeAutoprovisioning()).ToDataRes(types.Resource("gcp.project.gkeService.cluster.nodeAutoprovisioningConfig"))
+	},
+	"gcp.project.gkeService.cluster.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectGkeServiceCluster).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.gkeService.cluster.nodeAutoprovisioningConfig.enabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectGkeServiceClusterNodeAutoprovisioningConfig).GetEnabled()).ToDataRes(types.Bool)
@@ -10454,6 +10510,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.cloudRunService.service.buildConfig": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceService).GetBuildConfig()).ToDataRes(types.Resource("gcp.project.cloudRunService.service.buildSettings"))
 	},
+	"gcp.project.cloudRunService.service.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCloudRunServiceService).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
+	},
 	"gcp.project.cloudRunService.service.buildSettings.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCloudRunServiceServiceBuildSettings).GetName()).ToDataRes(types.String)
 	},
@@ -11185,6 +11244,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.secretmanagerService.secret.managedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetManagedBy()).ToDataRes(types.String)
+	},
+	"gcp.project.secretmanagerService.secret.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSecretmanagerServiceSecret).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.secretmanagerService.secret.version.resourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSecretmanagerServiceSecretVersion).GetResourcePath()).ToDataRes(types.String)
@@ -12329,6 +12391,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.vpnGateway.resourceManagerTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetResourceManagerTags()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"gcp.project.computeService.vpnGateway.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceVpnGateway).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
+	},
 	"gcp.project.computeService.vpnTunnel.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetId()).ToDataRes(types.String)
 	},
@@ -12394,6 +12459,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.vpnTunnel.selfLink": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetSelfLink()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.vpnTunnel.effectiveTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceVpnTunnel).GetEffectiveTags()).ToDataRes(types.Array(types.Resource("gcp.effectiveTag")))
 	},
 	"gcp.project.computeService.storagePool.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceStoragePool).GetId()).ToDataRes(types.String)
@@ -21189,6 +21257,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectTagBinding).Resource, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.effectiveTag.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpEffectiveTag).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.effectiveTag.tagKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpEffectiveTag).TagKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.effectiveTag.tagValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpEffectiveTag).TagValue, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.effectiveTag.namespacedTagKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpEffectiveTag).NamespacedTagKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.effectiveTag.namespacedTagValue": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpEffectiveTag).NamespacedTagValue, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.effectiveTag.inherited": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpEffectiveTag).Inherited, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.effectiveTag.tagKeyParent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpEffectiveTag).TagKeyParent, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.service.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpService).__id, ok = v.Value.(string)
 		return
@@ -22169,6 +22265,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceInstance).LocalSsdEncryptionMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.instance.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstance).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.instance.exposure.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceExposure).__id, ok = v.Value.(string)
 		return
@@ -22661,6 +22761,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceDisk).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.disk.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceDisk).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.attachedDisk.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceAttachedDisk).__id, ok = v.Value.(string)
 		return
@@ -23081,6 +23185,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceFirewall).Network, ok = plugin.RawToTValue[*mqlGcpProjectComputeServiceNetwork](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.firewall.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceFirewall).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.network.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetwork).__id, ok = v.Value.(string)
 		return
@@ -23171,6 +23279,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.network.networkProfile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceNetwork).NetworkProfile, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.network.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceNetwork).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.subnetwork.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23295,6 +23407,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.subnetwork.utilizationDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceSubnetwork).UtilizationDetails, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.subnetwork.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceSubnetwork).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.subnetwork.logConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -23933,6 +24049,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectStorageServiceBucket).SoftDeleteTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"gcp.project.storageService.bucket.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectStorageServiceBucket).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.storageService.bucket.accessControl.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectStorageServiceBucketAccessControl).__id, ok = v.Value.(string)
 		return
@@ -24335,6 +24455,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.sqlService.instance.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstance).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.sqlService.instance.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstance).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.sqlService.instance.onPremisesConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25093,6 +25217,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectBigqueryServiceDataset).ExternalDatasetReference, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.bigqueryService.dataset.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceDataset).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.bigqueryService.dataset.accessEntry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceDatasetAccessEntry).__id, ok = v.Value.(string)
 		return
@@ -25283,6 +25411,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceTable).BigLakeConfiguration, ok = plugin.RawToTValue[*mqlGcpProjectBigqueryServiceTableBigLakeConfig](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigqueryService.table.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceTable).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25743,6 +25875,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.dnsService.managedzone.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDnsServiceManagedzone).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.dnsService.managedzone.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDnsServiceManagedzone).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.dnsService.managedzone.dnsKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26299,6 +26435,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.gkeService.cluster.nodeAutoprovisioning": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectGkeServiceCluster).NodeAutoprovisioning, ok = plugin.RawToTValue[*mqlGcpProjectGkeServiceClusterNodeAutoprovisioningConfig](v.Value, v.Error)
+		return
+	},
+	"gcp.project.gkeService.cluster.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectGkeServiceCluster).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.gkeService.cluster.nodeAutoprovisioningConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30781,6 +30921,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCloudRunServiceService).BuildConfig, ok = plugin.RawToTValue[*mqlGcpProjectCloudRunServiceServiceBuildSettings](v.Value, v.Error)
 		return
 	},
+	"gcp.project.cloudRunService.service.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCloudRunServiceService).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.cloudRunService.service.buildSettings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCloudRunServiceServiceBuildSettings).__id, ok = v.Value.(string)
 		return
@@ -31855,6 +31999,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.secretmanagerService.secret.managedBy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSecretmanagerServiceSecret).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.secretmanagerService.secret.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSecretmanagerServiceSecret).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.secretmanagerService.secret.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33525,6 +33673,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceVpnGateway).ResourceManagerTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.vpnGateway.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceVpnGateway).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.vpnTunnel.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).__id, ok = v.Value.(string)
 		return
@@ -33615,6 +33767,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.vpnTunnel.selfLink": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceVpnTunnel).SelfLink, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.vpnTunnel.effectiveTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceVpnTunnel).EffectiveTags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.storagePool.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -48908,6 +49064,75 @@ func (c *mqlGcpProjectTagBinding) GetResource() *plugin.TValue[string] {
 	return &c.Resource
 }
 
+// mqlGcpEffectiveTag for the gcp.effectiveTag resource
+type mqlGcpEffectiveTag struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpEffectiveTagInternal it will be used here
+	TagKey             plugin.TValue[string]
+	TagValue           plugin.TValue[string]
+	NamespacedTagKey   plugin.TValue[string]
+	NamespacedTagValue plugin.TValue[string]
+	Inherited          plugin.TValue[bool]
+	TagKeyParent       plugin.TValue[string]
+}
+
+// createGcpEffectiveTag creates a new instance of this resource
+func createGcpEffectiveTag(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpEffectiveTag{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.effectiveTag", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpEffectiveTag) MqlName() string {
+	return "gcp.effectiveTag"
+}
+
+func (c *mqlGcpEffectiveTag) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpEffectiveTag) GetTagKey() *plugin.TValue[string] {
+	return &c.TagKey
+}
+
+func (c *mqlGcpEffectiveTag) GetTagValue() *plugin.TValue[string] {
+	return &c.TagValue
+}
+
+func (c *mqlGcpEffectiveTag) GetNamespacedTagKey() *plugin.TValue[string] {
+	return &c.NamespacedTagKey
+}
+
+func (c *mqlGcpEffectiveTag) GetNamespacedTagValue() *plugin.TValue[string] {
+	return &c.NamespacedTagValue
+}
+
+func (c *mqlGcpEffectiveTag) GetInherited() *plugin.TValue[bool] {
+	return &c.Inherited
+}
+
+func (c *mqlGcpEffectiveTag) GetTagKeyParent() *plugin.TValue[string] {
+	return &c.TagKeyParent
+}
+
 // mqlGcpService for the gcp.service resource
 type mqlGcpService struct {
 	MqlRuntime *plugin.Runtime
@@ -50951,6 +51176,7 @@ type mqlGcpProjectComputeServiceInstance struct {
 	Subnetworks                     plugin.TValue[[]any]
 	ServiceAccountRefs              plugin.TValue[[]any]
 	LocalSsdEncryptionMode          plugin.TValue[string]
+	EffectiveTags                   plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceInstance creates a new instance of this resource
@@ -51346,6 +51572,22 @@ func (c *mqlGcpProjectComputeServiceInstance) GetServiceAccountRefs() *plugin.TV
 
 func (c *mqlGcpProjectComputeServiceInstance) GetLocalSsdEncryptionMode() *plugin.TValue[string] {
 	return &c.LocalSsdEncryptionMode
+}
+
+func (c *mqlGcpProjectComputeServiceInstance) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.instance", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
 }
 
 // mqlGcpProjectComputeServiceInstanceExposure for the gcp.project.computeService.instance.exposure resource
@@ -52245,6 +52487,7 @@ type mqlGcpProjectComputeServiceDisk struct {
 	SatisfiesPzs                plugin.TValue[bool]
 	SourceDisk                  plugin.TValue[*mqlGcpProjectComputeServiceDisk]
 	ManagedBy                   plugin.TValue[string]
+	EffectiveTags               plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceDisk creates a new instance of this resource
@@ -52515,6 +52758,22 @@ func (c *mqlGcpProjectComputeServiceDisk) GetSourceDisk() *plugin.TValue[*mqlGcp
 func (c *mqlGcpProjectComputeServiceDisk) GetManagedBy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
 		return c.managedBy()
+	})
+}
+
+func (c *mqlGcpProjectComputeServiceDisk) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.disk", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
 	})
 }
 
@@ -53168,6 +53427,7 @@ type mqlGcpProjectComputeServiceFirewall struct {
 	LogConfig                plugin.TValue[any]
 	LogConfigMetadata        plugin.TValue[string]
 	Network                  plugin.TValue[*mqlGcpProjectComputeServiceNetwork]
+	EffectiveTags            plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceFirewall creates a new instance of this resource
@@ -53357,6 +53617,22 @@ func (c *mqlGcpProjectComputeServiceFirewall) GetNetwork() *plugin.TValue[*mqlGc
 	})
 }
 
+func (c *mqlGcpProjectComputeServiceFirewall) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.firewall", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
+}
+
 // mqlGcpProjectComputeServiceNetwork for the gcp.project.computeService.network resource
 type mqlGcpProjectComputeServiceNetwork struct {
 	MqlRuntime *plugin.Runtime
@@ -53384,6 +53660,7 @@ type mqlGcpProjectComputeServiceNetwork struct {
 	FirewallPolicy                        plugin.TValue[string]
 	FirewallPolicyRef                     plugin.TValue[*mqlGcpProjectComputeServiceFirewallPolicy]
 	NetworkProfile                        plugin.TValue[string]
+	EffectiveTags                         plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceNetwork creates a new instance of this resource
@@ -53573,6 +53850,22 @@ func (c *mqlGcpProjectComputeServiceNetwork) GetNetworkProfile() *plugin.TValue[
 	return &c.NetworkProfile
 }
 
+func (c *mqlGcpProjectComputeServiceNetwork) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.network", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
+}
+
 // mqlGcpProjectComputeServiceSubnetwork for the gcp.project.computeService.subnetwork resource
 type mqlGcpProjectComputeServiceSubnetwork struct {
 	MqlRuntime *plugin.Runtime
@@ -53608,6 +53901,7 @@ type mqlGcpProjectComputeServiceSubnetwork struct {
 	SystemReservedInternalIpv6Ranges plugin.TValue[[]any]
 	SystemReservedExternalIpv6Ranges plugin.TValue[[]any]
 	UtilizationDetails               plugin.TValue[any]
+	EffectiveTags                    plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceSubnetwork creates a new instance of this resource
@@ -53789,6 +54083,22 @@ func (c *mqlGcpProjectComputeServiceSubnetwork) GetSystemReservedExternalIpv6Ran
 
 func (c *mqlGcpProjectComputeServiceSubnetwork) GetUtilizationDetails() *plugin.TValue[any] {
 	return &c.UtilizationDetails
+}
+
+func (c *mqlGcpProjectComputeServiceSubnetwork) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.subnetwork", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
 }
 
 // mqlGcpProjectComputeServiceSubnetworkLogConfig for the gcp.project.computeService.subnetwork.logConfig resource
@@ -54785,6 +55095,7 @@ type mqlGcpProjectStorageServiceBucket struct {
 	Billing                         plugin.TValue[any]
 	Owner                           plugin.TValue[any]
 	SoftDeleteTime                  plugin.TValue[*time.Time]
+	EffectiveTags                   plugin.TValue[[]any]
 }
 
 // createGcpProjectStorageServiceBucket creates a new instance of this resource
@@ -55122,6 +55433,22 @@ func (c *mqlGcpProjectStorageServiceBucket) GetOwner() *plugin.TValue[any] {
 
 func (c *mqlGcpProjectStorageServiceBucket) GetSoftDeleteTime() *plugin.TValue[*time.Time] {
 	return &c.SoftDeleteTime
+}
+
+func (c *mqlGcpProjectStorageServiceBucket) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.storageService.bucket", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
 }
 
 // mqlGcpProjectStorageServiceBucketAccessControl for the gcp.project.storageService.bucket.accessControl resource
@@ -55652,6 +55979,7 @@ type mqlGcpProjectSqlServiceInstance struct {
 	Nodes                                      plugin.TValue[[]any]
 	OnPremisesConfig                           plugin.TValue[*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration]
 	ManagedBy                                  plugin.TValue[string]
+	EffectiveTags                              plugin.TValue[[]any]
 }
 
 // createGcpProjectSqlServiceInstance creates a new instance of this resource
@@ -56092,6 +56420,22 @@ func (c *mqlGcpProjectSqlServiceInstance) GetOnPremisesConfig() *plugin.TValue[*
 func (c *mqlGcpProjectSqlServiceInstance) GetManagedBy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
 		return c.managedBy()
+	})
+}
+
+func (c *mqlGcpProjectSqlServiceInstance) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
 	})
 }
 
@@ -57597,6 +57941,7 @@ type mqlGcpProjectBigqueryServiceDataset struct {
 	ManagedBy                    plugin.TValue[string]
 	IsCaseInsensitive            plugin.TValue[bool]
 	ExternalDatasetReference     plugin.TValue[any]
+	EffectiveTags                plugin.TValue[[]any]
 }
 
 // createGcpProjectBigqueryServiceDataset creates a new instance of this resource
@@ -57780,6 +58125,22 @@ func (c *mqlGcpProjectBigqueryServiceDataset) GetExternalDatasetReference() *plu
 	return &c.ExternalDatasetReference
 }
 
+func (c *mqlGcpProjectBigqueryServiceDataset) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.bigqueryService.dataset", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
+}
+
 // mqlGcpProjectBigqueryServiceDatasetAccessEntry for the gcp.project.bigqueryService.dataset.accessEntry resource
 type mqlGcpProjectBigqueryServiceDatasetAccessEntry struct {
 	MqlRuntime *plugin.Runtime
@@ -57907,6 +58268,7 @@ type mqlGcpProjectBigqueryServiceTable struct {
 	PrimaryKeyColumns              plugin.TValue[[]any]
 	ForeignKeys                    plugin.TValue[[]any]
 	BigLakeConfiguration           plugin.TValue[*mqlGcpProjectBigqueryServiceTableBigLakeConfig]
+	EffectiveTags                  plugin.TValue[[]any]
 }
 
 // createGcpProjectBigqueryServiceTable creates a new instance of this resource
@@ -58158,6 +58520,22 @@ func (c *mqlGcpProjectBigqueryServiceTable) GetForeignKeys() *plugin.TValue[[]an
 
 func (c *mqlGcpProjectBigqueryServiceTable) GetBigLakeConfiguration() *plugin.TValue[*mqlGcpProjectBigqueryServiceTableBigLakeConfig] {
 	return &c.BigLakeConfiguration
+}
+
+func (c *mqlGcpProjectBigqueryServiceTable) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.bigqueryService.table", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
 }
 
 // mqlGcpProjectBigqueryServiceTableBigLakeConfig for the gcp.project.bigqueryService.table.bigLakeConfig resource
@@ -59063,6 +59441,7 @@ type mqlGcpProjectDnsServiceManagedzone struct {
 	RecordSets                   plugin.TValue[[]any]
 	IamPolicy                    plugin.TValue[[]any]
 	ManagedBy                    plugin.TValue[string]
+	EffectiveTags                plugin.TValue[[]any]
 }
 
 // createGcpProjectDnsServiceManagedzone creates a new instance of this resource
@@ -59267,6 +59646,22 @@ func (c *mqlGcpProjectDnsServiceManagedzone) GetIamPolicy() *plugin.TValue[[]any
 func (c *mqlGcpProjectDnsServiceManagedzone) GetManagedBy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
 		return c.managedBy()
+	})
+}
+
+func (c *mqlGcpProjectDnsServiceManagedzone) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.dnsService.managedzone", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
 	})
 }
 
@@ -59799,6 +60194,7 @@ type mqlGcpProjectGkeServiceCluster struct {
 	StatusMessage                            plugin.TValue[string]
 	NodePoolAutoConfig                       plugin.TValue[any]
 	NodeAutoprovisioning                     plugin.TValue[*mqlGcpProjectGkeServiceClusterNodeAutoprovisioningConfig]
+	EffectiveTags                            plugin.TValue[[]any]
 }
 
 // createGcpProjectGkeServiceCluster creates a new instance of this resource
@@ -60262,6 +60658,22 @@ func (c *mqlGcpProjectGkeServiceCluster) GetNodePoolAutoConfig() *plugin.TValue[
 
 func (c *mqlGcpProjectGkeServiceCluster) GetNodeAutoprovisioning() *plugin.TValue[*mqlGcpProjectGkeServiceClusterNodeAutoprovisioningConfig] {
 	return &c.NodeAutoprovisioning
+}
+
+func (c *mqlGcpProjectGkeServiceCluster) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.gkeService.cluster", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
 }
 
 // mqlGcpProjectGkeServiceClusterNodeAutoprovisioningConfig for the gcp.project.gkeService.cluster.nodeAutoprovisioningConfig resource
@@ -71229,6 +71641,7 @@ type mqlGcpProjectCloudRunServiceService struct {
 	ManualInstanceCount                        plugin.TValue[int64]
 	Urls                                       plugin.TValue[[]any]
 	BuildConfig                                plugin.TValue[*mqlGcpProjectCloudRunServiceServiceBuildSettings]
+	EffectiveTags                              plugin.TValue[[]any]
 }
 
 // createGcpProjectCloudRunServiceService creates a new instance of this resource
@@ -71490,6 +71903,22 @@ func (c *mqlGcpProjectCloudRunServiceService) GetUrls() *plugin.TValue[[]any] {
 
 func (c *mqlGcpProjectCloudRunServiceService) GetBuildConfig() *plugin.TValue[*mqlGcpProjectCloudRunServiceServiceBuildSettings] {
 	return &c.BuildConfig
+}
+
+func (c *mqlGcpProjectCloudRunServiceService) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.cloudRunService.service", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
 }
 
 // mqlGcpProjectCloudRunServiceServiceBuildSettings for the gcp.project.cloudRunService.service.buildSettings resource
@@ -73821,6 +74250,7 @@ type mqlGcpProjectSecretmanagerServiceSecret struct {
 	PolicyMemberNamePrincipal        plugin.TValue[string]
 	PolicyMemberUidPrincipal         plugin.TValue[string]
 	ManagedBy                        plugin.TValue[string]
+	EffectiveTags                    plugin.TValue[[]any]
 }
 
 // createGcpProjectSecretmanagerServiceSecret creates a new instance of this resource
@@ -74029,6 +74459,22 @@ func (c *mqlGcpProjectSecretmanagerServiceSecret) GetPolicyMemberUidPrincipal() 
 func (c *mqlGcpProjectSecretmanagerServiceSecret) GetManagedBy() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
 		return c.managedBy()
+	})
+}
+
+func (c *mqlGcpProjectSecretmanagerServiceSecret) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.secretmanagerService.secret", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
 	})
 }
 
@@ -77895,6 +78341,7 @@ type mqlGcpProjectComputeServiceVpnGateway struct {
 	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 	VpnInterfaces       plugin.TValue[[]any]
 	ResourceManagerTags plugin.TValue[map[string]any]
+	EffectiveTags       plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceVpnGateway creates a new instance of this resource
@@ -78002,6 +78449,22 @@ func (c *mqlGcpProjectComputeServiceVpnGateway) GetResourceManagerTags() *plugin
 	return &c.ResourceManagerTags
 }
 
+func (c *mqlGcpProjectComputeServiceVpnGateway) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.vpnGateway", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
+}
+
 // mqlGcpProjectComputeServiceVpnTunnel for the gcp.project.computeService.vpnTunnel resource
 type mqlGcpProjectComputeServiceVpnTunnel struct {
 	MqlRuntime *plugin.Runtime
@@ -78029,6 +78492,7 @@ type mqlGcpProjectComputeServiceVpnTunnel struct {
 	VpnGatewayInterface          plugin.TValue[int64]
 	ResourceManagerTags          plugin.TValue[map[string]any]
 	SelfLink                     plugin.TValue[string]
+	EffectiveTags                plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceVpnTunnel creates a new instance of this resource
@@ -78214,6 +78678,22 @@ func (c *mqlGcpProjectComputeServiceVpnTunnel) GetResourceManagerTags() *plugin.
 
 func (c *mqlGcpProjectComputeServiceVpnTunnel) GetSelfLink() *plugin.TValue[string] {
 	return &c.SelfLink
+}
+
+func (c *mqlGcpProjectComputeServiceVpnTunnel) GetEffectiveTags() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveTags, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.computeService.vpnTunnel", c.__id, "effectiveTags")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveTags()
+	})
 }
 
 // mqlGcpProjectComputeServiceStoragePool for the gcp.project.computeService.storagePool resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -67,6 +67,13 @@ gcp.cloudIdentity.membership.memberKey 13.15.1
 gcp.cloudIdentity.membership.name 13.15.1
 gcp.cloudIdentity.membership.roles 13.15.1
 gcp.cloudIdentity.membership.type 13.15.1
+gcp.effectiveTag 13.37.1
+gcp.effectiveTag.inherited 13.37.1
+gcp.effectiveTag.namespacedTagKey 13.37.1
+gcp.effectiveTag.namespacedTagValue 13.37.1
+gcp.effectiveTag.tagKey 13.37.1
+gcp.effectiveTag.tagKeyParent 13.37.1
+gcp.effectiveTag.tagValue 13.37.1
 gcp.essentialContact 9.0.0
 gcp.essentialContact.email 9.0.0
 gcp.essentialContact.languageTag 9.0.0
@@ -777,6 +784,7 @@ gcp.project.bigqueryService.dataset.defaultCollation 13.1.2
 gcp.project.bigqueryService.dataset.defaultPartitionExpirationMs 13.1.2
 gcp.project.bigqueryService.dataset.defaultTableExpirationMs 11.6.6
 gcp.project.bigqueryService.dataset.description 9.0.0
+gcp.project.bigqueryService.dataset.effectiveTags 13.37.1
 gcp.project.bigqueryService.dataset.externalDatasetReference 13.16.3
 gcp.project.bigqueryService.dataset.id 9.0.0
 gcp.project.bigqueryService.dataset.isCaseInsensitive 13.1.2
@@ -850,6 +858,7 @@ gcp.project.bigqueryService.table.created 9.0.0
 gcp.project.bigqueryService.table.datasetId 9.0.0
 gcp.project.bigqueryService.table.description 9.0.0
 gcp.project.bigqueryService.table.dlpDataProfile 13.14.2
+gcp.project.bigqueryService.table.effectiveTags 13.37.1
 gcp.project.bigqueryService.table.expirationTime 9.0.0
 gcp.project.bigqueryService.table.externalDataConfig 9.0.0
 gcp.project.bigqueryService.table.foreignKey 13.36.1
@@ -1536,6 +1545,7 @@ gcp.project.cloudRunService.service.customAudiences 13.1.2
 gcp.project.cloudRunService.service.defaultUriDisabled 13.1.2
 gcp.project.cloudRunService.service.deleted 9.0.0
 gcp.project.cloudRunService.service.description 9.0.0
+gcp.project.cloudRunService.service.effectiveTags 13.37.1
 gcp.project.cloudRunService.service.encryptionKeyRef 13.27.2
 gcp.project.cloudRunService.service.etag 13.1.2
 gcp.project.cloudRunService.service.expired 9.0.0
@@ -1786,6 +1796,7 @@ gcp.project.computeService.disk.created 9.0.0
 gcp.project.computeService.disk.description 9.0.0
 gcp.project.computeService.disk.diskEncryption 13.37.1
 gcp.project.computeService.disk.diskEncryptionKey 9.0.0
+gcp.project.computeService.disk.effectiveTags 13.37.1
 gcp.project.computeService.disk.enableConfidentialCompute 11.6.6
 gcp.project.computeService.disk.guestOsFeatures 9.0.0
 gcp.project.computeService.disk.id 9.0.0
@@ -1845,6 +1856,7 @@ gcp.project.computeService.firewall.description 9.0.0
 gcp.project.computeService.firewall.destinationRanges 9.0.0
 gcp.project.computeService.firewall.direction 9.0.0
 gcp.project.computeService.firewall.disabled 9.0.0
+gcp.project.computeService.firewall.effectiveTags 13.37.1
 gcp.project.computeService.firewall.id 9.0.0
 gcp.project.computeService.firewall.logConfig 13.7.2
 gcp.project.computeService.firewall.logConfigMetadata 13.18.1
@@ -1997,6 +2009,7 @@ gcp.project.computeService.instance.created 9.0.0
 gcp.project.computeService.instance.deletionProtection 9.0.0
 gcp.project.computeService.instance.description 9.0.0
 gcp.project.computeService.instance.disks 9.0.0
+gcp.project.computeService.instance.effectiveTags 13.37.1
 gcp.project.computeService.instance.enableDisplay 9.0.0
 gcp.project.computeService.instance.exposure 13.24.1
 gcp.project.computeService.instance.exposure.firewallAllowsIngress 13.24.1
@@ -2256,6 +2269,7 @@ gcp.project.computeService.network 9.0.0
 gcp.project.computeService.network.autoCreateSubnetworks 9.0.0
 gcp.project.computeService.network.created 9.0.0
 gcp.project.computeService.network.description 9.0.0
+gcp.project.computeService.network.effectiveTags 13.37.1
 gcp.project.computeService.network.enableUlaInternalIpv6 9.0.0
 gcp.project.computeService.network.firewallPolicy 11.6.6
 gcp.project.computeService.network.firewallPolicyRef 13.27.2
@@ -2566,6 +2580,7 @@ gcp.project.computeService.subnetwork 9.0.0
 gcp.project.computeService.subnetwork.allowSubnetCidrRoutesOverlap 13.16.3
 gcp.project.computeService.subnetwork.created 9.0.0
 gcp.project.computeService.subnetwork.description 9.0.0
+gcp.project.computeService.subnetwork.effectiveTags 13.37.1
 gcp.project.computeService.subnetwork.enableFlowLogs 9.0.0
 gcp.project.computeService.subnetwork.externalIpv6Prefix 9.0.0
 gcp.project.computeService.subnetwork.fingerprint 9.0.0
@@ -2687,6 +2702,7 @@ gcp.project.computeService.urlMaps 11.6.6
 gcp.project.computeService.vpnGateway 11.6.6
 gcp.project.computeService.vpnGateway.created 11.6.6
 gcp.project.computeService.vpnGateway.description 11.6.6
+gcp.project.computeService.vpnGateway.effectiveTags 13.37.1
 gcp.project.computeService.vpnGateway.gatewayIpVersion 11.6.6
 gcp.project.computeService.vpnGateway.id 11.6.6
 gcp.project.computeService.vpnGateway.labels 11.6.6
@@ -2701,6 +2717,7 @@ gcp.project.computeService.vpnTunnel 11.6.6
 gcp.project.computeService.vpnTunnel.created 11.6.6
 gcp.project.computeService.vpnTunnel.description 11.6.6
 gcp.project.computeService.vpnTunnel.detailedStatus 11.6.6
+gcp.project.computeService.vpnTunnel.effectiveTags 13.37.1
 gcp.project.computeService.vpnTunnel.id 11.6.6
 gcp.project.computeService.vpnTunnel.ikeVersion 11.6.6
 gcp.project.computeService.vpnTunnel.labels 11.6.6
@@ -3272,6 +3289,7 @@ gcp.project.dnsService.managedzone.dnssecConfig 9.0.0
 gcp.project.dnsService.managedzone.dnssecDefaultKeyAlgorithms 13.18.1
 gcp.project.dnsService.managedzone.dnssecEnabled 13.1.2
 gcp.project.dnsService.managedzone.dnssecNonExistence 13.22.2
+gcp.project.dnsService.managedzone.effectiveTags 13.37.1
 gcp.project.dnsService.managedzone.forwardingTargets 13.18.1
 gcp.project.dnsService.managedzone.iamPolicy 13.9.1
 gcp.project.dnsService.managedzone.id 9.0.0
@@ -3574,6 +3592,7 @@ gcp.project.gkeService.cluster.databaseEncryptionKey 13.2.3
 gcp.project.gkeService.cluster.databaseEncryptionState 13.2.3
 gcp.project.gkeService.cluster.defaultMaxPodsPerNode 13.21.2
 gcp.project.gkeService.cluster.description 9.0.0
+gcp.project.gkeService.cluster.effectiveTags 13.37.1
 gcp.project.gkeService.cluster.enableKubernetesAlpha 9.0.0
 gcp.project.gkeService.cluster.enableTpu 11.6.6
 gcp.project.gkeService.cluster.enabledK8sBetaApis 13.1.2
@@ -4929,6 +4948,7 @@ gcp.project.secretmanagerService.secret 11.1.0
 gcp.project.secretmanagerService.secret.annotations 11.1.0
 gcp.project.secretmanagerService.secret.createTime 11.1.0
 gcp.project.secretmanagerService.secret.customerManagedEncryptionEnabled 13.21.2
+gcp.project.secretmanagerService.secret.effectiveTags 13.37.1
 gcp.project.secretmanagerService.secret.etag 11.1.0
 gcp.project.secretmanagerService.secret.expireTime 11.1.0
 gcp.project.secretmanagerService.secret.iamPolicy 11.1.0
@@ -5142,6 +5162,7 @@ gcp.project.sqlService.instance.diskEncryptionStatus 9.0.0
 gcp.project.sqlService.instance.dnsName 11.6.6
 gcp.project.sqlService.instance.dnsNames 13.16.3
 gcp.project.sqlService.instance.drReplica 13.27.2
+gcp.project.sqlService.instance.effectiveTags 13.37.1
 gcp.project.sqlService.instance.etag 13.1.2
 gcp.project.sqlService.instance.failoverReplica 9.0.0
 gcp.project.sqlService.instance.failoverReplicaRef 13.27.2
@@ -5341,6 +5362,7 @@ gcp.project.storageService.bucket.defaultKmsKey 13.2.3
 gcp.project.storageService.bucket.defaultObjectAccessControl 13.37.1
 gcp.project.storageService.bucket.defaultObjectAcl 13.12.2
 gcp.project.storageService.bucket.dlpDataProfile 13.14.2
+gcp.project.storageService.bucket.effectiveTags 13.37.1
 gcp.project.storageService.bucket.encryption 11.0.57
 gcp.project.storageService.bucket.hierarchicalNamespace 13.16.3
 gcp.project.storageService.bucket.iamConfiguration 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -52,7 +52,9 @@
     "backupdr.managementServers.list",
     "batch.jobs.list",
     "bigquery.connections.list",
+    "bigquery.datasets.listEffectiveTags",
     "bigquery.reservations.list",
+    "bigquery.tables.listEffectiveTags",
     "bigtable.appProfiles.list",
     "binaryauthorization.attestors.list",
     "binaryauthorization.policy.get",
@@ -90,6 +92,7 @@
     "cloudsql.backupRuns.list",
     "cloudsql.databases.list",
     "cloudsql.instances.list",
+    "cloudsql.instances.listEffectiveTags",
     "cloudsql.sslCerts.list",
     "cloudsql.users.list",
     "cloudtasks.queues.getIamPolicy",
@@ -99,10 +102,12 @@
     "compute.backendBuckets.list",
     "compute.backendServices.list",
     "compute.disks.list",
+    "compute.disks.listEffectiveTags",
     "compute.externalVpnGateways.list",
     "compute.firewallPolicies.get",
     "compute.firewallPolicies.list",
     "compute.firewalls.list",
+    "compute.firewalls.listEffectiveTags",
     "compute.healthChecks.list",
     "compute.images.getIamPolicy",
     "compute.images.list",
@@ -110,6 +115,7 @@
     "compute.instanceGroups.list",
     "compute.instanceTemplates.list",
     "compute.instances.list",
+    "compute.instances.listEffectiveTags",
     "compute.interconnectAttachments.list",
     "compute.interconnects.list",
     "compute.machineTypes.get",
@@ -117,6 +123,7 @@
     "compute.networkEndpointGroups.list",
     "compute.networks.get",
     "compute.networks.list",
+    "compute.networks.listEffectiveTags",
     "compute.packetMirrorings.list",
     "compute.projects.get",
     "compute.publicAdvertisedPrefixes.list",
@@ -133,6 +140,7 @@
     "compute.sslCertificates.list",
     "compute.sslPolicies.list",
     "compute.storagePools.list",
+    "compute.subnetworks.listEffectiveTags",
     "compute.targetHttpProxies.list",
     "compute.targetHttpsProxies.list",
     "compute.targetPools.list",
@@ -140,10 +148,13 @@
     "compute.targetTcpProxies.list",
     "compute.urlMaps.list",
     "compute.vpnGateways.list",
+    "compute.vpnGateways.listEffectiveTags",
     "compute.vpnTunnels.list",
+    "compute.vpnTunnels.listEffectiveTags",
     "compute.zones.get",
     "compute.zones.list",
     "container.clusters.list",
+    "container.clusters.listEffectiveTags",
     "containeranalysis.occurrences.list",
     "dataflow.jobs.list",
     "dataplex.assets.list",
@@ -178,6 +189,7 @@
     "dns.dnsKeys.list",
     "dns.managedZones.getIamPolicy",
     "dns.managedZones.list",
+    "dns.managedZones.listEffectiveTags",
     "dns.policies.list",
     "dns.resourceRecordSets.list",
     "dns.responsePolicies.list",
@@ -262,7 +274,6 @@
     "redis.backups.list",
     "redis.clusters.list",
     "redis.instances.list",
-    "resourcemanager.effectiveTags.list",
     "resourcemanager.projects.get",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.resourceTagBindings.list",
@@ -271,8 +282,10 @@
     "run.operations.list",
     "run.services.getIamPolicy",
     "run.services.list",
+    "run.services.listEffectiveTags",
     "secretmanager.secrets.getIamPolicy",
     "secretmanager.secrets.list",
+    "secretmanager.secrets.listEffectiveTags",
     "secretmanager.versions.list",
     "serviceusage.services.get",
     "serviceusage.services.list",
@@ -590,10 +603,22 @@
       "source_file": "bigquery_connection.go"
     },
     {
+      "permission": "bigquery.datasets.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
+    },
+    {
       "permission": "bigquery.reservations.list",
       "service": "bigquery",
       "action": "ListReservations",
       "source_file": "bigquery_reservation.go"
+    },
+    {
+      "permission": "bigquery.tables.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "bigtable.appProfiles.list",
@@ -830,6 +855,12 @@
       "source_file": "sql.go"
     },
     {
+      "permission": "cloudsql.instances.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
+    },
+    {
       "permission": "cloudsql.sslCerts.list",
       "service": "cloudsql",
       "action": "SslCerts.List",
@@ -884,6 +915,12 @@
       "source_file": "compute.go"
     },
     {
+      "permission": "compute.disks.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
+    },
+    {
       "permission": "compute.externalVpnGateways.list",
       "service": "compute",
       "action": "ExternalVpnGateways.List",
@@ -912,6 +949,12 @@
       "service": "compute",
       "action": "Firewalls.List",
       "source_file": "compute.go"
+    },
+    {
+      "permission": "compute.firewalls.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "compute.healthChecks.list",
@@ -962,6 +1005,12 @@
       "source_file": "compute.go"
     },
     {
+      "permission": "compute.instances.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
+    },
+    {
       "permission": "compute.interconnectAttachments.list",
       "service": "compute",
       "action": "InterconnectAttachments.AggregatedList",
@@ -1002,6 +1051,12 @@
       "service": "compute",
       "action": "Networks.List",
       "source_file": "compute.go"
+    },
+    {
+      "permission": "compute.networks.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "compute.packetMirrorings.list",
@@ -1130,6 +1185,12 @@
       "source_file": "compute.go"
     },
     {
+      "permission": "compute.subnetworks.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
+    },
+    {
       "permission": "compute.targetHttpProxies.list",
       "service": "compute",
       "action": "TargetHttpProxies.AggregatedList",
@@ -1172,10 +1233,22 @@
       "source_file": "compute.go"
     },
     {
+      "permission": "compute.vpnGateways.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
+    },
+    {
       "permission": "compute.vpnTunnels.list",
       "service": "compute",
       "action": "VpnTunnels.AggregatedList",
       "source_file": "compute.go"
+    },
+    {
+      "permission": "compute.vpnTunnels.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "compute.zones.get",
@@ -1212,6 +1285,12 @@
       "service": "container",
       "action": "ListClusters",
       "source_file": "gke.go"
+    },
+    {
+      "permission": "container.clusters.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "containeranalysis.occurrences.list",
@@ -1416,6 +1495,12 @@
       "service": "dns",
       "action": "ManagedZones.List",
       "source_file": "dns.go"
+    },
+    {
+      "permission": "dns.managedZones.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "dns.policies.list",
@@ -1935,12 +2020,6 @@
       "source_file": "redis.go"
     },
     {
-      "permission": "resourcemanager.effectiveTags.list",
-      "service": "resourcemanager",
-      "action": "EffectiveTags.List",
-      "source_file": "effective_tags.go"
-    },
-    {
       "permission": "resourcemanager.folders.get",
       "service": "resourcemanager",
       "action": "Folders.Get",
@@ -2051,6 +2130,12 @@
       "source_file": "cloudrun.go"
     },
     {
+      "permission": "run.services.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
+    },
+    {
       "permission": "secretmanager.secrets.getIamPolicy",
       "service": "secretmanager",
       "action": "GetIamPolicy",
@@ -2061,6 +2146,12 @@
       "service": "secretmanager",
       "action": "ListSecrets",
       "source_file": "secretmanager.go"
+    },
+    {
+      "permission": "secretmanager.secrets.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "secretmanager.versions.list",
@@ -2163,6 +2254,12 @@
       "service": "storage",
       "action": "Buckets.List",
       "source_file": "storage.go"
+    },
+    {
+      "permission": "storage.buckets.listEffectiveTags",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "storage.buckets.listEffectiveTags",

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -262,6 +262,7 @@
     "redis.backups.list",
     "redis.clusters.list",
     "redis.instances.list",
+    "resourcemanager.effectiveTags.list",
     "resourcemanager.projects.get",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.resourceTagBindings.list",
@@ -1932,6 +1933,12 @@
       "service": "redis",
       "action": "ListInstances",
       "source_file": "redis.go"
+    },
+    {
+      "permission": "resourcemanager.effectiveTags.list",
+      "service": "resourcemanager",
+      "action": "EffectiveTags.List",
+      "source_file": "effective_tags.go"
     },
     {
       "permission": "resourcemanager.folders.get",


### PR DESCRIPTION
Adds `gcp.effectiveTag` and an `effectiveTags` accessor across the resources GCP supports tag bindings for, so a policy can reach the tags that actually apply to a resource rather than only the ones bound to it directly.

## Why

Resource Manager tags drive conditional IAM grants and organization-policy enforcement, and they inherit down the hierarchy. Coverage today is one resource done correctly (`storage.bucket.tags`) plus two that look right and are not:

`computeService.vpnGateway.resourceManagerTags` and `vpnTunnel.resourceManagerTags` read `Params.ResourceManagerTags` off the compute struct, which is **the tags supplied at create time only**. Same word, different semantics. A check written against them passes on a resource that carries the tag by inheritance, which is the failure direction that matters. Both are now `@maturity("deprecated")` pointing at `effectiveTags`.

## What

`gcp.effectiveTag` carries `tagKey`, `tagValue`, `namespacedTagKey`, `namespacedTagValue`, `tagKeyParent`, and `inherited`. `inherited` is the point of the type: it separates a resource that was deliberately tagged from one that only sits beneath a tagged parent.

```
// resources tagged directly, not by inheritance from the project
gcp.compute.instances.where(effectiveTags.any(namespacedTagKey == "123456789/environment" && inherited == false))

// anything that reaches production data but was never tagged for it
gcp.project.sqlService.instances.where(effectiveTags.none(namespacedTagValue == "123456789/env/prod"))
```

Wired onto 15 resources: compute `instance` / `disk` / `network` / `subnetwork` / `firewall` / `vpnGateway` / `vpnTunnel`, `sqlService.instance`, `gkeService.cluster`, `cloudRunService.service`, `bigqueryService.dataset` / `table`, `secretmanagerService.secret`, `dnsService.managedzone`, `storageService.bucket`.

The existing `bucket.tags` field is untouched. It stays correct; it just cannot report `inherited`, because the endpoint behind it returns a flat map.

## Implementation notes

Compute resource names are derived from `selfLink` rather than reassembled from project/zone/region. Every compute response carries it, and it removes the zonal-vs-regional branch that disks alone would need. `cacheSelfLink` lives on the `Internal` struct for the five resources that do not already expose `selfLink`.

The cache key is `<fullResourceName>/<tagValue>`. An inherited tag value applies to every resource beneath its parent, so keying on the tag value alone would collapse every resource's copy onto whichever was created first and report one resource's tags for all of them. There is a test pinning this.

Accessors live together in `effective_tags.go` rather than scattered across the per-service files, since they are one feature.

## Schema note for review

`gcp.effectiveTag` is a sub-resource where CLAUDE.md's sub-resource bar would strictly say `[]dict`: its id is parent-qualified rather than natural, and it holds no typed refs. I went typed deliberately, on the grounds that the bar is written against per-parent data containers and this is a *shared* type used by 15 resources, where `inherited` is a genuine audit predicate rather than a data field. Happy to switch it to `[]dict` if reviewers disagree.

## Tests

20 new cases covering the `selfLink` conversion (zonal, regional, global, beta, `compute.googleapis.com` host form, empty, prefix-only, foreign host), the cache-key collision properties, and the field-reading helper including the "read failure must not be reported as a missing value" case.

## Open: the validated permissions list

**This is why the PR is a draft.** One test fails: `TestGCPPermissionsMatchValidatedList`.

`effectiveTags.list` is authorized against the *target* resource's own permission. Per the Resource Manager docs, the API "utilizes the existing resource-specific `<resource>.listEffectiveTags` IAM permission" — so the auto-derived `resourcemanager.effectiveTags.list` is not a real permission. This repo already documents the identical trap for `EffectiveTagBindingCollections.Get`, which is overridden to `storage.buckets.listEffectiveTags`.

The override map holds one permission per method and cannot express this, because a single call site serves every taggable resource. This PR adds a post-derivation expansion (`gcpPermissionExpansions`) so one derived permission can map onto the set it stands for, and the manifest now lists 15 per-resource permissions instead of the bogus one.

What is **not** done: `validatedGCPPermissions` in `permissions_test.go` has not been updated. That list carries an explicit contract that every entry is confirmed against the live IAM API first, and I could only confirm the naming *pattern* plus `bigquery.tables.listEffectiveTags` and `storage.buckets.listEffectiveTags` from the docs. The remaining 13 names are inferred from the pattern and need:

```
python3 providers/gcp/resources/validate_permissions.py providers/gcp/resources/gcp.permissions.json
```

Worth noting that the test compares the manifest against the validated list, so it would **not** independently catch a wrong name — both sides are edited together. That is exactly why the list's contract exists, and why I left it alone rather than making the test green.

Two questions that also need a live project, both of which could change the code:

1. Whether `effectiveTags.list` needs the regional `cloudresourcemanager` endpoint the way the bucket call does. Implemented global-endpoint-only; will add routing if the API demands it.
2. Whether every one of the 15 resource types actually supports tag bindings. Any that do not would be dead schema and should be dropped from the rollout.

Sources: [Create and manage tags](https://docs.cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing), [Control access with tags (BigQuery)](https://docs.cloud.google.com/bigquery/docs/tags)
