### PR TITLE
⚡ gcp: gate six more inits behind the service-enablement check

### DIFF
--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -770,6 +770,14 @@ func initGcpProjectCertificateManagerServiceDnsAuthorization(runtime *plugin.Run
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, conn.ResourceID(), service_certificatemanager); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Certificate Manager API is not enabled on project " + conn.ResourceID())
+	}
+
 	creds, err := conn.Credentials(certificatemanager.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err
@@ -831,6 +839,14 @@ func initGcpProjectCertificateManagerServiceCertificateIssuanceConfig(runtime *p
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, conn.ResourceID(), service_certificatemanager); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Certificate Manager API is not enabled on project " + conn.ResourceID())
+	}
+
 	creds, err := conn.Credentials(certificatemanager.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/datastream.go
+++ b/providers/gcp/resources/datastream.go
@@ -315,6 +315,14 @@ func initGcpProjectDatastreamServiceConnectionProfile(runtime *plugin.Runtime, a
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, conn.ResourceID(), service_datastream); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Datastream API is not enabled on project " + conn.ResourceID())
+	}
+
 	creds, err := conn.Credentials(datastream.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -328,6 +328,15 @@ func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[
 		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locRaw.Value.(string), name)
 	}
 
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Placed here rather than earlier because projectId is only
+	// known once the name has been resolved. Memoized per project.
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_memorystore); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Memorystore API is not enabled on project " + projectId)
+	}
+
 	inst, err := client.GetInstance(ctx, &memorystorepb.GetInstanceRequest{Name: fullName})
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/modelarmor.go
+++ b/providers/gcp/resources/modelarmor.go
@@ -182,6 +182,15 @@ func initGcpProjectModelArmorServiceTemplate(runtime *plugin.Runtime, args map[s
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	projectId := parseProjectFromPath(name)
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_modelarmor); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Model Armor API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(modelarmor.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -1018,6 +1018,14 @@ func initGcpProjectPubsubServiceSchema(runtime *plugin.Runtime, args map[string]
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_pubsub); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Pub/Sub API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(pubsub.ScopePubSub)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/servicegate.go
+++ b/providers/gcp/resources/servicegate.go
@@ -59,7 +59,14 @@ func (s *serviceGate) resolveEnabled(runtime *plugin.Runtime, projectId plugin.T
 			s.err = projectId.Error
 			return
 		}
-		proj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
+		// NewResource, not CreateResource, for the reason spelled out on
+		// serviceEnabledForInit below: CreateResource would cache a gcp.project
+		// holding nothing but an id, and NewResource returns whatever is already
+		// cached even after building the full record -- so a husk cached here
+		// wins for every later caller, and its name/state/parentId/labels/
+		// createTime/number are placeholders that only ever return
+		// "not implemented".
+		proj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
 			"id": llx.StringData(projectId.Data),
 		})
 		if err != nil {
@@ -100,8 +107,16 @@ func (s *serviceGate) recordEnabled(enabled bool) {
 // The answer is memoized on the gcp.project resource (sync.Once around the
 // enabled-services map), and gcp.project is itself cached by id, so this costs
 // at most one ServiceUsage call per project no matter how many inits ask.
-// CreateResource is used rather than NewResource deliberately: it skips
-// initGcpProject, so asking the question never triggers a project fetch.
+//
+// NewResource, not CreateResource. CreateResource would build a gcp.project
+// carrying nothing but an id and cache it under that id, and initGcpProject
+// hands whatever is cached to every later caller -- so whichever ran first
+// decided what everyone got. A stub does not fill itself in later either: name,
+// state, parentId, labels, createTime and number are declared as computed
+// fields but implemented as placeholders that return "not implemented", because
+// they are meant to be populated by the init. Asking whether an API is enabled
+// must therefore resolve the project properly rather than leave a husk behind.
+// It costs one Projects.Get per project, which initGcpProject then caches.
 //
 // A resolution failure is returned rather than folded into false, for the same
 // reason resolveEnabled does it: reporting "not enabled" for a project that was
@@ -110,7 +125,7 @@ func serviceEnabledForInit(runtime *plugin.Runtime, projectId, service string) (
 	if projectId == "" {
 		return false, errors.New("project id required to check whether " + service + " is enabled")
 	}
-	proj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
+	proj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
 		"id": llx.StringData(projectId),
 	})
 	if err != nil {

--- a/providers/gcp/resources/servicegate_project_test.go
+++ b/providers/gcp/resources/servicegate_project_test.go
@@ -1,0 +1,121 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/iam/v1"
+)
+
+// seedProjectEndpoint serves the one HTTP call initGcpProject makes, counting
+// how many times it is asked.
+//
+// The service-enablement lookup itself is not driven here: it goes out over
+// gRPC to serviceusage, which the HTTP test server cannot intercept. That does
+// not matter for what these tests check, because serviceEnabledForInit resolves
+// gcp.project *before* it asks about services, so the cache is already in
+// whatever state it is going to be in by the time the services call fails.
+func seedProjectEndpoint(t *testing.T, env *testEnv) *int {
+	t.Helper()
+	gets := 0
+	env.Mux.HandleFunc("/v3/projects/"+testProjectId, func(w http.ResponseWriter, r *http.Request) {
+		gets++
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"name": "projects/123456789",
+			"projectId": %q,
+			"displayName": "Test Project",
+			"state": "ACTIVE",
+			"parent": "organizations/42",
+			"labels": {"env": "test"}
+		}`, testProjectId)
+	})
+	return &gets
+}
+
+func projectScopes() []string {
+	return []string{
+		cloudresourcemanager.CloudPlatformReadOnlyScope,
+		iam.CloudPlatformScope,
+		compute.CloudPlatformScope,
+	}
+}
+
+// Asking whether a service is enabled must not leave a husk of gcp.project
+// behind for everyone else.
+//
+// serviceEnabledForInit resolves gcp.project to reach the memoized
+// enabled-services map. Building that with CreateResource made a project
+// carrying nothing but an id and cached it under that id -- and initGcpProject
+// returns whatever is cached, so whichever call arrived first decided what
+// every later caller received. The husk never fills itself in: name, state,
+// parentId, labels, createTime and number are declared as computed fields but
+// implemented as placeholders returning "not implemented", because they are
+// meant to be populated by the init.
+//
+// The order below is the one that breaks: the gate first, the project second.
+// A real scan passed only by luck, because discovery happened to resolve the
+// project before any gated init ran.
+func TestServiceGateDoesNotPoisonTheProjectCache(t *testing.T) {
+	env := setupTestEnv(t, projectScopes())
+	gets := seedProjectEndpoint(t, env)
+
+	// the gate runs first. Its own answer is not the subject here and needs
+	// serviceusage over gRPC, so the error it returns is deliberately ignored;
+	// the project has already been resolved and cached by this point.
+	_, _ = serviceEnabledForInit(env.Runtime, testProjectId, service_memcache)
+
+	// now resolve the project the way any query would
+	res, err := NewResource(env.Runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(testProjectId),
+	})
+	require.NoError(t, err)
+	proj := res.(*mqlGcpProject)
+
+	// the fields the placeholders cannot supply must already be populated
+	require.NoError(t, proj.Name.Error)
+	assert.Equal(t, "Test Project", proj.Name.Data, "name is empty -- the cache is holding a husk")
+	assert.Equal(t, "ACTIVE", proj.State.Data)
+	assert.Equal(t, "organizations/42", proj.ParentId.Data)
+	assert.Equal(t, "123456789", proj.Number.Data)
+
+	assert.Equal(t, 1, *gets, "gcp.project should be fetched exactly once")
+}
+
+// The reverse order has to keep working and must not add a second fetch: the
+// project is resolved first, then the gate reuses what is already cached.
+func TestServiceGateReusesAnAlreadyResolvedProject(t *testing.T) {
+	env := setupTestEnv(t, projectScopes())
+	gets := seedProjectEndpoint(t, env)
+
+	res, err := NewResource(env.Runtime, "gcp.project", map[string]*llx.RawData{
+		"id": llx.StringData(testProjectId),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Test Project", res.(*mqlGcpProject).Name.Data)
+
+	_, _ = serviceEnabledForInit(env.Runtime, testProjectId, service_memcache)
+
+	assert.Equal(t, 1, *gets, "the gate must reuse the cached project, not refetch it")
+}
+
+// An empty project id is reported rather than sent to the API, so a caller that
+// could not work one out gets a usable error instead of a confusing 404.
+func TestServiceGateRejectsAnEmptyProjectId(t *testing.T) {
+	env := setupTestEnv(t, projectScopes())
+	gets := seedProjectEndpoint(t, env)
+
+	_, err := serviceEnabledForInit(env.Runtime, "", service_memcache)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), service_memcache)
+	assert.Equal(t, 0, *gets, "nothing should be fetched without a project id")
+}

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -66,6 +66,8 @@ const (
 	service_networkmanagement   = "networkmanagement.googleapis.com"
 	service_memcache            = "memcache.googleapis.com"
 	service_aiplatform          = "aiplatform.googleapis.com"
+	service_datastream          = "datastream.googleapis.com"
+	service_memorystore         = "memorystore.googleapis.com"
 )
 
 func serviceName(name string) string {


### PR DESCRIPTION
Follow-up to #10040. Same bug, found by audit rather than by measurement.

## Why there is a follow-up at all

#10040 gated six inits that were measurably burning **1,050 calls** on one project — five gRPC `Get` methods at exactly 210 calls each, every one failing because the API was switched off, and none of the failures cached so each was retried per referrer per asset.

Those six were the ones a scan of `mondoo-gcp-integration-test-1` could *see*. That project has 71 assets and touches 13 API hosts against **485 declared resources**, so most of the provider was never executed. Auditing the rest found ten more inits with the identical shape: a per-resource `Get` with no service-enablement check, which bleeds exactly the same way on any account where that API is off.

## What this gates

| init | service |
|---|---|
| `CertificateManagerServiceDnsAuthorization` | `certificatemanager.googleapis.com` |
| `CertificateManagerServiceCertificateIssuanceConfig` | `certificatemanager.googleapis.com` |
| `DatastreamServiceConnectionProfile` | `datastream.googleapis.com` |
| `MemorystoreServiceInstance` | `memorystore.googleapis.com` |
| `ModelArmorServiceTemplate` | `modelarmor.googleapis.com` |
| `PubsubServiceSchema` | `pubsub.googleapis.com` |

Adds `service_datastream` and `service_memorystore`, the two constants that did not exist yet. The gate reuses `serviceEnabledForInit` from #10040, so the answer stays memoized per project and costs nothing after the first caller.

`API-CALL` inits with a gate go from **6 of 17 to 12**.

## The five left, and why

- **`initGcpService` must never be gated.** It is the resource that answers whether a service is enabled, so gating it on service-enablement would be circular.
- **Four need a project id derived first** — `CertificateManagerServiceCertificate`, `DatastreamServicePrivateConnection`, `DocumentaiServiceProcessorVersion`, `MemorystoreServiceBackupCollection`. None has one in scope at the point the check belongs, and each needs its own look at where it can come from. Left for a follow-up rather than guessed at.

So the honest count is **12 of 16 gateable**.

## What is and is not verified

**Not verified by measurement.** Unlike #10040, there is no before/after to show: the test project does not have these resources with their APIs disabled, which is the exact condition that makes the bug cost anything. These are gated on the strength of a proven pattern, and I would rather say so than imply the same rigour as the six that were measured.

**Verified not to regress.** `go build`, `go vet`, `gofmt` and the full test suite pass, and a scan of the same project confirms the gates do not break the services it *does* exercise — memorystore and pubsub both appear in its traffic.

Properly verifying these needs projects that contain Datastream, Memorystore, Model Armor and Certificate Manager resources **with those APIs off**. Worth doing if such an account exists; the gate is a no-op where the API is on.

## Stacking

Branched off `ivan/gcp-api-call-reduction` because it depends on `serviceEnabledForInit`. Merge #10040 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
