### PR TITLE
✨ os: add mariadb.conf.slowQueryLogFile, reading both names MariaDB accepts

### DIFF
--- a/providers/os/resources/mariadb.go
+++ b/providers/os/resources/mariadb.go
@@ -347,6 +347,23 @@ func (s *mqlMariadbConf) slowQueryLog(serverOptions map[string]any) (bool, error
 	return optionBool(serverOptions, "slow_query_log"), nil
 }
 
+// slowQueryLogFile reads the two spellings MariaDB accepts for one setting.
+// log_slow_query_file is the name its own packages write into 50-server.cnf on
+// Debian and Ubuntu; slow_query_log_file is the MySQL-compatible synonym, and
+// the server reports the value under that name whichever one set it. Reading
+// only the MySQL name reports nothing on a packaged server whose administrator
+// uncommented the line the package shipped, which is the configuration this
+// field exists to locate.
+//
+// When a file sets both, MariaDB takes the last one it reads; the merged option
+// map cannot express that order, so the native spelling is preferred here.
+func (s *mqlMariadbConf) slowQueryLogFile(serverOptions map[string]any) (string, error) {
+	if v := optionString(serverOptions, "log_slow_query_file"); v != "" {
+		return v, nil
+	}
+	return optionString(serverOptions, "slow_query_log_file"), nil
+}
+
 func (s *mqlMariadbConf) serverAuditLogging(serverOptions map[string]any) (bool, error) {
 	return optionBool(serverOptions, "server_audit_logging"), nil
 }

--- a/providers/os/resources/mysql_internal_test.go
+++ b/providers/os/resources/mysql_internal_test.go
@@ -633,3 +633,51 @@ func TestVersion_IsNullWithoutCommandExecution(t *testing.T) {
 	require.NoError(t, mysqlVersion.Error)
 	assert.Empty(t, mysqlVersion.Data)
 }
+
+// MariaDB accepts two names for the slow query log path and treats them as one
+// setting. log_slow_query_file is what its Debian and Ubuntu packages write
+// into 50-server.cnf, so a reader that knows only the MySQL-compatible
+// slow_query_log_file reports nothing on a packaged server whose administrator
+// enabled the line the package shipped — and an operator cannot then check the
+// mode of a file that holds full statement text.
+func TestMariadbConf_SlowQueryLogFileReadsBothSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		fixture  string
+		expected string
+		why      string
+	}{
+		{
+			"mysql_debian13_mariadb.toml",
+			"/var/log/mysql/mariadb-slow.log",
+			"log_slow_query_file is the spelling the Debian package ships",
+		},
+		{
+			"mysql_mariadb114.toml",
+			"/var/log/mysql/compat-name-slow.log",
+			"slow_query_log_file is the MySQL-compatible synonym",
+		},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			conf := mariadbConf(t, tc.fixture)
+
+			enabled := conf.GetSlowQueryLog()
+			require.NoError(t, enabled.Error)
+			assert.True(t, enabled.Data, "the fixture enables slow query logging")
+
+			path := conf.GetSlowQueryLogFile()
+			require.NoError(t, path.Error)
+			assert.Equal(t, tc.expected, path.Data, tc.why)
+		})
+	}
+}
+
+// A server that sets neither name reports an empty path rather than a guess.
+// MariaDB derives the file from the host name under datadir in that case, which
+// is not something the option file says.
+func TestMariadbConf_SlowQueryLogFileIsEmptyWhenUnset(t *testing.T) {
+	conf := mariadbConf(t, "mysql_almalinux9_mariadb.toml")
+
+	path := conf.GetSlowQueryLogFile()
+	require.NoError(t, path.Error)
+	assert.Empty(t, path.Data)
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -4190,6 +4190,14 @@ mariadb.conf {
   generalLogFile(serverOptions) string
   // slow_query_log option
   slowQueryLog(serverOptions) bool
+  // Path the slow query log is written to
+  //
+  // Read from log_slow_query_file, the spelling the Debian and Ubuntu
+  // packages write, falling back to the MySQL-compatible
+  // slow_query_log_file. MariaDB treats the two as one setting. Empty
+  // when neither is set, in which case the server derives the name from
+  // the host name and writes it under datadir.
+  slowQueryLogFile(serverOptions) string
   // server_audit_logging option, from the server_audit plugin
   serverAuditLogging(serverOptions) bool
   // server_audit_events option split into audited event classes

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -6714,6 +6714,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mariadb.conf.slowQueryLog": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMariadbConf).GetSlowQueryLog()).ToDataRes(types.Bool)
 	},
+	"mariadb.conf.slowQueryLogFile": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMariadbConf).GetSlowQueryLogFile()).ToDataRes(types.String)
+	},
 	"mariadb.conf.serverAuditLogging": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMariadbConf).GetServerAuditLogging()).ToDataRes(types.Bool)
 	},
@@ -21140,6 +21143,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mariadb.conf.slowQueryLog": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMariadbConf).SlowQueryLog, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"mariadb.conf.slowQueryLogFile": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMariadbConf).SlowQueryLogFile, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"mariadb.conf.serverAuditLogging": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -50374,6 +50381,7 @@ type mqlMariadbConf struct {
 	GeneralLog                         plugin.TValue[bool]
 	GeneralLogFile                     plugin.TValue[string]
 	SlowQueryLog                       plugin.TValue[bool]
+	SlowQueryLogFile                   plugin.TValue[string]
 	ServerAuditLogging                 plugin.TValue[bool]
 	ServerAuditEvents                  plugin.TValue[[]any]
 	ServerAuditFilePath                plugin.TValue[string]
@@ -51020,6 +51028,17 @@ func (c *mqlMariadbConf) GetSlowQueryLog() *plugin.TValue[bool] {
 		}
 
 		return c.slowQueryLog(vargServerOptions.Data)
+	})
+}
+
+func (c *mqlMariadbConf) GetSlowQueryLogFile() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.SlowQueryLogFile, func() (string, error) {
+		vargServerOptions := c.GetServerOptions()
+		if vargServerOptions.Error != nil {
+			return "", vargServerOptions.Error
+		}
+
+		return c.slowQueryLogFile(vargServerOptions.Data)
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2176,6 +2176,7 @@ mariadb.conf.skipNameResolve 13.39.1
 mariadb.conf.skipNetworking 13.39.1
 mariadb.conf.skipShowDatabase 13.39.1
 mariadb.conf.slowQueryLog 13.39.1
+mariadb.conf.slowQueryLogFile 13.40.9
 mariadb.conf.socket 13.39.1
 mariadb.conf.sqlMode 13.39.1
 mariadb.conf.sslCaFile 13.39.1

--- a/providers/os/resources/testdata/mysql_debian13_mariadb.toml
+++ b/providers/os/resources/testdata/mysql_debian13_mariadb.toml
@@ -258,7 +258,8 @@ bind-address            = 127.0.0.1
 # Enable this if you want to have error logging into a separate file
 #log_error = /var/log/mysql/error.log
 # Enable the slow query log to see queries with especially long duration
-#log_slow_query_file    = /var/log/mysql/mariadb-slow.log
+log_slow_query_file    = /var/log/mysql/mariadb-slow.log
+slow_query_log         = 1
 #log_slow_query_time    = 10
 #log_slow_verbosity     = query_plan,explain
 #log-queries-not-using-indexes

--- a/providers/os/resources/testdata/mysql_mariadb114.toml
+++ b/providers/os/resources/testdata/mysql_mariadb114.toml
@@ -223,8 +223,8 @@ basedir                 = /usr
 #log_error = /var/log/mysql/error.log
 
 # Enable the slow query log to see queries with especially long duration
-#log_slow_query_file    = /var/log/mysql/mariadb-slow.log
-#slow_query_log         = 1
+slow_query_log_file    = /var/log/mysql/compat-name-slow.log
+slow_query_log         = 1
 #log_slow_query_time    = 10
 #log_slow_verbosity     = query_plan,explain
 #log-queries-not-using-indexes


### PR DESCRIPTION
Closes #10034.

`mariadb.conf` reported that slow query logging was *on* and not where the file was, so an operator could not check the mode of a file that holds full statement text. `mysql.conf` has had the field all along, and `generalLogFile` is typed on both.

## The part the issue's suggested one-liner would have missed

MariaDB accepts **two names for this setting**, and its own Debian and Ubuntu packages write the one that is not the MySQL name. From `50-server.cnf` as shipped:

```
# Enable the slow query log to see queries with especially long duration
#log_slow_query_file    = /var/log/mysql/mariadb-slow.log
#slow_query_log         = 1
```

Confirmed on a real 10.11 server rather than from documentation — with only `log_slow_query_file` set in an option file, the server reports it back under the other name:

```
$ mariadb -e 'SHOW VARIABLES LIKE "slow_query_log_file"'
slow_query_log_file    /var/log/mysql/from-packaged-name.log

$ mariadbd --verbose --help | grep -E 'slow-query-log-file|log-slow-query-file'
    --log-slow-query-file=name
    --slow-query-log-file=name
```

So `optionString(serverOptions, "slow_query_log_file")` on its own returns `""` for a packaged server whose administrator uncommented the line the package shipped — exactly the configuration this field exists to locate. The accessor reads `log_slow_query_file` first and falls back to the compatible name.

When a file sets both, MariaDB takes the last one it reads. The merged option map cannot express that order, so the native spelling wins and the comment says so.

## Tests that would have caught it

The Debian 13 fixture now carries the packaged spelling **enabled**, and the 11.4 fixture the compatible one, so both paths are exercised. Reverting the accessor to the single-name version fails the first:

```
--- FAIL: TestMariadbConf_SlowQueryLogFileReadsBothSpellings/mysql_debian13_mariadb.toml
        expected: "/var/log/mysql/mariadb-slow.log"
        actual  : ""
```

A third test pins the unset case to an empty string rather than a guess: MariaDB derives the name from the host name under `datadir`, which is not something the option file says.

## Verified against MariaDB 10.11

The audit the issue describes, end to end, finding something real on a stock container:

```
$ mql run docker container maria -c 'file(mariadb.conf.slowQueryLogFile) { path permissions { other_readable } user.name }'
  path:           "/var/log/mysql/from-packaged-name.log"
  other_readable: true
  user.name:      "mysql"
```

| check | result |
| --- | --- |
| packaged spelling, live server | `/var/log/mysql/from-packaged-name.log` |
| matches what the server itself reports | yes |
| host without MariaDB | `""`, and a check against it **fails** rather than passing vacuously |
| every other `mariadb.conf` field vs a build from current `main` | byte-identical |

## The issue's second question

> `mysql.conf` has `relayLogBasename` / `logBinBasename`-style path fields that `mariadb.conf` does not appear to expose.

It does not — **neither resource has them**, so there is no parity gap here. Both expose `logBin`, which carries the basename when `log_bin` is given a path. The remaining differences in that area are real product differences rather than gaps: `mysql.conf` has `binlogExpireLogsSeconds` and `binlogEncryption`, and `mariadb.conf` has the MariaDB-native `expireLogsDays` and `encryptBinlog`.

A typed `relayLog` on both would be a reasonable separate addition, since the relay log's permissions are a standard hardening item and neither resource locates it today. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)