### PR TITLE
🛑 inventory: remove the deprecated `fleet` asset category alias

### DIFF
--- a/providers-sdk/v1/inventory/asset.go
+++ b/providers-sdk/v1/inventory/asset.go
@@ -137,9 +137,6 @@ func NewState(state string) State {
 }
 
 var AssetCategory_schemevalue = map[string]AssetCategory{
-	// FIXME: DEPRECATED, remove in v11.0 vv
-	"fleet": AssetCategory_CATEGORY_INVENTORY,
-	// ^^
 	"inventory": AssetCategory_CATEGORY_INVENTORY,
 	"cicd":      AssetCategory_CATEGORY_CICD,
 }


### PR DESCRIPTION
Removes the `"fleet"` alias from `AssetCategory_schemevalue`:

```go
var AssetCategory_schemevalue = map[string]AssetCategory{
	// FIXME: DEPRECATED, remove in v11.0 vv
	"fleet": AssetCategory_CATEGORY_INVENTORY,
	// ^^
	"inventory": AssetCategory_CATEGORY_INVENTORY,
	"cicd":      AssetCategory_CATEGORY_CICD,
}
```

`"inventory"` is the supported spelling for `CATEGORY_INVENTORY`. The marker asked for removal in v11.0; we are heading into v14.

## Behavior change

`AssetCategory.UnmarshalJSON` looks the string up in this map and errors when it misses. So an inventory that still says `category: fleet` goes from silently accepted to:

```
unknown backend value: "fleet"
```

That is the intended outcome — a named error rather than a silent alias — but it is the user-visible part of this PR and worth a reviewer's eye.

## Relationship to #9993

⚠️ **#9993 is still open and touches these exact lines.** It adds a `log.Warn()` for `fleet` instead of removing it, per the warn-then-remove convention. This PR deletes the lines that PR adds, so the two supersede each other — merging this one makes #9993 moot and it should be closed.

If the preference is to ship the warning first and remove in a later release, close **this** PR instead and land #9993.

## Scope check

- Only one reference to `"fleet"` as an asset category exists in the repo (the map entry itself).
- No inventory fixture, testdata YAML, or JSON in the repo sets `category: fleet`.
- Unrelated `"fleet"` hits in the AWS/GCP providers are AppStream and GKE fleets — a different concept, untouched.

## Test plan

- [x] `go build ./...`
- [x] `go test ./providers-sdk/v1/inventory/...` (incl. `ansibleinventory`, `domainlist`, `manager`)
- [x] `gofmt` clean
