### PR TITLE
✨ github: list a repository's files recursively with allFiles

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -974,7 +974,17 @@ github.repository @defaults("fullName") {
   // Teams granted access to the repository, with the permission each one holds
   teams() []github.repository.team
   // List of files in the repository
+  //
+  // Only the root of the default branch. Use `allFiles` to walk the whole tree.
   files() []github.file
+  // Every entry in the repository's default branch, listed recursively
+  //
+  // Directory entries appear alongside files, each carrying its full path from
+  // the repository root. The list comes from a single Git Trees API call, so it
+  // reaches arbitrary depth rather than the one level `files` returns. Empty
+  // when the repository has no commits. Git records a submodule as a commit
+  // entry, which is reported with type "submodule".
+  allFiles() []github.file
   // List of releases for the repository
   releases() []github.release
   // Repository owner

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -1370,6 +1370,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.repository.files": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetFiles()).ToDataRes(types.Array(types.Resource("github.file")))
 	},
+	"github.repository.allFiles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetAllFiles()).ToDataRes(types.Array(types.Resource("github.file")))
+	},
 	"github.repository.releases": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetReleases()).ToDataRes(types.Array(types.Resource("github.release")))
 	},
@@ -4094,6 +4097,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.repository.files": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubRepository).Files, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"github.repository.allFiles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).AllFiles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"github.repository.releases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9158,6 +9165,7 @@ type mqlGithubRepository struct {
 	AdminCollaborators                   plugin.TValue[[]any]
 	Teams                                plugin.TValue[[]any]
 	Files                                plugin.TValue[[]any]
+	AllFiles                             plugin.TValue[[]any]
 	Releases                             plugin.TValue[[]any]
 	Owner                                plugin.TValue[*mqlGithubUser]
 	Webhooks                             plugin.TValue[[]any]
@@ -9556,6 +9564,22 @@ func (c *mqlGithubRepository) GetFiles() *plugin.TValue[[]any] {
 		}
 
 		return c.files()
+	})
+}
+
+func (c *mqlGithubRepository) GetAllFiles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AllFiles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("github.repository", c.__id, "allFiles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.allFiles()
 	})
 }
 

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -566,6 +566,7 @@ github.repository 9.0.0
 github.repository.actionsSettings 11.4.131
 github.repository.adminCollaborators 11.4.14
 github.repository.advancedSecurityEnabled 11.4.131
+github.repository.allFiles 13.8.4
 github.repository.allMergeRequests 9.1.12
 github.repository.allowAutoMerge 9.0.0
 github.repository.allowForking 9.0.0

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -1576,6 +1576,81 @@ func newMqlGithubFileDoesNotExist(runtime *plugin.Runtime, ownerName string, rep
 	return res.(*mqlGithubFile), nil
 }
 
+// allFiles lists every entry in the repository's default branch in one Git Trees
+// API call. files() returns the root level only, so a query built on it cannot
+// see anything nested more than one directory deep.
+func (g *mqlGithubRepository) allFiles() ([]any, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
+	}
+
+	if g.DefaultBranchName.Error != nil {
+		return nil, g.DefaultBranchName.Error
+	}
+	ref := g.DefaultBranchName.Data
+	if ref == "" {
+		ref = "HEAD"
+	}
+
+	tree, _, err := conn.Client().Git.GetTree(conn.Context(), ownerLogin, repoName, ref, true)
+	if err != nil {
+		// An empty repository has no tree to read.
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "409") {
+			return []any{}, nil
+		}
+		log.Error().Err(err).Msg("unable to get repository tree")
+		return nil, err
+	}
+
+	if tree.GetTruncated() {
+		log.Warn().
+			Str("owner", ownerLogin).
+			Str("repo", repoName).
+			Msg("repository tree was truncated by the GitHub API, the file listing is incomplete")
+	}
+
+	res := []any{}
+	for i := range tree.Entries {
+		entryPath := convert.ToValue(tree.Entries[i].Path)
+		fileType := gitTreeEntryType(convert.ToValue(tree.Entries[i].Type))
+
+		mqlFile, err := CreateResource(g.MqlRuntime, "github.file", map[string]*llx.RawData{
+			"path":        llx.StringData(entryPath),
+			"name":        llx.StringData(path.Base(entryPath)),
+			"type":        llx.StringData(fileType),
+			"sha":         llx.StringDataPtr(tree.Entries[i].SHA),
+			"isBinary":    llx.BoolData(isBinaryFile(fileType, entryPath)),
+			"ownerName":   llx.StringData(ownerLogin),
+			"repoName":    llx.StringData(repoName),
+			"downloadUrl": llx.StringDataPtr(nil),
+			"exists":      llx.BoolData(true),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlFile)
+	}
+	return res, nil
+}
+
+// gitTreeEntryType maps a Git object type onto the vocabulary github.file.type
+// already uses, so allFiles and files can be filtered the same way.
+func gitTreeEntryType(objectType string) string {
+	switch objectType {
+	case "tree":
+		return "dir"
+	case "blob":
+		return "file"
+	case "commit":
+		return "submodule"
+	default:
+		return objectType
+	}
+}
+
 func (g *mqlGithubRepository) files() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -1597,8 +1597,10 @@ func (g *mqlGithubRepository) allFiles() ([]any, error) {
 
 	tree, _, err := conn.Client().Git.GetTree(conn.Context(), ownerLogin, repoName, ref, true)
 	if err != nil {
-		// An empty repository has no tree to read.
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "409") {
+		// An empty repository has no tree to read: 404 when the ref does not
+		// resolve, 409 when the repository carries no commits.
+		switch githubResponseStatus(err) {
+		case http.StatusNotFound, http.StatusConflict:
 			return []any{}, nil
 		}
 		log.Error().Err(err).Msg("unable to get repository tree")
@@ -1612,7 +1614,7 @@ func (g *mqlGithubRepository) allFiles() ([]any, error) {
 			Msg("repository tree was truncated by the GitHub API, the file listing is incomplete")
 	}
 
-	res := []any{}
+	res := make([]any, 0, len(tree.Entries))
 	for i := range tree.Entries {
 		entryPath := convert.ToValue(tree.Entries[i].Path)
 		fileType := gitTreeEntryType(convert.ToValue(tree.Entries[i].Type))

--- a/providers/github/resources/github_repo_test.go
+++ b/providers/github/resources/github_repo_test.go
@@ -169,3 +169,31 @@ func TestGithubResponseStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestGitTreeEntryType(t *testing.T) {
+	tests := []struct {
+		objectType string
+		want       string
+	}{
+		{objectType: "blob", want: "file"},
+		{objectType: "tree", want: "dir"},
+		{objectType: "commit", want: "submodule"},
+		{objectType: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.objectType, func(t *testing.T) {
+			assert.Equal(t, tt.want, gitTreeEntryType(tt.objectType))
+		})
+	}
+}
+
+func TestIsBinaryFileFromTreeEntry(t *testing.T) {
+	// Tree entries carry a full path, so the extension has to be read off the
+	// last segment rather than by splitting the whole path on ".".
+	assert.True(t, isBinaryFile("file", "tools/vendor/bin/helper.so"))
+	assert.True(t, isBinaryFile("file", "build/my.app.exe"))
+	assert.False(t, isBinaryFile("file", "docs/readme.md"))
+	assert.False(t, isBinaryFile("dir", "tools/vendor/bin"))
+	assert.False(t, isBinaryFile("submodule", "third_party/dep"))
+}


### PR DESCRIPTION
`github.repository.files` returns the root of the default branch, and `github.file.files` descends one directory at a time. A query that wants to see the whole tree has to nest a level per depth, so anything written that way stops at whatever depth its author spelled out.

mondoohq/cnspec#3380 is the concrete case — the binary-artifacts check:

```mql
github.repository.files.all( isBinary == false )
github.repository.files.where( type == "dir" ).all( files.where( type != "dir").all( isBinary == false) )
```

Root plus one level. A committed binary at `tools/vendor/bin/x` is never examined and the check passes, which is a false negative on exactly the case the check exists for, since committed binaries are usually buried rather than sitting in the root.

## The change

`github.repository.allFiles` reads the whole default-branch tree in one Git Trees API call with `recursive=1`. Arbitrary depth, one request rather than one per directory.

```mql
github.repository.allFiles.where(type == "file").all(isBinary == false)
```

Git object types are mapped onto the vocabulary `github.file.type` already uses, so `allFiles` and `files` filter identically:

| Git object | `github.file.type` |
|---|---|
| `blob` | `file` |
| `tree` | `dir` |
| `commit` (submodule) | `submodule` |

- An empty repository has no tree; GitHub answers 404 or 409, and both yield an empty list rather than an error.
- The API truncates very large trees (100k entries / 7MB). A truncated listing is logged as a warning so an incomplete result is visible rather than silent.
- `downloadUrl` is not in the Trees API response and is left null; `content()` still works, since it resolves from the path.

## Verification

Against `mondoohq/cnspec` with a real token:

```
{ n: github.repository.allFiles.length, dirs: github.repository.allFiles.where(type == "dir").length }
→ n: 21770, dirs: 13821
```

```
$ git ls-tree -r -t origin/main | wc -l          # 21770
$ git ls-tree -r -t origin/main | awk '$2=="tree"' | wc -l   # 13821
```

Exact match. Unit tests cover the type mapping and the extension handling for nested paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)