### PR TITLE
🟢 ci: give the link check a timeout it can live with

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -1,5 +1,13 @@
 {
-  "aliveStatusCodes": [429, 200, 406],
+  "aliveStatusCodes": [
+    429,
+    200,
+    406
+  ],
+  "timeout": "30s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "10s",
   "ignorePatterns": [
     {
       "pattern": "^https:\\/\\/wiki\\.jenkins\\.io\\/display\\/JENKINS\\/Building\\+a\\+software\\+project"


### PR DESCRIPTION
The markdown link check has failed on **every pull request since ~09:50 today**, including on `main` itself:

```
08-18T10:40  failure  main
08-18T10:38  failure  ivan/gcp-api-call-reduction
08-18T10:21  failure  main
08-18T10:17  failure  ivan/skill-classifier-createresource
08-18T09:55  failure  skill/init-arg-form
--- before that: 30 consecutive successes ---
```

The dead link it reports is `https://nmap.org/download.html` in `providers/nmap/README.md`, which none of those branches touch.

## The link is not dead

It answers **200, in about 15 seconds**. `markdown-link-check` defaults to a 10 second timeout with no retries, so a site that slow comes back as `Status: 0 AggregateError [ETIMEDOUT]` and the run fails.

Reproduced both states locally against the exact file that broke `main`:

```
# current config
$ npx markdown-link-check -c <current> providers/nmap/README.md
  [✖] https://nmap.org/download.html → Status: 0
  ERROR: 1 dead link found!

# this config
$ npx markdown-link-check -c .github/actions/link-check/config.json providers/nmap/README.md
  [✓] https://nmap.org/download.html
```

## The change

```json
"timeout": "30s",
"retryOn429": true,
"retryCount": 3,
"fallbackRetryDelay": "10s",
```

`aliveStatusCodes` and the three existing `ignorePatterns` are untouched.

## Why config rather than a re-run

The workflow has no path filter, so it checks every markdown file in the repository on every PR. One slow external host therefore blocks everyone, and re-running only helps until the next time nmap.org is slow. Raising the timeout treats the cause; the alternative — adding `nmap.org` to `ignorePatterns` — would stop checking a link that is genuinely fine.

Re-running the other affected PRs after this merges should clear them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)