### PR TITLE
🐛 azure: stop a private endpoint pointed at a first-party service failing the endpoint list

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -4562,7 +4562,22 @@ private azure.subscription.networkService.privateEndpoint.serviceconnection @def
   id string
   // Connection name
   name string
-  // Private link service being connected to
+  // Resource ID of the connection target
+  //
+  // The ARM ID of whatever the endpoint connects to. For a connection to a
+  // Private Link service this is that service's ID, and privateLinkService
+  // resolves it. For a connection to a first-party service (a storage
+  // account, a SQL server, a key vault, a Cosmos DB account) this is the
+  // target resource's own ID, which spans too many resource types for a
+  // single reference, so it is reported here as an ID.
+  privateLinkServiceId string
+  // Private Link service being connected to, or null when the target is a first-party service
+  //
+  // Resolves the provider-side Private Link service the endpoint consumes, so
+  // its visibility and auto-approval subscription lists and its own endpoint
+  // connections can be examined from the consumer side. Null for a connection
+  // to a first-party service, which has no Private Link service of its own;
+  // privateLinkServiceId names the target in that case.
   privateLinkService() azure.subscription.networkService.privateLinkService
   // Group IDs obtained from the remote resource
   groupIds []string

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -7062,6 +7062,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).GetName()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkServiceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).GetPrivateLinkServiceId()).ToDataRes(types.String)
+	},
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkService": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).GetPrivateLinkService()).ToDataRes(types.Resource("azure.subscription.networkService.privateLinkService"))
 	},
@@ -27278,6 +27281,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkServiceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection).PrivateLinkServiceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkService": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -62724,13 +62731,14 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpoint) GetPrivateDnsZoneGro
 type mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnectionInternal
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	PrivateLinkService plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateLinkService]
-	GroupIds           plugin.TValue[[]any]
-	ConnectionStatus   plugin.TValue[string]
-	RequestMessage     plugin.TValue[string]
+	// optional: if you define mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnectionInternal it will be used here
+	Id                   plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	PrivateLinkServiceId plugin.TValue[string]
+	PrivateLinkService   plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateLinkService]
+	GroupIds             plugin.TValue[[]any]
+	ConnectionStatus     plugin.TValue[string]
+	RequestMessage       plugin.TValue[string]
 }
 
 // createAzureSubscriptionNetworkServicePrivateEndpointServiceconnection creates a new instance of this resource
@@ -62771,6 +62779,10 @@ func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) Get
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) GetPrivateLinkServiceId() *plugin.TValue[string] {
+	return &c.PrivateLinkServiceId
 }
 
 func (c *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) GetPrivateLinkService() *plugin.TValue[*mqlAzureSubscriptionNetworkServicePrivateLinkService] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -4417,6 +4417,7 @@ azure.subscription.networkService.privateEndpoint.serviceconnection.groupIds 11.
 azure.subscription.networkService.privateEndpoint.serviceconnection.id 11.4.28
 azure.subscription.networkService.privateEndpoint.serviceconnection.name 11.4.28
 azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkService 13.9.3
+azure.subscription.networkService.privateEndpoint.serviceconnection.privateLinkServiceId 13.36.1
 azure.subscription.networkService.privateEndpoint.serviceconnection.requestMessage 11.4.28
 azure.subscription.networkService.privateEndpoint.subnet 13.26.1
 azure.subscription.networkService.privateEndpoint.tags 11.4.28

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -2363,33 +2363,30 @@ func privateLinkServiceConnectionToMql(runtime *plugin.Runtime, c *network.Priva
 
 	res, err := CreateResource(runtime, "azure.subscription.networkService.privateEndpoint.serviceconnection",
 		map[string]*llx.RawData{
-			"__id":             llx.StringData(subResourceCacheID(c.ID, parentID, collection, convert.ToValue(c.Name))),
-			"id":               llx.StringDataPtr(c.ID),
-			"name":             llx.StringDataPtr(c.Name),
-			"groupIds":         llx.ArrayData(groupIds, types.String),
-			"connectionStatus": llx.StringData(connectionStatus),
-			"requestMessage":   llx.StringData(requestMessage),
+			"__id":                 llx.StringData(subResourceCacheID(c.ID, parentID, collection, convert.ToValue(c.Name))),
+			"id":                   llx.StringDataPtr(c.ID),
+			"name":                 llx.StringDataPtr(c.Name),
+			"privateLinkServiceId": llx.StringData(plsId),
+			"groupIds":             llx.ArrayData(groupIds, types.String),
+			"connectionStatus":     llx.StringData(connectionStatus),
+			"requestMessage":       llx.StringData(requestMessage),
 		})
 	if err != nil {
 		return nil, err
 	}
-	mqlConn := res.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection)
-	mqlConn.cachePrivateLinkServiceId = plsId
-	return mqlConn, nil
-}
-
-type mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnectionInternal struct {
-	cachePrivateLinkServiceId string
+	return res.(*mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection), nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServicePrivateEndpointServiceconnection) privateLinkService() (*mqlAzureSubscriptionNetworkServicePrivateLinkService, error) {
-	plsId := a.cachePrivateLinkServiceId
-	if plsId == "" {
+	// A connection to a first-party PaaS resource puts that resource's own ARM
+	// id in privateLinkServiceId, so there is no private link service to
+	// resolve. privateLinkServiceId still reports the target.
+	if _, ok := parsePrivateLinkServiceID(a.PrivateLinkServiceId.Data); !ok {
 		a.PrivateLinkService.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.privateLinkService", map[string]*llx.RawData{
-		"id": llx.StringData(plsId),
+		"id": llx.StringData(a.PrivateLinkServiceId.Data),
 	})
 	if err != nil {
 		return nil, err
@@ -2552,6 +2549,49 @@ func privateLinkServiceToMql(runtime *plugin.Runtime, pls *network.PrivateLinkSe
 	return res.(*mqlAzureSubscriptionNetworkServicePrivateLinkService), nil
 }
 
+// privateLinkServiceTarget names the private link service an ARM resource id
+// refers to, split into the parts the private-link-services API needs.
+type privateLinkServiceTarget struct {
+	SubscriptionID string
+	ResourceGroup  string
+	Name           string
+}
+
+// parsePrivateLinkServiceID reports whether an ARM resource id names a
+// Microsoft.Network/privateLinkServices resource, and returns its parts when it
+// does.
+//
+// A private endpoint's properties.privateLinkServiceId carries either shape the
+// endpoint can take: a private link service somebody built to expose their own
+// service, or, far more commonly, the first-party PaaS resource the endpoint
+// connects to, whose own ARM id goes in that same field. Callers have to
+// discriminate before asking the private-link-services API for it, because a
+// storage account id has no privateLinkServices component to read a name from.
+func parsePrivateLinkServiceID(id string) (privateLinkServiceTarget, bool) {
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return privateLinkServiceTarget{}, false
+	}
+	if !strings.EqualFold(resourceID.Provider, "Microsoft.Network") || resourceID.ResourceGroup == "" {
+		return privateLinkServiceTarget{}, false
+	}
+	name, err := resourceID.Component("privateLinkServices")
+	if err != nil {
+		return privateLinkServiceTarget{}, false
+	}
+	// A child of a private link service is not the service: an ip
+	// configuration's id also carries a privateLinkServices component, and
+	// reading the name out of it would silently return the parent instead.
+	if len(resourceID.Path) != 1 {
+		return privateLinkServiceTarget{}, false
+	}
+	return privateLinkServiceTarget{
+		SubscriptionID: resourceID.SubscriptionID,
+		ResourceGroup:  resourceID.ResourceGroup,
+		Name:           name,
+	}, true
+}
+
 func initAzureSubscriptionNetworkServicePrivateLinkService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 {
 		return args, nil, nil
@@ -2567,13 +2607,9 @@ func initAzureSubscriptionNetworkServicePrivateLinkService(runtime *plugin.Runti
 	if !ok {
 		return nil, nil, errors.New("id must be a non-nil string value")
 	}
-	resourceID, err := ParseResourceID(id)
-	if err != nil {
-		return nil, nil, err
-	}
-	name, err := resourceID.Component("privateLinkServices")
-	if err != nil {
-		return nil, nil, err
+	target, ok := parsePrivateLinkServiceID(id)
+	if !ok {
+		return nil, nil, fmt.Errorf("%q is not a private link service id", id)
 	}
 	// Already fetched by an earlier reference: NewResource consults the
 	// cache only after this init returns, so without this the same target is
@@ -2582,13 +2618,13 @@ func initAzureSubscriptionNetworkServicePrivateLinkService(runtime *plugin.Runti
 		return args, cached, nil
 	}
 
-	client, err := network.NewPrivateLinkServicesClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+	client, err := network.NewPrivateLinkServicesClient(target.SubscriptionID, conn.Token(), &arm.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.Get(context.Background(), resourceID.ResourceGroup, name, nil)
+	resp, err := client.Get(context.Background(), target.ResourceGroup, target.Name, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/azure/resources/network_privatelink_test.go
+++ b/providers/azure/resources/network_privatelink_test.go
@@ -1,0 +1,115 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSub = "00000000-0000-0000-0000-000000000000"
+
+func TestParsePrivateLinkServiceID(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		wantOk  bool
+		wantPLS privateLinkServiceTarget
+	}{
+		{
+			name:   "a private link service id parses",
+			id:     "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.Network/privateLinkServices/my-pls",
+			wantOk: true,
+			wantPLS: privateLinkServiceTarget{
+				SubscriptionID: testSub,
+				ResourceGroup:  "rg1",
+				Name:           "my-pls",
+			},
+		},
+		{
+			// ARM resource ids are case-insensitive, and the casing a caller
+			// sees depends on which API returned the id.
+			name:   "casing does not matter",
+			id:     "/subscriptions/" + testSub + "/resourcegroups/rg1/providers/microsoft.network/privatelinkservices/my-pls",
+			wantOk: true,
+			wantPLS: privateLinkServiceTarget{
+				SubscriptionID: testSub,
+				ResourceGroup:  "rg1",
+				Name:           "my-pls",
+			},
+		},
+
+		// Every case below is a shape privateLinkServiceId actually holds in
+		// the field. A private endpoint pointed at a first-party service
+		// carries that service's own id, and it is by far the common shape --
+		// a Private Link service is what you build to expose your OWN service.
+		{
+			name: "a storage account target is not a private link service",
+			id:   "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/acct",
+		},
+		{
+			name: "a sql server target is not a private link service",
+			id:   "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.Sql/servers/srv",
+		},
+		{
+			name: "a key vault target is not a private link service",
+			id:   "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.KeyVault/vaults/kv",
+		},
+		{
+			name: "a cosmos db target is not a private link service",
+			id:   "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/cosmos",
+		},
+		{
+			// The provider gate matters on its own: without it a
+			// Microsoft.Network resource that has no privateLinkServices
+			// component would still have to be rejected by the component
+			// lookup, and any future Microsoft.X/privateLinkServices type
+			// would be fetched from the wrong API.
+			name: "another network resource is not a private link service",
+			id:   "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet",
+		},
+		{
+			// Reading the name out of a child id would return the parent
+			// service, quietly reporting the wrong resource rather than
+			// nothing.
+			name: "a child of a private link service is not the service",
+			id:   "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.Network/privateLinkServices/my-pls/ipConfigurations/ipc1",
+		},
+		{
+			name: "a subscription-scoped id has no resource group",
+			id:   "/subscriptions/" + testSub + "/providers/Microsoft.Network/privateLinkServices/my-pls",
+		},
+		{name: "empty"},
+		{name: "not a resource id at all", id: "my-pls"},
+		{name: "uneven components", id: "/subscriptions/" + testSub + "/resourceGroups"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parsePrivateLinkServiceID(tc.id)
+			require.Equal(t, tc.wantOk, ok)
+			assert.Equal(t, tc.wantPLS, got)
+		})
+	}
+}
+
+// The bug being fixed: the init read the service name straight out of the id
+// with Component("privateLinkServices"), which errors on every first-party
+// target. That error propagated out of NewResource and failed the whole
+// privateEndpoints query, so one storage-backed endpoint took the entire
+// collection down. Pin both halves: the old read still fails, and the
+// discrimination now used in its place does not.
+func TestFirstPartyTargetNoLongerErrors(t *testing.T) {
+	storageTarget := "/subscriptions/" + testSub + "/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/acct"
+
+	resourceID, err := ParseResourceID(storageTarget)
+	require.NoError(t, err, "a first-party target is a perfectly valid resource id")
+	_, err = resourceID.Component("privateLinkServices")
+	require.Error(t, err, "reading a service name out of a storage account id must fail -- this is the bug")
+
+	_, ok := parsePrivateLinkServiceID(storageTarget)
+	assert.False(t, ok, "the same id must be classified, not fetched")
+}


### PR DESCRIPTION
A private endpoint pointed at a storage account, a SQL server, or a key vault failed the whole `privateEndpoints` collection.

## What ARM actually returns

`properties.privateLinkServiceId` on a private endpoint's service connection carries either of two shapes:

| endpoint targets | `privateLinkServiceId` holds |
|---|---|
| a Private Link service somebody built | `/…/providers/Microsoft.Network/privateLinkServices/my-pls` |
| a first-party service | that resource's own id, e.g. `/…/providers/Microsoft.Storage/storageAccounts/acct` |

The second is the common one — a Private Link service is what you build to expose *your own* service, not what you get when you privately connect to PaaS.

## The bug

`initAzureSubscriptionNetworkServicePrivateLinkService` assumed the first shape and read the name straight out of the id:

```go
name, err := resourceID.Component("privateLinkServices")
if err != nil {
    return nil, nil, err
}
```

A storage account id has no `privateLinkServices` component, so this errored with ``ID was missing the `privateLinkServices` element``. The error propagated out of `NewResource` in `privateLinkService()`, and because that is an accessor on a list element, **one storage-backed endpoint failed the entire endpoint list** — the other endpoints, and every other selected field, went with it.

## The fix

`parsePrivateLinkServiceID` discriminates the two shapes before anything is fetched, so:

- `privateLinkService` resolves a real Private Link service, and is **null** when the target is a first-party service — which is the honest answer, not an error.
- the new `privateLinkServiceId` field reports the target in **both** cases, so the fact that matters ("what does this endpoint connect to") is no longer lost.

The target spans too many resource types for one reference and MQL has no union type, so it is reported as an ID rather than a typed accessor. `privateLinkService` remains the typed edge for the one shape that can be modelled. A follow-up could add typed accessors for the common first-party targets (`storageAccount`, `sqlServer`, `keyVault`), with the ID staying as the escape hatch for the long tail.

The helper also rejects a Private Link service's own children — an ip configuration's id carries the same `privateLinkServices` component, and reading a name out of one would have quietly fetched the **parent** service instead of returning nothing.

## Verification

Live, against a subscription with three storage-backed private endpoints. Before: the query errored outright. After:

```
azure.subscription.network.privateEndpoints: [
  0: {
    name: "…-storage1-privateendpoint"
    privateLinkServiceConnections: [
      0: {
        name: "…-storage1-PV"
        privateLinkService: null
        privateLinkServiceId: "/subscriptions/…/providers/Microsoft.Storage/storageAccounts/…"
        connectionStatus: "Approved"
        groupIds: [ 0: "blob" ]
      }
    ]
  }
  … 2 more, same shape
]
```

## Tests

`network_privatelink_test.go` covers `parsePrivateLinkServiceID` against every shape the field actually holds — a Private Link service (including lower-cased ARM casing), storage / SQL / key vault / Cosmos targets, another `Microsoft.Network` type, a child ip configuration, a subscription-scoped id, and malformed input.

`TestFirstPartyTargetNoLongerErrors` pins the regression from both sides: the removed `Component("privateLinkServices")` read **must still fail** on a first-party id, and the discrimination that replaced it must not. A future refactor that reintroduces the parse cannot pass quietly.

`go test ./resources/` passes for the whole azure provider.
