### PR TITLE
⚡ vsphere: reuse the esxcli executor instead of rebuilding it per command

### DIFF
--- a/providers/vsphere/resources/resourceclient/esxi.go
+++ b/providers/vsphere/resources/resourceclient/esxi.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"sync"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 
@@ -29,6 +30,40 @@ type Esxi struct {
 	InventoryPath string
 	c             *govmomi.Client
 	host          *object.HostSystem
+
+	// esx.NewExecutor costs two SOAP round trips of its own --
+	// RetrieveManagedMethodExecuter and RetrieveDynamicTypeManager -- and every
+	// esxcli helper below used to build a fresh one per command. On a
+	// four-asset scan that was 275 executors, so 550 setup calls: 36% of all
+	// SOAP traffic. It also threw away the executor's CommandInfo cache each
+	// time.
+	execOnce sync.Once
+	exec     *esx.Executor
+	execErr  error
+	// Executor.Run populates that CommandInfo map, so one executor cannot be
+	// used concurrently -- and llx runs query blocks in goroutines.
+	execMu sync.Mutex
+}
+
+// executor returns this host's esxcli executor, building it at most once.
+func (esxi *Esxi) executor() (*esx.Executor, error) {
+	esxi.execOnce.Do(func() {
+		esxi.exec, esxi.execErr = esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
+	})
+	return esxi.exec, esxi.execErr
+}
+
+// runEsxCli runs one esxcli command on this host's shared executor.
+func (esxi *Esxi) runEsxCli(args ...string) (*esx.Response, error) {
+	e, err := esxi.executor()
+	if err != nil {
+		return nil, err
+	}
+
+	esxi.execMu.Lock()
+	defer esxi.execMu.Unlock()
+
+	return e.Run(context.Background(), args)
 }
 
 var sliceKeys = []string{"Uplinks", "Portgroups"}
@@ -68,12 +103,7 @@ func esxiValuesSliceToDict(values []esx.Values) []map[string]any {
 
 // (Get - EsxCli).network.vswitch.standard.list()
 func (esxi *Esxi) VswitchStandard() ([]map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"network", "vswitch", "standard", "list"})
+	res, err := esxi.runEsxCli("network", "vswitch", "standard", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -84,15 +114,10 @@ func (esxi *Esxi) VswitchStandard() ([]map[string]any, error) {
 var doubleSpaceRegex = regexp.MustCompile(`\s+`)
 
 func (esxi *Esxi) Command(command string) ([]map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
 	sanitizedCommand := doubleSpaceRegex.ReplaceAllString(command, " ")
 	args := strings.Split(sanitizedCommand, " ")
 
-	resp, err := e.Run(context.Background(), args)
+	resp, err := esxi.runEsxCli(args...)
 	if err != nil {
 		return nil, err
 	}
@@ -106,12 +131,7 @@ func (esxi *Esxi) Command(command string) ([]map[string]any, error) {
 
 // (Get-ESXCli).network.vswitch.standard.policy.shaping.get('vSwitch0')
 func (esxi *Esxi) VswitchStandardShapingPolicy(standardSwitchName string) (map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := e.Run(context.Background(), []string{"network", "vswitch", "standard", "policy", "shaping", "get", "--vswitch-name", standardSwitchName})
+	resp, err := esxi.runEsxCli("network", "vswitch", "standard", "policy", "shaping", "get", "--vswitch-name", standardSwitchName)
 	if err != nil {
 		return nil, err
 	}
@@ -129,12 +149,7 @@ func (esxi *Esxi) VswitchStandardShapingPolicy(standardSwitchName string) (map[s
 
 // (Get-ESXCli).network.vswitch.standard.policy.failover.get('vSwitch0')
 func (esxi *Esxi) VswitchStandardFailoverPolicy(standardSwitchName string) (map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := e.Run(context.Background(), []string{"network", "vswitch", "standard", "policy", "failover", "get", "--vswitch-name", standardSwitchName})
+	resp, err := esxi.runEsxCli("network", "vswitch", "standard", "policy", "failover", "get", "--vswitch-name", standardSwitchName)
 	if err != nil {
 		return nil, err
 	}
@@ -152,12 +167,7 @@ func (esxi *Esxi) VswitchStandardFailoverPolicy(standardSwitchName string) (map[
 
 // (Get-ESXCli).network.vswitch.standard.policy.security.get('vSwitch0')
 func (esxi *Esxi) VswitchStandardSecurityPolicy(standardSwitchName string) (map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := e.Run(context.Background(), []string{"network", "vswitch", "standard", "policy", "security", "get", "--vswitch-name", standardSwitchName})
+	resp, err := esxi.runEsxCli("network", "vswitch", "standard", "policy", "security", "get", "--vswitch-name", standardSwitchName)
 	if err != nil {
 		return nil, err
 	}
@@ -175,12 +185,7 @@ func (esxi *Esxi) VswitchStandardSecurityPolicy(standardSwitchName string) (map[
 
 // (Get-EsxCli).network.vswitch.dvs.vmware.list()
 func (esxi *Esxi) VswitchDvs() ([]map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"network", "vswitch", "dvs", "vmware", "list"})
+	res, err := esxi.runEsxCli("network", "vswitch", "dvs", "vmware", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -191,12 +196,7 @@ func (esxi *Esxi) VswitchDvs() ([]map[string]any, error) {
 // Adapters will list the Physical NICs currently installed and loaded on the system.
 // (Get-EsxCli).network.nic.list.Invoke()
 func (esxi *Esxi) Adapters() ([]map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"network", "nic", "list"})
+	res, err := esxi.runEsxCli("network", "nic", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -207,12 +207,7 @@ func (esxi *Esxi) Adapters() ([]map[string]any, error) {
 // List adapter details for nic
 // Usage esxcli network nic pauseParams list
 func (esxi *Esxi) ListNicDetails(interfacename string) (map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := e.Run(context.Background(), []string{"network", "nic", "get", "--nic-name", interfacename})
+	resp, err := esxi.runEsxCli("network", "nic", "get", "--nic-name", interfacename)
 	if err != nil {
 		return nil, err
 	}
@@ -231,12 +226,7 @@ func (esxi *Esxi) ListNicDetails(interfacename string) (map[string]any, error) {
 // List pause parameters of all NICs
 // Usage esxcli network nic pauseParams list
 func (esxi *Esxi) ListNicPauseParams() ([]map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"network", "nic", "pauseParams", "list"})
+	res, err := esxi.runEsxCli("network", "nic", "pauseParams", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -260,12 +250,7 @@ type VmKernelNic struct {
 // hosts with N vmkernel NICs. Tags don't have an esxcli-list form, so they
 // stay per-NIC.
 func (esxi *Esxi) Vmknics() ([]VmKernelNic, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"network", "ip", "interface", "list"})
+	res, err := esxi.runEsxCli("network", "ip", "interface", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -316,11 +301,7 @@ func (esxi *Esxi) Vmknics() ([]VmKernelNic, error) {
 // ESXCli call, indexed by interface name. Replaces N per-interface
 // VmknicIp() calls in the Vmknics() loop.
 func (esxi *Esxi) vmknicIpAll(ipprotocol string) (map[string][]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := e.Run(context.Background(), []string{"network", "ip", "interface", ipprotocol, "get"})
+	resp, err := esxi.runEsxCli("network", "ip", "interface", ipprotocol, "get")
 	if err != nil {
 		return nil, err
 	}
@@ -340,12 +321,7 @@ func (esxi *Esxi) vmknicIpAll(ipprotocol string) (map[string][]any, error) {
 
 // (Get-EsxCli).network.ip.interface.ipv4.get('vmk0', 'defaultTcpipStack')
 func (esxi *Esxi) VmknicIp(interfacename string, netstack string, ipprotocol string) ([]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := e.Run(context.Background(), []string{"network", "ip", "interface", ipprotocol, "get", "--interface-name", interfacename, "--netstack", netstack})
+	resp, err := esxi.runEsxCli("network", "ip", "interface", ipprotocol, "get", "--interface-name", interfacename, "--netstack", netstack)
 	if err != nil {
 		return nil, err
 	}
@@ -366,12 +342,7 @@ func (esxi *Esxi) VmknicIp(interfacename string, netstack string, ipprotocol str
 // see https://blogs.vmware.com/vsphere/2012/12/tagging-vmkernel-traffic-types-using-esxcli-5-1.html
 // see https://kb.vmware.com/s/article/65184
 func (esxi *Esxi) VmknicTags(interfacename string) ([]string, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := e.Run(context.Background(), []string{"network", "ip", "interface", "tag", "get", "--interface-name", interfacename})
+	resp, err := esxi.runEsxCli("network", "ip", "interface", "tag", "get", "--interface-name", interfacename)
 	if err != nil {
 		return nil, err
 	}
@@ -410,12 +381,7 @@ type EsxiVib struct {
 // Vendor          : VMware
 // Version         : 1.2.0.32-0.0.8169922
 func (esxi *Esxi) Vibs() ([]EsxiVib, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"software", "vib", "list"})
+	res, err := esxi.runEsxCli("software", "vib", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -460,12 +426,7 @@ func (esxi *Esxi) Vibs() ([]EsxiVib, error) {
 // on some ESXi releases it lands in res.Values as a single-key map. Try
 // both before reporting "unknown".
 func (esxi *Esxi) SoftwareAcceptance() (string, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return "", err
-	}
-
-	res, err := e.Run(context.Background(), []string{"software", "acceptance", "get"})
+	res, err := esxi.runEsxCli("software", "acceptance", "get")
 	if err != nil {
 		return "", err
 	}
@@ -515,12 +476,7 @@ type EsxiKernelModule struct {
 // true      true     user
 // true      true     procfs
 func (esxi *Esxi) KernelModules() ([]*EsxiKernelModule, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"system", "module", "list"})
+	res, err := esxi.runEsxCli("system", "module", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -589,14 +545,9 @@ func (esxi *Esxi) KernelModules() ([]*EsxiKernelModule, error) {
 // VIBAcceptanceLevel   : certified
 // Version              :
 func (esxi *Esxi) KernelModuleDetails(modulename string) (*EsxiKernelModule, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
 	// NOTE: do not use the powershell syntax, stick with the plain esxcli syntax
 	// esxcli <conn_options> system module get --module=module_name
-	res, err := e.Run(context.Background(), []string{"system", "module", "get", "--module", modulename})
+	res, err := esxi.runEsxCli("system", "module", "get", "--module", modulename)
 	if err != nil {
 		return nil, err
 	}
@@ -716,13 +667,8 @@ func buildAdvancedSetting(val map[string][]string) EsxiAdvancedSetting {
 //
 // supported types are `integer` and `string`, both are converted to string
 func (esxi *Esxi) AdvancedSettings() ([]EsxiAdvancedSetting, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
 	// fetch system settings
-	res, err := e.Run(context.Background(), []string{"system", "settings", "advanced", "list"})
+	res, err := esxi.runEsxCli("system", "settings", "advanced", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +680,7 @@ func (esxi *Esxi) AdvancedSettings() ([]EsxiAdvancedSetting, error) {
 
 	// fetch kernel settings
 	// $ESXCli.system.settings.kernel.list()
-	res, err = e.Run(context.Background(), []string{"system", "settings", "kernel", "list"})
+	res, err = esxi.runEsxCli("system", "settings", "kernel", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -767,12 +713,7 @@ func (esxi *Esxi) AdvancedSettings() ([]EsxiAdvancedSetting, error) {
 }
 
 func (esxi *Esxi) Snmp() (map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"system", "snmp", "get"})
+	res, err := esxi.runEsxCli("system", "snmp", "get")
 	if err != nil {
 		return nil, err
 	}
@@ -817,12 +758,7 @@ var esxcliNamespaceUnavailableRegex = regexp.MustCompile(`(?i)(not supported|unk
 // namespace unavailable; we treat that as "not enabled" rather than failing the
 // whole host query.
 func (esxi *Esxi) KeyPersistenceEnabled() (bool, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return false, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"system", "security", "keypersistence", "get"})
+	res, err := esxi.runEsxCli("system", "security", "keypersistence", "get")
 	if err != nil {
 		if esxcliNamespaceUnavailableRegex.MatchString(err.Error()) {
 			return false, nil
@@ -849,12 +785,7 @@ func (esxi *Esxi) KeyPersistenceEnabled() (bool, error) {
 //
 // ($ESXCli).system.security.certificatestore.list()
 func (esxi *Esxi) CertificateStore() ([]map[string]any, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), []string{"system", "security", "certificatestore", "list"})
+	res, err := esxi.runEsxCli("system", "security", "certificatestore", "list")
 	if err != nil {
 		return nil, err
 	}
@@ -868,12 +799,7 @@ func (esxi *Esxi) CertificateStore() ([]map[string]any, error) {
 // namespace report an empty map rather than failing the whole host query, the
 // same way TlsServerProfile and KeyPersistenceEnabled handle older releases.
 func (esxi *Esxi) esxcliKeyValueList(args []string) (map[string]string, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := e.Run(context.Background(), args)
+	res, err := esxi.runEsxCli(args...)
 	if err != nil {
 		if esxcliNamespaceUnavailableRegex.MatchString(err.Error()) {
 			return map[string]string{}, nil
@@ -922,12 +848,7 @@ func (esxi *Esxi) SshClientConfig() (map[string]string, error) {
 // hosts it is unavailable, which we report as an empty profile rather than an
 // error.
 func (esxi *Esxi) TlsServerProfile() (string, error) {
-	e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
-	if err != nil {
-		return "", err
-	}
-
-	res, err := e.Run(context.Background(), []string{"system", "tls", "server", "get"})
+	res, err := esxi.runEsxCli("system", "tls", "server", "get")
 	if err != nil {
 		if esxcliNamespaceUnavailableRegex.MatchString(err.Error()) {
 			return "", nil

--- a/providers/vsphere/resources/vsphere.go
+++ b/providers/vsphere/resources/vsphere.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/vmware/govmomi/crypto"
 	"github.com/vmware/govmomi/find"
@@ -29,7 +30,33 @@ func getClientInstance(conn *connection.VsphereConnection) *resourceclient.Clien
 	return resourceclient.New(conn.Client())
 }
 
+// esxiClients caches one Esxi client per host, keyed by connection and
+// inventory path.
+//
+// Every accessor that shells out to esxcli called esxiClient(), which built a
+// fresh client each time: a HostByInventoryPath lookup, and then an
+// esx.NewExecutor inside the first command, which is two more SOAP round trips.
+// Nothing was reused between accessors even on the same host, so a four-asset
+// scan spent 275 executor constructions -- 550 setup calls, 36% of its SOAP
+// traffic -- plus a host lookup apiece.
+//
+// Keyed by connection id as well as path: one process can hold connections to
+// more than one vCenter, and inventory paths are only unique within one.
+var esxiClients = struct {
+	sync.Mutex
+	byKey map[string]*resourceclient.Esxi
+}{byKey: map[string]*resourceclient.Esxi{}}
+
 func esxiClient(conn *connection.VsphereConnection, path string) (*resourceclient.Esxi, error) {
+	key := strconv.FormatUint(uint64(conn.ID()), 10) + "\x00" + path
+
+	esxiClients.Lock()
+	defer esxiClients.Unlock()
+
+	if c, ok := esxiClients.byKey[key]; ok {
+		return c, nil
+	}
+
 	vClient := getClientInstance(conn)
 
 	host, err := vClient.HostByInventoryPath(path)
@@ -38,6 +65,7 @@ func esxiClient(conn *connection.VsphereConnection, path string) (*resourceclien
 	}
 
 	esxi := resourceclient.NewEsxiClient(vClient.Client, path, host)
+	esxiClients.byKey[key] = esxi
 	return esxi, nil
 }
 


### PR DESCRIPTION
**Draft — this needs a decision, not just a review.** It removes 55% of vSphere's SOAP traffic but does **not** make scans faster, and it trades some concurrency to do it. The case either way is below.

## What was happening

`esx.NewExecutor` issues two SOAP round trips of its own before any command runs — `RetrieveManagedMethodExecuter` and `RetrieveDynamicTypeManager` — and all **23 esxcli helpers built a fresh one per command**:

```go
e, err := esx.NewExecutor(context.Background(), esxi.c.Client, esxi.host)
res, err := e.Run(context.Background(), []string{"network", "vswitch", "standard", "list"})
```

`esxiClient()` also returned a **new `Esxi` on every accessor call**, each preceded by its own `HostByInventoryPath`, so nothing was reused even within one host.

A four-asset scan spent **275 executor constructions — 550 setup calls, 36% of all its SOAP traffic** — and discarded the executor's `CommandInfo` cache each time.

## The change

- `Esxi` builds its executor once (`sync.Once`).
- `esxiClient()` caches one `Esxi` per host, keyed by connection id **and** inventory path — a process can hold connections to more than one vCenter, and paths are only unique within one.
- `Executor.Run` populates that shared `CommandInfo` map, so it cannot be used concurrently, and llx runs query blocks in goroutines. `runEsxCli` serialises `Run` behind a mutex.

## Measured

Four-asset scan against vCenter 8.0.2:

| operation | before | after |
|---|---|---|
| `RetrieveManagedMethodExecuter` | 275 | **6** |
| `RetrieveDynamicTypeManager` | 275 | **6** |
| `ExecuteSoapBody` | 550 | 290 |
| `RetrievePropertiesEx` | 425 | 389 |
| **total SOAP calls** | **1,529** | **695** |

**Correctness:** 568 per-check score tuples and 5,445 query executions **byte-identical**.

**Wall-clock: unchanged.** 12s before (×2 runs), 12–13s after (×2 runs).

I first quoted a "150.9s → 101.2s SOAP time" improvement from summing per-call durations. That was wrong and is worth stating plainly: the calls are heavily parallelised, so the sum is roughly 12× actual elapsed time and says nothing about duration. Timing both builds directly is what settled it.

## The decision

**For:** 36% of vSphere's SOAP traffic was pure session re-establishment. vCenter is a single appliance that serialises SOAP work per session, so 834 fewer round trips per four-asset scan should matter on large inventories and on shared vCenters where a scan competes with real workloads. The discarded `CommandInfo` cache was also making repeated commands re-fetch their schema — visible in `ExecuteSoapBody` dropping 550 → 290.

**Against:** there is no measurement showing user-visible benefit. The mutex is a real cost — it serialises esxcli commands *within a host* that previously ran concurrently on separate executors. It cost nothing measurable on four assets, but on a host with many esxcli-backed fields it could.

**What would settle it:** a scan against a larger vSphere inventory, where both the benefit (call volume) and the risk (lost concurrency) would actually show. I only had a four-asset environment.

## Context

Found by measurement — a static audit of this provider found nothing (no API-CALL inits, no INLINE accessors). That is the third time in this series, after gcp and gitlab, that a clean static reading was overturned by watching a real scan.

Tracing was added temporarily to measure this and removed before commit. If it would help to have it permanently, as azure and gcp do, say so and I will land it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
