### PR TITLE
🐛 ms365: resolve the principal name on role assignments

### DIFF
--- a/providers/ms365/go.mod
+++ b/providers/ms365/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/microsoft/kiota-abstractions-go v1.9.4
 	github.com/microsoft/kiota-authentication-azure-go v1.3.1
+	github.com/microsoft/kiota-serialization-json-go v1.1.4
 	github.com/microsoftgraph/msgraph-beta-sdk-go v0.165.0
 	github.com/microsoftgraph/msgraph-sdk-go v1.101.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.1
@@ -76,7 +77,6 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/microsoft/kiota-http-go v1.5.6 // indirect
 	github.com/microsoft/kiota-serialization-form-go v1.1.3 // indirect
-	github.com/microsoft/kiota-serialization-json-go v1.1.4 // indirect
 	github.com/microsoft/kiota-serialization-multipart-go v1.1.2 // indirect
 	github.com/microsoft/kiota-serialization-text-go v1.1.3 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/providers/ms365/resources/structs.go
+++ b/providers/ms365/resources/structs.go
@@ -235,6 +235,14 @@ func directoryObjectDisplayName(additionalData map[string]any) string {
 	return ""
 }
 
+// displayNamer matches every concrete directory type the Graph discriminator
+// produces that carries a typed displayName -- user, group, servicePrincipal,
+// device and so on. Matching on the accessor rather than enumerating the types
+// keeps this working when a principal turns out to be a kind we did not list.
+type displayNamer interface {
+	GetDisplayName() *string
+}
+
 // directoryPrincipalInfo derives the short principal type (e.g. "user",
 // "group", "servicePrincipal") and display name for a directory principal,
 // such as the assignee on a role assignment. Both values are best-effort and
@@ -246,7 +254,20 @@ func directoryPrincipalInfo(p models.DirectoryObjectable) (principalType string,
 	if t := normalizeOwnerType(p.GetOdataType()); t != nil {
 		principalType = *t
 	}
-	principalName = directoryObjectDisplayName(p.GetAdditionalData())
+	// An $expand-ed principal is deserialized through the discriminator, which
+	// builds a concrete type (*models.User, *models.Group, ...) where
+	// displayName is a typed property and so never reaches AdditionalData --
+	// leaving the bag empty and the name blank. Read the typed accessor first
+	// and keep the bag as the fallback for a bare DirectoryObject, which has no
+	// typed displayName at all.
+	if named, ok := p.(displayNamer); ok {
+		if n := named.GetDisplayName(); n != nil {
+			principalName = *n
+		}
+	}
+	if principalName == "" {
+		principalName = directoryObjectDisplayName(p.GetAdditionalData())
+	}
 	return principalType, principalName
 }
 

--- a/providers/ms365/resources/structs_test.go
+++ b/providers/ms365/resources/structs_test.go
@@ -6,8 +6,10 @@ package resources
 import (
 	"testing"
 
+	kjson "github.com/microsoft/kiota-serialization-json-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Guards against the inverted nil-check the function used to carry —
@@ -68,4 +70,75 @@ func TestDirectoryPrincipalInfo(t *testing.T) {
 		assert.Empty(t, pt)
 		assert.Empty(t, pn)
 	})
+
+	t.Run("typed principal reads its typed displayName", func(t *testing.T) {
+		u := models.NewUser()
+		u.SetOdataType(ptr("#microsoft.graph.user"))
+		u.SetDisplayName(ptr("Alice Admin"))
+		pt, pn := directoryPrincipalInfo(u)
+		assert.Equal(t, "user", pt)
+		assert.Equal(t, "Alice Admin", pn)
+	})
+}
+
+// The role-assignment request uses $expand=principal, so the SDK deserializes
+// the principal through CreateDirectoryObjectFromDiscriminatorValue and builds
+// a concrete *models.User whose displayName is a TYPED property. It therefore
+// never lands in AdditionalData.
+//
+// A fixture built with models.NewDirectoryObject() + SetAdditionalData is a
+// shape production never produces, so a test using one passes while the real
+// path returns "". Decode the actual payload instead.
+func TestDirectoryPrincipalInfoFromExpandedPrincipal(t *testing.T) {
+	const payload = `{
+	  "id": "ra-1",
+	  "principalId": "u-1",
+	  "principal": {
+	    "@odata.type": "#microsoft.graph.user",
+	    "id": "u-1",
+	    "displayName": "Alice Admin",
+	    "userPrincipalName": "alice@contoso.com"
+	  }
+	}`
+
+	node, err := kjson.NewJsonParseNode([]byte(payload))
+	require.NoError(t, err)
+	parsed, err := node.GetObjectValue(models.CreateUnifiedRoleAssignmentFromDiscriminatorValue)
+	require.NoError(t, err)
+
+	principal := parsed.(models.UnifiedRoleAssignmentable).GetPrincipal()
+	require.NotNil(t, principal)
+	assert.IsType(t, &models.User{}, principal, "the discriminator builds a concrete type")
+	assert.Empty(t, principal.GetAdditionalData(),
+		"displayName is typed on *models.User, so AdditionalData is empty -- this is why the bag read failed")
+
+	pt, pn := directoryPrincipalInfo(principal)
+	assert.Equal(t, "user", pt)
+	assert.Equal(t, "Alice Admin", pn)
+}
+
+// A group principal resolves the same way, through the shared accessor rather
+// than a per-type branch.
+func TestDirectoryPrincipalInfoFromExpandedGroup(t *testing.T) {
+	const payload = `{"@odata.type":"#microsoft.graph.group","id":"g-1","displayName":"Global Admins"}`
+
+	node, err := kjson.NewJsonParseNode([]byte(payload))
+	require.NoError(t, err)
+	parsed, err := node.GetObjectValue(models.CreateDirectoryObjectFromDiscriminatorValue)
+	require.NoError(t, err)
+
+	pt, pn := directoryPrincipalInfo(parsed.(models.DirectoryObjectable))
+	assert.Equal(t, "group", pt)
+	assert.Equal(t, "Global Admins", pn)
+}
+
+// A bare DirectoryObject has no typed displayName, so the AdditionalData
+// fallback must still work.
+func TestDirectoryPrincipalInfoFallsBackToAdditionalData(t *testing.T) {
+	p := models.NewDirectoryObject()
+	p.SetOdataType(ptr("#microsoft.graph.user"))
+	p.SetAdditionalData(map[string]any{"displayName": "Bare Object"})
+	pt, pn := directoryPrincipalInfo(p)
+	assert.Equal(t, "user", pt)
+	assert.Equal(t, "Bare Object", pn)
 }


### PR DESCRIPTION
## Problem

`microsoft.rolemanagement.roleassignment.principalName` is always `""`, on every tenant, while `principalType` on the same row resolves correctly.

The request uses `$expand=principal`, so the SDK deserializes the principal through `CreateDirectoryObjectFromDiscriminatorValue`, which builds a **concrete** type — `*models.User`, `*models.Group`, `*models.ServicePrincipal` — where `displayName` is a **typed property**. Kiota only routes properties that have *no* field deserializer into `AdditionalData`, so `displayName` never lands there.

`directoryPrincipalInfo` read the name out of that bag, so it always came back blank. Confirmed by decoding the exact payload Graph returns:

```
principal concrete type:   *models.User
principal AdditionalData:  map[string]interface{}{}     <- empty
typed displayName getter:  Alice Admin
provider result:  principalType="user"  principalName=""
```

## Impact

A privileged-role report renders a list of nameless principals. Any audit keyed on `principalName` — "which named accounts hold Global Administrator", `.where(principalName != "")` — matches nothing, and the empty result looks like a clean answer.

## Fix

Read the typed accessor through a small `displayNamer` interface, keeping the `AdditionalData` read as the fallback for a bare `DirectoryObject` (which genuinely has no typed `displayName`).

Matching on the accessor rather than enumerating `Userable` / `Groupable` / `ServicePrincipalable` means this keeps working when a principal turns out to be a kind we did not list — device, orgContact, and so on.

## Verification

Live-checked against a built-in admin role on the ms365 test tenant:

```
role assignments      : 7
with a principalName  : 7   (was 0 before the fix)
principalType present : 7
```

(Names themselves omitted — this repo is public.)

## Tests

The existing `TestDirectoryPrincipalInfo` passed over this bug: every case built a bare `models.NewDirectoryObject()` and hand-set `SetAdditionalData(map[string]any{"displayName": …})` — a shape the discriminator never produces when `@odata.type` is present.

- `TestDirectoryPrincipalInfoFromExpandedPrincipal` decodes the real `$expand=principal` payload, asserts the discriminator built a `*models.User`, asserts `AdditionalData` is empty (documenting *why* the old read failed), then asserts the name resolves.
- `TestDirectoryPrincipalInfoFromExpandedGroup` covers a group through the same shared accessor.
- `TestDirectoryPrincipalInfoFallsBackToAdditionalData` pins the bare-`DirectoryObject` fallback so the fix does not regress it.
- Both new decode tests **fail against the previous code** with `""` — verified by reverting the read and re-running.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] New tests fail against the pre-fix code (regression coverage verified)
- [x] `gofmt` clean, `go mod tidy` clean
- [x] `make providers/build/ms365` succeeds
- [x] Live-verified against a real role assignment set
