### PR TITLE
ci: add verify-sequence check for ADRs

### DIFF
--- a/.github/workflows/verify-sequence.yml
+++ b/.github/workflows/verify-sequence.yml
@@ -1,0 +1,44 @@
+name: Verify Sequences
+
+on:
+  pull_request:
+    paths:
+      - "docs/adr/*.md"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  verify-sequence:
+    name: Verify Sequences
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          owner: mondoohq
+          repositories: verify-sequence
+
+      - name: Checkout verify-sequence action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: mondoohq/verify-sequence
+          ref: 9dca90c3101e79fad4a43c96e99ffc055ba518dc # v0.0.2
+          token: ${{ steps.generate-token.outputs.token }}
+          path: .github/actions/verify-sequence
+
+      - name: Check ADR sequence
+        uses: ./.github/actions/verify-sequence
+        with:
+          patterns: |
+            docs/adr/*.md
+          mode: diff


### PR DESCRIPTION
## Summary
- Add [`mondoohq/verify-sequence`](https://github.com/mondoohq/verify-sequence) action to check ADR files for duplicate or conflicting sequence numbers
- Runs in `diff` mode on `pull_request` events, only when `docs/adr/*.md` files change
- Uses mondoo-mergebot app token to access the private action repo (same pattern as `go-auto-approve`)

## Notes for reviewers

**`pull-requests: write` permission:** The action posts a PR comment when sequence issues are found and updates it once resolved.

**SHA pinning:** The action is pinned to a full commit SHA with a version comment (`# v0.0.2`).

## Test plan
- [x] PR adding a new ADR with valid sequence → check passes, no comment
- [x] PR adding an ADR with duplicate sequence number → check fails, comment posted