### PR TITLE
🐛 ms365: stop one unassignable role from failing the whole role inventory

### DIFF
--- a/providers/ms365/resources/errors.go
+++ b/providers/ms365/resources/errors.go
@@ -11,6 +11,46 @@ import (
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
 
+// graphErrorCode returns the Microsoft Graph error code carried by an
+// ODataError -- "Request_ResourceNotFound", "Authorization_RequestDenied" and
+// so on -- or "" when the error is not an ODataError or carries no code.
+// Both the v1 and the beta SDK model the payload separately, so both are
+// checked.
+func graphErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var betaOdataErr *betaodataerrors.ODataError
+	if errors.As(err, &betaOdataErr) && betaOdataErr != nil {
+		if payload := betaOdataErr.GetErrorEscaped(); payload != nil {
+			if code := payload.GetCode(); code != nil {
+				return *code
+			}
+		}
+	}
+
+	var oDataErr *odataerrors.ODataError
+	if errors.As(err, &oDataErr) && oDataErr != nil {
+		if payload := oDataErr.GetErrorEscaped(); payload != nil {
+			if code := payload.GetCode(); code != nil {
+				return *code
+			}
+		}
+	}
+
+	return ""
+}
+
+// isResourceNotFound reports whether Graph rejected the request because a
+// referenced directory object no longer exists. Graph raises this for the whole
+// request when an $expand cannot resolve one of its targets, so callers that
+// expand a reference need it to tell a dangling reference apart from a real
+// failure.
+func isResourceNotFound(err error) bool {
+	return graphErrorCode(err) == "Request_ResourceNotFound"
+}
+
 func transformError(err error) error {
 	var betaOdataErr *betaodataerrors.ODataError
 	if errors.As(err, &betaOdataErr) {

--- a/providers/ms365/resources/errors_test.go
+++ b/providers/ms365/resources/errors_test.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	betaodataerrors "github.com/microsoftgraph/msgraph-beta-sdk-go/models/odataerrors"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
+	"github.com/stretchr/testify/assert"
+)
+
+func odataErrWithCode(code string) *odataerrors.ODataError {
+	payload := odataerrors.NewMainError()
+	payload.SetCode(&code)
+	err := odataerrors.NewODataError()
+	err.SetErrorEscaped(payload)
+	return err
+}
+
+func betaODataErrWithCode(code string) *betaodataerrors.ODataError {
+	payload := betaodataerrors.NewMainError()
+	payload.SetCode(&code)
+	err := betaodataerrors.NewODataError()
+	err.SetErrorEscaped(payload)
+	return err
+}
+
+func TestGraphErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil error", nil, ""},
+		{"plain error", errors.New("boom"), ""},
+		{"v1 odata error", odataErrWithCode("Request_ResourceNotFound"), "Request_ResourceNotFound"},
+		{"beta odata error", betaODataErrWithCode("Request_ResourceNotFound"), "Request_ResourceNotFound"},
+		{"other v1 code", odataErrWithCode("Authorization_RequestDenied"), "Authorization_RequestDenied"},
+		{"wrapped odata error", fmt.Errorf("fetching assignments: %w", odataErrWithCode("Request_ResourceNotFound")), "Request_ResourceNotFound"},
+		{"odata error with no payload", odataerrors.NewODataError(), ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, graphErrorCode(tc.err))
+		})
+	}
+}
+
+// The classifier gates a retry, so it must not fire on a transport failure --
+// retrying without $expand would silently drop the principal detail from every
+// assignment on what is really a network problem.
+func TestIsResourceNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"v1 resource not found", odataErrWithCode("Request_ResourceNotFound"), true},
+		{"beta resource not found", betaODataErrWithCode("Request_ResourceNotFound"), true},
+		{"wrapped resource not found", fmt.Errorf("wrapped: %w", odataErrWithCode("Request_ResourceNotFound")), true},
+		{"permission denied is not a missing resource", odataErrWithCode("Authorization_RequestDenied"), false},
+		{"throttling is not a missing resource", odataErrWithCode("TooManyRequests"), false},
+		{"transport error is not a missing resource", &net.DNSError{Err: "no such host"}, false},
+		{"plain error", errors.New("Request_ResourceNotFound"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isResourceNotFound(tc.err))
+		})
+	}
+}

--- a/providers/ms365/resources/rolemanagement.go
+++ b/providers/ms365/resources/rolemanagement.go
@@ -231,6 +231,19 @@ func (a *mqlMicrosoftRolemanagementRoledefinition) assignments() ([]any, error) 
 	ctx := context.Background()
 	resp, err := graphClient.RoleManagement().Directory().RoleAssignments().Get(ctx, requestConfig)
 	if err != nil {
+		// Graph answers Request_ResourceNotFound when the role definition has
+		// no directory role behind it to hold assignments. Several built-in
+		// definitions are templates a tenant never instantiates, and they are
+		// returned by roleDefinitions all the same, so this is reachable on
+		// every tenant. It means "this role has no assignments to enumerate",
+		// not "the request failed" -- and returning the error would fail the
+		// caller's whole role list, since assignments is resolved per role.
+		if isResourceNotFound(err) {
+			log.Debug().
+				Str("roleDefinitionId", roleDefinitionId).
+				Msg("ms365> role definition has no assignable directory role; reporting no assignments")
+			return []any{}, nil
+		}
 		return nil, transformError(err)
 	}
 	roleAssignments, err := iterate[models.UnifiedRoleAssignmentable](ctx, resp, graphClient.GetAdapter(), models.CreateUnifiedRoleAssignmentCollectionResponseFromDiscriminatorValue)


### PR DESCRIPTION
## Problem

`microsoft.roles.list { assignments }` fails outright — the whole query returns nothing on a tenant with 145 role definitions.

`/roleManagement/directory/roleDefinitions` returns every built-in definition, including templates a tenant never instantiates as a directory role. Filtering `roleAssignments` by such a definition's id makes Graph answer `Request_ResourceNotFound` rather than an empty collection.

`assignments` is resolved per role definition, so that single error fails the caller's entire list.

## Note on the original diagnosis

This was first reported as *"one deleted principal kills the role inventory"*, on the theory that `$expand=principal` was failing over a dangling reference. **That turned out to be wrong.** Instrumenting the retry showed the id Graph rejects is the **role definition's own id**, not a principal's — and a retry without the expansion failed identically. The role it fires on is a built-in definition, so this is reachable on any tenant rather than depending on offboarding history.

## Impact

The highest-value security query in the provider — who holds which directory role — returns nothing, with a message that names a GUID and nothing else. The failure is not tenant-specific.

## Fix

Treat `Request_ResourceNotFound` on that lookup as "this role has no assignments to enumerate" and return an empty list. Every other error is still surfaced.

Adds a shared `graphErrorCode` helper next to `transformError`, covering the v1 and beta `ODataError` payloads and wrapped errors, plus an `isResourceNotFound` predicate over it.

## Verification

Same tenant, after the fix:

```
roles returned          : 145     <- the whole query failed before
roles with assignments  : 11
assignments returned    : 29
```

## Tests

`resources/errors_test.go`:

- `TestGraphErrorCode` — v1 and beta payloads, wrapped errors, a payload-less `ODataError`, a plain error, nil.
- `TestIsResourceNotFound` — the predicate gates a **degradation**, so the important cases are the negatives: it must not match `Authorization_RequestDenied`, `TooManyRequests`, or a transport error. Degrading on any of those would report an empty assignment list for a role that genuinely has assignments, which is exactly the silent-wrong-answer failure this PR is meant to avoid.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] `gofmt` clean
- [x] `make providers/build/ms365` succeeds
- [x] Live-verified: 145 roles and 29 assignments returned where the query previously failed
