### PR TITLE
🐛 ms365: populate serviceprincipal.termsOfServiceUrl instead of leaving it unset

### DIFF
--- a/providers/ms365/resources/serviceprincipals.go
+++ b/providers/ms365/resources/serviceprincipals.go
@@ -196,10 +196,10 @@ var servicePrincipalFields = []string{
 	"logoutUrl",
 	"servicePrincipalNames",
 	"signInAudience",
+	// sources termsOfServiceUrl; omitting it leaves that field unset, not null
+	"info",
 	"preferredSingleSignOnMode",
 	"notificationEmailAddresses",
-	"appRoleAssignmentRequired",
-	"accountEnabled",
 	"verifiedPublisher",
 	"appRoles",
 	"oauth2PermissionScopes",
@@ -433,10 +433,17 @@ func newMqlMicrosoftServicePrincipal(runtime *plugin.Runtime, sp models.ServiceP
 		"passwordCredentials":        llx.ArrayData(secrets, types.Resource("microsoft.passwordCredential")),
 		"oauth2PermissionScopes":     llx.ArrayData(oauth2PermissionScopes, types.Dict),
 	}
-	info := sp.GetInfo()
-	if info != nil {
-		args["termsOfServiceUrl"] = llx.StringDataPtr(info.GetTermsOfServiceUrl())
+	// Set unconditionally. A CreateResource arg map must never omit a declared
+	// field: an omitted key leaves the field UNSET rather than null, and an
+	// unset field crosses the plugin boundary as an empty DataRes that surfaces
+	// client-side as "encountered a primitive with no type information", with
+	// no attribution back to the field.
+	var termsOfServiceUrl *string
+	if info := sp.GetInfo(); info != nil {
+		termsOfServiceUrl = info.GetTermsOfServiceUrl()
 	}
+	args["termsOfServiceUrl"] = llx.StringDataPtr(termsOfServiceUrl)
+
 	mqlResource, err := CreateResource(runtime, "microsoft.serviceprincipal", args)
 	if err != nil {
 		return nil, err

--- a/providers/ms365/resources/serviceprincipals_test.go
+++ b/providers/ms365/resources/serviceprincipals_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// servicePrincipalSourcedProperties maps a Graph property that must appear in
+// the $select list to the microsoft.serviceprincipal field it populates.
+//
+// $select restricts the payload, so a field the creator reads out of a property
+// that was not selected reads as absent forever. When that read is also
+// conditional, the arg key is skipped entirely and the MQL field ends up UNSET
+// rather than null -- which surfaces to the user as "encountered a primitive
+// with no type information" with no attribution. termsOfServiceUrl shipped that
+// way because "info" was missing here.
+var servicePrincipalSourcedProperties = map[string]string{
+	"info":              "termsOfServiceUrl",
+	"verifiedPublisher": "verifiedPublisher",
+	"appRoles":          "appRoles",
+	"appId":             "appId",
+	"displayName":       "name",
+}
+
+func TestServicePrincipalFieldsCoverSourcedProperties(t *testing.T) {
+	selected := make(map[string]bool, len(servicePrincipalFields))
+	for _, f := range servicePrincipalFields {
+		selected[f] = true
+	}
+	for property, field := range servicePrincipalSourcedProperties {
+		assert.Truef(t, selected[property],
+			"$select is missing %q, which sources microsoft.serviceprincipal.%s; "+
+				"Graph will omit it and the field will never resolve", property, field)
+	}
+}
+
+// A duplicated entry is harmless on the wire but signals the list is being
+// edited without being read, which is how "info" went missing in the first
+// place.
+func TestServicePrincipalFieldsHasNoDuplicates(t *testing.T) {
+	seen := map[string]int{}
+	for _, f := range servicePrincipalFields {
+		seen[f]++
+	}
+	for f, n := range seen {
+		assert.Equalf(t, 1, n, "servicePrincipalFields lists %q %d times", f, n)
+	}
+}


### PR DESCRIPTION
## Problem

`microsoft.serviceprincipal.termsOfServiceUrl` is never set — not null, **unset** — on every service principal, on every tenant.

`"info"` is missing from `servicePrincipalFields`, so `$select` strips it from the response and `sp.GetInfo()` always returns nil. The creator only added the arg inside that nil check:

```go
info := sp.GetInfo()
if info != nil {
    args["termsOfServiceUrl"] = llx.StringDataPtr(info.GetTermsOfServiceUrl())
}
```

so the key was never added and `SetAllData` never touched the field.

## Impact

An unset field crosses the plugin boundary as an empty `DataRes`. The client reports:

```
x provider returned no data and no error for a field; the field was never set
  on the resource (provider bug) field=termsOfServiceUrl resource=microsoft.serviceprincipal
x llx: encountered a primitive with no type information, coercing to null
```

The runtime literally labels it a provider bug. Every `microsoft.serviceprincipals { … termsOfServiceUrl }` query hits it, with no attribution beyond the field name.

## Fix

- Add `"info"` to the `$select` list.
- Set the arg **unconditionally**, so a service principal with no `info` object reads as *null* rather than *unset*. A `CreateResource` arg map must never conditionally omit a declared field.
- Drop two entries that were duplicated in the select list.

## Verification

Live-checked: the diagnostic is gone, and a service principal that publishes a terms-of-service URL now reports it, where all 227 previously read unset.

```
microsoft.serviceprincipals.length                              : 227
microsoft.serviceprincipals.where(termsOfServiceUrl != null).length : 1
```

## Tests

`resources/serviceprincipals_test.go`, in the shape of the existing `TestUserSelectFieldsCoverJobContactFields`:

- `TestServicePrincipalFieldsCoverSourcedProperties` — asserts every Graph property the creator reads is actually in the `$select` list, keyed to the MQL field it populates. This is the guard that was missing: it catches `$select` drift for the whole resource, not just this one field.
- `TestServicePrincipalFieldsHasNoDuplicates` — a duplicate is harmless on the wire but signals the list is being edited without being read, which is how `info` went missing.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] `gofmt` clean
- [x] `make providers/build/ms365` succeeds
- [x] Live-verified: diagnostic gone, real value surfaced
