### PR TITLE
🐛 azure: split the Cosmos DB CORS origin list so a wildcard can be found

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -8619,7 +8619,10 @@ azure.subscription.cosmosDbService.account @defaults("name kind location") {
   defaultConsistencyLevel string
   // Network ACL bypass setting ("None" or "AzureServices")
   networkAclBypass string
-  // Allowed origins from the account's CORS policies (empty when CORS is not configured)
+  // Allowed origins from the account's CORS policies
+  //
+  // One entry per origin, gathered across every CORS policy on the account.
+  // Empty when CORS is not configured. An entry of "*" allows any origin.
   corsAllowedOrigins []string
   // Names of the regions the account is deployed to (more than one indicates multi-region)
   locations []string

--- a/providers/azure/resources/cosmosdb.go
+++ b/providers/azure/resources/cosmosdb.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -303,6 +304,33 @@ func cosmosEnumStrPtr[T ~string](v *T) *string {
 	return &s
 }
 
+// cosmosCorsOrigins flattens a Cosmos DB account's CORS policies into one origin
+// per element.
+//
+// ARM models allowedOrigins as a single string holding a comma-separated list
+// rather than an array, so reporting it whole produced one element such as
+// "https://app.example.com,*". An origin inside that element matches nothing a
+// query would compare against: corsAllowedOrigins.none(_ == "*") passed on an
+// account that allows every origin, and any(_ == "https://app.example.com")
+// failed on an account that allows it.
+//
+// Duplicates are kept. An account can carry several CORS policies, and repeating
+// an origin across them is what the account is actually configured with.
+func cosmosCorsOrigins(policies []*cosmosdb.CorsPolicy) []any {
+	origins := []any{}
+	for _, cors := range policies {
+		if cors == nil || cors.AllowedOrigins == nil {
+			continue
+		}
+		for _, origin := range strings.Split(*cors.AllowedOrigins, ",") {
+			if origin = strings.TrimSpace(origin); origin != "" {
+				origins = append(origins, origin)
+			}
+		}
+	}
+	return origins
+}
+
 // cosmosNetworkConsistency extracts the default consistency level, network ACL
 // bypass setting, CORS allowed origins, and deployed region names from a Cosmos
 // DB account's properties. Consistency level and ACL bypass stay nil (null in
@@ -318,11 +346,7 @@ func cosmosNetworkConsistency(props *cosmosdb.DatabaseAccountGetProperties) (def
 		defaultConsistencyLevel = cosmosEnumStrPtr(props.ConsistencyPolicy.DefaultConsistencyLevel)
 	}
 	networkAclBypass = cosmosEnumStrPtr(props.NetworkACLBypass)
-	for _, cors := range props.Cors {
-		if cors != nil && cors.AllowedOrigins != nil {
-			corsAllowedOrigins = append(corsAllowedOrigins, *cors.AllowedOrigins)
-		}
-	}
+	corsAllowedOrigins = cosmosCorsOrigins(props.Cors)
 	for _, loc := range props.Locations {
 		if loc != nil && loc.LocationName != nil {
 			locations = append(locations, *loc.LocationName)

--- a/providers/azure/resources/cosmosdb_cors_test.go
+++ b/providers/azure/resources/cosmosdb_cors_test.go
@@ -1,0 +1,118 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	cosmosdb "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func corsPolicy(allowedOrigins string) *cosmosdb.CorsPolicy {
+	return &cosmosdb.CorsPolicy{AllowedOrigins: &allowedOrigins}
+}
+
+func TestCosmosCorsOrigins(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		policies []*cosmosdb.CorsPolicy
+		want     []any
+	}{
+		{
+			// The shape the bug turned on: ARM packs the whole list into one
+			// string, so this used to be a single element.
+			name:     "a comma-separated list becomes one entry per origin",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("https://app.example.com,https://admin.example.com")},
+			want:     []any{"https://app.example.com", "https://admin.example.com"},
+		},
+		{
+			name:     "the portal writes the list with spaces after the commas",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("https://a.example.com, https://b.example.com")},
+			want:     []any{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			name:     "a single origin still yields one entry",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("https://app.example.com")},
+			want:     []any{"https://app.example.com"},
+		},
+		{
+			name:     "a wildcard is its own entry",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("*")},
+			want:     []any{"*"},
+		},
+		{
+			name:     "several policies are gathered together",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("https://a.example.com"), corsPolicy("https://b.example.com,*")},
+			want:     []any{"https://a.example.com", "https://b.example.com", "*"},
+		},
+		{
+			// Repeating an origin across policies is what the account is
+			// configured with, so it is reported rather than collapsed.
+			name:     "duplicates across policies are kept",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("https://a.example.com"), corsPolicy("https://a.example.com")},
+			want:     []any{"https://a.example.com", "https://a.example.com"},
+		},
+		{
+			name:     "empty segments are dropped",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("https://a.example.com,,  ,https://b.example.com")},
+			want:     []any{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			name:     "an empty origin string yields nothing",
+			policies: []*cosmosdb.CorsPolicy{corsPolicy("")},
+			want:     []any{},
+		},
+		{
+			name:     "a nil policy element is skipped, not dereferenced",
+			policies: []*cosmosdb.CorsPolicy{nil, corsPolicy("*")},
+			want:     []any{"*"},
+		},
+		{
+			name:     "a policy with no origins is skipped",
+			policies: []*cosmosdb.CorsPolicy{{}},
+			want:     []any{},
+		},
+		{
+			// Non-nil so a query can assert on length without a null guard.
+			name:     "no policies at all",
+			policies: nil,
+			want:     []any{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cosmosCorsOrigins(tc.policies)
+			assert.NotNil(t, got)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The audit this field exists for: an account that allows every origin must be
+// findable. While the whole list was one element, neither of these comparisons
+// could match, so a wildcard beside a real origin read as safe.
+func TestCosmosCorsWildcardIsFindable(t *testing.T) {
+	origins := cosmosCorsOrigins([]*cosmosdb.CorsPolicy{
+		corsPolicy("https://app.example.com,*"),
+	})
+
+	assert.Contains(t, origins, "*", "a wildcard packed beside another origin must still be found")
+	assert.Contains(t, origins, "https://app.example.com")
+	assert.NotContains(t, origins, "https://app.example.com,*",
+		"the unsplit string must not survive as an entry")
+}
+
+// cosmosNetworkConsistency is the caller, so pin that it passes the policies
+// through rather than reintroducing the whole-string append.
+func TestCosmosNetworkConsistencyCorsIsSplit(t *testing.T) {
+	props := &cosmosdb.DatabaseAccountGetProperties{
+		Cors: []*cosmosdb.CorsPolicy{corsPolicy("https://a.example.com,*")},
+	}
+	_, _, origins, _ := cosmosNetworkConsistency(props)
+	assert.Equal(t, []any{"https://a.example.com", "*"}, origins)
+
+	_, _, empty, locations := cosmosNetworkConsistency(nil)
+	assert.Equal(t, []any{}, empty)
+	assert.Equal(t, []any{}, locations)
+}


### PR DESCRIPTION
`corsAllowedOrigins.none(_ == "*")` returned **true** on a Cosmos DB account that allows every origin.

## The defect

ARM models a CORS policy's `allowedOrigins` as **one string holding a comma-separated list**, not an array:

```go
// armcosmos/v4/models.go
type CorsPolicy struct {
	// REQUIRED; The origin domains that are permitted to make a request against the service via CORS.
	AllowedOrigins *string
	…
}
```

The value was appended whole, so an account allowing two origins produced a single entry:

```go
corsAllowedOrigins = append(corsAllowedOrigins, *cors.AllowedOrigins)  // "https://app.example.com,*"
```

Nothing a query compares against can match an origin buried inside that entry. The field looked populated and read exactly backwards:

| query | account allows | reported |
|---|---|---|
| `corsAllowedOrigins.none(_ == "*")` | every origin | `true` ❌ |
| `corsAllowedOrigins.any(_ == "https://app.example.com")` | that origin | `false` ❌ |

## The fix

`cosmosCorsOrigins` splits on the comma, trims the spaces the portal writes after them, drops empty segments, and gathers every policy on the account. Duplicates across policies are **kept** — repeating an origin is what the account is configured with, so collapsing it would report something the account does not say.

Scope is Cosmos only. The `corsAllowedOrigins` fields of the same name on web appsites and container-app ingress come from genuine SDK `[]*string` slices and were already correct.

## Verification

Live, on a Cosmos account, by setting `cors` to the packed shape ARM actually stores. ARM confirms the storage shape first:

```
$ az resource update --ids …/databaseAccounts/… \
    --set 'properties.cors=[{"allowedOrigins":"https://app.example.com,*"}]'
[ { "allowedOrigins": "https://app.example.com,*" } ]     ← one string, as documented
```

**Before** — the wildcard is invisible and the account reads safe:

```
azure.subscription.cosmosDb.accounts: [
  0: {
    name: "…-cosmos-…"
    [].none(): true
    corsAllowedOrigins: [ 0: "https://app.example.com,*" ]
  }
]
```

**After** — two entries, and the wildcard is found:

```
azure.subscription.cosmosDb.accounts: [
  0: {
    name: "…-cosmos-…"
    [].none(): false
    corsAllowedOrigins: [ 0: "https://app.example.com"  1: "*" ]
  }
]
```

The account was returned to no CORS policy afterwards (`az cosmosdb show --query cors` → `[]`).

## Tests

`cosmosdb_cors_test.go` tables `cosmosCorsOrigins` against the SDK type: the comma-separated list, the portal's spaces-after-commas form, a single origin, a bare wildcard, several policies gathered together, duplicates kept, empty segments dropped, an empty origin string, a nil policy element, a policy with no origins, and no policies at all (non-nil result so a query can assert on length without a null guard).

`TestCosmosCorsWildcardIsFindable` states the audit the field exists for, and asserts the unsplit string does **not** survive as an entry. `TestCosmosNetworkConsistencyCorsIsSplit` pins the caller so the whole-string append cannot come back.

Schema doc updated to say the field is one entry per origin. `go test ./...` is green across the provider.
