### PR TITLE
🐛 azure: stop key rotation policies aliasing across vaults

### DIFF
--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -423,14 +423,20 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) keys() ([]any, error) {
 	return res, nil
 }
 
+// id returns the full key identifier, which is the vault URI plus the key name
+// and so already unique.
+//
+// It used to parse the identifier and return the bare key name. That is not a
+// cache key: two vaults holding a key of the same name -- the same "cmk" in a
+// production and a staging vault, say -- produced one key, and every rotation
+// row after the first reported the first vault's answer. A vault with rotation
+// switched off inherited "enabled: true" from a vault that had it on.
+//
+// Parsing also meant an identifier the regex did not recognize failed the whole
+// resource rather than one field. Every other Key Vault resource returns its own
+// identifier here; this one was the outlier.
 func (a *mqlAzureSubscriptionKeyVaultServiceKeyAutorotation) id() (string, error) {
-	id := a.Kid.Data
-	kvid, err := parseKeyVaultId(id)
-	if err != nil {
-		return "", err
-	}
-
-	return kvid.Name, nil
+	return a.Kid.Data, nil
 }
 
 func (a *mqlAzureSubscriptionKeyVaultServiceVault) autorotation() ([]any, error) {
@@ -451,6 +457,14 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) autorotation() ([]any, error)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
+			// The same data-plane listing keys() walks, so it degrades the same
+			// way: a caller holding the vault's control-plane read but not the
+			// keys data action gets 403 here, and that should not fail the whole
+			// vault list.
+			if isAzureNotConfigured(err) {
+				log.Warn().Err(err).Msg("could not list azure keys for rotation policies, returning partial results")
+				return res, nil
+			}
 			return nil, err
 		}
 

--- a/providers/azure/resources/keyvault_autorotation_test.go
+++ b/providers/azure/resources/keyvault_autorotation_test.go
@@ -1,0 +1,86 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// TestKeyVaultAutorotationDoesNotAliasAcrossVaults pins the defect directly: the
+// rotation resource derived its cache key by parsing the key identifier and
+// returning the bare key name, so a key called "cmk" in a production vault and a
+// key called "cmk" in a staging vault were one resource. CreateResource returns
+// the cached occupant of a key it has already seen, so the second vault's
+// rotation row reported the first vault's answer -- a vault with rotation
+// switched off reading "enabled: true".
+//
+// The list length stayed right and every row looked plausible, which is why this
+// had to be pinned through the runtime cache rather than by comparing ids.
+func TestKeyVaultAutorotationDoesNotAliasAcrossVaults(t *testing.T) {
+	runtime := cacheIDTestRuntime()
+	mk := func(kid string, enabled bool) *mqlAzureSubscriptionKeyVaultServiceKeyAutorotation {
+		r, err := CreateResource(runtime, "azure.subscription.keyVaultService.key.autorotation",
+			map[string]*llx.RawData{
+				"kid":     llx.StringData(kid),
+				"enabled": llx.BoolData(enabled),
+			})
+		require.NoError(t, err)
+		return r.(*mqlAzureSubscriptionKeyVaultServiceKeyAutorotation)
+	}
+
+	rotating := mk("https://vault-prod.vault.azure.net/keys/cmk", true)
+	notRotating := mk("https://vault-staging.vault.azure.net/keys/cmk", false)
+
+	assert.NotEqual(t, rotating.MqlID(), notRotating.MqlID(),
+		"the same key name in two vaults must not share a cache key")
+	// The failure this guards: the unrotated key reporting the rotated key's answer.
+	assert.False(t, notRotating.Enabled.Data)
+	assert.True(t, rotating.Enabled.Data)
+
+	// The name alone is what collided, so keep that visible -- it is the thing a
+	// future refactor would be tempted to go back to.
+	prod, err := parseKeyVaultId(rotating.Kid.Data)
+	require.NoError(t, err)
+	staging, err := parseKeyVaultId(notRotating.Kid.Data)
+	require.NoError(t, err)
+	require.Equal(t, prod.Name, staging.Name, "both keys are named cmk")
+	assert.NotEqual(t, prod.Vault, staging.Vault, "only the vault tells them apart")
+}
+
+// Two keys in one vault were already distinct, and must stay so.
+func TestKeyVaultAutorotationSeparatesKeysInOneVault(t *testing.T) {
+	runtime := cacheIDTestRuntime()
+	mk := func(kid string, enabled bool) *mqlAzureSubscriptionKeyVaultServiceKeyAutorotation {
+		r, err := CreateResource(runtime, "azure.subscription.keyVaultService.key.autorotation",
+			map[string]*llx.RawData{"kid": llx.StringData(kid), "enabled": llx.BoolData(enabled)})
+		require.NoError(t, err)
+		return r.(*mqlAzureSubscriptionKeyVaultServiceKeyAutorotation)
+	}
+
+	a := mk("https://vault.vault.azure.net/keys/signing", true)
+	b := mk("https://vault.vault.azure.net/keys/encryption", false)
+	assert.NotEqual(t, a.MqlID(), b.MqlID())
+	assert.True(t, a.Enabled.Data)
+	assert.False(t, b.Enabled.Data)
+}
+
+// The old id() returned parseKeyVaultId's error, which failed the whole resource
+// rather than one field. A managed HSM identifier, or anything else the regex
+// does not recognize, must still produce a row.
+func TestKeyVaultAutorotationIDDoesNotDependOnParsing(t *testing.T) {
+	runtime := cacheIDTestRuntime()
+	for _, kid := range []string{
+		"https://myhsm.managedhsm.azure.net/keys/cmk",
+		"not-a-key-vault-identifier",
+	} {
+		r, err := CreateResource(runtime, "azure.subscription.keyVaultService.key.autorotation",
+			map[string]*llx.RawData{"kid": llx.StringData(kid), "enabled": llx.BoolData(false)})
+		require.NoError(t, err, "an unparseable identifier must not fail the resource: %q", kid)
+		assert.Equal(t, kid, r.(*mqlAzureSubscriptionKeyVaultServiceKeyAutorotation).MqlID())
+	}
+}


### PR DESCRIPTION
A key called `cmk` in a production vault and a key called `cmk` in a staging vault were **one resource**.

## The defect

`azure.subscription.keyVaultService.key.autorotation` derived its cache key by parsing the key identifier and returning the bare key name:

```go
func (a *mqlAzureSubscriptionKeyVaultServiceKeyAutorotation) id() (string, error) {
	kvid, err := parseKeyVaultId(a.Kid.Data)
	if err != nil {
		return "", err
	}
	return kvid.Name, nil   // "cmk"
}
```

The resource is created without an explicit `__id`, so the generated `createAzureSubscriptionKeyVaultServiceKeyAutorotation` falls back to `id()` for the cache key. `CreateResource` returns the cached occupant of a key it has already seen, so **every rotation row after the first reported the first vault's answer** — a vault with rotation switched off reading `enabled: true` from a vault that had it on.

This is the silent kind of wrong: the list keeps its right length and every row looks plausible.

`id()` now returns the full identifier (`https://vault.vault.azure.net/keys/cmk`), which is vault-qualified and therefore already unique. That is what **every other** Key Vault resource does — `key`, `secret`, `certificate`, `managedHsm` all return their own id; autorotation was the lone outlier.

It also removes a second failure mode: deriving a cache key by parsing meant an identifier the regex did not recognize failed the *whole resource* rather than one field.

## A 403 in the same lister

The rotation lister walks the same data-plane key listing `keys()` does, on the same client — but did not degrade the same way. A caller holding the vault's control-plane read without the keys data action got a 403 that failed the entire vault list, while `keys()` warned and continued. Now both go through `isAzureNotConfigured`.

## Tests

`keyvault_autorotation_test.go` pins the collision **through the real runtime cache**, using the same pattern as the existing `cache_id_test.go` aliasing tests, and asserts the corrupted *value* rather than just distinct ids — an id comparison would pass on a fix that was still subtly wrong.

Confirmed the tests fail against the pre-fix code, which is what makes them worth having:

```
--- FAIL: TestKeyVaultAutorotationDoesNotAliasAcrossVaults
    Error:    Should not be: "cmk"
    Messages: the same key name in two vaults must not share a cache key
    Error:    Should be false            ← the staging vault reading the prod vault's answer
--- FAIL: TestKeyVaultAutorotationIDDoesNotDependOnParsing
    Messages: an unparseable identifier must not fail the resource: "not-a-key-vault-identifier"
```

Also covered: two keys in one vault stay distinct, and an unparseable identifier still produces a row.

## Verification

Live, against a vault whose data plane denies the caller. Both listers now degrade identically instead of `autorotation` failing the vault list:

```
! could not list azure keys, returning partial results                        error=… 403 Forbidden …
! could not list azure keys for rotation policies, returning partial results  error=… 403 Forbidden …
azure.subscription.keyVault.vaults: [
  0: { vaultName: "…", keys: [], autorotation: [] }
]
```

The aliasing itself is proven through the runtime cache in the unit test rather than live — reproducing it needs two vaults each holding a same-named key, and this subscription's only vault denies data-plane access. The unit test exercises the same generated create path the provider uses, and asserts the wrong value the bug produced.

`go test ./...` is green across the provider.
