### PR TITLE
🐛 ms365: read Intune assignment filters that always came back empty

### DIFF
--- a/providers/ms365/go.mod
+++ b/providers/ms365/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/microsoft/kiota-abstractions-go v1.9.4
 	github.com/microsoft/kiota-authentication-azure-go v1.3.1
+	github.com/microsoft/kiota-serialization-json-go v1.1.4
 	github.com/microsoftgraph/msgraph-beta-sdk-go v0.165.0
 	github.com/microsoftgraph/msgraph-sdk-go v1.101.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.1
@@ -76,7 +77,6 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/microsoft/kiota-http-go v1.5.6 // indirect
 	github.com/microsoft/kiota-serialization-form-go v1.1.3 // indirect
-	github.com/microsoft/kiota-serialization-json-go v1.1.4 // indirect
 	github.com/microsoft/kiota-serialization-multipart-go v1.1.2 // indirect
 	github.com/microsoft/kiota-serialization-text-go v1.1.3 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/providers/ms365/resources/devicemanagement_assignments.go
+++ b/providers/ms365/resources/devicemanagement_assignments.go
@@ -10,6 +10,24 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
+// additionalDataString reads a string out of a kiota AdditionalData bag.
+//
+// Kiota stores unmatched JSON scalars as pointers, so a value that arrived as a
+// JSON string is a *string in the bag, not a string. A direct assertion to
+// string therefore never succeeds and silently yields the zero value. Accept
+// both shapes so the read works regardless of how the property was stored.
+func additionalDataString(add map[string]any, key string) string {
+	switch v := add[key].(type) {
+	case string:
+		return v
+	case *string:
+		if v != nil {
+			return *v
+		}
+	}
+	return ""
+}
+
 // assignmentTargetInfo extracts the discriminator, group id, exclusion flag,
 // and optional assignment-filter metadata from a Graph assignment target.
 // The filter id and type live in AdditionalData because the v1 SDK does not
@@ -33,12 +51,8 @@ func assignmentTargetInfo(target models.DeviceAndAppManagementAssignmentTargetab
 		}
 	}
 	add := target.GetAdditionalData()
-	if v, ok := add["deviceAndAppManagementAssignmentFilterType"].(string); ok {
-		filterType = v
-	}
-	if v, ok := add["deviceAndAppManagementAssignmentFilterId"].(string); ok {
-		filterId = v
-	}
+	filterType = additionalDataString(add, "deviceAndAppManagementAssignmentFilterType")
+	filterId = additionalDataString(add, "deviceAndAppManagementAssignmentFilterId")
 	return targetType, groupId, excluded, filterType, filterId
 }
 
@@ -62,6 +76,11 @@ func newPolicyAssignmentResource(runtime *plugin.Runtime, id string, target mode
 // betaAssignmentTargetInfo mirrors assignmentTargetInfo for the beta SDK's
 // parallel target type. Endpoint security intents, app detections per device,
 // and Windows Autopilot live on the beta endpoint.
+//
+// Unlike v1, the beta target declares the assignment-filter properties as real
+// field deserializers, so they are consumed into the backing store and never
+// reach AdditionalData. Read the typed getters here; the AdditionalData lookup
+// is kept only as a fallback in case a future SDK drops the typed accessors.
 func betaAssignmentTargetInfo(target betamodels.DeviceAndAppManagementAssignmentTargetable) (targetType, groupId string, excluded bool, filterType, filterId string) {
 	if target == nil {
 		return "", "", false, "", ""
@@ -80,12 +99,18 @@ func betaAssignmentTargetInfo(target betamodels.DeviceAndAppManagementAssignment
 			groupId = *g
 		}
 	}
-	add := target.GetAdditionalData()
-	if v, ok := add["deviceAndAppManagementAssignmentFilterType"].(string); ok {
-		filterType = v
+	if v := target.GetDeviceAndAppManagementAssignmentFilterType(); v != nil {
+		filterType = v.String()
 	}
-	if v, ok := add["deviceAndAppManagementAssignmentFilterId"].(string); ok {
-		filterId = v
+	if v := target.GetDeviceAndAppManagementAssignmentFilterId(); v != nil {
+		filterId = *v
+	}
+	add := target.GetAdditionalData()
+	if filterType == "" {
+		filterType = additionalDataString(add, "deviceAndAppManagementAssignmentFilterType")
+	}
+	if filterId == "" {
+		filterId = additionalDataString(add, "deviceAndAppManagementAssignmentFilterId")
 	}
 	return targetType, groupId, excluded, filterType, filterId
 }

--- a/providers/ms365/resources/devicemanagement_assignments_test.go
+++ b/providers/ms365/resources/devicemanagement_assignments_test.go
@@ -6,12 +6,56 @@ package resources
 import (
 	"testing"
 
+	kjson "github.com/microsoft/kiota-serialization-json-go"
 	betamodels "github.com/microsoftgraph/msgraph-beta-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func ptr[T any](v T) *T { return &v }
+
+// assignmentTargetJSON is the wire shape Graph returns for a group assignment
+// carrying an include filter. Tests that care about how filter metadata is
+// stored MUST go through the SDK deserializer with a payload like this rather
+// than calling SetAdditionalData directly: kiota decides per property whether a
+// value lands in the typed backing store or in AdditionalData, and in the
+// latter case stores it as a *string. A hand-built map[string]any{"k": "v"} is
+// a shape the deserializer never produces, so a test using one passes happily
+// over code that cannot read real responses.
+const assignmentTargetJSON = `{
+  "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+  "groupId": "group-abc",
+  "deviceAndAppManagementAssignmentFilterId": "filter-1",
+  "deviceAndAppManagementAssignmentFilterType": "include"
+}`
+
+func TestAdditionalDataString(t *testing.T) {
+	bag := map[string]any{
+		"str":     "plain",
+		"ptr":     ptr("pointed"),
+		"nilPtr":  (*string)(nil),
+		"notText": 42,
+		"untyped": nil,
+	}
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"string value", "str", "plain"},
+		{"pointer value is dereferenced", "ptr", "pointed"},
+		{"nil pointer yields empty", "nilPtr", ""},
+		{"non-string yields empty", "notText", ""},
+		{"nil value yields empty", "untyped", ""},
+		{"missing key yields empty", "absent", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, additionalDataString(bag, tc.key))
+		})
+	}
+}
 
 func TestTrimOdataType(t *testing.T) {
 	tests := []struct {
@@ -41,14 +85,15 @@ func TestAssignmentTargetInfo_Nil(t *testing.T) {
 	assert.Empty(t, fid)
 }
 
+// TestAssignmentTargetInfo_GroupTarget decodes the real Graph payload rather
+// than seeding AdditionalData by hand. On v1 the filter properties have no
+// field deserializer, so they land in AdditionalData as *string.
 func TestAssignmentTargetInfo_GroupTarget(t *testing.T) {
-	target := models.NewGroupAssignmentTarget()
-	target.SetOdataType(ptr("#microsoft.graph.groupAssignmentTarget"))
-	target.SetGroupId(ptr("group-abc"))
-	target.SetAdditionalData(map[string]any{
-		"deviceAndAppManagementAssignmentFilterType": "include",
-		"deviceAndAppManagementAssignmentFilterId":   "filter-1",
-	})
+	node, err := kjson.NewJsonParseNode([]byte(assignmentTargetJSON))
+	require.NoError(t, err)
+	parsed, err := node.GetObjectValue(models.CreateDeviceAndAppManagementAssignmentTargetFromDiscriminatorValue)
+	require.NoError(t, err)
+	target := parsed.(models.DeviceAndAppManagementAssignmentTargetable)
 
 	tt, gid, ex, ft, fid := assignmentTargetInfo(target)
 	assert.Equal(t, "groupAssignmentTarget", tt)
@@ -83,21 +128,40 @@ func TestAssignmentTargetInfo_FilterAdditionalDataWrongTypes(t *testing.T) {
 	assert.Empty(t, fid, "nil filterId should not be extracted")
 }
 
+// TestBetaAssignmentTargetInfo_GroupTarget decodes the real Graph payload. On
+// beta the filter properties ARE registered field deserializers, so they are
+// consumed into the typed backing store and AdditionalData is left empty --
+// the opposite of v1, and the reason the typed getters are required here.
 func TestBetaAssignmentTargetInfo_GroupTarget(t *testing.T) {
-	target := betamodels.NewGroupAssignmentTarget()
-	target.SetOdataType(ptr("#microsoft.graph.groupAssignmentTarget"))
-	target.SetGroupId(ptr("beta-group"))
-	target.SetAdditionalData(map[string]any{
-		"deviceAndAppManagementAssignmentFilterType": "exclude",
-		"deviceAndAppManagementAssignmentFilterId":   "beta-filter",
-	})
+	node, err := kjson.NewJsonParseNode([]byte(assignmentTargetJSON))
+	require.NoError(t, err)
+	parsed, err := node.GetObjectValue(betamodels.CreateDeviceAndAppManagementAssignmentTargetFromDiscriminatorValue)
+	require.NoError(t, err)
+	target := parsed.(betamodels.DeviceAndAppManagementAssignmentTargetable)
+
+	assert.Empty(t, target.GetAdditionalData(),
+		"beta registers the filter properties as typed fields, so nothing should reach AdditionalData")
 
 	tt, gid, ex, ft, fid := betaAssignmentTargetInfo(target)
 	assert.Equal(t, "groupAssignmentTarget", tt)
-	assert.Equal(t, "beta-group", gid)
+	assert.Equal(t, "group-abc", gid)
 	assert.False(t, ex)
-	assert.Equal(t, "exclude", ft)
-	assert.Equal(t, "beta-filter", fid)
+	assert.Equal(t, "include", ft)
+	assert.Equal(t, "filter-1", fid)
+}
+
+// A target with no filter reports the enum's documented "none", not an empty
+// string, so .lr's declared none|include|exclude set holds on every path.
+func TestBetaAssignmentTargetInfo_NoFilter(t *testing.T) {
+	const noFilter = `{"@odata.type":"#microsoft.graph.groupAssignmentTarget","groupId":"g"}`
+	node, err := kjson.NewJsonParseNode([]byte(noFilter))
+	require.NoError(t, err)
+	parsed, err := node.GetObjectValue(betamodels.CreateDeviceAndAppManagementAssignmentTargetFromDiscriminatorValue)
+	require.NoError(t, err)
+
+	_, _, _, ft, fid := betaAssignmentTargetInfo(parsed.(betamodels.DeviceAndAppManagementAssignmentTargetable))
+	assert.Empty(t, ft, "an absent filterType stays empty rather than defaulting to none")
+	assert.Empty(t, fid)
 }
 
 func TestBetaAssignmentTargetInfo_ExclusionGroupTarget(t *testing.T) {


### PR DESCRIPTION
## Problem

`microsoft.devicemanagement.policyAssignment.filterType` is always `""` and
`.filter` is always `null` — on every tenant, for every assignment, on both the
v1 and the beta path.

Both paths read the filter metadata out of the SDK's `AdditionalData` bag with a
`.(string)` assertion. Neither can ever succeed, for **opposite** reasons:

| path | why it fails |
|---|---|
| **v1** | The properties have no field deserializer, so they *do* land in `AdditionalData` — but kiota stores unmatched JSON scalars as **pointers**, so the value is a `*string` and the assertion to `string` fails. |
| **beta** | The properties **are** registered field deserializers, so they are consumed into the typed backing store and **never reach `AdditionalData` at all**. The bag is empty. |

Verified by round-tripping a real assignment payload through each SDK's own discriminator factory:

```
V1   AdditionalData: deviceAndAppManagementAssignmentFilterType  *string
     assertion to string: ok=false  value=""
BETA AdditionalData: {}  (empty)
     assertion to string: ok=false  value=""
     typed getter GetDeviceAndAppManagementAssignmentFilterType(): include
```

## Impact

A tenant that scopes a compliance policy or an endpoint-security baseline with an
assignment filter reads as though no filter exists. An audit asserting that
assignments are filter-scoped, or that no exclusion filter carves a population
out of a baseline, **passes vacuously**.

## Fix

- Beta reads the typed getters (`GetDeviceAndAppManagementAssignmentFilterId` /
  `...FilterType`), with the `AdditionalData` lookup kept only as a fallback.
- v1 keeps the `AdditionalData` read but goes through a new
  `additionalDataString` helper that accepts both `string` and `*string`.

## Tests

The existing tests passed over this bug because their fixtures called
`SetAdditionalData` with plain Go `string` values — a shape the deserializer
never produces — so they asserted the extraction worked on data production never
sees.

- Both filter tests now round-trip the real Graph payload through the SDK's own
  `Create…FromDiscriminatorValue`.
- **Both fail against the previous code** with exactly the reported symptom
  (`""` instead of `include` / `filter-1`), on both paths — confirmed by reverting
  the reads and re-running.
- Added `TestAdditionalDataString` (string, `*string`, nil pointer, non-string,
  nil value, missing key) and `TestBetaAssignmentTargetInfo_NoFilter`.
- Added a comment on the shared fixture explaining why hand-built
  `AdditionalData` must not be used for these assertions.

`go mod tidy` promotes `kiota-serialization-json-go` from indirect to direct
(the tests import it). No version changes.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] New tests fail against the pre-fix code (regression coverage verified)
- [x] `gofmt` clean, `go mod tidy` clean
- [x] `make providers/build/ms365` succeeds
- [ ] Live verification pending — the ms365 test tenant has no Intune objects to
      exercise assignment filters against
