### PR TITLE
🛑 remove deprecated min_mondoo_version from the resource schema

### DIFF
--- a/providers-sdk/v1/resources/resources.pb.go
+++ b/providers-sdk/v1/resources/resources.pb.go
@@ -633,7 +633,7 @@ const file_resources_proto_rawDesc = "" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
 	"\boptional\x18\x03 \x01(\bR\boptional\"6\n" +
 	"\x04Init\x12.\n" +
-	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\xd8\x04\n" +
+	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\xec\x04\n" +
 	"\fResourceInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12B\n" +
@@ -652,7 +652,7 @@ const file_resources_proto_rawDesc = "" +
 	"\bmaturity\x18  \x01(\tR\bmaturity\x1aR\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
-	"\x05value\x18\x02 \x01(\v2\x17.mondoo.resources.FieldR\x05value:\x028\x01J\x04\b\x19\x10\x1a\"\xa3\x03\n" +
+	"\x05value\x18\x02 \x01(\v2\x17.mondoo.resources.FieldR\x05value:\x028\x01J\x04\b\x19\x10\x1aR\x12min_mondoo_version\"\xb7\x03\n" +
 	"\x05Field\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12!\n" +
@@ -668,7 +668,7 @@ const file_resources_proto_rawDesc = "" +
 	"\vis_embedded\x18\x19 \x01(\bR\n" +
 	"isEmbedded\x12\x1a\n" +
 	"\bmaturity\x18\x1a \x01(\tR\bmaturity\x12/\n" +
-	"\x06others\x18\x1d \x03(\v2\x17.mondoo.resources.FieldR\x06othersJ\x04\b\x17\x10\x18B.Z,go.mondoo.com/mql/providers-sdk/v1/resourcesb\x06proto3"
+	"\x06others\x18\x1d \x03(\v2\x17.mondoo.resources.FieldR\x06othersJ\x04\b\x17\x10\x18R\x12min_mondoo_versionB.Z,go.mondoo.com/mql/providers-sdk/v1/resourcesb\x06proto3"
 
 var (
 	file_resources_proto_rawDescOnce sync.Once

--- a/providers-sdk/v1/resources/resources.pb.go
+++ b/providers-sdk/v1/resources/resources.pb.go
@@ -321,15 +321,10 @@ type ResourceInfo struct {
 	// Note: Please do not use this field, it is only temporary and will be
 	// removed in the future once binding resources are mandatory for all
 	// executions.
-	Others   []*ResourceInfo `protobuf:"bytes,29,rep,name=others,proto3" json:"others,omitempty"`
-	Maturity string          `protobuf:"bytes,32,opt,name=maturity,proto3" json:"maturity,omitempty"`
-	// DEPRECATED: remove in v14, not used anymore as of v13.
-	// We now use min_provider_version to show what providers we require.
-	//
-	// Deprecated: Marked as deprecated in resources.proto.
-	MinMondooVersion string `protobuf:"bytes,25,opt,name=min_mondoo_version,json=minMondooVersion,proto3" json:"min_mondoo_version,omitempty"` // ^^
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Others        []*ResourceInfo `protobuf:"bytes,29,rep,name=others,proto3" json:"others,omitempty"`
+	Maturity      string          `protobuf:"bytes,32,opt,name=maturity,proto3" json:"maturity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ResourceInfo) Reset() {
@@ -467,14 +462,6 @@ func (x *ResourceInfo) GetMaturity() string {
 	return ""
 }
 
-// Deprecated: Marked as deprecated in resources.proto.
-func (x *ResourceInfo) GetMinMondooVersion() string {
-	if x != nil {
-		return x.MinMondooVersion
-	}
-	return ""
-}
-
 type Field struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	Name               string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -486,14 +473,9 @@ type Field struct {
 	IsPrivate          bool                   `protobuf:"varint,22,opt,name=is_private,json=isPrivate,proto3" json:"is_private,omitempty"`
 	MinProviderVersion string                 `protobuf:"bytes,30,opt,name=min_provider_version,json=minProviderVersion,proto3" json:"min_provider_version,omitempty"`
 	Provider           string                 `protobuf:"bytes,27,opt,name=provider,proto3" json:"provider,omitempty"`
-	// DEPRECATED: remove in v14, not used anymore as of v13.
-	// We now use min_provider_version to show what providers we require.
-	//
-	// Deprecated: Marked as deprecated in resources.proto.
-	MinMondooVersion   string `protobuf:"bytes,23,opt,name=min_mondoo_version,json=minMondooVersion,proto3" json:"min_mondoo_version,omitempty"`
-	IsImplicitResource bool   `protobuf:"varint,24,opt,name=is_implicit_resource,json=isImplicitResource,proto3" json:"is_implicit_resource,omitempty"`
-	IsEmbedded         bool   `protobuf:"varint,25,opt,name=is_embedded,json=isEmbedded,proto3" json:"is_embedded,omitempty"`
-	Maturity           string `protobuf:"bytes,26,opt,name=maturity,proto3" json:"maturity,omitempty"`
+	IsImplicitResource bool                   `protobuf:"varint,24,opt,name=is_implicit_resource,json=isImplicitResource,proto3" json:"is_implicit_resource,omitempty"`
+	IsEmbedded         bool                   `protobuf:"varint,25,opt,name=is_embedded,json=isEmbedded,proto3" json:"is_embedded,omitempty"`
+	Maturity           string                 `protobuf:"bytes,26,opt,name=maturity,proto3" json:"maturity,omitempty"`
 	// This field contains references to other providers with the same
 	// resource/field.
 	// Note: Please do not use this field, it is only temporary and will be
@@ -597,14 +579,6 @@ func (x *Field) GetProvider() string {
 	return ""
 }
 
-// Deprecated: Marked as deprecated in resources.proto.
-func (x *Field) GetMinMondooVersion() string {
-	if x != nil {
-		return x.MinMondooVersion
-	}
-	return ""
-}
-
 func (x *Field) GetIsImplicitResource() bool {
 	if x != nil {
 		return x.IsImplicitResource
@@ -659,7 +633,7 @@ const file_resources_proto_rawDesc = "" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
 	"\boptional\x18\x03 \x01(\bR\boptional\"6\n" +
 	"\x04Init\x12.\n" +
-	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\x84\x05\n" +
+	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\xd8\x04\n" +
 	"\fResourceInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12B\n" +
@@ -675,11 +649,10 @@ const file_resources_proto_rawDesc = "" +
 	"\acontext\x18\x1e \x01(\tR\acontext\x12\x1a\n" +
 	"\bprovider\x18\x1b \x01(\tR\bprovider\x126\n" +
 	"\x06others\x18\x1d \x03(\v2\x1e.mondoo.resources.ResourceInfoR\x06others\x12\x1a\n" +
-	"\bmaturity\x18  \x01(\tR\bmaturity\x120\n" +
-	"\x12min_mondoo_version\x18\x19 \x01(\tB\x02\x18\x01R\x10minMondooVersion\x1aR\n" +
+	"\bmaturity\x18  \x01(\tR\bmaturity\x1aR\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
-	"\x05value\x18\x02 \x01(\v2\x17.mondoo.resources.FieldR\x05value:\x028\x01\"\xcf\x03\n" +
+	"\x05value\x18\x02 \x01(\v2\x17.mondoo.resources.FieldR\x05value:\x028\x01J\x04\b\x19\x10\x1a\"\xa3\x03\n" +
 	"\x05Field\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12!\n" +
@@ -691,12 +664,11 @@ const file_resources_proto_rawDesc = "" +
 	"is_private\x18\x16 \x01(\bR\tisPrivate\x120\n" +
 	"\x14min_provider_version\x18\x1e \x01(\tR\x12minProviderVersion\x12\x1a\n" +
 	"\bprovider\x18\x1b \x01(\tR\bprovider\x120\n" +
-	"\x12min_mondoo_version\x18\x17 \x01(\tB\x02\x18\x01R\x10minMondooVersion\x120\n" +
 	"\x14is_implicit_resource\x18\x18 \x01(\bR\x12isImplicitResource\x12\x1f\n" +
 	"\vis_embedded\x18\x19 \x01(\bR\n" +
 	"isEmbedded\x12\x1a\n" +
 	"\bmaturity\x18\x1a \x01(\tR\bmaturity\x12/\n" +
-	"\x06others\x18\x1d \x03(\v2\x17.mondoo.resources.FieldR\x06othersB.Z,go.mondoo.com/mql/providers-sdk/v1/resourcesb\x06proto3"
+	"\x06others\x18\x1d \x03(\v2\x17.mondoo.resources.FieldR\x06othersJ\x04\b\x17\x10\x18B.Z,go.mondoo.com/mql/providers-sdk/v1/resourcesb\x06proto3"
 
 var (
 	file_resources_proto_rawDescOnce sync.Once

--- a/providers-sdk/v1/resources/resources.proto
+++ b/providers-sdk/v1/resources/resources.proto
@@ -48,8 +48,9 @@ message Init {
 }
 
 message ResourceInfo {
-  // 25 = min_mondoo_version, removed in v14 (superseded by min_provider_version)
+  // 25 = min_mondoo_version, removed in v14 (use min_provider_version)
   reserved 25;
+  reserved "min_mondoo_version";
 
   // Canonical resource id. When a ResourceInfo is reached via an alias entry
   // in Schema.resources, `id` is the original (aliased-to) resource name, not
@@ -79,8 +80,9 @@ message ResourceInfo {
 }
 
 message Field {
-  // 23 = min_mondoo_version, removed in v14 (superseded by min_provider_version)
+  // 23 = min_mondoo_version, removed in v14 (use min_provider_version)
   reserved 23;
+  reserved "min_mondoo_version";
 
   string name = 1;
   string type = 2;

--- a/providers-sdk/v1/resources/resources.proto
+++ b/providers-sdk/v1/resources/resources.proto
@@ -48,6 +48,9 @@ message Init {
 }
 
 message ResourceInfo {
+  // 25 = min_mondoo_version, removed in v14 (superseded by min_provider_version)
+  reserved 25;
+
   // Canonical resource id. When a ResourceInfo is reached via an alias entry
   // in Schema.resources, `id` is the original (aliased-to) resource name, not
   // the alias key. Consumers that need the lookup key should use the map key
@@ -73,14 +76,12 @@ message ResourceInfo {
   repeated ResourceInfo others = 29;
 
   string maturity = 32;
-
-  // DEPRECATED: remove in v14, not used anymore as of v13.
-  // We now use min_provider_version to show what providers we require.
-  string min_mondoo_version = 25 [deprecated = true];
-  // ^^
 }
 
 message Field {
+  // 23 = min_mondoo_version, removed in v14 (superseded by min_provider_version)
+  reserved 23;
+
   string name = 1;
   string type = 2;
   bool is_mandatory = 3;
@@ -90,10 +91,6 @@ message Field {
   bool is_private = 22;
   string min_provider_version = 30;
   string provider = 27;
-
-  // DEPRECATED: remove in v14, not used anymore as of v13.
-  // We now use min_provider_version to show what providers we require.
-  string min_mondoo_version = 23 [deprecated = true];
   bool is_implicit_resource = 24;
   bool is_embedded = 25;
   string maturity = 26;

--- a/providers-sdk/v1/resources/resources_vtproto.pb.go
+++ b/providers-sdk/v1/resources/resources_vtproto.pb.go
@@ -392,15 +392,6 @@ func (m *ResourceInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0xd2
 	}
-	if len(m.MinMondooVersion) > 0 {
-		i -= len(m.MinMondooVersion)
-		copy(dAtA[i:], m.MinMondooVersion)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MinMondooVersion)))
-		i--
-		dAtA[i] = 0x1
-		i--
-		dAtA[i] = 0xca
-	}
 	if m.Private {
 		i--
 		if m.Private {
@@ -585,15 +576,6 @@ func (m *Field) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i--
 		dAtA[i] = 0xc0
-	}
-	if len(m.MinMondooVersion) > 0 {
-		i -= len(m.MinMondooVersion)
-		copy(dAtA[i:], m.MinMondooVersion)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MinMondooVersion)))
-		i--
-		dAtA[i] = 0x1
-		i--
-		dAtA[i] = 0xba
 	}
 	if m.IsPrivate {
 		i--
@@ -816,10 +798,6 @@ func (m *ResourceInfo) SizeVT() (n int) {
 	if m.Private {
 		n += 3
 	}
-	l = len(m.MinMondooVersion)
-	if l > 0 {
-		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
 	l = len(m.Defaults)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -886,10 +864,6 @@ func (m *Field) SizeVT() (n int) {
 	}
 	if m.IsPrivate {
 		n += 3
-	}
-	l = len(m.MinMondooVersion)
-	if l > 0 {
-		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.IsImplicitResource {
 		n += 3
@@ -2052,38 +2026,6 @@ func (m *ResourceInfo) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Private = bool(v != 0)
-		case 25:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MinMondooVersion", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.MinMondooVersion = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
 		case 26:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Defaults", wireType)
@@ -2549,38 +2491,6 @@ func (m *Field) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.IsPrivate = bool(v != 0)
-		case 23:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MinMondooVersion", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.MinMondooVersion = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
 		case 24:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field IsImplicitResource", wireType)


### PR DESCRIPTION
`ResourceInfo.min_mondoo_version` (field 25) and `Field.min_mondoo_version` (field 23) have been carrying this since v13:

```
// DEPRECATED: remove in v14, not used anymore as of v13.
// We now use min_provider_version to show what providers we require.
```

This removes them. Both are already `[deprecated = true]`.

## Why it is safe

- **No Go reader or writer in this repo** outside the generated marshalling code. `grep MinMondooVersion` over non-generated sources returns nothing.
- **No Go reader or writer in cnspec** either — the only hits there are stale keys inside `cli/reporter/testdata/report-ubuntu.json`, which are inert extra fields in a fixture.
- **The `.lr` toolchain never emitted it.** `providers-sdk/v1/mqlr/` has no reference, and no generated `*.resources.json` contains the key.
- `min_provider_version` (fields 31 / 30) already carries the signal.

## Wire compatibility

Both field numbers are marked `reserved`, so they can never be silently reused by a future field:

```proto
message ResourceInfo {
  // 25 = min_mondoo_version, removed in v14 (superseded by min_provider_version)
  reserved 25;
```

An older client that still sends the field will have it ignored rather than misparsed.

## Test plan

- [x] `go generate ./providers-sdk/v1/resources` — regenerated `.pb.go` and `_vtproto.pb.go`, no residual `MinMondooVersion`
- [x] `go build ./...`
- [x] `go test ./providers-sdk/v1/resources/...`
- [x] `go test ./providers/` (schema merge + extensible schema)
- [x] `gofmt` clean
