### PR TITLE
🐛 azure: read the encryption key on storage accounts that use a customer-managed key

### DIFF
--- a/providers/azure/resources/security_helpers.go
+++ b/providers/azure/resources/security_helpers.go
@@ -4,9 +4,35 @@
 package resources
 
 import (
+	"strings"
+
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+// keyVaultKeyURI builds the canonical Key Vault key identifier from the parts
+// ARM reports on a resource's customer-managed-key settings.
+//
+// ARM returns the vault URI WITH a trailing slash
+// ("https://myvault.vault.azure.net/"), so appending "/keys/" naively yields a
+// doubled separator that parseKeyVaultId's regex rejects -- the key then reads
+// as an error on exactly the resources that use a customer-managed key. Trim
+// the separator rather than assuming ARM's shape.
+//
+// Returns "" when either required part is missing, which callers surface as a
+// null reference rather than a broken URI.
+func keyVaultKeyURI(vaultURI, keyName, keyVersion string) string {
+	vaultURI = strings.TrimSuffix(strings.TrimSpace(vaultURI), "/")
+	keyName = strings.TrimSpace(keyName)
+	if vaultURI == "" || keyName == "" {
+		return ""
+	}
+	uri := vaultURI + "/keys/" + keyName
+	if keyVersion = strings.TrimSpace(keyVersion); keyVersion != "" {
+		uri += "/" + keyVersion
+	}
+	return uri
+}
 
 // newKeyVaultKeyResource creates a typed azure.subscription.keyVaultService.key
 // reference from a Key Vault key URI (e.g. https://myvault.vault.azure.net/keys/mykey/version).

--- a/providers/azure/resources/security_helpers_test.go
+++ b/providers/azure/resources/security_helpers_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyVaultKeyURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		vault   string
+		key     string
+		version string
+		want    string
+	}{
+		{
+			// The shape ARM actually returns: keyVaultUri carries a trailing
+			// slash. Appending "/keys/" without trimming produced "//keys/",
+			// which parseKeyVaultId rejects.
+			name:  "trailing slash on the vault uri is trimmed",
+			vault: "https://myvault.vault.azure.net/", key: "cmk",
+			want: "https://myvault.vault.azure.net/keys/cmk",
+		},
+		{
+			name:  "no trailing slash still works",
+			vault: "https://myvault.vault.azure.net", key: "cmk",
+			want: "https://myvault.vault.azure.net/keys/cmk",
+		},
+		{
+			name:  "version is appended when present",
+			vault: "https://myvault.vault.azure.net/", key: "cmk", version: "abc123",
+			want: "https://myvault.vault.azure.net/keys/cmk/abc123",
+		},
+		{
+			name:  "managed hsm uri",
+			vault: "https://myhsm.managedhsm.azure.net/", key: "cmk",
+			want: "https://myhsm.managedhsm.azure.net/keys/cmk",
+		},
+		{"missing vault yields empty", "", "cmk", "", ""},
+		{"missing key yields empty", "https://myvault.vault.azure.net/", "", "", ""},
+		{"a bare slash is not a vault", "/", "cmk", "", ""},
+		{"whitespace is not a vault", "   ", "cmk", "", ""},
+		{
+			name:  "blank version is not appended",
+			vault: "https://myvault.vault.azure.net/", key: "cmk", version: "  ",
+			want: "https://myvault.vault.azure.net/keys/cmk",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, keyVaultKeyURI(tc.vault, tc.key, tc.version))
+		})
+	}
+}
+
+// The URI this helper builds is fed straight to parseKeyVaultId, so the
+// contract that matters is not the string shape but that the result actually
+// parses. Asserting against the real parser is what would have caught the
+// original bug: the naive concatenation produced a plausible-looking URI that
+// only the regex rejected.
+func TestKeyVaultKeyURIRoundTripsThroughTheParser(t *testing.T) {
+	cases := []struct {
+		name            string
+		vault, key, ver string
+		wantVault       string
+		wantName        string
+		wantVersion     string
+	}{
+		{"arm shape with trailing slash", "https://myvault.vault.azure.net/", "cmk", "", "myvault", "cmk", ""},
+		{"with version", "https://myvault.vault.azure.net/", "cmk", "v1", "myvault", "cmk", "v1"},
+		{"managed hsm", "https://myhsm.managedhsm.azure.net/", "cmk", "", "myhsm", "cmk", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uri := keyVaultKeyURI(tc.vault, tc.key, tc.ver)
+			require.NotEmpty(t, uri)
+
+			parsed, err := parseKeyVaultId(uri)
+			require.NoError(t, err, "the URI this helper builds must parse: %q", uri)
+			assert.Equal(t, tc.wantVault, parsed.Vault)
+			assert.Equal(t, "keys", parsed.Type)
+			assert.Equal(t, tc.wantName, parsed.Name)
+			assert.Equal(t, tc.wantVersion, parsed.Version)
+		})
+	}
+}
+
+// Pin the regression directly: the pre-fix concatenation must be the thing that
+// fails, so a future refactor that reintroduces it cannot pass silently.
+func TestNaiveConcatenationIsRejectedByTheParser(t *testing.T) {
+	const armVaultURI = "https://myvault.vault.azure.net/" // as ARM returns it
+
+	naive := armVaultURI + "/keys/" + "cmk"
+	assert.Contains(t, naive, "//keys/")
+	_, err := parseKeyVaultId(naive)
+	require.Error(t, err, "the doubled separator must not parse -- this is the bug being fixed")
+
+	fixed := keyVaultKeyURI(armVaultURI, "cmk", "")
+	_, err = parseKeyVaultId(fixed)
+	require.NoError(t, err)
+}

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -1162,13 +1162,10 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) encryptionKeySource() (strin
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) encryptionKey() (*mqlAzureSubscriptionKeyVaultServiceKey, error) {
-	if a.cacheEncryptionKeyVaultURI == "" || a.cacheEncryptionKeyName == "" {
+	keyURI := keyVaultKeyURI(a.cacheEncryptionKeyVaultURI, a.cacheEncryptionKeyName, a.cacheEncryptionKeyVersion)
+	if keyURI == "" {
 		a.EncryptionKey.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
-	}
-	keyURI := a.cacheEncryptionKeyVaultURI + "/keys/" + a.cacheEncryptionKeyName
-	if a.cacheEncryptionKeyVersion != "" {
-		keyURI += "/" + a.cacheEncryptionKeyVersion
 	}
 	return newKeyVaultKeyResource(a.MqlRuntime, keyURI)
 }


### PR DESCRIPTION
## Problem

`azure.subscription.storageService.account.encryptionKey` errors on **every** storage account whose encryption key lives in Key Vault:

```
cannot parse azure keyvault id: https://<vault>.vault.azure.net//keys/<key>
```

ARM returns `keyVaultUri` **with a trailing slash**. The accessor appended `/keys/` to it:

```go
keyURI := a.cacheEncryptionKeyVaultURI + "/keys/" + a.cacheEncryptionKeyName
//        https://<vault>.vault.azure.net/  +  /keys/  ->  //keys/
```

`parseKeyVaultId`'s regex requires exactly one separator after `.azure.net`, so the parse fails.

## Impact

The field fails for exactly the accounts where it carries meaning. Live, on a test subscription, split perfectly by configuration:

```
keySource=Microsoft.Storage    encryptionKey -> null    (correct: platform-managed)
keySource=Microsoft.Storage    encryptionKey -> null    (correct)
keySource=Microsoft.Storage    encryptionKey -> null    (correct)
keySource=Microsoft.Keyvault   encryptionKey -> Error: cannot parse azure keyvault id
keySource=Microsoft.Keyvault   encryptionKey -> Error: cannot parse azure keyvault id
keySource=Microsoft.Keyvault   encryptionKey -> Error: cannot parse azure keyvault id
```

"Storage accounts must use a customer-managed key from an approved vault" cannot be answered for any **compliant** account — the compliant ones are precisely the rows that error.

## Fix

Build the identifier through a shared `keyVaultKeyURI` helper that trims the separator rather than assuming ARM's shape.

Two siblings already handle this by hand — `datafactory.go:182` and `synapse.go:232` both call `strings.TrimSuffix(uri, "/")` before the identical concatenation — so the omission was local to storage. Folding all three onto the shared helper is left as a follow-up so this change stays scoped to the defect.

## Verification

Same subscription, after the fix:

```
securityteam…  keySource=Microsoft.Keyvault  encryptionKey.keyName="…-activitylog-key"
securityteam…  keySource=Microsoft.Keyvault  encryptionKey.keyName="…-activitylog-key"
securityteam…  keySource=Microsoft.Keyvault  encryptionKey.keyName="…-activitylog-key2"
```

## Tests

`resources/security_helpers_test.go`:

- `TestKeyVaultKeyURI` — the ARM shape (trailing slash), the already-trimmed shape, version appended, managed-HSM hosts, and the empty/whitespace cases that must yield `""` so callers surface null rather than a broken URI.
- `TestKeyVaultKeyURIRoundTripsThroughTheParser` — asserts the built URI actually **parses**, and that each component comes back correct. This is the assertion that matters: the bug produced a plausible-looking string that only the regex rejected, so testing the string shape alone would not have caught it.
- `TestNaiveConcatenationIsRejectedByTheParser` — pins the regression directly, asserting the pre-fix concatenation still fails to parse while the helper's output succeeds, so a refactor that reintroduces it cannot pass silently.

## Test plan

- [x] `go test ./resources/` passes in `providers/azure/`
- [x] `gofmt` clean
- [x] `make providers/build/azure` succeeds
- [x] Live-verified against three storage accounts using customer-managed keys
