### PR TITLE
⚡ gitlab: stop re-running discovery and re-fetching projects per asset

### DIFF
--- a/providers/gitlab/connection/connection.go
+++ b/providers/gitlab/connection/connection.go
@@ -192,6 +192,21 @@ func (c *GitLabConnection) Project() (*gitlab.Project, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Discovery listed this project already, and that listing returns the full
+	// object. Reuse it rather than spending a GetProject per asset. Falls
+	// through when the project was not discovered -- scanned directly, or
+	// addressed by path rather than id -- so nothing depends on the cache.
+	if idStr, ok := pid.(string); ok {
+		if id, cerr := strconv.Atoi(idStr); cerr == nil {
+			if p := cachedDiscoveredProject(c.url, id); p != nil {
+				log.Debug().Int("id", id).Msg("using project from discovery")
+				c.project = p
+				return c.project, nil
+			}
+		}
+	}
+
 	log.Debug().Interface("id", pid).Msgf("finding project")
 
 	c.project, _, err = c.Client().Projects.GetProject(pid, nil)

--- a/providers/gitlab/connection/connection.go
+++ b/providers/gitlab/connection/connection.go
@@ -6,10 +6,12 @@ package connection
 import (
 	"errors"
 	"fmt"
+	nethttp "net/http"
 	"net/url"
 	"os"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -69,7 +71,17 @@ func NewGitLabConnection(id uint32, asset *inventory.Asset, conf *inventory.Conf
 		opts = gitlab.WithBaseURL(url)
 	}
 
-	client, err := gitlab.NewClient(token, opts)
+	// Log every call at debug, the way the azure and gcp providers do. Without
+	// it a slow GitLab scan cannot be attributed to anything: GitLab paginates
+	// heavily and fans out per project, so "which call, how many times" is the
+	// only question worth asking and there was previously no way to ask it.
+	traced := &nethttp.Client{Transport: &apiTraceTransport{}}
+	clientOpts := []gitlab.ClientOptionFunc{gitlab.WithHTTPClient(traced)}
+	if opts != nil {
+		clientOpts = append(clientOpts, opts)
+	}
+
+	client, err := gitlab.NewClient(token, clientOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -275,4 +287,30 @@ func groupSubgroups(conn *GitLabConnection, gid any) ([]*gitlab.Group, error) {
 	}
 
 	return groups, nil
+}
+
+// apiTraceTransport logs every GitLab API request with its method, path, status
+// and duration at debug level. The query string is dropped deliberately: it
+// carries pagination cursors and, on some endpoints, tokens.
+type apiTraceTransport struct{ base nethttp.RoundTripper }
+
+func (t *apiTraceTransport) RoundTrip(r *nethttp.Request) (*nethttp.Response, error) {
+	b := t.base
+	if b == nil {
+		b = nethttp.DefaultTransport
+	}
+	start := time.Now()
+	resp, err := b.RoundTrip(r)
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	log.Debug().
+		Str("method", r.Method).
+		Str("url", r.URL.Host+r.URL.Path).
+		Int("status", status).
+		Dur("duration", time.Since(start)).
+		Err(err).
+		Msg("gitlab api call")
+	return resp, err
 }

--- a/providers/gitlab/connection/project_cache.go
+++ b/providers/gitlab/connection/project_cache.go
@@ -1,0 +1,72 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"strconv"
+	"sync"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// discoveredProjects holds the projects discovery already listed, so the
+// per-asset connections it spawns do not each re-fetch their own.
+//
+// Discovery finds project assets by listing a group's projects, and that
+// listing returns the full project object. Every asset it emits then builds its
+// own GitLabConnection, whose Project() did a GetProject for the record
+// discovery already had: on a 36-project group that was 36 of the scan's 41
+// remaining API calls.
+//
+// The resource cache cannot serve this. It is attached to a child runtime only
+// after Connect() returns (plugin/service.go), so detect() -- which runs inside
+// Connect() -- has nothing to read, and the MQL gitlab.project resources exist
+// only if some policy happened to query gitlab.group.projects. Discovery's list
+// is fetched unconditionally, which is what makes it the reliable source.
+//
+// Keyed by instance URL as well as project id, because one process can scan
+// more than one GitLab and ids are only unique within an instance.
+var discoveredProjects = struct {
+	sync.RWMutex
+	byKey map[string]*gitlab.Project
+}{byKey: map[string]*gitlab.Project{}}
+
+func projectCacheKey(url string, id int) string {
+	return url + "\x00" + strconv.Itoa(id)
+}
+
+// CacheDiscoveredProjects records projects a listing already returned. Called by
+// discovery; a nil entry or a project with no id is skipped rather than stored,
+// so a partial listing cannot poison a later lookup.
+func CacheDiscoveredProjects(url string, projects []*gitlab.Project) {
+	if len(projects) == 0 {
+		return
+	}
+	discoveredProjects.Lock()
+	defer discoveredProjects.Unlock()
+	for _, p := range projects {
+		if p == nil || p.ID == 0 {
+			continue
+		}
+		discoveredProjects.byKey[projectCacheKey(url, int(p.ID))] = p
+	}
+}
+
+// cachedDiscoveredProject returns a project a listing already fetched, or nil.
+func cachedDiscoveredProject(url string, id int) *gitlab.Project {
+	if id == 0 {
+		return nil
+	}
+	discoveredProjects.RLock()
+	defer discoveredProjects.RUnlock()
+	return discoveredProjects.byKey[projectCacheKey(url, id)]
+}
+
+// FlushDiscoveredProjects drops everything cached. Exported for tests, which
+// would otherwise leak state between cases.
+func FlushDiscoveredProjects() {
+	discoveredProjects.Lock()
+	defer discoveredProjects.Unlock()
+	clear(discoveredProjects.byKey)
+}

--- a/providers/gitlab/connection/project_cache_test.go
+++ b/providers/gitlab/connection/project_cache_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestCacheDiscoveredProjects(t *testing.T) {
+	t.Cleanup(FlushDiscoveredProjects)
+	FlushDiscoveredProjects()
+
+	CacheDiscoveredProjects("https://gitlab.com", []*gitlab.Project{
+		{ID: 1, Name: "alpha"},
+		{ID: 2, Name: "beta"},
+	})
+
+	got := cachedDiscoveredProject("https://gitlab.com", 1)
+	assert.NotNil(t, got)
+	assert.Equal(t, "alpha", got.Name)
+
+	assert.Nil(t, cachedDiscoveredProject("https://gitlab.com", 99), "an undiscovered project must fall through to a fetch")
+}
+
+// Ids are only unique within a GitLab instance, so a self-hosted project 1 must
+// not be served for gitlab.com's project 1.
+func TestCacheIsScopedToTheInstance(t *testing.T) {
+	t.Cleanup(FlushDiscoveredProjects)
+	FlushDiscoveredProjects()
+
+	CacheDiscoveredProjects("https://gitlab.com", []*gitlab.Project{{ID: 1, Name: "saas"}})
+	CacheDiscoveredProjects("https://git.acme.internal", []*gitlab.Project{{ID: 1, Name: "self-hosted"}})
+
+	assert.Equal(t, "saas", cachedDiscoveredProject("https://gitlab.com", 1).Name)
+	assert.Equal(t, "self-hosted", cachedDiscoveredProject("https://git.acme.internal", 1).Name)
+	assert.Nil(t, cachedDiscoveredProject("https://other.example", 1))
+}
+
+// A listing that returns a nil entry or an id-less project must not poison the
+// cache: storing those would make a later lookup return a hollow record instead
+// of falling through to a real fetch.
+func TestCacheSkipsUnusableEntries(t *testing.T) {
+	t.Cleanup(FlushDiscoveredProjects)
+	FlushDiscoveredProjects()
+
+	CacheDiscoveredProjects("https://gitlab.com", []*gitlab.Project{nil, {ID: 0, Name: "no id"}, {ID: 7, Name: "good"}})
+
+	assert.Nil(t, cachedDiscoveredProject("https://gitlab.com", 0))
+	assert.NotNil(t, cachedDiscoveredProject("https://gitlab.com", 7))
+}
+
+func TestCacheIgnoresAnEmptyListing(t *testing.T) {
+	t.Cleanup(FlushDiscoveredProjects)
+	FlushDiscoveredProjects()
+
+	CacheDiscoveredProjects("https://gitlab.com", nil)
+	assert.Nil(t, cachedDiscoveredProject("https://gitlab.com", 1))
+}

--- a/providers/gitlab/provider/discovery.go
+++ b/providers/gitlab/provider/discovery.go
@@ -35,7 +35,17 @@ var iacTargets = []string{
 }
 
 func (s *Service) discover(root *inventory.Asset, conn *connection.GitLabConnection) (*inventory.Inventory, error) {
-	if conn.Conf.Discover == nil {
+	// Targets, not just the pointer. inventory.WithoutDiscovery() clones a
+	// config with Discover set to an empty &Discovery{} rather than nil, and
+	// every asset this discovery emits is cloned that way -- so a nil check
+	// alone let discovery run again for each of them. discoverGroups is called
+	// before anything reads Targets, so each re-run cost a GetGroup, a
+	// ListSubGroups and a ListDescendantGroups for a group already resolved.
+	//
+	// Measured on a 36-project group: 149 API calls for 37 assets, of which 110
+	// were those three group URLs fetched once per asset. The azure provider
+	// already guards on Targets this way.
+	if conn.Conf.Discover == nil || len(conn.Conf.Discover.Targets) == 0 {
 		return nil, nil
 	}
 

--- a/providers/gitlab/provider/discovery.go
+++ b/providers/gitlab/provider/discovery.go
@@ -278,6 +278,10 @@ func discoverGroupProjects(conn *connection.GitLabConnection, gid any) ([]*gitla
 		page = resp.NextPage
 	}
 
+	// Hand these to the connection package so the per-asset connections this
+	// discovery is about to spawn do not each re-fetch their own project.
+	connection.CacheDiscoveredProjects(conn.Conf.Options["url"], projects)
+
 	return projects, nil
 }
 


### PR DESCRIPTION
**149 → 5 API calls (−96.6%)** on a 36-project group, with byte-identical results. Two bugs, both in the per-asset connection lifecycle.

A static audit of this provider found **nothing**: zero API-CALL inits, zero INLINE accessors, no asset-identity adoption, and its per-item fetches (`pipeline.loadDetails`, `project.projectDetails`, `user.fetchUser`) are all correctly `sync.Once`-memoized and shared across fields. Both of these only showed up when watching a real scan.

## 1. Discovery re-ran for every asset it produced

`inventory.WithoutDiscovery()` clones a config with `Discover` set to an **empty `&Discovery{}`, not nil**. Every asset discovery emits is cloned that way. But `discover()` guarded on the pointer:

```go
if conn.Conf.Discover == nil {   // never true after WithoutDiscovery()
	return nil, nil
}
...
targets := conn.Conf.Discover.Targets                       // read...
groupAssets, groups, err := s.discoverGroups(root, conn)    // ...but this runs first
```

So the guard never fired and each of the 37 assets repeated a `GetGroup`, a `ListSubGroups` and a `ListDescendantGroups` for a group already resolved, plus a project-discovery pass. The per-asset sequence is unmistakable in a debug log:

```
DBG Started a new runtime (35 total)
DBG finding group id=5409231                        → GET /groups/5409231
DBG calling list subgroups with mondoolabs          → GET /groups/mondoolabs/subgroups
DBG calling list descendant groups with mondoolabs  → GET /groups/mondoolabs/descendant_groups
DBG discover projects
```

Those three URLs were **110 of the original 149 calls**. Guarding on `Targets` — which the **azure provider already does** (`provider/provider.go:312`), making gitlab the outlier — takes them to one each. Empty targets can only come from `WithoutDiscovery()`; `parseDiscover` always sets at least `["auto"]`.

## 2. Every asset then re-fetched its own project

Discovery finds project assets by listing a group's projects, and that listing returns the full project object. Each asset's connection then spent a `GetProject` for the record discovery already had — the remaining 36 calls.

Discovery now hands those projects to the connection package, and `Project()` consults them before fetching. `GetProject` stays as the fallback, so a project scanned directly, or addressed by path rather than id, is unaffected.

Keyed by **instance URL as well as project id**: ids are only unique within a GitLab instance, and one process can scan more than one.

### Why not the MQL resource cache

Worth recording, since it is the obvious first idea. The shared resource cache is attached to a child runtime only **after `Connect()` returns** (`plugin/service.go`), so `detect()` — which runs inside `Connect()` — has nothing to read. And even in resource-land, the `gitlab.project` MQL resources exist only if some policy happened to query `gitlab.group.projects`. Discovery's listing is fetched unconditionally, which is what makes it the reliable source.

## Measured

`cnspec scan gitlab --group mondoolabs --discover projects` — 36 projects, 37 assets:

| | calls |
|---|---|
| before | **149** |
| after the discovery guard | 41 |
| **after both** | **5** |

| URL | before | after |
|---|---|---|
| `/groups/mondoolabs/subgroups` | 37 | 1 |
| `/groups/mondoolabs/descendant_groups` | 37 | 1 |
| `/groups/5409231` | 36 | 0 |
| `/projects/{id}` | 36 | **0** |

The five remaining calls are each made once and all needed: the group, its subgroups, its descendant groups, and two project listings.

**Correctness:** the 1,262 per-check score tuples are **byte-identical**, as are the 49,470 query executions and the 37-asset set.

## Also: API tracing

The connection now logs every call at debug — method, host+path, status, duration — the way azure's `apiTracePolicy` and gcp's `apiTraceTransport` already do. **None of this was measurable without it**, and a slow GitLab scan was previously unattributable. The query string is dropped deliberately: GitLab puts pagination cursors there, and tokens on some endpoints.

## Tests

Unit tests cover the project cache: instance scoping (a self-hosted project 1 must not be served for gitlab.com's project 1), nil and id-less entries being skipped rather than stored, and an empty listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
