### PR TITLE
🛑 remove the deprecated providers-url / providers_url setting

### DIFF
--- a/apps/mql/cmd/login.go
+++ b/apps/mql/cmd/login.go
@@ -37,8 +37,6 @@ func init() {
 	LoginCmd.Flags().StringP("token", "t", "", "Set a client registration token")
 	LoginCmd.Flags().StringToString("annotation", nil, "Set the client annotations")
 	LoginCmd.Flags().String("updates-url", "", "Set the updates URL for mql and provider updates")
-	LoginCmd.Flags().String("providers-url", "", "Set the providers URL (deprecated: use updates-url instead)")
-	_ = LoginCmd.Flags().MarkHidden("providers-url")
 	LoginCmd.Flags().String("name", "", "Set asset name")
 	LoginCmd.Flags().String("api-endpoint", "", "Set the Mondoo API endpoint")
 	LoginCmd.Flags().Int("timer", 0, "Set the scan interval in minutes")
@@ -68,11 +66,10 @@ You remain logged in until you explicitly log out using the 'logout' subcommand.
 		token, _ := cmd.Flags().GetString("token")
 		annotations, _ := cmd.Flags().GetStringToString("annotation")
 		updatesURL, _ := cmd.Flags().GetString("updates-url")
-		providersURL, _ := cmd.Flags().GetString("providers-url")
 		timer, _ := cmd.Flags().GetInt("timer")
 		splay, _ := cmd.Flags().GetInt("splay")
 		apiEndpointOverride, _ := cmd.Flags().GetString("api-endpoint")
-		err := register(token, annotations, updatesURL, providersURL, timer, splay, apiEndpointOverride)
+		err := register(token, annotations, updatesURL, timer, splay, apiEndpointOverride)
 		if err != nil {
 			if err == tokenValidationErr {
 				log.Error().Msg(err.Error())
@@ -115,7 +112,7 @@ You remain logged in until you explicitly log out using the 'logout' subcommand.
 	},
 }
 
-func register(token string, annotations map[string]string, updatesURL string, providersURL string, timer int, splay int, apiEndpointOverride string) error {
+func register(token string, annotations map[string]string, updatesURL string, timer int, splay int, apiEndpointOverride string) error {
 	var err error
 	var credential *upstream.ServiceAccountCredentials
 
@@ -215,10 +212,6 @@ func register(token string, annotations map[string]string, updatesURL string, pr
 		viper.Set("annotations", annotations)
 		if updatesURL != "" {
 			viper.Set("updates_url", updatesURL)
-		}
-		if providersURL != "" {
-			log.Warn().Msgf("providers-url is deprecated, please use updates-url: %s", strings.TrimSuffix(providersURL, "/providers"))
-			viper.Set("providers_url", providersURL)
 		}
 		if timer > 0 {
 			viper.Set("scan_interval.timer", timer)

--- a/apps/mql/cmd/login_test.go
+++ b/apps/mql/cmd/login_test.go
@@ -6,81 +6,40 @@ package cmd
 import (
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoginCmd_ProvidersURLFlag(t *testing.T) {
-	// Test that the providers-url flag is properly defined on the LoginCmd
-	flag := LoginCmd.Flags().Lookup("providers-url")
-	require.NotNil(t, flag, "providers-url flag should be defined")
-	assert.Equal(t, "", flag.DefValue, "providers-url default value should be empty")
-	assert.Equal(t, "string", flag.Value.Type(), "providers-url should be a string flag")
+func TestLoginCmd_ProvidersURLFlagRemoved(t *testing.T) {
+	// providers-url was deprecated in favor of updates-url and removed in v14.
+	// Guard against it being reintroduced.
+	assert.Nil(t, LoginCmd.Flags().Lookup("providers-url"),
+		"providers-url was removed in v14; use updates-url instead")
 }
 
-func TestProvidersURLViperSet(t *testing.T) {
-	tests := []struct {
-		name              string
-		providersURL      string
-		expectInConfig    bool
-		expectedConfigVal string
-	}{
-		{
-			name:              "with valid providers-url",
-			providersURL:      "https://my-custom-provider.com",
-			expectInConfig:    true,
-			expectedConfigVal: "https://my-custom-provider.com",
-		},
-		{
-			name:           "with empty providers-url",
-			providersURL:   "",
-			expectInConfig: false,
-		},
-		{
-			name:              "with custom path providers-url",
-			providersURL:      "https://internal.example.com/providers",
-			expectInConfig:    true,
-			expectedConfigVal: "https://internal.example.com/providers",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Reset viper before each test
-			viper.Reset()
-
-			// Simulate the behavior in the register function
-			if tt.providersURL != "" {
-				viper.Set("providers_url", tt.providersURL)
-			}
-
-			// Verify the viper state
-			if tt.expectInConfig {
-				assert.True(t, viper.IsSet("providers_url"), "providers_url should be set in viper")
-				assert.Equal(t, tt.expectedConfigVal, viper.GetString("providers_url"))
-			} else {
-				assert.False(t, viper.IsSet("providers_url"), "providers_url should not be set in viper")
-			}
-		})
-	}
+func TestLoginCmd_UpdatesURLFlag(t *testing.T) {
+	flag := LoginCmd.Flags().Lookup("updates-url")
+	require.NotNil(t, flag, "updates-url flag should be defined")
+	assert.Equal(t, "", flag.DefValue, "updates-url default value should be empty")
+	assert.Equal(t, "string", flag.Value.Type(), "updates-url should be a string flag")
 }
 
-func TestLoginCmd_GetProvidersURLFromFlag(t *testing.T) {
+func TestLoginCmd_GetUpdatesURLFromFlag(t *testing.T) {
 	// Reset any previous flag values
-	err := LoginCmd.Flags().Set("providers-url", "")
+	err := LoginCmd.Flags().Set("updates-url", "")
 	require.NoError(t, err)
 
 	// Test setting the flag value
-	err = LoginCmd.Flags().Set("providers-url", "https://custom-provider.example.com")
+	err = LoginCmd.Flags().Set("updates-url", "https://internal.example.com")
 	require.NoError(t, err)
 
 	// Retrieve the value
-	providersURL, err := LoginCmd.Flags().GetString("providers-url")
+	updatesURL, err := LoginCmd.Flags().GetString("updates-url")
 	require.NoError(t, err)
-	assert.Equal(t, "https://custom-provider.example.com", providersURL)
+	assert.Equal(t, "https://internal.example.com", updatesURL)
+
 	// Reset the flag for other tests
-	err = LoginCmd.Flags().Set("providers-url", "")
+	err = LoginCmd.Flags().Set("updates-url", "")
 	require.NoError(t, err)
 }
 
@@ -94,7 +53,7 @@ func TestLoginCmd_AllFlags(t *testing.T) {
 	}{
 		{"token", "t", "", "string"},
 		{"annotation", "", "[]", "stringToString"},
-		{"providers-url", "", "", "string"},
+		{"updates-url", "", "", "string"},
 		{"name", "", "", "string"},
 		{"api-endpoint", "", "", "string"},
 		{"timer", "", "0", "int"},

--- a/apps/mql/cmd/root.go
+++ b/apps/mql/cmd/root.go
@@ -110,7 +110,6 @@ func init() {
 	_ = viper.BindPFlag("auto_update", rootCmd.PersistentFlags().Lookup("auto-update"))
 	_ = viper.BindEnv("features")
 	_ = viper.BindEnv("updates_url")
-	_ = viper.BindEnv("providers_url")
 
 	config.Init(rootCmd)
 }

--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -248,14 +248,9 @@ func checkStatus(ctx context.Context) (Status, error) {
 	}
 
 	// Determine the providers URL:
-	// 1. If providers_url is explicitly set, use it (deprecated)
-	// 2. Otherwise, if updates_url is set, use updates_url + "/providers"
-	// 3. Otherwise, use the default
-	if opts.ProvidersURL != "" {
-		updatesURL := strings.TrimSuffix(opts.ProvidersURL, "/providers")
-		log.Warn().Msgf("providers_url is deprecated, please use updates_url: %s", updatesURL)
-		s.Client.ProvidersURL = opts.ProvidersURL
-	} else if opts.UpdatesURL != "" {
+	// 1. If updates_url is set, use updates_url + "/providers"
+	// 2. Otherwise, use the default
+	if opts.UpdatesURL != "" {
 		s.Client.ProvidersURL = opts.UpdatesURL + "/providers"
 	} else {
 		s.Client.ProvidersURL = providers.DefaultProviderRegistryURL

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -207,12 +207,6 @@ func GetUpdatesURL() string {
 	return viper.GetString("updates_url")
 }
 
-// GetProvidersURL returns the providers_url setting from viper config.
-// Returns empty string if not set (caller should use default).
-func GetProvidersURL() string {
-	return viper.GetString("providers_url")
-}
-
 // GetFeatures returns the features from viper config.
 // This can be called after InitViperConfig() to get features before cobra initialization.
 func GetFeatures() mql.Features {
@@ -304,14 +298,8 @@ type CommonOpts struct {
 	// UpdatesURL is the base URL where updates are fetched from
 	// if not set, the default Mondoo releases URL is used (https://releases.mondoo.com)
 	// This can be a custom URL for an internal release registry
-	// If ProvidersURL is not set, providers will be fetched from UpdatesURL + "/providers"
+	// Providers are fetched from UpdatesURL + "/providers"
 	UpdatesURL string `json:"updates_url,omitempty" mapstructure:"updates_url"`
-
-	// ProvidersURL is the URL where providers are downloaded from
-	// if not set, the default Mondoo provider URL is used
-	// This can be a custom URL for an internal provider registry
-	// Deprecated: use UpdatesURL instead
-	ProvidersURL string `json:"providers_url,omitempty" mapstructure:"providers_url"`
 }
 
 // Workload Identity Federation

--- a/cli/providers/providers.go
+++ b/cli/providers/providers.go
@@ -61,16 +61,9 @@ func detectConnectorName(args []string, rootCmd *cobra.Command, commands []*Comm
 	config.InitViperConfig()
 
 	// Determine the providers URL:
-	// 1. If providers_url is explicitly set, use it (deprecated)
-	// 2. Otherwise, if updates_url is set, use updates_url + "/providers"
-	// 3. Otherwise, use the default
-	if viper.IsSet("providers_url") {
-		if providersURL := viper.GetString("providers_url"); providersURL != "" {
-			updatesURL := strings.TrimSuffix(providersURL, "/providers")
-			log.Warn().Msgf("providers_url is deprecated, please use updates_url: %s", updatesURL)
-			providers.SetProviderRegistry(providers.NewMondooProviderRegistry(providers.WithBaseURL(providersURL)))
-		}
-	} else if viper.IsSet("updates_url") {
+	// 1. If updates_url is set, use updates_url + "/providers"
+	// 2. Otherwise, use the default
+	if viper.IsSet("updates_url") {
 		if updatesURL := viper.GetString("updates_url"); updatesURL != "" {
 			providers.SetProviderRegistry(providers.NewMondooProviderRegistry(providers.WithBaseURL(updatesURL + "/providers")))
 		}


### PR DESCRIPTION
`providers-url` / `providers_url` was deprecated in favor of `updates-url` / `updates_url`. Every path that read it already logged a warning naming the replacement, so users on the old setting have been told. This removes it.

Provider downloads now always resolve as `updates_url + "/providers"`, falling back to `providers.DefaultProviderRegistryURL`.

## What is removed

| Surface | Location |
|---|---|
| `--providers-url` flag on `mql login` (hidden) | `apps/mql/cmd/login.go` |
| `providersURL` plumbing through `register()` | `apps/mql/cmd/login.go` |
| `providers_url` env binding | `apps/mql/cmd/root.go` |
| `CommonOpts.ProvidersURL` config field | `cli/config/config.go` |
| `config.GetProvidersURL()` (no callers) | `cli/config/config.go` |
| deprecated branch in `detectConnectorName` | `cli/providers/providers.go` |
| deprecated branch in `checkStatus` | `apps/mql/cmd/status.go` |

## User-visible impact

- `mql login --providers-url=...` now fails with an unknown-flag error instead of warning.
- A `providers_url` key left in `mondoo.yml` is ignored rather than honored-with-a-warning. Anyone pointing at an internal registry needs `updates_url` set to the base URL (without the trailing `/providers`) — which is exactly what the warning has been telling them to do.
- The `providers_url` env binding is gone.

## Deliberately kept

`Status.Client.ProvidersURL` (`apps/mql/cmd/status.go`, serialized as `providersUrl`) stays. Despite the matching name it is the **output** of `mql status` — the effective provider-registry URL being reported — not the deprecated input. Its resolution now just loses its first branch.

## Tests

The three existing tests in `login_test.go` all asserted the flag *exists*, so deleting them would leave the removal unpinned. Replaced with:

- `TestLoginCmd_ProvidersURLFlagRemoved` — asserts `Lookup("providers-url")` is nil, so the flag cannot be reintroduced unnoticed
- `TestLoginCmd_UpdatesURLFlag` / `TestLoginCmd_GetUpdatesURLFromFlag` — the same coverage the deleted tests gave, moved onto the surviving flag
- `TestLoginCmd_AllFlags` — the `providers-url` entry swapped for `updates-url`, which was missing from the inventory

## Test plan

- [x] `go build ./...`
- [x] `go test ./apps/mql/cmd/... ./cli/...` — all packages pass
- [x] `gofmt` clean
- [x] no residual `providers_url` / `providers-url` references outside the `Status` output field
