### PR TITLE
🐛 os: fit the scheduled task script on the Windows command line

### DIFF
--- a/providers/os/resources/powershell/encode.go
+++ b/providers/os/resources/powershell/encode.go
@@ -12,6 +12,29 @@ import (
 	"golang.org/x/text/encoding/unicode"
 )
 
+const (
+	// MaxCommandLength is the largest command line Windows will accept. A
+	// longer one is rejected before PowerShell ever runs, and the failure
+	// arrives as a generic non-zero exit — which reads like the queried
+	// feature not being installed rather than like a bug in the script.
+	MaxCommandLength = 8191
+
+	// MaxScriptLength is the largest script that Encode can still fit inside
+	// MaxCommandLength. Encoding widens the script to UTF-16 (x2) and base64
+	// encodes it (x4/3), and Encode additionally prepends a $ProgressPreference
+	// assignment to the script and an interpreter invocation to the command
+	// line. The measured ceiling is 3016 characters; this leaves a small margin
+	// under it. Keep embedded scripts below this and assert it in a test —
+	// see TestScheduledTasksScriptFitsCommandLine for the pattern.
+	MaxScriptLength = 3000
+)
+
+// FitsCommandLine reports whether script still fits on a Windows command line
+// once Encode has widened and base64 encoded it.
+func FitsCommandLine(script string) bool {
+	return len(Encode(script)) <= MaxCommandLength
+}
+
 // interpreters holds the executable names that Encode/EncodeUnix/Wrap emit as
 // the leading token of a self-contained PowerShell invocation.
 var interpreters = map[string]bool{

--- a/providers/os/resources/powershell/encode_test.go
+++ b/providers/os/resources/powershell/encode_test.go
@@ -4,6 +4,7 @@
 package powershell_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,4 +67,33 @@ func TestSplitInvocation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// MaxScriptLength is a magic number, so derive the real ceiling by binary
+// search over Encode rather than trusting the arithmetic. If Encode ever grows
+// another prefix, this fails and the constant has to come down with it.
+func TestMaxScriptLengthIsUnderTheRealCeiling(t *testing.T) {
+	fits := func(n int) bool {
+		return len(powershell.Encode(strings.Repeat("a", n))) <= powershell.MaxCommandLength
+	}
+
+	lo, hi := 0, 16384 // hi is known not to fit
+	for lo+1 < hi {
+		mid := (lo + hi) / 2
+		if fits(mid) {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	ceiling := lo
+
+	assert.Equal(t, 3016, ceiling,
+		"the measured script ceiling moved; update powershell.MaxScriptLength")
+	assert.True(t, fits(ceiling))
+	assert.False(t, fits(ceiling+1))
+
+	assert.LessOrEqual(t, powershell.MaxScriptLength, ceiling,
+		"MaxScriptLength must stay at or below the measured ceiling")
+	assert.True(t, powershell.FitsCommandLine(strings.Repeat("a", powershell.MaxScriptLength)))
 }

--- a/providers/os/resources/powershell/scriptlength_test.go
+++ b/providers/os/resources/powershell/scriptlength_test.go
@@ -81,9 +81,9 @@ func flattenStringExpr(e ast.Expr) (string, bool) {
 		if v.Op != token.ADD {
 			return "", false
 		}
-		l, lok := flattenStringExpr(v.X)
-		r, rok := flattenStringExpr(v.Y)
-		if !lok || !rok {
+		l, leftOK := flattenStringExpr(v.X)
+		r, rightOK := flattenStringExpr(v.Y)
+		if !leftOK || !rightOK {
 			return "", false
 		}
 		return l + r, true

--- a/providers/os/resources/powershell/scriptlength_test.go
+++ b/providers/os/resources/powershell/scriptlength_test.go
@@ -1,0 +1,244 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package powershell_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+)
+
+// knownOverCap records the embedded scripts that already exceed the command-line
+// cap. They are listed rather than fixed here because each needs a live target
+// to verify a rewrite against, and both are tracked separately. The point of the
+// list is that it may not grow: a script added or grown past the cap that is not
+// on it fails this test.
+//
+// A script over the cap does not fail loudly. The target rejects the command
+// before PowerShell runs, and the non-zero exit reads like the queried feature
+// being absent — an empty answer rather than an error — which is how these
+// shipped unnoticed.
+var knownOverCap = map[string]string{
+	// Sent to the target with powershell.Encode over the same path as
+	// SCHEDULED_TASKS, so this is broken on Windows targets today. Needs a
+	// Windows host to verify any rewrite: it walks the ProfileList registry
+	// hive and the IdentityStore cache.
+	"providers/os/resources/users/ps1getlocalusers.go:getLocalUsersScript": "tracked separately; needs a Windows host to verify a rewrite",
+
+	// Runs on the *scanner* host, not a remote target, and only as a fallback
+	// when the Exchange admin REST endpoint is unavailable. On a Linux or macOS
+	// scanner the shell is `sh -c`, where ARG_MAX is megabytes and the cap does
+	// not apply; it only breaks when the scanner itself runs Windows.
+	"providers/ms365/resources/ms365_exchange.go:exchangeReport": "scanner-side fallback; only affected on a Windows scanner host",
+}
+
+// psMarkers identify a string literal as a PowerShell script.
+var psMarkers = []string{
+	"$ErrorActionPreference", "PSCustomObject", "ConvertTo-Json", "ForEach-Object",
+	"Select-Object", "Where-Object", "Out-String", "Import-Module", "Get-Item",
+	"Get-Content", "Get-CimInstance", "Get-WmiObject", "Get-ItemProperty",
+	"Get-", "Set-", "New-Object", "Invoke-", "Test-Path", "Add-Type", "Export-",
+	"$_.", "[System.", "-ErrorAction",
+}
+
+func looksLikePowerShell(s string) bool {
+	n := 0
+	for _, m := range psMarkers {
+		if strings.Contains(s, m) {
+			n++
+		}
+	}
+	// Two independent markers keeps out incidental matches such as "Get-" in a URL.
+	return n >= 2
+}
+
+// flattenStringExpr resolves a string literal, or a chain of "+"-concatenated
+// string literals, into its value. Anything else yields ok=false.
+func flattenStringExpr(e ast.Expr) (string, bool) {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return "", false
+		}
+		s, err := strconv.Unquote(v.Value)
+		if err != nil {
+			return "", false
+		}
+		return s, true
+	case *ast.BinaryExpr:
+		if v.Op != token.ADD {
+			return "", false
+		}
+		l, lok := flattenStringExpr(v.X)
+		r, rok := flattenStringExpr(v.Y)
+		if !lok || !rok {
+			return "", false
+		}
+		return l + r, true
+	case *ast.ParenExpr:
+		return flattenStringExpr(v.X)
+	}
+	return "", false
+}
+
+type scriptFinding struct {
+	file, name string
+	line       int
+	src, enc   int
+}
+
+func (f scriptFinding) key() string { return f.file + ":" + f.name }
+
+// TestEmbeddedPowerShellScriptsFitCommandLine measures every embedded PowerShell
+// script in the tree against the command-line cap.
+//
+// It measures the *literal* length, which is what a static pass can see. Two
+// classes of script are therefore only partly covered, and the headroom column
+// is an upper bound for both:
+//
+//   - Templates filled in at run time. The ms365 reports interpolate OAuth
+//     tokens, and the cloud metadata helpers interpolate IMDS tokens; a JWT is
+//     itself on the order of a kilobyte, so several of these are much closer to
+//     the cap in production than they read here.
+//   - Scripts whose interpolated part is unbounded: SidLookupScript grows with
+//     the number of local accounts, AclScript and the registry helpers with a
+//     path, and filesfind.BuildPowershellCmd with MQL arguments the user wrote.
+//
+// Bounding those needs a check at the point of assembly rather than here.
+func TestEmbeddedPowerShellScriptsFitCommandLine(t *testing.T) {
+	root := "../../../.."
+
+	var found []scriptFinding
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			// .claude holds developer worktrees, which are whole extra copies
+			// of the tree and would be measured many times over.
+			case ".git", ".claude", "node_modules", "dist", "testdata", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil
+		}
+		abs, _ := filepath.Abs(path)
+		rootAbs, _ := filepath.Abs(root)
+		rel, _ := filepath.Rel(rootAbs, abs)
+		rel = filepath.ToSlash(rel)
+
+		record := func(name string, e ast.Expr, pos token.Pos) {
+			s, ok := flattenStringExpr(e)
+			if !ok || len(s) < 120 || !looksLikePowerShell(s) {
+				return
+			}
+			found = append(found, scriptFinding{
+				file: rel, name: name, line: fset.Position(pos).Line,
+				src: len(s), enc: len(powershell.Encode(s)),
+			})
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch d := n.(type) {
+			case *ast.ValueSpec: // const and var declarations, package or function scope
+				for i, nm := range d.Names {
+					if i < len(d.Values) {
+						record(nm.Name, d.Values[i], nm.Pos())
+					}
+				}
+			case *ast.AssignStmt: // function-local `cmd := ` + "`" + `…` + "`" + `
+				for i, lhs := range d.Lhs {
+					if i >= len(d.Rhs) {
+						break
+					}
+					name := "(local)"
+					if id, ok := lhs.(*ast.Ident); ok {
+						name = id.Name + " (local)"
+					}
+					record(name, d.Rhs[i], lhs.Pos())
+				}
+			case *ast.CallExpr: // powershell.Encode("…inline literal…")
+				sel, ok := d.Fun.(*ast.SelectorExpr)
+				if !ok || len(d.Args) != 1 {
+					return true
+				}
+				switch sel.Sel.Name {
+				case "Encode", "EncodeUnix", "Wrap":
+					record(sel.Sel.Name+"(inline)", d.Args[0], d.Lparen)
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+
+	// If the walk finds nothing the test would pass vacuously, which is the
+	// failure mode this whole file exists to prevent.
+	require.Greater(t, len(found), 20, "the sweep found almost no scripts; the walk root is probably wrong")
+
+	sort.Slice(found, func(i, j int) bool { return found[i].enc > found[j].enc })
+
+	var table strings.Builder
+	fmt.Fprintf(&table, "\n%-52s %-34s %6s %8s %9s  %s\n",
+		"FILE", "SCRIPT", "SRC", "ENCODED", "HEADROOM", "STATUS")
+	for _, f := range found {
+		status := "ok"
+		switch {
+		case f.enc > powershell.MaxCommandLength:
+			status = "OVER CAP"
+		case f.src > powershell.MaxScriptLength:
+			status = "over budget"
+		case powershell.MaxCommandLength-f.enc < 1500:
+			status = "tight"
+		}
+		fmt.Fprintf(&table, "%-52s %-34s %6d %8d %9d  %s\n",
+			f.file, f.name, f.src, f.enc, powershell.MaxCommandLength-f.enc, status)
+	}
+	fmt.Fprintf(&table, "\n%d embedded scripts measured\n", len(found))
+	t.Log(table.String())
+
+	seen := map[string]bool{}
+	for _, f := range found {
+		seen[f.key()] = true
+		if f.enc <= powershell.MaxCommandLength {
+			continue
+		}
+		assert.Contains(t, knownOverCap, f.key(),
+			"%s:%d %s is %d chars (%d encoded), over the %d character cap. "+
+				"Compact it, or split it into two round trips — do not raise the cap.",
+			f.file, f.line, f.name, f.src, f.enc, powershell.MaxCommandLength)
+	}
+
+	// Keep the exception list honest: an entry that no longer exceeds the cap,
+	// or that names a script that no longer exists, has to come off it.
+	for _, f := range found {
+		if _, ok := knownOverCap[f.key()]; ok {
+			assert.Greater(t, f.enc, powershell.MaxCommandLength,
+				"%s now fits (%d encoded); remove it from knownOverCap", f.key(), f.enc)
+		}
+	}
+	for key := range knownOverCap {
+		assert.True(t, seen[key], "knownOverCap names %s, which the sweep did not find; remove it", key)
+	}
+}

--- a/providers/os/resources/windows/scheduledtask.go
+++ b/providers/os/resources/windows/scheduledtask.go
@@ -14,7 +14,20 @@ import (
 // MultipleInstances, Compatibility) are stringified via "$(...)" so they
 // serialize as their names rather than raw integers, and the polymorphic
 // trigger objects are flattened into a single union shape keyed by their CIM
-// class name.
+// class name: Select-Object yields null for a property the concrete trigger
+// class does not carry.
+//
+// The script has to stay under powershell.MaxScriptLength. It is passed to the
+// target base64-encoded as UTF-16, so it arrives roughly three times its source
+// length against a fixed command-line cap, and a script that overruns the cap
+// fails in a way that reads like the Task Scheduler being unavailable rather
+// than like a script that is too long. TestScheduledTasksScriptFitsCommandLine
+// guards the budget; if a property has to be added and the script no longer
+// fits, split it into two round trips rather than raising the cap.
+//
+// Property lists are spelled out and cmdlets are named in full deliberately.
+// Aliases (%, ?, gci) can be absent or redefined under Constrained Language
+// Mode and JEA, which is exactly where this resource is used.
 const SCHEDULED_TASKS = `
 $ErrorActionPreference = 'Stop'
 Get-ScheduledTask | ForEach-Object {
@@ -22,78 +35,42 @@ Get-ScheduledTask | ForEach-Object {
   $p = $t.Principal
   $s = $t.Settings
   [PSCustomObject]@{
-    Name               = $t.TaskName
-    Path               = $t.TaskPath
-    URI                = $t.URI
-    State              = "$($t.State)"
-    Description        = $t.Description
-    Author             = $t.Author
-    Documentation      = $t.Documentation
+    Name = $t.TaskName
+    Path = $t.TaskPath
+    URI = $t.URI
+    State = "$($t.State)"
+    Description = $t.Description
+    Author = $t.Author
+    Documentation = $t.Documentation
     SecurityDescriptor = $t.SecurityDescriptor
-    Source             = $t.Source
-    Date               = $t.Date
-    Principal          = if ($p) {
-      [PSCustomObject]@{
-        UserId      = $p.UserId
-        GroupId     = $p.GroupId
-        DisplayName = $p.DisplayName
-        LogonType   = "$($p.LogonType)"
-        RunLevel    = "$($p.RunLevel)"
-      }
+    Source = $t.Source
+    Date = $t.Date
+    Principal = if ($p) {
+      $p | Select-Object UserId, GroupId, DisplayName,
+        @{ Name = 'LogonType'; Expression = { "$($_.LogonType)" } },
+        @{ Name = 'RunLevel'; Expression = { "$($_.RunLevel)" } }
     } else { $null }
-    Actions = @($t.Actions | ForEach-Object {
-      [PSCustomObject]@{
-        Execute          = $_.Execute
-        Arguments        = $_.Arguments
-        WorkingDirectory = $_.WorkingDirectory
-      }
-    })
-    Triggers = @($t.Triggers | ForEach-Object {
-      $tr = $_
-      [PSCustomObject]@{
-        Type                        = $tr.CimClass.CimClassName
-        Enabled                     = $tr.Enabled
-        StartBoundary               = $tr.StartBoundary
-        EndBoundary                 = $tr.EndBoundary
-        ExecutionTimeLimit          = $tr.ExecutionTimeLimit
-        RepetitionInterval          = $tr.Repetition.Interval
-        RepetitionDuration          = $tr.Repetition.Duration
-        RepetitionStopAtDurationEnd = $tr.Repetition.StopAtDurationEnd
-        Delay                       = $tr.Delay
-        RandomDelay                 = $tr.RandomDelay
-        DaysInterval                = $tr.DaysInterval
-        WeeksInterval               = $tr.WeeksInterval
-        DaysOfWeek                  = $tr.DaysOfWeek
-        UserId                      = $tr.UserId
-      }
-    })
+    Actions = @($t.Actions | Select-Object Execute, Arguments, WorkingDirectory)
+    Triggers = @($t.Triggers | Select-Object @{ Name = 'Type'; Expression = { $_.CimClass.CimClassName } },
+      Enabled, StartBoundary, EndBoundary, ExecutionTimeLimit,
+      @{ Name = 'RepetitionInterval'; Expression = { $_.Repetition.Interval } },
+      @{ Name = 'RepetitionDuration'; Expression = { $_.Repetition.Duration } },
+      @{ Name = 'RepetitionStopAtDurationEnd'; Expression = { $_.Repetition.StopAtDurationEnd } },
+      Delay, RandomDelay, DaysInterval, WeeksInterval, DaysOfWeek, UserId)
     Settings = if ($s) {
-      [PSCustomObject]@{
-        Enabled                         = $s.Enabled
-        Hidden                          = $s.Hidden
-        AllowDemandStart                = $s.AllowDemandStart
-        AllowHardTerminate              = $s.AllowHardTerminate
-        StartWhenAvailable              = $s.StartWhenAvailable
-        RunOnlyIfNetworkAvailable       = $s.RunOnlyIfNetworkAvailable
-        RunOnlyIfIdle                   = $s.RunOnlyIfIdle
-        WakeToRun                       = $s.WakeToRun
-        DisallowStartIfOnBatteries      = $s.DisallowStartIfOnBatteries
-        StopIfGoingOnBatteries          = $s.StopIfGoingOnBatteries
-        DisallowStartOnRemoteAppSession = $s.DisallowStartOnRemoteAppSession
-        RestartCount                    = $s.RestartCount
-        RestartInterval                 = $s.RestartInterval
-        ExecutionTimeLimit              = $s.ExecutionTimeLimit
-        MultipleInstances               = "$($s.MultipleInstances)"
-        Priority                        = $s.Priority
-        DeleteExpiredTaskAfter          = $s.DeleteExpiredTaskAfter
-        Compatibility                   = "$($s.Compatibility)"
-        IdleDuration                    = $s.IdleSettings.IdleDuration
-        IdleWaitTimeout                 = $s.IdleSettings.WaitTimeout
-        IdleStopOnIdleEnd               = $s.IdleSettings.StopOnIdleEnd
-        IdleRestartOnIdle               = $s.IdleSettings.RestartOnIdle
-        NetworkId                       = $s.NetworkSettings.Id
-        NetworkName                     = $s.NetworkSettings.Name
-      }
+      $s | Select-Object Enabled, Hidden, AllowDemandStart, AllowHardTerminate,
+        StartWhenAvailable, RunOnlyIfNetworkAvailable, RunOnlyIfIdle, WakeToRun,
+        DisallowStartIfOnBatteries, StopIfGoingOnBatteries, DisallowStartOnRemoteAppSession,
+        RestartCount, RestartInterval, ExecutionTimeLimit,
+        @{ Name = 'MultipleInstances'; Expression = { "$($_.MultipleInstances)" } },
+        Priority, DeleteExpiredTaskAfter,
+        @{ Name = 'Compatibility'; Expression = { "$($_.Compatibility)" } },
+        @{ Name = 'IdleDuration'; Expression = { $_.IdleSettings.IdleDuration } },
+        @{ Name = 'IdleWaitTimeout'; Expression = { $_.IdleSettings.WaitTimeout } },
+        @{ Name = 'IdleStopOnIdleEnd'; Expression = { $_.IdleSettings.StopOnIdleEnd } },
+        @{ Name = 'IdleRestartOnIdle'; Expression = { $_.IdleSettings.RestartOnIdle } },
+        @{ Name = 'NetworkId'; Expression = { $_.NetworkSettings.Id } },
+        @{ Name = 'NetworkName'; Expression = { $_.NetworkSettings.Name } }
     } else { $null }
   }
 } | ConvertTo-Json -Depth 5`

--- a/providers/os/resources/windows/scheduledtask_test.go
+++ b/providers/os/resources/windows/scheduledtask_test.go
@@ -10,7 +10,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
 )
+
+// A script that no longer fits on the command line does not fail loudly. The
+// target rejects the command before PowerShell runs, and the non-zero exit
+// reads like the Task Scheduler being unavailable rather than like a script
+// that outgrew the cap — which is how SCHEDULED_TASKS shipped at 3555
+// characters (9626 encoded) against an 8191 cap without anyone noticing.
+func TestScheduledTasksScriptFitsCommandLine(t *testing.T) {
+	scripts := map[string]string{
+		"SCHEDULED_TASKS": SCHEDULED_TASKS,
+		// Built per task, so measure it with a long real-world path and name.
+		"ScheduledTaskInfoScript": ScheduledTaskInfoScript(
+			`\Microsoft\Windows\UpdateOrchestrator\`, "Schedule Scan Static Task"),
+	}
+	for name, script := range scripts {
+		t.Run(name, func(t *testing.T) {
+			assert.LessOrEqual(t, len(script), powershell.MaxScriptLength,
+				"script is too long to be encoded onto a Windows command line; "+
+					"split it into two round trips rather than raising the cap")
+			// The source-length budget is a proxy. Assert the real constraint too.
+			assert.True(t, powershell.FitsCommandLine(script),
+				"encoded length %d exceeds the %d character command-line cap",
+				len(powershell.Encode(script)), powershell.MaxCommandLength)
+		})
+	}
+}
 
 func TestWindowsScheduledTasks(t *testing.T) {
 	r, err := os.Open("./testdata/scheduled-tasks.json")


### PR DESCRIPTION
Fixes #10072.

## The bug

`SCHEDULED_TASKS` is **3555 characters**, which `powershell.Encode` turns into a **9626 character** command line against Windows' **8191** cap. `windows.scheduledTask` fails on real hosts today.

It fails in the worst available way. The command is rejected *before* PowerShell runs, so what comes back is a non-zero exit with no useful stderr, which reads as "the Task Scheduler is not available" — a clean empty answer rather than an error. That is why it shipped unnoticed.

## The budget, measured rather than assumed

`Encode` prepends `$ProgressPreference='SilentlyContinue';` (39 chars) to the *script*, then base64-encodes it as UTF-16 (x2 for the widening, x4/3 for base64), then prepends `powershell.exe -NoProfile -EncodedCommand ` (42 chars) to the *command line*.

The naive `8191 x 3/4 / 2` = 3071 ignores both prefixes. Binary search over the real `Encode` gives the true ceiling:

| | |
|---|---|
| `Encode(3016 chars)` | 8190 — fits |
| `Encode(3017 chars)` | 8194 — does not |

**3016 characters** is the real ceiling. `MaxScriptLength` is set to 3000 to leave a margin, and `TestMaxScriptLengthIsUnderTheRealCeiling` re-derives the 3016 by binary search on every run, so if `Encode` ever grows another prefix the constant is forced down with it rather than silently becoming wrong.

## What was cut, and why it was safe

**Step 1 — over-selection: zero wins.** The script emits 57 properties; all 57 are decoded, and every decoded field is referenced by the resource layer and surfaced as an MQL field. Checked mechanically, not by eye. There was nothing free to drop.

**Step 2 — redundancy.** The size came out of the shape instead. Writing `Execute = $_.Execute` for 57 properties is a `ForEach-Object` pipeline stage that `Select-Object` does directly, and the column alignment was 717 characters of padding on its own.

**3555 -> 2325 characters (-34.6%), 6346 encoded, 1845 characters of headroom.** Compaction was sufficient; no split was needed, so there is no merge step and no new place for a partial-result bug.

**What was deliberately not done:** no aliases (`%`, `?`, `gci`), no one-lining. Aliases can be absent or redefined under Constrained Language Mode and JEA, which is exactly the kind of hardened host this resource is pointed at. Cmdlet names and property lists are spelled out in full, and `Name`/`Expression` are used rather than `n`/`e`.

## Verifying the output shape did not change

The Go parser has to keep working, so the shape is the thing to protect. I ran both the old and new script under `pwsh` 7.4 against a stub that fakes `Get-ScheduledTask` with objects mirroring the CIM shape, and diffed the JSON.

| case | result |
|---|---|
| fully populated task, 3 triggers, 2 actions, all settings | **byte-identical JSON** |
| polymorphic trigger union (logon trigger missing 12 properties) | byte-identical — all 12 null in both |
| `Principal` and `Settings` null | byte-identical |
| settings object with almost every property unset | byte-identical — null, not zero, in both |
| single task (bare object, not an array) | byte-identical |
| zero tasks | byte-identical |
| collections present but empty (`@()`) | byte-identical |

**One intentional difference**, in the case where a collection property is entirely absent/null rather than an empty array:

| | `Actions`/`Triggers` |
|---|---|
| before | `[ { "Execute": null, "Arguments": null, "WorkingDirectory": null } ]` |
| after | `[]` |

`$null | ForEach-Object { ... }` runs once — `$null` is a real pipeline item — so the old script fabricated one all-null entry, which the resource layer would have turned into a phantom trigger resource with an empty type. `Select-Object` yields nothing. The new behaviour is correct; I am calling it out because it is a behaviour change and because it moves an assertion on a triggerless task from failing to vacuously true, which is the direction worth knowing about.

## Local vs. live host

- **Verified locally:** the budget arithmetic, the 34.6% reduction, old/new equivalence across the seven cases above under `pwsh` 7.4, that the guard fails on the old script and passes on the new one, and that every existing parser test passes **unchanged** (they were not touched).
- **Not verified, needs a Windows host:** that the script still returns what it should from the real `Get-ScheduledTask`. The equivalence proof is old-vs-new under one interpreter against a stub; it does **not** establish behaviour against real CIM instances, and I am not inferring that from the parser tests. Specifically unconfirmed: that `Select-Object` on a real CIM instance yields null for a property the class does not carry without raising a non-terminating error under `$ErrorActionPreference = 'Stop'` (it does on the PSCustomObject analog), and whether real CIM returns `@()` or `$null` for a triggerless task, which is what decides whether the difference above is ever observable.

## The systemic sweep

`TestEmbeddedPowerShellScriptsFitCommandLine` walks the tree, finds every embedded PowerShell script by AST — package-level `const` and `var`, function-local literals, and inline `Encode`/`Wrap` arguments — measures each, and fails on any that is over the cap and not in `knownOverCap`. **47 scripts measured.** Run it with `-v` for the full table.

Two are already over:

| script | src | encoded | over by | why it is filed rather than fixed here |
|---|---|---|---|---|
| `ms365_exchange.go` `exchangeReport` (#10083) | 5322 | 14338 | 6147 | Runs on the **scanner** host, not a remote target, and only as a fallback when the Exchange admin REST endpoint is unavailable. On a Linux/macOS scanner the shell is `sh -c`, where `ARG_MAX` is megabytes and the cap does not apply — it only breaks when the scanner itself runs Windows. |
| `users/ps1getlocalusers.go` `getLocalUsersScript` (#10082) | 5294 | 14266 | 6075 | **Same delivery path and same failure mode as this bug** — `RunCommand(powershell.Encode(...))` to a Windows target. Needs a 43% cut and a Windows host to verify: it walks the ProfileList registry hive and the IdentityStore cache. |

Filed as #10082 and #10083 rather than bundled in, since neither is small or mechanical and both need a live target.

The same pass turned up one more defect that is not about length but breaks the same way and inflates the command line ~7x: `windows_routes_pwsh.go` calls `powershell.Encode` and then passes the result to a helper that encodes it again, so the payload decodes to the text of another `powershell.exe -EncodedCommand` invocation. All three Windows route paths are affected. Filed as #10084; the fix is three deleted lines but confirming routes still come back needs a Windows host.

The sweep measures *literal* length, which is what a static pass can see. Two classes are only partly covered and I have noted this in the test: templates filled at run time (the ms365 reports interpolate OAuth tokens, the metadata helpers interpolate IMDS tokens — a JWT is itself around a kilobyte, so `teamsReport` at 2199 + two JWTs is likely over the cap in production on a Windows scanner), and scripts whose interpolated part is unbounded (`SidLookupScript` grows with the local account count, `filesfind.BuildPowershellCmd` with MQL arguments the user wrote). Bounding those needs a check at the point of assembly.

## Note on #10064

That PR found this class of bug and added `PSMaxScriptLength` plus `TestDnsServerScriptsFitCommandLine` in the `windows` package. This generalises the same mechanism rather than adding a second one: the constants move to the `powershell` package, next to the `Encode` they are a property of, so the sweep and every provider can share them. When #10064 merges, its local `PSMaxScriptLength` can be dropped in favour of `powershell.MaxScriptLength` — no compile conflict either way, just a duplicate to tidy up.

Do not merge yet.
