### PR TITLE
🐛 gcp: stop a BigQuery base-table reference standing in for the real table

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -372,25 +372,74 @@ func (g *mqlGcpProjectBigqueryServiceTableBigLakeConfig) connection() (*mqlGcpPr
 	return notFound()
 }
 
-// resolveBaseTable builds the typed table that a snapshot or clone derives from.
-// The BigQuery base-table reference carries only project/dataset/table IDs, so
-// the table's location is inherited from the owning table (a base table lives in
-// the same location as its snapshots and clones).
+// bigqueryTableId is the resource identity of a table. The runtime stores the
+// resource under this value, so it is also what a cache lookup has to rebuild.
+func bigqueryTableId(projectId, datasetId, tableId string) string {
+	return fmt.Sprintf("gcp.project.bigqueryService.table/%s/%s/%s", projectId, datasetId, tableId)
+}
+
+// bigqueryTableCacheKey is the runtime cache key for a table resource, in the
+// runtime's "<resource name>\x00<id>" form.
+func bigqueryTableCacheKey(projectId, datasetId, tableId string) string {
+	return "gcp.project.bigqueryService.table\x00" + bigqueryTableId(projectId, datasetId, tableId)
+}
+
+// resolveBaseTable returns the table that a snapshot or clone derives from.
+//
+// The BigQuery reference carries only project/dataset/table IDs. Building a
+// resource out of those alone is not safe: the table has no init, so the
+// resource would be created from exactly those args and every other field would
+// read null. Worse, the runtime cache is first-writer-wins on the table's id, so
+// that stand-in would take the key and be handed back to the later full listing
+// of the same table, discarding the metadata that listing had just fetched.
+//
+// So the reference is resolved instead. A table already listed in this scan is
+// returned straight from the cache at no cost; otherwise exactly that one
+// table's metadata is fetched. Listing the whole referenced dataset would cost
+// one API call per table in it to answer a single reference.
+//
+// A base table that has been deleted, or that lives in a project the caller
+// cannot read, resolves to null rather than to a stand-in.
 func (g *mqlGcpProjectBigqueryServiceTable) resolveBaseTable(ref *bigquery.Table) (*mqlGcpProjectBigqueryServiceTable, error) {
 	if ref == nil {
 		return nil, nil
 	}
-	location := ""
-	if g.Location.Error == nil {
-		location = g.Location.Data
+
+	key := bigqueryTableCacheKey(ref.ProjectID, ref.DatasetID, ref.TableID)
+	if cached, ok := g.MqlRuntime.Resources.Get(key); ok {
+		return cached.(*mqlGcpProjectBigqueryServiceTable), nil
 	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
-		"id":        llx.StringData(ref.TableID),
-		"projectId": llx.StringData(ref.ProjectID),
-		"datasetId": llx.StringData(ref.DatasetID),
-		"name":      llx.StringData(ref.TableID),
-		"location":  llx.StringData(location),
-	})
+
+	conn, ok := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, errors.New("resolving a base table requires a GCP connection")
+	}
+	httpClient, err := conn.Client("https://www.googleapis.com/auth/bigquery")
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	client, err := bigquery.NewClient(ctx, ref.ProjectID, option.WithHTTPClient(httpClient))
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	table := client.DatasetInProject(ref.ProjectID, ref.DatasetID).Table(ref.TableID)
+	metadata, err := table.Metadata(ctx)
+	if err != nil {
+		// A snapshot outlives the table it was taken from, so a missing or
+		// unreadable base table is an ordinary state rather than a failure.
+		// Report it as null instead of failing the whole table listing.
+		log.Debug().Err(err).
+			Str("project", ref.ProjectID).
+			Str("dataset", ref.DatasetID).
+			Str("table", ref.TableID).
+			Msg("could not read base table metadata")
+		return nil, nil
+	}
+
+	res, err := newMqlBigqueryTable(g.MqlRuntime, table, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -673,6 +722,26 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 			return nil, err
 		}
 
+		mqlInstance, err := newMqlBigqueryTable(g.MqlRuntime, table, metadata)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlInstance)
+	}
+
+	return res, nil
+}
+
+// newMqlBigqueryTable maps a BigQuery table and its metadata onto the mql
+// resource.
+//
+// Every path that produces a gcp.project.bigqueryService.table goes through
+// here. The resource cache is first-writer-wins on
+// "gcp.project.bigqueryService.table/<project>/<dataset>/<table>", so a partially
+// populated table built anywhere else would take that key and stand in for the
+// real one for the rest of the scan.
+func newMqlBigqueryTable(runtime *plugin.Runtime, table *bigquery.Table, metadata *bigquery.TableMetadata) (plugin.Resource, error) {
+	{
 		var kmsName string
 		if metadata.EncryptionConfig != nil {
 			kmsName = metadata.EncryptionConfig.KMSKeyName
@@ -752,7 +821,7 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 				if fk == nil {
 					continue
 				}
-				mqlFk, err := newMqlBigqueryForeignKey(g.MqlRuntime, table, fk)
+				mqlFk, err := newMqlBigqueryForeignKey(runtime, table, fk)
 				if err != nil {
 					return nil, err
 				}
@@ -765,7 +834,7 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 		// managed-storage table that has no external files at all.
 		bigLakeData := llx.NilData
 		if blc := metadata.BigLakeConfiguration; blc != nil {
-			mqlBigLake, err := CreateResource(g.MqlRuntime, "gcp.project.bigqueryService.table.bigLakeConfig", map[string]*llx.RawData{
+			mqlBigLake, err := CreateResource(runtime, "gcp.project.bigqueryService.table.bigLakeConfig", map[string]*llx.RawData{
 				"__id":        llx.StringData(fmt.Sprintf("%s/%s/%s/bigLakeConfig", table.ProjectID, table.DatasetID, table.TableID)),
 				"storageUri":  llx.StringData(blc.StorageURI),
 				"fileFormat":  llx.StringData(string(blc.FileFormat)),
@@ -780,7 +849,7 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 			bigLakeData = llx.ResourceData(mqlBigLake, "gcp.project.bigqueryService.table.bigLakeConfig")
 		}
 
-		mqlInstance, err := CreateResource(g.MqlRuntime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
+		mqlInstance, err := CreateResource(runtime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
 			"id":                             llx.StringData(table.TableID),
 			"projectId":                      llx.StringData(table.ProjectID),
 			"datasetId":                      llx.StringData(table.DatasetID),
@@ -826,10 +895,8 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 		if metadata.CloneDefinition != nil {
 			mqlTable.cacheCloneBaseTable = metadata.CloneDefinition.BaseTableReference
 		}
-		res = append(res, mqlInstance)
-
+		return mqlInstance, nil
 	}
-	return res, nil
 }
 
 func (g *mqlGcpProjectBigqueryServiceTable) id() (string, error) {
@@ -847,7 +914,7 @@ func (g *mqlGcpProjectBigqueryServiceTable) id() (string, error) {
 		return "", g.Id.Error
 	}
 	id := g.Id.Data
-	return fmt.Sprintf("gcp.project.bigqueryService.table/%s/%s/%s", projectId, datasetId, id), nil
+	return bigqueryTableId(projectId, datasetId, id), nil
 }
 
 func (g *mqlGcpProjectBigqueryServiceDataset) models() ([]any, error) {

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -428,15 +428,23 @@ func (g *mqlGcpProjectBigqueryServiceTable) resolveBaseTable(ref *bigquery.Table
 	table := client.DatasetInProject(ref.ProjectID, ref.DatasetID).Table(ref.TableID)
 	metadata, err := table.Metadata(ctx)
 	if err != nil {
-		// A snapshot outlives the table it was taken from, so a missing or
-		// unreadable base table is an ordinary state rather than a failure.
-		// Report it as null instead of failing the whole table listing.
-		log.Debug().Err(err).
-			Str("project", ref.ProjectID).
-			Str("dataset", ref.DatasetID).
-			Str("table", ref.TableID).
-			Msg("could not read base table metadata")
-		return nil, nil
+		// A snapshot outlives the table it was taken from, so a base table that
+		// is gone or that this caller cannot read is an ordinary state rather
+		// than a failure. Report it as null.
+		//
+		// Anything else (a timeout, a 500, a quota rejection) is a real failure
+		// and has to surface: degrading it to null would report "no base table"
+		// for a table that exists, and a check asserting the base table is
+		// absent would pass on a network blip.
+		if isSkippable(err) {
+			log.Debug().Err(err).
+				Str("project", ref.ProjectID).
+				Str("dataset", ref.DatasetID).
+				Str("table", ref.TableID).
+				Msg("could not read base table metadata")
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	res, err := newMqlBigqueryTable(g.MqlRuntime, table, metadata)
@@ -741,162 +749,160 @@ func (g *mqlGcpProjectBigqueryServiceDataset) tables() ([]any, error) {
 // populated table built anywhere else would take that key and stand in for the
 // real one for the rest of the scan.
 func newMqlBigqueryTable(runtime *plugin.Runtime, table *bigquery.Table, metadata *bigquery.TableMetadata) (plugin.Resource, error) {
-	{
-		var kmsName string
-		if metadata.EncryptionConfig != nil {
-			kmsName = metadata.EncryptionConfig.KMSKeyName
-		}
+	var kmsName string
+	if metadata.EncryptionConfig != nil {
+		kmsName = metadata.EncryptionConfig.KMSKeyName
+	}
 
-		var clusteringFields []any
-		if metadata.Clustering != nil {
-			clusteringFields = convert.SliceAnyToInterface(metadata.Clustering.Fields)
-		}
+	var clusteringFields []any
+	if metadata.Clustering != nil {
+		clusteringFields = convert.SliceAnyToInterface(metadata.Clustering.Fields)
+	}
 
-		externalDataConfig, err := convert.JsonToDict(metadata.ExternalDataConfig)
-		if err != nil {
-			return nil, err
-		}
+	externalDataConfig, err := convert.JsonToDict(metadata.ExternalDataConfig)
+	if err != nil {
+		return nil, err
+	}
 
-		materializedView, err := convert.JsonToDict(metadata.MaterializedView)
-		if err != nil {
-			return nil, err
-		}
+	materializedView, err := convert.JsonToDict(metadata.MaterializedView)
+	if err != nil {
+		return nil, err
+	}
 
-		rangePartitioning, err := convert.JsonToDict(metadata.RangePartitioning)
-		if err != nil {
-			return nil, err
-		}
+	rangePartitioning, err := convert.JsonToDict(metadata.RangePartitioning)
+	if err != nil {
+		return nil, err
+	}
 
-		schema, err := convert.JsonToDictSlice(metadata.Schema)
-		if err != nil {
-			return nil, err
-		}
+	schema, err := convert.JsonToDictSlice(metadata.Schema)
+	if err != nil {
+		return nil, err
+	}
 
-		timePartitioning, err := convert.JsonToDict(metadata.TimePartitioning)
-		if err != nil {
-			return nil, err
-		}
+	timePartitioning, err := convert.JsonToDict(metadata.TimePartitioning)
+	if err != nil {
+		return nil, err
+	}
 
-		var snapshotTime *time.Time
-		if metadata.SnapshotDefinition != nil {
-			snapshotTime = &metadata.SnapshotDefinition.SnapshotTime
-		}
+	var snapshotTime *time.Time
+	if metadata.SnapshotDefinition != nil {
+		snapshotTime = &metadata.SnapshotDefinition.SnapshotTime
+	}
 
-		var cloneTime *time.Time
-		if metadata.CloneDefinition != nil {
-			cloneTime = &metadata.CloneDefinition.CloneTime
-		}
+	var cloneTime *time.Time
+	if metadata.CloneDefinition != nil {
+		cloneTime = &metadata.CloneDefinition.CloneTime
+	}
 
-		// Most tables declare no staleness bound. Keep the field null in that
-		// case rather than reporting "", which would read as a real interval of
-		// zero (always fresh) instead of "not configured".
-		var maxStaleness *string
-		if metadata.MaxStaleness != nil {
-			s := metadata.MaxStaleness.String()
-			maxStaleness = &s
-		}
+	// Most tables declare no staleness bound. Keep the field null in that
+	// case rather than reporting "", which would read as a real interval of
+	// zero (always fresh) instead of "not configured".
+	var maxStaleness *string
+	if metadata.MaxStaleness != nil {
+		s := metadata.MaxStaleness.String()
+		maxStaleness = &s
+	}
 
-		// A table with nothing buffered reports no streaming buffer. Leave the
-		// timestamp null rather than letting it default to the zero time, which
-		// would read as 1 January year 1 on every table that is not streaming.
-		var streamingBufferBytes, streamingBufferRows int64
-		var streamingBufferOldest *time.Time
-		if sb := metadata.StreamingBuffer; sb != nil {
-			streamingBufferBytes = int64(sb.EstimatedBytes)
-			streamingBufferRows = int64(sb.EstimatedRows)
-			if !sb.OldestEntryTime.IsZero() {
-				streamingBufferOldest = &sb.OldestEntryTime
+	// A table with nothing buffered reports no streaming buffer. Leave the
+	// timestamp null rather than letting it default to the zero time, which
+	// would read as 1 January year 1 on every table that is not streaming.
+	var streamingBufferBytes, streamingBufferRows int64
+	var streamingBufferOldest *time.Time
+	if sb := metadata.StreamingBuffer; sb != nil {
+		streamingBufferBytes = int64(sb.EstimatedBytes)
+		streamingBufferRows = int64(sb.EstimatedRows)
+		if !sb.OldestEntryTime.IsZero() {
+			streamingBufferOldest = &sb.OldestEntryTime
+		}
+	}
+
+	primaryKeyColumns := []any{}
+	foreignKeys := []any{}
+	if tc := metadata.TableConstraints; tc != nil {
+		if tc.PrimaryKey != nil {
+			for _, col := range tc.PrimaryKey.Columns {
+				primaryKeyColumns = append(primaryKeyColumns, col)
 			}
 		}
-
-		primaryKeyColumns := []any{}
-		foreignKeys := []any{}
-		if tc := metadata.TableConstraints; tc != nil {
-			if tc.PrimaryKey != nil {
-				for _, col := range tc.PrimaryKey.Columns {
-					primaryKeyColumns = append(primaryKeyColumns, col)
-				}
+		for _, fk := range tc.ForeignKeys {
+			if fk == nil {
+				continue
 			}
-			for _, fk := range tc.ForeignKeys {
-				if fk == nil {
-					continue
-				}
-				mqlFk, err := newMqlBigqueryForeignKey(runtime, table, fk)
-				if err != nil {
-					return nil, err
-				}
-				foreignKeys = append(foreignKeys, mqlFk)
-			}
-		}
-
-		// Only a BigLake managed table carries this. Leaving it null keeps a
-		// check for an unencrypted storage URI from matching an ordinary
-		// managed-storage table that has no external files at all.
-		bigLakeData := llx.NilData
-		if blc := metadata.BigLakeConfiguration; blc != nil {
-			mqlBigLake, err := CreateResource(runtime, "gcp.project.bigqueryService.table.bigLakeConfig", map[string]*llx.RawData{
-				"__id":        llx.StringData(fmt.Sprintf("%s/%s/%s/bigLakeConfig", table.ProjectID, table.DatasetID, table.TableID)),
-				"storageUri":  llx.StringData(blc.StorageURI),
-				"fileFormat":  llx.StringData(string(blc.FileFormat)),
-				"tableFormat": llx.StringData(string(blc.TableFormat)),
-			})
+			mqlFk, err := newMqlBigqueryForeignKey(runtime, table, fk)
 			if err != nil {
 				return nil, err
 			}
-			mqlBigLakeRes := mqlBigLake.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig)
-			mqlBigLakeRes.cacheProjectId = table.ProjectID
-			mqlBigLakeRes.cacheConnectionId = blc.ConnectionID
-			bigLakeData = llx.ResourceData(mqlBigLake, "gcp.project.bigqueryService.table.bigLakeConfig")
+			foreignKeys = append(foreignKeys, mqlFk)
 		}
+	}
 
-		mqlInstance, err := CreateResource(runtime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
-			"id":                             llx.StringData(table.TableID),
-			"projectId":                      llx.StringData(table.ProjectID),
-			"datasetId":                      llx.StringData(table.DatasetID),
-			"name":                           llx.StringData(metadata.Name),
-			"location":                       llx.StringData(metadata.Location),
-			"description":                    llx.StringData(metadata.Description),
-			"labels":                         llx.MapData(convert.MapToInterfaceMap(metadata.Labels), types.String),
-			"useLegacySQL":                   llx.BoolData(metadata.UseLegacySQL),
-			"requirePartitionFilter":         llx.BoolData(metadata.RequirePartitionFilter),
-			"created":                        llx.TimeData(metadata.CreationTime),
-			"modified":                       llx.TimeData(metadata.LastModifiedTime),
-			"numBytes":                       llx.IntData(metadata.NumBytes),
-			"numLongTermBytes":               llx.IntData(metadata.NumLongTermBytes),
-			"numRows":                        llx.IntData(int64(metadata.NumRows)),
-			"type":                           llx.StringData(string(metadata.Type)),
-			"expirationTime":                 llx.TimeData(metadata.ExpirationTime),
-			"kmsName":                        llx.StringData(kmsName),
-			"snapshotTime":                   llx.TimeDataPtr(snapshotTime),
-			"cloneTime":                      llx.TimeDataPtr(cloneTime),
-			"viewQuery":                      llx.StringData(metadata.ViewQuery),
-			"clusteringFields":               llx.DictData(clusteringFields),
-			"externalDataConfig":             llx.DictData(externalDataConfig),
-			"materializedView":               llx.DictData(materializedView),
-			"rangePartitioning":              llx.DictData(rangePartitioning),
-			"timePartitioning":               llx.DictData(timePartitioning),
-			"schema":                         llx.ArrayData(schema, types.Dict),
-			"maxStaleness":                   llx.StringDataPtr(maxStaleness),
-			"streamingBufferEstimatedBytes":  llx.IntData(streamingBufferBytes),
-			"streamingBufferEstimatedRows":   llx.IntData(streamingBufferRows),
-			"streamingBufferOldestEntryTime": llx.TimeDataPtr(streamingBufferOldest),
-			"primaryKeyColumns":              llx.ArrayData(primaryKeyColumns, types.String),
-			"foreignKeys":                    llx.ArrayData(foreignKeys, types.Resource("gcp.project.bigqueryService.table.foreignKey")),
-			"bigLakeConfiguration":           bigLakeData,
+	// Only a BigLake managed table carries this. Leaving it null keeps a
+	// check for an unencrypted storage URI from matching an ordinary
+	// managed-storage table that has no external files at all.
+	bigLakeData := llx.NilData
+	if blc := metadata.BigLakeConfiguration; blc != nil {
+		mqlBigLake, err := CreateResource(runtime, "gcp.project.bigqueryService.table.bigLakeConfig", map[string]*llx.RawData{
+			"__id":        llx.StringData(fmt.Sprintf("%s/%s/%s/bigLakeConfig", table.ProjectID, table.DatasetID, table.TableID)),
+			"storageUri":  llx.StringData(blc.StorageURI),
+			"fileFormat":  llx.StringData(string(blc.FileFormat)),
+			"tableFormat": llx.StringData(string(blc.TableFormat)),
 		})
 		if err != nil {
 			return nil, err
 		}
-		mqlTable := mqlInstance.(*mqlGcpProjectBigqueryServiceTable)
-		mqlTable.cacheKmsKeyName = kmsName
-		if metadata.SnapshotDefinition != nil {
-			mqlTable.cacheSnapshotBaseTable = metadata.SnapshotDefinition.BaseTableReference
-		}
-		if metadata.CloneDefinition != nil {
-			mqlTable.cacheCloneBaseTable = metadata.CloneDefinition.BaseTableReference
-		}
-		return mqlInstance, nil
+		mqlBigLakeRes := mqlBigLake.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig)
+		mqlBigLakeRes.cacheProjectId = table.ProjectID
+		mqlBigLakeRes.cacheConnectionId = blc.ConnectionID
+		bigLakeData = llx.ResourceData(mqlBigLake, "gcp.project.bigqueryService.table.bigLakeConfig")
 	}
+
+	mqlInstance, err := CreateResource(runtime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
+		"id":                             llx.StringData(table.TableID),
+		"projectId":                      llx.StringData(table.ProjectID),
+		"datasetId":                      llx.StringData(table.DatasetID),
+		"name":                           llx.StringData(metadata.Name),
+		"location":                       llx.StringData(metadata.Location),
+		"description":                    llx.StringData(metadata.Description),
+		"labels":                         llx.MapData(convert.MapToInterfaceMap(metadata.Labels), types.String),
+		"useLegacySQL":                   llx.BoolData(metadata.UseLegacySQL),
+		"requirePartitionFilter":         llx.BoolData(metadata.RequirePartitionFilter),
+		"created":                        llx.TimeData(metadata.CreationTime),
+		"modified":                       llx.TimeData(metadata.LastModifiedTime),
+		"numBytes":                       llx.IntData(metadata.NumBytes),
+		"numLongTermBytes":               llx.IntData(metadata.NumLongTermBytes),
+		"numRows":                        llx.IntData(int64(metadata.NumRows)),
+		"type":                           llx.StringData(string(metadata.Type)),
+		"expirationTime":                 llx.TimeData(metadata.ExpirationTime),
+		"kmsName":                        llx.StringData(kmsName),
+		"snapshotTime":                   llx.TimeDataPtr(snapshotTime),
+		"cloneTime":                      llx.TimeDataPtr(cloneTime),
+		"viewQuery":                      llx.StringData(metadata.ViewQuery),
+		"clusteringFields":               llx.DictData(clusteringFields),
+		"externalDataConfig":             llx.DictData(externalDataConfig),
+		"materializedView":               llx.DictData(materializedView),
+		"rangePartitioning":              llx.DictData(rangePartitioning),
+		"timePartitioning":               llx.DictData(timePartitioning),
+		"schema":                         llx.ArrayData(schema, types.Dict),
+		"maxStaleness":                   llx.StringDataPtr(maxStaleness),
+		"streamingBufferEstimatedBytes":  llx.IntData(streamingBufferBytes),
+		"streamingBufferEstimatedRows":   llx.IntData(streamingBufferRows),
+		"streamingBufferOldestEntryTime": llx.TimeDataPtr(streamingBufferOldest),
+		"primaryKeyColumns":              llx.ArrayData(primaryKeyColumns, types.String),
+		"foreignKeys":                    llx.ArrayData(foreignKeys, types.Resource("gcp.project.bigqueryService.table.foreignKey")),
+		"bigLakeConfiguration":           bigLakeData,
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlTable := mqlInstance.(*mqlGcpProjectBigqueryServiceTable)
+	mqlTable.cacheKmsKeyName = kmsName
+	if metadata.SnapshotDefinition != nil {
+		mqlTable.cacheSnapshotBaseTable = metadata.SnapshotDefinition.BaseTableReference
+	}
+	if metadata.CloneDefinition != nil {
+		mqlTable.cacheCloneBaseTable = metadata.CloneDefinition.BaseTableReference
+	}
+	return mqlInstance, nil
 }
 
 func (g *mqlGcpProjectBigqueryServiceTable) id() (string, error) {

--- a/providers/gcp/resources/bigquery_basetable_test.go
+++ b/providers/gcp/resources/bigquery_basetable_test.go
@@ -1,0 +1,176 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+const bigqueryScope = "https://www.googleapis.com/auth/bigquery"
+
+// listedTable stands in for what dataset.tables() produces: a table carrying its
+// full metadata.
+func listedTable(t *testing.T, runtime *plugin.Runtime, project, dataset, table string, numRows int64) *mqlGcpProjectBigqueryServiceTable {
+	t.Helper()
+	res, err := CreateResource(runtime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
+		"id":        llx.StringData(table),
+		"projectId": llx.StringData(project),
+		"datasetId": llx.StringData(dataset),
+		"name":      llx.StringData(table),
+		"location":  llx.StringData("US"),
+		"numRows":   llx.IntData(numRows),
+	})
+	require.NoError(t, err)
+	return res.(*mqlGcpProjectBigqueryServiceTable)
+}
+
+// serveTableMetadata answers the BigQuery tables.get call for one table.
+func serveTableMetadata(env *testEnv, project, dataset, table string, numRows int64, calls *int) {
+	path := fmt.Sprintf("/bigquery/v2/projects/%s/datasets/%s/tables/%s", project, dataset, table)
+	env.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			*calls++
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"kind": "bigquery#table",
+			"tableReference": {"projectId": %q, "datasetId": %q, "tableId": %q},
+			"friendlyName": %q,
+			"location": "US",
+			"type": "TABLE",
+			"numRows": "%d",
+			"numBytes": "8192"
+		}`, project, dataset, table, table, numRows)
+	})
+}
+
+// TestBaseTableResolutionDoesNotPoisonTheListedTable is the regression test.
+//
+// gcp.project.bigqueryService.table has no init, so building one from a bare
+// project/dataset/table reference produces a resource whose every other field is
+// unset. The runtime cache is first-writer-wins on the table's id, so that
+// stand-in does not merely shortchange its own reader: it takes the key, and the
+// later full listing of the same table is handed the stand-in back instead of
+// the metadata it just fetched.
+//
+// This bites across datasets, where a snapshot in one dataset references a base
+// table in another and the reference is resolved before that dataset is listed.
+func TestBaseTableResolutionDoesNotPoisonTheListedTable(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	serveTableMetadata(env, "test-project", "prod", "orders", 4200, nil)
+
+	// A snapshot in dataset "snaps" whose base table lives in dataset "prod".
+	snapshot := listedTable(t, env.Runtime, "test-project", "snaps", "orders_snapshot", 0)
+	ref := &bigquery.Table{ProjectID: "test-project", DatasetID: "prod", TableID: "orders"}
+
+	// Resolved before dataset "prod" is ever listed.
+	resolved, err := snapshot.resolveBaseTable(ref)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+
+	// Dataset "prod" is listed afterwards, with the base table's real metadata.
+	listed := listedTable(t, env.Runtime, "test-project", "prod", "orders", 4200)
+
+	assert.True(t, listed.NumRows.IsSet(),
+		"numRows must be set on the listed table")
+	assert.Equal(t, int64(4200), listed.NumRows.Data,
+		"listing a table after its reference was resolved must yield real metadata, not a reference stand-in")
+}
+
+// TestBaseTableResolutionReusesAListedTable pins that an already-listed base
+// table costs no API call. Resolving through the referenced dataset's table list
+// would instead cost one call per table in that dataset to answer one reference.
+func TestBaseTableResolutionReusesAListedTable(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	calls := 0
+	serveTableMetadata(env, "test-project", "prod", "orders", 4200, &calls)
+
+	listedTable(t, env.Runtime, "test-project", "prod", "orders", 4200)
+	snapshot := listedTable(t, env.Runtime, "test-project", "snaps", "orders_snapshot", 0)
+
+	resolved, err := snapshot.resolveBaseTable(&bigquery.Table{
+		ProjectID: "test-project", DatasetID: "prod", TableID: "orders",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+
+	assert.Equal(t, int64(4200), resolved.NumRows.Data,
+		"a resolved base table must be the real table")
+	assert.Zero(t, calls, "an already-listed base table must not be re-fetched")
+}
+
+// TestBaseTableResolutionFetchesAnUnlistedTable covers the miss path: a base
+// table in a dataset this query never listed still resolves to real metadata.
+func TestBaseTableResolutionFetchesAnUnlistedTable(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	calls := 0
+	serveTableMetadata(env, "test-project", "prod", "orders", 77, &calls)
+
+	snapshot := listedTable(t, env.Runtime, "test-project", "snaps", "orders_snapshot", 0)
+	resolved, err := snapshot.resolveBaseTable(&bigquery.Table{
+		ProjectID: "test-project", DatasetID: "prod", TableID: "orders",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+
+	assert.Equal(t, int64(77), resolved.NumRows.Data)
+	assert.Equal(t, "orders", resolved.Name.Data)
+	assert.Equal(t, 1, calls, "exactly one table is fetched, not the whole dataset")
+}
+
+// TestBaseTableResolutionToleratesAMissingBaseTable keeps a snapshot readable
+// after its base table is deleted. The reference outlives the table, so this is
+// an ordinary state and must not fail the listing that contains the snapshot.
+func TestBaseTableResolutionToleratesAMissingBaseTable(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	env.Mux.HandleFunc("/bigquery/v2/projects/test-project/datasets/prod/tables/gone",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"error":{"code":404,"message":"Not found: Table gone"}}`)
+		})
+
+	snapshot := listedTable(t, env.Runtime, "test-project", "snaps", "orders_snapshot", 0)
+	resolved, err := snapshot.resolveBaseTable(&bigquery.Table{
+		ProjectID: "test-project", DatasetID: "prod", TableID: "gone",
+	})
+
+	require.NoError(t, err, "a deleted base table must not fail the query")
+	assert.Nil(t, resolved, "a deleted base table resolves to null")
+}
+
+// TestResolveBaseTableHandlesAbsentReference keeps the null path intact for a
+// table that is neither a snapshot nor a clone.
+func TestResolveBaseTableHandlesAbsentReference(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	table := listedTable(t, env.Runtime, "test-project", "prod", "orders", 1)
+
+	resolved, err := table.resolveBaseTable(nil)
+	require.NoError(t, err)
+	assert.Nil(t, resolved, "a table with no base-table reference resolves to nothing")
+}
+
+// TestBigqueryTableCacheKeyMatchesResourceId pins the cache key against the
+// identity the runtime actually stores the resource under. If id() changes shape
+// and the key does not, every lookup silently misses: correctness survives but
+// the fetch-avoidance does not, and the miss is invisible.
+func TestBigqueryTableCacheKeyMatchesResourceId(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	table := listedTable(t, env.Runtime, "p", "d", "tbl", 1)
+
+	id, err := table.id()
+	require.NoError(t, err)
+	assert.Equal(t, "gcp.project.bigqueryService.table\x00"+id, bigqueryTableCacheKey("p", "d", "tbl"))
+
+	cached, ok := env.Runtime.Resources.Get(bigqueryTableCacheKey("p", "d", "tbl"))
+	require.True(t, ok, "the key must find the resource the runtime stored")
+	assert.Same(t, table, cached)
+}

--- a/providers/gcp/resources/bigquery_basetable_test.go
+++ b/providers/gcp/resources/bigquery_basetable_test.go
@@ -147,6 +147,48 @@ func TestBaseTableResolutionToleratesAMissingBaseTable(t *testing.T) {
 	assert.Nil(t, resolved, "a deleted base table resolves to null")
 }
 
+// TestBaseTableResolutionToleratesAForbiddenBaseTable covers the other half of
+// "nothing to read here": a base table in a project this caller cannot see.
+// Like a deleted table, it resolves to null rather than failing the listing.
+func TestBaseTableResolutionToleratesAForbiddenBaseTable(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	env.Mux.HandleFunc("/bigquery/v2/projects/other-project/datasets/prod/tables/orders",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, `{"error":{"code":403,"message":"Access Denied: Table orders"}}`)
+		})
+
+	snapshot := listedTable(t, env.Runtime, "test-project", "snaps", "orders_snapshot", 0)
+	resolved, err := snapshot.resolveBaseTable(&bigquery.Table{
+		ProjectID: "other-project", DatasetID: "prod", TableID: "orders",
+	})
+
+	require.NoError(t, err, "an unreadable base table must not fail the query")
+	assert.Nil(t, resolved, "an unreadable base table resolves to null")
+}
+
+// TestBaseTableResolutionSurfacesRealFailures is the counterweight to the two
+// tolerate tests. Only "gone" and "cannot see it" mean null; anything else is a
+// failure to read a table that exists, and folding it into null would report an
+// absent base table as fact. A check asserting a snapshot has no base table
+// would then pass on a failed request rather than on a real answer.
+func TestBaseTableResolutionSurfacesRealFailures(t *testing.T) {
+	env := setupTestEnv(t, []string{bigqueryScope})
+	env.Mux.HandleFunc("/bigquery/v2/projects/test-project/datasets/prod/tables/orders",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":{"code":400,"message":"Invalid request"}}`)
+		})
+
+	snapshot := listedTable(t, env.Runtime, "test-project", "snaps", "orders_snapshot", 0)
+	resolved, err := snapshot.resolveBaseTable(&bigquery.Table{
+		ProjectID: "test-project", DatasetID: "prod", TableID: "orders",
+	})
+
+	require.Error(t, err, "a failure that is not a missing or unreadable table must surface")
+	assert.Nil(t, resolved)
+}
+
 // TestResolveBaseTableHandlesAbsentReference keeps the null path intact for a
 // table that is neither a snapshot nor a clone.
 func TestResolveBaseTableHandlesAbsentReference(t *testing.T) {


### PR DESCRIPTION
`snapshotBaseTable` and `cloneBaseTable` built their result out of the bare reference BigQuery returns. That resource then took the real table's cache key.

## The bug

`gcp.project.bigqueryService.table` has no `init`, so `NewResource` falls through to `Create` with whatever args it was handed. `resolveBaseTable` handed it five: project, dataset, table id, name, location. Every other field on the resulting resource is unset.

That alone would just be a thin answer for whoever read `snapshotBaseTable`. The real problem is the cache. Both `NewResource` and `CreateResource` end the same way:

```go
mqlId := res.MqlID()
id := name + "\x00" + mqlId
if x, ok := runtime.Resources.Get(id); ok {
    return x, nil          // first writer wins
}
runtime.Resources.Set(id, res)
```

The table's id is `gcp.project.bigqueryService.table/<project>/<dataset>/<table>`, which the stand-in and the real table compute identically. So whichever is created first owns the key for the rest of the scan, and the stand-in wins whenever a reference is resolved before that table is listed. `dataset.tables()` then calls `CreateResource` with the metadata it just fetched, gets the stand-in back, and discards it.

This is the same failure the neighbouring `TestAccessEntryKeyDistinguishesReferenceEntries` was written for, one resource over.

**When it bites:** a snapshot or clone whose base table lives in a different dataset (or project) from the snapshot, where the reference is resolved before that dataset is listed. Within a single dataset it usually hides, because `tables()` creates every table in the dataset before any field accessor runs.

**What it looks like:** `numRows`, `numBytes`, `schema`, `kmsName`, `created` and the rest read null on a table that was fetched successfully, with nothing to attribute it to.

## The fix

Resolve the reference instead of fabricating a resource for it:

1. Look the table up in the runtime cache by its id. Already listed in this scan → return it, no API call.
2. Otherwise fetch exactly that one table's metadata and build it fully.

A stand-in is never created, so nothing partial can take the key.

**Why not resolve through the referenced dataset's table list?** `tables()` calls `table.Metadata(ctx)` once per table, so listing a dataset to answer one reference costs one API call per table in it. The single-table fetch costs one, and the cache hit costs zero.

**Deleted and unreadable base tables now resolve to null** rather than to a stand-in carrying only a name. A snapshot outlives the table it was taken from, so that is an ordinary state, and it must not fail the listing that contains the snapshot. Null is also the honest answer: the previous behaviour returned an object carrying identifiers and nulls for everything else, which reads as "here is the table" rather than "could not read it".

Every path that builds a table resource now goes through `newMqlBigqueryTable`, extracted from the `tables()` loop, so there is exactly one place a partially populated table could come from.

`bigqueryTableId` is shared between `id()` and the cache-key builder so the two cannot drift. A silent drift there would not break correctness, but every lookup would miss and the fetch-avoidance would quietly disappear, so there is a test pinning them together.

## Verification

Six tests, driven through the existing `testEnv` httptest server so the fetch path is real rather than stubbed.

Confirmed they discriminate: reverting `resolveBaseTable` to its previous body and re-running fails three of them.

```
--- FAIL: TestBaseTableResolutionDoesNotPoisonTheListedTable
        Messages: numRows must be set on the listed table
        Messages: listing a table after its reference was resolved must yield
                  real metadata, not a reference stand-in
--- FAIL: TestBaseTableResolutionFetchesAnUnlistedTable
        Messages: exactly one table is fetched, not the whole dataset
--- FAIL: TestBaseTableResolutionToleratesAMissingBaseTable
        Messages: a deleted base table resolves to null
```

The other two (cache reuse, nil reference) pass before and after, which is correct: those are the paths the old code already got right.

| test | pins |
|---|---|
| `DoesNotPoisonTheListedTable` | the regression: a later listing wins over an earlier reference |
| `ReusesAListedTable` | an already-listed base table costs zero API calls |
| `FetchesAnUnlistedTable` | a miss fetches exactly one table, not the dataset |
| `ToleratesAMissingBaseTable` | a deleted base table is null, not an error |
| `HandlesAbsentReference` | a plain table still resolves to nothing |
| `CacheKeyMatchesResourceId` | the key matches what the runtime actually stored |

`go test ./...` passes in `providers/gcp/`. No schema change, no new API permissions.

## Overlap with #10014

#10014 adds `bigqueryTableByRef` for its new `foreignKeys.referencedTable` and `bigLakeConfiguration.connection` accessors, written to avoid this same hazard. Whichever merges second should drop its duplicate and use the resolution path from this PR. I'll reconcile it.
