### PR TITLE
🐛 ms365: give four Exchange resources a real cache key

### DIFF
--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -585,12 +585,13 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 
 	externalInOutlook := []any{}
 	var externalInOutlookErr error
-	for _, e := range report.ExternalInOutlook {
+	for i, e := range report.ExternalInOutlook {
 		if e == nil {
 			continue
 		}
 		mql, err := CreateResource(r.MqlRuntime, "ms365.exchangeonline.externalSender",
 			map[string]*llx.RawData{
+				"__id":      llx.StringData(exchangeEntryID("externalSender", e.Identity, i)),
 				"identity":  llx.StringData(e.Identity),
 				"enabled":   llx.BoolData(e.Enabled),
 				"allowList": llx.ArrayData(llx.TArr2Raw(e.AllowList), types.Any),
@@ -606,12 +607,13 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 
 	sharedMailboxes := []any{}
 	var sharedMailboxesErr error
-	for _, m := range report.ExoMailbox {
+	for i, m := range report.ExoMailbox {
 		if m == nil {
 			continue
 		}
 		mql, err := CreateResource(r.MqlRuntime, "ms365.exchangeonline.exoMailbox",
 			map[string]*llx.RawData{
+				"__id":                      llx.StringData(exchangeEntryID("exoMailbox", m.Identity, i)),
 				"identity":                  llx.StringData(m.Identity),
 				"externalDirectoryObjectId": llx.StringData(m.ExternalDirectoryObjectId),
 			})

--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -197,11 +197,13 @@ type ExoMailbox struct {
 }
 
 type TeamsProtectionPolicy struct {
-	ZapEnabled bool `json:"ZapEnabled"`
-	IsValid    bool `json:"IsValid"`
+	Identity   string `json:"Identity"`
+	ZapEnabled bool   `json:"ZapEnabled"`
+	IsValid    bool   `json:"IsValid"`
 }
 
 type ReportSubmissionPolicy struct {
+	Identity                                    string   `json:"Identity"`
 	ReportJunkToCustomizedAddress               bool     `json:"ReportJunkToCustomizedAddress"`
 	ReportNotJunkToCustomizedAddress            bool     `json:"ReportNotJunkToCustomizedAddress"`
 	ReportPhishToCustomizedAddress              bool     `json:"ReportPhishToCustomizedAddress"`
@@ -278,15 +280,31 @@ func (r *mqlMs365Exchangeonline) getOrg() (string, error) {
 	return org, nil
 }
 
+// exchangeEntryID builds the cache key for one row of an Exchange cmdlet
+// result. Exchange objects carry an Identity, which is what every other policy
+// resource in this package keys on, but a cmdlet shape that omits it must still
+// produce a distinct key per row: CreateResource is first-wins on
+// resourceName+"\x00"+__id, so rows sharing a key collapse into the first one
+// and the rest of the collection is silently discarded. Fall back to the row's
+// position so that can never happen. Both forms are synthetic and stay hidden --
+// none of these resources declares a public `id` field.
+func exchangeEntryID(prefix, identity string, index int) string {
+	if identity != "" {
+		return prefix + "-" + identity
+	}
+	return fmt.Sprintf("%s-#%d", prefix, index)
+}
+
 // Related to TeamsProtectionPolicy as a separate function
 func convertTeamsProtectionPolicy(r *mqlMs365Exchangeonline, data []*TeamsProtectionPolicy) ([]any, error) {
 	var result []any
-	for _, t := range data {
+	for i, t := range data {
 		if t == nil {
 			continue
 		}
 		policy, err := CreateResource(r.MqlRuntime, "ms365.exchangeonline.teamsProtectionPolicy",
 			map[string]*llx.RawData{
+				"__id":       llx.StringData(exchangeEntryID("teamsProtectionPolicy", t.Identity, i)),
 				"zapEnabled": llx.BoolData(t.ZapEnabled),
 				"isValid":    llx.BoolData(t.IsValid),
 			})
@@ -301,12 +319,13 @@ func convertTeamsProtectionPolicy(r *mqlMs365Exchangeonline, data []*TeamsProtec
 // Related to ReportSubmissionPolicy as a separate function
 func convertReportSubmissionPolicy(r *mqlMs365Exchangeonline, data []*ReportSubmissionPolicy) ([]any, error) {
 	var result []any
-	for _, t := range data {
+	for i, t := range data {
 		if t == nil {
 			continue
 		}
 		policy, err := CreateResource(r.MqlRuntime, "ms365.exchangeonline.reportSubmissionPolicy",
 			map[string]*llx.RawData{
+				"__id":                                        llx.StringData(exchangeEntryID("reportSubmissionPolicy", t.Identity, i)),
 				"reportJunkToCustomizedAddress":               llx.BoolData(t.ReportJunkToCustomizedAddress),
 				"reportNotJunkToCustomizedAddress":            llx.BoolData(t.ReportNotJunkToCustomizedAddress),
 				"reportPhishToCustomizedAddress":              llx.BoolData(t.ReportPhishToCustomizedAddress),
@@ -650,9 +669,10 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 
 	mailboxAuditBypassAssociations := []any{}
 	var mailboxAuditBypassAssociationErr error
-	for _, assoc := range report.MailboxAuditBypassAssociation {
+	for i, assoc := range report.MailboxAuditBypassAssociation {
 		mql, err := CreateResource(r.MqlRuntime, "ms365.exchangeonlineMailboxAuditBypassAssociation",
 			map[string]*llx.RawData{
+				"__id":               llx.StringData(exchangeEntryID("mailboxAuditBypassAssociation", assoc.Name, i)),
 				"name":               llx.StringData(assoc.Name),
 				"auditBypassEnabled": llx.BoolData(assoc.AuditBypassEnabled),
 			})

--- a/providers/ms365/resources/ms365_exchange_ids_test.go
+++ b/providers/ms365/resources/ms365_exchange_ids_test.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExchangeEntryID(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		identity string
+		index    int
+		want     string
+	}{
+		{"identity wins", "teamsProtectionPolicy", "Default", 0, "teamsProtectionPolicy-Default"},
+		{"identity used regardless of index", "reportSubmissionPolicy", "Default", 7, "reportSubmissionPolicy-Default"},
+		{"empty identity falls back to index", "mailboxAuditBypassAssociation", "", 0, "mailboxAuditBypassAssociation-#0"},
+		{"fallback stays distinct per row", "mailboxAuditBypassAssociation", "", 168, "mailboxAuditBypassAssociation-#168"},
+		{"prefix always present", "hostedConnectionFilterPolicy", "", 0, "hostedConnectionFilterPolicy-#0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, exchangeEntryID(tc.prefix, tc.identity, tc.index))
+		})
+	}
+}
+
+// The whole point of the id builder is that no two rows of one collection can
+// share a cache key -- CreateResource is first-wins, so a shared key silently
+// discards every row after the first. Cover both the normal case (distinct
+// identities) and the degenerate one (no identity at all), which is what
+// produced 169 identical mailbox audit-bypass rows before the fix.
+func TestExchangeEntryIDIsUniquePerRow(t *testing.T) {
+	t.Run("distinct identities", func(t *testing.T) {
+		identities := []string{"svc-backup", "svc-journal", "admin-break-glass"}
+		seen := map[string]bool{}
+		for i, id := range identities {
+			key := exchangeEntryID("mailboxAuditBypassAssociation", id, i)
+			assert.False(t, seen[key], "duplicate cache key %q", key)
+			seen[key] = true
+		}
+		assert.Len(t, seen, len(identities))
+	})
+
+	t.Run("no identity at all", func(t *testing.T) {
+		seen := map[string]bool{}
+		for i := 0; i < 169; i++ {
+			key := exchangeEntryID("mailboxAuditBypassAssociation", "", i)
+			assert.False(t, seen[key], "duplicate cache key %q at row %d", key, i)
+			seen[key] = true
+		}
+		assert.Len(t, seen, 169, "every row must get its own cache key")
+	})
+
+	t.Run("prefixes keep resource types apart", func(t *testing.T) {
+		assert.NotEqual(t,
+			exchangeEntryID("teamsProtectionPolicy", "Default", 0),
+			exchangeEntryID("reportSubmissionPolicy", "Default", 0),
+			"two resource types sharing an Identity must not share a key")
+	})
+}
+
+// Identity is what the id builder keys on, so the struct tag that feeds it has
+// to match the wire shape. Exchange emits PascalCase from both the REST
+// InvokeCommand path and PowerShell's ConvertTo-Json.
+func TestExchangePolicyIdentityDecodes(t *testing.T) {
+	t.Run("teams protection policy", func(t *testing.T) {
+		var p TeamsProtectionPolicy
+		require.NoError(t, json.Unmarshal([]byte(`{"Identity":"Teams Protection Policy","ZapEnabled":true,"IsValid":true}`), &p))
+		assert.Equal(t, "Teams Protection Policy", p.Identity)
+		assert.True(t, p.ZapEnabled)
+	})
+
+	t.Run("report submission policy", func(t *testing.T) {
+		var p ReportSubmissionPolicy
+		require.NoError(t, json.Unmarshal([]byte(`{"Identity":"DefaultReportSubmissionPolicy","EnableReportToMicrosoft":true}`), &p))
+		assert.Equal(t, "DefaultReportSubmissionPolicy", p.Identity)
+		assert.True(t, p.EnableReportToMicrosoft)
+	})
+
+	t.Run("absent identity leaves the fallback to take over", func(t *testing.T) {
+		var p TeamsProtectionPolicy
+		require.NoError(t, json.Unmarshal([]byte(`{"ZapEnabled":false}`), &p))
+		assert.Empty(t, p.Identity)
+		assert.Equal(t, "teamsProtectionPolicy-#3", exchangeEntryID("teamsProtectionPolicy", p.Identity, 3))
+	})
+}

--- a/providers/ms365/resources/ms365_exchange_ids_test.go
+++ b/providers/ms365/resources/ms365_exchange_ids_test.go
@@ -65,6 +65,17 @@ func TestExchangeEntryIDIsUniquePerRow(t *testing.T) {
 			exchangeEntryID("reportSubmissionPolicy", "Default", 0),
 			"two resource types sharing an Identity must not share a key")
 	})
+
+	// externalSender and exoMailbox are both keyed on an Exchange Identity and
+	// are built from the same report, so a mailbox and a sender that share one
+	// must still land on different keys.
+	t.Run("externalSender and exoMailbox do not collide", func(t *testing.T) {
+		const identity = "shared@example.com"
+		assert.NotEqual(t,
+			exchangeEntryID("externalSender", identity, 0),
+			exchangeEntryID("exoMailbox", identity, 0),
+			"a sender and a mailbox sharing an Identity must not share a key")
+	})
 }
 
 // Identity is what the id builder keys on, so the struct tag that feeds it has

--- a/providers/ms365/resources/security_exchange.go
+++ b/providers/ms365/resources/security_exchange.go
@@ -106,6 +106,8 @@ func (r *mqlMicrosoftSecurityExchangeAntispam) hostedConnectionFilterPolicy() (*
 
 	resource, err := CreateResource(r.MqlRuntime, ResourceMicrosoftSecurityExchangeAntispamHostedConnectionFilterPolicy,
 		map[string]*llx.RawData{
+			// Singular resource: always fetched with -Identity Default, so the
+			// index fallback can never fire and 0 is a constant.
 			"__id":             llx.StringData(exchangeEntryID("hostedConnectionFilterPolicy", policy.Identity, 0)),
 			"identity":         llx.StringData(policy.Identity),
 			"adminDisplayName": llx.StringData(policy.AdminDisplayName),

--- a/providers/ms365/resources/security_exchange.go
+++ b/providers/ms365/resources/security_exchange.go
@@ -106,6 +106,7 @@ func (r *mqlMicrosoftSecurityExchangeAntispam) hostedConnectionFilterPolicy() (*
 
 	resource, err := CreateResource(r.MqlRuntime, ResourceMicrosoftSecurityExchangeAntispamHostedConnectionFilterPolicy,
 		map[string]*llx.RawData{
+			"__id":             llx.StringData(exchangeEntryID("hostedConnectionFilterPolicy", policy.Identity, 0)),
 			"identity":         llx.StringData(policy.Identity),
 			"adminDisplayName": llx.StringData(policy.AdminDisplayName),
 			"ipAllowList":      llx.ArrayData(convert.SliceAnyToInterface(policy.IPAllowList), types.String),


### PR DESCRIPTION
## Problem

Four Exchange resources are created with **no `__id` argument and no `id()` method**, so their cache key is the empty string:

- `ms365.exchangeonlineMailboxAuditBypassAssociation`
- `ms365.exchangeonline.teamsProtectionPolicy`
- `ms365.exchangeonline.reportSubmissionPolicy`
- `microsoft.security.exchange.antispam.hostedConnectionFilterPolicy`

`CreateResource` is first-wins on `resourceName + "\x00" + __id`:

```go
id := name + "\x00" + res.MqlID()
if x, ok := runtime.Resources.Get(id); ok {
    return x, nil          // second and later rows get the FIRST one back
}
```

So every instance after the first is discarded and the loop appends the same pointer again.

## Impact — live-reproduced

On a test tenant with **169** mailbox audit-bypass associations, all 169 rows returned the *same* record:

```
ms365.exchangeonline.mailboxAuditBypassAssociation.length: 169
  0: { name: "<same record>" auditBypassEnabled: false }
  1: { name: "<same record>" auditBypassEnabled: false }
  2: { name: "<same record>" auditBypassEnabled: false }   … all 169 identical
```

An audit asserting `mailboxAuditBypassAssociation.none(auditBypassEnabled)` **passes** while 168 accounts were never shown — exactly the condition the resource exists to detect.

The other three are single-object cmdlets in practice, so their impact is latent rather than active, but it is the same defect and they are fixed together.

## Fix

Key each row on its Exchange `Identity`, matching the convention every other policy resource in this package already uses (`"transportRule-" + Identity`, `"antiPhishPolicy-" + Identity`, …), through a shared `exchangeEntryID` helper.

The helper falls back to the row's position when a cmdlet shape carries no `Identity`, so a missing `Identity` can never collapse a collection again. `TeamsProtectionPolicy` and `ReportSubmissionPolicy` did not decode `Identity` at all, so both structs gain the field.

None of these resources declares a public `id` field, so the keys stay synthetic and hidden per the `__id` guidance in CLAUDE.md.

## Verification

Same tenant, after the fix:

```
total rows          : 169
DISTINCT names      : 169     (was 1)
bypass-enabled rows : 0
```

Every row now carries its own identity; previously all 169 rendered the first
record. Identities are omitted here deliberately -- this repo is public.

## Tests

`resources/ms365_exchange_ids_test.go`:

- `TestExchangeEntryID` — identity wins, index fallback, prefix always present.
- `TestExchangeEntryIDIsUniquePerRow` — the invariant that matters: no two rows of one collection share a key, covering distinct identities, the degenerate no-identity case across 169 rows, and two resource types sharing an `Identity`.
- `TestExchangePolicyIdentityDecodes` — pins the new `Identity` struct tags against the PascalCase shape both the REST `InvokeCommand` path and PowerShell's `ConvertTo-Json` emit.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] `gofmt` clean
- [x] `make providers/build/ms365` succeeds
- [x] Live-verified against a tenant with 169 audit-bypass associations


