### PR TITLE
🎉 okta-13.6.1, ms365-13.12.2

### DIFF
--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.12.1",
+	Version:         "13.12.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "okta",
 	ID:              "go.mondoo.com/cnquery/v9/providers/okta",
-	Version:         "13.6.0",
+	Version:         "13.6.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### okta (13.6.1)
- ⚡ okta: fetch the organization record once per connection

### ms365 (13.12.2)
- ⚡ ms365: read user registration details from the tenant report, not per user