### PR TITLE
🐛 ms365: stop every user's license resolving to one shared object

### DIFF
--- a/providers/ms365/resources/users.go
+++ b/providers/ms365/resources/users.go
@@ -252,6 +252,17 @@ func (a *mqlMicrosoftUser) microsoftParent() (*mqlMicrosoft, error) {
 	return resource.(*mqlMicrosoft), nil
 }
 
+// userAssignedLicenseID is the cache key for a microsoft.user.assignedLicense.
+//
+// The SKU id alone does not identify the assignment. A license assignment only
+// exists in the context of one user, and disabledPlans varies per user for the
+// same SKU, so keying on the SKU makes every user holding it share one cache
+// entry. CreateResource is first-wins, so the first user's disabledPlans would
+// then be reported for everyone else on that SKU. The key carries both.
+func userAssignedLicenseID(userID, skuID string) string {
+	return userID + "/" + skuID
+}
+
 func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicrosoftUser, error) {
 	identities := []any{}
 	uid := convert.ToValue(u.GetId())
@@ -287,7 +298,7 @@ func newMqlMicrosoftUser(runtime *plugin.Runtime, u models.Userable) (*mqlMicros
 
 			mqlAssignedLicenses, err := CreateResource(runtime, "microsoft.user.assignedLicense",
 				map[string]*llx.RawData{
-					"__id":          llx.StringData(skuId),
+					"__id":          llx.StringData(userAssignedLicenseID(uid, skuId)),
 					"disabledPlans": llx.ArrayData(convert.SliceAnyToInterface(disabledPlanStrings), types.String),
 					"skuId":         llx.StringData(skuId),
 				})

--- a/providers/ms365/resources/users_assignedlicense_test.go
+++ b/providers/ms365/resources/users_assignedlicense_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserAssignedLicenseID(t *testing.T) {
+	tests := []struct {
+		name   string
+		userID string
+		skuID  string
+		want   string
+	}{
+		{"user and sku", "user-1", "sku-a", "user-1/sku-a"},
+		{"empty sku still scoped to the user", "user-1", "", "user-1/"},
+		{"empty user still scoped to the sku", "", "sku-a", "/sku-a"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, userAssignedLicenseID(tc.userID, tc.skuID))
+		})
+	}
+}
+
+// The defect this key fixes: two users holding the same SKU produced the same
+// cache key, so CreateResource returned the first user's resource for the
+// second and its disabledPlans were reported for both. Assert the two
+// dimensions that must stay independent.
+func TestUserAssignedLicenseIDDistinguishesUsersAndSkus(t *testing.T) {
+	t.Run("same sku, different users", func(t *testing.T) {
+		alice := userAssignedLicenseID("alice", "ENTERPRISEPACK")
+		bob := userAssignedLicenseID("bob", "ENTERPRISEPACK")
+		assert.NotEqual(t, alice, bob,
+			"two users on the same SKU must not share a cache key")
+	})
+
+	t.Run("same user, different skus", func(t *testing.T) {
+		e3 := userAssignedLicenseID("alice", "ENTERPRISEPACK")
+		ems := userAssignedLicenseID("alice", "EMS")
+		assert.NotEqual(t, e3, ems,
+			"one user's two licenses must not share a cache key")
+	})
+
+	t.Run("a whole tenant of shared skus stays distinct", func(t *testing.T) {
+		const sku = "ENTERPRISEPACK"
+		users := []string{"alice", "bob", "carol", "dave", "erin"}
+		seen := map[string]bool{}
+		for _, u := range users {
+			key := userAssignedLicenseID(u, sku)
+			assert.False(t, seen[key], "duplicate cache key %q", key)
+			seen[key] = true
+		}
+		assert.Len(t, seen, len(users))
+	})
+
+	t.Run("the key is stable for the same pair", func(t *testing.T) {
+		assert.Equal(t,
+			userAssignedLicenseID("alice", "ENTERPRISEPACK"),
+			userAssignedLicenseID("alice", "ENTERPRISEPACK"),
+			"the same user and SKU must resolve to one cached resource")
+	})
+}


### PR DESCRIPTION
## Problem

`microsoft.user.assignedLicense` is keyed on the SKU GUID alone:

```go
"__id":          llx.StringData(skuId),
"disabledPlans": llx.ArrayData(...),
"skuId":         llx.StringData(skuId),
```

A license assignment only exists in the context of one user, and `disabledPlans` varies per user for the same SKU. `CreateResource` is first-wins on `resourceName + "\x00" + __id`, and `createMicrosoftUserAssignedLicense` has no `id()` fallback, so the explicit `__id` is the whole key — every user holding the same SKU collapses into one cached instance.

## Impact

Whichever user is materialized first supplies `disabledPlans` for everyone else on that SKU.

A tenant where Alice has `ENTERPRISEPACK` with `YAMMER_ENTERPRISE` and `SWAY` disabled, and Bob has the same `ENTERPRISEPACK` with nothing disabled, reports **Alice's** disabled-plan list on Bob's record and on every other E3 user. An audit such as "no licensed user has Exchange Online disabled" reads one user's state and reports it for the whole tenant. Nothing errors.

## Fix

Key on the user id and the SKU together, via a small `userAssignedLicenseID` helper that documents why both dimensions are required. The key stays synthetic and hidden (no public `id` field); `skuId` remains a public field.

## Tests

`resources/users_assignedlicense_test.go`:

- `TestUserAssignedLicenseID` — key shape, including the empty-component cases.
- `TestUserAssignedLicenseIDDistinguishesUsersAndSkus` — the invariants that matter: two users on the same SKU never share a key, one user's two licenses never share a key, a tenant of users on one shared SKU stays fully distinct, and the key is stable for the same pair (so one user's license still resolves to a single cached resource).

## Verification

Live-checked against the ms365 test tenant: 25 users, 21 license assignments before and after the change — no regression.

The wrong-data case could **not** be reproduced there: all 21 users hold the same SKU and every one has an empty `disabledPlans`, so the aliased objects render identically and the defect is invisible in output on that tenant. Demonstrating it live needs a tenant where two users on one SKU have different service plans disabled. The defect itself is not in doubt — it follows from the first-wins cache lookup and the key omitting the user — but flagging honestly that the live check confirms non-regression, not the fix's effect.

## Related

`microsoft.settingValue` (`settings.go`) has the identical defect — keyed on the bare setting name, so `AllowToAddGuests` aliases between the `Group.Unified` and `Group.Unified.Guest` templates. Not touched here to keep this PR to the license fix.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] `gofmt` clean
- [x] `make providers/build/ms365` succeeds
- [x] Live-checked for non-regression (21 assignments unchanged)
- [ ] Wrong-data case needs a tenant with differing `disabledPlans`
