### PR TITLE
🎉 gcp-13.37.1, aws-13.53.4, ms365-13.12.1, gitlab-13.6.2

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.53.3",
+	Version:         "13.53.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.37.0",
+	Version: "13.37.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.6.1",
+	Version: "13.6.2",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.12.0",
+	Version:         "13.12.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.37.1)
- ⚡ gcp: gate the last four inits behind the service-enablement check (#10045)
- ⚡ gcp: gate six more inits behind the service-enablement check (#10042)
- ⚡ gcp: stop spending calls that cannot succeed and refetching the project (#10040)

### aws (13.53.4)
- ⚡ aws: resolve IAM users and groups from the account list (#10044)

### ms365 (13.12.1)
- ⚡ ms365: resolve an application service principal from the tenant list (#10046)

### gitlab (13.6.2)
- ⚡ gitlab: stop re-running discovery and re-fetching projects per asset (#10047)