### PR TITLE
🐛 redisdb: read instance.port from CONFIG rather than INFO

### DIFF
--- a/providers/redisdb/resources/instance.go
+++ b/providers/redisdb/resources/instance.go
@@ -60,7 +60,6 @@ func initRedisdbInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	args["mode"] = llx.StringData(mode)
 	args["os"] = llx.StringData(info["os"])
 	args["runId"] = llx.StringData(info["run_id"])
-	args["port"] = llx.IntData(atoiOr(info["tcp_port"], atoiOr(cfg["port"], 0)))
 
 	res, err := CreateResource(runtime, "redisdb.instance", args)
 	if err != nil {
@@ -83,6 +82,7 @@ func (r *mqlRedisdbInstance) setConfigFields(cfg map[string]string, readable boo
 		r.Bind = plugin.TValue[[]any]{State: null}
 		r.BindsAllInterfaces = plugin.TValue[bool]{State: null}
 		r.RequirepassSet = plugin.TValue[bool]{State: null}
+		r.Port = plugin.TValue[int64]{State: null}
 		r.TlsPort = plugin.TValue[int64]{State: null}
 		r.TlsEnabled = plugin.TValue[bool]{State: null}
 		r.TlsAuthClients = plugin.TValue[string]{State: null}
@@ -102,6 +102,12 @@ func (r *mqlRedisdbInstance) setConfigFields(cfg map[string]string, readable boo
 	r.Bind = plugin.TValue[[]any]{Data: bindList, State: set}
 	r.BindsAllInterfaces = plugin.TValue[bool]{Data: bindsAll(bind), State: set}
 	r.RequirepassSet = plugin.TValue[bool]{Data: cfg["requirepass"] != "", State: set}
+	// The configured plaintext port, not the port the server happens to be
+	// serving on. INFO's tcp_port reports whichever listener is active, so on a
+	// TLS-only server -- "port 0" with a TLS listener bound -- it reports the
+	// TLS port, and reading it here would make a correctly configured server
+	// indistinguishable from one still accepting cleartext connections.
+	r.Port = plugin.TValue[int64]{Data: atoiOr(cfg["port"], 0), State: set}
 	r.TlsPort = plugin.TValue[int64]{Data: tlsPort, State: set}
 	r.TlsEnabled = plugin.TValue[bool]{Data: tlsPort != 0, State: set}
 	r.TlsAuthClients = plugin.TValue[string]{Data: cfg["tls-auth-clients"], State: set}


### PR DESCRIPTION
Fixes #10066

## The problem

`redisdb.instance.port` is documented as *"Plaintext TCP port, or 0 when the plaintext listener is disabled"*, but it was populated from `INFO server`'s `tcp_port` — which reports **whichever listener is currently active**, not the configured plaintext port.

On a server configured the way the TLS documentation recommends, with the plaintext listener closed:

```ini
port 0
tls-port 6379
```

Redis reports `tcp_port:6379` in `INFO` (that is the TLS listener), so the field returned `6379` for a server with no plaintext listener at all. `CONFIG GET port` returns `0` there.

```console
$ redis-cli --tls --cacert /tls/ca.crt -a … CONFIG GET port
port
0
$ redis-cli --tls --cacert /tls/ca.crt -a … INFO server | grep tcp_port
tcp_port:6379
```

## The fix

`port` moves into `setConfigFields` alongside `tlsPort`, which already reads from CONFIG. Two consequences beyond the obvious one:

- it now reports the **configured** plaintext port, which is what the field documents
- it is **null**, rather than a misleading number, when the connecting credential cannot read the config ACL category — the same degradation the other CONFIG-derived fields already have

## Verified

Against Redis 7.4.10 in Docker, TLS-only (`port 0`, `tls-port 6379`):

| | before | after |
|---|---|---|
| `port` | `6379` | `0` |
| `tlsPort` | `6379` | `6379` |
| `tlsEnabled` | `true` | `true` |

`go test ./...` and `gofmt` clean.

## Downstream

cnspec shipped a check reading `redisdb.instance.port == 0`. It failed on every correctly configured TLS-only server — precisely the servers its own remediation produced — and was removed. With this fix it is restored unchanged in mondoohq/cnspec#3523, where the `redis-tls` fixture in `content/validation/live/` is its regression test.

The nearest content-side workaround was `tlsEnabled && port == tlsPort`, which is correct only *because* of this bug and inverts once it is fixed — worth naming so nobody adopts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)