### PR TITLE
⚡ gcp: stop spending calls that cannot succeed and refetching the project

### DIFF
--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -413,19 +413,6 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 	}
 	projectId := g.ProjectId.Data
 
-	if g.Regions.Error != nil {
-		return nil, g.Regions.Error
-	}
-	regions := g.Regions.Data
-	if len(regions) == 0 {
-		// regions data has not been fetched, we need to get it
-		r, err := g.regions()
-		if err != nil {
-			return nil, err
-		}
-		regions = r
-	}
-
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 
 	creds, err := conn.Credentials(run.DefaultAuthScopes()...)
@@ -446,14 +433,16 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 		MaxInstanceCount int32 `json:"maxInstanceCount"`
 	}
 
-	var wg sync.WaitGroup
+	// One call for every region. Cloud Run v2 accepts "-" as the location, which
+	// this provider previously fanned out over ~43 regions to achieve: verified
+	// against the live API, projects/{p}/locations/-/services returns 200 with
+	// services from every region. (ListJobs rejects the same wildcard with
+	// INVALID_ARGUMENT, which is why the jobs lister below still fans out.)
+	// Each service's own region is read back off its resource name.
 	var services []any
-	wg.Add(len(regions))
-	mux := &sync.Mutex{}
-	for _, region := range regions {
-		go func(region string) {
-			defer wg.Done()
-			it := runSvc.ListServices(ctx, &runpb.ListServicesRequest{Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, region)})
+	{
+		{
+			it := runSvc.ListServices(ctx, &runpb.ListServicesRequest{Parent: fmt.Sprintf("projects/%s/locations/-", projectId)})
 			for {
 				s, err := it.Next()
 				if err == iterator.Done {
@@ -592,7 +581,7 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 				mqlS, err := CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.service", map[string]*llx.RawData{
 					"id":                            llx.StringData(s.Name),
 					"projectId":                     llx.StringData(projectId),
-					"region":                        llx.StringData(region),
+					"region":                        llx.StringData(parseLocationFromPath(s.Name)),
 					"name":                          llx.StringData(parseResourceName(s.Name)),
 					"description":                   llx.StringData(s.Description),
 					"generation":                    llx.IntData(s.Generation),
@@ -641,13 +630,10 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 					continue
 				}
 				mqlS.(*mqlGcpProjectCloudRunServiceService).cacheEncryptionKey = s.GetTemplate().GetEncryptionKey()
-				mux.Lock()
 				services = append(services, mqlS)
-				mux.Unlock()
 			}
-		}(region.(string))
+		}
 	}
-	wg.Wait()
 	return services, nil
 }
 

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -440,199 +440,195 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 	// INVALID_ARGUMENT, which is why the jobs lister below still fans out.)
 	// Each service's own region is read back off its resource name.
 	var services []any
-	{
-		{
-			it := runSvc.ListServices(ctx, &runpb.ListServicesRequest{Parent: fmt.Sprintf("projects/%s/locations/-", projectId)})
-			for {
-				s, err := it.Next()
-				if err == iterator.Done {
-					break
-				}
-				if err != nil {
-					log.Error().Err(err).Send()
-					break
-				}
+	it := runSvc.ListServices(ctx, &runpb.ListServicesRequest{Parent: fmt.Sprintf("projects/%s/locations/-", projectId)})
+	for {
+		s, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Error().Err(err).Send()
+			break
+		}
 
-				var mqlTemplate plugin.Resource
-				if s.Template != nil {
-					var scalingCfg map[string]any
-					if s.Template.Scaling != nil {
-						scalingCfg, err = convert.JsonToDict(mqlRevisionScaling{
-							MinInstanceCount: s.Template.Scaling.MinInstanceCount,
-							MaxInstanceCount: s.Template.Scaling.MaxInstanceCount,
-						})
-						if err != nil {
-							log.Error().Err(err).Send()
-						}
-					}
-
-					templateId := fmt.Sprintf("gcp.project.cloudRunService.service/%s/%s/revisionTemplate", projectId, s.Name)
-					mqlVpcAccessCfg, err := mqlVpcAccessConfig(g.MqlRuntime, templateId+"/vpcAccess", s.Template.VpcAccess)
-					if err != nil {
-						log.Error().Err(err).Send()
-					}
-
-					mqlContainers, err := mqlContainers(g.MqlRuntime, s.Template.Containers, templateId)
-					if err != nil {
-						log.Error().Err(err).Send()
-					}
-
-					mqlTemplate, err = CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.service.revisionTemplate", map[string]*llx.RawData{
-						"id":                                   llx.StringData(templateId),
-						"projectId":                            llx.StringData(projectId),
-						"name":                                 llx.StringData(s.Template.Revision),
-						"labels":                               llx.MapData(convert.MapToInterfaceMap(s.Template.Labels), types.String),
-						"annotations":                          llx.MapData(convert.MapToInterfaceMap(s.Template.Annotations), types.String),
-						"scaling":                              llx.DictData(scalingCfg),
-						"vpcAccessConfig":                      llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
-						"timeout":                              llx.TimeData(llx.DurationToTime(s.Template.GetTimeout().GetSeconds())),
-						"serviceAccountEmail":                  llx.StringData(s.Template.ServiceAccount),
-						"containers":                           llx.ArrayData(mqlContainers, "gcp.project.cloudRunService.container"),
-						"volumes":                              llx.ArrayData(mqlVolumes(s.Template.Volumes), types.Dict),
-						"executionEnvironment":                 llx.StringData(s.Template.ExecutionEnvironment.String()),
-						"encryptionKey":                        llx.StringData(s.Template.EncryptionKey),
-						"maxInstanceRequestConcurrency":        llx.IntData(int64(s.Template.MaxInstanceRequestConcurrency)),
-						"encryptionKeyRevocationAction":        llx.StringData(s.Template.GetEncryptionKeyRevocationAction().String()),
-						"encryptionKeyShutdownDurationSeconds": llx.IntData(s.Template.GetEncryptionKeyShutdownDuration().GetSeconds()),
-						"serviceMesh":                          llx.StringData(s.Template.GetServiceMesh().GetMesh()),
-						"sessionAffinity":                      llx.BoolData(s.Template.GetSessionAffinity()),
-						"healthCheckDisabled":                  llx.BoolData(s.Template.GetHealthCheckDisabled()),
-						"nodeSelectorAccelerator":              llx.StringData(s.Template.GetNodeSelector().GetAccelerator()),
-						"gpuZonalRedundancyDisabled":           llx.BoolData(s.Template.GetGpuZonalRedundancyDisabled()),
-					})
-					if err != nil {
-						log.Error().Err(err).Send()
-					}
-				}
-
-				mqlTraffic := make([]any, 0, len(s.Traffic))
-				for _, t := range s.Traffic {
-					mqlTraffic = append(mqlTraffic, map[string]any{
-						"type":     t.Type.String(),
-						"revision": t.Revision,
-						"percent":  strconv.Itoa(int(t.Percent)),
-						"tag":      t.Tag,
-					})
-				}
-
-				mqlTerminalCondition, err := mqlCondition(g.MqlRuntime, s.TerminalCondition, s.Name, "terminal")
-				if err != nil {
-					log.Error().Err(err).Send()
-				}
-
-				mqlConditions := make([]any, 0, len(s.Conditions))
-				for i, c := range s.Conditions {
-					mqlCondition, err := mqlCondition(g.MqlRuntime, c, s.Name, fmt.Sprintf("%d", i))
-					if err != nil {
-						log.Error().Err(err).Send()
-					}
-					mqlConditions = append(mqlConditions, mqlCondition)
-				}
-
-				mqlTrafficStatuses := make([]any, 0, len(s.TrafficStatuses))
-				for _, t := range s.TrafficStatuses {
-					mqlTrafficStatuses = append(mqlTrafficStatuses, map[string]any{
-						"type":     t.Type.String(),
-						"revision": t.Revision,
-						"percent":  strconv.Itoa(int(t.Percent)),
-						"tag":      t.Tag,
-						"uri":      t.Uri,
-					})
-				}
-
-				baDict, err := protoToDict(s.BinaryAuthorization)
-				if err != nil {
-					log.Error().Err(err).Msg("failed to convert BinaryAuthorization to dict")
-				}
-				var baUseDefault bool
-				var baBreakglass string
-				if s.BinaryAuthorization != nil {
-					baUseDefault = s.BinaryAuthorization.GetUseDefault()
-					baBreakglass = s.BinaryAuthorization.GetBreakglassJustification()
-				}
-				// Only a service Cloud Run built from source carries a build
-				// config. Leaving it null on image-deployed services keeps a
-				// check on the base image or build identity from matching a
-				// service that was never built here.
-				buildConfigData := llx.NilData
-				if bc := s.GetBuildConfig(); bc != nil {
-					mqlBuild, err := CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.service.buildSettings", map[string]*llx.RawData{
-						"__id":                   llx.StringData(fmt.Sprintf("%s/buildConfig", s.Name)),
-						"name":                   llx.StringData(bc.GetName()),
-						"sourceLocation":         llx.StringData(bc.GetSourceLocation()),
-						"functionTarget":         llx.StringData(bc.GetFunctionTarget()),
-						"imageUri":               llx.StringData(bc.GetImageUri()),
-						"baseImage":              llx.StringData(bc.GetBaseImage()),
-						"enableAutomaticUpdates": llx.BoolData(bc.GetEnableAutomaticUpdates()),
-						"workerPool":             llx.StringData(bc.GetWorkerPool()),
-						"environmentVariables":   llx.MapData(convert.MapToInterfaceMap(bc.GetEnvironmentVariables()), types.String),
-					})
-					if err != nil {
-						// Match the surrounding loop: one malformed build config
-						// must not drop the whole service list. The field stays
-						// null rather than reporting a build that was not read.
-						log.Error().Err(err).Str("service", s.Name).Msg("failed to create cloud run build config")
-					} else {
-						mqlBuild.(*mqlGcpProjectCloudRunServiceServiceBuildSettings).cacheServiceAccount = bc.GetServiceAccount()
-						buildConfigData = llx.ResourceData(mqlBuild, "gcp.project.cloudRunService.service.buildSettings")
-					}
-				}
-
-				mqlS, err := CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.service", map[string]*llx.RawData{
-					"id":                            llx.StringData(s.Name),
-					"projectId":                     llx.StringData(projectId),
-					"region":                        llx.StringData(parseLocationFromPath(s.Name)),
-					"name":                          llx.StringData(parseResourceName(s.Name)),
-					"description":                   llx.StringData(s.Description),
-					"generation":                    llx.IntData(s.Generation),
-					"labels":                        llx.MapData(convert.MapToInterfaceMap(s.Labels), types.String),
-					"annotations":                   llx.MapData(convert.MapToInterfaceMap(s.Annotations), types.String),
-					"created":                       llx.TimeDataPtr(timestampAsTimePtr(s.CreateTime)),
-					"updated":                       llx.TimeDataPtr(timestampAsTimePtr(s.UpdateTime)),
-					"deleted":                       llx.TimeDataPtr(timestampAsTimePtr(s.DeleteTime)),
-					"expired":                       llx.TimeDataPtr(timestampAsTimePtr(s.ExpireTime)),
-					"creator":                       llx.StringData(s.Creator),
-					"lastModifier":                  llx.StringData(s.LastModifier),
-					"ingress":                       llx.StringData(s.Ingress.String()),
-					"invokerIamDisabled":            llx.BoolData(s.InvokerIamDisabled),
-					"iapEnabled":                    llx.BoolData(s.IapEnabled),
-					"threatDetectionEnabled":        llx.BoolData(s.ThreatDetectionEnabled),
-					"launchStage":                   llx.StringData(s.LaunchStage.String()),
-					"template":                      llx.ResourceData(mqlTemplate, "gcp.project.cloudRunService.service.revisionTemplate"),
-					"traffic":                       llx.ArrayData(mqlTraffic, types.Dict),
-					"observedGeneration":            llx.IntData(s.ObservedGeneration),
-					"terminalCondition":             llx.ResourceData(mqlTerminalCondition, "gcp.project.cloudRunService.condition"),
-					"conditions":                    llx.ArrayData(mqlConditions, types.Resource("gcp.project.cloudRunService.condition")),
-					"latestReadyRevision":           llx.StringData(s.LatestReadyRevision),
-					"latestCreatedRevision":         llx.StringData(s.LatestCreatedRevision),
-					"trafficStatuses":               llx.ArrayData(mqlTrafficStatuses, types.Dict),
-					"uri":                           llx.StringData(s.Uri),
-					"reconciling":                   llx.BoolData(s.Reconciling),
-					"customAudiences":               llx.ArrayData(convert.SliceAnyToInterface(s.CustomAudiences), types.String),
-					"defaultUriDisabled":            llx.BoolData(s.DefaultUriDisabled),
-					"satisfiesPzs":                  llx.BoolData(s.SatisfiesPzs),
-					"scalingMode":                   llx.StringData(s.GetScaling().GetScalingMode().String()),
-					"minInstanceCount":              llx.IntData(int64(s.GetScaling().GetMinInstanceCount())),
-					"maxInstanceCount":              llx.IntData(int64(s.GetScaling().GetMaxInstanceCount())),
-					"manualInstanceCount":           llx.IntData(int64(s.GetScaling().GetManualInstanceCount())),
-					"urls":                          llx.ArrayData(convert.SliceAnyToInterface(s.GetUrls()), types.String),
-					"buildConfig":                   buildConfigData,
-					"uid":                           llx.StringData(s.Uid),
-					"etag":                          llx.StringData(s.Etag),
-					"client":                        llx.StringData(s.Client),
-					"clientVersion":                 llx.StringData(s.ClientVersion),
-					"binaryAuthorization":           llx.DictData(baDict),
-					"binaryAuthorizationUseDefault": llx.BoolData(baUseDefault),
-					"binaryAuthorizationBreakglassJustification": llx.StringData(baBreakglass),
+		var mqlTemplate plugin.Resource
+		if s.Template != nil {
+			var scalingCfg map[string]any
+			if s.Template.Scaling != nil {
+				scalingCfg, err = convert.JsonToDict(mqlRevisionScaling{
+					MinInstanceCount: s.Template.Scaling.MinInstanceCount,
+					MaxInstanceCount: s.Template.Scaling.MaxInstanceCount,
 				})
 				if err != nil {
 					log.Error().Err(err).Send()
-					continue
 				}
-				mqlS.(*mqlGcpProjectCloudRunServiceService).cacheEncryptionKey = s.GetTemplate().GetEncryptionKey()
-				services = append(services, mqlS)
+			}
+
+			templateId := fmt.Sprintf("gcp.project.cloudRunService.service/%s/%s/revisionTemplate", projectId, s.Name)
+			mqlVpcAccessCfg, err := mqlVpcAccessConfig(g.MqlRuntime, templateId+"/vpcAccess", s.Template.VpcAccess)
+			if err != nil {
+				log.Error().Err(err).Send()
+			}
+
+			mqlContainers, err := mqlContainers(g.MqlRuntime, s.Template.Containers, templateId)
+			if err != nil {
+				log.Error().Err(err).Send()
+			}
+
+			mqlTemplate, err = CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.service.revisionTemplate", map[string]*llx.RawData{
+				"id":                                   llx.StringData(templateId),
+				"projectId":                            llx.StringData(projectId),
+				"name":                                 llx.StringData(s.Template.Revision),
+				"labels":                               llx.MapData(convert.MapToInterfaceMap(s.Template.Labels), types.String),
+				"annotations":                          llx.MapData(convert.MapToInterfaceMap(s.Template.Annotations), types.String),
+				"scaling":                              llx.DictData(scalingCfg),
+				"vpcAccessConfig":                      llx.ResourceData(mqlVpcAccessCfg, "gcp.project.cloudRunService.vpcAccessConfig"),
+				"timeout":                              llx.TimeData(llx.DurationToTime(s.Template.GetTimeout().GetSeconds())),
+				"serviceAccountEmail":                  llx.StringData(s.Template.ServiceAccount),
+				"containers":                           llx.ArrayData(mqlContainers, "gcp.project.cloudRunService.container"),
+				"volumes":                              llx.ArrayData(mqlVolumes(s.Template.Volumes), types.Dict),
+				"executionEnvironment":                 llx.StringData(s.Template.ExecutionEnvironment.String()),
+				"encryptionKey":                        llx.StringData(s.Template.EncryptionKey),
+				"maxInstanceRequestConcurrency":        llx.IntData(int64(s.Template.MaxInstanceRequestConcurrency)),
+				"encryptionKeyRevocationAction":        llx.StringData(s.Template.GetEncryptionKeyRevocationAction().String()),
+				"encryptionKeyShutdownDurationSeconds": llx.IntData(s.Template.GetEncryptionKeyShutdownDuration().GetSeconds()),
+				"serviceMesh":                          llx.StringData(s.Template.GetServiceMesh().GetMesh()),
+				"sessionAffinity":                      llx.BoolData(s.Template.GetSessionAffinity()),
+				"healthCheckDisabled":                  llx.BoolData(s.Template.GetHealthCheckDisabled()),
+				"nodeSelectorAccelerator":              llx.StringData(s.Template.GetNodeSelector().GetAccelerator()),
+				"gpuZonalRedundancyDisabled":           llx.BoolData(s.Template.GetGpuZonalRedundancyDisabled()),
+			})
+			if err != nil {
+				log.Error().Err(err).Send()
 			}
 		}
+
+		mqlTraffic := make([]any, 0, len(s.Traffic))
+		for _, t := range s.Traffic {
+			mqlTraffic = append(mqlTraffic, map[string]any{
+				"type":     t.Type.String(),
+				"revision": t.Revision,
+				"percent":  strconv.Itoa(int(t.Percent)),
+				"tag":      t.Tag,
+			})
+		}
+
+		mqlTerminalCondition, err := mqlCondition(g.MqlRuntime, s.TerminalCondition, s.Name, "terminal")
+		if err != nil {
+			log.Error().Err(err).Send()
+		}
+
+		mqlConditions := make([]any, 0, len(s.Conditions))
+		for i, c := range s.Conditions {
+			mqlCondition, err := mqlCondition(g.MqlRuntime, c, s.Name, fmt.Sprintf("%d", i))
+			if err != nil {
+				log.Error().Err(err).Send()
+			}
+			mqlConditions = append(mqlConditions, mqlCondition)
+		}
+
+		mqlTrafficStatuses := make([]any, 0, len(s.TrafficStatuses))
+		for _, t := range s.TrafficStatuses {
+			mqlTrafficStatuses = append(mqlTrafficStatuses, map[string]any{
+				"type":     t.Type.String(),
+				"revision": t.Revision,
+				"percent":  strconv.Itoa(int(t.Percent)),
+				"tag":      t.Tag,
+				"uri":      t.Uri,
+			})
+		}
+
+		baDict, err := protoToDict(s.BinaryAuthorization)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to convert BinaryAuthorization to dict")
+		}
+		var baUseDefault bool
+		var baBreakglass string
+		if s.BinaryAuthorization != nil {
+			baUseDefault = s.BinaryAuthorization.GetUseDefault()
+			baBreakglass = s.BinaryAuthorization.GetBreakglassJustification()
+		}
+		// Only a service Cloud Run built from source carries a build
+		// config. Leaving it null on image-deployed services keeps a
+		// check on the base image or build identity from matching a
+		// service that was never built here.
+		buildConfigData := llx.NilData
+		if bc := s.GetBuildConfig(); bc != nil {
+			mqlBuild, err := CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.service.buildSettings", map[string]*llx.RawData{
+				"__id":                   llx.StringData(fmt.Sprintf("%s/buildConfig", s.Name)),
+				"name":                   llx.StringData(bc.GetName()),
+				"sourceLocation":         llx.StringData(bc.GetSourceLocation()),
+				"functionTarget":         llx.StringData(bc.GetFunctionTarget()),
+				"imageUri":               llx.StringData(bc.GetImageUri()),
+				"baseImage":              llx.StringData(bc.GetBaseImage()),
+				"enableAutomaticUpdates": llx.BoolData(bc.GetEnableAutomaticUpdates()),
+				"workerPool":             llx.StringData(bc.GetWorkerPool()),
+				"environmentVariables":   llx.MapData(convert.MapToInterfaceMap(bc.GetEnvironmentVariables()), types.String),
+			})
+			if err != nil {
+				// Match the surrounding loop: one malformed build config
+				// must not drop the whole service list. The field stays
+				// null rather than reporting a build that was not read.
+				log.Error().Err(err).Str("service", s.Name).Msg("failed to create cloud run build config")
+			} else {
+				mqlBuild.(*mqlGcpProjectCloudRunServiceServiceBuildSettings).cacheServiceAccount = bc.GetServiceAccount()
+				buildConfigData = llx.ResourceData(mqlBuild, "gcp.project.cloudRunService.service.buildSettings")
+			}
+		}
+
+		mqlS, err := CreateResource(g.MqlRuntime, "gcp.project.cloudRunService.service", map[string]*llx.RawData{
+			"id":                            llx.StringData(s.Name),
+			"projectId":                     llx.StringData(projectId),
+			"region":                        llx.StringData(parseLocationFromPath(s.Name)),
+			"name":                          llx.StringData(parseResourceName(s.Name)),
+			"description":                   llx.StringData(s.Description),
+			"generation":                    llx.IntData(s.Generation),
+			"labels":                        llx.MapData(convert.MapToInterfaceMap(s.Labels), types.String),
+			"annotations":                   llx.MapData(convert.MapToInterfaceMap(s.Annotations), types.String),
+			"created":                       llx.TimeDataPtr(timestampAsTimePtr(s.CreateTime)),
+			"updated":                       llx.TimeDataPtr(timestampAsTimePtr(s.UpdateTime)),
+			"deleted":                       llx.TimeDataPtr(timestampAsTimePtr(s.DeleteTime)),
+			"expired":                       llx.TimeDataPtr(timestampAsTimePtr(s.ExpireTime)),
+			"creator":                       llx.StringData(s.Creator),
+			"lastModifier":                  llx.StringData(s.LastModifier),
+			"ingress":                       llx.StringData(s.Ingress.String()),
+			"invokerIamDisabled":            llx.BoolData(s.InvokerIamDisabled),
+			"iapEnabled":                    llx.BoolData(s.IapEnabled),
+			"threatDetectionEnabled":        llx.BoolData(s.ThreatDetectionEnabled),
+			"launchStage":                   llx.StringData(s.LaunchStage.String()),
+			"template":                      llx.ResourceData(mqlTemplate, "gcp.project.cloudRunService.service.revisionTemplate"),
+			"traffic":                       llx.ArrayData(mqlTraffic, types.Dict),
+			"observedGeneration":            llx.IntData(s.ObservedGeneration),
+			"terminalCondition":             llx.ResourceData(mqlTerminalCondition, "gcp.project.cloudRunService.condition"),
+			"conditions":                    llx.ArrayData(mqlConditions, types.Resource("gcp.project.cloudRunService.condition")),
+			"latestReadyRevision":           llx.StringData(s.LatestReadyRevision),
+			"latestCreatedRevision":         llx.StringData(s.LatestCreatedRevision),
+			"trafficStatuses":               llx.ArrayData(mqlTrafficStatuses, types.Dict),
+			"uri":                           llx.StringData(s.Uri),
+			"reconciling":                   llx.BoolData(s.Reconciling),
+			"customAudiences":               llx.ArrayData(convert.SliceAnyToInterface(s.CustomAudiences), types.String),
+			"defaultUriDisabled":            llx.BoolData(s.DefaultUriDisabled),
+			"satisfiesPzs":                  llx.BoolData(s.SatisfiesPzs),
+			"scalingMode":                   llx.StringData(s.GetScaling().GetScalingMode().String()),
+			"minInstanceCount":              llx.IntData(int64(s.GetScaling().GetMinInstanceCount())),
+			"maxInstanceCount":              llx.IntData(int64(s.GetScaling().GetMaxInstanceCount())),
+			"manualInstanceCount":           llx.IntData(int64(s.GetScaling().GetManualInstanceCount())),
+			"urls":                          llx.ArrayData(convert.SliceAnyToInterface(s.GetUrls()), types.String),
+			"buildConfig":                   buildConfigData,
+			"uid":                           llx.StringData(s.Uid),
+			"etag":                          llx.StringData(s.Etag),
+			"client":                        llx.StringData(s.Client),
+			"clientVersion":                 llx.StringData(s.ClientVersion),
+			"binaryAuthorization":           llx.DictData(baDict),
+			"binaryAuthorizationUseDefault": llx.BoolData(baUseDefault),
+			"binaryAuthorizationBreakglassJustification": llx.StringData(baBreakglass),
+		})
+		if err != nil {
+			log.Error().Err(err).Send()
+			continue
+		}
+		mqlS.(*mqlGcpProjectCloudRunServiceService).cacheEncryptionKey = s.GetTemplate().GetEncryptionKey()
+		services = append(services, mqlS)
 	}
 	return services, nil
 }

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -549,9 +549,18 @@ func getSubnetworkByUrl(subnetUrl string, runtime *plugin.Runtime) (*mqlGcpProje
 
 	// Use NewResource so initGcpProjectComputeServiceSubnetwork runs and
 	// populates every field instead of leaving the resource partially set.
+	//
+	// regionUrl has to go in the args, not just onto cacheRegionUrl afterwards.
+	// The init matches a listed subnetwork on name, project *and* region, and
+	// with no regionUrl its region is "", which matches nothing. It then falls
+	// through to a direct Get carrying that empty region and GCP rejects it:
+	//   GET .../projects/{p}/regions//subnetworks/{n} -> 400 Invalid value for
+	//   field 'region': ''
+	// which surfaces as an errored check rather than a resolved subnetwork.
 	res, err := NewResource(runtime, "gcp.project.computeService.subnetwork", map[string]*llx.RawData{
 		"name":      llx.StringData(name),
 		"projectId": llx.StringData(project),
+		"regionUrl": llx.StringData(regionUrl),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -653,3 +653,19 @@ func getZoneByUrl(zoneUrl string, runtime *plugin.Runtime) (*mqlGcpProjectComput
 	}
 	return res.(*mqlGcpProjectComputeServiceZone), nil
 }
+
+// cachedResource returns a resource already built in this runtime, or nil.
+//
+// The runtime keys its resource cache on resourceName + "\x00" + id. Callers
+// that check the cache before doing I/O need that same key, and spelling it out
+// at each call site means a future change to the format has to find every copy.
+// Mirrors the helper of the same name in the azure provider.
+func cachedResource(runtime *plugin.Runtime, resourceName, id string) plugin.Resource {
+	if id == "" || runtime == nil || runtime.Resources == nil {
+		return nil
+	}
+	if res, ok := runtime.Resources.Get(resourceName + "\x00" + id); ok {
+		return res
+	}
+	return nil
+}

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.36.0",
-  "generated_at": "2026-08-17T11:57:54-07:00",
+  "version": "13.37.0",
+  "generated_at": "2026-08-17T22:07:44-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -105,6 +105,15 @@ func initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[str
 		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locRaw.Value.(string), name)
 	}
 
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. The answer is memoized per project, so this is free after the
+	// first caller.
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_memcache); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Cloud Memorystore for Memcached API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(memcache.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -98,7 +98,7 @@ func initGcpProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	// is referenced from a dozen files (iam, logging, apikeys, cloud functions,
 	// filestore, shared VPC, the service gate, discovery), which on one measured
 	// scan meant 452 identical Projects.Get calls, half of all HTTP traffic.
-	if cached, ok := runtime.Resources.Get(ResourceGcpProject + "\x00" + projectRef); ok {
+	if cached := cachedResource(runtime, ResourceGcpProject, projectRef); cached != nil {
 		return args, cached, nil
 	}
 

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -92,6 +92,16 @@ func initGcpProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return nil, nil, errors.New("gcp.project requires a project id")
 	}
 
+	// NewResource consults the resource cache only after this init returns, so
+	// without this check every typed project reference re-fetches a record the
+	// runtime is already holding and the result is then discarded. gcp.project
+	// is referenced from a dozen files (iam, logging, apikeys, cloud functions,
+	// filestore, shared VPC, the service gate, discovery), which on one measured
+	// scan meant 452 identical Projects.Get calls, half of all HTTP traffic.
+	if cached, ok := runtime.Resources.Get(ResourceGcpProject + "\x00" + projectRef); ok {
+		return args, cached, nil
+	}
+
 	project, err := svc.Projects.Get(fmt.Sprintf("projects/%s", projectRef)).Do()
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/servicegate.go
+++ b/providers/gcp/resources/servicegate.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -83,4 +84,41 @@ func (s *serviceGate) recordEnabled(enabled bool) {
 	s.once.Do(func() {
 		s.enabled = enabled
 	})
+}
+
+// serviceEnabledForInit reports whether service is enabled on projectId.
+//
+// The serviceGate above is embedded in a service resource's Internal struct,
+// which init functions cannot use: they are plain functions with no receiver to
+// hang state on. They need the check just as much, though, and for a more
+// expensive reason -- an init that goes straight to a per-resource Get against a
+// disabled API fails, and the failure is not cached, so it is repeated for every
+// referrer on every asset. One scan of a project with Vertex AI and Memcache
+// switched off spent 1,050 calls that way, 40% of all its API traffic, on five
+// Get methods that could not have succeeded.
+//
+// The answer is memoized on the gcp.project resource (sync.Once around the
+// enabled-services map), and gcp.project is itself cached by id, so this costs
+// at most one ServiceUsage call per project no matter how many inits ask.
+// CreateResource is used rather than NewResource deliberately: it skips
+// initGcpProject, so asking the question never triggers a project fetch.
+//
+// A resolution failure is returned rather than folded into false, for the same
+// reason resolveEnabled does it: reporting "not enabled" for a project that was
+// never successfully checked would turn an unknown into a confident wrong answer.
+func serviceEnabledForInit(runtime *plugin.Runtime, projectId, service string) (bool, error) {
+	if projectId == "" {
+		return false, errors.New("project id required to check whether " + service + " is enabled")
+	}
+	proj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(projectId),
+	})
+	if err != nil {
+		return false, err
+	}
+	p, ok := proj.(*mqlGcpProject)
+	if !ok {
+		return false, errors.New("unexpected resource type for gcp.project")
+	}
+	return p.isServiceEnabled(service)
 }

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -64,6 +64,8 @@ const (
 	service_pam                 = "privilegedaccessmanager.googleapis.com"
 	service_networkconnectivity = "networkconnectivity.googleapis.com"
 	service_networkmanagement   = "networkmanagement.googleapis.com"
+	service_memcache            = "memcache.googleapis.com"
+	service_aiplatform          = "aiplatform.googleapis.com"
 )
 
 func serviceName(name string) string {

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -1105,10 +1105,11 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 
 	// Accept either the full resource path or a short name + location from
 	// the asset-identifier-driven discovery path.
-	var fullName, region string
+	var fullName, region, projectId string
 	if strings.HasPrefix(name, "projects/") {
 		fullName = name
 		region = parseLocationFromPath(name)
+		projectId = parseProjectFromPath(name)
 	} else {
 		locRaw := args["location"]
 		projRaw := args["projectId"]
@@ -1116,7 +1117,17 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 			return nil, nil, errors.New("vertexai custom job init: projectId and location required when name is not a full resource path")
 		}
 		region = locRaw.Value.(string)
-		fullName = fmt.Sprintf("projects/%s/locations/%s/customJobs/%s", projRaw.Value.(string), region, name)
+		projectId = projRaw.Value.(string)
+		fullName = fmt.Sprintf("projects/%s/locations/%s/customJobs/%s", projectId, region, name)
+	}
+
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. The answer is memoized per project, so this is free after the
+	// first caller.
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_aiplatform); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Vertex AI API is not enabled on project " + projectId)
 	}
 
 	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
@@ -1180,6 +1191,16 @@ func initGcpProjectVertexaiServiceEndpoint(runtime *plugin.Runtime, args map[str
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. The answer is memoized per project, so this is free after the
+	// first caller.
+	projectId := parseProjectFromPath(name)
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_aiplatform); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Vertex AI API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err
@@ -1240,6 +1261,16 @@ func initGcpProjectVertexaiServicePipelineJob(runtime *plugin.Runtime, args map[
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. The answer is memoized per project, so this is free after the
+	// first caller.
+	projectId := parseProjectFromPath(name)
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_aiplatform); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Vertex AI API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err
@@ -1300,6 +1331,16 @@ func initGcpProjectVertexaiServiceNotebookRuntimeTemplate(runtime *plugin.Runtim
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. The answer is memoized per project, so this is free after the
+	// first caller.
+	projectId := parseProjectFromPath(name)
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_aiplatform); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Vertex AI API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err
@@ -2459,6 +2500,16 @@ func initGcpProjectVertexaiServiceSchedule(runtime *plugin.Runtime, args map[str
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. The answer is memoized per project, so this is free after the
+	// first caller.
+	projectId := parseProjectFromPath(name)
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_aiplatform); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Vertex AI API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(aiplatform.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Problem

A scan of one 71-asset GCP project made **2,651 API calls**, and roughly 58% of them could not produce anything. For scale, azure sits at 1.9 calls per asset and aws at 10.8 after its fixes; this was 37.

| waste | calls | share |
|---|---|---|
| `Get`s against APIs that are not enabled | 1,050 | 40% |
| Project record refetched | 452 | 17% |
| Cloud Run region fan-out (avoidable half) | 42 | 1.6% |

## 1. Calls against disabled APIs — 1,050

Five gRPC `Get` methods, at *exactly* 210 calls each: `CloudMemcache/GetInstance` and Vertex AI's `GetPipelineJob`, `GetNotebookRuntimeTemplate`, `GetCustomJob`, `GetEndpoint`. Every single one failed:

```
552  PermissionDenied  "Agent Platform API..."     (Vertex AI not enabled)
288  Unimplemented     404 Not Found
210  PermissionDenied  "Cloud Memorystore..."      (Memcache not enabled)
```

210 is ~3 calls per asset across 71 assets. The failures are not cached, so they repeat for every referrer on every asset.

The provider already has the mechanism to avoid this. `serviceGate` answers "is this API enabled on this project", memoized, and **29 files use it** — but `memcache.go` and `vertexai.go` use it zero times, and their inits go straight to a per-resource `Get`.

The gate could not simply be reused: it is embedded in a service resource's `Internal` struct, and init functions are plain functions with no receiver to hold state on. `serviceEnabledForInit` reaches the same memoized answer (`sync.Once` around the enabled-services map on `gcp.project`). It deliberately uses `CreateResource` rather than `NewResource`, so asking the question never runs `initGcpProject` and never triggers a project fetch. A resolution failure is returned rather than folded into `false`, matching `resolveEnabled` — reporting "not enabled" for a project that was never successfully checked would turn an unknown into a confident wrong answer.

## 2. The project record fetched 452 times

`initGcpProject` called `Projects.Get` unconditionally. `NewResource` consults the resource cache only *after* the init returns, so every typed project reference re-fetched a record the runtime was already holding, and `gcp.project` is referenced from a dozen files. 452 calls, one distinct URL.

## 3. Cloud Run fanned out over 43 regions

Tested against the live API rather than assumed:

| call | `locations/-` | result |
|---|---|---|
| `ListServices` | **HTTP 200** | works — 43 calls become 1 |
| `ListJobs` | HTTP 400 `INVALID_ARGUMENT` | unsupported, fan-out kept |

Each service's region now comes from its own resource name, and the region list this function no longer needs is not fetched. Artifact Registry's 46-call fan-out is left alone — the code already documents that its API rejects the wildcard.

## 4. A pre-existing bug the others exposed

The first post-fix run moved one check from `skip` to `error`. Chasing it found that `getSubnetworkByUrl` computes a region URL and never passes it into the args — it only sets `cacheRegionUrl` *after* `NewResource` returns. So the init always ran with `region == ""`, its match condition `subnetRegion == region` could never hold against a real subnetwork, and it fell through to a direct `Get`:

```
GET .../projects/{p}/regions//subnetworks/{name}   ->  400 Invalid value for field 'region': ''
```

Note the empty path segment. The changes above only altered which lookups took that path. Passing `regionUrl` in the args fixes it, and also removes calls, since the list scan can now match instead of falling back.

This is verified safe: the init always returns either a resource or an error, never `(args, nil, nil)`, so the runtime never builds a resource from args containing that init-only key.

The same shape explains one of the improvements below — the baseline's `gke-backup-plan-exists` failure was `The resource id projects/ is invalid`, an empty *project* id. Both are one defect: an identifier computed and then not threaded through.

## Result

**2,651 → 1,113 calls (−58.0%)**, same 71 assets.

| target | before | after |
|---|---|---|
| failing `Get`s | 1,050 | 0 |
| project refetch | 452 | 3 |
| Cloud Run `ListServices` | 43 | 1 |
| empty-region subnetwork `Get`s | 3 | 0 |

**Correctness.** Of 6,996 score tuples, **4 differ**, all on one asset, and every one is a baseline *error* that now resolves — two to `result 100` with `data-completion` going 0 → 100 (so they evaluate real data rather than passing on absence), two to `skip`. No regressions.

Determinism was verified rather than assumed: two independent runs of the fixed build produced **byte-identical** score tuples, which is what ruled out the unlocked `GetOrCompute` race (mondoohq/server#18630) as an explanation for the differences.

`gcp.permissions.json` regenerates with a version bump only — the manifest was already stale on main against `config.go`'s 13.37.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
