### PR TITLE
🐛 os: report an unset my.cnf count as null instead of zero

### DIFF
--- a/providers/os/resources/mariadb.go
+++ b/providers/os/resources/mariadb.go
@@ -174,7 +174,12 @@ func (s *mqlMariadbConf) skipNameResolve(serverOptions map[string]any) (bool, er
 }
 
 func (s *mqlMariadbConf) maxConnections(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "max_connections", 0), nil
+	v, ok := optionCount(serverOptions, "max_connections")
+	if !ok {
+		s.MaxConnections.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 // TLS
@@ -234,23 +239,48 @@ func (s *mqlMariadbConf) pluginLoad(serverOptions map[string]any) ([]any, error)
 }
 
 func (s *mqlMariadbConf) simplePasswordCheckMinimalLength(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "simple_password_check_minimal_length", 0), nil
+	v, ok := optionCount(serverOptions, "simple_password_check_minimal_length")
+	if !ok {
+		s.SimplePasswordCheckMinimalLength.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMariadbConf) simplePasswordCheckDigits(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "simple_password_check_digits", 0), nil
+	v, ok := optionCount(serverOptions, "simple_password_check_digits")
+	if !ok {
+		s.SimplePasswordCheckDigits.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMariadbConf) simplePasswordCheckLetters(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "simple_password_check_letters_same_case", 0), nil
+	v, ok := optionCount(serverOptions, "simple_password_check_letters_same_case")
+	if !ok {
+		s.SimplePasswordCheckLetters.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMariadbConf) simplePasswordCheckOtherCharacters(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "simple_password_check_other_characters", 0), nil
+	v, ok := optionCount(serverOptions, "simple_password_check_other_characters")
+	if !ok {
+		s.SimplePasswordCheckOtherCharacters.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMariadbConf) passwordReuseCheckInterval(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "password_reuse_check_interval", 0), nil
+	v, ok := optionCount(serverOptions, "password_reuse_check_interval")
+	if !ok {
+		s.PasswordReuseCheckInterval.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 // filesystem and privileges
@@ -328,7 +358,12 @@ func (s *mqlMariadbConf) logError(serverOptions map[string]any) (string, error) 
 }
 
 func (s *mqlMariadbConf) logWarnings(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "log_warnings", 0), nil
+	v, ok := optionCount(serverOptions, "log_warnings")
+	if !ok {
+		s.LogWarnings.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMariadbConf) logOutput(serverOptions map[string]any) ([]any, error) {
@@ -391,11 +426,21 @@ func (s *mqlMariadbConf) binlogFormat(serverOptions map[string]any) (string, err
 }
 
 func (s *mqlMariadbConf) expireLogsDays(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "expire_logs_days", 0), nil
+	v, ok := optionCount(serverOptions, "expire_logs_days")
+	if !ok {
+		s.ExpireLogsDays.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMariadbConf) serverId(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "server_id", 0), nil
+	v, ok := optionCount(serverOptions, "server_id")
+	if !ok {
+		s.ServerId.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMariadbConf) gtidStrictMode(serverOptions map[string]any) (bool, error) {

--- a/providers/os/resources/mycnf.go
+++ b/providers/os/resources/mycnf.go
@@ -448,6 +448,28 @@ func optionInt(options map[string]any, key string, fallback int64) int64 {
 	return n
 }
 
+// optionCount resolves an option that counts something, reporting whether the
+// option files set it at all. An absent count is not a zero: max_connections=0
+// is not a configuration a server can run with, and a field that reports one
+// lets a bounds check pass on a server whose real limit is higher. The caller
+// marks the field null in that case, so "the files do not say" stays distinct
+// from "the files say zero".
+//
+// A value that does not parse is treated as absent for the same reason. These
+// options are counts and intervals, where a suffixed or malformed value is a
+// misconfiguration rather than a number to report.
+func optionCount(options map[string]any, key string) (int64, bool) {
+	raw := strings.TrimSpace(optionString(options, key))
+	if raw == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 func optionList(options map[string]any, key string) []any {
 	return toAnySlice(mycnf.SplitList(optionString(options, key)))
 }

--- a/providers/os/resources/mysql.go
+++ b/providers/os/resources/mysql.go
@@ -184,7 +184,12 @@ func (s *mqlMysqlConf) skipNameResolve(serverOptions map[string]any) (bool, erro
 }
 
 func (s *mqlMysqlConf) maxConnections(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "max_connections", 0), nil
+	v, ok := optionCount(serverOptions, "max_connections")
+	if !ok {
+		s.MaxConnections.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 // TLS
@@ -268,7 +273,12 @@ func (s *mqlMysqlConf) validatePasswordPolicy(serverOptions map[string]any) (str
 }
 
 func (s *mqlMysqlConf) validatePasswordLength(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "validate_password.length", 0), nil
+	v, ok := optionCount(serverOptions, "validate_password.length")
+	if !ok {
+		s.ValidatePasswordLength.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMysqlConf) validatePasswordCheckUserName(serverOptions map[string]any) (bool, error) {
@@ -276,15 +286,30 @@ func (s *mqlMysqlConf) validatePasswordCheckUserName(serverOptions map[string]an
 }
 
 func (s *mqlMysqlConf) defaultPasswordLifetime(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "default_password_lifetime", 0), nil
+	v, ok := optionCount(serverOptions, "default_password_lifetime")
+	if !ok {
+		s.DefaultPasswordLifetime.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMysqlConf) passwordHistory(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "password_history", 0), nil
+	v, ok := optionCount(serverOptions, "password_history")
+	if !ok {
+		s.PasswordHistory.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMysqlConf) passwordReuseInterval(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "password_reuse_interval", 0), nil
+	v, ok := optionCount(serverOptions, "password_reuse_interval")
+	if !ok {
+		s.PasswordReuseInterval.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMysqlConf) passwordRequireCurrent(serverOptions map[string]any) (bool, error) {
@@ -366,7 +391,12 @@ func (s *mqlMysqlConf) logError(serverOptions map[string]any) (string, error) {
 }
 
 func (s *mqlMysqlConf) logErrorVerbosity(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "log_error_verbosity", 0), nil
+	v, ok := optionCount(serverOptions, "log_error_verbosity")
+	if !ok {
+		s.LogErrorVerbosity.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMysqlConf) logOutput(serverOptions map[string]any) ([]any, error) {
@@ -412,7 +442,12 @@ func (s *mqlMysqlConf) binlogFormat(serverOptions map[string]any) (string, error
 }
 
 func (s *mqlMysqlConf) binlogExpireLogsSeconds(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "binlog_expire_logs_seconds", 0), nil
+	v, ok := optionCount(serverOptions, "binlog_expire_logs_seconds")
+	if !ok {
+		s.BinlogExpireLogsSeconds.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMysqlConf) binlogEncryption(serverOptions map[string]any) (bool, error) {
@@ -420,7 +455,12 @@ func (s *mqlMysqlConf) binlogEncryption(serverOptions map[string]any) (bool, err
 }
 
 func (s *mqlMysqlConf) serverId(serverOptions map[string]any) (int64, error) {
-	return optionInt(serverOptions, "server_id", 0), nil
+	v, ok := optionCount(serverOptions, "server_id")
+	if !ok {
+		s.ServerId.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return v, nil
 }
 
 func (s *mqlMysqlConf) gtidMode(serverOptions map[string]any) (string, error) {

--- a/providers/os/resources/mysql_internal_test.go
+++ b/providers/os/resources/mysql_internal_test.go
@@ -681,3 +681,49 @@ func TestMariadbConf_SlowQueryLogFileIsEmptyWhenUnset(t *testing.T) {
 	require.NoError(t, path.Error)
 	assert.Empty(t, path.Data)
 }
+
+// An option no file sets reads null, not zero. max_connections=0 is not a
+// configuration a server can run with, so reporting it lets a bounds check pass
+// on a server whose real limit is higher — the direction that matters. port is
+// the exception: 3306 is what the server uses when no file names one.
+func TestMariadbConf_AbsentCountsAreNullNotZero(t *testing.T) {
+	conf := mariadbConf(t, "mysql_almalinux9_mariadb.toml")
+
+	for _, tc := range []struct {
+		name string
+		get  func() *plugin.TValue[int64]
+	}{
+		{"maxConnections", conf.GetMaxConnections},
+		{"serverId", conf.GetServerId},
+		{"logWarnings", conf.GetLogWarnings},
+		{"expireLogsDays", conf.GetExpireLogsDays},
+		{"simplePasswordCheckMinimalLength", conf.GetSimplePasswordCheckMinimalLength},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := tc.get()
+			require.NoError(t, v.Error)
+			assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, v.State,
+				"an option the files do not set has to read null")
+		})
+	}
+
+	port := conf.GetPort()
+	require.NoError(t, port.Error)
+	assert.Equal(t, int64(3306), port.Data, "port keeps the default the server would use")
+}
+
+// A count the files do set still reads as a number.
+func TestMariadbConf_PresentCountsStillRead(t *testing.T) {
+	conf := mariadbConf(t, "mysql_debian13_mariadb.toml")
+
+	// the fixture sets expire_logs_days and leaves max_connections commented
+	set := conf.GetExpireLogsDays()
+	require.NoError(t, set.Error)
+	assert.NotEqual(t, plugin.StateIsSet|plugin.StateIsNull, set.State)
+	assert.Equal(t, int64(10), set.Data)
+
+	unset := conf.GetMaxConnections()
+	require.NoError(t, unset.Error)
+	assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, unset.State,
+		"the same fixture leaves max_connections unset, and that has to stay null")
+}

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -3649,7 +3649,7 @@ private haproxy.config.peersSection @defaults("name") {
 // Pair with `postgresql.hba` and `postgresql.ident` for the auxiliary
 // configuration files. By default the file is located by probing the
 // well-known paths for Debian/Ubuntu and RPM installations; pass an
-// explicit path with `postgresql.conf(path: "/path/to/postgresql.conf")`.
+// explicit path with `postgresql.conf("/path/to/postgresql.conf")`.
 postgresql.conf {
   init(path? string)
   // Primary configuration file
@@ -3810,8 +3810,13 @@ mysql {
 // By default the file is located by probing the well-known paths for
 // Debian/Ubuntu and RPM installations, and returns nothing when the host
 // runs MariaDB rather than MySQL. Pass an explicit path with
-// `mysql.conf(path: "/etc/mysql/my.cnf")` to parse a file regardless of
+// `mysql.conf("/etc/mysql/my.cnf")` to parse a file regardless of
 // which product it belongs to.
+//
+// Values come from the option files. A setting given on the
+// command line, which is how a container usually configures MySQL,
+// is not visible here, and an option no file sets reads null rather
+// than zero.
 mysql.conf {
   init(path? string)
   // Primary option file
@@ -4071,8 +4076,13 @@ mariadb {
 // By default the file is located by probing the well-known paths for
 // Debian/Ubuntu and RPM installations, and returns nothing when the host
 // runs MySQL rather than MariaDB. Pass an explicit path with
-// `mariadb.conf(path: "/etc/mysql/mariadb.cnf")` to parse a file regardless
+// `mariadb.conf("/etc/mysql/mariadb.cnf")` to parse a file regardless
 // of which product it belongs to.
+//
+// Values come from the option files. A setting given on the
+// command line, which is how a container usually configures MariaDB,
+// is not visible here, and an option no file sets reads null rather
+// than zero.
 mariadb.conf {
   init(path? string)
   // Primary option file
@@ -7022,7 +7032,7 @@ secpol {
 // control directives that govern which peers and clients may interact with
 // the daemon, and `fudge` carries reference-clock adjustments. `settings`
 // returns every effective directive line. Select a file with
-// `ntp.conf(path: "...")`.
+// `ntp.conf("...")`.
 ntp.conf {
   init(path string)
   // File of the NTP service configuration
@@ -7052,7 +7062,7 @@ ntp.conf {
 // where the control socket listens; and `keyFile`, `makeStep`, and
 // `rtcSync` cover the authentication key file, clock-stepping policy, and
 // real-time-clock synchronization. Select an alternate file with
-// `chrony.conf(path: "...")`; the default resolves to `/etc/chrony.conf`
+// `chrony.conf("...")`; the default resolves to `/etc/chrony.conf`
 // (RHEL family) or `/etc/chrony/chrony.conf` (Debian family).
 chrony.conf {
   init(path string)


### PR DESCRIPTION
Found while auditing whether `mariadb.conf` is production ready, after #10037.

`mysql.conf` and `mariadb.conf` reported **0** for every numeric option that no option file sets. Zero is not a value these servers run with, so the field read as a configured setting rather than as an absence — and a bounds check passed on a server that exceeded the bound:

```
# container started with --max-connections=777, no file mentions it
$ mql run docker container maria -c 'mariadb.conf.maxConnections <= 500'
[ok] value: 0
```

The host looks compliant precisely when nothing in the files constrains it. After:

```
[failed] mariadb.conf.maxConnections <= 500
  expected: <= 500
  actual:   _
```

## What changed

Seventeen accessors move from a zero fallback to a presence check — `max_connections`, `server_id`, `log_warnings`, `expire_logs_days`, the `simple_password_check` family and `password_reuse_check_interval` on MariaDB; the `validate_password` family, `password_history`, `default_password_lifetime`, `log_error_verbosity` and `binlog_expire_logs_seconds` on MySQL. A value that does not parse is treated as absent for the same reason.

`port` keeps its 3306 fallback, and now says why: that is the port the server uses when no file names one, which is a real value. A count of zero is not.

## The boundary, now written down

Both resources report **what the option files say**. Options given on the command line — how a container usually configures these servers — are in no file and are invisible here. That is inherent to a config-file resource, but nothing said so; the audit that prompted this had the server running 777 from its command line while every file was silent.

## Blast radius, measured

Against a provider built from current `main`, on MariaDB 10.11:

| field | main | this PR |
| --- | --- | --- |
| `maxConnections` | `0` | `null` |
| `serverId` | `0` | `null` |
| `logWarnings` | `0` | `null` |
| `simplePasswordCheckMinimalLength` | `0` | `null` |
| `passwordReuseCheckInterval` | `0` | `null` |
| `expireLogsDays` (image sets it) | `10` | `10` |
| `port` | `3306` | `3306` |
| every string, bool, list and map field | — | identical |

Tests pin both directions: absent counts must carry `StateIsSet\|StateIsNull`, and a count the fixture does set must still read as a number.

**This is a behaviour change for anyone comparing these fields to `0`.** A policy written as `maxConnections == 0` to mean "unset" now needs `== null`; one written as `<= N` stops passing on hosts where the files say nothing, which is the point.

## Also in these doc comments

Five resources documented the init argument as `mysql.conf(path: "...")`, which does not compile:

```
failed to compile: resource chrony.conf does not have a field named path
```

The positional form is what works, verified against a live server for `chrony.conf`, `ntp.conf` and `postgresql.conf` as well as the two here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)