### PR TITLE
🐛 llx/checksum: fold a nil result like the zero result

### DIFF
--- a/llx/checksum/checksum.go
+++ b/llx/checksum/checksum.go
@@ -289,10 +289,19 @@ func canonPrimitive(h *Hasher, p *llx.Primitive, depth int) error {
 // CanonResult hashes an llx.Result's error and data. The CodeId is NOT
 // hashed here — callers hash the row key themselves (it is the map key /
 // primary key at every call site).
+//
+// A nil Result folds exactly like the zero Result. proto3 maps cannot
+// represent a nil message value, so a nil inside an in-memory result map
+// round-trips through marshal/unmarshal as a non-nil empty Result: nil and
+// zero are one value on the wire, and hashing them differently would make
+// the same logical row checksum differently before and after storage — the
+// exact divergence that breaks write-time emission against a recompute
+// from the stored row. The fold direction (nil adopts the zero encoding,
+// never the reverse) is deliberate: decoded rows can never contain a nil,
+// so no checksum of stored data moves and AlgoVersion stays at "1".
 func CanonResult(h *Hasher, r *llx.Result) error {
 	if r == nil {
-		h.Str("<nil>")
-		return nil
+		r = &llx.Result{}
 	}
 	h.Str(r.Error)
 	return CanonPrimitive(h, r.Data)

--- a/llx/checksum/checksum_test.go
+++ b/llx/checksum/checksum_test.go
@@ -378,3 +378,52 @@ func TestCanonDepthLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, CanonPrimitive(NewHasher("t"), &llx.Primitive{Type: string(types.Dict), Value: b}))
 }
+
+// TestCanonResultNilIsZeroResult pins the nil/zero fold: proto3 maps cannot
+// hold a nil message value, so a nil Result inside an in-memory result map
+// round-trips through marshal/unmarshal as a non-nil empty Result. Nil and
+// zero are one value on the wire, and must be one value in the hash —
+// otherwise a row hashed at write time (in memory, nil present) can never
+// match the same row recomputed from storage (decoded, nil gone), and the
+// unchanged-scan comparison reads it as permanently changed.
+func TestCanonResultNilIsZeroResult(t *testing.T) {
+	withNil := &llx.ResourceRecording{
+		Resource: "user", Id: "root",
+		Fields: map[string]*llx.Result{"gone": nil},
+	}
+	withZero := &llx.ResourceRecording{
+		Resource: "user", Id: "root",
+		Fields: map[string]*llx.Result{"gone": {}},
+	}
+
+	dNil, err := HashResourceRow(withNil)
+	require.NoError(t, err)
+	dZero, err := HashResourceRow(withZero)
+	require.NoError(t, err)
+	assert.Equal(t, dNil, dZero, "nil and the zero Result are one value on the wire, so they must be one value in the hash")
+
+	// The motivating property, end to end: the in-memory hash equals the
+	// hash of the same recording after a storage round trip.
+	blob, err := proto.Marshal(withNil)
+	require.NoError(t, err)
+	decoded := &llx.ResourceRecording{}
+	require.NoError(t, proto.Unmarshal(blob, decoded))
+	dDecoded, err := HashResourceRow(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, dNil, dDecoded, "write-time hash must equal the recompute from the stored row")
+
+	// Golden for the shared encoding, and the fold direction is the zero
+	// Result's encoding: hashes of decoded rows (which can never contain a
+	// nil) are unchanged by the fold, so AlgoVersion stays at "1".
+	assert.Equal(t, "2d282e44733823be", hex(dZero))
+
+	// The row-level nil sentinel is untouched by the fold — HashDataRow's
+	// golden above pins it separately.
+	present := &llx.Result{Data: llx.StringPrimitive("v")}
+	dPresent, err := HashResourceRow(&llx.ResourceRecording{
+		Resource: "user", Id: "root",
+		Fields: map[string]*llx.Result{"gone": present},
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, dNil, dPresent, "a present value still differs from an absent one")
+}


### PR DESCRIPTION
## What

`CanonResult` now folds a nil `*llx.Result` exactly like the zero `Result`, instead of giving it its own `"<nil>"` sentinel.

## Why

proto3 maps cannot represent a nil message value: a nil inside an in-memory result map (`ResourceRecording.Fields`, `ScoredRiskFactor.Data`) round-trips through marshal/unmarshal as a **non-nil empty** `Result`. Nil and zero are one value on the wire — hashing them differently makes the same logical row checksum differently before and after storage.

Today both hash sites (cnspec's scandb pass, server recompute) read post-round-trip rows, so nothing diverges in production. But it is the single blocker for hashing rows **at insert time** (mondoohq/cnspec#3225's next step, which removes the whole second pass over the scan database): a write-time hash of a row carrying a nil map value could never match the recompute from storage — the row reads permanently "changed", fail-open and invisible.

## Fold direction is load-bearing

Nil adopts the **zero Result's** encoding, never the reverse. Decoded rows can never contain a nil, so **no checksum of stored data moves and AlgoVersion stays at "1"**:

- all pre-existing goldens pass unchanged (`TestHashDataRowGolden` incl. the row-level nil sentinel, which is deliberately untouched);
- a new golden pins the shared encoding, plus an end-to-end marshal/unmarshal parity assertion.

## Verification

Ran cnspec's scandb write-time-vs-stored parity corpus (15 shapes: empty containers, upserts, unicode+NUL, error rows, hostile floats, empty resource ids, nil map values) against this branch: **15/15 rows bit-identical**, with the nil-in-map row's *stored* value byte-identical to before the fold — only the write-time side moved to match. Before the fold it was the single divergence (14/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)