### PR TITLE
🛑 llx: remove deprecated dictNotEmptyV2

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -583,9 +583,6 @@ func init() {
 			"in":           {f: dictIn, Label: "in"},
 			"notIn":        {f: dictNotIn, Label: "notIn"},
 			string("find"): {f: dictFindV2, Label: "find"},
-			// NOTE: the following functions are internal ONLY!
-			// We have not yet decided if and how these may be exposed to users
-			"notEmpty": {f: dictNotEmptyV2},
 		},
 		types.Version: {
 			string("==" + types.Nil):     {f: stringCmpNilV2, Label: "=="},

--- a/llx/builtin_map.go
+++ b/llx/builtin_map.go
@@ -607,24 +607,6 @@ func dictNotEmpty(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*R
 	}
 }
 
-// Deprecated: replace with calls to the empty type
-func dictNotEmptyV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
-	if bind.Value == nil {
-		return BoolFalse, 0, nil
-	}
-
-	switch x := bind.Value.(type) {
-	case string:
-		return BoolData(len(x) != 0), 0, nil
-	case []any:
-		return BoolData(len(x) != 0), 0, nil
-	case map[string]any:
-		return BoolData(len(x) != 0), 0, nil
-	default:
-		return nil, 0, errors.New("dict value does not support field `notEmpty`")
-	}
-}
-
 func dictBlockCallV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
 	switch bind.Value.(type) {
 	case []any:


### PR DESCRIPTION
`dictNotEmptyV2` in `llx/builtin_map.go` was marked:

```go
// Deprecated: replace with calls to the empty type
```

That replacement already exists and is already wired up, so the deprecated handler had no remaining reason to exist.

## Why it is safe

- **The replacement is live.** `dictNotEmpty` (no `V2`) is registered at `llx/builtin.go:469` as `string("!=" + types.Empty)` for dict — literally "calls to the empty type", exactly what the deprecation notice pointed at. That handler is untouched.
- **It was never a supported user-facing function.** Its only registration sat under this comment in the dict builtin table:
  ```go
  // NOTE: the following functions are internal ONLY!
  // We have not yet decided if and how these may be exposed to users
  "notEmpty": {f: dictNotEmptyV2},
  ```
- **Nothing calls it.** No hits in this repo outside its own definition and registration, none in cnspec, and none in shipped query packs or policies.
- **No init-time validator breakage.** `validateBuiltinFunctionsV2()` requires dict to mirror every *string* function; `types.String` never registered `notEmpty`, so dropping the dict entry does not trip it. The `llx` tests exercise that init path and pass.

## Deliberately left alone

`arrayNotEmptyV2` stays. Only the dict handler carried the deprecation marker, so this does not touch the array side.

## Test plan

- [x] `go build ./...`
- [x] `go test ./llx/... ./mqlc/...` — covers the `init()` validator that panics on a malformed builtin table
- [x] `go test ./mqlx/...`
- [x] `gofmt` clean
