### PR TITLE
⚡ okta: fetch the organization record once per connection

### DIFF
--- a/providers/okta/connection/connection.go
+++ b/providers/okta/connection/connection.go
@@ -6,13 +6,14 @@ package connection
 import (
 	"context"
 	"errors"
+	"github.com/rs/zerolog/log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/okta/okta-sdk-golang/v6/okta"
 	goCache "github.com/patrickmn/go-cache"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
@@ -51,6 +52,20 @@ type OktaConnection struct {
 	// the generated SDK, so the raw endpoints in resources/sdk authenticate the
 	// same way the SDK-served ones do.
 	authorize func(req *http.Request) error
+	// orgSettings is the org record, fetched at most once.
+	//
+	// There is exactly one organization per connection, but initOktaOrganization
+	// fetched it unconditionally and NewResource runs an init before it consults
+	// the resource cache -- so every query referencing okta.organization spent
+	// its own GET /api/v1/org. A scan of a near-empty org made 7 API calls, 5 of
+	// them this one. The count follows how many checks mention the organization,
+	// so it grows with policy breadth rather than with org size.
+	//
+	// The resource cache cannot serve this: the org's id comes back in the
+	// response, so there is no key to look it up by beforehand.
+	orgOnce     sync.Once
+	orgSettings *okta.OrgSetting
+	orgErr      error
 	// apiExtension is the client for the endpoints the generated SDK does not
 	// serve correctly. It is immutable once built, so it is shared rather than
 	// rebuilt by each caller.
@@ -244,7 +259,9 @@ func (c *OktaConnection) ApiExtension() *sdk.ApiExtension {
 }
 
 func (c *OktaConnection) Identifier() (string, error) {
-	settings, _, err := c.client.OrgSettingGeneralAPI.GetOrgSettings(context.Background()).Execute()
+	// Through the memoized accessor: this and initOktaOrganization are the only
+	// two readers of the org record, and both used to fetch their own.
+	settings, err := c.OrgSettings(context.Background())
 	if err != nil {
 		return "", errors.Join(errors.New("failed to get Okta org ID"), err)
 	}
@@ -253,4 +270,15 @@ func (c *OktaConnection) Identifier() (string, error) {
 	}
 
 	return *settings.Id, nil
+}
+
+// OrgSettings returns the organization record, fetching it at most once per
+// connection. See the orgSettings field for why this is memoized here rather
+// than through the resource cache.
+func (c *OktaConnection) OrgSettings(ctx context.Context) (*okta.OrgSetting, error) {
+	c.orgOnce.Do(func() {
+		settings, _, err := c.Client().OrgSettingGeneralAPI.GetOrgSettings(ctx).Execute()
+		c.orgSettings, c.orgErr = settings, err
+	})
+	return c.orgSettings, c.orgErr
 }

--- a/providers/okta/resources/organization.go
+++ b/providers/okta/resources/organization.go
@@ -28,8 +28,7 @@ func initOktaOrganization(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	conn := runtime.Connection.(*connection.OktaConnection)
 
 	ctx := context.Background()
-	client := conn.Client()
-	settings, _, err := client.OrgSettingGeneralAPI.GetOrgSettings(ctx).Execute()
+	settings, err := conn.OrgSettings(ctx)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Problem

`initOktaOrganization` fetched `GET /api/v1/org` unconditionally:

```go
settings, _, err := client.OrgSettingGeneralAPI.GetOrgSettings(ctx).Execute()
```

`NewResource` runs an init **before** it consults the resource cache, so every query referencing `okta.organization` spent its own fetch. `Identifier()` on the connection fetched it a second way.

A scan of a near-empty org made **7 API calls, 5 of them this one** — the fetches spread across the scan, one per query that mentioned the organization.

## Why not the resource cache

The org's id arrives **in the response**, so there is no key to look it up by beforehand — unlike the gcp project refetch (#10040), where the project id was already known from the connection config.

There is exactly one organization per connection, so the connection memoizes it and both readers go through that.

## Measured

`cnspec scan okta --organization <org>`:

| | before | after |
|---|---|---|
| `GET /api/v1/org` | **5** | **1** |
| total API calls | **7** | **3** |

**Correctness:** the 34 per-check score tuples and 1,337 query executions are **identical**.

The saving follows **how many checks mention the organization**, not org size — so it grows with policy breadth rather than staying fixed at four calls.

## What I deliberately did not change

The eight per-user accessors — `roles`, `groups`, `factors`, `blocks`, `appLinks`, `grants`, `clients`, `identityProviders` — are genuinely N+1. Measured directly: 8 users produced 8 `/users/{id}/roles` and 8 `/users/{id}/groups` calls.

**Okta has no bulk endpoint for any of them.** That is the API's design, not a provider defect, and on a large org it is the cost that would actually dominate. Nothing here can fix it; the accessors are already lazy, so nothing is fetched unless a policy asks.

## Caveat on the test org

The org available for testing has **8 users, 2 groups and 0 applications**. The six per-application accessors never executed, and the per-user fan-out was too small to stress. So "okta is otherwise clean" is a weaker claim than it was for gitlab, where 36 projects exercised the fan-out properly. A richer org would be needed to say more.

## Context

Found by measurement. The static audit was clean — 0 API-CALL inits, 0 INLINE accessors, no asset-identity adoption — which is the same profile gitlab and vsphere gave before scans found their largest defects. Tracing was added temporarily to measure this and removed before commit; okta has no permanent API tracing, and adding it (as gitlab now has) would be worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
