### PR TITLE
⭐ azure: armnetwork v11 and the fields it unlocks

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -45,14 +45,14 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2 v2.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10 v10.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11 v11.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/policyinsights/armpolicyinsights v0.10.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v5 v5.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview v1.2.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments/v2 v2.0.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -136,8 +136,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 h1:d
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0/go.mod h1:6z3b+JdBLH0eMzfBex/cvEIoEFVEwXuB0wbgdfN11iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2 v2.0.0 h1:iyx6jFFyRo8/9FQiyHRTjoUluopwt+9lvOtRBhfB7Y8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers/v2 v2.0.0/go.mod h1:LSdxfHhUzKllvM+sYDf1wrcQrbInrF4iXJ/NMk7fK90=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10 v10.0.0 h1:DI6sDa/IfWSjPCo6G7CuO9sekRNajIfg134SP1C13js=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10 v10.0.0/go.mod h1:oSXzE/x+1AxZplJylWMM4BCq+RkQ3XM2uc9IkIgcBKk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11 v11.0.0 h1:6BG7Llwh8IcxjCQu7KZ7jMjtoMhKjvVP+pOmdQh1Nyw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11 v11.0.0/go.mod h1:R3CG1mTV3BAxKaJl0hG2dU7FusEXL4vE4uCWKac01ew=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v3 v3.0.0 h1:PQCYE8OR+vgoTJ1Vq6EutuoMN8n6LgJygxMSHNTsuYY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v3 v3.0.0/go.mod h1:s9hOdyntXLv/Y+IzJ6+O021/eAo7omS8Y6KwwICcG58=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/policyinsights/armpolicyinsights v0.10.0 h1:AzaqGJAacR0jIOJ8MQy3VZ1IHv00DW7bneMA7hx6PXk=
@@ -150,8 +150,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns/v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns/v2 v2.0.0/go.mod h1:bM1rJt5FapRKM0cO01k9nMNJJWvYDh7NSMRYLOzlhPo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview v1.2.0 h1:ZQaGjVbDGmFxdhZK4YMVKl/FPnYh+JOKNYaGj9byrKo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview v1.2.0/go.mod h1:B/ISjKE6y8n0C9rnrIoVjv6RnXii3xIXjwYjKo/smh0=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.1.0 h1:uWMMZcg8Lg9EMjlZQiig9pGnNdvDXphCSNMPVoeFDBk=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.1.0/go.mod h1:g3X+LCYOwmSxuN0qx3clm33onm8e3f6fbN0Em11XFJs=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.2.0 h1:Ygo+ZXpYq/EAwZL5Pc5sO4jjQcy2VZ8Z78CAcARGyd8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.2.0/go.mod h1:e0I35UPaUN0VmTu/FtUQMMRD6ePrNRYJVpXrkudePjs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0 h1:GOtQKZTIc4/HnWIEqGqtkMHLXIlwa4GpT8BB5JGH+tc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0/go.mod h1:o1BW30aoyqKYcQKAMNWs0UAkT30Z2FZzmCNo7hrGHjM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v4 v4.0.0 h1:xXVDKm0Nd3I9Sz2AcRm/L4+fm7xZjAWI/AkU73m0Ato=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -3046,6 +3046,12 @@ azure.subscription.networkService.loadBalancer @defaults("id name location") {
   sku string
   // Load Balancer SKU tier ("Global" or "Regional")
   skuTier string
+  // Load Balancer operating mode
+  //
+  // "Advanced" for a load balancer running in advanced mode, empty for the
+  // standard behavior. Advanced mode changes how backend pools and rules
+  // are evaluated.
+  mode string
   // List of Load Balancer probes
   probes() []azure.subscription.networkService.probe
   // List of Load Balancer backend address pools
@@ -3147,6 +3153,12 @@ private azure.subscription.networkService.frontendIpConfig @defaults("id name") 
   privateIpAddress string
   // Resource ID of the DDoS custom policy bound to this frontend IP configuration (empty when none)
   ddosCustomPolicyId string
+  // Whether connection tracking is enabled on this frontend
+  //
+  // Connection tracking keeps per-flow state so that return traffic is
+  // matched to the flow that opened it. Null when the load balancer does
+  // not report the setting.
+  enableConnectionTracking bool
 }
 
 // Azure Load Balancer rule
@@ -3331,10 +3343,12 @@ private azure.subscription.networkService.interface.effectiveRoute @defaults("na
   addressPrefix []string
   // Where matching traffic is sent
   //
-  // One of VirtualNetworkGateway, VnetLocal, Internet, VirtualAppliance, or
-  // None. A route to None discards the traffic.
+  // One of VirtualNetworkGateway, VnetLocal, Internet, VirtualAppliance,
+  // VirtualApplianceEcmp, or None. A route to None discards the traffic.
+  // VirtualApplianceEcmp carries several next hop addresses that share the
+  // traffic, so a filter looking only for VirtualAppliance misses it.
   nextHopType string
-  // Next hop addresses, set only when nextHopType is VirtualAppliance
+  // Next hop addresses, set only when nextHopType is VirtualAppliance or VirtualApplianceEcmp
   nextHopIpAddress []string
   // Whether BGP route propagation is disabled on the route's table
   disableBgpRoutePropagation bool
@@ -3415,6 +3429,11 @@ private azure.subscription.networkService.ipAddress @defaults("name location ipA
   ipTags []dict
   // NAT gateway using this public IP; null when the address is not used by a NAT gateway
   natGateway() azure.subscription.networkService.natGateway
+  // Whether the address has been migrated to the v2 platform
+  //
+  // Reports the migration off the retiring Basic SKU. Null when Azure does
+  // not report a migration state for the address.
+  upgradedToV2 bool
 }
 
 // Azure Network Bastion host
@@ -3831,6 +3850,12 @@ azure.subscription.networkService.applicationGateway @defaults("id name location
   userAssignedIdentities() []azure.subscription.managedIdentity
   // Gateway IP configurations that bind the application gateway into a subnet
   gatewayIpConfigs() []azure.subscription.networkService.applicationGateway.gatewayIpConfig
+  // Whether the gateway omits its default Server header from responses
+  //
+  // When false the gateway advertises itself in every response, disclosing
+  // the platform to anyone probing the endpoint. Null when the gateway does
+  // not carry a global configuration block.
+  disableDefaultServerHeaderInResponse bool
 }
 
 // Azure Application Gateway IP configuration
@@ -4211,9 +4236,10 @@ private azure.subscription.networkService.applicationFirewallPolicy.managedRuleS
   state string
   // Action that replaces the rule's own when it matches
   //
-  // One of "Allow", "Block", "Log", "JSChallenge", or empty to keep the
-  // rule set's action. "Log" downgrades a blocking rule to detection
-  // only while the policy as a whole still reports Prevention mode.
+  // One of "Allow", "Block", "Log", "JSChallenge", "CAPTCHA",
+  // "AnomalyScoring", or empty to keep the rule set's action. "Log"
+  // downgrades a blocking rule to detection only while the policy as a
+  // whole still reports Prevention mode.
   action string
   // Override sensitivity applied when the rule matches (anomaly-scoring rule sets)
   sensitivity string
@@ -4238,9 +4264,9 @@ private azure.subscription.networkService.applicationFirewallPolicy.customRule @
   ruleType string
   // Action taken when every match condition holds
   //
-  // One of "Allow", "Block", "Log", or "JSChallenge". An "Allow" rule
-  // short-circuits the managed rule sets for matching requests, and a
-  // "Log" rule records without blocking.
+  // One of "Allow", "Block", "Log", "JSChallenge", or "CAPTCHA". An
+  // "Allow" rule short-circuits the managed rule sets for matching
+  // requests, and a "Log" rule records without blocking.
   action string
   // Whether the rule is evaluated
   //
@@ -4663,6 +4689,10 @@ azure.subscription.networkService.virtualHub @defaults("id name location sku") {
   virtualRouterAsn int
   // VirtualRouter IP addresses
   virtualRouterIps []string
+  // IPv6 address prefix of the hub, empty on an IPv4-only hub
+  addressPrefixV6 string
+  // VirtualRouter IPv6 addresses, empty on an IPv4-only hub
+  virtualRouterIpsV6 []string
   // Provisioning state
   provisioningState string
   // Current routing state ("None", "Provisioning", "Provisioned", "Failed")
@@ -4729,6 +4759,12 @@ private azure.subscription.networkService.virtualHub.vnetConnection @defaults("i
   etag string
   // Whether secured-hub Internet-egress filtering is enabled for the spoke
   enableInternetSecurity bool
+  // Whether the connection peers over IPv6 only
+  //
+  // When true the spoke reaches the hub over IPv6 and no IPv4 peering is
+  // established, which changes what the connection can reach. Null when the
+  // hub does not report the setting.
+  enableOnlyIPv6Peering bool
   // Provisioning state
   provisioningState string
   // Routing configuration (associated route table, propagated route tables/labels, static routes)
@@ -4864,6 +4900,12 @@ azure.subscription.networkService.expressRouteCircuit @defaults("id name locatio
   provisioningState string
   // Outer QinQ tag identifying the circuit's traffic
   stag int
+  // Redundancy the circuit is provisioned with
+  //
+  // One of "Standard", "High", or "Maximum". A Standard circuit has a single
+  // connection path, so it is a single point of failure for the hybrid link
+  // it carries. Empty when the provider does not report a resiliency level.
+  resiliencyLevel string
   // BGP peerings (private, microsoft, Azure private) configured on the circuit
   peerings() []azure.subscription.networkService.expressRouteCircuit.peering
   // Connection authorizations issued for the circuit
@@ -5352,10 +5394,31 @@ azure.subscription.networkService.virtualAppliance @defaults("id name location")
   marketplaceVersion string
   // Address prefix assigned to the appliance
   addressPrefix string
+  // IPv6 address prefix assigned to the appliance, empty on an IPv4-only appliance
+  addressPrefixV6 string
+  // Private IPv6 address of the appliance, empty on an IPv4-only appliance
+  privateIpAddressV6 string
+  // IP versions the appliance is configured for
+  //
+  // Each entry is "IPv4" or "IPv6". An appliance carrying both is
+  // dual-stack, so an audit reading only the IPv4 fields sees half of
+  // its address surface.
+  addressFamily []string
   // Deployment type (for example PartnerManaged for SaaS appliances)
   deploymentType string
   // Public key used for SSH login to the appliance
   sshPublicKey string
+  // Phase of the appliance migration workflow, empty when no migration has run
+  //
+  // For example Prepare, Execute, Commit, or Abort.
+  migrationPhase string
+  // Detailed status of the current migration phase, empty when no migration has run
+  migrationPhaseStatus string
+  // Migration workflow in progress or last performed
+  //
+  // One of "MigrateToNewILBArchitecture" or "MigrateToNewOSVersion". Empty
+  // when no migration has run.
+  migrationType string
   // Virtual hub the appliance is deployed in
   virtualHub() azure.subscription.networkService.virtualHub
 }
@@ -5428,6 +5491,11 @@ azure.subscription.networkService.publicIpPrefix @defaults("id name location") {
   ipTags []dict
   // Custom IP prefix (BYOIP) the range is drawn from
   customIpPrefix() azure.subscription.networkService.customIpPrefix
+  // Whether the prefix has been migrated to the v2 platform
+  //
+  // Reports the migration off the retiring Basic SKU. Null when Azure does
+  // not report a migration state for the prefix.
+  upgradedToV2 bool
 }
 
 // Azure custom IP prefix
@@ -12676,6 +12744,13 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   secureScore string
   // Cost management report granularity ("ProtectedItemLevel", "ProtectedItemWithParentTag", or "VaultLevel"); empty when unset
   costManagementGranularityLevel string
+  // Region of choice status for the vault
+  //
+  // One of "Enabled", "Disabled", or "Invalid"; empty when unset. When
+  // enabled the vault replicates backups to a chosen secondary region
+  // rather than the default paired region, which is what a data residency
+  // audit needs to read.
+  regionOfChoiceStatus string
   // Security settings (soft delete, immutability, enhanced security)
   securitySettings() azure.subscription.recoveryServicesService.vault.securitySettings
   // Encryption settings

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -5715,6 +5715,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.loadBalancer.skuTier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceLoadBalancer).GetSkuTier()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.loadBalancer.mode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceLoadBalancer).GetMode()).ToDataRes(types.String)
+	},
 	"azure.subscription.networkService.loadBalancer.probes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceLoadBalancer).GetProbes()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.probe")))
 	},
@@ -5831,6 +5834,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.frontendIpConfig.ddosCustomPolicyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetDdosCustomPolicyId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.frontendIpConfig.enableConnectionTracking": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).GetEnableConnectionTracking()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.loadBalancerRule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceLoadBalancerRule).GetId()).ToDataRes(types.String)
@@ -6083,6 +6089,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.ipAddress.natGateway": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetNatGateway()).ToDataRes(types.Resource("azure.subscription.networkService.natGateway"))
+	},
+	"azure.subscription.networkService.ipAddress.upgradedToV2": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceIpAddress).GetUpgradedToV2()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.bastionHost.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceBastionHost).GetId()).ToDataRes(types.String)
@@ -6527,6 +6536,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.applicationGateway.gatewayIpConfigs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetGatewayIpConfigs()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.applicationGateway.gatewayIpConfig")))
+	},
+	"azure.subscription.networkService.applicationGateway.disableDefaultServerHeaderInResponse": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GetDisableDefaultServerHeaderInResponse()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig).GetId()).ToDataRes(types.String)
@@ -7275,6 +7287,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.virtualHub.virtualRouterIps": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).GetVirtualRouterIps()).ToDataRes(types.Array(types.String))
 	},
+	"azure.subscription.networkService.virtualHub.addressPrefixV6": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).GetAddressPrefixV6()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.virtualHub.virtualRouterIpsV6": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).GetVirtualRouterIpsV6()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.networkService.virtualHub.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).GetProvisioningState()).ToDataRes(types.String)
 	},
@@ -7334,6 +7352,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.virtualHub.vnetConnection.enableInternetSecurity": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection).GetEnableInternetSecurity()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.networkService.virtualHub.vnetConnection.enableOnlyIPv6Peering": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection).GetEnableOnlyIPv6Peering()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.virtualHub.vnetConnection.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection).GetProvisioningState()).ToDataRes(types.String)
@@ -7478,6 +7499,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.expressRouteCircuit.stag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceExpressRouteCircuit).GetStag()).ToDataRes(types.Int)
+	},
+	"azure.subscription.networkService.expressRouteCircuit.resiliencyLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceExpressRouteCircuit).GetResiliencyLevel()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.expressRouteCircuit.peerings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceExpressRouteCircuit).GetPeerings()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.expressRouteCircuit.peering")))
@@ -7962,11 +7986,29 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.virtualAppliance.addressPrefix": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetAddressPrefix()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.virtualAppliance.addressPrefixV6": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetAddressPrefixV6()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.virtualAppliance.privateIpAddressV6": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetPrivateIpAddressV6()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.virtualAppliance.addressFamily": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetAddressFamily()).ToDataRes(types.Array(types.String))
+	},
 	"azure.subscription.networkService.virtualAppliance.deploymentType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetDeploymentType()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.virtualAppliance.sshPublicKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetSshPublicKey()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.virtualAppliance.migrationPhase": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetMigrationPhase()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.virtualAppliance.migrationPhaseStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetMigrationPhaseStatus()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.virtualAppliance.migrationType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetMigrationType()).ToDataRes(types.String)
 	},
 	"azure.subscription.networkService.virtualAppliance.virtualHub": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).GetVirtualHub()).ToDataRes(types.Resource("azure.subscription.networkService.virtualHub"))
@@ -8048,6 +8090,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.publicIpPrefix.customIpPrefix": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePublicIpPrefix).GetCustomIpPrefix()).ToDataRes(types.Resource("azure.subscription.networkService.customIpPrefix"))
+	},
+	"azure.subscription.networkService.publicIpPrefix.upgradedToV2": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServicePublicIpPrefix).GetUpgradedToV2()).ToDataRes(types.Bool)
 	},
 	"azure.subscription.networkService.customIpPrefix.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceCustomIpPrefix).GetId()).ToDataRes(types.String)
@@ -15824,6 +15869,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.recoveryServicesService.vault.costManagementGranularityLevel": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetCostManagementGranularityLevel()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.vault.regionOfChoiceStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetRegionOfChoiceStatus()).ToDataRes(types.String)
 	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetSecuritySettings()).ToDataRes(types.Resource("azure.subscription.recoveryServicesService.vault.securitySettings"))
@@ -24911,6 +24959,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceLoadBalancer).SkuTier, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.loadBalancer.mode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceLoadBalancer).Mode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.loadBalancer.probes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceLoadBalancer).Probes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -25085,6 +25137,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.frontendIpConfig.ddosCustomPolicyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).DdosCustomPolicyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.frontendIpConfig.enableConnectionTracking": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceFrontendIpConfig).EnableConnectionTracking, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.loadBalancerRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25449,6 +25505,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.ipAddress.natGateway": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).NatGateway, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceNatGateway](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.ipAddress.upgradedToV2": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceIpAddress).UpgradedToV2, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.bastionHost.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26081,6 +26141,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.applicationGateway.gatewayIpConfigs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).GatewayIpConfigs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.applicationGateway.disableDefaultServerHeaderInResponse": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceApplicationGateway).DisableDefaultServerHeaderInResponse, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.applicationGateway.gatewayIpConfig.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27179,6 +27243,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).VirtualRouterIps, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.virtualHub.addressPrefixV6": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).AddressPrefixV6, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualHub.virtualRouterIpsV6": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).VirtualRouterIpsV6, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.virtualHub.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualHub).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -27265,6 +27337,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.virtualHub.vnetConnection.enableInternetSecurity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection).EnableInternetSecurity, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualHub.vnetConnection.enableOnlyIPv6Peering": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection).EnableOnlyIPv6Peering, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.virtualHub.vnetConnection.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27465,6 +27541,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.expressRouteCircuit.stag": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceExpressRouteCircuit).Stag, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.expressRouteCircuit.resiliencyLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExpressRouteCircuit).ResiliencyLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.expressRouteCircuit.peerings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28171,12 +28251,36 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).AddressPrefix, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.virtualAppliance.addressPrefixV6": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).AddressPrefixV6, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualAppliance.privateIpAddressV6": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).PrivateIpAddressV6, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualAppliance.addressFamily": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).AddressFamily, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.virtualAppliance.deploymentType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).DeploymentType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.virtualAppliance.sshPublicKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).SshPublicKey, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualAppliance.migrationPhase": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).MigrationPhase, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualAppliance.migrationPhaseStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).MigrationPhaseStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.virtualAppliance.migrationType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceVirtualAppliance).MigrationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.virtualAppliance.virtualHub": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28293,6 +28397,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.publicIpPrefix.customIpPrefix": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServicePublicIpPrefix).CustomIpPrefix, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceCustomIpPrefix](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.publicIpPrefix.upgradedToV2": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServicePublicIpPrefix).UpgradedToV2, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.customIpPrefix.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39585,6 +39693,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.recoveryServicesService.vault.costManagementGranularityLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).CostManagementGranularityLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.vault.regionOfChoiceStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).RegionOfChoiceStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -57130,6 +57242,7 @@ type mqlAzureSubscriptionNetworkServiceLoadBalancer struct {
 	Etag              plugin.TValue[string]
 	Sku               plugin.TValue[string]
 	SkuTier           plugin.TValue[string]
+	Mode              plugin.TValue[string]
 	Probes            plugin.TValue[[]any]
 	BackendPools      plugin.TValue[[]any]
 	FrontendIpConfigs plugin.TValue[[]any]
@@ -57210,6 +57323,10 @@ func (c *mqlAzureSubscriptionNetworkServiceLoadBalancer) GetSku() *plugin.TValue
 
 func (c *mqlAzureSubscriptionNetworkServiceLoadBalancer) GetSkuTier() *plugin.TValue[string] {
 	return &c.SkuTier
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceLoadBalancer) GetMode() *plugin.TValue[string] {
+	return &c.Mode
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceLoadBalancer) GetProbes() *plugin.TValue[[]any] {
@@ -57605,18 +57722,19 @@ type mqlAzureSubscriptionNetworkServiceFrontendIpConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionNetworkServiceFrontendIpConfigInternal
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Type               plugin.TValue[string]
-	Etag               plugin.TValue[string]
-	Properties         plugin.TValue[any]
-	Zones              plugin.TValue[[]any]
-	IsPublic           plugin.TValue[bool]
-	PublicIpAddressId  plugin.TValue[string]
-	PublicIpAddress    plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
-	Subnet             plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
-	PrivateIpAddress   plugin.TValue[string]
-	DdosCustomPolicyId plugin.TValue[string]
+	Id                       plugin.TValue[string]
+	Name                     plugin.TValue[string]
+	Type                     plugin.TValue[string]
+	Etag                     plugin.TValue[string]
+	Properties               plugin.TValue[any]
+	Zones                    plugin.TValue[[]any]
+	IsPublic                 plugin.TValue[bool]
+	PublicIpAddressId        plugin.TValue[string]
+	PublicIpAddress          plugin.TValue[*mqlAzureSubscriptionNetworkServiceIpAddress]
+	Subnet                   plugin.TValue[*mqlAzureSubscriptionNetworkServiceSubnet]
+	PrivateIpAddress         plugin.TValue[string]
+	DdosCustomPolicyId       plugin.TValue[string]
+	EnableConnectionTracking plugin.TValue[bool]
 }
 
 // createAzureSubscriptionNetworkServiceFrontendIpConfig creates a new instance of this resource
@@ -57726,6 +57844,10 @@ func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetPrivateIpAddress
 
 func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetDdosCustomPolicyId() *plugin.TValue[string] {
 	return &c.DdosCustomPolicyId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceFrontendIpConfig) GetEnableConnectionTracking() *plugin.TValue[bool] {
+	return &c.EnableConnectionTracking
 }
 
 // mqlAzureSubscriptionNetworkServiceLoadBalancerRule for the azure.subscription.networkService.loadBalancerRule resource
@@ -58453,6 +58575,7 @@ type mqlAzureSubscriptionNetworkServiceIpAddress struct {
 	IdleTimeoutInMinutes plugin.TValue[int64]
 	IpTags               plugin.TValue[[]any]
 	NatGateway           plugin.TValue[*mqlAzureSubscriptionNetworkServiceNatGateway]
+	UpgradedToV2         plugin.TValue[bool]
 }
 
 // createAzureSubscriptionNetworkServiceIpAddress creates a new instance of this resource
@@ -58582,6 +58705,10 @@ func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetNatGateway() *plugin.TV
 
 		return c.natGateway()
 	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceIpAddress) GetUpgradedToV2() *plugin.TValue[bool] {
+	return &c.UpgradedToV2
 }
 
 // mqlAzureSubscriptionNetworkServiceBastionHost for the azure.subscription.networkService.bastionHost resource
@@ -59756,30 +59883,31 @@ type mqlAzureSubscriptionNetworkServiceApplicationGateway struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionNetworkServiceApplicationGatewayInternal
-	Id                        plugin.TValue[string]
-	Name                      plugin.TValue[string]
-	Location                  plugin.TValue[string]
-	Tags                      plugin.TValue[map[string]any]
-	Type                      plugin.TValue[string]
-	Etag                      plugin.TValue[string]
-	Properties                plugin.TValue[any]
-	Policy                    plugin.TValue[*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy]
-	WafConfiguration          plugin.TValue[[]any]
-	SslPolicyType             plugin.TValue[string]
-	SslMinProtocolVersion     plugin.TValue[string]
-	SslCipherSuites           plugin.TValue[[]any]
-	Listeners                 plugin.TValue[[]any]
-	SslCertificates           plugin.TValue[[]any]
-	FrontendIpConfigs         plugin.TValue[[]any]
-	BackendHttpSettings       plugin.TValue[[]any]
-	SslProfiles               plugin.TValue[[]any]
-	TrustedRootCertificates   plugin.TValue[[]any]
-	TrustedClientCertificates plugin.TValue[[]any]
-	PrincipalId               plugin.TValue[string]
-	TenantId                  plugin.TValue[string]
-	IdentityType              plugin.TValue[string]
-	UserAssignedIdentities    plugin.TValue[[]any]
-	GatewayIpConfigs          plugin.TValue[[]any]
+	Id                                   plugin.TValue[string]
+	Name                                 plugin.TValue[string]
+	Location                             plugin.TValue[string]
+	Tags                                 plugin.TValue[map[string]any]
+	Type                                 plugin.TValue[string]
+	Etag                                 plugin.TValue[string]
+	Properties                           plugin.TValue[any]
+	Policy                               plugin.TValue[*mqlAzureSubscriptionNetworkServiceApplicationFirewallPolicy]
+	WafConfiguration                     plugin.TValue[[]any]
+	SslPolicyType                        plugin.TValue[string]
+	SslMinProtocolVersion                plugin.TValue[string]
+	SslCipherSuites                      plugin.TValue[[]any]
+	Listeners                            plugin.TValue[[]any]
+	SslCertificates                      plugin.TValue[[]any]
+	FrontendIpConfigs                    plugin.TValue[[]any]
+	BackendHttpSettings                  plugin.TValue[[]any]
+	SslProfiles                          plugin.TValue[[]any]
+	TrustedRootCertificates              plugin.TValue[[]any]
+	TrustedClientCertificates            plugin.TValue[[]any]
+	PrincipalId                          plugin.TValue[string]
+	TenantId                             plugin.TValue[string]
+	IdentityType                         plugin.TValue[string]
+	UserAssignedIdentities               plugin.TValue[[]any]
+	GatewayIpConfigs                     plugin.TValue[[]any]
+	DisableDefaultServerHeaderInResponse plugin.TValue[bool]
 }
 
 // createAzureSubscriptionNetworkServiceApplicationGateway creates a new instance of this resource
@@ -59961,6 +60089,10 @@ func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetGatewayIpConfi
 
 		return c.gatewayIpConfigs()
 	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceApplicationGateway) GetDisableDefaultServerHeaderInResponse() *plugin.TValue[bool] {
+	return &c.DisableDefaultServerHeaderInResponse
 }
 
 // mqlAzureSubscriptionNetworkServiceApplicationGatewayGatewayIpConfig for the azure.subscription.networkService.applicationGateway.gatewayIpConfig resource
@@ -62394,6 +62526,8 @@ type mqlAzureSubscriptionNetworkServiceVirtualHub struct {
 	HubRoutingPreference       plugin.TValue[string]
 	VirtualRouterAsn           plugin.TValue[int64]
 	VirtualRouterIps           plugin.TValue[[]any]
+	AddressPrefixV6            plugin.TValue[string]
+	VirtualRouterIpsV6         plugin.TValue[[]any]
 	ProvisioningState          plugin.TValue[string]
 	RoutingState               plugin.TValue[string]
 	SecurityProviderName       plugin.TValue[string]
@@ -62498,6 +62632,14 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualHub) GetVirtualRouterAsn() *pl
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualHub) GetVirtualRouterIps() *plugin.TValue[[]any] {
 	return &c.VirtualRouterIps
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualHub) GetAddressPrefixV6() *plugin.TValue[string] {
+	return &c.AddressPrefixV6
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualHub) GetVirtualRouterIpsV6() *plugin.TValue[[]any] {
+	return &c.VirtualRouterIpsV6
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualHub) GetProvisioningState() *plugin.TValue[string] {
@@ -62674,6 +62816,7 @@ type mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection struct {
 	Name                   plugin.TValue[string]
 	Etag                   plugin.TValue[string]
 	EnableInternetSecurity plugin.TValue[bool]
+	EnableOnlyIPv6Peering  plugin.TValue[bool]
 	ProvisioningState      plugin.TValue[string]
 	RoutingConfiguration   plugin.TValue[any]
 	RemoteVirtualNetwork   plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork]
@@ -62730,6 +62873,10 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection) GetEtag() *
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection) GetEnableInternetSecurity() *plugin.TValue[bool] {
 	return &c.EnableInternetSecurity
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection) GetEnableOnlyIPv6Peering() *plugin.TValue[bool] {
+	return &c.EnableOnlyIPv6Peering
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualHubVnetConnection) GetProvisioningState() *plugin.TValue[string] {
@@ -62946,6 +63093,7 @@ type mqlAzureSubscriptionNetworkServiceExpressRouteCircuit struct {
 	AuthorizationStatus              plugin.TValue[string]
 	ProvisioningState                plugin.TValue[string]
 	Stag                             plugin.TValue[int64]
+	ResiliencyLevel                  plugin.TValue[string]
 	Peerings                         plugin.TValue[[]any]
 	Authorizations                   plugin.TValue[[]any]
 }
@@ -63081,6 +63229,10 @@ func (c *mqlAzureSubscriptionNetworkServiceExpressRouteCircuit) GetProvisioningS
 
 func (c *mqlAzureSubscriptionNetworkServiceExpressRouteCircuit) GetStag() *plugin.TValue[int64] {
 	return &c.Stag
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceExpressRouteCircuit) GetResiliencyLevel() *plugin.TValue[string] {
+	return &c.ResiliencyLevel
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceExpressRouteCircuit) GetPeerings() *plugin.TValue[[]any] {
@@ -64627,21 +64779,27 @@ type mqlAzureSubscriptionNetworkServiceVirtualAppliance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionNetworkServiceVirtualApplianceInternal
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Location           plugin.TValue[string]
-	Tags               plugin.TValue[map[string]any]
-	Type               plugin.TValue[string]
-	Etag               plugin.TValue[string]
-	ProvisioningState  plugin.TValue[string]
-	Asn                plugin.TValue[int64]
-	Vendor             plugin.TValue[string]
-	BundledScaleUnit   plugin.TValue[string]
-	MarketplaceVersion plugin.TValue[string]
-	AddressPrefix      plugin.TValue[string]
-	DeploymentType     plugin.TValue[string]
-	SshPublicKey       plugin.TValue[string]
-	VirtualHub         plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualHub]
+	Id                   plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	Location             plugin.TValue[string]
+	Tags                 plugin.TValue[map[string]any]
+	Type                 plugin.TValue[string]
+	Etag                 plugin.TValue[string]
+	ProvisioningState    plugin.TValue[string]
+	Asn                  plugin.TValue[int64]
+	Vendor               plugin.TValue[string]
+	BundledScaleUnit     plugin.TValue[string]
+	MarketplaceVersion   plugin.TValue[string]
+	AddressPrefix        plugin.TValue[string]
+	AddressPrefixV6      plugin.TValue[string]
+	PrivateIpAddressV6   plugin.TValue[string]
+	AddressFamily        plugin.TValue[[]any]
+	DeploymentType       plugin.TValue[string]
+	SshPublicKey         plugin.TValue[string]
+	MigrationPhase       plugin.TValue[string]
+	MigrationPhaseStatus plugin.TValue[string]
+	MigrationType        plugin.TValue[string]
+	VirtualHub           plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualHub]
 }
 
 // createAzureSubscriptionNetworkServiceVirtualAppliance creates a new instance of this resource
@@ -64729,12 +64887,36 @@ func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetAddressPrefix() 
 	return &c.AddressPrefix
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetAddressPrefixV6() *plugin.TValue[string] {
+	return &c.AddressPrefixV6
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetPrivateIpAddressV6() *plugin.TValue[string] {
+	return &c.PrivateIpAddressV6
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetAddressFamily() *plugin.TValue[[]any] {
+	return &c.AddressFamily
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetDeploymentType() *plugin.TValue[string] {
 	return &c.DeploymentType
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetSshPublicKey() *plugin.TValue[string] {
 	return &c.SshPublicKey
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetMigrationPhase() *plugin.TValue[string] {
+	return &c.MigrationPhase
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetMigrationPhaseStatus() *plugin.TValue[string] {
+	return &c.MigrationPhaseStatus
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetMigrationType() *plugin.TValue[string] {
+	return &c.MigrationType
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceVirtualAppliance) GetVirtualHub() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualHub] {
@@ -64880,6 +65062,7 @@ type mqlAzureSubscriptionNetworkServicePublicIpPrefix struct {
 	ResourceGuid      plugin.TValue[string]
 	IpTags            plugin.TValue[[]any]
 	CustomIpPrefix    plugin.TValue[*mqlAzureSubscriptionNetworkServiceCustomIpPrefix]
+	UpgradedToV2      plugin.TValue[bool]
 }
 
 // createAzureSubscriptionNetworkServicePublicIpPrefix creates a new instance of this resource
@@ -64993,6 +65176,10 @@ func (c *mqlAzureSubscriptionNetworkServicePublicIpPrefix) GetCustomIpPrefix() *
 
 		return c.customIpPrefix()
 	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServicePublicIpPrefix) GetUpgradedToV2() *plugin.TValue[bool] {
+	return &c.UpgradedToV2
 }
 
 // mqlAzureSubscriptionNetworkServiceCustomIpPrefix for the azure.subscription.networkService.customIpPrefix resource
@@ -92696,6 +92883,7 @@ type mqlAzureSubscriptionRecoveryServicesServiceVault struct {
 	PrivateEndpointStateForSiteRecovery plugin.TValue[string]
 	SecureScore                         plugin.TValue[string]
 	CostManagementGranularityLevel      plugin.TValue[string]
+	RegionOfChoiceStatus                plugin.TValue[string]
 	SecuritySettings                    plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings]
 	Encryption                          plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultEncryption]
 	MonitoringSettings                  plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultMonitoringSettings]
@@ -92814,6 +93002,10 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSecureScore() *plu
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetCostManagementGranularityLevel() *plugin.TValue[string] {
 	return &c.CostManagementGranularityLevel
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetRegionOfChoiceStatus() *plugin.TValue[string] {
+	return &c.RegionOfChoiceStatus
 }
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSecuritySettings() *plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3689,6 +3689,7 @@ azure.subscription.networkService.applicationGateway.backendHttpSettings.trusted
 azure.subscription.networkService.applicationGateway.backendHttpSettings.trustedRootCertificateNames 13.29.1
 azure.subscription.networkService.applicationGateway.backendHttpSettings.validateCertChainAndExpiry 13.29.1
 azure.subscription.networkService.applicationGateway.backendHttpSettings.validateSNI 13.29.1
+azure.subscription.networkService.applicationGateway.disableDefaultServerHeaderInResponse 13.35.1
 azure.subscription.networkService.applicationGateway.etag 9.0.13
 azure.subscription.networkService.applicationGateway.frontendIpConfig 13.18.1
 azure.subscription.networkService.applicationGateway.frontendIpConfig.id 13.18.1
@@ -3906,6 +3907,7 @@ azure.subscription.networkService.expressRouteCircuit.peeringLocation 13.12.2
 azure.subscription.networkService.expressRouteCircuit.peerings 13.12.2
 azure.subscription.networkService.expressRouteCircuit.properties 13.12.2
 azure.subscription.networkService.expressRouteCircuit.provisioningState 13.12.2
+azure.subscription.networkService.expressRouteCircuit.resiliencyLevel 13.35.1
 azure.subscription.networkService.expressRouteCircuit.serviceProviderName 13.12.2
 azure.subscription.networkService.expressRouteCircuit.serviceProviderNotes 13.12.2
 azure.subscription.networkService.expressRouteCircuit.serviceProviderProvisioningState 13.12.2
@@ -4048,6 +4050,7 @@ azure.subscription.networkService.firewallPolicy.type 9.0.8
 azure.subscription.networkService.firewalls 9.0.8
 azure.subscription.networkService.frontendIpConfig 9.0.8
 azure.subscription.networkService.frontendIpConfig.ddosCustomPolicyId 13.25.1
+azure.subscription.networkService.frontendIpConfig.enableConnectionTracking 13.35.1
 azure.subscription.networkService.frontendIpConfig.etag 9.0.8
 azure.subscription.networkService.frontendIpConfig.id 9.0.8
 azure.subscription.networkService.frontendIpConfig.isPublic 9.0.8
@@ -4150,6 +4153,7 @@ azure.subscription.networkService.ipAddress.skuName 13.25.1
 azure.subscription.networkService.ipAddress.skuTier 13.25.1
 azure.subscription.networkService.ipAddress.tags 9.0.1
 azure.subscription.networkService.ipAddress.type 9.0.1
+azure.subscription.networkService.ipAddress.upgradedToV2 13.35.1
 azure.subscription.networkService.ipAddress.zones 13.1.8
 azure.subscription.networkService.ipAllocation 13.25.1
 azure.subscription.networkService.ipAllocation.allocationTags 13.25.1
@@ -4187,6 +4191,7 @@ azure.subscription.networkService.loadBalancer.inboundNatPools 9.0.8
 azure.subscription.networkService.loadBalancer.inboundNatRules 9.0.8
 azure.subscription.networkService.loadBalancer.loadBalancerRules 9.0.8
 azure.subscription.networkService.loadBalancer.location 9.0.8
+azure.subscription.networkService.loadBalancer.mode 13.35.1
 azure.subscription.networkService.loadBalancer.name 9.0.8
 azure.subscription.networkService.loadBalancer.outboundRules 9.0.8
 azure.subscription.networkService.loadBalancer.probes 9.0.8
@@ -4398,6 +4403,7 @@ azure.subscription.networkService.publicIpPrefix.skuName 13.25.1
 azure.subscription.networkService.publicIpPrefix.skuTier 13.25.1
 azure.subscription.networkService.publicIpPrefix.tags 13.25.1
 azure.subscription.networkService.publicIpPrefix.type 13.25.1
+azure.subscription.networkService.publicIpPrefix.upgradedToV2 13.35.1
 azure.subscription.networkService.publicIpPrefix.zones 13.25.1
 azure.subscription.networkService.publicIpPrefixes 13.25.1
 azure.subscription.networkService.route 11.4.28
@@ -4603,7 +4609,9 @@ azure.subscription.networkService.trafficManagerProfile.trafficViewEnrollmentSta
 azure.subscription.networkService.trafficManagerProfile.type 13.12.2
 azure.subscription.networkService.trafficManagerProfiles 13.12.2
 azure.subscription.networkService.virtualAppliance 13.25.1
+azure.subscription.networkService.virtualAppliance.addressFamily 13.35.1
 azure.subscription.networkService.virtualAppliance.addressPrefix 13.25.1
+azure.subscription.networkService.virtualAppliance.addressPrefixV6 13.35.1
 azure.subscription.networkService.virtualAppliance.asn 13.25.1
 azure.subscription.networkService.virtualAppliance.bundledScaleUnit 13.25.1
 azure.subscription.networkService.virtualAppliance.deploymentType 13.25.1
@@ -4611,7 +4619,11 @@ azure.subscription.networkService.virtualAppliance.etag 13.25.1
 azure.subscription.networkService.virtualAppliance.id 13.25.1
 azure.subscription.networkService.virtualAppliance.location 13.25.1
 azure.subscription.networkService.virtualAppliance.marketplaceVersion 13.25.1
+azure.subscription.networkService.virtualAppliance.migrationPhase 13.35.1
+azure.subscription.networkService.virtualAppliance.migrationPhaseStatus 13.35.1
+azure.subscription.networkService.virtualAppliance.migrationType 13.35.1
 azure.subscription.networkService.virtualAppliance.name 13.25.1
+azure.subscription.networkService.virtualAppliance.privateIpAddressV6 13.35.1
 azure.subscription.networkService.virtualAppliance.provisioningState 13.25.1
 azure.subscription.networkService.virtualAppliance.sshPublicKey 13.25.1
 azure.subscription.networkService.virtualAppliance.tags 13.25.1
@@ -4621,6 +4633,7 @@ azure.subscription.networkService.virtualAppliance.virtualHub 13.25.1
 azure.subscription.networkService.virtualAppliances 13.25.1
 azure.subscription.networkService.virtualHub 13.12.2
 azure.subscription.networkService.virtualHub.addressPrefix 13.12.2
+azure.subscription.networkService.virtualHub.addressPrefixV6 13.35.1
 azure.subscription.networkService.virtualHub.allowBranchToBranchTraffic 13.12.2
 azure.subscription.networkService.virtualHub.azureFirewall 13.12.2
 azure.subscription.networkService.virtualHub.etag 13.12.2
@@ -4650,9 +4663,11 @@ azure.subscription.networkService.virtualHub.tags 13.12.2
 azure.subscription.networkService.virtualHub.type 13.12.2
 azure.subscription.networkService.virtualHub.virtualRouterAsn 13.12.2
 azure.subscription.networkService.virtualHub.virtualRouterIps 13.12.2
+azure.subscription.networkService.virtualHub.virtualRouterIpsV6 13.35.1
 azure.subscription.networkService.virtualHub.virtualWan 13.12.2
 azure.subscription.networkService.virtualHub.vnetConnection 13.12.2
 azure.subscription.networkService.virtualHub.vnetConnection.enableInternetSecurity 13.12.2
+azure.subscription.networkService.virtualHub.vnetConnection.enableOnlyIPv6Peering 13.35.1
 azure.subscription.networkService.virtualHub.vnetConnection.etag 13.12.2
 azure.subscription.networkService.virtualHub.vnetConnection.id 13.12.2
 azure.subscription.networkService.virtualHub.vnetConnection.name 13.12.2
@@ -5198,6 +5213,7 @@ azure.subscription.recoveryServicesService.vault.redundancySettings 13.3.3
 azure.subscription.recoveryServicesService.vault.redundancySettings.crossRegionRestore 13.3.3
 azure.subscription.recoveryServicesService.vault.redundancySettings.id 13.3.3
 azure.subscription.recoveryServicesService.vault.redundancySettings.storageRedundancy 13.3.3
+azure.subscription.recoveryServicesService.vault.regionOfChoiceStatus 13.35.1
 azure.subscription.recoveryServicesService.vault.secureScore 13.3.3
 azure.subscription.recoveryServicesService.vault.securitySettings 13.3.3
 azure.subscription.recoveryServicesService.vault.securitySettings.enhancedSecurityState 13.3.3

--- a/providers/azure/resources/bugfix_regression_test.go
+++ b/providers/azure/resources/bugfix_regression_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	compute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
 	clusters "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	compute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -26,7 +26,7 @@ import (
 	"go.mondoo.com/mql/v13/utils/stringx"
 	"golang.org/x/sync/errgroup"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 )
 
 func (a *mqlAzureSubscriptionNetworkService) id() (string, error) {
@@ -659,6 +659,10 @@ func (a *mqlAzureSubscriptionNetworkService) loadBalancers() ([]any, error) {
 				lbSkuName = (*string)(lb.SKU.Name)
 				lbSkuTier = (*string)(lb.SKU.Tier)
 			}
+			var lbMode string
+			if lb.Properties != nil && lb.Properties.Mode != nil {
+				lbMode = string(*lb.Properties.Mode)
+			}
 			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.loadBalancer",
 				map[string]*llx.RawData{
 					"id":         llx.StringDataPtr(lb.ID),
@@ -667,6 +671,7 @@ func (a *mqlAzureSubscriptionNetworkService) loadBalancers() ([]any, error) {
 					"etag":       llx.StringDataPtr(lb.Etag),
 					"sku":        llx.StringDataPtr(lbSkuName),
 					"skuTier":    llx.StringDataPtr(lbSkuTier),
+					"mode":       llx.StringData(lbMode),
 					"tags":       llx.MapData(convert.PtrMapStrToInterface(lb.Tags), types.String),
 					"type":       llx.StringDataPtr(lb.Type),
 					"properties": llx.DictData(lbProps),
@@ -762,7 +767,9 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 		var privateIpAddress string
 		var ddosCustomPolicyId string
 		var publicIpAddressIDPtr, subnetIDPtr *string
+		var enableConnectionTracking *bool
 		if ipConfig.Properties != nil {
+			enableConnectionTracking = ipConfig.Properties.EnableConnectionTracking
 			if ipConfig.Properties.PublicIPAddress != nil && ipConfig.Properties.PublicIPAddress.ID != nil {
 				isPublic = true
 				publicIpAddressId = *ipConfig.Properties.PublicIPAddress.ID
@@ -791,6 +798,8 @@ func (a *mqlAzureSubscriptionNetworkServiceLoadBalancer) frontendIpConfigs() ([]
 				"publicIpAddressId":  llx.StringData(publicIpAddressId),
 				"privateIpAddress":   llx.StringData(privateIpAddress),
 				"ddosCustomPolicyId": llx.StringData(ddosCustomPolicyId),
+
+				"enableConnectionTracking": llx.BoolDataPtr(enableConnectionTracking),
 			})
 		if err != nil {
 			return nil, err
@@ -3579,6 +3588,13 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 		userAssignedIdentityIds = sortedUserAssignedIdentityIDs(ag.Identity.UserAssignedIdentities)
 	}
 
+	// The default Server header suppression lives on the gateway's global
+	// configuration block, which is absent on gateways that never set one.
+	var disableDefaultServerHeaderInResponse *bool
+	if ag.Properties != nil && ag.Properties.GlobalConfiguration != nil {
+		disableDefaultServerHeaderInResponse = ag.Properties.GlobalConfiguration.DisableDefaultServerHeaderInResponse
+	}
+
 	args := map[string]*llx.RawData{
 		"id":                        llx.StringDataPtr(ag.ID),
 		"name":                      llx.StringDataPtr(ag.Name),
@@ -3600,6 +3616,8 @@ func azureAppGatewayToMql(runtime *plugin.Runtime, ag network.ApplicationGateway
 		"principalId":               llx.StringDataPtr(principalId),
 		"tenantId":                  llx.StringDataPtr(tenantId),
 		"identityType":              llx.StringDataPtr(identityType),
+
+		"disableDefaultServerHeaderInResponse": llx.BoolDataPtr(disableDefaultServerHeaderInResponse),
 	}
 
 	mqlAg, err := CreateResource(runtime, "azure.subscription.networkService.applicationGateway", args)
@@ -4454,10 +4472,12 @@ func azureFirewallPolicyToMql(runtime *plugin.Runtime, fwp network.FirewallPolic
 func azureIpToMql(runtime *plugin.Runtime, ip network.PublicIPAddress) (*mqlAzureSubscriptionNetworkServiceIpAddress, error) {
 	var ipAllocationMethod, ipVersion, ddosProtectionMode, associatedResourceId string
 	var ipAddr, publicIpPrefixId, natGatewayId *string
+	var upgradedToV2 *bool
 	var idleTimeoutInMinutes int64
 	ipTags := []any{}
 	if ip.Properties != nil {
 		ipAddr = ip.Properties.IPAddress
+		upgradedToV2 = ip.Properties.UpgradedToV2
 		if ip.Properties.PublicIPAllocationMethod != nil {
 			ipAllocationMethod = string(*ip.Properties.PublicIPAllocationMethod)
 		}
@@ -4517,6 +4537,7 @@ func azureIpToMql(runtime *plugin.Runtime, ip network.PublicIPAddress) (*mqlAzur
 			"skuTier":              llx.StringData(skuTier),
 			"idleTimeoutInMinutes": llx.IntData(idleTimeoutInMinutes),
 			"ipTags":               llx.ArrayData(ipTags, types.Dict),
+			"upgradedToV2":         llx.BoolDataPtr(upgradedToV2),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/network_appgateway_test.go
+++ b/providers/azure/resources/network_appgateway_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/azure/resources/network_avnm.go
+++ b/providers/azure/resources/network_avnm.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_avnm_test.go
+++ b/providers/azure/resources/network_avnm_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_connectivity.go
+++ b/providers/azure/resources/network_connectivity.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_connectivity_test.go
+++ b/providers/azure/resources/network_connectivity_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_expansion.go
+++ b/providers/azure/resources/network_expansion.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	trafficmanager "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -557,6 +557,8 @@ func azureVirtualHubToMql(runtime *plugin.Runtime, h *network.VirtualHub) (plugi
 		"provisioningState":          llx.StringDataPtr(nil),
 		"routingState":               llx.StringDataPtr(nil),
 		"securityProviderName":       llx.StringDataPtr(nil),
+		"addressPrefixV6":            llx.StringDataPtr(nil),
+		"virtualRouterIpsV6":         llx.ArrayData([]any{}, types.String),
 	}
 
 	var wanId, fwId *string
@@ -591,6 +593,15 @@ func azureVirtualHubToMql(runtime *plugin.Runtime, h *network.VirtualHub) (plugi
 			}
 		}
 		args["virtualRouterIps"] = llx.ArrayData(ips, types.String)
+
+		args["addressPrefixV6"] = llx.StringDataPtr(props.AddressPrefixV6)
+		ipsV6 := []any{}
+		for _, ip := range props.VirtualRouterIPsV6 {
+			if ip != nil {
+				ipsV6 = append(ipsV6, *ip)
+			}
+		}
+		args["virtualRouterIpsV6"] = llx.ArrayData(ipsV6, types.String)
 
 		if props.VirtualWan != nil {
 			wanId = props.VirtualWan.ID
@@ -744,8 +755,13 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualHub) vnetConnections() ([]any,
 			var routingDict any
 			var provState *string
 			var remoteId *string
+			var enableOnlyIPv6Peering *bool
 			if c.Properties != nil {
 				enableInternetSecurity = c.Properties.EnableInternetSecurity
+				if c.Properties.EnableOnlyIPv6Peering != nil {
+					b := *c.Properties.EnableOnlyIPv6Peering == network.EnableOnlyIPv6PeeringStateEnabled
+					enableOnlyIPv6Peering = &b
+				}
 				if c.Properties.RoutingConfiguration != nil {
 					d, err := convert.JsonToDict(c.Properties.RoutingConfiguration)
 					if err != nil {
@@ -767,6 +783,7 @@ func (a *mqlAzureSubscriptionNetworkServiceVirtualHub) vnetConnections() ([]any,
 					"name":                   llx.StringDataPtr(c.Name),
 					"etag":                   llx.StringDataPtr(c.Etag),
 					"enableInternetSecurity": llx.BoolDataPtr(enableInternetSecurity),
+					"enableOnlyIPv6Peering":  llx.BoolDataPtr(enableOnlyIPv6Peering),
 					"provisioningState":      llx.StringDataPtr(provState),
 					"routingConfiguration":   llx.DictData(routingDict),
 				})
@@ -974,6 +991,7 @@ func azureExpressRouteCircuitToMql(runtime *plugin.Runtime, c *network.ExpressRo
 		"authorizationStatus":              llx.StringDataPtr(nil),
 		"provisioningState":                llx.StringDataPtr(nil),
 		"stag":                             llx.IntDataDefault[int32](nil, 0),
+		"resiliencyLevel":                  llx.StringDataPtr(nil),
 	}
 
 	if c.SKU != nil {
@@ -1006,6 +1024,10 @@ func azureExpressRouteCircuitToMql(runtime *plugin.Runtime, c *network.ExpressRo
 		if props.ProvisioningState != nil {
 			s := string(*props.ProvisioningState)
 			args["provisioningState"] = llx.StringData(s)
+		}
+		if props.ResiliencyLevel != nil {
+			s := string(*props.ResiliencyLevel)
+			args["resiliencyLevel"] = llx.StringData(s)
 		}
 		if props.ExpressRoutePort != nil {
 			args["expressRoutePortId"] = llx.StringDataPtr(props.ExpressRoutePort.ID)

--- a/providers/azure/resources/network_firewallpolicy_test.go
+++ b/providers/azure/resources/network_firewallpolicy_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_ip_prefixes.go
+++ b/providers/azure/resources/network_ip_prefixes.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -62,7 +62,9 @@ func azurePublicIpPrefixToMql(runtime *plugin.Runtime, prefix *network.PublicIPP
 	var prefixLength int64
 	ipTags := []any{}
 	var customIpPrefixId *string
+	var upgradedToV2 *bool
 	if p := prefix.Properties; p != nil {
+		upgradedToV2 = p.UpgradedToV2
 		if p.ProvisioningState != nil {
 			provisioningState = string(*p.ProvisioningState)
 		}
@@ -109,6 +111,7 @@ func azurePublicIpPrefixToMql(runtime *plugin.Runtime, prefix *network.PublicIPP
 			"skuTier":           llx.StringData(skuTier),
 			"resourceGuid":      llx.StringData(resourceGuid),
 			"ipTags":            llx.ArrayData(ipTags, types.Dict),
+			"upgradedToV2":      llx.BoolDataPtr(upgradedToV2),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/network_ipgroup.go
+++ b/providers/azure/resources/network_ipgroup.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_ipgroup_test.go
+++ b/providers/azure/resources/network_ipgroup_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/azure/resources/network_lb_bastion_ipconfig.go
+++ b/providers/azure/resources/network_lb_bastion_ipconfig.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )

--- a/providers/azure/resources/network_nic_effective_routes.go
+++ b/providers/azure/resources/network_nic_effective_routes.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/azure/connection"

--- a/providers/azure/resources/network_nic_effective_typed.go
+++ b/providers/azure/resources/network_nic_effective_typed.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strconv"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"

--- a/providers/azure/resources/network_nic_effective_typed_test.go
+++ b/providers/azure/resources/network_nic_effective_typed_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 )
 
 func TestRuleString(t *testing.T) {

--- a/providers/azure/resources/network_nic_ipconfig.go
+++ b/providers/azure/resources/network_nic_ipconfig.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_nic_ipconfig_test.go
+++ b/providers/azure/resources/network_nic_ipconfig_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/azure/resources/network_perimeter.go
+++ b/providers/azure/resources/network_perimeter.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_perimeter_test.go
+++ b/providers/azure/resources/network_perimeter_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/azure/resources/network_test.go
+++ b/providers/azure/resources/network_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	trafficmanager "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager"
 	"github.com/stretchr/testify/assert"
 )

--- a/providers/azure/resources/network_tier3_test.go
+++ b/providers/azure/resources/network_tier3_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/network_virtual_appliances.go
+++ b/providers/azure/resources/network_virtual_appliances.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -46,11 +46,28 @@ func (a *mqlAzureSubscriptionNetworkService) virtualAppliances() ([]any, error) 
 			}
 			var provisioningState, addressPrefix, deploymentType, sshPublicKey string
 			var vendor, bundledScaleUnit, marketplaceVersion string
+			var addressPrefixV6, privateIpAddressV6 string
+			var migrationPhase, migrationPhaseStatus, migrationType string
+			addressFamily := []any{}
 			var asn int64
 			var virtualHubId *string
 			if p := nva.Properties; p != nil {
 				if p.ProvisioningState != nil {
 					provisioningState = string(*p.ProvisioningState)
+				}
+				addressPrefixV6 = convert.ToValue(p.AddressPrefixV6)
+				privateIpAddressV6 = convert.ToValue(p.PrivateIPAddressV6)
+				for _, af := range p.AddressFamily {
+					if af != nil {
+						addressFamily = append(addressFamily, string(*af))
+					}
+				}
+				if ms := p.MigrationStatus; ms != nil {
+					migrationPhase = convert.ToValue(ms.MigrationPhase)
+					migrationPhaseStatus = convert.ToValue(ms.MigrationPhaseStatus)
+					if ms.MigrationType != nil {
+						migrationType = string(*ms.MigrationType)
+					}
 				}
 				addressPrefix = convert.ToValue(p.AddressPrefix)
 				deploymentType = convert.ToValue(p.DeploymentType)
@@ -83,6 +100,13 @@ func (a *mqlAzureSubscriptionNetworkService) virtualAppliances() ([]any, error) 
 					"addressPrefix":      llx.StringData(addressPrefix),
 					"deploymentType":     llx.StringData(deploymentType),
 					"sshPublicKey":       llx.StringData(sshPublicKey),
+
+					"addressPrefixV6":      llx.StringData(addressPrefixV6),
+					"privateIpAddressV6":   llx.StringData(privateIpAddressV6),
+					"addressFamily":        llx.ArrayData(addressFamily, types.String),
+					"migrationPhase":       llx.StringData(migrationPhase),
+					"migrationPhaseStatus": llx.StringData(migrationPhaseStatus),
+					"migrationType":        llx.StringData(migrationType),
 				})
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/network_waf_rules.go
+++ b/providers/azure/resources/network_waf_rules.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"fmt"
 
-	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -341,6 +341,11 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 		costManagementGranularityLevel = string(*props.CostManagementSettings.GranularityLevel)
 	}
 
+	var regionOfChoiceStatus string
+	if props.RegionOfChoiceSettings != nil && props.RegionOfChoiceSettings.Status != nil {
+		regionOfChoiceStatus = string(*props.RegionOfChoiceSettings.Status)
+	}
+
 	resource, err := CreateResource(runtime, ResourceAzureSubscriptionRecoveryServicesServiceVault,
 		map[string]*llx.RawData{
 			"id":                                  llx.StringDataPtr(vault.ID),
@@ -357,6 +362,7 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 			"privateEndpointStateForSiteRecovery": llx.StringData(privateEndpointStateForSiteRecovery),
 			"secureScore":                         llx.StringData(secureScore),
 			"costManagementGranularityLevel":      llx.StringData(costManagementGranularityLevel),
+			"regionOfChoiceStatus":                llx.StringData(regionOfChoiceStatus),
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Bumps two Azure ARM SDKs and adds the fields they expose on resources the provider already ships. Companion to #10010, which carries the pure dependency bumps from the same sweep.

## Bumps

| Module | From | To |
|---|---|---|
| `resourcemanager/network/armnetwork` | v10.0.0 | **v11.0.0** |
| `resourcemanager/recoveryservices/armrecoveryservices/v3` | v3.1.0 | v3.2.0 |

## Breaking changes that did not reach a shipped field

`armnetwork` v11 is a major, but its entire breaking surface is **two operations**:

- `ServiceGatewaysClient.BeginUpdateAddressLocations` became non-LRO
- `ServiceGatewaysClient.BeginUpdateServices` became non-LRO

`apidiff` between v10.0.0 and v11.0.0 reports exactly four removed exported symbols — those two methods and their two option types. Intersecting that removal set against every capitalised identifier used in `providers/azure` returns **empty**: the provider does not reference `ServiceGatewaysClient` at all. This is stated from the grep rather than inferred from a green build, since a clean compile would look identical if we had used the client and the new synchronous signature happened to be accepted.

`structdiff --types-from providers/azure` reports **no removed and no retyped field** on any type the provider names — only three additive ones (`ApplicationRule.SourceKubeSelectorGroups`, `IPTag.FirstPartyServiceTagID`, `LoadBalancerPropertiesFormat.Mode`).

The migration cost from the bump itself is **25 changed lines across 25 files, every one an import path**. The alias (`network`) carries no version, so it needed no edit. One comment naming `armnetwork v10` was deliberately left alone: it records that v9 misshaped `EffectiveNetworkSecurityGroup.TagMap` and v10 corrected it, which is a fact about history, not about the current pin.

`armrecoveryservices` v3.2.0 is additive only: a new `RegionOfChoiceSettings` struct and the `VaultProperties` field pointing at it.

## New fields

All 16 read from responses the provider **already fetches**, so this adds **no new API call** and the permission manifest is unchanged at **330 entries**. `.lr.versions` entries are all at `13.35.1` (current `13.35.0` plus a patch); `config.go` is untouched.

| Resource | Field | Why it matters |
|---|---|---|
| `applicationGateway` | `disableDefaultServerHeaderInResponse` | When false the gateway advertises itself in every response. Standard banner-disclosure check with no field until now. |
| `expressRouteCircuit` | `resiliencyLevel` | `Standard` / `High` / `Maximum`. A Standard circuit is a single point of failure for the hybrid link it carries. |
| `ipAddress`, `publicIpPrefix` | `upgradedToV2` | Migration state off the retiring Basic SKU. |
| `recoveryServicesService.vault` | `regionOfChoiceStatus` | Whether backups replicate to a chosen secondary region rather than the default paired region. Data-residency question. |
| `virtualHub.vnetConnection` | `enableOnlyIPv6Peering` | Changes what the spoke can reach over the peering. |
| `virtualHub` | `addressPrefixV6`, `virtualRouterIpsV6` | IPv6 half of the hub address plan. |
| `virtualAppliance` | `addressPrefixV6`, `privateIpAddressV6`, `addressFamily` | An audit reading only the IPv4 fields sees half a dual-stack appliance's address surface. |
| `virtualAppliance` | `migrationPhase`, `migrationPhaseStatus`, `migrationType` | NVA migration workflow state. |
| `loadBalancer` | `mode` | New `Advanced` operating mode. |
| `frontendIpConfig` | `enableConnectionTracking` | Per-flow state tracking on the frontend. |

`VirtualApplianceMigrationStatus` is three scalars with no natural ID and no nested resource references, so per the sub-resource bar it is flattened onto `virtualAppliance` with a `migration*` prefix rather than given its own resource.

`EnableOnlyIPv6Peering` is a two-state SDK enum (`Enabled` / `Disabled`) and is modelled as a `bool`. `RegionOfChoiceSettings.Status` has three states (`Enabled` / `Disabled` / `Invalid`), so it stays a string to avoid collapsing `Invalid` into `false`.

Each new field is seeded in its resource's argument map at every construction site, including the pre-seeded default blocks in `network_expansion.go`, so a resource built along a path where the SDK omits the value reports null rather than degrading the field for the whole list.

## Enum comment corrections

`enumdrift.py` reported 23 hits against `azure.lr`. **Only 3 are genuine.** `azure.lr` spans roughly 30 Azure SDKs while the tool was pointed at armnetwork, so any field belonging to another service gets paired against whichever armnetwork enum has a similar value set. Running the same check against v10 confirmed **none** of the drift was introduced by this bump.

Fixed, each confirmed against the SDK type that actually backs the field:

- `interface.effectiveRoute.nextHopType` — added `VirtualApplianceEcmp` (`EffectiveRoute.NextHopType` is `*RouteNextHopType`). A route through ECMP appliances was invisible to a `nextHopType == "VirtualAppliance"` filter. The neighbouring `nextHopIpAddress` comment claimed those addresses are set only for `VirtualAppliance`; corrected to name both.
- `applicationFirewallPolicy.managedRuleSet.ruleGroupOverride.rule.action` — added `CAPTCHA` and `AnomalyScoring`. The field is `ManagedRuleOverride.Action *ActionType`, which carries both; the tool paired it against `WebApplicationFirewallAction` and so under-reported.
- `applicationFirewallPolicy.customRule.action` — added `CAPTCHA` (`*WebApplicationFirewallAction`).

Deliberately **not** changed, because the comments are already correct — `frontDoorService.wafPolicy.*` is backed by **armfrontdoor**, not armnetwork:

- `matchCondition.matchVariable` — armfrontdoor's enum is `Cookies` / `RequestHeader` / `SocketAddr`, exactly as documented. Applying the reported "fix" would have told policy authors to match on `RequestCookies` / `RequestHeaders`, values that endpoint never returns.
- `matchCondition.operator` — `RegEx` and `ServiceTagMatch` are correct for Front Door; `Regex` is armnetwork's spelling.
- `customRule.ruleType` — armfrontdoor's `RuleType` has no `Invalid` member.
- `managedRuleSet.ruleSetAction` — `ManagedRuleSetActionType` is exactly `Block` / `Log` / `Redirect`.

The remaining hits sit on armsql, armredis, armdeployments, Defender and Microsoft Graph types. Some may carry real drift against *their own* SDKs; that is a separate audit and does not belong in an armnetwork bump.

## Verification

```
cd providers/azure && go build ./... && go test ./... && gofmt -l .
```

Builds clean, all tests pass, `gofmt` reports nothing. `go.sum` moves only the two intended modules — no unrelated `go mod tidy` drift rode along. `azure.permissions.json` is unchanged (the regenerated file differs only in the `version` and `generated_at` metadata, which reflects the 13.35.0 release on main rather than anything here, so it is left as-is).

## Not verified

**No part of this was exercised against a live Azure subscription.** Every claim above rests on the compiler, the unit tests, the SDK diffs and the SDK type definitions — not on an API response. Specifically unproven:

- whether `upgradedToV2` is populated on addresses and prefixes in practice, or only on ones Azure has actually processed;
- whether `GlobalConfiguration` is present on ordinary Application Gateways or only on those that have explicitly configured it (the field is modelled null-safe either way);
- whether `regionOfChoiceSettings` appears on vaults that have never enabled the feature;
- whether `MigrationStatus` is populated outside an in-flight NVA migration.

In each case an absent value yields null rather than a wrong reading, so the failure mode is a missing answer and not a false one. Live confirmation against a subscription with an ExpressRoute circuit, an NVA and a Recovery Services vault would be worth doing before anyone writes policy against these.
