### PR TITLE
⚡ aws: resolve IAM users and groups from the account list

### DIFF
--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -201,6 +201,75 @@ func ParsePasswordPolicy(passwordPolicy *iamtypes.PasswordPolicy) map[string]any
 // (aws.iam.passwordPolicy) rather than only through the aws.iam accessor. A bare
 // instantiation has no __id, so it delegates to the parent accessor to populate
 // the policy data.
+// iamUserFromList resolves an IAM user out of the aws.iam users list, which a
+// scan fetches once for the whole account, instead of spending a GetUser per
+// referrer.
+//
+// The init runs before NewResource consults the resource cache, and the cache is
+// keyed on the resource's ARN while this lookup arrives with a name, so the
+// ARN-keyed check cannot fire and every reference re-fetched the same user: one
+// measured scan spent 59 GetUser calls on 4 distinct users.
+//
+// Resolving from the list costs nothing extra because ListUsers is already made
+// once per scan, and it loses no data: everything ListUsers omits is resolved
+// lazily anyway -- tags() through ListUserTags, and permissionsBoundary()
+// through its own GetUser fallback when the boundary was never set.
+//
+// Returns nil when the list cannot be read or holds no match, so callers keep
+// their existing fetch as the fallback rather than turning a readable user into
+// an error.
+func iamUserFromList(runtime *plugin.Runtime, name, arn string) *mqlAwsIamUser {
+	obj, err := NewResource(runtime, "aws.iam", map[string]*llx.RawData{})
+	if err != nil {
+		return nil
+	}
+	users := obj.(*mqlAwsIam).GetUsers()
+	if users.Error != nil {
+		return nil
+	}
+	for i := range users.Data {
+		usr, ok := users.Data[i].(*mqlAwsIamUser)
+		if !ok {
+			continue
+		}
+		if arn != "" && usr.Arn.Data == arn {
+			return usr
+		}
+		if name != "" && usr.Name.Data == name {
+			return usr
+		}
+	}
+	return nil
+}
+
+// iamGroupFromList is the group counterpart of iamUserFromList. GetGroup made no
+// calls in the account measured, so this is a latent case rather than a measured
+// one -- but the group init has no cache check at all, so it is the weaker of
+// the two.
+func iamGroupFromList(runtime *plugin.Runtime, name, arn string) *mqlAwsIamGroup {
+	obj, err := NewResource(runtime, "aws.iam", map[string]*llx.RawData{})
+	if err != nil {
+		return nil
+	}
+	groups := obj.(*mqlAwsIam).GetGroups()
+	if groups.Error != nil {
+		return nil
+	}
+	for i := range groups.Data {
+		grp, ok := groups.Data[i].(*mqlAwsIamGroup)
+		if !ok {
+			continue
+		}
+		if arn != "" && grp.Arn.Data == arn {
+			return grp
+		}
+		if name != "" && grp.Name.Data == name {
+			return grp
+		}
+	}
+	return nil
+}
+
 func initAwsIamPasswordPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if _, ok := args["__id"]; ok {
 		return args, nil, nil
@@ -1088,6 +1157,15 @@ func initAwsIamUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	if args["name"] == nil {
 		return nil, nil, errors.New("name required to fetch aws iam user")
 	}
+
+	// Resolve from the account's user list before falling back to a GetUser the
+	// ARN-keyed cache check above cannot serve, because this lookup is by name.
+	if name, ok := args["name"].Value.(string); ok && name != "" {
+		if usr := iamUserFromList(runtime, name, ""); usr != nil {
+			return args, usr, nil
+		}
+	}
+
 	conn := runtime.Connection.(*connection.AwsConnection)
 
 	svc := conn.Iam("")
@@ -2036,6 +2114,26 @@ func initAwsIamGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	}
 	if args["arn"] == nil && args["name"] == nil {
 		return nil, nil, errors.New("arn or name required to fetch aws iam group")
+	}
+
+	// Same as the user init: resolve from the account's group list first. This
+	// one has no cache check at all, so without it every reference to a group
+	// paid for its own GetGroup.
+	// args["x"] on an absent key is a nil *llx.RawData; dereferencing it panics
+	// the provider and takes the whole scan with it, and only one of the two is
+	// guaranteed present here.
+	wantName := ""
+	if args["name"] != nil {
+		wantName, _ = args["name"].Value.(string)
+	}
+	wantArn := ""
+	if args["arn"] != nil {
+		wantArn, _ = args["arn"].Value.(string)
+	}
+	if wantName != "" || wantArn != "" {
+		if grp := iamGroupFromList(runtime, wantName, wantArn); grp != nil {
+			return args, grp, nil
+		}
 	}
 
 	conn := runtime.Connection.(*connection.AwsConnection)

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -201,6 +201,21 @@ func ParsePasswordPolicy(passwordPolicy *iamtypes.PasswordPolicy) map[string]any
 // (aws.iam.passwordPolicy) rather than only through the aws.iam accessor. A bare
 // instantiation has no __id, so it delegates to the parent accessor to populate
 // the policy data.
+func initAwsIamPasswordPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	iam, err := NewResource(runtime, "aws.iam", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	pp := iam.(*mqlAwsIam).GetPasswordPolicy()
+	if pp.Error != nil {
+		return nil, nil, pp.Error
+	}
+	return args, pp.Data, nil
+}
+
 // iamUserFromList resolves an IAM user out of the aws.iam users list, which a
 // scan fetches once for the whole account, instead of spending a GetUser per
 // referrer.
@@ -232,8 +247,14 @@ func iamUserFromList(runtime *plugin.Runtime, name, arn string) *mqlAwsIamUser {
 		if !ok {
 			continue
 		}
-		if arn != "" && usr.Arn.Data == arn {
-			return usr
+		// An ARN identifies exactly one user, so when the caller has one it
+		// decides on its own. Testing both per element would let an ARN match on
+		// one entry beat a name match on another purely by list order.
+		if arn != "" {
+			if usr.Arn.Data == arn {
+				return usr
+			}
+			continue
 		}
 		if name != "" && usr.Name.Data == name {
 			return usr
@@ -260,29 +281,20 @@ func iamGroupFromList(runtime *plugin.Runtime, name, arn string) *mqlAwsIamGroup
 		if !ok {
 			continue
 		}
-		if arn != "" && grp.Arn.Data == arn {
-			return grp
+		// An ARN identifies exactly one group, so when the caller has one it
+		// decides on its own. Testing both per element would let an ARN match on
+		// one entry beat a name match on another purely by list order.
+		if arn != "" {
+			if grp.Arn.Data == arn {
+				return grp
+			}
+			continue
 		}
 		if name != "" && grp.Name.Data == name {
 			return grp
 		}
 	}
 	return nil
-}
-
-func initAwsIamPasswordPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if _, ok := args["__id"]; ok {
-		return args, nil, nil
-	}
-	iam, err := NewResource(runtime, "aws.iam", map[string]*llx.RawData{})
-	if err != nil {
-		return nil, nil, err
-	}
-	pp := iam.(*mqlAwsIam).GetPasswordPolicy()
-	if pp.Error != nil {
-		return nil, nil, pp.Error
-	}
-	return args, pp.Data, nil
 }
 
 func (a *mqlAwsIam) passwordPolicy() (*mqlAwsIamPasswordPolicy, error) {


### PR DESCRIPTION
## Problem

`initAwsIamUser` resolves a user **by name** with `GetUser`, but the cache check above it keys on **ARN**:

```go
if cached := cachedArgByArn(runtime, ResourceAwsIamUser, args); cached != nil {
	return args, cached, nil
}
```

Callers pass `name`, never `arn`, so that check can never fire, and `NewResource` consults the resource cache only *after* the init returns. Every reference therefore re-fetched the same user. One measured scan spent **59 `GetUser` calls on 4 distinct users**.

`initAwsIamGroup` is the same shape with **no cache check at all**, so it is the weaker of the two.

## Fix

Both inits now resolve from the account's own list first — the same pattern `initAwsIamPasswordPolicy` already uses a few lines above in this file, and the one azure (`initFromServiceList`), gcp and k8s (`initNamespacedResource`) use throughout.

`ListUsers` and `ListGroups` are each **already made once per scan**, so consulting them costs nothing extra. Each init keeps its own `Get` as the fallback when the list cannot be read or holds no match, so nothing regresses on an account where listing is denied but the targeted call is allowed.

## No data is lost

Worth spelling out, because the SDK is explicit that IAM's listing operations are lossy:

> IAM resource-listing operations return a subset of the available attributes… This operation does **not** return the following attributes: `PermissionsBoundary`, `Tags`. To view all of the information for a user, see `GetUser`.

Both are already handled lazily on this resource, which is what makes the swap safe:

- `tags()` is a computed field that fetches through `ListUserTags`
- `permissionsBoundary()` is a computed field with its own `GetUser` fallback for exactly the case where the boundary was never set

The `users()` lister already relies on this — it does not populate tags either. The init setting them eagerly was the inconsistent one.

## Measured

| | before | after |
|---|---|---|
| `GetUser` | **59** (4 distinct users) | **0** |
| `ListUsers` | 1 | 1 |

Zero rather than the 4 I expected: once a user is resolved from the list it is cached, so nothing refetches.

**Verification caveat, stated plainly.** The account gained an asset between the two runs (169 → 170), so a strict score diff was invalid. Restricted to the **168 assets present in both**: 14,480 score tuples each, and **2 differ** — an S3 check reporting `cannot find field 'encryption' in resource 'aws.s3.bucket'`. That is a policy/schema mismatch from #10026 (v14-pre) reworking `aws.lr`; this change touches no S3 code. Flagged separately, since a shipped compliance check is currently erroring against a field the provider no longer has.

Total went 1,833 → 1,794 rather than the full −59 because `DescribeSnapshots` rose 34 → 50 in the same run — the concurrency-dependent duplication tracked in mondoohq/server#18630, which varies run to run and is unrelated.

`GetGroup` was already 0 on this account, so **the group half is unverified by measurement**. It is the same shape, and the one with no cache check at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
