### PR TITLE
📄 skills: correct what makes a named init argument compile

### DIFF
--- a/.claude/skills/new-resource/SKILL.md
+++ b/.claude/skills/new-resource/SKILL.md
@@ -104,14 +104,23 @@ Each of these is in CLAUDE.md. Each still gets walked into, because the failure 
 
 `strings` on the binary will not settle it: Go concatenates string literals, so even terms you know are present grep to zero. Rebuild, or use a control.
 
-**The init argument form is positional, not named.** This is not in CLAUDE.md and the `nginx.conf` doc comment gets it wrong:
+**A named init argument resolves against the resource's fields, not its init parameters.** `init(path? string)` does not make `r(path: "…")` compile. The resource has to *declare* a field of that name:
 
-```
-bind9(path: "/etc/named.conf")   # failed to compile: resource bind9 does not have a field named path
-bind9("/etc/named.conf")         # works
+| resource | `init` | declares `path` | `r(path: "…")` | `r("…")` |
+|---|---|---|---|---|
+| `file` | `init(path string)` | **yes** | works | works |
+| `sshd.config` | `init(path? string)` | no | `does not have a field named path` | works |
+
+The two are otherwise the same shape, so the field is the whole difference. `os.lr` is split almost evenly — **32** resources taking a path declare the field and accept the named form, **41** do not and are positional-only — which means guessing gets it wrong about half the time. `sshd.config`, `mysql.conf`, `mariadb.conf`, `bind9`, `nginx.conf`, `apache2.conf`, `chrony.conf`, `ntp.conf`, `postgresql.conf` and every `parse.*` reach their file through `file()` and declare no `path`; `fstab`, `java.keystore`, `mount.point`, `registrykey` and most `*.packages` declare it and work either way.
+
+Check before writing the doc comment, and run the form you wrote:
+
+```bash
+# note the trailing space, not "{": a resource may be declared `name @defaults(...) {`
+grep -A20 '^<resource> ' providers/<p>/resources/<p>.lr | grep -E '^\s+path\s+string'
 ```
 
-Write the positional form in the resource's doc comment, and use it for local verification.
+If you want the named form on a resource that lacks the field, that is a **schema change, not a doc fix**: declare `path string`, accepting that it then duplicates `file.path`, and only where the duplicate earns its place. Five resources' comments documented a form that could not compile — the cheap correction is the positional one.
 
 ## 4. Build and test without clobbering the installed provider
 

--- a/.claude/skills/new-resource/SKILL.md
+++ b/.claude/skills/new-resource/SKILL.md
@@ -113,6 +113,14 @@ Each of these is in CLAUDE.md. Each still gets walked into, because the failure 
 
 The two are otherwise the same shape, so the field is the whole difference. `os.lr` is split almost evenly — **32** resources taking a path declare the field and accept the named form, **41** do not and are positional-only — which means guessing gets it wrong about half the time. `sshd.config`, `mysql.conf`, `mariadb.conf`, `bind9`, `nginx.conf`, `apache2.conf`, `chrony.conf`, `ntp.conf`, `postgresql.conf` and every `parse.*` reach their file through `file()` and declare no `path`; `fstab`, `java.keystore`, `mount.point`, `registrykey` and most `*.packages` declare it and work either way.
 
+It is a property of **each argument**, not of the resource. `parse.ini` declares `delimiter` and not `path`, so the two halves of one init behave differently, and mixing is allowed:
+
+```
+parse.ini("/tmp/x.ini")                      # works
+parse.ini(path: "/tmp/x.ini")                # does not have a field named path
+parse.ini("/tmp/x.ini", delimiter: "=")      # works: positional path, named delimiter
+```
+
 Check before writing the doc comment, and run the form you wrote:
 
 ```bash


### PR DESCRIPTION
The `new-resource` skill told readers the init argument form is **positional, not named**. That is what the failure looks like from one resource, and it is wrong as a rule — noticed by @chris-rock while reviewing #10038, which corrected five doc comments to the positional form.

## The actual rule

A named argument resolves against the resource's **declared fields**, not against its init parameters. Both of these take a path:

| resource | `init` | declares `path` | `r(path: "…")` | `r("…")` |
|---|---|---|---|---|
| `file` | `init(path string)` | **yes** | works | works |
| `sshd.config` | `init(path? string)` | no | `does not have a field named path` | works |

Verified against a live container:

```
$ mql run docker container t1 -c 'file(path: "/etc/hostname").exists'
[ok] value: true

$ mql run docker container t1 -c 'sshd.config(path: "/etc/ssh/sshd_config").file.path'
failed to compile: resource sshd.config does not have a field named path

$ mql run docker container t1 -c 'sshd.config("/etc/ssh/sshd_config").file.path'
sshd.config.file.path: "/etc/ssh/sshd_config"
```

`fstab(path: "…")` compiles too, and `parse.json(path: "…")` does not — same split, same cause.

## Why it matters more than a wording fix

`os.lr` is split almost evenly: **32** resources that take a path declare the field and accept the named form, **41** do not and are positional-only. Guessing is a coin flip. The config resources people reach for most — `sshd.config`, `mysql.conf`, `mariadb.conf`, `bind9`, `nginx.conf`, `apache2.conf`, `chrony.conf`, `ntp.conf`, `postgresql.conf`, every `parse.*` — reach their file through `file()` and declare no `path`, which is why the doc comments drifted to a form that cannot compile.

The section now carries the rule, the pair that demonstrates it, which side the common resources fall on, and a check to run before writing a doc comment:

```bash
# note the trailing space, not "{": a resource may be declared `name @defaults(...) {`
grep -A20 '^<resource> ' providers/<p>/resources/<p>.lr | grep -E '^\s+path\s+string'
```

That grep is in the skill because the first version I wrote used `'^<resource> {'` and silently missed `file`, which is declared `file @defaults("path size permissions.string") {`. Both forms were run against `os.lr` before committing.

## And the option it leaves open

If someone wants the named form on a resource that lacks the field, the skill now says what that costs: declaring `path string` duplicates `file.path`, so it is a schema decision rather than a documentation one — not something to do reflexively to make a comment true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)