### PR TITLE
⭐ gcp: resolve Cloud Storage URIs to the buckets they name

### DIFF
--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -336,6 +336,13 @@ func (g *mqlGcpProjectBigqueryServiceTableForeignKey) referencedTable() (*mqlGcp
 	return tbl, nil
 }
 
+// bucket resolves the Cloud Storage bucket named in storageUri. A BigLake
+// table is only as private as the bucket behind it, so this is what lets the
+// table's exposure be read from the bucket's own IAM policy.
+func (g *mqlGcpProjectBigqueryServiceTableBigLakeConfig) bucket() (*mqlGcpProjectStorageServiceBucket, error) {
+	return resolveGcsBucketFromURI(g.MqlRuntime, g.StorageUri.Data, &g.Bucket)
+}
+
 // connection resolves the BigLake connection through the project's connection
 // list, which is already fetched and fully populated.
 //

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -3512,6 +3512,14 @@ private gcp.project.sqlService.instance.onPremisesConfiguration @defaults("hostP
   dmsManaged bool
   // Cloud Storage path of the dump file used to seed the replica
   dumpFilePath string
+  // Cloud Storage bucket holding the source database dump
+  //
+  // Resolves the bucket named in dumpFilePath. A dump of an external database
+  // is a full copy of its contents, so the bucket's IAM policy and
+  // public-access-prevention setting decide who can read that copy. Null when
+  // no dump file is configured, and when the bucket sits in a project this
+  // credential cannot read.
+  dumpFileBucket() gcp.project.storageService.bucket
   // Cloud SQL instance this instance replicates from, when the source is itself a Cloud SQL instance
   sourceInstance() gcp.project.sqlService.instance
 }
@@ -4225,7 +4233,19 @@ private gcp.project.bigqueryService.table @defaults("id") {
 // `tableFormat` fields report the layout of the files behind the table.
 private gcp.project.bigqueryService.table.bigLakeConfig @defaults("storageUri fileFormat") {
   // Cloud Storage URI the table's data files are read from
+  //
+  // In `gs://bucket/prefix/` form. The bucket alone is reachable through
+  // bucket; this field is kept because it also carries the object prefix
+  // inside the bucket, which the reference cannot round-trip.
   storageUri string
+  // Cloud Storage bucket holding the table's data files
+  //
+  // Resolves the bucket named in storageUri, so the table's exposure can be
+  // read from the bucket's own IAM policy and public-access-prevention
+  // setting. A BigLake table is only as private as the bucket behind it.
+  // Null when the URI names no bucket, and when the bucket sits in a project
+  // this credential cannot read.
+  bucket() gcp.project.storageService.bucket
   // Format of the underlying data files (PARQUET)
   fileFormat string
   // Open table format layered over the data files (ICEBERG)

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -5863,6 +5863,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.sqlService.instance.onPremisesConfiguration.dumpFilePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration).GetDumpFilePath()).ToDataRes(types.String)
 	},
+	"gcp.project.sqlService.instance.onPremisesConfiguration.dumpFileBucket": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration).GetDumpFileBucket()).ToDataRes(types.Resource("gcp.project.storageService.bucket"))
+	},
 	"gcp.project.sqlService.instance.onPremisesConfiguration.sourceInstance": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration).GetSourceInstance()).ToDataRes(types.Resource("gcp.project.sqlService.instance"))
 	},
@@ -6510,6 +6513,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfig.storageUri": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig).GetStorageUri()).ToDataRes(types.String)
+	},
+	"gcp.project.bigqueryService.table.bigLakeConfig.bucket": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig).GetBucket()).ToDataRes(types.Resource("gcp.project.storageService.bucket"))
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfig.fileFormat": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig).GetFileFormat()).ToDataRes(types.String)
@@ -23796,6 +23802,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration).DumpFilePath, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.sqlService.instance.onPremisesConfiguration.dumpFileBucket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration).DumpFileBucket, ok = plugin.RawToTValue[*mqlGcpProjectStorageServiceBucket](v.Value, v.Error)
+		return
+	},
 	"gcp.project.sqlService.instance.onPremisesConfiguration.sourceInstance": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration).SourceInstance, ok = plugin.RawToTValue[*mqlGcpProjectSqlServiceInstance](v.Value, v.Error)
 		return
@@ -24730,6 +24740,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfig.storageUri": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig).StorageUri, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.bigqueryService.table.bigLakeConfig.bucket": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectBigqueryServiceTableBigLakeConfig).Bucket, ok = plugin.RawToTValue[*mqlGcpProjectStorageServiceBucket](v.Value, v.Error)
 		return
 	},
 	"gcp.project.bigqueryService.table.bigLakeConfig.fileFormat": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -54686,6 +54700,7 @@ type mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration struct {
 	SslOption         plugin.TValue[string]
 	DmsManaged        plugin.TValue[bool]
 	DumpFilePath      plugin.TValue[string]
+	DumpFileBucket    plugin.TValue[*mqlGcpProjectStorageServiceBucket]
 	SourceInstance    plugin.TValue[*mqlGcpProjectSqlServiceInstance]
 }
 
@@ -54747,6 +54762,22 @@ func (c *mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration) GetDmsManaged()
 
 func (c *mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration) GetDumpFilePath() *plugin.TValue[string] {
 	return &c.DumpFilePath
+}
+
+func (c *mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration) GetDumpFileBucket() *plugin.TValue[*mqlGcpProjectStorageServiceBucket] {
+	return plugin.GetOrCompute[*mqlGcpProjectStorageServiceBucket](&c.DumpFileBucket, func() (*mqlGcpProjectStorageServiceBucket, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.sqlService.instance.onPremisesConfiguration", c.__id, "dumpFileBucket")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectStorageServiceBucket), nil
+			}
+		}
+
+		return c.dumpFileBucket()
+	})
 }
 
 func (c *mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration) GetSourceInstance() *plugin.TValue[*mqlGcpProjectSqlServiceInstance] {
@@ -56748,6 +56779,7 @@ type mqlGcpProjectBigqueryServiceTableBigLakeConfig struct {
 	__id       string
 	mqlGcpProjectBigqueryServiceTableBigLakeConfigInternal
 	StorageUri  plugin.TValue[string]
+	Bucket      plugin.TValue[*mqlGcpProjectStorageServiceBucket]
 	FileFormat  plugin.TValue[string]
 	TableFormat plugin.TValue[string]
 	Connection  plugin.TValue[*mqlGcpProjectBigqueryServiceConnection]
@@ -56787,6 +56819,22 @@ func (c *mqlGcpProjectBigqueryServiceTableBigLakeConfig) MqlID() string {
 
 func (c *mqlGcpProjectBigqueryServiceTableBigLakeConfig) GetStorageUri() *plugin.TValue[string] {
 	return &c.StorageUri
+}
+
+func (c *mqlGcpProjectBigqueryServiceTableBigLakeConfig) GetBucket() *plugin.TValue[*mqlGcpProjectStorageServiceBucket] {
+	return plugin.GetOrCompute[*mqlGcpProjectStorageServiceBucket](&c.Bucket, func() (*mqlGcpProjectStorageServiceBucket, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.bigqueryService.table.bigLakeConfig", c.__id, "bucket")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectStorageServiceBucket), nil
+			}
+		}
+
+		return c.bucket()
+	})
 }
 
 func (c *mqlGcpProjectBigqueryServiceTableBigLakeConfig) GetFileFormat() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -819,6 +819,7 @@ gcp.project.bigqueryService.routine.projectId 9.0.0
 gcp.project.bigqueryService.routine.type 9.0.0
 gcp.project.bigqueryService.table 9.0.0
 gcp.project.bigqueryService.table.bigLakeConfig 13.36.1
+gcp.project.bigqueryService.table.bigLakeConfig.bucket 13.36.1
 gcp.project.bigqueryService.table.bigLakeConfig.connection 13.36.1
 gcp.project.bigqueryService.table.bigLakeConfig.fileFormat 13.36.1
 gcp.project.bigqueryService.table.bigLakeConfig.storageUri 13.36.1
@@ -5068,6 +5069,7 @@ gcp.project.sqlService.instance.onPremisesConfiguration 13.36.1
 gcp.project.sqlService.instance.onPremisesConfiguration.caCertificate 13.36.1
 gcp.project.sqlService.instance.onPremisesConfiguration.clientCertificate 13.36.1
 gcp.project.sqlService.instance.onPremisesConfiguration.dmsManaged 13.36.1
+gcp.project.sqlService.instance.onPremisesConfiguration.dumpFileBucket 13.36.1
 gcp.project.sqlService.instance.onPremisesConfiguration.dumpFilePath 13.36.1
 gcp.project.sqlService.instance.onPremisesConfiguration.hostPort 13.36.1
 gcp.project.sqlService.instance.onPremisesConfiguration.sourceInstance 13.36.1

--- a/providers/gcp/resources/gcs_uri.go
+++ b/providers/gcp/resources/gcs_uri.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// gcsBucketFromURI pulls the bucket name out of a Cloud Storage URI.
+//
+// Callers hand us whatever the owning API reported, which is not always a
+// well-formed gs:// URI: a scheme-less "my-bucket/dump.sql" and a bare bucket
+// name both appear in practice, and an empty value means the feature is simply
+// not configured. Anything without a usable bucket segment returns "" so the
+// reference reads as null rather than resolving to something invented.
+func gcsBucketFromURI(uri string) string {
+	s := strings.TrimSpace(uri)
+	if s == "" {
+		return ""
+	}
+	s = strings.TrimPrefix(s, "gs://")
+	// A URI that was nothing but the scheme names no bucket.
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		s = s[:i]
+	}
+	// Guard against a leading slash producing an empty first segment.
+	if s == "" {
+		return ""
+	}
+	return s
+}
+
+// resolveGcsBucketFromURI resolves the bucket named in a Cloud Storage URI.
+//
+// Bucket names are globally unique, so the bucket resource's init resolves one
+// from its name alone. A bucket in a project this credential cannot read is a
+// supported configuration -- a BigLake table may well read from a bucket owned
+// by another team -- so a failed lookup reports null rather than failing the
+// parent resource.
+func resolveGcsBucketFromURI(runtime *plugin.Runtime, uri string, field *plugin.TValue[*mqlGcpProjectStorageServiceBucket]) (*mqlGcpProjectStorageServiceBucket, error) {
+	name := gcsBucketFromURI(uri)
+	if name == "" {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	res, err := NewResource(runtime, "gcp.project.storageService.bucket", map[string]*llx.RawData{
+		"name": llx.StringData(name),
+	})
+	if err != nil {
+		log.Debug().Err(err).Str("bucket", name).Msg("could not resolve Cloud Storage bucket")
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return res.(*mqlGcpProjectStorageServiceBucket), nil
+}

--- a/providers/gcp/resources/gcs_uri_test.go
+++ b/providers/gcp/resources/gcs_uri_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGcsBucketFromURI pins the parsing behind the bucket references on
+// BigLake tables and Cloud SQL on-premises configurations.
+//
+// The failure that matters is the silent one: returning a wrong bucket name
+// resolves to a real but unrelated bucket, and the reference then reports that
+// bucket's IAM policy as if it governed this table's data. Every input that
+// does not clearly name a bucket must return "" so the field reads null.
+func TestGcsBucketFromURI(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{name: "bucket and object prefix", uri: "gs://my-lake/warehouse/table/", want: "my-lake"},
+		{name: "bucket only, trailing slash", uri: "gs://my-lake/", want: "my-lake"},
+		{name: "bucket only, no trailing slash", uri: "gs://my-lake", want: "my-lake"},
+		{name: "single object", uri: "gs://db-dumps/prod-2026-08-17.sql.gz", want: "db-dumps"},
+		{name: "dotted bucket name", uri: "gs://logs.example.com/access/", want: "logs.example.com"},
+		{name: "wildcard object glob", uri: "gs://my-lake/data/*.parquet", want: "my-lake"},
+
+		// Shapes seen without the scheme.
+		{name: "scheme-less with path", uri: "db-dumps/prod.sql", want: "db-dumps"},
+		{name: "bare bucket name", uri: "my-lake", want: "my-lake"},
+
+		// Nothing resolvable -- all must read as null, not as a guess.
+		{name: "empty", uri: "", want: ""},
+		{name: "whitespace only", uri: "   ", want: ""},
+		{name: "scheme only", uri: "gs://", want: ""},
+		{name: "scheme with empty first segment", uri: "gs:///object", want: ""},
+		{name: "leading slash", uri: "/object", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, gcsBucketFromURI(tt.uri))
+		})
+	}
+}

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -1074,6 +1074,13 @@ func (g *mqlGcpProjectSqlServiceInstanceSettingsIpConfiguration) network() (*mql
 	return n, nil
 }
 
+// dumpFileBucket resolves the Cloud Storage bucket holding the source database
+// dump. A dump is a full copy of the external database's contents, so the
+// bucket's own IAM policy decides who can read that copy.
+func (g *mqlGcpProjectSqlServiceInstanceOnPremisesConfiguration) dumpFileBucket() (*mqlGcpProjectStorageServiceBucket, error) {
+	return resolveGcsBucketFromURI(g.MqlRuntime, g.DumpFilePath.Data, &g.DumpFileBucket)
+}
+
 func (g *mqlGcpProjectSqlServiceInstance) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error


### PR DESCRIPTION
Follow-up to #10014, which is merged but not yet released.

## The gap

#10014 added two `gs://` URIs that name a Cloud Storage bucket, both as raw strings:

- `gcp.project.bigqueryService.table.bigLakeConfig.storageUri`
- `gcp.project.sqlService.instance.onPremisesConfiguration.dumpFilePath`

A BigLake table is only as private as the bucket its data files sit in, and a Cloud SQL dump file is a **full copy** of an external database's contents. In both cases the exposure question belongs to the bucket, and neither resource could reach it.

```mql
# now expressible in one policy
gcp.projects.all(
  bigqueryService.tables.where(bigLakeConfiguration != null).all(
    bigLakeConfiguration.bucket.iamPolicy.none(/allUsers|allAuthenticatedUsers/) ) )
```

## What changed

| Resource | Added |
|---|---|
| `bigqueryService.table.bigLakeConfig` | `bucket() gcp.project.storageService.bucket` |
| `sqlService.instance.onPremisesConfiguration` | `dumpFileBucket() gcp.project.storageService.bucket` |

Both raw URIs are **kept, not deprecated** — they carry the object prefix and file name *inside* the bucket, which a bucket reference cannot round-trip. This is the case CLAUDE.md carves out from the deprecate-the-duplicate rule.

## How it resolves

Through the bucket resource's existing `init`, which resolves from a **name alone** — bucket names are globally unique in GCS, so one `Buckets.Get` returns everything including project and location. That init already comments that it exists for exactly this shape ("cross-resource references like a Datastream connection profile pointing at a GCS bucket"); this reuses it rather than adding a second path.

No new permissions: `gcp.permissions.json` regenerates unchanged at 287.

A bucket in a project the credential cannot read is a supported configuration — a BigLake table may well read from another team's bucket — so a failed lookup logs at debug and reports **null**, rather than failing the table or the SQL instance.

## The parser

`gcsBucketFromURI` is the one piece of real logic, and its failure mode is the dangerous kind: returning a *wrong* bucket name resolves to a real but unrelated bucket, and the reference then reports that bucket's IAM policy as if it governed this table's data. So every input that does not clearly name a bucket returns `""` and reads as null.

Table-tested across 13 cases, including the ones that must **not** resolve: `""`, whitespace, `gs://`, `gs:///object`, `/object`. Also covers the scheme-less shapes that appear in practice (`db-dumps/prod.sql`, a bare bucket name), dotted bucket names, and object globs.

## Considered and rejected from #10014

- `onPremisesConfiguration.caCertificate` / `clientCertificate` — PEM content, not references.
- `onPremisesConfiguration.hostPort` — an external database endpoint, not a modeled resource.
- `secret.policyMemberNamePrincipal` / `policyMemberUidPrincipal` — IAM principal identifiers for use in conditions, not pointers at a modeled resource.
- `bigLakeConfig.connection`, `foreignKey.referencedTable`, `onPremisesConfiguration.sourceInstance` — already typed in #10014.

I also checked #10013 (azure armnetwork v11) for the same problem and found nothing: every field it added is a scalar or enum, with no raw IDs.

## Testing

```
cd providers/gcp && go build ./... && go test ./... && gofmt -l resources/
```

All gcp packages pass, gofmt clean, `gcp.permissions.json` unchanged. Two new `.lr.versions` entries at `13.36.1`.

**Not verified against live GCP.** The parser is unit-tested and the resolution path is one the provider already uses, but no claim here rests on an API response.
