### PR TITLE
✨ os: report a git-origin purl on AI agent skill resources

### DIFF
--- a/providers/os/resources/ai_agents.go
+++ b/providers/os/resources/ai_agents.go
@@ -29,6 +29,9 @@ func (r *mqlRoo) skills() ([]interface{}, error) {
 
 func (r *mqlRooSkill) id() (string, error)     { return "roo.skill/" + r.Source.Data, nil }
 func (r *mqlRooSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlRooSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Cline ---
 
@@ -52,6 +55,9 @@ func (r *mqlCline) skills() ([]interface{}, error) {
 
 func (r *mqlClineSkill) id() (string, error)     { return "cline.skill/" + r.Source.Data, nil }
 func (r *mqlClineSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlClineSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Kiro CLI ---
 
@@ -72,6 +78,9 @@ func (r *mqlKiro) skills() ([]interface{}, error) {
 
 func (r *mqlKiroSkill) id() (string, error)     { return "kiro.skill/" + r.Source.Data, nil }
 func (r *mqlKiroSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlKiroSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Continue ---
 
@@ -92,6 +101,9 @@ func (r *mqlContinuedev) skills() ([]interface{}, error) {
 
 func (r *mqlContinuedevSkill) id() (string, error)     { return "continuedev.skill/" + r.Source.Data, nil }
 func (r *mqlContinuedevSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlContinuedevSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Trae ---
 
@@ -112,6 +124,9 @@ func (r *mqlTrae) skills() ([]interface{}, error) {
 
 func (r *mqlTraeSkill) id() (string, error)     { return "trae.skill/" + r.Source.Data, nil }
 func (r *mqlTraeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlTraeSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- OpenCode ---
 
@@ -132,6 +147,9 @@ func (r *mqlOpencode) skills() ([]interface{}, error) {
 
 func (r *mqlOpencodeSkill) id() (string, error)     { return "opencode.skill/" + r.Source.Data, nil }
 func (r *mqlOpencodeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlOpencodeSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Pi ---
 
@@ -152,6 +170,9 @@ func (r *mqlPi) skills() ([]interface{}, error) {
 
 func (r *mqlPiSkill) id() (string, error)     { return "pi.skill/" + r.Source.Data, nil }
 func (r *mqlPiSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlPiSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Mistral Vibe ---
 
@@ -172,6 +193,9 @@ func (r *mqlMistralVibe) skills() ([]interface{}, error) {
 
 func (r *mqlMistralVibeSkill) id() (string, error)     { return "mistral.vibe.skill/" + r.Source.Data, nil }
 func (r *mqlMistralVibeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlMistralVibeSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Antigravity (Google) ---
 
@@ -192,6 +216,9 @@ func (r *mqlAntigravity) skills() ([]interface{}, error) {
 
 func (r *mqlAntigravitySkill) id() (string, error)     { return "antigravity.skill/" + r.Source.Data, nil }
 func (r *mqlAntigravitySkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlAntigravitySkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- IBM Bob ---
 
@@ -212,6 +239,9 @@ func (r *mqlIbmBob) skills() ([]interface{}, error) {
 
 func (r *mqlIbmBobSkill) id() (string, error)     { return "ibm.bob.skill/" + r.Source.Data, nil }
 func (r *mqlIbmBobSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlIbmBobSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- OpenClaw ---
 
@@ -232,6 +262,9 @@ func (r *mqlOpenclaw) skills() ([]interface{}, error) {
 
 func (r *mqlOpenclawSkill) id() (string, error)     { return "openclaw.skill/" + r.Source.Data, nil }
 func (r *mqlOpenclawSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlOpenclawSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Snowflake Cortex Code ---
 
@@ -254,6 +287,9 @@ func (r *mqlSnowflakeCortexSkill) id() (string, error) {
 	return "snowflake.cortex.skill/" + r.Source.Data, nil
 }
 func (r *mqlSnowflakeCortexSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlSnowflakeCortexSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Junie (JetBrains) ---
 
@@ -274,6 +310,9 @@ func (r *mqlJunie) skills() ([]interface{}, error) {
 
 func (r *mqlJunieSkill) id() (string, error)     { return "junie.skill/" + r.Source.Data, nil }
 func (r *mqlJunieSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlJunieSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Augment ---
 
@@ -294,6 +333,9 @@ func (r *mqlAugment) skills() ([]interface{}, error) {
 
 func (r *mqlAugmentSkill) id() (string, error)     { return "augment.skill/" + r.Source.Data, nil }
 func (r *mqlAugmentSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlAugmentSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Warp ---
 
@@ -316,6 +358,9 @@ func (r *mqlWarp) skills() ([]interface{}, error) {
 
 func (r *mqlWarpSkill) id() (string, error)     { return "warp.skill/" + r.Source.Data, nil }
 func (r *mqlWarpSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlWarpSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Kilo Code ---
 
@@ -336,6 +381,9 @@ func (r *mqlKilocode) skills() ([]interface{}, error) {
 
 func (r *mqlKilocodeSkill) id() (string, error)     { return "kilocode.skill/" + r.Source.Data, nil }
 func (r *mqlKilocodeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlKilocodeSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- OpenHands ---
 
@@ -356,6 +404,9 @@ func (r *mqlOpenhands) skills() ([]interface{}, error) {
 
 func (r *mqlOpenhandsSkill) id() (string, error)     { return "openhands.skill/" + r.Source.Data, nil }
 func (r *mqlOpenhandsSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlOpenhandsSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
 
 // --- Qwen Code ---
 
@@ -376,3 +427,6 @@ func (r *mqlQwenCode) skills() ([]interface{}, error) {
 
 func (r *mqlQwenCodeSkill) id() (string, error)     { return "qwen.code.skill/" + r.Source.Data, nil }
 func (r *mqlQwenCodeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
+func (r *mqlQwenCodeSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}

--- a/providers/os/resources/ai_coding_tools.go
+++ b/providers/os/resources/ai_coding_tools.go
@@ -426,21 +426,28 @@ func findGitPath(afs *afero.Afero, startPath string) (root string, gitPath strin
 // (`.git` is a file with a `gitdir:` line), HEAD lives in the per-worktree git
 // dir and config lives in the shared common git dir.
 func resolveGitConfigAndHead(afs *afero.Afero, root, gitPath string) (configPath, headPath string) {
+	commonDir, worktreeDir := resolveGitDirs(afs, root, gitPath)
+	return filepath.Join(commonDir, "config"), filepath.Join(worktreeDir, "HEAD")
+}
+
+// resolveGitDirs returns the shared common git dir (holding config, refs and
+// packed-refs) and the per-worktree git dir (holding HEAD) for a .git entry.
+// For a plain `.git` directory both are that directory. For a linked worktree
+// (`.git` is a file with a `gitdir:` line) the per-worktree git dir holds HEAD
+// while the shared data lives in the common git dir.
+func resolveGitDirs(afs *afero.Afero, root, gitPath string) (commonDir, worktreeDir string) {
 	info, err := afs.Stat(gitPath)
 	if err == nil && info.IsDir() {
-		return filepath.Join(gitPath, "config"), filepath.Join(gitPath, "HEAD")
+		return gitPath, gitPath
 	}
 
 	worktreeGitDir, ok := parseGitdirFile(afs, gitPath, root)
 	if !ok {
 		// Unreadable or malformed pointer: best-effort, treat as if inline.
-		return filepath.Join(gitPath, "config"), filepath.Join(gitPath, "HEAD")
+		return gitPath, gitPath
 	}
 
-	headPath = filepath.Join(worktreeGitDir, "HEAD")
-	commonDir := resolveGitCommonDir(afs, worktreeGitDir)
-	configPath = filepath.Join(commonDir, "config")
-	return configPath, headPath
+	return resolveGitCommonDir(afs, worktreeGitDir), worktreeGitDir
 }
 
 // parseGitdirFile reads a `.git` pointer file and returns the absolute git dir
@@ -595,6 +602,117 @@ func parseGitHeadBranch(afs *afero.Afero, headPath string) string {
 		return ""
 	}
 	return strings.TrimPrefix(line, refPrefix)
+}
+
+// skillPURL derives a package URL (purl) for a skill from the path of its
+// SKILL.md definition. When the skill directory sits inside a git checkout
+// whose origin remote points at github.com, the purl pins the checkout's
+// current HEAD commit:
+//
+//	pkg:github/<org>/<repo>@<first 12 chars of HEAD sha>?skill=<skill dir name>
+//
+// It returns "" when the skill is not inside a git checkout, the checkout has
+// no github.com origin remote, or the HEAD commit cannot be resolved. A
+// coordinate is never guessed: an empty purl means provenance is unknown.
+func skillPURL(afs *afero.Afero, sourcePath string) string {
+	if sourcePath == "" {
+		return ""
+	}
+	skillDir := filepath.Dir(sourcePath)
+	root, gitPath, ok := findGitPath(afs, skillDir)
+	if !ok {
+		return ""
+	}
+
+	commonDir, worktreeDir := resolveGitDirs(afs, root, gitPath)
+	origin := parseGitRemotes(afs, filepath.Join(commonDir, "config"))["origin"]
+	host, slug := parseGitRemoteURL(origin)
+	if host != "github.com" {
+		return ""
+	}
+	org, repo, ok := strings.Cut(slug, "/")
+	if !ok || org == "" || repo == "" || strings.Contains(repo, "/") {
+		return ""
+	}
+
+	sha := resolveGitHeadSha(afs, commonDir, worktreeDir)
+	if sha == "" {
+		return ""
+	}
+	return "pkg:github/" + org + "/" + repo + "@" + sha[:12] + "?skill=" + filepath.Base(skillDir)
+}
+
+// resolveGitHeadSha resolves the commit sha HEAD points at using only file
+// reads: a detached HEAD carries the sha directly, otherwise the named ref is
+// looked up as a loose ref file and then in packed-refs. It returns "" when
+// the sha cannot be resolved.
+func resolveGitHeadSha(afs *afero.Afero, commonDir, worktreeDir string) string {
+	data, err := afs.ReadFile(filepath.Join(worktreeDir, "HEAD"))
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(line, "ref:") {
+		// detached HEAD: the commit sha is stored directly
+		if isGitCommitSha(line) {
+			return line
+		}
+		return ""
+	}
+	ref := strings.TrimSpace(strings.TrimPrefix(line, "ref:"))
+	if ref == "" {
+		return ""
+	}
+
+	// Loose ref file: the per-worktree git dir first (worktree-local refs),
+	// then the shared common dir.
+	dirs := []string{worktreeDir}
+	if commonDir != worktreeDir {
+		dirs = append(dirs, commonDir)
+	}
+	for _, dir := range dirs {
+		if data, err := afs.ReadFile(filepath.Join(dir, ref)); err == nil {
+			if sha := strings.TrimSpace(string(data)); isGitCommitSha(sha) {
+				return sha
+			}
+		}
+	}
+	return packedRefSha(afs, filepath.Join(commonDir, "packed-refs"), ref)
+}
+
+// packedRefSha looks up ref in a git packed-refs file (`<sha> <ref>` lines;
+// `#` comment and `^` peel lines are skipped). It returns "" when the ref is
+// absent or the file is unreadable.
+func packedRefSha(afs *afero.Afero, packedRefsPath, ref string) string {
+	data, err := afs.ReadFile(packedRefsPath)
+	if err != nil {
+		return ""
+	}
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
+			continue
+		}
+		sha, name, ok := strings.Cut(line, " ")
+		if ok && strings.TrimSpace(name) == ref && isGitCommitSha(sha) {
+			return sha
+		}
+	}
+	return ""
+}
+
+// isGitCommitSha reports whether s is a full hex commit id (40 characters for
+// SHA-1 repositories, 64 for SHA-256 repositories).
+func isGitCommitSha(s string) bool {
+	if len(s) != 40 && len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 // vscodeUserDataDir returns the platform-specific User data directory of a

--- a/providers/os/resources/ai_coding_tools_test.go
+++ b/providers/os/resources/ai_coding_tools_test.go
@@ -106,6 +106,133 @@ func TestCollectSkillFilesDedupsSourcePaths(t *testing.T) {
 	require.Len(t, skills, 1)
 }
 
+// writeGitCheckout writes a minimal .git directory with an origin remote and
+// a HEAD ref pointing at sha via a loose ref file.
+func writeGitCheckout(t *testing.T, fs afero.Fs, root, originURL, sha string) {
+	t.Helper()
+	gitDir := root + "/.git"
+	require.NoError(t, fs.MkdirAll(gitDir+"/refs/heads", 0o755))
+	config := "[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = " + originURL + "\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+	require.NoError(t, afero.WriteFile(fs, gitDir+"/config", []byte(config), 0o644))
+	require.NoError(t, afero.WriteFile(fs, gitDir+"/HEAD", []byte("ref: refs/heads/main\n"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, gitDir+"/refs/heads/main", []byte(sha+"\n"), 0o644))
+}
+
+func TestSkillPURL(t *testing.T) {
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+
+	t.Run("github origin with loose ref", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "git@github.com:acme/skills.git", sha)
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "pkg:github/acme/skills@0123456789ab?skill=deploy",
+			skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("https origin URL", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "https://github.com/acme/skills.git", sha)
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "pkg:github/acme/skills@0123456789ab?skill=deploy",
+			skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("packed refs", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "git@github.com:acme/skills.git", sha)
+		require.NoError(t, mem.Remove("/repo/.git/refs/heads/main"))
+		packed := "# pack-refs with: peeled fully-peeled sorted\n" +
+			sha + " refs/heads/main\n" +
+			"^deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"
+		require.NoError(t, afero.WriteFile(mem, "/repo/.git/packed-refs", []byte(packed), 0o644))
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "pkg:github/acme/skills@0123456789ab?skill=deploy",
+			skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("detached HEAD resolves", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "git@github.com:acme/skills.git", sha)
+		require.NoError(t, afero.WriteFile(mem, "/repo/.git/HEAD", []byte(sha+"\n"), 0o644))
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "pkg:github/acme/skills@0123456789ab?skill=deploy",
+			skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("linked worktree", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		// main checkout holds the shared config and refs
+		writeGitCheckout(t, mem, "/repo", "git@github.com:acme/skills.git", sha)
+		// linked worktree: .git file pointing at the per-worktree git dir
+		wtGitDir := "/repo/.git/worktrees/wt"
+		require.NoError(t, mem.MkdirAll(wtGitDir, 0o755))
+		require.NoError(t, afero.WriteFile(mem, "/wt/.git", []byte("gitdir: "+wtGitDir+"\n"), 0o644))
+		require.NoError(t, afero.WriteFile(mem, wtGitDir+"/commondir", []byte("../..\n"), 0o644))
+		require.NoError(t, afero.WriteFile(mem, wtGitDir+"/HEAD", []byte("ref: refs/heads/main\n"), 0o644))
+		writeSkill(t, mem, "/wt/skills", "deploy")
+
+		assert.Equal(t, "pkg:github/acme/skills@0123456789ab?skill=deploy",
+			skillPURL(afs, "/wt/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("no git checkout", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeSkill(t, mem, "/plain/skills", "deploy")
+
+		assert.Equal(t, "", skillPURL(afs, "/plain/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("non-github origin", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "git@gitlab.com:acme/skills.git", sha)
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "", skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("no origin remote", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "git@github.com:acme/skills.git", sha)
+		config := "[remote \"upstream\"]\n\turl = git@github.com:other/skills.git\n"
+		require.NoError(t, afero.WriteFile(mem, "/repo/.git/config", []byte(config), 0o644))
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "", skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("unresolvable HEAD ref", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "git@github.com:acme/skills.git", sha)
+		require.NoError(t, mem.Remove("/repo/.git/refs/heads/main"))
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "", skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+
+	t.Run("malformed sha in ref file", func(t *testing.T) {
+		mem := afero.NewMemMapFs()
+		afs := &afero.Afero{Fs: mem}
+		writeGitCheckout(t, mem, "/repo", "git@github.com:acme/skills.git", sha)
+		require.NoError(t, afero.WriteFile(mem, "/repo/.git/refs/heads/main", []byte("not-a-sha\n"), 0o644))
+		writeSkill(t, mem, "/repo/skills", "deploy")
+
+		assert.Equal(t, "", skillPURL(afs, "/repo/skills/deploy/SKILL.md"))
+	})
+}
+
 func TestFileURIToPath(t *testing.T) {
 	cases := []struct {
 		uri  string

--- a/providers/os/resources/claude_code.go
+++ b/providers/os/resources/claude_code.go
@@ -552,6 +552,10 @@ func (r *mqlClaudeCodeSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlClaudeCodeSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
+
 func (r *mqlClaudeCodeProject) id() (string, error) {
 	return "claude.code.project/" + r.Path.Data, nil
 }

--- a/providers/os/resources/cursor.go
+++ b/providers/os/resources/cursor.go
@@ -141,6 +141,10 @@ func (r *mqlCursorSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlCursorSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
+
 // Helper types
 
 type cursorMCPConfig struct {

--- a/providers/os/resources/gemini.go
+++ b/providers/os/resources/gemini.go
@@ -127,6 +127,10 @@ func (r *mqlGeminiSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlGeminiSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
+
 // Helper types
 
 type geminiSettings struct {

--- a/providers/os/resources/github_copilot.go
+++ b/providers/os/resources/github_copilot.go
@@ -127,6 +127,10 @@ func (r *mqlGithubCopilotSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlGithubCopilotSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
+
 // Helper types
 
 type copilotApp struct {

--- a/providers/os/resources/goose.go
+++ b/providers/os/resources/goose.go
@@ -117,6 +117,10 @@ func (r *mqlGooseSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlGooseSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
+
 // Helper types
 
 type gooseConfig struct {

--- a/providers/os/resources/openai_codex.go
+++ b/providers/os/resources/openai_codex.go
@@ -437,6 +437,10 @@ func (r *mqlOpenaiCodexSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlOpenaiCodexSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
+
 func (r *mqlOpenaiCodexMcpServer) running() (*llx.AssetValue, error) {
 	return mcpServerAsset(r), nil
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13706,6 +13706,8 @@ private claude.code.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Claude Code project
@@ -13938,6 +13940,8 @@ private openai.codex.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // OpenAI Codex MCP server
@@ -14164,6 +14168,8 @@ private cursor.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // GitHub Copilot CLI instance
@@ -14267,6 +14273,8 @@ private github.copilot.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Goose AI agent (Block) instance
@@ -14356,6 +14364,8 @@ private goose.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Gemini CLI (Google) instance
@@ -14454,6 +14464,8 @@ private gemini.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Windsurf editor (Codeium) instance
@@ -14595,6 +14607,8 @@ private windsurf.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Zed editor instance
@@ -14739,6 +14753,8 @@ private roo.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Cline AI agent instance
@@ -14797,6 +14813,8 @@ private cline.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Kiro CLI (AWS) instance
@@ -14854,6 +14872,8 @@ private kiro.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Continue (open-source AI coding assistant) instance
@@ -14935,6 +14955,8 @@ private continuedev.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Trae AI assistant (ByteDance) instance
@@ -15016,6 +15038,8 @@ private trae.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // OpenCode AI coding assistant instance
@@ -15098,6 +15122,8 @@ private opencode.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Pi AI agent instance
@@ -15179,6 +15205,8 @@ private pi.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Mistral Vibe (Mistral AI) instance
@@ -15261,6 +15289,8 @@ private mistral.vibe.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Antigravity (Google) instance
@@ -15344,6 +15374,8 @@ private antigravity.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // IBM Bob instance
@@ -15425,6 +15457,8 @@ private ibm.bob.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // OpenClaw AI agent instance
@@ -15506,6 +15540,8 @@ private openclaw.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Snowflake Cortex Code instance
@@ -15589,6 +15625,8 @@ private snowflake.cortex.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Junie (JetBrains AI agent) instance
@@ -15670,6 +15708,8 @@ private junie.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Augment Code instance
@@ -15751,6 +15791,8 @@ private augment.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Warp AI terminal instance
@@ -15833,6 +15875,8 @@ private warp.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Kilo Code AI agent instance
@@ -15914,6 +15958,8 @@ private kilocode.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // OpenHands AI agent instance (formerly OpenDevin)
@@ -15996,6 +16042,8 @@ private openhands.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // Qwen Code (Alibaba) instance
@@ -16077,6 +16125,8 @@ private qwen.code.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
+  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  purl() string
 }
 
 // SR-IOV network devices

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13706,7 +13706,7 @@ private claude.code.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -13940,7 +13940,7 @@ private openai.codex.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14168,7 +14168,7 @@ private cursor.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14273,7 +14273,7 @@ private github.copilot.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14364,7 +14364,7 @@ private goose.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14464,7 +14464,7 @@ private gemini.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14607,7 +14607,7 @@ private windsurf.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14753,7 +14753,7 @@ private roo.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14813,7 +14813,7 @@ private cline.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14872,7 +14872,7 @@ private kiro.skill @defaults("name") @maturity("preview") {
   content string
   // SHA-256 hash of the skill content, for integrity checks
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -14955,7 +14955,7 @@ private continuedev.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15038,7 +15038,7 @@ private trae.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15122,7 +15122,7 @@ private opencode.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15205,7 +15205,7 @@ private pi.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15289,7 +15289,7 @@ private mistral.vibe.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15374,7 +15374,7 @@ private antigravity.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15457,7 +15457,7 @@ private ibm.bob.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15540,7 +15540,7 @@ private openclaw.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15625,7 +15625,7 @@ private snowflake.cortex.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15708,7 +15708,7 @@ private junie.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15791,7 +15791,7 @@ private augment.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15875,7 +15875,7 @@ private warp.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -15958,7 +15958,7 @@ private kilocode.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -16042,7 +16042,7 @@ private openhands.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 
@@ -16125,7 +16125,7 @@ private qwen.code.skill @defaults("name") @maturity("preview") {
   // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
   // known-good skill definition against a baseline.
   sha256() string
-  // Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
+  // Package URL identifying the skill's git origin
   purl() string
 }
 

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -14076,6 +14076,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"claude.code.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeCodeSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"claude.code.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlClaudeCodeSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"claude.code.project.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeCodeProject).GetPath()).ToDataRes(types.String)
 	},
@@ -14235,6 +14238,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openai.codex.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiCodexSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"openai.codex.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenaiCodexSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"openai.codex.mcpServer.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiCodexMcpServer).GetName()).ToDataRes(types.String)
 	},
@@ -14379,6 +14385,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cursor.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCursorSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"cursor.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCursorSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"github.copilot.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubCopilot).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -14445,6 +14454,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.copilot.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubCopilotSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"github.copilot.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubCopilotSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"goose.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoose).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -14507,6 +14519,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"goose.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGooseSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"goose.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGooseSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"gemini.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGemini).GetConfigPath()).ToDataRes(types.String)
@@ -14573,6 +14588,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gemini.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGeminiSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"gemini.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGeminiSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"windsurf.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindsurf).GetConfigPath()).ToDataRes(types.String)
@@ -14664,6 +14682,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windsurf.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindsurfSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"windsurf.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindsurfSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"zed.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlZed).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -14739,6 +14760,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"roo.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRooSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"roo.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRooSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"cline.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCline).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -14771,6 +14795,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"cline.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClineSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"cline.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlClineSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"kiro.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKiro).GetConfigPath()).ToDataRes(types.String)
@@ -14805,6 +14832,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"kiro.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKiroSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"kiro.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKiroSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"continuedev.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlContinuedev).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -14837,6 +14867,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"continuedev.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlContinuedevSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"continuedev.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlContinuedevSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"trae.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTrae).GetConfigPath()).ToDataRes(types.String)
@@ -14871,6 +14904,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"trae.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTraeSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"trae.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTraeSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"opencode.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpencode).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -14903,6 +14939,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"opencode.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpencodeSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"opencode.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpencodeSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"pi.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPi).GetConfigPath()).ToDataRes(types.String)
@@ -14937,6 +14976,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"pi.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPiSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"pi.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPiSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"mistral.vibe.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMistralVibe).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -14969,6 +15011,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mistral.vibe.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMistralVibeSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"mistral.vibe.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMistralVibeSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"antigravity.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAntigravity).GetConfigPath()).ToDataRes(types.String)
@@ -15003,6 +15048,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"antigravity.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAntigravitySkill).GetSha256()).ToDataRes(types.String)
 	},
+	"antigravity.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAntigravitySkill).GetPurl()).ToDataRes(types.String)
+	},
 	"ibm.bob.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIbmBob).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -15035,6 +15083,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"ibm.bob.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlIbmBobSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"ibm.bob.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlIbmBobSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"openclaw.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenclaw).GetConfigPath()).ToDataRes(types.String)
@@ -15069,6 +15120,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openclaw.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenclawSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"openclaw.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenclawSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"snowflake.cortex.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSnowflakeCortex).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -15101,6 +15155,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"snowflake.cortex.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSnowflakeCortexSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"snowflake.cortex.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlSnowflakeCortexSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"junie.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlJunie).GetConfigPath()).ToDataRes(types.String)
@@ -15135,6 +15192,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"junie.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlJunieSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"junie.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlJunieSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"augment.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAugment).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -15167,6 +15227,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"augment.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAugmentSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"augment.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAugmentSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"warp.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWarp).GetConfigPath()).ToDataRes(types.String)
@@ -15201,6 +15264,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"warp.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWarpSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"warp.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWarpSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"kilocode.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKilocode).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -15233,6 +15299,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"kilocode.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKilocodeSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"kilocode.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKilocodeSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"openhands.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenhands).GetConfigPath()).ToDataRes(types.String)
@@ -15267,6 +15336,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openhands.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenhandsSkill).GetSha256()).ToDataRes(types.String)
 	},
+	"openhands.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenhandsSkill).GetPurl()).ToDataRes(types.String)
+	},
 	"qwen.code.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlQwenCode).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -15299,6 +15371,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"qwen.code.skill.sha256": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlQwenCodeSkill).GetSha256()).ToDataRes(types.String)
+	},
+	"qwen.code.skill.purl": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlQwenCodeSkill).GetPurl()).ToDataRes(types.String)
 	},
 	"sriov.physicalFunctions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlSriov).GetPhysicalFunctions()).ToDataRes(types.Array(types.Resource("sriov.physicalFunction")))
@@ -32341,6 +32416,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlClaudeCodeSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"claude.code.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlClaudeCodeSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"claude.code.project.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlClaudeCodeProject).__id, ok = v.Value.(string)
 		return
@@ -32581,6 +32660,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenaiCodexSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"openai.codex.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenaiCodexSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"openai.codex.mcpServer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenaiCodexMcpServer).__id, ok = v.Value.(string)
 		return
@@ -32805,6 +32888,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlCursorSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"cursor.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCursorSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"github.copilot.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubCopilot).__id, ok = v.Value.(string)
 		return
@@ -32909,6 +32996,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGithubCopilotSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"github.copilot.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubCopilotSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"goose.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoose).__id, ok = v.Value.(string)
 		return
@@ -33003,6 +33094,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"goose.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGooseSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"goose.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGooseSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gemini.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33103,6 +33198,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gemini.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGeminiSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gemini.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGeminiSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"windsurf.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33245,6 +33344,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlWindsurfSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"windsurf.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindsurfSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"zed.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlZed).__id, ok = v.Value.(string)
 		return
@@ -33361,6 +33464,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlRooSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"roo.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRooSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"cline.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCline).__id, ok = v.Value.(string)
 		return
@@ -33411,6 +33518,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cline.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlClineSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cline.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlClineSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"kiro.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33465,6 +33576,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlKiroSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"kiro.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKiroSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"continuedev.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlContinuedev).__id, ok = v.Value.(string)
 		return
@@ -33515,6 +33630,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"continuedev.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlContinuedevSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"continuedev.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlContinuedevSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"trae.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33569,6 +33688,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlTraeSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"trae.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTraeSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"opencode.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpencode).__id, ok = v.Value.(string)
 		return
@@ -33619,6 +33742,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"opencode.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpencodeSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"opencode.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpencodeSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"pi.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33673,6 +33800,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlPiSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"pi.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPiSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"mistral.vibe.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMistralVibe).__id, ok = v.Value.(string)
 		return
@@ -33723,6 +33854,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mistral.vibe.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMistralVibeSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mistral.vibe.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMistralVibeSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"antigravity.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33777,6 +33912,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAntigravitySkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"antigravity.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAntigravitySkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"ibm.bob.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlIbmBob).__id, ok = v.Value.(string)
 		return
@@ -33827,6 +33966,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ibm.bob.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlIbmBobSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ibm.bob.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlIbmBobSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openclaw.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33881,6 +34024,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenclawSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"openclaw.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenclawSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"snowflake.cortex.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlSnowflakeCortex).__id, ok = v.Value.(string)
 		return
@@ -33931,6 +34078,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"snowflake.cortex.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlSnowflakeCortexSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"snowflake.cortex.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlSnowflakeCortexSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"junie.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33985,6 +34136,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlJunieSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"junie.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlJunieSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"augment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAugment).__id, ok = v.Value.(string)
 		return
@@ -34035,6 +34190,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"augment.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAugmentSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"augment.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAugmentSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"warp.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34089,6 +34248,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlWarpSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"warp.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWarpSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"kilocode.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKilocode).__id, ok = v.Value.(string)
 		return
@@ -34139,6 +34302,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"kilocode.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKilocodeSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"kilocode.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKilocodeSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openhands.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34193,6 +34360,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenhandsSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"openhands.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenhandsSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"qwen.code.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlQwenCode).__id, ok = v.Value.(string)
 		return
@@ -34243,6 +34414,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"qwen.code.skill.sha256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlQwenCodeSkill).Sha256, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"qwen.code.skill.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlQwenCodeSkill).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"sriov.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -84353,6 +84528,7 @@ type mqlClaudeCodeSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createClaudeCodeSkill creates a new instance of this resource
@@ -84419,6 +84595,12 @@ func (c *mqlClaudeCodeSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlClaudeCodeSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlClaudeCodeSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -85035,6 +85217,7 @@ type mqlOpenaiCodexSkill struct {
 	Plugin      plugin.TValue[string]
 	Content     plugin.TValue[string]
 	Sha256      plugin.TValue[string]
+	Purl        plugin.TValue[string]
 }
 
 // createOpenaiCodexSkill creates a new instance of this resource
@@ -85097,6 +85280,12 @@ func (c *mqlOpenaiCodexSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlOpenaiCodexSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlOpenaiCodexSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -85701,6 +85890,7 @@ type mqlCursorSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createCursorSkill creates a new instance of this resource
@@ -85767,6 +85957,12 @@ func (c *mqlCursorSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlCursorSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlCursorSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -86051,6 +86247,7 @@ type mqlGithubCopilotSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createGithubCopilotSkill creates a new instance of this resource
@@ -86117,6 +86314,12 @@ func (c *mqlGithubCopilotSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlGithubCopilotSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlGithubCopilotSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -86344,6 +86547,7 @@ type mqlGooseSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createGooseSkill creates a new instance of this resource
@@ -86410,6 +86614,12 @@ func (c *mqlGooseSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlGooseSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlGooseSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -86644,6 +86854,7 @@ type mqlGeminiSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createGeminiSkill creates a new instance of this resource
@@ -86710,6 +86921,12 @@ func (c *mqlGeminiSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlGeminiSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlGeminiSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -87090,6 +87307,7 @@ type mqlWindsurfSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createWindsurfSkill creates a new instance of this resource
@@ -87156,6 +87374,12 @@ func (c *mqlWindsurfSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlWindsurfSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlWindsurfSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -87473,6 +87697,7 @@ type mqlRooSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createRooSkill creates a new instance of this resource
@@ -87539,6 +87764,12 @@ func (c *mqlRooSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlRooSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlRooSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -87654,6 +87885,7 @@ type mqlClineSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createClineSkill creates a new instance of this resource
@@ -87720,6 +87952,12 @@ func (c *mqlClineSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlClineSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlClineSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -87835,6 +88073,7 @@ type mqlKiroSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createKiroSkill creates a new instance of this resource
@@ -87901,6 +88140,12 @@ func (c *mqlKiroSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlKiroSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlKiroSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -88016,6 +88261,7 @@ type mqlContinuedevSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createContinuedevSkill creates a new instance of this resource
@@ -88082,6 +88328,12 @@ func (c *mqlContinuedevSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlContinuedevSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlContinuedevSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -88197,6 +88449,7 @@ type mqlTraeSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createTraeSkill creates a new instance of this resource
@@ -88263,6 +88516,12 @@ func (c *mqlTraeSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlTraeSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlTraeSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -88378,6 +88637,7 @@ type mqlOpencodeSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createOpencodeSkill creates a new instance of this resource
@@ -88444,6 +88704,12 @@ func (c *mqlOpencodeSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlOpencodeSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlOpencodeSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -88559,6 +88825,7 @@ type mqlPiSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createPiSkill creates a new instance of this resource
@@ -88625,6 +88892,12 @@ func (c *mqlPiSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlPiSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlPiSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -88740,6 +89013,7 @@ type mqlMistralVibeSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createMistralVibeSkill creates a new instance of this resource
@@ -88806,6 +89080,12 @@ func (c *mqlMistralVibeSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlMistralVibeSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlMistralVibeSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -88921,6 +89201,7 @@ type mqlAntigravitySkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createAntigravitySkill creates a new instance of this resource
@@ -88987,6 +89268,12 @@ func (c *mqlAntigravitySkill) GetContent() *plugin.TValue[string] {
 func (c *mqlAntigravitySkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlAntigravitySkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -89102,6 +89389,7 @@ type mqlIbmBobSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createIbmBobSkill creates a new instance of this resource
@@ -89168,6 +89456,12 @@ func (c *mqlIbmBobSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlIbmBobSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlIbmBobSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -89283,6 +89577,7 @@ type mqlOpenclawSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createOpenclawSkill creates a new instance of this resource
@@ -89349,6 +89644,12 @@ func (c *mqlOpenclawSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlOpenclawSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlOpenclawSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -89464,6 +89765,7 @@ type mqlSnowflakeCortexSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createSnowflakeCortexSkill creates a new instance of this resource
@@ -89530,6 +89832,12 @@ func (c *mqlSnowflakeCortexSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlSnowflakeCortexSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlSnowflakeCortexSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -89645,6 +89953,7 @@ type mqlJunieSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createJunieSkill creates a new instance of this resource
@@ -89711,6 +90020,12 @@ func (c *mqlJunieSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlJunieSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlJunieSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -89826,6 +90141,7 @@ type mqlAugmentSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createAugmentSkill creates a new instance of this resource
@@ -89892,6 +90208,12 @@ func (c *mqlAugmentSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlAugmentSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlAugmentSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -90007,6 +90329,7 @@ type mqlWarpSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createWarpSkill creates a new instance of this resource
@@ -90073,6 +90396,12 @@ func (c *mqlWarpSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlWarpSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlWarpSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -90188,6 +90517,7 @@ type mqlKilocodeSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createKilocodeSkill creates a new instance of this resource
@@ -90254,6 +90584,12 @@ func (c *mqlKilocodeSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlKilocodeSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlKilocodeSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -90369,6 +90705,7 @@ type mqlOpenhandsSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createOpenhandsSkill creates a new instance of this resource
@@ -90435,6 +90772,12 @@ func (c *mqlOpenhandsSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlOpenhandsSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlOpenhandsSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 
@@ -90550,6 +90893,7 @@ type mqlQwenCodeSkill struct {
 	Source       plugin.TValue[string]
 	Content      plugin.TValue[string]
 	Sha256       plugin.TValue[string]
+	Purl         plugin.TValue[string]
 }
 
 // createQwenCodeSkill creates a new instance of this resource
@@ -90616,6 +90960,12 @@ func (c *mqlQwenCodeSkill) GetContent() *plugin.TValue[string] {
 func (c *mqlQwenCodeSkill) GetSha256() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Sha256, func() (string, error) {
 		return c.sha256()
+	})
+}
+
+func (c *mqlQwenCodeSkill) GetPurl() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
+		return c.purl()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -46,6 +46,7 @@ antigravity.skill.argumentHint 13.13.1
 antigravity.skill.content 13.13.1
 antigravity.skill.description 13.13.1
 antigravity.skill.name 13.13.1
+antigravity.skill.purl 13.40.10
 antigravity.skill.sha256 13.13.1
 antigravity.skill.source 13.13.1
 antigravity.skills 13.13.1
@@ -197,6 +198,7 @@ augment.skill.argumentHint 13.13.1
 augment.skill.content 13.13.1
 augment.skill.description 13.13.1
 augment.skill.name 13.13.1
+augment.skill.purl 13.40.10
 augment.skill.sha256 13.13.1
 augment.skill.source 13.13.1
 augment.skills 13.13.1
@@ -517,6 +519,7 @@ claude.code.skill.argumentHint 13.8.2
 claude.code.skill.content 13.8.2
 claude.code.skill.description 13.8.2
 claude.code.skill.name 13.8.2
+claude.code.skill.purl 13.40.10
 claude.code.skill.sha256 13.10.1
 claude.code.skill.source 13.8.2
 claude.code.skills 13.8.2
@@ -532,6 +535,7 @@ cline.skill.argumentHint 13.13.1
 cline.skill.content 13.13.1
 cline.skill.description 13.13.1
 cline.skill.name 13.13.1
+cline.skill.purl 13.40.10
 cline.skill.sha256 13.13.1
 cline.skill.source 13.13.1
 cline.skills 13.13.1
@@ -591,6 +595,7 @@ continuedev.skill.argumentHint 13.13.1
 continuedev.skill.content 13.13.1
 continuedev.skill.description 13.13.1
 continuedev.skill.name 13.13.1
+continuedev.skill.purl 13.40.10
 continuedev.skill.sha256 13.13.1
 continuedev.skill.source 13.13.1
 continuedev.skills 13.13.1
@@ -639,6 +644,7 @@ cursor.skill.argumentHint 13.10.1
 cursor.skill.content 13.10.1
 cursor.skill.description 13.10.1
 cursor.skill.name 13.10.1
+cursor.skill.purl 13.40.10
 cursor.skill.sha256 13.10.1
 cursor.skill.source 13.10.1
 cursor.skills 13.10.1
@@ -993,6 +999,7 @@ gemini.skill.argumentHint 13.13.1
 gemini.skill.content 13.13.1
 gemini.skill.description 13.13.1
 gemini.skill.name 13.13.1
+gemini.skill.purl 13.40.10
 gemini.skill.sha256 13.13.1
 gemini.skill.source 13.13.1
 gemini.skills 13.13.1
@@ -1019,6 +1026,7 @@ github.copilot.skill.argumentHint 13.12.1
 github.copilot.skill.content 13.12.1
 github.copilot.skill.description 13.12.1
 github.copilot.skill.name 13.12.1
+github.copilot.skill.purl 13.40.10
 github.copilot.skill.sha256 13.12.1
 github.copilot.skill.source 13.12.1
 github.copilot.skills 13.12.1
@@ -1065,6 +1073,7 @@ goose.skill.argumentHint 13.13.1
 goose.skill.content 13.13.1
 goose.skill.description 13.13.1
 goose.skill.name 13.13.1
+goose.skill.purl 13.40.10
 goose.skill.sha256 13.13.1
 goose.skill.source 13.13.1
 goose.skills 13.13.1
@@ -1347,6 +1356,7 @@ ibm.bob.skill.argumentHint 13.13.1
 ibm.bob.skill.content 13.13.1
 ibm.bob.skill.description 13.13.1
 ibm.bob.skill.name 13.13.1
+ibm.bob.skill.purl 13.40.10
 ibm.bob.skill.sha256 13.13.1
 ibm.bob.skill.source 13.13.1
 ibm.bob.skills 13.13.1
@@ -1728,6 +1738,7 @@ junie.skill.argumentHint 13.13.1
 junie.skill.content 13.13.1
 junie.skill.description 13.13.1
 junie.skill.name 13.13.1
+junie.skill.purl 13.40.10
 junie.skill.sha256 13.13.1
 junie.skill.source 13.13.1
 junie.skills 13.13.1
@@ -1770,6 +1781,7 @@ kilocode.skill.argumentHint 13.13.1
 kilocode.skill.content 13.13.1
 kilocode.skill.description 13.13.1
 kilocode.skill.name 13.13.1
+kilocode.skill.purl 13.40.10
 kilocode.skill.sha256 13.13.1
 kilocode.skill.source 13.13.1
 kilocode.skills 13.13.1
@@ -1783,6 +1795,7 @@ kiro.skill.argumentHint 13.13.1
 kiro.skill.content 13.13.1
 kiro.skill.description 13.13.1
 kiro.skill.name 13.13.1
+kiro.skill.purl 13.40.10
 kiro.skill.sha256 13.13.1
 kiro.skill.source 13.13.1
 kiro.skills 13.13.1
@@ -2228,6 +2241,7 @@ mistral.vibe.skill.argumentHint 13.13.1
 mistral.vibe.skill.content 13.13.1
 mistral.vibe.skill.description 13.13.1
 mistral.vibe.skill.name 13.13.1
+mistral.vibe.skill.purl 13.40.10
 mistral.vibe.skill.sha256 13.13.1
 mistral.vibe.skill.source 13.13.1
 mistral.vibe.skills 13.13.1
@@ -2683,6 +2697,7 @@ openai.codex.skill.content 13.8.2
 openai.codex.skill.description 13.8.2
 openai.codex.skill.name 13.8.2
 openai.codex.skill.plugin 13.8.2
+openai.codex.skill.purl 13.40.10
 openai.codex.skill.sha256 13.10.1
 openai.codex.skill.source 13.8.2
 openai.codex.skills 13.8.2
@@ -2696,6 +2711,7 @@ openclaw.skill.argumentHint 13.13.1
 openclaw.skill.content 13.13.1
 openclaw.skill.description 13.13.1
 openclaw.skill.name 13.13.1
+openclaw.skill.purl 13.40.10
 openclaw.skill.sha256 13.13.1
 openclaw.skill.source 13.13.1
 openclaw.skills 13.13.1
@@ -2709,6 +2725,7 @@ opencode.skill.argumentHint 13.13.1
 opencode.skill.content 13.13.1
 opencode.skill.description 13.13.1
 opencode.skill.name 13.13.1
+opencode.skill.purl 13.40.10
 opencode.skill.sha256 13.13.1
 opencode.skill.source 13.13.1
 opencode.skills 13.13.1
@@ -2722,6 +2739,7 @@ openhands.skill.argumentHint 13.13.1
 openhands.skill.content 13.13.1
 openhands.skill.description 13.13.1
 openhands.skill.name 13.13.1
+openhands.skill.purl 13.40.10
 openhands.skill.sha256 13.13.1
 openhands.skill.source 13.13.1
 openhands.skills 13.13.1
@@ -2913,6 +2931,7 @@ pi.skill.argumentHint 13.13.1
 pi.skill.content 13.13.1
 pi.skill.description 13.13.1
 pi.skill.name 13.13.1
+pi.skill.purl 13.40.10
 pi.skill.sha256 13.13.1
 pi.skill.source 13.13.1
 pi.skills 13.13.1
@@ -3172,6 +3191,7 @@ qwen.code.skill.argumentHint 13.13.1
 qwen.code.skill.content 13.13.1
 qwen.code.skill.description 13.13.1
 qwen.code.skill.name 13.13.1
+qwen.code.skill.purl 13.40.10
 qwen.code.skill.sha256 13.13.1
 qwen.code.skill.source 13.13.1
 qwen.code.skills 13.13.1
@@ -3212,6 +3232,7 @@ roo.skill.argumentHint 13.13.1
 roo.skill.content 13.13.1
 roo.skill.description 13.13.1
 roo.skill.name 13.13.1
+roo.skill.purl 13.40.10
 roo.skill.sha256 13.13.1
 roo.skill.source 13.13.1
 roo.skills 13.13.1
@@ -3358,6 +3379,7 @@ snowflake.cortex.skill.argumentHint 13.13.1
 snowflake.cortex.skill.content 13.13.1
 snowflake.cortex.skill.description 13.13.1
 snowflake.cortex.skill.name 13.13.1
+snowflake.cortex.skill.purl 13.40.10
 snowflake.cortex.skill.sha256 13.13.1
 snowflake.cortex.skill.source 13.13.1
 snowflake.cortex.skills 13.13.1
@@ -3808,6 +3830,7 @@ trae.skill.argumentHint 13.13.1
 trae.skill.content 13.13.1
 trae.skill.description 13.13.1
 trae.skill.name 13.13.1
+trae.skill.purl 13.40.10
 trae.skill.sha256 13.13.1
 trae.skill.source 13.13.1
 trae.skills 13.13.1
@@ -3926,6 +3949,7 @@ warp.skill.argumentHint 13.13.1
 warp.skill.content 13.13.1
 warp.skill.description 13.13.1
 warp.skill.name 13.13.1
+warp.skill.purl 13.40.10
 warp.skill.sha256 13.13.1
 warp.skill.source 13.13.1
 warp.skills 13.13.1
@@ -4623,6 +4647,7 @@ windsurf.skill.argumentHint 13.13.1
 windsurf.skill.content 13.13.1
 windsurf.skill.description 13.13.1
 windsurf.skill.name 13.13.1
+windsurf.skill.purl 13.40.10
 windsurf.skill.sha256 13.13.1
 windsurf.skill.source 13.13.1
 windsurf.skills 13.13.1

--- a/providers/os/resources/windsurf.go
+++ b/providers/os/resources/windsurf.go
@@ -145,6 +145,10 @@ func (r *mqlWindsurfSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlWindsurfSkill) purl() (string, error) {
+	return skillPURL(connectionAfs(r.MqlRuntime), r.Source.Data), nil
+}
+
 // Helper types
 
 type windsurfMCPConfig struct {


### PR DESCRIPTION
## What

Every AI agent skill resource (`claude.code.skill`, `openai.codex.skill`, `cursor.skill`, `github.copilot.skill`, `goose.skill`, `gemini.skill`, `windsurf.skill`, and the agent skill resources in `ai_agents.go` — `roo.skill`, `cline.skill`, `kiro.skill`, `continuedev.skill`, `trae.skill`, `opencode.skill`, `pi.skill`, `mistral.vibe.skill`, `antigravity.skill`, `ibm.bob.skill`, `openclaw.skill`, `snowflake.cortex.skill`, `junie.skill`, `augment.skill`, `warp.skill`, `kilocode.skill`, `openhands.skill`, `qwen.code.skill` — 25 resources total) gains an optional computed field:

```
// Package URL identifying the skill's git origin (empty when the skill is not inside a git checkout)
purl() string
```

The existing mandatory `sha256` field is unchanged.

## Derivation

Starting from the skill's `source` path (the SKILL.md file), the shared helper `skillPURL` in `ai_coding_tools.go`:

1. Walks parent directories up to a `.git` entry, supporting both a plain `.git` directory and the linked-worktree `.git` file form (`gitdir:` pointer + `commondir`), reusing the same repo-detection machinery the existing `repos()` fields use.
2. Parses the `origin` remote from the shared `.git/config` (the existing minimal INI reader).
3. If — and only if — the origin host is `github.com` with an `org/repo` slug, resolves the checkout's current HEAD commit with pure file reads: detached HEAD carries the sha directly, otherwise the ref is looked up as a loose ref file and then in `packed-refs`. The git binary is never executed.

The result is:

```
pkg:github/<org>/<repo>@<first 12 chars of HEAD sha>?skill=<skill dir name>
```

where the skill dir name is the base name of the directory containing SKILL.md.

## Caveats

- **A coordinate is never guessed.** No `.git`, no `origin` remote, a non-github origin, or an unresolvable HEAD all yield the empty string rather than a fabricated purl.
- The pinned version is the checkout's **current** HEAD, which may differ from the state the skill content was installed or published at — `sha256` remains the content-integrity signal; `purl` is provenance for where the checkout points right now.

## Testing

- New `TestSkillPURL` in `ai_coding_tools_test.go` covers: scp-style and https github origins, loose-ref and packed-refs resolution, detached HEAD (resolves), a linked worktree (`.git` file + `commondir`), and the negative cases (no git checkout, non-github origin, no origin remote, unresolvable ref, malformed sha) asserting the exact purl string or `""`.
- `go test ./providers/os/resources/` passes; the os provider builds.
- Generated via `./mqlr generate providers/os/resources/os.lr --dist providers/os/resources` (25 new `*.skill.purl` entries in `os.lr.versions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)