### PR TITLE
🐛 ms365: stop a 204 batch sub-response panicking the parse

### DIFF
--- a/providers/ms365/resources/batch.go
+++ b/providers/ms365/resources/batch.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
@@ -91,6 +92,16 @@ func batchGet[T serialization.Parsable](
 			out.errs[key] = fmt.Errorf("batch request failed with status %d", code)
 			continue
 		}
+		// A no-content success has no body to deserialize. GetBatchResponseById
+		// dereferences it anyway and panics, which the recover below would turn
+		// into a per-item error -- but this is not a failure. Graph answers 204
+		// for a sub-request whose target has no value for the selected property
+		// (for example signInActivity on a user who has never signed in), so
+		// leave the key out of both results and errs and let the field read
+		// null.
+		if hasCode && batchStatusHasNoBody(code) {
+			continue
+		}
 		// ...and recover defensively around the parse itself, since the helper
 		// can still panic on malformed/error bodies the status map does not flag.
 		val, err := safeGetBatchResponseByID[T](resp, id, constructor)
@@ -101,6 +112,16 @@ func batchGet[T serialization.Parsable](
 		out.results[key] = val
 	}
 	return out, nil
+}
+
+// batchStatusHasNoBody reports whether a successful batch sub-response status
+// carries no body, so there is nothing for the caller to deserialize.
+//
+// This has to be checked separately from the non-2xx guard because these codes
+// ARE successes: they fall inside the 2xx range and would otherwise reach the
+// parse, which panics on the absent body.
+func batchStatusHasNoBody(code int32) bool {
+	return code == http.StatusNoContent || code == http.StatusResetContent
 }
 
 // safeGetBatchResponseByID wraps msgraphgocore.GetBatchResponseById, which can

--- a/providers/ms365/resources/batch_test.go
+++ b/providers/ms365/resources/batch_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// batchStatusHasNoBody gates whether a sub-response reaches the deserializer.
+// Getting it wrong in either direction is a real bug: too narrow and a
+// body-less success panics the parse, too wide and a real payload is silently
+// dropped.
+func TestBatchStatusHasNoBody(t *testing.T) {
+	tests := []struct {
+		name string
+		code int32
+		want bool
+	}{
+		{"204 no content", http.StatusNoContent, true},
+		{"205 reset content", http.StatusResetContent, true},
+		{"200 ok carries a body", http.StatusOK, false},
+		{"201 created carries a body", http.StatusCreated, false},
+		{"202 accepted carries a body", http.StatusAccepted, false},
+		{"206 partial content carries a body", http.StatusPartialContent, false},
+		{"403 is handled by the non-2xx guard", http.StatusForbidden, false},
+		{"404 is handled by the non-2xx guard", http.StatusNotFound, false},
+		{"429 is handled by the non-2xx guard", http.StatusTooManyRequests, false},
+		{"zero value", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, batchStatusHasNoBody(tc.code))
+		})
+	}
+}
+
+// The two guards in batchGet must partition every status code: a non-2xx is an
+// error, a body-less 2xx is an absence, and everything else is parsed. A code
+// falling through both that has no body is exactly the 204 case that panicked.
+func TestBatchStatusGuardsPartitionAllCodes(t *testing.T) {
+	isFailure := func(code int32) bool { return code < 200 || code >= 300 }
+
+	for code := int32(100); code < 600; code++ {
+		failure := isFailure(code)
+		noBody := batchStatusHasNoBody(code)
+		assert.Falsef(t, failure && noBody,
+			"status %d is classified as both a failure and a body-less success", code)
+
+		if noBody {
+			assert.Truef(t, code >= 200 && code < 300,
+				"only a 2xx should reach the body-less branch, got %d", code)
+		}
+	}
+
+	assert.True(t, batchStatusHasNoBody(http.StatusNoContent),
+		"204 must be caught before the parse: it is a success, so the non-2xx guard lets it through, "+
+			"and GetBatchResponseById panics on the absent body")
+}


### PR DESCRIPTION
## Problem

`microsoft.users.list { signInActivity }` failed with a recovered nil-pointer dereference and returned **no users at all**:

```
Error: 3 errors occurred:
  * batch sub-response "…" could not be parsed (recovered panic):
    runtime error: invalid memory address or nil pointer dereference
```

`batchGet` skips the deserializer for a non-2xx sub-response, since the body is an error object rather than a `T`:

```go
if hasCode && (code < 200 || code >= 300) { … continue }
```

A **204 No Content** is a *success*, so it passes that guard and reaches `GetBatchResponseById`, which dereferences a body that is not there and panics. `safeGetBatchResponseByID` recovers it into a per-item error — so the field reported a **parse failure** for what is simply an absent value.

Instrumenting the batch layer confirmed it directly:

```
PROBE parse failed  hasCode=true  code=204  total=25
```

Graph answers 204 for a sub-request whose target has no value for the selected property — `signInActivity` on a user who has never signed in.

## Fix

Treat a body-less success as an absence: leave the key out of both `results` and `errs` so the field reads **null**. The panic recovery stays as defence in depth for genuinely malformed bodies.

## Verification

```
users returned      : 25   <- the whole list errored before
signInActivity data : 23
signInActivity null : 2    <- the users Graph answers 204 for
signInActivity error: 0
```

## Corrections to the original report

This was filed as *"the user list fails on throttling, on a partial 403, and on a recovered nil-pointer panic"*. Bisecting the fields showed only the third is a provider defect:

- **The 403 is correct behaviour.** `microsoft.users.list { userPrincipalName settings }` renders the full list with the error attached to the `settings` field of each user; the other fields resolve normally. The "1 error occurred" banner is mql summarising a per-field error, not a failed list. Surfacing it is right — it tells the user their app registration lacks the permission.
- **The 429 is a throttling symptom**, handled by the same per-item path as any other non-2xx. Nothing to fix in the batch layer; the request volume behind it is a separate matter.

Only the 204 case actually loses data, and it is the one fixed here.

## Tests

`resources/batch_test.go`:

- `TestBatchStatusHasNoBody` — 204 and 205 are body-less; 200/201/202/206 are not; 403/404/429 belong to the non-2xx guard.
- `TestBatchStatusGuardsPartitionAllCodes` — sweeps every status 100-599 and asserts the two guards never overlap and that only a 2xx reaches the body-less branch. A code falling through both *with* no body is precisely the 204 bug, so this pins the partition rather than the single value.

## Test plan

- [x] `go test ./resources/` passes in `providers/ms365/`
- [x] `gofmt` clean
- [x] `make providers/build/ms365` succeeds
- [x] Live-verified: 25 users returned, 2 correctly null, no panic
