### PR TITLE
🐛 ms365: report an uncollected Exchange section as null, not as "none"

### DIFF
--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -748,12 +748,8 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 	// resource views of the policies above, decoded from the same payload (see
 	// ms365_exchange_policies.go). The deprecated []dict accessors keep
 	// returning every property; these expose the security-relevant subset.
-	//
-	// assignPolicies mirrors the null/empty distinction used by the other typed
-	// resources above: a field absent from the report (isNull) becomes a null
-	// value rather than an empty list. The isNull check must be made by the
-	// caller on the concrete report field, since a nil []any boxed into an
-	// `any` parameter would no longer compare equal to nil.
+	// They go through exchangeNullableList for the same absent-vs-empty
+	// distinction as the raw dict fields above.
 
 	transportRules, transportRulesErr := convertTransportRules(r, report.TransportRule)
 	r.TransportRules = exchangeNullableList(isAbsentSection(report.TransportRule), transportRules, transportRulesErr)

--- a/providers/ms365/resources/ms365_exchange.go
+++ b/providers/ms365/resources/ms365_exchange.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -476,6 +477,64 @@ func (r *mqlMs365Exchangeonline) fetchExchangeReportViaPowershell(conn *connecti
 	return report, nil
 }
 
+// isAbsentSection reports whether an Exchange report section was never
+// populated, i.e. its cmdlet did not run or failed.
+//
+// fetchExchangeReport only errors when EVERY section fails, so a report with
+// one denied cmdlet is returned successfully with that one field left nil. The
+// distinction matters because a section that ran and matched nothing decodes to
+// a non-nil empty slice: absent means "not collected", empty means "collected,
+// none found".
+//
+// Sections declared as `any` are assigned from a []any, so a failed one can
+// hold a TYPED nil, which does not compare equal to nil. Check reflectively so
+// both shapes read as absent.
+func isAbsentSection(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Func:
+		return rv.IsNil()
+	}
+	return false
+}
+
+// exchangeNullableList builds the value for a list field sourced from one
+// report section. An absent section reads null rather than as an empty list.
+//
+// convert.JsonToDictSlice(nil) returns (nil, nil) -- no error -- and assigning
+// that with StateIsSet but no StateIsNull makes ToDataRes take the non-null
+// path, so the field renders as [] rather than null. That reports "this tenant
+// has none of these" as fact for data that was never collected.
+func exchangeNullableList(isAbsent bool, data []any, err error) plugin.TValue[[]any] {
+	if isAbsent {
+		return plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+	}
+	return plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet, Error: err}
+}
+
+// exchangeNullableDict is exchangeNullableList for a scalar dict field.
+// convert.JsonToDict(nil) behaves the same way, rendering as {} rather than
+// null.
+func exchangeNullableDict(isAbsent bool, data any, err error) plugin.TValue[any] {
+	if isAbsent {
+		return plugin.TValue[any]{State: plugin.StateIsSet | plugin.StateIsNull}
+	}
+	return plugin.TValue[any]{Data: data, State: plugin.StateIsSet, Error: err}
+}
+
+// exchangeNullableBool is exchangeNullableList for a bool derived from a
+// section. A derived false is indistinguishable from a real one, so an absent
+// section must read null instead.
+func exchangeNullableBool(isAbsent bool, data bool, err error) plugin.TValue[bool] {
+	if isAbsent {
+		return plugin.TValue[bool]{State: plugin.StateIsSet | plugin.StateIsNull}
+	}
+	return plugin.TValue[bool]{Data: data, State: plugin.StateIsSet, Error: err}
+}
+
 func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 	conn := r.MqlRuntime.Connection.(*connection.Ms365Connection)
 
@@ -535,53 +594,53 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 		}
 		mailboxesWithAudit = append(mailboxesWithAudit, mql)
 	}
-	r.MailboxesWithAudit = plugin.TValue[[]any]{Data: mailboxesWithAudit, State: plugin.StateIsSet, Error: mailboxesWithAuditErr}
+	r.MailboxesWithAudit = exchangeNullableList(isAbsentSection(report.Mailbox), mailboxesWithAudit, mailboxesWithAuditErr)
 
 	malwareFilterPolicy, malwareFilterPolicyErr := convert.JsonToDictSlice(report.MalwareFilterPolicy)
-	r.MalwareFilterPolicy = plugin.TValue[[]any]{Data: malwareFilterPolicy, State: plugin.StateIsSet, Error: malwareFilterPolicyErr}
+	r.MalwareFilterPolicy = exchangeNullableList(isAbsentSection(report.MalwareFilterPolicy), malwareFilterPolicy, malwareFilterPolicyErr)
 
 	hostedOutboundSpamFilterPolicy, hostedOutboundSpamFilterPolicyErr := convert.JsonToDictSlice(report.HostedOutboundSpamFilterPolicy)
-	r.HostedOutboundSpamFilterPolicy = plugin.TValue[[]any]{Data: hostedOutboundSpamFilterPolicy, State: plugin.StateIsSet, Error: hostedOutboundSpamFilterPolicyErr}
+	r.HostedOutboundSpamFilterPolicy = exchangeNullableList(isAbsentSection(report.HostedOutboundSpamFilterPolicy), hostedOutboundSpamFilterPolicy, hostedOutboundSpamFilterPolicyErr)
 
 	transportRule, transportRuleErr := convert.JsonToDictSlice(report.TransportRule)
-	r.TransportRule = plugin.TValue[[]any]{Data: transportRule, State: plugin.StateIsSet, Error: transportRuleErr}
+	r.TransportRule = exchangeNullableList(isAbsentSection(report.TransportRule), transportRule, transportRuleErr)
 
 	safeLinksPolicy, safeLinksPolicyErr := convert.JsonToDictSlice(report.SafeLinksPolicy)
-	r.SafeLinksPolicy = plugin.TValue[[]any]{Data: safeLinksPolicy, State: plugin.StateIsSet, Error: safeLinksPolicyErr}
+	r.SafeLinksPolicy = exchangeNullableList(isAbsentSection(report.SafeLinksPolicy), safeLinksPolicy, safeLinksPolicyErr)
 
 	safeAttachmentPolicy, safeAttachmentPolicyErr := convert.JsonToDictSlice(report.SafeAttachmentPolicy)
-	r.SafeAttachmentPolicy = plugin.TValue[[]any]{Data: safeAttachmentPolicy, State: plugin.StateIsSet, Error: safeAttachmentPolicyErr}
+	r.SafeAttachmentPolicy = exchangeNullableList(isAbsentSection(report.SafeAttachmentPolicy), safeAttachmentPolicy, safeAttachmentPolicyErr)
 
 	organizationConfig, organizationConfigErr := convert.JsonToDict(report.OrganizationConfig)
-	r.OrganizationConfig = plugin.TValue[any]{Data: organizationConfig, State: plugin.StateIsSet, Error: organizationConfigErr}
+	r.OrganizationConfig = exchangeNullableDict(isAbsentSection(report.OrganizationConfig), organizationConfig, organizationConfigErr)
 
 	antiPhishPolicy, antiPhishPolicyErr := convert.JsonToDictSlice(report.AntiPhishPolicy)
-	r.AntiPhishPolicy = plugin.TValue[[]any]{Data: antiPhishPolicy, State: plugin.StateIsSet, Error: antiPhishPolicyErr}
+	r.AntiPhishPolicy = exchangeNullableList(isAbsentSection(report.AntiPhishPolicy), antiPhishPolicy, antiPhishPolicyErr)
 
 	dkimSigningConfig, dkimSigningConfigErr := convert.JsonToDictSlice(report.DkimSigningConfig)
-	r.DkimSigningConfig = plugin.TValue[[]any]{Data: dkimSigningConfig, State: plugin.StateIsSet, Error: dkimSigningConfigErr}
+	r.DkimSigningConfig = exchangeNullableList(isAbsentSection(report.DkimSigningConfig), dkimSigningConfig, dkimSigningConfigErr)
 
 	owaMailboxPolicy, owaMailboxPolicyErr := convert.JsonToDictSlice(report.OwaMailboxPolicy)
-	r.OwaMailboxPolicy = plugin.TValue[[]any]{Data: owaMailboxPolicy, State: plugin.StateIsSet, Error: owaMailboxPolicyErr}
+	r.OwaMailboxPolicy = exchangeNullableList(isAbsentSection(report.OwaMailboxPolicy), owaMailboxPolicy, owaMailboxPolicyErr)
 
 	adminAuditLogConfig, adminAuditLogConfigErr := convert.JsonToDict(report.AdminAuditLogConfig)
-	r.AdminAuditLogConfig = plugin.TValue[any]{Data: adminAuditLogConfig, State: plugin.StateIsSet, Error: adminAuditLogConfigErr}
-	r.UnifiedAuditLogIngestionEnabled = plugin.TValue[bool]{Data: dictBoolValue(adminAuditLogConfig, "unifiedAuditLogIngestionEnabled"), State: plugin.StateIsSet, Error: adminAuditLogConfigErr}
+	r.AdminAuditLogConfig = exchangeNullableDict(isAbsentSection(report.AdminAuditLogConfig), adminAuditLogConfig, adminAuditLogConfigErr)
+	r.UnifiedAuditLogIngestionEnabled = exchangeNullableBool(isAbsentSection(report.AdminAuditLogConfig), dictBoolValue(adminAuditLogConfig, "unifiedAuditLogIngestionEnabled"), adminAuditLogConfigErr)
 
 	phishFilterPolicy, phishFilterPolicyErr := convert.JsonToDictSlice(report.PhishFilterPolicy)
-	r.PhishFilterPolicy = plugin.TValue[[]any]{Data: phishFilterPolicy, State: plugin.StateIsSet, Error: phishFilterPolicyErr}
+	r.PhishFilterPolicy = exchangeNullableList(isAbsentSection(report.PhishFilterPolicy), phishFilterPolicy, phishFilterPolicyErr)
 
 	mailbox, mailboxErr := convert.JsonToDictSlice(report.Mailbox)
-	r.Mailbox = plugin.TValue[[]any]{Data: mailbox, State: plugin.StateIsSet, Error: mailboxErr}
+	r.Mailbox = exchangeNullableList(isAbsentSection(report.Mailbox), mailbox, mailboxErr)
 
 	atpPolicyForO365, atpPolicyForO365Err := convert.JsonToDictSlice(report.AtpPolicyForO365)
-	r.AtpPolicyForO365 = plugin.TValue[[]any]{Data: atpPolicyForO365, State: plugin.StateIsSet, Error: atpPolicyForO365Err}
+	r.AtpPolicyForO365 = exchangeNullableList(isAbsentSection(report.AtpPolicyForO365), atpPolicyForO365, atpPolicyForO365Err)
 
 	sharingPolicy, sharingPolicyErr := convert.JsonToDictSlice(report.SharingPolicy)
-	r.SharingPolicy = plugin.TValue[[]any]{Data: sharingPolicy, State: plugin.StateIsSet, Error: sharingPolicyErr}
+	r.SharingPolicy = exchangeNullableList(isAbsentSection(report.SharingPolicy), sharingPolicy, sharingPolicyErr)
 
 	roleAssignmentPolicy, roleAssignmentPolicyErr := convert.JsonToDictSlice(report.RoleAssignmentPolicy)
-	r.RoleAssignmentPolicy = plugin.TValue[[]any]{Data: roleAssignmentPolicy, State: plugin.StateIsSet, Error: roleAssignmentPolicyErr}
+	r.RoleAssignmentPolicy = exchangeNullableList(isAbsentSection(report.RoleAssignmentPolicy), roleAssignmentPolicy, roleAssignmentPolicyErr)
 
 	externalInOutlook := []any{}
 	var externalInOutlookErr error
@@ -603,7 +662,7 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 
 		externalInOutlook = append(externalInOutlook, mql)
 	}
-	r.ExternalInOutlook = plugin.TValue[[]any]{Data: externalInOutlook, State: plugin.StateIsSet, Error: externalInOutlookErr}
+	r.ExternalInOutlook = exchangeNullableList(isAbsentSection(report.ExternalInOutlook), externalInOutlook, externalInOutlookErr)
 
 	sharedMailboxes := []any{}
 	var sharedMailboxesErr error
@@ -624,7 +683,7 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 
 		sharedMailboxes = append(sharedMailboxes, mql)
 	}
-	r.SharedMailboxes = plugin.TValue[[]any]{Data: sharedMailboxes, State: plugin.StateIsSet, Error: sharedMailboxesErr}
+	r.SharedMailboxes = exchangeNullableList(isAbsentSection(report.ExoMailbox), sharedMailboxes, sharedMailboxesErr)
 
 	// Related to TeamsProtectionPolicy
 	if report.TeamsProtectionPolicy != nil {
@@ -667,7 +726,7 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 	}
 
 	transportConfig, transportConfigErr := convert.JsonToDict(report.TransportConfig)
-	r.TransportConfig = plugin.TValue[any]{Data: transportConfig, State: plugin.StateIsSet, Error: transportConfigErr}
+	r.TransportConfig = exchangeNullableDict(isAbsentSection(report.TransportConfig), transportConfig, transportConfigErr)
 
 	mailboxAuditBypassAssociations := []any{}
 	var mailboxAuditBypassAssociationErr error
@@ -684,7 +743,7 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 		}
 		mailboxAuditBypassAssociations = append(mailboxAuditBypassAssociations, mql)
 	}
-	r.MailboxAuditBypassAssociation = plugin.TValue[[]any]{Data: mailboxAuditBypassAssociations, State: plugin.StateIsSet, Error: mailboxAuditBypassAssociationErr}
+	r.MailboxAuditBypassAssociation = exchangeNullableList(isAbsentSection(report.MailboxAuditBypassAssociation), mailboxAuditBypassAssociations, mailboxAuditBypassAssociationErr)
 
 	// resource views of the policies above, decoded from the same payload (see
 	// ms365_exchange_policies.go). The deprecated []dict accessors keep
@@ -695,57 +754,51 @@ func (r *mqlMs365Exchangeonline) getExchangeReport() error {
 	// value rather than an empty list. The isNull check must be made by the
 	// caller on the concrete report field, since a nil []any boxed into an
 	// `any` parameter would no longer compare equal to nil.
-	assignPolicies := func(isNull bool, data []any, err error) plugin.TValue[[]any] {
-		if isNull {
-			return plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
-		}
-		return plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet, Error: err}
-	}
 
 	transportRules, transportRulesErr := convertTransportRules(r, report.TransportRule)
-	r.TransportRules = assignPolicies(report.TransportRule == nil, transportRules, transportRulesErr)
+	r.TransportRules = exchangeNullableList(isAbsentSection(report.TransportRule), transportRules, transportRulesErr)
 
 	antiPhishPolicies, antiPhishPoliciesErr := convertAntiPhishPolicies(r, report.AntiPhishPolicy)
-	r.AntiPhishPolicies = assignPolicies(report.AntiPhishPolicy == nil, antiPhishPolicies, antiPhishPoliciesErr)
+	r.AntiPhishPolicies = exchangeNullableList(isAbsentSection(report.AntiPhishPolicy), antiPhishPolicies, antiPhishPoliciesErr)
 
 	safeLinksPolicies, safeLinksPoliciesErr := convertSafeLinksPolicies(r, report.SafeLinksPolicy)
-	r.SafeLinksPolicies = assignPolicies(report.SafeLinksPolicy == nil, safeLinksPolicies, safeLinksPoliciesErr)
+	r.SafeLinksPolicies = exchangeNullableList(isAbsentSection(report.SafeLinksPolicy), safeLinksPolicies, safeLinksPoliciesErr)
 
 	safeAttachmentPolicies, safeAttachmentPoliciesErr := convertSafeAttachmentPolicies(r, report.SafeAttachmentPolicy)
-	r.SafeAttachmentPolicies = assignPolicies(report.SafeAttachmentPolicy == nil, safeAttachmentPolicies, safeAttachmentPoliciesErr)
+	r.SafeAttachmentPolicies = exchangeNullableList(isAbsentSection(report.SafeAttachmentPolicy), safeAttachmentPolicies, safeAttachmentPoliciesErr)
 
 	malwareFilterPolicies, malwareFilterPoliciesErr := convertMalwareFilterPolicies(r, report.MalwareFilterPolicy)
-	r.MalwareFilterPolicies = assignPolicies(report.MalwareFilterPolicy == nil, malwareFilterPolicies, malwareFilterPoliciesErr)
+	r.MalwareFilterPolicies = exchangeNullableList(isAbsentSection(report.MalwareFilterPolicy), malwareFilterPolicies, malwareFilterPoliciesErr)
 
 	hostedContentFilterPolicies, hostedContentFilterPoliciesErr := convertHostedContentFilterPolicies(r, report.HostedContentFilterPolicy)
-	r.HostedContentFilterPolicies = assignPolicies(report.HostedContentFilterPolicy == nil, hostedContentFilterPolicies, hostedContentFilterPoliciesErr)
+	r.HostedContentFilterPolicies = exchangeNullableList(isAbsentSection(report.HostedContentFilterPolicy), hostedContentFilterPolicies, hostedContentFilterPoliciesErr)
 
 	hostedOutboundSpamFilterPolicies, hostedOutboundSpamFilterPoliciesErr := convertHostedOutboundSpamFilterPolicies(r, report.HostedOutboundSpamFilterPolicy)
-	r.HostedOutboundSpamFilterPolicies = assignPolicies(report.HostedOutboundSpamFilterPolicy == nil, hostedOutboundSpamFilterPolicies, hostedOutboundSpamFilterPoliciesErr)
+	r.HostedOutboundSpamFilterPolicies = exchangeNullableList(isAbsentSection(report.HostedOutboundSpamFilterPolicy), hostedOutboundSpamFilterPolicies, hostedOutboundSpamFilterPoliciesErr)
 
 	dkimSigningConfigs, dkimSigningConfigsErr := convertDkimSigningConfigs(r, report.DkimSigningConfig)
-	r.DkimSigningConfigs = assignPolicies(report.DkimSigningConfig == nil, dkimSigningConfigs, dkimSigningConfigsErr)
+	r.DkimSigningConfigs = exchangeNullableList(isAbsentSection(report.DkimSigningConfig), dkimSigningConfigs, dkimSigningConfigsErr)
 
 	authenticationPolicies, authenticationPoliciesErr := convertAuthenticationPolicies(r, report.AuthenticationPolicy)
-	r.AuthenticationPolicies = assignPolicies(report.AuthenticationPolicy == nil, authenticationPolicies, authenticationPoliciesErr)
+	r.AuthenticationPolicies = exchangeNullableList(isAbsentSection(report.AuthenticationPolicy), authenticationPolicies, authenticationPoliciesErr)
 
 	owaMailboxPolicies, owaMailboxPoliciesErr := convertOwaMailboxPolicies(r, report.OwaMailboxPolicy)
-	r.OwaMailboxPolicies = assignPolicies(report.OwaMailboxPolicy == nil, owaMailboxPolicies, owaMailboxPoliciesErr)
+	r.OwaMailboxPolicies = exchangeNullableList(isAbsentSection(report.OwaMailboxPolicy), owaMailboxPolicies, owaMailboxPoliciesErr)
 
 	remoteDomains, remoteDomainsErr := convertRemoteDomains(r, report.RemoteDomain)
-	r.RemoteDomains = assignPolicies(report.RemoteDomain == nil, remoteDomains, remoteDomainsErr)
+	r.RemoteDomains = exchangeNullableList(isAbsentSection(report.RemoteDomain), remoteDomains, remoteDomainsErr)
 
 	quarantinePolicies, quarantinePoliciesErr := convertQuarantinePolicies(r, report.QuarantinePolicy)
-	r.QuarantinePolicies = assignPolicies(report.QuarantinePolicy == nil, quarantinePolicies, quarantinePoliciesErr)
+	r.QuarantinePolicies = exchangeNullableList(isAbsentSection(report.QuarantinePolicy), quarantinePolicies, quarantinePoliciesErr)
 
 	atpPoliciesForO365, atpPoliciesForO365Err := convertAtpPoliciesForO365(r, report.AtpPolicyForO365)
-	r.AtpPoliciesForO365 = assignPolicies(report.AtpPolicyForO365 == nil, atpPoliciesForO365, atpPoliciesForO365Err)
+	r.AtpPoliciesForO365 = exchangeNullableList(isAbsentSection(report.AtpPolicyForO365), atpPoliciesForO365, atpPoliciesForO365Err)
 
 	sharingPolicies, sharingPoliciesErr := convertSharingPolicies(r, report.SharingPolicy)
-	r.SharingPolicies = assignPolicies(report.SharingPolicy == nil, sharingPolicies, sharingPoliciesErr)
+	r.SharingPolicies = exchangeNullableList(isAbsentSection(report.SharingPolicy), sharingPolicies, sharingPoliciesErr)
 
 	roleAssignmentPolicies, roleAssignmentPoliciesErr := convertRoleAssignmentPolicies(r, report.RoleAssignmentPolicy)
-	r.RoleAssignmentPolicies = assignPolicies(report.RoleAssignmentPolicy == nil, roleAssignmentPolicies, roleAssignmentPoliciesErr)
+	r.RoleAssignmentPolicies = exchangeNullableList(isAbsentSection(report.RoleAssignmentPolicy), roleAssignmentPolicies, roleAssignmentPoliciesErr)
 
 	r.fetched = true
 	return nil

--- a/providers/ms365/resources/ms365_exchange_sections_test.go
+++ b/providers/ms365/resources/ms365_exchange_sections_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+)
+
+func TestIsAbsentSection(t *testing.T) {
+	var typedNilSlice []any
+	var typedNilMap map[string]any
+	var boxedTypedNil any = typedNilSlice
+
+	tests := []struct {
+		name string
+		in   any
+		want bool
+	}{
+		{"untyped nil", nil, true},
+		{"typed nil slice", typedNilSlice, true},
+		{"typed nil slice boxed in any", boxedTypedNil, true},
+		{"typed nil map", typedNilMap, true},
+		{"nil pointer", (*ExchangeOnlineReport)(nil), true},
+		{"empty but non-nil slice", []any{}, false},
+		{"empty but non-nil map", map[string]any{}, false},
+		{"populated slice", []any{"x"}, false},
+		{"scalar", "value", false},
+		{"zero scalar", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAbsentSection(tc.in))
+		})
+	}
+}
+
+// The whole point: a section that RAN and matched nothing must stay an empty
+// list, while a section that never ran must read null.
+//
+// The converter cannot make that distinction for us -- it returns no error
+// either way -- so the caller has to test the report field itself. Marking the
+// field set-but-not-null is what turns "never collected" into a confident "none
+// found" on the wire.
+func TestExchangeNullableListDistinguishesAbsentFromEmpty(t *testing.T) {
+	t.Run("absent section reads null", func(t *testing.T) {
+		var absent []any
+		data, err := convert.JsonToDictSlice(absent)
+		assert.NoError(t, err, "an absent section converts without error, which is why it looks legitimate")
+
+		// what the previous code did with that value
+		old := plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet, Error: err}
+		assert.True(t, old.State&plugin.StateIsNull == 0,
+			"the old assignment marked the field set-and-not-null, so it rendered as []")
+
+		v := exchangeNullableList(isAbsentSection(absent), data, err)
+		assert.True(t, v.State&plugin.StateIsNull != 0, "must be null")
+		assert.True(t, v.State&plugin.StateIsSet != 0, "must also be marked set")
+	})
+
+	t.Run("section that ran with no results reads empty", func(t *testing.T) {
+		ran := []any{}
+		data, err := convert.JsonToDictSlice(ran)
+		v := exchangeNullableList(isAbsentSection(ran), data, err)
+		assert.True(t, v.State&plugin.StateIsNull == 0, "must NOT be null")
+		assert.Empty(t, v.Data)
+	})
+
+	t.Run("populated section keeps its data", func(t *testing.T) {
+		v := exchangeNullableList(false, []any{"a", "b"}, nil)
+		assert.Len(t, v.Data, 2)
+		assert.True(t, v.State&plugin.StateIsNull == 0)
+	})
+
+	t.Run("conversion error is preserved", func(t *testing.T) {
+		boom := errors.New("decode failed")
+		v := exchangeNullableList(false, nil, boom)
+		assert.Equal(t, boom, v.Error)
+	})
+}
+
+func TestExchangeNullableDict(t *testing.T) {
+	t.Run("absent section reads null", func(t *testing.T) {
+		var absent any
+		data, err := convert.JsonToDict(absent)
+		assert.NoError(t, err, "an absent section converts without error, which is why it looks legitimate")
+
+		old := plugin.TValue[any]{Data: data, State: plugin.StateIsSet, Error: err}
+		assert.True(t, old.State&plugin.StateIsNull == 0,
+			"the old assignment marked the field set-and-not-null, so it rendered as {}")
+
+		v := exchangeNullableDict(isAbsentSection(absent), data, err)
+		assert.True(t, v.State&plugin.StateIsNull != 0)
+	})
+
+	t.Run("present section keeps its data", func(t *testing.T) {
+		v := exchangeNullableDict(false, map[string]any{"k": "v"}, nil)
+		assert.Equal(t, map[string]any{"k": "v"}, v.Data)
+		assert.True(t, v.State&plugin.StateIsNull == 0)
+	})
+}
+
+// A derived bool is the most dangerous of the three: false is a legitimate
+// value, so an absent section reporting false is indistinguishable from a real
+// answer. unifiedAuditLogIngestionEnabled is exactly that field.
+func TestExchangeNullableBool(t *testing.T) {
+	t.Run("absent section reads null, not false", func(t *testing.T) {
+		v := exchangeNullableBool(true, false, nil)
+		assert.True(t, v.State&plugin.StateIsNull != 0,
+			"an uncollected section must not report false as fact")
+	})
+
+	t.Run("present false is reported", func(t *testing.T) {
+		v := exchangeNullableBool(false, false, nil)
+		assert.True(t, v.State&plugin.StateIsNull == 0)
+		assert.False(t, v.Data)
+	})
+
+	t.Run("present true is reported", func(t *testing.T) {
+		v := exchangeNullableBool(false, true, nil)
+		assert.True(t, v.Data)
+	})
+}


### PR DESCRIPTION
## Problem

`fetchExchangeReport` only returns an error when **every** section fails, so a report with one denied or failed cmdlet is returned successfully with that section left nil. About twenty fields then did:

```go
malwareFilterPolicy, err := convert.JsonToDictSlice(report.MalwareFilterPolicy)
r.MalwareFilterPolicy = plugin.TValue[[]any]{Data: malwareFilterPolicy, State: plugin.StateIsSet, Error: err}
```

`StateIsSet` with no `StateIsNull` makes `ToDataRes` take the non-null path, so the field renders as `[]` (or `{}`) — a confident *"this tenant has none of these"* for data that was never collected. The converter returns no error either way, so nothing surfaced.

The same failure produced **two different answers on one resource**: `transportRules` (typed) already read `null` while `transportRule` (dict) read `[]`.

### Affected fields

`malwareFilterPolicy`, `hostedOutboundSpamFilterPolicy`, `transportRule`, `safeLinksPolicy`, `safeAttachmentPolicy`, `organizationConfig`, `antiPhishPolicy`, `dkimSigningConfig`, `owaMailboxPolicy`, `adminAuditLogConfig`, `unifiedAuditLogIngestionEnabled`, `phishFilterPolicy`, `mailbox`, `atpPolicyForO365`, `sharingPolicy`, `roleAssignmentPolicy`, `externalInOutlook`, `sharedMailboxes`, `mailboxesWithAudit`, `mailboxAuditBypassAssociation`, `transportConfig`.

`mailboxAuditBypassAssociation` and `mailboxesWithAudit` are the ones that hurt: an audit asserting `mailboxAuditBypassAssociation.none(auditBypassEnabled)` **passes vacuously** when the cmdlet was denied.

`unifiedAuditLogIngestionEnabled` is the worst of the set — a derived `false` is indistinguishable from a real one, so a tenant with audit ingestion enabled but the `AdminAuditLogConfig` cmdlet denied reported it as **disabled**.

## Fix

Route all of them through `exchangeNullableList` / `exchangeNullableDict` / `exchangeNullableBool`, keyed on whether the report **section** is absent — not on the converted value, which cannot express the difference.

Sections declared as `any` are assigned from a `[]any`, so a failed one can hold a **typed nil** that does not compare equal to `nil`. `isAbsentSection` checks reflectively so both shapes read as absent. The 15 existing `report.X == nil` call sites are moved onto it too, since five of those fields are `any`-typed and had exactly that hole.

## Verification

On a tenant where two Exchange sections genuinely fail (a `gzip: invalid header` on the admin endpoint):

```
ms365.exchangeonline.phishFilterPolicy      : null   <- previously length 0, i.e. []
ms365.exchangeonline.transportRule.length   : 0      <- ran, genuinely no rules: still []
```

That is exactly the distinction: **absent → null**, **collected-but-empty → []**.

## A correction to the original report

This was first described as *"`convert.JsonToDictSlice(nil)` returns a non-nil empty slice"*. That is wrong — it returns `(nil, nil)`. I found this when the first version of the test failed. The **effect** is unchanged and the fix is the same: what makes the field render as `[]` is the `StateIsSet`-without-`StateIsNull` assignment, not the converter's return. The comments and tests state the accurate mechanism.

## Tests

`resources/ms365_exchange_sections_test.go`:

- `TestIsAbsentSection` — untyped nil, typed nil slice/map, a typed nil **boxed in `any`** (the case plain `== nil` misses), nil pointer, and the non-absent cases including empty-but-non-nil.
- `TestExchangeNullableListDistinguishesAbsentFromEmpty` — asserts the old assignment shape was set-and-not-null (documenting the bug), then that the new one is null, and that a section which ran with no results still reads empty.
- `TestExchangeNullableDict`, `TestExchangeNullableBool` — same distinction for the scalar and derived-bool cases.

## Note

The `gzip: invalid header` failure on `PhishFilterPolicy` and `TeamsProtectionPolicy` is a **separate** defect (reproducible on every run) and is not addressed here — this PR only makes such a failure report honestly.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] `gofmt` clean
- [x] `make providers/build/ms365` succeeds
- [x] Live-verified: failed section reads null, empty-but-collected section still reads []
