### PR TITLE
🟢 ci: stop checking nmap.org, which refuses CI traffic

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "^https:\\/\\/console\\.mistral\\.ai"
+    },
+    {
+      "pattern": "^https:\\/\\/nmap\\.org\\/"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #10043, which did not finish the job. `main` has failed the link check on every run since:

```
15:22  failure  fix/mycnf-absent-ints
15:16  failure  chris/ai-skill-purl
14:57  failure  main        ← after #10043 merged at 14:56
14:56  failure  main
14:50  failure  main
```

## What #10043 fixed, and what it did not

That PR raised the timeout because nmap.org was answering too slowly and reporting `ETIMEDOUT`. That was the failure at the time, and the timeout fixed it — the error has now changed:

```
[✖] https://nmap.org/download.html → Status: 0 Error: read ECONNRESET
```

The host is resetting the connection rather than being slow. No timeout helps with that, and `retryCount` only applies to 429 responses, so nothing retries it.

## The link is not broken

From an ordinary machine it answers 200 every time, three out of three:

```
attempt 1 -> 200 in 11.2s
attempt 2 -> 200 in 13.4s
attempt 3 -> 200 in 14.4s
```

Slow, but alive. It is the GitHub runners it refuses — the same behaviour `platform.openai.com` and `console.mistral.ai` show. Both are already in `ignorePatterns`, and both appear in the same failing logs with the identical `Status: 0`, ignored:

```
[/] https://console.mistral.ai → Status: 0
[/] https://platform.openai.com/api-keys → Status: 0
[✖] https://nmap.org/download.html → Status: 0 Error: read ECONNRESET
```

`nmap.org` joins them. Verified locally against the file that blocks `main`:

```
$ npx markdown-link-check -c .github/actions/link-check/config.json providers/nmap/README.md
  [/] https://nmap.org/download.html
```

The `timeout` and retry settings from #10043 stay — they address a different failure mode and are worth keeping.

## Ordering

This unblocks `main` and every open PR. #10038 is otherwise green at 24 checks and needs only this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)