### PR TITLE
🎉 github-13.9.0, gcp-13.37.0, azure-13.36.0, oci-13.21.0, os-13.40.9

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.35.0",
+	Version:   "13.36.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.36.0",
+	Version: "13.37.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.8.3",
+	Version:         "13.9.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.20.0",
+	Version:         "13.21.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.40.8",
+	Version: "13.40.9",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### github (13.9.0)
- ✨ github: report whether code scanning is configured (#10023)

### gcp (13.37.0)
- 🐛 gcp, azure: three field-resolution bugs found in live verification (#10024)
- ⭐ gcp: resolve Cloud Storage URIs to the buckets they name (#10021)
- 🐛 gcp: stop a BigQuery base-table reference standing in for the real table (#10018)
- ⭐ gcp: workload runtime fields for GKE, Cloud Run, DNS, and Compute (#10016)
- ⭐ gcp: data-plane security fields for Cloud SQL, BigQuery, and Secret Manager (#10014)

### azure (13.36.0)
- 🐛 gcp, azure: three field-resolution bugs found in live verification (#10024)
- ⭐ azure: Tier A passthrough fields across 25 existing resources (#10019)
- ⭐ azure: armnetwork v11 and the fields it unlocks (#10013)

### oci (13.21.0)
- ⭐ oci: resolve load balancer name references to the objects they name (#10020)
- ⭐ oci: expose SDK fields the listers already fetch (#10017)

### os (13.40.9)
- ⚡ os: size the tar read buffer from the entry header (#9898)
- ⚡ os: share one string between the tar file map key and the header name (#9867)
