### PR TITLE
🐛 gcp, azure: three field-resolution bugs found in live verification

### DIFF
--- a/providers/azure/resources/postgresql.go
+++ b/providers/azure/resources/postgresql.go
@@ -282,7 +282,12 @@ func (a *mqlAzureSubscriptionPostgreSqlService) flexibleServers() ([]any, error)
 			var delegatedSubnetId, privateDnsZoneId, sourceServerId *string
 			var maintenanceWindow any
 			if p := dbServer.Properties; p != nil {
-				fullVersion = p.MinorVersion
+				// Azure splits the engine version across two properties: version
+				// carries the major ("16") and minorVersion only the minor ("14").
+				// Publishing minorVersion on its own reports a PostgreSQL 16.14
+				// server as "14", which reads as PostgreSQL 14 -- the wrong major
+				// release, and older than what is actually running.
+				fullVersion = postgresFullVersion(stringEnumPtr(p.Version), p.MinorVersion)
 				administratorLogin = p.AdministratorLogin
 				state = stringEnumPtr(p.State)
 				availabilityZone = p.AvailabilityZone
@@ -872,4 +877,21 @@ func (a *mqlAzureSubscriptionPostgreSqlServiceFlexibleServer) threatProtectionSt
 		return "", nil
 	}
 	return string(*resp.Properties.State), nil
+}
+
+// postgresFullVersion joins Azure's split engine version into the single
+// "<major>.<minor>" string the fullVersion field documents.
+//
+// Returns nil when Azure reports only a major version, which the schema
+// describes as an empty fullVersion, so a caller cannot mistake a partial
+// answer for a complete one.
+func postgresFullVersion(version, minorVersion *string) *string {
+	if minorVersion == nil || *minorVersion == "" {
+		return nil
+	}
+	if version == nil || *version == "" {
+		return nil
+	}
+	full := *version + "." + *minorVersion
+	return &full
 }

--- a/providers/azure/resources/postgresql_fullversion_test.go
+++ b/providers/azure/resources/postgresql_fullversion_test.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+// TestPostgresFullVersion pins the join that fullVersion documents.
+//
+// Azure splits the engine version: properties.version carries the major ("16")
+// and properties.minorVersion only the minor ("14"). Publishing minorVersion on
+// its own reported a PostgreSQL 16.14 server as "14" -- read as PostgreSQL 14,
+// the wrong major release and older than what is running, which is exactly
+// backwards for a version-currency check.
+func TestPostgresFullVersion(t *testing.T) {
+	ver := func(s string) *string { return &s }
+	str := func(s string) *string { return &s }
+
+	tests := []struct {
+		name    string
+		version *string
+		minor   *string
+		want    *string
+	}{
+		{
+			name:    "major and minor join into the full version",
+			version: ver("16"),
+			minor:   str("14"),
+			want:    str("16.14"),
+		},
+		{
+			name:    "the live case that exposed the bug",
+			version: ver("16"),
+			minor:   str("4"),
+			want:    str("16.4"),
+		},
+		{
+			// documented as empty rather than guessed: a bare major is not a
+			// full version, and reporting one would look complete
+			name:    "missing minor yields no full version",
+			version: ver("16"),
+			minor:   nil,
+			want:    nil,
+		},
+		{
+			name:    "empty minor yields no full version",
+			version: ver("16"),
+			minor:   str(""),
+			want:    nil,
+		},
+		{
+			name:    "missing major yields no full version",
+			version: nil,
+			minor:   str("14"),
+			want:    nil,
+		},
+		{
+			name:    "empty major yields no full version",
+			version: ver(""),
+			minor:   str("14"),
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := postgresFullVersion(tc.version, tc.minor)
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("postgresFullVersion() = %q, want nil", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("postgresFullVersion() = nil, want %q", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Errorf("postgresFullVersion() = %q, want %q", *got, *tc.want)
+			}
+		})
+	}
+}
+
+// TestPostgresFullVersionNeverReportsAnOlderMajor is the regression itself: the
+// result must never be mistakable for a lower major release.
+func TestPostgresFullVersionNeverReportsAnOlderMajor(t *testing.T) {
+	v, minor := "16", "14"
+	got := postgresFullVersion(&v, &minor)
+	if got == nil {
+		t.Fatal("expected a full version")
+	}
+	if *got == "14" {
+		t.Fatalf("fullVersion reported %q for a PostgreSQL 16 server", *got)
+	}
+	if *got != "16.14" {
+		t.Errorf("fullVersion = %q, want \"16.14\"", *got)
+	}
+}

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -367,16 +368,58 @@ func (g *mqlGcpProjectBigqueryServiceTableBigLakeConfig) connection() (*mqlGcpPr
 	if conns.Error != nil {
 		return nil, conns.Error
 	}
+	wantLocation, wantID, ok := bigqueryConnectionKey(g.cacheConnectionId)
+	if !ok {
+		return notFound()
+	}
+
 	for _, c := range conns.Data {
 		conn, ok := c.(*mqlGcpProjectBigqueryServiceConnection)
 		if !ok || conn.Name.Error != nil {
 			continue
 		}
-		if conn.Name.Data == g.cacheConnectionId {
+		gotLocation, gotID, ok := bigqueryConnectionKey(conn.Name.Data)
+		if !ok {
+			continue
+		}
+		if gotLocation == wantLocation && gotID == wantID {
 			return conn, nil
 		}
 	}
 	return notFound()
+}
+
+// bigqueryConnectionKey reduces the two spellings BigQuery uses for a
+// connection to the (location, id) pair that actually identifies it.
+//
+// A table's biglakeConfiguration.connectionId comes back in the dotted form
+// "<project-id>.<location>.<connection>", while the connections list reports
+// "projects/<project-number>/locations/<location>/connections/<connection>".
+// The project segment is not comparable between them -- one is the project ID
+// and the other the project number -- so the leading segment is dropped and the
+// match is made on the parts that do identify the connection. Comparing the two
+// strings directly never matches, which left every BigLake table reporting no
+// connection at all.
+func bigqueryConnectionKey(s string) (location string, id string, ok bool) {
+	if strings.Contains(s, "/") {
+		parts := strings.Split(s, "/")
+		for i := 0; i+1 < len(parts); i += 2 {
+			switch parts[i] {
+			case "locations":
+				location = parts[i+1]
+			case "connections":
+				id = parts[i+1]
+			}
+		}
+		return location, id, location != "" && id != ""
+	}
+
+	// dotted form: <project>.<location>.<connection>
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return "", "", false
+	}
+	return parts[1], parts[2], parts[1] != "" && parts[2] != ""
 }
 
 // bigqueryTableId is the resource identity of a table. The runtime stores the

--- a/providers/gcp/resources/bigquery_connection_key_test.go
+++ b/providers/gcp/resources/bigquery_connection_key_test.go
@@ -1,0 +1,114 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+// TestBigqueryConnectionKey pins the reduction that makes a BigLake table's
+// connection resolvable at all.
+//
+// BigQuery reports the same connection two ways: a table's
+// biglakeConfiguration.connectionId is dotted and carries the project *ID*,
+// while the connections list is a resource path carrying the project *number*.
+// Comparing the raw strings never matches, so bigLakeConfiguration.connection
+// read null on every BigLake table until both sides were reduced to the
+// (location, id) pair below. The project segment is deliberately dropped: it is
+// the one part that is not comparable between the two spellings.
+func TestBigqueryConnectionKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		in           string
+		wantLocation string
+		wantID       string
+		wantOK       bool
+	}{
+		{
+			name:         "dotted form from biglakeConfiguration.connectionId",
+			in:           "tim-learning-project.us.mqlv-conn-3b5g1j",
+			wantLocation: "us",
+			wantID:       "mqlv-conn-3b5g1j",
+			wantOK:       true,
+		},
+		{
+			name:         "resource path from the connections list",
+			in:           "projects/629145041219/locations/us/connections/mqlv-conn-3b5g1j",
+			wantLocation: "us",
+			wantID:       "mqlv-conn-3b5g1j",
+			wantOK:       true,
+		},
+		{
+			// the pair the live bug was found on: these two must reduce equal
+			name:         "regional location",
+			in:           "projects/12345/locations/us-central1/connections/my-conn",
+			wantLocation: "us-central1",
+			wantID:       "my-conn",
+			wantOK:       true,
+		},
+		{
+			name:         "dotted form with a regional location",
+			in:           "my-project.us-central1.my-conn",
+			wantLocation: "us-central1",
+			wantID:       "my-conn",
+			wantOK:       true,
+		},
+		{
+			name:   "empty string is not a connection",
+			in:     "",
+			wantOK: false,
+		},
+		{
+			name:   "bare connection name has no location to match on",
+			in:     "my-conn",
+			wantOK: false,
+		},
+		{
+			name:   "two dotted segments is not the documented shape",
+			in:     "my-project.my-conn",
+			wantOK: false,
+		},
+		{
+			name:   "path without a connections segment",
+			in:     "projects/12345/locations/us",
+			wantOK: false,
+		},
+		{
+			name:   "path without a locations segment",
+			in:     "projects/12345/connections/my-conn",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLocation, gotID, gotOK := bigqueryConnectionKey(tc.in)
+			if gotOK != tc.wantOK {
+				t.Fatalf("bigqueryConnectionKey(%q) ok = %v, want %v", tc.in, gotOK, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if gotLocation != tc.wantLocation || gotID != tc.wantID {
+				t.Errorf("bigqueryConnectionKey(%q) = (%q, %q), want (%q, %q)",
+					tc.in, gotLocation, gotID, tc.wantLocation, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestBigqueryConnectionKeyMatchesAcrossSpellings is the regression itself: the
+// dotted and path spellings of one connection must reduce to the same key.
+func TestBigqueryConnectionKeyMatchesAcrossSpellings(t *testing.T) {
+	dottedLoc, dottedID, ok := bigqueryConnectionKey("tim-learning-project.us.mqlv-conn-3b5g1j")
+	if !ok {
+		t.Fatal("dotted form did not parse")
+	}
+	pathLoc, pathID, ok := bigqueryConnectionKey("projects/629145041219/locations/us/connections/mqlv-conn-3b5g1j")
+	if !ok {
+		t.Fatal("resource path did not parse")
+	}
+	if dottedLoc != pathLoc || dottedID != pathID {
+		t.Errorf("the same connection reduced differently: dotted=(%q,%q) path=(%q,%q)",
+			dottedLoc, dottedID, pathLoc, pathID)
+	}
+}

--- a/providers/gcp/resources/cloudscheduler.go
+++ b/providers/gcp/resources/cloudscheduler.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +18,26 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
+
+// initGcpProjectCloudSchedulerService fills in the project the service belongs to when the
+// resource is reached by its own type name rather than through the
+// gcp.project accessor. Without it the resource is built with an empty
+// projectId, and the serviceEnabled gate then asks Service Usage about
+// "projects/", which fails the whole query with an InvalidArgument.
+func initGcpProjectCloudSchedulerService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+
+	args["projectId"] = llx.StringData(conn.ResourceID())
+
+	return args, nil, nil
+}
 
 type mqlGcpProjectCloudSchedulerServiceInternal struct {
 	serviceGate

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -552,7 +552,7 @@ func init() {
 			Create: createGcpFolders,
 		},
 		"gcp.project.redisService": {
-			// to override args, implement: initGcpProjectRedisService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectRedisService,
 			Create: createGcpProjectRedisService,
 		},
 		"gcp.project.redisService.instance": {
@@ -904,7 +904,7 @@ func init() {
 			Create: createGcpProjectDnsServiceResponsePolicy,
 		},
 		"gcp.project.gkeService": {
-			// to override args, implement: initGcpProjectGkeService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectGkeService,
 			Create: createGcpProjectGkeService,
 		},
 		"gcp.project.gkeService.cluster": {
@@ -1636,7 +1636,7 @@ func init() {
 			Create: createGcpProjectCloudTasksServiceQueue,
 		},
 		"gcp.project.cloudSchedulerService": {
-			// to override args, implement: initGcpProjectCloudSchedulerService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initGcpProjectCloudSchedulerService,
 			Create: createGcpProjectCloudSchedulerService,
 		},
 		"gcp.project.cloudSchedulerService.job": {

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -22,6 +22,28 @@ import (
 	"google.golang.org/api/option"
 )
 
+// initGcpProjectGkeService fills in the project the service belongs to when the
+// resource is reached by its own type name (gcp.project.gkeService.clusters)
+// rather than through the gcp.project.gke() accessor. Without it the resource
+// is built with an empty projectId, and the serviceEnabled gate then asks
+// Service Usage about "projects/", which fails the whole query with an
+// InvalidArgument rather than returning clusters. Every sibling service
+// resource carries the same init.
+func initGcpProjectGkeService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+
+	args["projectId"] = llx.StringData(conn.ResourceID())
+
+	return args, nil, nil
+}
+
 type mqlGcpProjectGkeServiceInternal struct {
 	serviceGate
 }

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -24,6 +24,26 @@ import (
 	"google.golang.org/api/option"
 )
 
+// initGcpProjectRedisService fills in the project the service belongs to when the
+// resource is reached by its own type name rather than through the
+// gcp.project accessor. Without it the resource is built with an empty
+// projectId, and the serviceEnabled gate then asks Service Usage about
+// "projects/", which fails the whole query with an InvalidArgument.
+func initGcpProjectRedisService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	conn, ok := runtime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+
+	args["projectId"] = llx.StringData(conn.ResourceID())
+
+	return args, nil, nil
+}
+
 type mqlGcpProjectRedisServiceInternal struct {
 	serviceGate
 }

--- a/providers/gcp/resources/service_init_guard_test.go
+++ b/providers/gcp/resources/service_init_guard_test.go
@@ -1,0 +1,103 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEveryGatedServiceHasAnInit pins the other half of the serviceEnabled
+// contract. serviceGate guarantees the "is this API enabled" answer resolves on
+// every construction path, but it resolves it *from the resource's projectId* --
+// so a service resource that can be built without one is still broken.
+//
+// A gcp.project.<x>Service resource is reachable two ways: through the
+// gcp.project.<x>() accessor, which passes the project down, and by its own type
+// name (gcp.project.<x>Service.things), which builds it from no arguments at
+// all. On that second path the resource needs an init to fill projectId in from
+// the connection. Without one, projectId is empty, the gate asks Service Usage
+// about "projects/", and the query fails with
+//
+//	InvalidArgument: The resource id projects/ is invalid
+//
+// for the whole scan -- not for one field. This was found live against
+// gcp.project.gkeService.clusters, and cloudScheduler and redis had the same
+// hole; every other service already carried the init, which is exactly why the
+// omission was invisible.
+func TestEveryGatedServiceHasAnInit(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	gated := map[string]token.Position{} // resource type name -> where it is declared
+	inits := map[string]bool{}
+
+	fset := token.NewFileSet()
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Recv == nil && strings.HasPrefix(d.Name.Name, "init") {
+					inits[d.Name.Name] = true
+				}
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok || !strings.HasSuffix(ts.Name.Name, "Internal") {
+						continue
+					}
+					st, ok := ts.Type.(*ast.StructType)
+					if !ok || !embedsServiceGate(st) {
+						continue
+					}
+					resource := strings.TrimSuffix(ts.Name.Name, "Internal")
+					gated[resource] = fset.Position(ts.Pos())
+				}
+			}
+		}
+	}
+
+	if len(gated) == 0 {
+		t.Fatal("found no serviceGate-embedding resources; the scan is broken, not the code")
+	}
+
+	for resource, pos := range gated {
+		// mqlGcpProjectGkeService -> initGcpProjectGkeService
+		want := "init" + strings.TrimPrefix(resource, "mql")
+		if !inits[want] {
+			t.Errorf("%s: %s embeds serviceGate but has no %s. Reached by its own type "+
+				"name the resource is built with an empty projectId, and the gate then "+
+				"queries Service Usage for \"projects/\", failing the whole scan. Add an "+
+				"init that sets args[\"projectId\"] from conn.ResourceID().",
+				pos, resource, want)
+		}
+	}
+}
+
+// embedsServiceGate reports whether the struct embeds serviceGate.
+func embedsServiceGate(st *ast.StructType) bool {
+	for _, f := range st.Fields.List {
+		if len(f.Names) != 0 {
+			continue // named field, not an embed
+		}
+		if id, ok := f.Type.(*ast.Ident); ok && id.Name == "serviceGate" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Three defects found running the last 12 hours of gcp/oci/azure schema changes (#10013, #10014, #10016, #10017, #10018, #10019, #10020, #10021) against live GCP, Azure and OCI infrastructure. All three were invisible to compile checks and to the existing tests.

## 1. `gcp.project.<x>Service` reached by its own type name errors the whole scan

A service resource is reachable two ways: through the `gcp.project.<x>()` accessor, which passes the project down, and by its own type name (`gcp.project.gkeService.clusters`), which builds it from no arguments. The second path needs an `init` to fill `projectId` in from the connection.

`gkeService`, `cloudSchedulerService` and `redisService` had none, so `projectId` was empty and the `serviceEnabled` gate asked Service Usage about `projects/`:

```
rpc error: code = InvalidArgument desc = The resource id projects/ is invalid
```

That fails the **entire scan**, not one field. The other 25 gated services already carried the init, which is why the omission was invisible — there was no odd-looking code to read, only an absence. So this adds a guard test (`TestEveryGatedServiceHasAnInit`) that pairs every `serviceGate` with its `init`, rather than three one-off patches. The guard was confirmed to fail before the fix.

Pre-existing (from #9442), but it blocked verifying #10016's GKE fields.

## 2. `bigLakeConfiguration.connection` was null on every BigLake table

BigQuery spells one connection two ways:

| source | value |
|---|---|
| table's `biglakeConfiguration.connectionId` | `tim-learning-project.us.mqlv-conn-3b5g1j` (dotted, project **ID**) |
| connections list `name` | `projects/629145041219/locations/us/connections/mqlv-conn-3b5g1j` (path, project **number**) |

The accessor compared the two raw strings, which can never match. Both are now reduced to the `(location, id)` pair that identifies the connection; the project segment is dropped because it is the one part not comparable between the spellings.

From #10014.

## 3. Azure `postgreSqlService.flexibleServer.fullVersion` reported the wrong major release

`fullVersion` is documented as "full engine version including the minor release", but published Azure's `properties.minorVersion` on its own. A PostgreSQL **16.14** server reported:

```
version:     "16"
fullVersion: "14"
```

which reads as PostgreSQL 14 — the wrong major, and *older* than what is running. That is backwards for the check the field exists to support. Now joined into `16.14`, returning empty when Azure reports only a major version (what the schema already documents).

The field landed after azure-13.35.0 was cut and has not shipped, so the value is corrected in place rather than deprecated alongside a replacement.

From #10019.

## Verification

Each fix was re-queried against the still-live infrastructure before teardown:

- `gcp.project.gkeService.clusters` returns the cluster (`podAutoscalingHpaProfile: "PERFORMANCE"`); `cloudSchedulerService.jobs` and `redisService.instances` return `0` instead of erroring.
- `bigLakeConfiguration.connection` resolves to `projects/629145041219/locations/us/connections/mqlv-conn-3b5g1j` on an Iceberg BigLake table.
- `fullVersion` reports `16.14` on a PostgreSQL 16 flexible server and its read replica.

`go test ./resources/` passes for both providers.
