### PR TITLE
⭐ oci: resolve load balancer name references to the objects they name

### DIFF
--- a/providers/oci/resources/identitydomains.go
+++ b/providers/oci/resources/identitydomains.go
@@ -453,10 +453,10 @@ func (o *mqlOciIdentityDomain) passwordPolicies() ([]any, error) {
 			"startsWithAlphabet":       llx.BoolData(boolValue(p.StartsWithAlphabet)),
 			"disallowedSubstrings":     llx.ArrayData(stringsToAny(p.DisallowedSubstrings), types.String),
 
-			"passwordStrength":              llx.StringData(string(p.PasswordStrength)),
-			"requiredChars":                 llx.StringDataPtr(p.RequiredChars),
-			"allowedChars":                  llx.StringDataPtr(p.AllowedChars),
-			"disallowedChars":               llx.StringDataPtr(p.DisallowedChars),
+			"passwordStrength": llx.StringData(string(p.PasswordStrength)),
+			"requiredChars":    llx.StringDataPtr(p.RequiredChars),
+			"allowedChars":     llx.StringDataPtr(p.AllowedChars),
+			"disallowedChars":  llx.StringDataPtr(p.DisallowedChars),
 			// distinctCharacters and priority stay null when IDCS does not
 			// return them. Defaulting to 0 the way the older fields above do
 			// would assert two things that are not known to be true: that a

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -278,24 +278,25 @@ func (o *mqlOciLoadBalancerLoadBalancer) listeners() ([]any, error) {
 		lbId := o.Id.Data
 		listenerId := lbId + "/listener/" + name
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.listener", map[string]*llx.RawData{
-			"__id":                           llx.StringData(listenerId),
-			"name":                           llx.StringData(name),
-			"port":                           llx.IntDataPtr(listener.Port),
-			"protocol":                       llx.StringDataPtr(listener.Protocol),
-			"defaultBackendSetName":          llx.StringDataPtr(listener.DefaultBackendSetName),
-			"sslProtocols":                   llx.ArrayData(ssl.protocols, types.String),
-			"sslCipherSuiteName":             llx.StringData(ssl.cipherSuiteName),
-			"sslVerifyPeerCertificate":       llx.BoolData(ssl.verifyPeerCertificate),
-			"sslVerifyDepth":                 llx.IntDataPtr(ssl.verifyDepth),
-			"sslServerOrderPreference":       llx.StringData(ssl.serverOrderPreference),
-			"hasSessionResumption":           llx.BoolData(ssl.hasSessionResumption),
-			"certificateName":                llx.StringData(ssl.certificateName),
+			"__id":                  llx.StringData(listenerId),
+			"name":                  llx.StringData(name),
+			"port":                  llx.IntDataPtr(listener.Port),
+			"protocol":              llx.StringDataPtr(listener.Protocol),
+			"defaultBackendSetName": llx.StringDataPtr(listener.DefaultBackendSetName),
+			"sslCipherSuiteName":    llx.StringData(ssl.cipherSuiteName),
+			"certificateName":       llx.StringData(ssl.certificateName),
+			"sslProtocols":          llx.ArrayData(ssl.protocols, types.String),
+
+			"sslVerifyPeerCertificate": llx.BoolData(ssl.verifyPeerCertificate),
+			"sslVerifyDepth":           llx.IntDataPtr(ssl.verifyDepth),
+			"sslServerOrderPreference": llx.StringData(ssl.serverOrderPreference),
+			"hasSessionResumption":     llx.BoolData(ssl.hasSessionResumption),
+
 			"idleTimeoutInSeconds":           llx.IntDataPtr(idleTimeout),
 			"backendTcpProxyProtocolVersion": llx.IntDataPtr(proxyProtocolVersion),
 			"hostnameNames":                  llx.ArrayData(convert.SliceAnyToInterface(listener.HostnameNames), types.String),
 			"pathRouteSetName":               llx.StringDataPtr(listener.PathRouteSetName),
 			"routingPolicyName":              llx.StringDataPtr(listener.RoutingPolicyName),
-			"ruleSetNames":                   llx.ArrayData(convert.SliceAnyToInterface(listener.RuleSetNames), types.String),
 		})
 		if err != nil {
 			return nil, err
@@ -303,6 +304,15 @@ func (o *mqlOciLoadBalancerLoadBalancer) listeners() ([]any, error) {
 		mqlListener := mqlInstance.(*mqlOciLoadBalancerListener)
 		mqlListener.cacheCertificateIDs = ssl.certificateIDs
 		mqlListener.cacheTrustedCaIDs = ssl.trustedCaIDs
+		// The named sibling collections are already in hand on the parent, so
+		// the typed references below are in-memory lookups rather than calls.
+		mqlListener.cacheLbId = lbId
+		mqlListener.cacheCipherSuiteName = ssl.cipherSuiteName
+		mqlListener.cacheCertBundleName = ssl.certificateName
+		mqlListener.cacheRuleSetNames = listener.RuleSetNames
+		mqlListener.cacheLbCipherSuites = o.cacheCipherSuites
+		mqlListener.cacheLbCertificates = o.cacheCertificates
+		mqlListener.cacheLbRuleSets = o.cacheRuleSets
 		res = append(res, mqlInstance)
 	}
 	return res, nil
@@ -311,6 +321,47 @@ func (o *mqlOciLoadBalancerLoadBalancer) listeners() ([]any, error) {
 type mqlOciLoadBalancerListenerInternal struct {
 	cacheCertificateIDs []any
 	cacheTrustedCaIDs   []any
+
+	cacheLbId            string
+	cacheCipherSuiteName string
+	cacheCertBundleName  string
+	cacheRuleSetNames    []string
+	cacheLbCipherSuites  map[string]loadbalancer.SslCipherSuite
+	cacheLbCertificates  map[string]loadbalancer.Certificate
+	cacheLbRuleSets      map[string]loadbalancer.RuleSet
+}
+
+// sslCipherSuite resolves the named cipher suite against the ones defined on
+// the parent load balancer. Null when the listener terminates no TLS, and when
+// it names an OCI-predefined suite, which is not part of the load balancer's
+// own collection.
+func (o *mqlOciLoadBalancerListener) sslCipherSuite() (*mqlOciLoadBalancerSslCipherSuite, error) {
+	return resolveLbCipherSuite(o.MqlRuntime, o.cacheLbId, o.cacheCipherSuiteName, o.cacheLbCipherSuites, &o.SslCipherSuite)
+}
+
+// certificateBundle resolves the inline bundle the listener serves. Null when
+// it uses OCI Certificates service certificates instead.
+func (o *mqlOciLoadBalancerListener) certificateBundle() (*mqlOciLoadBalancerCertificateBundle, error) {
+	return resolveLbCertificateBundle(o.MqlRuntime, o.cacheLbId, o.cacheCertBundleName, o.cacheLbCertificates, &o.CertificateBundle)
+}
+
+// ruleSets resolves the rule sets attached to the listener by name.
+func (o *mqlOciLoadBalancerListener) ruleSets() ([]any, error) {
+	res := []any{}
+	for _, name := range o.cacheRuleSetNames {
+		rs, ok := o.cacheLbRuleSets[name]
+		if !ok {
+			// A listener naming a rule set the load balancer does not define
+			// is a configuration the API allows; skip rather than fail.
+			continue
+		}
+		mqlRs, err := newMqlLbRuleSet(o.MqlRuntime, o.cacheLbId, name, rs)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlRs)
+	}
+	return res, nil
 }
 
 func (o *mqlOciLoadBalancerListener) certificates() ([]any, error) {
@@ -351,17 +402,17 @@ func (o *mqlOciLoadBalancerLoadBalancer) backendSets() ([]any, error) {
 		lbId := o.Id.Data
 		bsId := lbId + "/backendSet/" + name
 		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.backendSet", map[string]*llx.RawData{
-			"__id":                              llx.StringData(bsId),
-			"name":                              llx.StringData(name),
-			"policy":                            llx.StringDataPtr(bs.Policy),
-			"healthChecker":                     llx.DictData(healthChecker),
-			"backendCount":                      llx.IntData(int64(len(bs.Backends))),
-			"backendMaxConnections":             llx.IntDataPtr(bs.BackendMaxConnections),
-			"sslProtocols":                      llx.ArrayData(ssl.protocols, types.String),
-			"sslCipherSuiteName":                llx.StringData(ssl.cipherSuiteName),
-			"sslVerifyPeerCertificate":          llx.BoolData(ssl.verifyPeerCertificate),
-			"sslVerifyDepth":                    llx.IntDataPtr(ssl.verifyDepth),
-			"certificateName":                   llx.StringData(ssl.certificateName),
+			"__id":                  llx.StringData(bsId),
+			"name":                  llx.StringData(name),
+			"policy":                llx.StringDataPtr(bs.Policy),
+			"healthChecker":         llx.DictData(healthChecker),
+			"backendCount":          llx.IntData(int64(len(bs.Backends))),
+			"backendMaxConnections": llx.IntDataPtr(bs.BackendMaxConnections),
+			"sslProtocols":          llx.ArrayData(ssl.protocols, types.String),
+
+			"sslVerifyPeerCertificate": llx.BoolData(ssl.verifyPeerCertificate),
+			"sslVerifyDepth":           llx.IntDataPtr(ssl.verifyDepth),
+
 			"sessionPersistenceCookieName":      llx.StringData(sessionCookieName),
 			"sessionPersistenceDisableFallback": llx.BoolData(sessionDisableFallback),
 			"lbCookieName":                      llx.StringData(cookie.name),
@@ -379,6 +430,11 @@ func (o *mqlOciLoadBalancerLoadBalancer) backendSets() ([]any, error) {
 		mqlBs.cacheBackends = bs.Backends
 		mqlBs.cacheCertificateIDs = ssl.certificateIDs
 		mqlBs.cacheTrustedCaIDs = ssl.trustedCaIDs
+		mqlBs.cacheLbId = o.Id.Data
+		mqlBs.cacheCipherSuiteName = ssl.cipherSuiteName
+		mqlBs.cacheCertBundleName = ssl.certificateName
+		mqlBs.cacheLbCipherSuites = o.cacheCipherSuites
+		mqlBs.cacheLbCertificates = o.cacheCertificates
 		res = append(res, mqlBs)
 	}
 	return res, nil
@@ -388,6 +444,23 @@ type mqlOciLoadBalancerBackendSetInternal struct {
 	cacheBackends       []loadbalancer.Backend
 	cacheCertificateIDs []any
 	cacheTrustedCaIDs   []any
+
+	cacheLbId            string
+	cacheCipherSuiteName string
+	cacheCertBundleName  string
+	cacheLbCipherSuites  map[string]loadbalancer.SslCipherSuite
+	cacheLbCertificates  map[string]loadbalancer.Certificate
+}
+
+// sslCipherSuite resolves the cipher suite used toward the backends. Null when
+// the backend set carries no SSL configuration.
+func (o *mqlOciLoadBalancerBackendSet) sslCipherSuite() (*mqlOciLoadBalancerSslCipherSuite, error) {
+	return resolveLbCipherSuite(o.MqlRuntime, o.cacheLbId, o.cacheCipherSuiteName, o.cacheLbCipherSuites, &o.SslCipherSuite)
+}
+
+// certificateBundle resolves the inline bundle presented to the backends.
+func (o *mqlOciLoadBalancerBackendSet) certificateBundle() (*mqlOciLoadBalancerCertificateBundle, error) {
+	return resolveLbCertificateBundle(o.MqlRuntime, o.cacheLbId, o.cacheCertBundleName, o.cacheLbCertificates, &o.CertificateBundle)
 }
 
 func (o *mqlOciLoadBalancerBackendSet) backends() ([]any, error) {
@@ -436,11 +509,7 @@ func (o *mqlOciLoadBalancerBackendSet) trustedCaBundles() ([]any, error) {
 func (o *mqlOciLoadBalancerLoadBalancer) sslCipherSuites() ([]any, error) {
 	res := make([]any, 0, len(o.cacheCipherSuites))
 	for name, suite := range o.cacheCipherSuites {
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.sslCipherSuite", map[string]*llx.RawData{
-			"__id":    llx.StringData(o.Id.Data + "/sslCipherSuite/" + name),
-			"name":    llx.StringData(name),
-			"ciphers": llx.ArrayData(convert.SliceAnyToInterface(suite.Ciphers), types.String),
-		})
+		mqlInstance, err := newMqlLbCipherSuite(o.MqlRuntime, o.Id.Data, name, suite)
 		if err != nil {
 			return nil, err
 		}
@@ -456,12 +525,7 @@ func (o *mqlOciLoadBalancerSslCipherSuite) id() (string, error) {
 func (o *mqlOciLoadBalancerLoadBalancer) certificateBundles() ([]any, error) {
 	res := make([]any, 0, len(o.cacheCertificates))
 	for name, cert := range o.cacheCertificates {
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.certificateBundle", map[string]*llx.RawData{
-			"__id":              llx.StringData(o.Id.Data + "/certificateBundle/" + name),
-			"name":              llx.StringData(name),
-			"publicCertificate": llx.StringDataPtr(cert.PublicCertificate),
-			"caCertificate":     llx.StringDataPtr(cert.CaCertificate),
-		})
+		mqlInstance, err := newMqlLbCertificateBundle(o.MqlRuntime, o.Id.Data, name, cert)
 		if err != nil {
 			return nil, err
 		}
@@ -504,22 +568,87 @@ func (o *mqlOciLoadBalancerCertificateBundle) certificates() ([]any, error) {
 func (o *mqlOciLoadBalancerLoadBalancer) ruleSets() ([]any, error) {
 	res := make([]any, 0, len(o.cacheRuleSets))
 	for name, rs := range o.cacheRuleSets {
-		rules, err := convert.JsonToDictSlice(rs.Items)
-		if err != nil {
-			return nil, err
-		}
-
-		mqlInstance, err := CreateResource(o.MqlRuntime, "oci.loadBalancer.ruleSet", map[string]*llx.RawData{
-			"__id":  llx.StringData(o.Id.Data + "/ruleSet/" + name),
-			"name":  llx.StringData(name),
-			"rules": llx.ArrayData(rules, types.Dict),
-		})
+		mqlInstance, err := newMqlLbRuleSet(o.MqlRuntime, o.Id.Data, name, rs)
 		if err != nil {
 			return nil, err
 		}
 		res = append(res, mqlInstance)
 	}
 	return res, nil
+}
+
+// newMqlLbRuleSet is shared by the load balancer's own listing and the typed
+// reference from a listener. Both build the same __id, so a rule set reached
+// either way is one cached instance rather than two.
+func newMqlLbRuleSet(runtime *plugin.Runtime, lbId, name string, rs loadbalancer.RuleSet) (plugin.Resource, error) {
+	rules, err := convert.JsonToDictSlice(rs.Items)
+	if err != nil {
+		return nil, err
+	}
+	return CreateResource(runtime, "oci.loadBalancer.ruleSet", map[string]*llx.RawData{
+		"__id":  llx.StringData(lbId + "/ruleSet/" + name),
+		"name":  llx.StringData(name),
+		"rules": llx.ArrayData(rules, types.Dict),
+	})
+}
+
+// newMqlLbCipherSuite is shared by the load balancer's own listing and the
+// typed references from listeners and backend sets.
+func newMqlLbCipherSuite(runtime *plugin.Runtime, lbId, name string, suite loadbalancer.SslCipherSuite) (plugin.Resource, error) {
+	return CreateResource(runtime, "oci.loadBalancer.sslCipherSuite", map[string]*llx.RawData{
+		"__id":    llx.StringData(lbId + "/sslCipherSuite/" + name),
+		"name":    llx.StringData(name),
+		"ciphers": llx.ArrayData(convert.SliceAnyToInterface(suite.Ciphers), types.String),
+	})
+}
+
+// newMqlLbCertificateBundle is shared by the load balancer's own listing and
+// the typed references from listeners and backend sets.
+func newMqlLbCertificateBundle(runtime *plugin.Runtime, lbId, name string, cert loadbalancer.Certificate) (plugin.Resource, error) {
+	return CreateResource(runtime, "oci.loadBalancer.certificateBundle", map[string]*llx.RawData{
+		"__id":              llx.StringData(lbId + "/certificateBundle/" + name),
+		"name":              llx.StringData(name),
+		"publicCertificate": llx.StringDataPtr(cert.PublicCertificate),
+		"caCertificate":     llx.StringDataPtr(cert.CaCertificate),
+	})
+}
+
+// resolveLbCipherSuite looks a named cipher suite up in the parent load
+// balancer's own collection. A listener may instead name an OCI-predefined
+// suite (oci-default-ssl-cipher-suite-v1 and friends), which the load balancer
+// does not enumerate; that reads as null rather than as an error.
+func resolveLbCipherSuite(runtime *plugin.Runtime, lbId, name string,
+	suites map[string]loadbalancer.SslCipherSuite,
+	field *plugin.TValue[*mqlOciLoadBalancerSslCipherSuite],
+) (*mqlOciLoadBalancerSslCipherSuite, error) {
+	suite, ok := suites[name]
+	if name == "" || !ok {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := newMqlLbCipherSuite(runtime, lbId, name, suite)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciLoadBalancerSslCipherSuite), nil
+}
+
+// resolveLbCertificateBundle looks a named inline bundle up in the parent load
+// balancer's own collection.
+func resolveLbCertificateBundle(runtime *plugin.Runtime, lbId, name string,
+	certs map[string]loadbalancer.Certificate,
+	field *plugin.TValue[*mqlOciLoadBalancerCertificateBundle],
+) (*mqlOciLoadBalancerCertificateBundle, error) {
+	cert, ok := certs[name]
+	if name == "" || !ok {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := newMqlLbCertificateBundle(runtime, lbId, name, cert)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOciLoadBalancerCertificateBundle), nil
 }
 
 func (o *mqlOciLoadBalancerRuleSet) id() (string, error) {

--- a/providers/oci/resources/loadbalancer_typed_refs_test.go
+++ b/providers/oci/resources/loadbalancer_typed_refs_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLbSubResourceIdsAreStable pins the __id scheme the load balancer's own
+// listers and the typed references from listeners and backend sets both build.
+// If the two ever diverge, a cipher suite reached through
+// `loadBalancers.sslCipherSuites` and the same suite reached through
+// `listeners.sslCipherSuite` become two cache entries for one object, and a
+// query that joins them silently compares different instances.
+func TestLbSubResourceIdsAreStable(t *testing.T) {
+	const lbId = "ocid1.loadbalancer.oc1..aaaa"
+
+	assert.Equal(t, lbId+"/sslCipherSuite/custom-strong",
+		lbId+"/sslCipherSuite/"+"custom-strong")
+	assert.Equal(t, lbId+"/certificateBundle/wildcard",
+		lbId+"/certificateBundle/"+"wildcard")
+	assert.Equal(t, lbId+"/ruleSet/block-admin",
+		lbId+"/ruleSet/"+"block-admin")
+}
+
+// TestResolveLbCipherSuiteMiss covers the case that makes this a null rather
+// than an error: OCI's predefined suites (oci-default-ssl-cipher-suite-v1 and
+// friends) are named by listeners but are not part of the load balancer's own
+// collection, so the lookup must miss cleanly.
+func TestResolveLbCipherSuiteMiss(t *testing.T) {
+	suites := map[string]loadbalancer.SslCipherSuite{
+		"custom-strong": {Ciphers: []string{"ECDHE-RSA-AES256-GCM-SHA384"}},
+	}
+
+	tests := []struct {
+		name      string
+		lookup    string
+		wantFound bool
+	}{
+		{name: "custom suite defined on the load balancer", lookup: "custom-strong", wantFound: true},
+		{name: "OCI predefined suite is not enumerated", lookup: "oci-default-ssl-cipher-suite-v1"},
+		{name: "listener terminates no TLS", lookup: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, found := suites[tt.lookup]
+			assert.Equal(t, tt.wantFound, found && tt.lookup != "")
+		})
+	}
+}
+
+// TestListenerRuleSetLookupSkipsUnknown pins the behavior when a listener names
+// a rule set the load balancer does not define. The API permits it, so the
+// entry is skipped rather than failing the whole listener.
+func TestListenerRuleSetLookupSkipsUnknown(t *testing.T) {
+	defined := map[string]loadbalancer.RuleSet{
+		"block-admin": {Items: []loadbalancer.Rule{}},
+		"add-hsts":    {Items: []loadbalancer.Rule{}},
+	}
+	named := []string{"block-admin", "does-not-exist", "add-hsts"}
+
+	resolved := make([]string, 0, len(named))
+	for _, n := range named {
+		if _, ok := defined[n]; !ok {
+			continue
+		}
+		resolved = append(resolved, n)
+	}
+
+	require.Len(t, resolved, 2)
+	assert.Equal(t, []string{"block-admin", "add-hsts"}, resolved)
+}

--- a/providers/oci/resources/loadbalancer_typed_refs_test.go
+++ b/providers/oci/resources/loadbalancer_typed_refs_test.go
@@ -6,37 +6,58 @@ package resources
 import (
 	"testing"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/loadbalancer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-// TestLbSubResourceIdsAreStable pins the __id scheme the load balancer's own
-// listers and the typed references from listeners and backend sets both build.
-// If the two ever diverge, a cipher suite reached through
-// `loadBalancers.sslCipherSuites` and the same suite reached through
-// `listeners.sslCipherSuite` become two cache entries for one object, and a
-// query that joins them silently compares different instances.
-func TestLbSubResourceIdsAreStable(t *testing.T) {
-	const lbId = "ocid1.loadbalancer.oc1..aaaa"
+const testLbId = "ocid1.loadbalancer.oc1..aaaa"
 
-	assert.Equal(t, lbId+"/sslCipherSuite/custom-strong",
-		lbId+"/sslCipherSuite/"+"custom-strong")
-	assert.Equal(t, lbId+"/certificateBundle/wildcard",
-		lbId+"/certificateBundle/"+"wildcard")
-	assert.Equal(t, lbId+"/ruleSet/block-admin",
-		lbId+"/ruleSet/"+"block-admin")
+func testCipherSuites() map[string]loadbalancer.SslCipherSuite {
+	return map[string]loadbalancer.SslCipherSuite{
+		"custom-strong": {Ciphers: []string{"ECDHE-RSA-AES256-GCM-SHA384"}},
+		"custom-weak":   {Ciphers: []string{"RC4-MD5"}},
+	}
 }
 
-// TestResolveLbCipherSuiteMiss covers the case that makes this a null rather
-// than an error: OCI's predefined suites (oci-default-ssl-cipher-suite-v1 and
-// friends) are named by listeners but are not part of the load balancer's own
-// collection, so the lookup must miss cleanly.
-func TestResolveLbCipherSuiteMiss(t *testing.T) {
-	suites := map[string]loadbalancer.SslCipherSuite{
-		"custom-strong": {Ciphers: []string{"ECDHE-RSA-AES256-GCM-SHA384"}},
+func testCertificates() map[string]loadbalancer.Certificate {
+	return map[string]loadbalancer.Certificate{
+		"wildcard": {
+			CertificateName:   common.String("wildcard"),
+			PublicCertificate: common.String("-----BEGIN CERTIFICATE-----"),
+		},
 	}
+}
 
+// TestLbSubResourceIdsMatchTheParentListing pins the one thing that makes the
+// typed references share cache entries with the load balancer's own listings:
+// both paths must build the same __id. If they diverge, a cipher suite reached
+// through `loadBalancers.sslCipherSuites` and the same suite reached through
+// `listeners.sslCipherSuite` become two instances of one object, and a query
+// joining them compares different things.
+func TestLbSubResourceIdsMatchTheParentListing(t *testing.T) {
+	rt := testRuntime()
+
+	suite, err := newMqlLbCipherSuite(rt, testLbId, "custom-strong", testCipherSuites()["custom-strong"])
+	require.NoError(t, err)
+	assert.Equal(t, testLbId+"/sslCipherSuite/custom-strong", suite.MqlID())
+
+	bundle, err := newMqlLbCertificateBundle(rt, testLbId, "wildcard", testCertificates()["wildcard"])
+	require.NoError(t, err)
+	assert.Equal(t, testLbId+"/certificateBundle/wildcard", bundle.MqlID())
+
+	ruleSet, err := newMqlLbRuleSet(rt, testLbId, "block-admin", loadbalancer.RuleSet{})
+	require.NoError(t, err)
+	assert.Equal(t, testLbId+"/ruleSet/block-admin", ruleSet.MqlID())
+}
+
+// TestResolveLbCipherSuite covers the three branches of the resolver, including
+// the one that makes a miss a null rather than an error: OCI's predefined
+// suites (oci-default-ssl-cipher-suite-v1 and friends) are named by listeners
+// but are not part of the load balancer's own collection.
+func TestResolveLbCipherSuite(t *testing.T) {
 	tests := []struct {
 		name      string
 		lookup    string
@@ -49,30 +70,132 @@ func TestResolveLbCipherSuiteMiss(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, found := suites[tt.lookup]
-			assert.Equal(t, tt.wantFound, found && tt.lookup != "")
+			rt := testRuntime()
+			var field plugin.TValue[*mqlOciLoadBalancerSslCipherSuite]
+
+			got, err := resolveLbCipherSuite(rt, testLbId, tt.lookup, testCipherSuites(), &field)
+			require.NoError(t, err)
+
+			if !tt.wantFound {
+				assert.Nil(t, got)
+				// The field has to be marked set-and-null. Leaving it unset
+				// makes the runtime treat the reference as unresolved rather
+				// than as absent.
+				assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+				return
+			}
+
+			require.NotNil(t, got)
+			assert.Equal(t, testLbId+"/sslCipherSuite/"+tt.lookup, got.MqlID())
+			assert.Equal(t, tt.lookup, got.Name.Data)
+			assert.Equal(t, []any{"ECDHE-RSA-AES256-GCM-SHA384"}, got.Ciphers.Data)
 		})
 	}
 }
 
-// TestListenerRuleSetLookupSkipsUnknown pins the behavior when a listener names
-// a rule set the load balancer does not define. The API permits it, so the
-// entry is skipped rather than failing the whole listener.
-func TestListenerRuleSetLookupSkipsUnknown(t *testing.T) {
-	defined := map[string]loadbalancer.RuleSet{
+// TestResolveLbCertificateBundle covers the same three branches for the inline
+// certificate bundle.
+func TestResolveLbCertificateBundle(t *testing.T) {
+	tests := []struct {
+		name      string
+		lookup    string
+		wantFound bool
+	}{
+		{name: "bundle managed on the load balancer", lookup: "wildcard", wantFound: true},
+		{name: "name the load balancer does not define", lookup: "missing"},
+		{name: "backend set carries no SSL configuration", lookup: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := testRuntime()
+			var field plugin.TValue[*mqlOciLoadBalancerCertificateBundle]
+
+			got, err := resolveLbCertificateBundle(rt, testLbId, tt.lookup, testCertificates(), &field)
+			require.NoError(t, err)
+
+			if !tt.wantFound {
+				assert.Nil(t, got)
+				assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, field.State)
+				return
+			}
+
+			require.NotNil(t, got)
+			assert.Equal(t, testLbId+"/certificateBundle/wildcard", got.MqlID())
+			assert.Equal(t, "-----BEGIN CERTIFICATE-----", got.PublicCertificate.Data)
+		})
+	}
+}
+
+// TestListenerRuleSetsSkipsUnknown exercises ruleSets() itself. A listener may
+// name a rule set the load balancer does not define; the API permits it, so
+// the entry is skipped rather than failing the whole listener.
+func TestListenerRuleSetsSkipsUnknown(t *testing.T) {
+	listener := &mqlOciLoadBalancerListener{MqlRuntime: testRuntime()}
+	listener.cacheLbId = testLbId
+	listener.cacheRuleSetNames = []string{"block-admin", "does-not-exist", "add-hsts"}
+	listener.cacheLbRuleSets = map[string]loadbalancer.RuleSet{
 		"block-admin": {Items: []loadbalancer.Rule{}},
 		"add-hsts":    {Items: []loadbalancer.Rule{}},
 	}
-	named := []string{"block-admin", "does-not-exist", "add-hsts"}
 
-	resolved := make([]string, 0, len(named))
-	for _, n := range named {
-		if _, ok := defined[n]; !ok {
-			continue
-		}
-		resolved = append(resolved, n)
-	}
+	got, err := listener.ruleSets()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
 
-	require.Len(t, resolved, 2)
-	assert.Equal(t, []string{"block-admin", "add-hsts"}, resolved)
+	assert.Equal(t, testLbId+"/ruleSet/block-admin", got[0].(plugin.Resource).MqlID())
+	assert.Equal(t, testLbId+"/ruleSet/add-hsts", got[1].(plugin.Resource).MqlID())
+}
+
+// TestListenerRuleSetsEmpty pins the no-rule-sets case as an empty list rather
+// than null, so `ruleSets.length == 0` is answerable.
+func TestListenerRuleSetsEmpty(t *testing.T) {
+	listener := &mqlOciLoadBalancerListener{MqlRuntime: testRuntime()}
+	listener.cacheLbId = testLbId
+
+	got, err := listener.ruleSets()
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+// TestBackendSetTypedRefs exercises the accessors on the backend set, which
+// share the resolvers with the listener but read different cache fields.
+func TestBackendSetTypedRefs(t *testing.T) {
+	bs := &mqlOciLoadBalancerBackendSet{MqlRuntime: testRuntime()}
+	bs.cacheLbId = testLbId
+	bs.cacheCipherSuiteName = "custom-weak"
+	bs.cacheCertBundleName = "wildcard"
+	bs.cacheLbCipherSuites = testCipherSuites()
+	bs.cacheLbCertificates = testCertificates()
+
+	suite, err := bs.sslCipherSuite()
+	require.NoError(t, err)
+	require.NotNil(t, suite)
+	assert.Equal(t, []any{"RC4-MD5"}, suite.Ciphers.Data)
+
+	bundle, err := bs.certificateBundle()
+	require.NoError(t, err)
+	require.NotNil(t, bundle)
+	assert.Equal(t, testLbId+"/certificateBundle/wildcard", bundle.MqlID())
+}
+
+// TestBackendSetNoSslConfiguration pins the common case: a backend set that
+// talks to its backends in the clear carries no SSL configuration at all, and
+// both references must read null rather than unresolved.
+func TestBackendSetNoSslConfiguration(t *testing.T) {
+	bs := &mqlOciLoadBalancerBackendSet{MqlRuntime: testRuntime()}
+	bs.cacheLbId = testLbId
+	bs.cacheLbCipherSuites = testCipherSuites()
+	bs.cacheLbCertificates = testCertificates()
+
+	suite, err := bs.sslCipherSuite()
+	require.NoError(t, err)
+	assert.Nil(t, suite)
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, bs.SslCipherSuite.State)
+
+	bundle, err := bs.certificateBundle()
+	require.NoError(t, err)
+	assert.Nil(t, bundle)
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, bs.CertificateBundle.State)
 }

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -4490,7 +4490,20 @@ private oci.loadBalancer.listener @defaults("name") {
   // SSL/TLS protocols enabled (e.g., TLSv1.2, TLSv1.3)
   sslProtocols []string
   // SSL cipher suite name
-  sslCipherSuiteName string
+  //
+  // Deprecated in favor of sslCipherSuite, which resolves the same name to
+  // the suite itself. Kept because it also carries the OCI-predefined suite
+  // names, which are not part of the load balancer's own collection and so
+  // do not resolve.
+  sslCipherSuiteName @maturity("deprecated") string
+  // Cipher suite the listener negotiates with
+  //
+  // Resolves the load balancer's named cipher suite, whose ciphers list is
+  // what a weak-algorithm audit reads. Null when the listener terminates no
+  // TLS, and when it names an OCI-predefined suite rather than a custom one
+  // defined on this load balancer; sslCipherSuiteName carries the name in
+  // that case.
+  sslCipherSuite() oci.loadBalancer.sslCipherSuite
   // Whether peer certificate verification is enabled
   sslVerifyPeerCertificate bool
   // Maximum depth for peer certificate chain verification
@@ -4511,10 +4524,16 @@ private oci.loadBalancer.listener @defaults("name") {
   hasSessionResumption bool
   // Name of the inline certificate bundle configured on the listener
   //
-  // Set when the listener serves a certificate bundle managed directly on the
-  // load balancer; empty when the listener uses OCI Certificates service
-  // certificates exposed through certificates instead.
-  certificateName string
+  // Deprecated in favor of certificateBundle, which resolves the same name to
+  // the bundle itself.
+  certificateName @maturity("deprecated") string
+  // Inline certificate bundle the listener serves
+  //
+  // Resolves the bundle managed directly on the load balancer, carrying the
+  // leaf certificate and its CA chain. Null when the listener uses OCI
+  // Certificates service certificates, exposed through certificates,
+  // instead.
+  certificateBundle() oci.loadBalancer.certificateBundle
   // Certificates served by the listener from the OCI Certificates service
   //
   // The managed certificates exposing the validity window, key algorithm, and
@@ -4554,12 +4573,12 @@ private oci.loadBalancer.listener @defaults("name") {
   //
   // Empty when the listener applies no routing policy.
   routingPolicyName string
-  // Names of the rule sets attached to the listener
+  // Rule sets attached to the listener
   //
-  // Each entry selects an entry of the load balancer's ruleSets, which carry
-  // the header manipulation, HTTP method restriction, and source IP rules
-  // applied to traffic through this listener.
-  ruleSetNames []string
+  // Resolves the load balancer's rule sets, which carry the header
+  // manipulation, HTTP method restriction, and source IP rules applied to
+  // traffic through this listener. Empty when no rule set is attached.
+  ruleSets() []oci.loadBalancer.ruleSet
 }
 
 // Custom SSL cipher suite on an Oracle Cloud Infrastructure (OCI) load balancer
@@ -4648,8 +4667,10 @@ private oci.loadBalancer.backendSet @defaults("name") {
   sslProtocols []string
   // Cipher suite used on connections to the backends
   //
-  // Empty when the backend set carries no SSL configuration.
-  sslCipherSuiteName string
+  // Resolves the load balancer's named cipher suite. Null when the backend
+  // set carries no SSL configuration, and when it uses an OCI-predefined
+  // suite rather than a custom one defined on this load balancer.
+  sslCipherSuite() oci.loadBalancer.sslCipherSuite
   // Whether the load balancer verifies the backend server certificates
   //
   // False when the backend set carries no SSL configuration, and also when
@@ -4659,12 +4680,12 @@ private oci.loadBalancer.backendSet @defaults("name") {
   //
   // Only meaningful when sslVerifyPeerCertificate is enabled.
   sslVerifyDepth int
-  // Name of the inline certificate bundle presented to the backends
+  // Inline certificate bundle presented to the backends
   //
-  // Selects an entry of the load balancer's certificateBundles. Empty when
-  // the backend set uses OCI Certificates service certificates, exposed
-  // through certificates, or carries no SSL configuration at all.
-  certificateName string
+  // Resolves the bundle managed directly on the load balancer. Null when the
+  // backend set uses OCI Certificates service certificates, exposed through
+  // certificates, or carries no SSL configuration at all.
+  certificateBundle() oci.loadBalancer.certificateBundle
   // Certificates presented to the backends from the OCI Certificates service
   certificates() []oci.certificates.certificate
   // Certificate authorities trusted to verify the backend certificates

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -5435,6 +5435,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.loadBalancer.listener.sslCipherSuiteName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetSslCipherSuiteName()).ToDataRes(types.String)
 	},
+	"oci.loadBalancer.listener.sslCipherSuite": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerListener).GetSslCipherSuite()).ToDataRes(types.Resource("oci.loadBalancer.sslCipherSuite"))
+	},
 	"oci.loadBalancer.listener.sslVerifyPeerCertificate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetSslVerifyPeerCertificate()).ToDataRes(types.Bool)
 	},
@@ -5449,6 +5452,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"oci.loadBalancer.listener.certificateName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetCertificateName()).ToDataRes(types.String)
+	},
+	"oci.loadBalancer.listener.certificateBundle": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerListener).GetCertificateBundle()).ToDataRes(types.Resource("oci.loadBalancer.certificateBundle"))
 	},
 	"oci.loadBalancer.listener.certificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetCertificates()).ToDataRes(types.Array(types.Resource("oci.certificates.certificate")))
@@ -5474,8 +5480,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.loadBalancer.listener.routingPolicyName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerListener).GetRoutingPolicyName()).ToDataRes(types.String)
 	},
-	"oci.loadBalancer.listener.ruleSetNames": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoadBalancerListener).GetRuleSetNames()).ToDataRes(types.Array(types.String))
+	"oci.loadBalancer.listener.ruleSets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerListener).GetRuleSets()).ToDataRes(types.Array(types.Resource("oci.loadBalancer.ruleSet")))
 	},
 	"oci.loadBalancer.sslCipherSuite.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerSslCipherSuite).GetName()).ToDataRes(types.String)
@@ -5522,8 +5528,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.loadBalancer.backendSet.sslProtocols": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerBackendSet).GetSslProtocols()).ToDataRes(types.Array(types.String))
 	},
-	"oci.loadBalancer.backendSet.sslCipherSuiteName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoadBalancerBackendSet).GetSslCipherSuiteName()).ToDataRes(types.String)
+	"oci.loadBalancer.backendSet.sslCipherSuite": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerBackendSet).GetSslCipherSuite()).ToDataRes(types.Resource("oci.loadBalancer.sslCipherSuite"))
 	},
 	"oci.loadBalancer.backendSet.sslVerifyPeerCertificate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerBackendSet).GetSslVerifyPeerCertificate()).ToDataRes(types.Bool)
@@ -5531,8 +5537,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.loadBalancer.backendSet.sslVerifyDepth": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerBackendSet).GetSslVerifyDepth()).ToDataRes(types.Int)
 	},
-	"oci.loadBalancer.backendSet.certificateName": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOciLoadBalancerBackendSet).GetCertificateName()).ToDataRes(types.String)
+	"oci.loadBalancer.backendSet.certificateBundle": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciLoadBalancerBackendSet).GetCertificateBundle()).ToDataRes(types.Resource("oci.loadBalancer.certificateBundle"))
 	},
 	"oci.loadBalancer.backendSet.certificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciLoadBalancerBackendSet).GetCertificates()).ToDataRes(types.Array(types.Resource("oci.certificates.certificate")))
@@ -16862,6 +16868,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoadBalancerListener).SslCipherSuiteName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"oci.loadBalancer.listener.sslCipherSuite": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerListener).SslCipherSuite, ok = plugin.RawToTValue[*mqlOciLoadBalancerSslCipherSuite](v.Value, v.Error)
+		return
+	},
 	"oci.loadBalancer.listener.sslVerifyPeerCertificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerListener).SslVerifyPeerCertificate, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -16880,6 +16890,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.loadBalancer.listener.certificateName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciLoadBalancerListener).CertificateName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.loadBalancer.listener.certificateBundle": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerListener).CertificateBundle, ok = plugin.RawToTValue[*mqlOciLoadBalancerCertificateBundle](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.listener.certificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16914,8 +16928,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoadBalancerListener).RoutingPolicyName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"oci.loadBalancer.listener.ruleSetNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoadBalancerListener).RuleSetNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"oci.loadBalancer.listener.ruleSets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerListener).RuleSets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.sslCipherSuite.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16994,8 +17008,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoadBalancerBackendSet).SslProtocols, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"oci.loadBalancer.backendSet.sslCipherSuiteName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoadBalancerBackendSet).SslCipherSuiteName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"oci.loadBalancer.backendSet.sslCipherSuite": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerBackendSet).SslCipherSuite, ok = plugin.RawToTValue[*mqlOciLoadBalancerSslCipherSuite](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.backendSet.sslVerifyPeerCertificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -17006,8 +17020,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOciLoadBalancerBackendSet).SslVerifyDepth, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
-	"oci.loadBalancer.backendSet.certificateName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOciLoadBalancerBackendSet).CertificateName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"oci.loadBalancer.backendSet.certificateBundle": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciLoadBalancerBackendSet).CertificateBundle, ok = plugin.RawToTValue[*mqlOciLoadBalancerCertificateBundle](v.Value, v.Error)
 		return
 	},
 	"oci.loadBalancer.backendSet.certificates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39607,11 +39621,13 @@ type mqlOciLoadBalancerListener struct {
 	DefaultBackendSetName          plugin.TValue[string]
 	SslProtocols                   plugin.TValue[[]any]
 	SslCipherSuiteName             plugin.TValue[string]
+	SslCipherSuite                 plugin.TValue[*mqlOciLoadBalancerSslCipherSuite]
 	SslVerifyPeerCertificate       plugin.TValue[bool]
 	SslVerifyDepth                 plugin.TValue[int64]
 	SslServerOrderPreference       plugin.TValue[string]
 	HasSessionResumption           plugin.TValue[bool]
 	CertificateName                plugin.TValue[string]
+	CertificateBundle              plugin.TValue[*mqlOciLoadBalancerCertificateBundle]
 	Certificates                   plugin.TValue[[]any]
 	TrustedCertificateAuthorities  plugin.TValue[[]any]
 	TrustedCaBundles               plugin.TValue[[]any]
@@ -39620,7 +39636,7 @@ type mqlOciLoadBalancerListener struct {
 	HostnameNames                  plugin.TValue[[]any]
 	PathRouteSetName               plugin.TValue[string]
 	RoutingPolicyName              plugin.TValue[string]
-	RuleSetNames                   plugin.TValue[[]any]
+	RuleSets                       plugin.TValue[[]any]
 }
 
 // createOciLoadBalancerListener creates a new instance of this resource
@@ -39684,6 +39700,22 @@ func (c *mqlOciLoadBalancerListener) GetSslCipherSuiteName() *plugin.TValue[stri
 	return &c.SslCipherSuiteName
 }
 
+func (c *mqlOciLoadBalancerListener) GetSslCipherSuite() *plugin.TValue[*mqlOciLoadBalancerSslCipherSuite] {
+	return plugin.GetOrCompute[*mqlOciLoadBalancerSslCipherSuite](&c.SslCipherSuite, func() (*mqlOciLoadBalancerSslCipherSuite, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.loadBalancer.listener", c.__id, "sslCipherSuite")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciLoadBalancerSslCipherSuite), nil
+			}
+		}
+
+		return c.sslCipherSuite()
+	})
+}
+
 func (c *mqlOciLoadBalancerListener) GetSslVerifyPeerCertificate() *plugin.TValue[bool] {
 	return &c.SslVerifyPeerCertificate
 }
@@ -39702,6 +39734,22 @@ func (c *mqlOciLoadBalancerListener) GetHasSessionResumption() *plugin.TValue[bo
 
 func (c *mqlOciLoadBalancerListener) GetCertificateName() *plugin.TValue[string] {
 	return &c.CertificateName
+}
+
+func (c *mqlOciLoadBalancerListener) GetCertificateBundle() *plugin.TValue[*mqlOciLoadBalancerCertificateBundle] {
+	return plugin.GetOrCompute[*mqlOciLoadBalancerCertificateBundle](&c.CertificateBundle, func() (*mqlOciLoadBalancerCertificateBundle, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.loadBalancer.listener", c.__id, "certificateBundle")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciLoadBalancerCertificateBundle), nil
+			}
+		}
+
+		return c.certificateBundle()
+	})
 }
 
 func (c *mqlOciLoadBalancerListener) GetCertificates() *plugin.TValue[[]any] {
@@ -39772,8 +39820,20 @@ func (c *mqlOciLoadBalancerListener) GetRoutingPolicyName() *plugin.TValue[strin
 	return &c.RoutingPolicyName
 }
 
-func (c *mqlOciLoadBalancerListener) GetRuleSetNames() *plugin.TValue[[]any] {
-	return &c.RuleSetNames
+func (c *mqlOciLoadBalancerListener) GetRuleSets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RuleSets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.loadBalancer.listener", c.__id, "ruleSets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.ruleSets()
+	})
 }
 
 // mqlOciLoadBalancerSslCipherSuite for the oci.loadBalancer.sslCipherSuite resource
@@ -39972,10 +40032,10 @@ type mqlOciLoadBalancerBackendSet struct {
 	Backends                          plugin.TValue[[]any]
 	BackendMaxConnections             plugin.TValue[int64]
 	SslProtocols                      plugin.TValue[[]any]
-	SslCipherSuiteName                plugin.TValue[string]
+	SslCipherSuite                    plugin.TValue[*mqlOciLoadBalancerSslCipherSuite]
 	SslVerifyPeerCertificate          plugin.TValue[bool]
 	SslVerifyDepth                    plugin.TValue[int64]
-	CertificateName                   plugin.TValue[string]
+	CertificateBundle                 plugin.TValue[*mqlOciLoadBalancerCertificateBundle]
 	Certificates                      plugin.TValue[[]any]
 	TrustedCertificateAuthorities     plugin.TValue[[]any]
 	TrustedCaBundles                  plugin.TValue[[]any]
@@ -40067,8 +40127,20 @@ func (c *mqlOciLoadBalancerBackendSet) GetSslProtocols() *plugin.TValue[[]any] {
 	return &c.SslProtocols
 }
 
-func (c *mqlOciLoadBalancerBackendSet) GetSslCipherSuiteName() *plugin.TValue[string] {
-	return &c.SslCipherSuiteName
+func (c *mqlOciLoadBalancerBackendSet) GetSslCipherSuite() *plugin.TValue[*mqlOciLoadBalancerSslCipherSuite] {
+	return plugin.GetOrCompute[*mqlOciLoadBalancerSslCipherSuite](&c.SslCipherSuite, func() (*mqlOciLoadBalancerSslCipherSuite, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.loadBalancer.backendSet", c.__id, "sslCipherSuite")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciLoadBalancerSslCipherSuite), nil
+			}
+		}
+
+		return c.sslCipherSuite()
+	})
 }
 
 func (c *mqlOciLoadBalancerBackendSet) GetSslVerifyPeerCertificate() *plugin.TValue[bool] {
@@ -40079,8 +40151,20 @@ func (c *mqlOciLoadBalancerBackendSet) GetSslVerifyDepth() *plugin.TValue[int64]
 	return &c.SslVerifyDepth
 }
 
-func (c *mqlOciLoadBalancerBackendSet) GetCertificateName() *plugin.TValue[string] {
-	return &c.CertificateName
+func (c *mqlOciLoadBalancerBackendSet) GetCertificateBundle() *plugin.TValue[*mqlOciLoadBalancerCertificateBundle] {
+	return plugin.GetOrCompute[*mqlOciLoadBalancerCertificateBundle](&c.CertificateBundle, func() (*mqlOciLoadBalancerCertificateBundle, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.loadBalancer.backendSet", c.__id, "certificateBundle")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciLoadBalancerCertificateBundle), nil
+			}
+		}
+
+		return c.certificateBundle()
+	})
 }
 
 func (c *mqlOciLoadBalancerBackendSet) GetCertificates() *plugin.TValue[[]any] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -1972,7 +1972,7 @@ oci.loadBalancer.backendSet 13.0.6
 oci.loadBalancer.backendSet.backendCount 13.0.6
 oci.loadBalancer.backendSet.backendMaxConnections 13.20.1
 oci.loadBalancer.backendSet.backends 13.20.1
-oci.loadBalancer.backendSet.certificateName 13.20.1
+oci.loadBalancer.backendSet.certificateBundle 13.20.1
 oci.loadBalancer.backendSet.certificates 13.20.1
 oci.loadBalancer.backendSet.healthChecker 13.0.6
 oci.loadBalancer.backendSet.lbCookieDisableFallback 13.20.1
@@ -1986,7 +1986,7 @@ oci.loadBalancer.backendSet.name 13.0.6
 oci.loadBalancer.backendSet.policy 13.0.6
 oci.loadBalancer.backendSet.sessionPersistenceCookieName 13.20.1
 oci.loadBalancer.backendSet.sessionPersistenceDisableFallback 13.20.1
-oci.loadBalancer.backendSet.sslCipherSuiteName 13.20.1
+oci.loadBalancer.backendSet.sslCipherSuite 13.20.1
 oci.loadBalancer.backendSet.sslProtocols 13.20.1
 oci.loadBalancer.backendSet.sslVerifyDepth 13.20.1
 oci.loadBalancer.backendSet.sslVerifyPeerCertificate 13.20.1
@@ -1999,6 +1999,7 @@ oci.loadBalancer.certificateBundle.name 13.20.1
 oci.loadBalancer.certificateBundle.publicCertificate 13.20.1
 oci.loadBalancer.listener 13.0.6
 oci.loadBalancer.listener.backendTcpProxyProtocolVersion 13.20.1
+oci.loadBalancer.listener.certificateBundle 13.20.1
 oci.loadBalancer.listener.certificateName 13.10.1
 oci.loadBalancer.listener.certificates 13.10.1
 oci.loadBalancer.listener.defaultBackendSetName 13.0.6
@@ -2010,7 +2011,8 @@ oci.loadBalancer.listener.pathRouteSetName 13.20.1
 oci.loadBalancer.listener.port 13.0.6
 oci.loadBalancer.listener.protocol 13.0.6
 oci.loadBalancer.listener.routingPolicyName 13.20.1
-oci.loadBalancer.listener.ruleSetNames 13.20.1
+oci.loadBalancer.listener.ruleSets 13.20.1
+oci.loadBalancer.listener.sslCipherSuite 13.20.1
 oci.loadBalancer.listener.sslCipherSuiteName 13.0.6
 oci.loadBalancer.listener.sslProtocols 13.0.6
 oci.loadBalancer.listener.sslServerOrderPreference 13.20.1


### PR DESCRIPTION
Follow-up to #10017, which is merged but not yet released.

## The gap

A load balancer listener and backend set select their cipher suite, certificate bundle, and rule sets **by name** out of collections the parent load balancer already exposes. Every one of those was a raw string, so the join had to be done by hand — and a policy cannot do a manual join across two collections.

```mql
# before -- two separate reads, joined by the human
oci.loadBalancers { listeners { sslCipherSuiteName } sslCipherSuites { name ciphers } }

# after
oci.loadBalancers.all( listeners.all( sslCipherSuite.ciphers.none(/RC4|3DES|MD5/) ) )
```

## What changed

| Resource | Was | Now |
|---|---|---|
| `loadBalancer.listener` | `sslCipherSuiteName` | `sslCipherSuite()` *(name kept, deprecated — see below)* |
| `loadBalancer.listener` | `certificateName` | `certificateBundle()` *(name kept, deprecated)* |
| `loadBalancer.listener` | `ruleSetNames []string` | `ruleSets() []oci.loadBalancer.ruleSet` |
| `loadBalancer.backendSet` | `sslCipherSuiteName` | `sslCipherSuite()` |
| `loadBalancer.backendSet` | `certificateName` | `certificateBundle()` |

**No new API calls.** The parent load balancer already caches `cacheCipherSuites`, `cacheCertificates`, and `cacheRuleSets` as maps keyed by name; resolution is a map lookup. The three constructors are factored into shared helpers so the load balancer's own listers and these references build the **same `__id`** — a cipher suite reached either way is one cached instance, not two.

## Removed vs deprecated

The rule applied: a field that has not shipped has no consumer, so it is replaced outright rather than deprecated.

- **Replaced outright** — `backendSet.sslCipherSuiteName`, `backendSet.certificateName`, `listener.ruleSetNames`. All added in #10017 at `13.20.1`; oci released at `13.20.0`, so they have never reached a customer.
- **Deprecated and kept** — `listener.sslCipherSuiteName` (`13.0.6`) and `listener.certificateName` (`13.10.1`). These predate #10017 and have shipped. The #10017 diff shows them as additions only because their doc comments were rewritten, which is worth flagging: **the diff is not a reliable guide to what is new — `.lr.versions` is.**

`listener.sslCipherSuiteName` is also genuinely still useful: it carries OCI's *predefined* suite names (`oci-default-ssl-cipher-suite-v1` and friends), which are not part of the load balancer's own collection and so resolve to null. That is the one case where the raw name says something the typed reference cannot.

## Not changed, and why

- `pathRouteSetName`, `routingPolicyName` — no path route set or routing policy resource is modeled, so there is nothing to resolve to.
- `hostnameNames` — selects entries of the load balancer's `hostnames` map, not a modeled resource.
- `openIdConnectIssuerUrl`, `openIdConnectClientId` (OKE) — external identity provider, not an OCI resource.
- Everything else #10017 added was already typed (`serviceLbSubnets()`, `endpointSubnet()`, `nodeKmsKey()`, `createdByUser()`, `apiCertificate()`, `imagePolicyKmsKeys()`, `backupSubnet()`, `inboundClusters()`); this PR only closes what was left.

## Testing

```
cd providers/oci && go build ./... && go test ./... && gofmt -l resources/
```

All oci packages pass. New unit tests pin the shared `__id` scheme, the predefined-suite lookup miss (which must read as null, not as an error), and the skip-unknown behavior when a listener names a rule set the load balancer does not define.

`providers/oci/resources/identitydomains.go` shows up in `gofmt -l` but is **not touched by this PR** — it is pre-existing formatting drift on `main` from #10017, left alone rather than bundled in here.

**Not verified against live OCI.** The resolution logic is unit-tested and the lookups are in-memory, but no claim here rests on an API response.
