### PR TITLE
🐛 azure: stop an absent feature reported as an ARM 400 failing the whole collection

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -663,9 +663,10 @@ func (a *mqlAzureSubscriptionAksServiceCluster) privateEndpointConnections() ([]
 	if err != nil {
 		// Private endpoint connections are absent on clusters without private
 		// networking, and the endpoint returns 403 when the caller lacks
-		// access. Treat both as "no connections" rather than failing.
-		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) && (respErr.StatusCode == http.StatusNotFound || respErr.StatusCode == http.StatusForbidden) {
+		// access. A cluster that is not a private-link private cluster -- the
+		// default shape -- answers 400 ClusterIsNotAPrivateLinkCluster, which
+		// is the same absence. None of them should fail the cluster list.
+		if isAzureNotConfigured(err) {
 			return []any{}, nil
 		}
 		return nil, err

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -1094,9 +1094,12 @@ func (a *mqlAzureSubscriptionCloudDefenderService) regulatoryComplianceStandards
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusForbidden {
-				log.Warn().Err(err).Msg("could not list regulatory compliance standards due to access denied")
+			// A subscription with no standard pricing bundle has no regulatory
+			// compliance surface at all, and says so with a 400 rather than an
+			// empty list. That, a 403, and a 404 are all "nothing to report
+			// here", not a reason to fail the whole Defender query.
+			if isAzureNotConfigured(err) {
+				log.Warn().Err(err).Msg("could not list regulatory compliance standards")
 				return res, nil
 			}
 			return nil, err
@@ -1179,9 +1182,8 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceRegulatoryComplianceStandard) c
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusForbidden {
-				log.Warn().Err(err).Msg("could not list regulatory compliance controls due to access denied")
+			if isAzureNotConfigured(err) {
+				log.Warn().Err(err).Msg("could not list regulatory compliance controls")
 				return res, nil
 			}
 			return nil, err

--- a/providers/azure/resources/shared.go
+++ b/providers/azure/resources/shared.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 )
@@ -40,6 +42,12 @@ func parseAzureTimestamp(s *string) *time.Time {
 // data action on the sub-resource. Neither should fail the surrounding query:
 // the honest answer is a null field, not an error on every row.
 //
+// Some resource providers answer 400 instead, for the same "there is nothing
+// here" reason. Those are matched by code, never by status alone, because 400
+// also carries the two things that must NOT be swallowed: a request the caller
+// got wrong, and a resource whose provisioning state has not settled yet. See
+// azureNotApplicableCodes.
+//
 // It deliberately does NOT match 429 or 5xx. A throttled or failing call
 // proves nothing about configuration, and swallowing it would report an
 // authoritative "not configured" for a resource that may well be configured.
@@ -48,7 +56,93 @@ func isAzureNotConfigured(err error) bool {
 	if !errors.As(err, &respErr) {
 		return false
 	}
-	return respErr.StatusCode == http.StatusNotFound || respErr.StatusCode == http.StatusForbidden
+	if respErr.StatusCode == http.StatusNotFound || respErr.StatusCode == http.StatusForbidden {
+		return true
+	}
+	return azureFeatureNotApplicable(respErr.StatusCode, respErr.ErrorCode, azureErrorSubcode(respErr))
+}
+
+// azureNotApplicableCodes maps an ARM error code to the subcode that has to
+// accompany it, or "" when the code alone is specific enough. Keys and values
+// are lower-cased; matching is case-insensitive.
+//
+// This is an allowlist rather than a status check because a 400 from ARM means
+// three different things, and only one of them is an absence:
+//
+//   - the feature this sub-resource describes does not exist on the parent, and
+//     never will unless it is reconfigured. That is the honest empty answer, and
+//     what is listed below.
+//   - the parent's provisioning state has not settled ("Cannot fetch databases
+//     while resource is in state 'Creating'", "API Management service is
+//     activating"). Retrying succeeds, so reporting empty would report an
+//     authoritative "no databases" for a cluster that has them.
+//   - the request itself is wrong: a malformed filter, an API version the
+//     provider does not accept. That is our bug, and swallowing it hides it.
+//
+// Only the first belongs here, so every entry names the resource and quotes the
+// message ARM returns with it.
+var azureNotApplicableCodes = map[string]string{
+	// AKS private endpoint connections: "Cluster <name> is not a private link
+	// service based private cluster." Answered by every cluster that is not a
+	// private-link private cluster, which is the default shape. The code itself
+	// is the generic BadRequest, so the subcode is what tells this apart from a
+	// request the caller got wrong.
+	"badrequest": "clusterisnotaprivatelinkcluster",
+
+	// Azure SQL long-term retention: "Long Term Retention is not supported :
+	// Not supported for master." Every server has a master database, so every
+	// server produces this.
+	"longtermretentionpolicynotsupported": "",
+
+	// Defender for Cloud regulatory compliance: "Regulatory compliance is not
+	// supported for subscription '...' as it has no standard pricing bundle."
+	// ARM puts the whole sentence in the code field for this one.
+	"subscription with no standard pricing bundle": "",
+}
+
+// azureFeatureNotApplicable reports whether an ARM 400's code and subcode name
+// a feature that is absent from the parent rather than a fault.
+func azureFeatureNotApplicable(statusCode int, code, subcode string) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	wantSubcode, ok := azureNotApplicableCodes[strings.ToLower(strings.TrimSpace(code))]
+	if !ok {
+		return false
+	}
+	return wantSubcode == "" || wantSubcode == strings.ToLower(strings.TrimSpace(subcode))
+}
+
+// azureErrorSubcode reads the subcode out of an ARM error body.
+//
+// azcore surfaces only the code (ResponseError.ErrorCode), and some providers
+// leave that generic and put the useful discriminator in a sibling subcode
+// field. Reading the body back is safe and cheap: azcore already downloaded it
+// to build the error, and runtime.Payload serves the cached copy rather than
+// re-reading the stream.
+func azureErrorSubcode(respErr *azcore.ResponseError) string {
+	if respErr == nil || respErr.RawResponse == nil {
+		return ""
+	}
+	body, err := runtime.Payload(respErr.RawResponse)
+	if err != nil || len(body) == 0 {
+		return ""
+	}
+	// ARM sends the error bare or wrapped in an "error" envelope, depending on
+	// the resource provider.
+	var envelope struct {
+		Subcode string `json:"subcode"`
+		Error   struct {
+			Subcode string `json:"subcode"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) != nil {
+		return ""
+	}
+	if envelope.Subcode != "" {
+		return envelope.Subcode
+	}
+	return envelope.Error.Subcode
 }
 
 // missingResourceID reports that a resource was asked for without an id, and

--- a/providers/azure/resources/shared_notconfigured_test.go
+++ b/providers/azure/resources/shared_notconfigured_test.go
@@ -1,0 +1,196 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// armError builds the error azcore hands a caller for a real ARM failure
+// response, so the classifier is tested against the payload shape rather than
+// against a hand-set ErrorCode field. The code and subcode are read out of the
+// body exactly as they are in production.
+func armError(status int, body string) error {
+	reqURL, err := url.Parse("https://management.azure.com/subscriptions/sub/resourceGroups/rg")
+	if err != nil {
+		panic(err)
+	}
+	resp := &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    &http.Request{Method: http.MethodGet, URL: reqURL},
+	}
+	return runtime.NewResponseError(resp)
+}
+
+func asResponseError(t *testing.T, err error) *azcore.ResponseError {
+	t.Helper()
+	var respErr *azcore.ResponseError
+	require.ErrorAs(t, err, &respErr)
+	return respErr
+}
+
+// Every body below was captured from a live subscription. They are the whole
+// reason the 400 handling is an allowlist rather than a status check: three of
+// them mean "there is nothing here" and three mean "ask again" or "you asked
+// wrong", and only the status code is the same.
+const (
+	// A cluster that is not a private-link private cluster -- the default shape.
+	bodyAksNotPrivateLink = `{
+  "code": "BadRequest",
+  "details": null,
+  "message": "Cluster my-cluster is not a private link service based private cluster.",
+  "subcode": "ClusterIsNotAPrivateLinkCluster"
+}`
+	// Every SQL server has a master database, and master never supports LTR.
+	bodySqlLtrUnsupported = `{"error":{"code":"LongTermRetentionPolicyNotSupported","message":"Long Term Retention is not supported : Not supported for master."}}`
+	// A subscription without Defender's standard tier.
+	bodyDefenderNoBundle = `{"error":{"code":"Subscription with no standard pricing bundle","message":"Regulatory compliance is not supported for subscription 'sub' as it has no standard pricing bundle"}}`
+
+	// A Kusto cluster mid-provision. Retrying succeeds, so swallowing this
+	// would report "no databases" for a cluster that has them.
+	bodyKustoStillCreating = `{"error":{"code":"BadRequest","message":"Cannot fetch databases while resource is in state 'Creating'."}}`
+	// An API Management service mid-activation. Same story.
+	bodyApimActivating = `{"error":{"code":"InvalidOperation","message":"API Management service is activating"}}`
+	// A request we got wrong. Must stay an error, or the bug hides as an
+	// authoritative empty result.
+	bodyBadApiVersion = `{"error":{"code":"InvalidApiVersionParameter","message":"The api-version '1999-01-01' is invalid."}}`
+)
+
+// The defect: isAzureNotConfigured matched 404 and 403 only, so a resource
+// provider that reports an absent feature with a 400 failed the whole
+// collection instead of one field. A public AKS cluster took the entire cluster
+// list down with it.
+func TestIsAzureNotConfiguredAcceptsTheAbsence400s(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"aks cluster is not a private link cluster", bodyAksNotPrivateLink},
+		{"sql long-term retention not supported", bodySqlLtrUnsupported},
+		{"defender has no standard pricing bundle", bodyDefenderNoBundle},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, isAzureNotConfigured(armError(http.StatusBadRequest, tc.body)))
+		})
+	}
+}
+
+// The other half of the fix, and the reason it is not simply "400 counts too":
+// a 400 also carries transient state and our own bad requests. Degrading either
+// to an empty collection reports an authoritative "nothing here" for a resource
+// that has something.
+func TestIsAzureNotConfiguredRejectsTransientAndCallerErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"kusto cluster still provisioning", http.StatusBadRequest, bodyKustoStillCreating},
+		{"api management still activating", http.StatusBadRequest, bodyApimActivating},
+		{"our api version is wrong", http.StatusBadRequest, bodyBadApiVersion},
+		{"a 400 with no body at all", http.StatusBadRequest, ""},
+		{"a 409 conflict on unsettled state", http.StatusConflict, `{"error":{"code":"RequestConflict","message":"provisioning state is not terminal"}}`},
+		{"throttled", http.StatusTooManyRequests, `{"error":{"code":"TooManyRequests","message":"slow down"}}`},
+		{"server error", http.StatusInternalServerError, `{"error":{"code":"InternalServerError","message":"boom"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.False(t, isAzureNotConfigured(armError(tc.status, tc.body)))
+		})
+	}
+}
+
+// A generic BadRequest code is only accepted with its subcode, so the same code
+// without it -- which is what a caller error looks like -- must not match.
+func TestBadRequestNeedsItsSubcode(t *testing.T) {
+	withSubcode := armError(http.StatusBadRequest, bodyAksNotPrivateLink)
+	require.True(t, isAzureNotConfigured(withSubcode))
+
+	withoutSubcode := armError(http.StatusBadRequest,
+		`{"code":"BadRequest","message":"Something else was wrong with the request."}`)
+	assert.False(t, isAzureNotConfigured(withoutSubcode))
+
+	wrongSubcode := armError(http.StatusBadRequest,
+		`{"code":"BadRequest","message":"nope","subcode":"SomethingElseEntirely"}`)
+	assert.False(t, isAzureNotConfigured(wrongSubcode))
+}
+
+func TestAzureFeatureNotApplicable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		status  int
+		code    string
+		subcode string
+		want    bool
+	}{
+		{"aks", http.StatusBadRequest, "BadRequest", "ClusterIsNotAPrivateLinkCluster", true},
+		// ARM ids and error codes both vary in casing depending on the API.
+		{"casing is ignored", http.StatusBadRequest, "badrequest", "clusterisnotaprivatelinkcluster", true},
+		{"whitespace is trimmed", http.StatusBadRequest, " BadRequest ", " ClusterIsNotAPrivateLinkCluster ", true},
+		{"a code that needs no subcode", http.StatusBadRequest, "LongTermRetentionPolicyNotSupported", "", true},
+		{"a subcode on such a code is ignored", http.StatusBadRequest, "LongTermRetentionPolicyNotSupported", "Whatever", true},
+		{"a code with spaces in it", http.StatusBadRequest, "Subscription with no standard pricing bundle", "", true},
+
+		{"generic code without its subcode", http.StatusBadRequest, "BadRequest", "", false},
+		{"unknown code", http.StatusBadRequest, "SomethingNew", "", false},
+		{"empty code", http.StatusBadRequest, "", "", false},
+		// The status gate matters on its own: an allowlisted code arriving with
+		// a different status is a different situation than the one measured.
+		{"right code, wrong status", http.StatusConflict, "LongTermRetentionPolicyNotSupported", "", false},
+		{"404 goes through the status check, not here", http.StatusNotFound, "ResourceNotFound", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, azureFeatureNotApplicable(tc.status, tc.code, tc.subcode))
+		})
+	}
+}
+
+func TestAzureErrorSubcode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"bare envelope", bodyAksNotPrivateLink, "ClusterIsNotAPrivateLinkCluster"},
+		{"wrapped envelope", `{"error":{"code":"BadRequest","subcode":"Wrapped"}}`, "Wrapped"},
+		{"no subcode", bodySqlLtrUnsupported, ""},
+		{"empty body", "", ""},
+		{"not json", "<html>gateway timeout</html>", ""},
+		{"subcode is not a string", `{"code":"BadRequest","subcode":42}`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := armError(http.StatusBadRequest, tc.body)
+			respErr := asResponseError(t, err)
+			assert.Equal(t, tc.want, azureErrorSubcode(respErr))
+		})
+	}
+
+	assert.Empty(t, azureErrorSubcode(nil), "a nil error has no subcode")
+}
+
+// azcore builds the error by reading the body, and the classifier reads it again
+// to get the subcode. Pin that the second read works -- if azcore ever stopped
+// caching the payload, the subcode would silently read empty and every AKS
+// cluster would start failing again.
+func TestSubcodeSurvivesAzcoreConsumingTheBody(t *testing.T) {
+	err := armError(http.StatusBadRequest, bodyAksNotPrivateLink)
+	respErr := asResponseError(t, err)
+
+	require.Equal(t, "BadRequest", respErr.ErrorCode, "azcore read the code out of the body")
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, "ClusterIsNotAPrivateLinkCluster", azureErrorSubcode(respErr),
+			"read %d must still see the body", i+1)
+	}
+}


### PR DESCRIPTION
`isAzureNotConfigured` matched 404 and 403 only. Several resource providers report an **absent feature** with a 400 instead, and those failed the surrounding query rather than one field.

## The three sites, each measured live

| resource | ARM answer | why every account hits it |
|---|---|---|
| `aks.clusters { privateEndpointConnections }` | 400 `BadRequest` / subcode `ClusterIsNotAPrivateLinkCluster` — *"Cluster X is not a private link service based private cluster."* | a non-private-link cluster is the **default** shape; one such cluster failed the whole cluster list |
| `sql.servers { databases { longTermRetentionPolicy } }` | 400 `LongTermRetentionPolicyNotSupported` | every server has a `master` database and master never supports LTR |
| `cloudDefender { regulatoryComplianceStandards }` and its `controls` | 400 `Subscription with no standard pricing bundle` | any subscription without Defender's standard tier |

## Why an allowlist and not "400 counts too"

ARM uses one status code for three different situations, and only one of them is an absence. The sweep that found this also captured the other two, from the same subscription in the same run:

```
400 BadRequest    "Cannot fetch databases while resource is in state 'Creating'."   ← Kusto, mid-provision
400 InvalidOperation  "API Management service is activating"                        ← APIM, mid-activation
409 RequestConflict   "...provisioning state is not terminal..."                    ← Kusto, mid-provision
```

Those pass on retry. Degrading them to an empty collection would report an authoritative *"this cluster has no databases"* for a cluster that has them — a worse bug than the one being fixed, because it produces a confident wrong answer instead of an error. A malformed request of our own (wrong api-version, bad filter) is the third case, and swallowing it would hide our bug.

So `azureNotApplicableCodes` is an allowlist keyed on error code, gated to 400, and every entry quotes the message it was measured from. Transients and caller errors keep propagating.

*(This is a correction to my own earlier triage, which had grouped the Kusto 400 in with the AKS one. Reading the captured payloads showed they are different situations — the Kusto cluster was still provisioning during the sweep.)*

## Reading the subcode

AKS leaves its `code` as the generic `BadRequest` and puts the useful discriminator in a sibling `subcode`, which azcore does not surface (`ResponseError.ErrorCode` is the `code` field only). `azureErrorSubcode` reads it back out of the response body.

That second read is safe and cheap, and the test pins it: azcore already downloaded the body to build the error, and `runtime.Payload` serves the **cached** copy rather than re-reading a consumed stream. If azcore ever stopped caching, `TestSubcodeSurvivesAzcoreConsumingTheBody` fails rather than every AKS cluster silently breaking again.

## Scope

Folded into `isAzureNotConfigured` so all 39 call sites pick it up. The three sites that hand-rolled their own status check now call the shared helper, which also gives them the 404 handling they were missing.

## Verification

Live. `master` now reports a null policy instead of failing the server list:

```
azure.subscription.sql.servers: [
  0: {
    name: "…-sql-server1"
    databases: [
      0: { name: "master",  longTermRetentionPolicy: null }
      1: { name: "…-SQL-1", longTermRetentionPolicy: null }
    ]
  }
]
```

Cross-checked that `null` is honest rather than hiding data — `az` returns the identical error for the same database, so mql now agrees with the CLI:

```
$ az sql db ltr-policy show …
ERROR: (LongTermRetentionPolicyNotSupported) Long Term Retention is not supported : …
```

## Tests

`shared_notconfigured_test.go` builds real `azcore` errors from **the response bodies captured live**, via `runtime.NewResponseError`, so the classifier is tested against the payload shape rather than a hand-set `ErrorCode` field:

- the three absence 400s are accepted;
- the Kusto provisioning 400, the APIM activation 400, a bad api-version 400, a bodyless 400, the 409, a 429 and a 500 are all **rejected**;
- `BadRequest` without its subcode, or with a different subcode, is rejected;
- `azureFeatureNotApplicable` gets a table over status/code/subcode including casing, whitespace, and codes containing spaces;
- `azureErrorSubcode` covers both ARM envelopes plus empty, non-JSON, and non-string-subcode bodies.

The pre-existing `TestIsAzureNotConfigured` — which asserts a bare 400 must **not** be swallowed — still passes unchanged. `go test ./...` is green across the provider.
