### PR TITLE
✨ github: report whether code scanning is configured

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -1006,7 +1006,20 @@ github.repository @defaults("fullName") {
   // Secret scanning alerts for the repository
   secretScanningAlerts() []github.secretScanningAlert
   // Code scanning alerts for the repository
+  //
+  // Empty both when the repository has no open alerts and when code scanning
+  // was never turned on, so pair it with `codeScanningEnabled` before reading
+  // an empty list as a clean result.
   codeScanningAlerts() []github.codeScanningAlert
+  // Whether code scanning is configured for the repository
+  //
+  // True when CodeQL default setup reports `configured`, and also when at
+  // least one code scanning analysis has been uploaded, which is how advanced
+  // setup through a GitHub Actions workflow presents itself. Null when neither
+  // can be read, for example with a token that lacks the `security_events`
+  // scope, so an authorization failure is not reported as the feature being
+  // off.
+  codeScanningEnabled() bool
   // Self-hosted runners for the repository
   runners() []github.runner
   // Deployment environments for the repository

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -1418,6 +1418,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.repository.codeScanningAlerts": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetCodeScanningAlerts()).ToDataRes(types.Array(types.Resource("github.codeScanningAlert")))
 	},
+	"github.repository.codeScanningEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubRepository).GetCodeScanningEnabled()).ToDataRes(types.Bool)
+	},
 	"github.repository.runners": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubRepository).GetRunners()).ToDataRes(types.Array(types.Resource("github.runner")))
 	},
@@ -4158,6 +4161,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.repository.codeScanningAlerts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubRepository).CodeScanningAlerts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"github.repository.codeScanningEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubRepository).CodeScanningEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"github.repository.runners": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9174,6 +9181,7 @@ type mqlGithubRepository struct {
 	DependabotAlerts                     plugin.TValue[[]any]
 	SecretScanningAlerts                 plugin.TValue[[]any]
 	CodeScanningAlerts                   plugin.TValue[[]any]
+	CodeScanningEnabled                  plugin.TValue[bool]
 	Runners                              plugin.TValue[[]any]
 	Environments                         plugin.TValue[[]any]
 	Deployments                          plugin.TValue[[]any]
@@ -9800,6 +9808,12 @@ func (c *mqlGithubRepository) GetCodeScanningAlerts() *plugin.TValue[[]any] {
 		}
 
 		return c.codeScanningAlerts()
+	})
+}
+
+func (c *mqlGithubRepository) GetCodeScanningEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CodeScanningEnabled, func() (bool, error) {
+		return c.codeScanningEnabled()
 	})
 }
 

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -579,6 +579,7 @@ github.repository.closedIssues 9.0.0
 github.repository.closedMergeRequests 9.1.12
 github.repository.codeOfConductFile 11.4.14
 github.repository.codeScanningAlerts 11.4.121
+github.repository.codeScanningEnabled 13.8.4
 github.repository.codeSecurityEnabled 13.0.8
 github.repository.codeowners 13.0.8
 github.repository.codeowners.content 13.0.8

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -2391,6 +2391,49 @@ func (g *mqlGithubCodeScanningAlert) id() (string, error) {
 	return "github.codeScanningAlert/" + strconv.FormatInt(g.Number.Data, 10), nil
 }
 
+// codeScanningEnabled answers whether the repository has code scanning
+// configured at all. codeScanningAlerts returns an empty list both for a
+// repository with no findings and for one that never enabled scanning, so a
+// check asserting there are no open alerts cannot tell the two apart without
+// this.
+//
+// Two endpoints are needed because the two setup modes report differently.
+// Default setup is visible on the default-setup endpoint. Advanced setup runs
+// from a GitHub Actions workflow, never reports a configured default setup,
+// and shows up only as uploaded analyses.
+func (g *mqlGithubRepository) codeScanningEnabled() (bool, error) {
+	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return false, err
+	}
+
+	setup, _, setupErr := conn.Client().CodeScanning.GetDefaultSetupConfiguration(conn.Context(), ownerLogin, repoName)
+	if setupErr == nil && setup.GetState() == "configured" {
+		return true, nil
+	}
+
+	analyses, _, analysisErr := conn.Client().CodeScanning.ListAnalysesForRepo(conn.Context(), ownerLogin, repoName,
+		&github.AnalysesListOptions{ListOptions: github.ListOptions{PerPage: 1}})
+	if analysisErr == nil {
+		return len(analyses) > 0, nil
+	}
+
+	// A repository with scanning available but no analysis yet answers 404
+	// here, which is a real negative rather than an unknown, provided the
+	// default-setup endpoint answered.
+	if githubResponseStatus(analysisErr) == http.StatusNotFound && setupErr == nil {
+		return false, nil
+	}
+
+	log.Debug().
+		Str("owner", ownerLogin).Str("repo", repoName).
+		AnErr("defaultSetup", setupErr).AnErr("analyses", analysisErr).
+		Msg("unable to determine whether code scanning is enabled")
+	g.CodeScanningEnabled.State = plugin.StateIsSet | plugin.StateIsNull
+	return false, nil
+}
+
 func (g *mqlGithubRepository) codeScanningAlerts() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 	ownerLogin, repoName, err := repoOwnerAndName(g)


### PR DESCRIPTION
For mondoohq/cnspec#3381 item 1.

`github.repository.codeScanningAlerts` returns an empty list in two very different situations: a repository with code scanning enabled and no open alerts, and a repository where code scanning was **never turned on**. A check asserting `none(state == "open")` passes on both, so the weaker posture produces the same green result as the stronger one.

## Why an existing field doesn't close it

`codeSecurityEnabled` and `advancedSecurityEnabled` describe GHAS licensing, and both read `false` on `mondoohq/cnspec` — which does run CodeQL. Requiring them would fail a repository that scans. There is no field on `github.repository` that answers the question.

## The change

`github.repository.codeScanningEnabled` reads two endpoints, because the two setup modes report differently:

| Setup mode | How it shows up |
|---|---|
| Default setup (CodeQL configured in repo settings) | `GET /repos/{o}/{r}/code-scanning/default-setup` → `state: configured` |
| Advanced setup (a GitHub Actions workflow) | never reports a configured default setup; visible only as uploaded analyses |

So the field is true when default setup is `configured` **or** at least one analysis exists.

When neither endpoint can be read, the field is **null** rather than false, so a token lacking `security_events` does not report the feature as switched off. `codeScanningAlerts`'s doc comment now points at this field.

## Verification

Live, against real repositories:

```
mondoohq/cnspec        enabled=true   alerts=470   ← advanced setup; advancedSecurityEnabled reads false
tas50/cinc-server-ng   enabled=true   alerts=24
tas50/cookstyle        enabled=false  alerts=0     ← the vacuous-pass case, now detectable
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)