### PR TITLE
⚡ gcp: gate the last four inits behind the service-enablement check

### DIFF
--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -726,6 +726,14 @@ func initGcpProjectCertificateManagerServiceCertificate(runtime *plugin.Runtime,
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, conn.ResourceID(), service_certificatemanager); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Certificate Manager API is not enabled on project " + conn.ResourceID())
+	}
+
 	creds, err := conn.Credentials(certificatemanager.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/datastream.go
+++ b/providers/gcp/resources/datastream.go
@@ -541,6 +541,14 @@ func initGcpProjectDatastreamServicePrivateConnection(runtime *plugin.Runtime, a
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, conn.ResourceID(), service_datastream); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Datastream API is not enabled on project " + conn.ResourceID())
+	}
+
 	creds, err := conn.Credentials(datastream.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/documentai.go
+++ b/providers/gcp/resources/documentai.go
@@ -267,6 +267,9 @@ func initGcpProjectDocumentaiServiceProcessorVersion(runtime *plugin.Runtime, ar
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 	projectId := parseProjectFromPath(name)
+	if projectId == "" {
+		return nil, nil, fmt.Errorf("cannot determine project from processor version name %q", name)
+	}
 	// Ask whether the API is on before paying for a Get that cannot succeed
 	// without it. Memoized per project, so this is free after the first caller.
 	if enabled, err := serviceEnabledForInit(runtime, projectId, service_documentai); err != nil {

--- a/providers/gcp/resources/documentai.go
+++ b/providers/gcp/resources/documentai.go
@@ -266,6 +266,15 @@ func initGcpProjectDocumentaiServiceProcessorVersion(runtime *plugin.Runtime, ar
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	projectId := parseProjectFromPath(name)
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, projectId, service_documentai); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Document AI API is not enabled on project " + projectId)
+	}
+
 	creds, err := conn.Credentials(documentai.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -645,6 +645,14 @@ func initGcpProjectMemorystoreServiceBackupCollection(runtime *plugin.Runtime, a
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
+	// Ask whether the API is on before paying for a Get that cannot succeed
+	// without it. Memoized per project, so this is free after the first caller.
+	if enabled, err := serviceEnabledForInit(runtime, conn.ResourceID(), service_memorystore); err != nil {
+		return nil, nil, err
+	} else if !enabled {
+		return nil, nil, errors.New("Memorystore API is not enabled on project " + conn.ResourceID())
+	}
+
 	creds, err := conn.Credentials(memorystore.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -68,6 +68,7 @@ const (
 	service_aiplatform          = "aiplatform.googleapis.com"
 	service_datastream          = "datastream.googleapis.com"
 	service_memorystore         = "memorystore.googleapis.com"
+	service_documentai          = "documentai.googleapis.com"
 )
 
 func serviceName(name string) string {


### PR DESCRIPTION
Closes the audit started in #10040 and continued in #10042.

Every gcp init that makes a per-resource `Get` now asks whether the API is enabled first, so an account with the service switched off no longer pays for a call that cannot succeed and is not cached.

## Why these four were left out, and why that was wrong

The earlier audit looked for an available project id by grepping each init body for `projectId`, `parseProjectFromPath` or `"projects/"`. Three of these already call `conn.ResourceID()` further down and the fourth derives one from the processor-version path it is handed — so the grep missed them and I reported them as needing a project id derived first. All four had one available.

## What this gates

| init | service |
|---|---|
| `CertificateManagerServiceCertificate` | `certificatemanager.googleapis.com` |
| `DatastreamServicePrivateConnection` | `datastream.googleapis.com` |
| `MemorystoreServiceBackupCollection` | `memorystore.googleapis.com` |
| `DocumentaiServiceProcessorVersion` | `documentai.googleapis.com` |

Adds `service_documentai`.

**API-CALL inits go from 12 gated of 17 to 16.** The one remaining is `initGcpService`, which must never be gated — it is the resource that *answers* whether a service is enabled, so gating it would be circular.

## Why this class matters

The six gated in #10040 were burning **1,050 calls on a single 71-asset project** — five gRPC `Get` methods at exactly 210 each, every one failing because the API was off, none of the failures cached, so each retried per referrer per asset. That was 40% of the project's entire API traffic.

## What is and is not verified

**Not verified by measurement**, same as #10042. The test project has none of these resources with their APIs disabled, which is the condition that makes the bug cost anything. These are gated on a pattern proven by the six that *were* measured.

**Verified not to regress**: 71 assets, **1,110 calls against 1,111** before this change, and the **6,996 per-check score tuples are byte-identical**. Zero gate rejections, as expected — this project has these APIs enabled, so the gates pass straight through. `gofmt`, `go build`, `go vet` and the full test suite pass.

Properly verifying these needs projects containing Certificate Manager, Datastream, Memorystore or Document AI resources **with those APIs off**. The gate is a no-op wherever the API is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
