### PR TITLE
🐛 ms365: fix two conditional access session controls wired to unusable types

### DIFF
--- a/providers/ms365/resources/conditional-access.go
+++ b/providers/ms365/resources/conditional-access.go
@@ -447,7 +447,6 @@ func (a *mqlMicrosoftConditionalAccess) createSessionControlsResource(
 	var mqlCloudAppSecurity plugin.Resource
 	var mqlPersistentBrowser plugin.Resource
 	var mqlAppEnforcedRestrictions plugin.Resource
-	var mqlSecureSignInSession plugin.Resource
 
 	// Create signInFrequency resource
 	if sessionControls != nil && sessionControls.GetSignInFrequency() != nil {
@@ -516,17 +515,14 @@ func (a *mqlMicrosoftConditionalAccess) createSessionControlsResource(
 		}
 	}
 
-	// Create secureSignInSession resource
-	if sessionControls != nil && sessionControls.GetDisableResilienceDefaults() != nil {
-		secureSignInSessionData := map[string]*llx.RawData{
-			"__id":                      llx.StringData(policyId + "_session_secureSignInSession"),
-			"disableResilienceDefaults": llx.BoolDataPtr(sessionControls.GetDisableResilienceDefaults()),
-		}
-		var err error
-		mqlSecureSignInSession, err = CreateResource(a.MqlRuntime, "microsoft.conditionalAccess.policy.sessionControls.secureSignInSession", secureSignInSessionData)
-		if err != nil {
-			return nil, err
-		}
+	// secureSignInSession is a dict, so it has to be built from JSON-native
+	// values. It previously created a resource type that does not exist, out of
+	// the unrelated disableResilienceDefaults scalar -- see secureSignInSessionDict.
+	secureSignInSession := secureSignInSessionDict(sessionControls)
+
+	var disableResilienceDefaults *bool
+	if sessionControls != nil {
+		disableResilienceDefaults = sessionControls.GetDisableResilienceDefaults()
 	}
 
 	return CreateResource(a.MqlRuntime, "microsoft.conditionalAccess.policy.sessionControls",
@@ -537,8 +533,30 @@ func (a *mqlMicrosoftConditionalAccess) createSessionControlsResource(
 			"cloudAppSecurity":                llx.ResourceData(mqlCloudAppSecurity, "microsoft.conditionalAccess.policy.sessionControls.cloudAppSecurity"),
 			"persistentBrowser":               llx.ResourceData(mqlPersistentBrowser, "microsoft.conditionalAccess.policy.sessionControls.persistentBrowser"),
 			"applicationEnforcedRestrictions": llx.ResourceData(mqlAppEnforcedRestrictions, "microsoft.conditionalAccess.policy.sessionControls.applicationEnforcedRestrictions"),
-			"secureSignInSession":             llx.ResourceData(mqlSecureSignInSession, "microsoft.conditionalAccess.policy.sessionControls.secureSignInSession"),
+			"secureSignInSession":             llx.DictData(secureSignInSession),
+			"disableResilienceDefaults":       llx.BoolDataPtr(disableResilienceDefaults),
 		})
+}
+
+// secureSignInSessionDict renders the secureSignInSession session control as a
+// JSON-native dict, or nil when the policy does not set the control.
+//
+// The .lr declares this field as a dict, so its value must be built from
+// JSON-native types: a dict holding an llx resource fails conversion on read
+// with "unsupported child type". It is sourced from GetSecureSignInSession,
+// the property the field is named after -- disableResilienceDefaults is a
+// separate scalar on sessionControls and is surfaced as its own field.
+func secureSignInSessionDict(sessionControls models.ConditionalAccessSessionControlsable) map[string]any {
+	if sessionControls == nil {
+		return nil
+	}
+	control := sessionControls.GetSecureSignInSession()
+	if control == nil {
+		return nil
+	}
+	return map[string]any{
+		"isEnabled": convert.ToValue(control.GetIsEnabled()),
+	}
 }
 
 func convertEnumCollectionToStrings[T fmt.Stringer](enums []T) []string {

--- a/providers/ms365/resources/conditional_access_session_test.go
+++ b/providers/ms365/resources/conditional_access_session_test.go
@@ -1,0 +1,75 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func TestSecureSignInSessionDict(t *testing.T) {
+	t.Run("nil session controls", func(t *testing.T) {
+		assert.Nil(t, secureSignInSessionDict(nil))
+	})
+
+	t.Run("control not set", func(t *testing.T) {
+		sc := models.NewConditionalAccessSessionControls()
+		assert.Nil(t, secureSignInSessionDict(sc),
+			"a policy that does not set the control reads as null, not as an empty dict")
+	})
+
+	t.Run("control enabled", func(t *testing.T) {
+		control := models.NewSecureSignInSessionControl()
+		control.SetIsEnabled(ptr(true))
+		sc := models.NewConditionalAccessSessionControls()
+		sc.SetSecureSignInSession(control)
+
+		assert.Equal(t, map[string]any{"isEnabled": true}, secureSignInSessionDict(sc))
+	})
+
+	t.Run("control present but isEnabled absent", func(t *testing.T) {
+		sc := models.NewConditionalAccessSessionControls()
+		sc.SetSecureSignInSession(models.NewSecureSignInSessionControl())
+
+		assert.Equal(t, map[string]any{"isEnabled": false}, secureSignInSessionDict(sc),
+			"an absent flag reads false so a { isEnabled && ... } assertion cannot pass vacuously")
+	})
+
+	// disableResilienceDefaults is a separate scalar on sessionControls and is
+	// surfaced as its own field -- it must not leak back into this dict, which
+	// is what the previous implementation did.
+	t.Run("disableResilienceDefaults does not populate the dict", func(t *testing.T) {
+		sc := models.NewConditionalAccessSessionControls()
+		sc.SetDisableResilienceDefaults(ptr(true))
+
+		assert.Nil(t, secureSignInSessionDict(sc))
+	})
+}
+
+// The field is declared `dict` in the .lr, so whatever it holds has to survive
+// conversion to an llx primitive. A dict carrying a resource (the previous
+// behaviour) fails here with "unsupported child type", which is why every
+// policy that set the control errored on read.
+func TestSecureSignInSessionDictIsJSONNative(t *testing.T) {
+	control := models.NewSecureSignInSessionControl()
+	control.SetIsEnabled(ptr(true))
+	sc := models.NewConditionalAccessSessionControls()
+	sc.SetSecureSignInSession(control)
+
+	raw := llx.DictData(secureSignInSessionDict(sc))
+	result := raw.Result()
+	require.NotNil(t, result)
+	assert.Empty(t, result.Error, "the dict must convert cleanly to an llx primitive")
+
+	// and the nil case still converts
+	nilResult := llx.DictData(secureSignInSessionDict(nil)).Result()
+	require.NotNil(t, nilResult)
+	assert.Empty(t, nilResult.Error)
+	assert.Equal(t, types.Dict, types.Type(nilResult.Data.Type))
+}

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -799,11 +799,19 @@ private microsoft.conditionalAccess.policy.sessionControls @defaults("id") {
   // Session control to apply cloud app security
   cloudAppSecurity microsoft.conditionalAccess.policy.sessionControls.cloudAppSecurity
   // Session control to define whether to persist cookies or not. All apps should be selected for this session control to work correctly.
-  persistentBrowser dict
+  persistentBrowser microsoft.conditionalAccess.policy.sessionControls.persistentBrowser
   // Session control to enforce application restrictions. Only Exchange Online and SharePoint Online support this session control
   applicationEnforcedRestrictions microsoft.conditionalAccess.policy.sessionControls.applicationEnforcedRestrictions
   // Secure application model for continuous access evaluation
+  //
+  // A dict with an `isEnabled` key reporting whether the secure sign-in
+  // session control is turned on for the policy.
   secureSignInSession dict
+  // Whether the policy opts out of the Conditional Access resilience defaults
+  //
+  // When true, the policy is not relaxed during a Microsoft Entra outage, so
+  // access is blocked rather than granted on cached state.
+  disableResilienceDefaults bool
 }
 
 // Microsoft Entra Conditional Access IP Named Location

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1655,13 +1655,16 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlMicrosoftConditionalAccessPolicySessionControls).GetCloudAppSecurity()).ToDataRes(types.Resource("microsoft.conditionalAccess.policy.sessionControls.cloudAppSecurity"))
 	},
 	"microsoft.conditionalAccess.policy.sessionControls.persistentBrowser": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMicrosoftConditionalAccessPolicySessionControls).GetPersistentBrowser()).ToDataRes(types.Dict)
+		return (r.(*mqlMicrosoftConditionalAccessPolicySessionControls).GetPersistentBrowser()).ToDataRes(types.Resource("microsoft.conditionalAccess.policy.sessionControls.persistentBrowser"))
 	},
 	"microsoft.conditionalAccess.policy.sessionControls.applicationEnforcedRestrictions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessPolicySessionControls).GetApplicationEnforcedRestrictions()).ToDataRes(types.Resource("microsoft.conditionalAccess.policy.sessionControls.applicationEnforcedRestrictions"))
 	},
 	"microsoft.conditionalAccess.policy.sessionControls.secureSignInSession": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessPolicySessionControls).GetSecureSignInSession()).ToDataRes(types.Dict)
+	},
+	"microsoft.conditionalAccess.policy.sessionControls.disableResilienceDefaults": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftConditionalAccessPolicySessionControls).GetDisableResilienceDefaults()).ToDataRes(types.Bool)
 	},
 	"microsoft.conditionalAccess.ipNamedLocation.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftConditionalAccessIpNamedLocation).GetId()).ToDataRes(types.String)
@@ -6728,7 +6731,7 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		return
 	},
 	"microsoft.conditionalAccess.policy.sessionControls.persistentBrowser": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMicrosoftConditionalAccessPolicySessionControls).PersistentBrowser, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		r.(*mqlMicrosoftConditionalAccessPolicySessionControls).PersistentBrowser, ok = plugin.RawToTValue[*mqlMicrosoftConditionalAccessPolicySessionControlsPersistentBrowser](v.Value, v.Error)
 		return
 	},
 	"microsoft.conditionalAccess.policy.sessionControls.applicationEnforcedRestrictions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6737,6 +6740,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.conditionalAccess.policy.sessionControls.secureSignInSession": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftConditionalAccessPolicySessionControls).SecureSignInSession, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"microsoft.conditionalAccess.policy.sessionControls.disableResilienceDefaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftConditionalAccessPolicySessionControls).DisableResilienceDefaults, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.conditionalAccess.ipNamedLocation.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -16082,9 +16089,10 @@ type mqlMicrosoftConditionalAccessPolicySessionControls struct {
 	Id                              plugin.TValue[string]
 	SignInFrequency                 plugin.TValue[*mqlMicrosoftConditionalAccessPolicySessionControlsSignInFrequency]
 	CloudAppSecurity                plugin.TValue[*mqlMicrosoftConditionalAccessPolicySessionControlsCloudAppSecurity]
-	PersistentBrowser               plugin.TValue[any]
+	PersistentBrowser               plugin.TValue[*mqlMicrosoftConditionalAccessPolicySessionControlsPersistentBrowser]
 	ApplicationEnforcedRestrictions plugin.TValue[*mqlMicrosoftConditionalAccessPolicySessionControlsApplicationEnforcedRestrictions]
 	SecureSignInSession             plugin.TValue[any]
+	DisableResilienceDefaults       plugin.TValue[bool]
 }
 
 // createMicrosoftConditionalAccessPolicySessionControls creates a new instance of this resource
@@ -16136,7 +16144,7 @@ func (c *mqlMicrosoftConditionalAccessPolicySessionControls) GetCloudAppSecurity
 	return &c.CloudAppSecurity
 }
 
-func (c *mqlMicrosoftConditionalAccessPolicySessionControls) GetPersistentBrowser() *plugin.TValue[any] {
+func (c *mqlMicrosoftConditionalAccessPolicySessionControls) GetPersistentBrowser() *plugin.TValue[*mqlMicrosoftConditionalAccessPolicySessionControlsPersistentBrowser] {
 	return &c.PersistentBrowser
 }
 
@@ -16146,6 +16154,10 @@ func (c *mqlMicrosoftConditionalAccessPolicySessionControls) GetApplicationEnfor
 
 func (c *mqlMicrosoftConditionalAccessPolicySessionControls) GetSecureSignInSession() *plugin.TValue[any] {
 	return &c.SecureSignInSession
+}
+
+func (c *mqlMicrosoftConditionalAccessPolicySessionControls) GetDisableResilienceDefaults() *plugin.TValue[bool] {
+	return &c.DisableResilienceDefaults
 }
 
 // mqlMicrosoftConditionalAccessIpNamedLocation for the microsoft.conditionalAccess.ipNamedLocation resource

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -202,6 +202,7 @@ microsoft.conditionalAccess.policy.sessionControls.applicationEnforcedRestrictio
 microsoft.conditionalAccess.policy.sessionControls.cloudAppSecurity 11.1.38
 microsoft.conditionalAccess.policy.sessionControls.cloudAppSecurity.cloudAppSecurityType 11.1.38
 microsoft.conditionalAccess.policy.sessionControls.cloudAppSecurity.isEnabled 11.1.38
+microsoft.conditionalAccess.policy.sessionControls.disableResilienceDefaults 13.12.1
 microsoft.conditionalAccess.policy.sessionControls.id 11.1.38
 microsoft.conditionalAccess.policy.sessionControls.persistentBrowser 11.1.38
 microsoft.conditionalAccess.policy.sessionControls.persistentBrowser.isEnabled 11.1.38


### PR DESCRIPTION
## Problem

Two session controls were populated with values their declared types cannot hold. One of them fails the **entire** conditional access policy list.

### 1. `secureSignInSession` — fails the whole `policies` list

```go
mqlSecureSignInSession, err = CreateResource(a.MqlRuntime,
    "microsoft.conditionalAccess.policy.sessionControls.secureSignInSession", …)
```

That resource **is not declared** — no block in `ms365.lr`, no entry in `resourceFactories`. So `CreateResource` returns `cannot find resource … in this provider`, which propagates `createSessionControlsResource` → `createPolicyResource` → `policies()`.

A single policy with `disableResilienceDefaults` set therefore fails the tenant's whole CA inventory. The guard is on `!= nil`, not on `true`, so a returned `false` is enough to trigger it.

It was also built from `disableResilienceDefaults` — an unrelated scalar — rather than the property the field is named after. The SDK does expose `GetSecureSignInSession()`; it was simply never read.

### 2. `persistentBrowser` — unreadable on exactly the policies that set it

Declared `dict` in the `.lr`, assigned with `llx.ResourceData(...)`. `RawToTValue[any]` accepts the resource at write time, so nothing fails at creation — but reading it runs `ToDataRes(types.Dict)` → `dict2primitive`, which returns:

```
failed to convert dict to primitive, unsupported child type:
  *resources.mqlMicrosoftConditionalAccessPolicySessionControlsPersistentBrowser
```

Policies *without* the control read `null` cleanly, so the error lands on precisely the policies that configure it.

The `sessionControls.persistentBrowser` resource was already declared and correctly populated — just **orphaned**: nothing in the schema referenced it. I found it independently while building a schema reachability graph; it is the only resource of 182 that no field type points at.

## Fix

- `secureSignInSession` stays a `dict` and is now built JSON-native from `GetSecureSignInSession()`, via a `secureSignInSessionDict` helper.
- `persistentBrowser` takes the resource type that already existed, matching `signInFrequency`, `cloudAppSecurity` and `applicationEnforcedRestrictions`.
- `disableResilienceDefaults` becomes its own `bool` field, so the data the old code tried to expose is not lost. New `.lr.versions` entry at `13.12.1`.

## On the type change

`persistentBrowser`'s declared type changes, which is normally breaking. It is safe here because **the field could not be read at all**: any query touching it on a policy that set the control returned a conversion error. No working consumer can depend on the old shape.

## Tests

`resources/conditional_access_session_test.go`:

- `TestSecureSignInSessionDict` — nil controls, control absent (must be null, not an empty dict), enabled, present-but-flag-absent (reads `false` so `{ isEnabled && … }` cannot pass vacuously), and a case asserting `disableResilienceDefaults` does **not** leak back into the dict.
- `TestSecureSignInSessionDictIsJSONNative` — runs the value through `llx.DictData(...).Result()` and asserts no conversion error. This is the assertion that would have caught bug 2: a dict carrying a resource fails here.

## Verification

- `mql run ms365 --info` now resolves `sessionControls { persistentBrowser { mode isEnabled } }` as a typed sub-resource; that query did not compile before.
- The full query runs clean against the test tenant.
- **Not proven on live data:** the tenant has zero conditional access policies, so the populated path is unexercised. Bug 1 is proven structurally (the resource name has no factory entry, so `CreateResource` cannot succeed) and bug 2 by the dict-conversion test. Confirming end-to-end needs a tenant with a CA policy that sets a persistent-browser or secure-sign-in-session control.

## Test plan

- [x] `./mqlr generate` — codegen up to date; `.lr.versions` entry added at 13.12.1
- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] `gofmt` clean
- [x] `make providers/build/ms365` succeeds
- [x] Schema verified via `--info`; query runs clean
- [ ] Live data verification pending a tenant with conditional access policies
