### PR TITLE
🐛 azure: report two dead APIs as the absences they are

### DIFF
--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	authorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
@@ -752,8 +754,47 @@ func (a *mqlAzureSubscriptionAuthorizationServiceClassicAdministrator) id() (str
 	return a.Id.Data, nil
 }
 
-// classicAdministrators lists legacy ASM co-admins / service admins on the subscription.
-// CIS 1.21 requires this to be empty. Distinct from RBAC role assignments.
+// azureProviderNotInRegion reports whether the error is ARM saying the resource
+// provider is not deployed in that region.
+//
+// A subscription's location list includes staging and edge regions that most
+// services never ship to, so any per-region fan-out hits this routinely. It
+// means there is nothing there to find, which is a different thing from being
+// unable to look.
+func azureProviderNotInRegion(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.ErrorCode == "NoRegisteredProviderFound"
+}
+
+// azureClassicAdministratorsRetired reports whether the error is ARM saying the
+// classic administrators resource type no longer exists.
+//
+// The retirement removed the type from the Microsoft.Authorization namespace
+// rather than emptying it, so ARM answers 404 InvalidResourceType. The code is
+// checked alongside the status so that a genuinely missing subscription, which
+// is also a 404 but carries SubscriptionNotFound, still reports as the error it
+// is.
+func azureClassicAdministratorsRetired(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == http.StatusNotFound && respErr.ErrorCode == "InvalidResourceType"
+}
+
+// classicAdministrators lists legacy ASM co-admins and service admins on the
+// subscription. Distinct from RBAC role assignments, which roleAssignments
+// covers.
+//
+// Azure retired classic subscription administrators on 31 August 2024 and
+// removed the resource type with them, so every subscription now answers this
+// with 404 InvalidResourceType. That is not a fault to report: it means the
+// subscription has no classic administrators, which is also the answer an audit
+// of this field is looking for. Returning the 404 instead failed the field on
+// every subscription in existence.
 func (a *mqlAzureSubscriptionAuthorizationService) classicAdministrators() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -767,10 +808,13 @@ func (a *mqlAzureSubscriptionAuthorizationService) classicAdministrators() ([]an
 	}
 
 	pager := client.NewListPager(nil)
-	var res []any
+	res := []any{}
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
+			if azureClassicAdministratorsRetired(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
 		for _, ca := range page.Value {

--- a/providers/azure/resources/iam_deadapi_test.go
+++ b/providers/azure/resources/iam_deadapi_test.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/stretchr/testify/assert"
+)
+
+func armCodedError(status int, code string) error {
+	return &azcore.ResponseError{StatusCode: status, ErrorCode: code}
+}
+
+// classicAdministrators returned ARM's 404 raw, so the field failed on every
+// subscription: Azure retired the resource type on 31 August 2024 and removed it
+// from the Microsoft.Authorization namespace rather than emptying it.
+//
+// The status is checked alongside the code deliberately. A genuinely missing
+// subscription is also a 404, and that one must keep reporting as an error
+// rather than as "no classic administrators".
+func TestAzureClassicAdministratorsRetired(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "the retirement shape",
+			err:  armCodedError(http.StatusNotFound, "InvalidResourceType"),
+			want: true,
+		},
+		{
+			name: "wrapped, as a pager returns it",
+			err:  fmt.Errorf("listing failed: %w", armCodedError(http.StatusNotFound, "InvalidResourceType")),
+			want: true,
+		},
+		{
+			// The case the code check exists for.
+			name: "a missing subscription is still an error",
+			err:  armCodedError(http.StatusNotFound, "SubscriptionNotFound"),
+		},
+		{
+			name: "a 404 with no code",
+			err:  armCodedError(http.StatusNotFound, ""),
+		},
+		{
+			name: "the right code on the wrong status",
+			err:  armCodedError(http.StatusBadRequest, "InvalidResourceType"),
+		},
+		{
+			name: "no permission to read the subscription is still an error",
+			err:  armCodedError(http.StatusForbidden, "AuthorizationFailed"),
+		},
+		{
+			// A network blip must never be reported as an authoritative empty.
+			name: "a transport error is not a retirement",
+			err:  errors.New("dial tcp: connection reset by peer"),
+		},
+		{name: "nil"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, azureClassicAdministratorsRetired(tc.err))
+		})
+	}
+}
+
+// A subscription's location list includes staging and edge regions most services
+// never ship to, so a per-region fan-out hits NoRegisteredProviderFound
+// routinely. It means there is nothing there, which is not the same as being
+// unable to look -- so it is logged at debug and everything else stays a warning.
+func TestAzureProviderNotInRegion(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "the provider is not deployed in that region",
+			err:  armCodedError(http.StatusBadRequest, "NoRegisteredProviderFound"),
+			want: true,
+		},
+		{
+			// Matched on the code alone, because ARM has not been consistent
+			// about which status it pairs this with.
+			name: "the same code on another status",
+			err:  armCodedError(http.StatusNotFound, "NoRegisteredProviderFound"),
+			want: true,
+		},
+		{
+			name: "wrapped",
+			err:  fmt.Errorf("region westus: %w", armCodedError(http.StatusBadRequest, "NoRegisteredProviderFound")),
+			want: true,
+		},
+		{
+			// The case this must not swallow: it is the reason the warning
+			// stream exists.
+			name: "access denied is a real problem",
+			err:  armCodedError(http.StatusForbidden, "AuthorizationFailed"),
+		},
+		{
+			name: "throttling is a real problem",
+			err:  armCodedError(http.StatusTooManyRequests, "TooManyRequests"),
+		},
+		{
+			name: "a transport error is not an absence",
+			err:  errors.New("context deadline exceeded"),
+		},
+		{name: "nil"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, azureProviderNotInRegion(tc.err))
+		})
+	}
+}
+
+// The two classifiers must not overlap: each one's shape must be rejected by the
+// other, or a real regional problem could be reported as a retirement.
+func TestDeadApiClassifiersAreDisjoint(t *testing.T) {
+	retirement := armCodedError(http.StatusNotFound, "InvalidResourceType")
+	notInRegion := armCodedError(http.StatusBadRequest, "NoRegisteredProviderFound")
+
+	assert.False(t, azureProviderNotInRegion(retirement))
+	assert.False(t, azureClassicAdministratorsRetired(notInRegion))
+}

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -210,6 +210,17 @@ func (a *mqlAzureSubscriptionRecoveryServicesService) deletedVaults() ([]any, er
 				if err != nil {
 					// One unreachable or access-denied region shouldn't fail the
 					// whole listing; log it and continue with the rest.
+					//
+					// Most of them are neither. The location list is every region
+					// the subscription can see, and Recovery Services is not
+					// deployed in all of them: staging and edge regions answer
+					// NoRegisteredProviderFound. That is an expected absence, so
+					// it stays out of the warning stream a real access problem
+					// needs to stand out in.
+					if azureProviderNotInRegion(err) {
+						log.Debug().Err(err).Str("location", location).Msg("recovery services is not available in region")
+						return nil
+					}
 					log.Warn().Err(err).Str("location", location).Msg("could not list deleted recovery services vaults in region")
 					return nil
 				}


### PR DESCRIPTION
Two places treated *"there is nothing here"* as a failure.

## `classicAdministrators` failed on every subscription in existence

Azure retired classic subscription administrators on **31 August 2024** and removed the resource type from the `Microsoft.Authorization` namespace rather than emptying it. Confirmed live against the raw API:

```
$ az rest --method get --url ".../providers/Microsoft.Authorization/classicAdministrators?api-version=2015-07-01"
ERROR: Not Found({"error":{"code":"InvalidResourceType",
  "message":"The resource type could not be found in the namespace 'Microsoft.Authorization' for api version '2015-07-01'."}})
```

The pager error was returned raw, so the field failed on every subscription. An empty list is both the truth — there are no classic administrators, because there cannot be — and the answer an audit of this field is looking for.

The **status is checked alongside the code**, so a genuinely missing subscription (also a 404, but `SubscriptionNotFound`) still reports as the error it is. Same for a 403, throttling, and any transport error.

## `deletedVaults` warned about 13 regions per query

`deletedVaults` fans out across every location the subscription can see, and Recovery Services is not deployed in all of them — staging and edge regions answer `NoRegisteredProviderFound`. That is an expected absence, but it went through the same `log.Warn` an access-denied does.

Measured on one subscription, with the new debug line counting the hits:

```
$ mql run azure … --log-level debug -c 'azure.subscription.recoveryServices.deletedVaults { name }' \
    | grep -c "recovery services is not available in region"
13
```

13 warnings per query is the noise a real access problem has to stand out from. Those are now `debug`; every other error keeps its warning.

## Tests

`iam_deadapi_test.go` tables both classifiers. The cases that matter are the **rejections**, since each classifier's job is to swallow one specific thing and nothing else:

- `azureClassicAdministratorsRetired` — accepts the retirement shape (bare and wrapped, as a pager returns it); rejects `SubscriptionNotFound`, a 404 with no code, the right code on the wrong status, a 403, and a transport error.
- `azureProviderNotInRegion` — accepts the code on either status ARM pairs it with; rejects `AuthorizationFailed`, throttling, and a transport error.
- `TestDeadApiClassifiersAreDisjoint` — neither classifier matches the other's shape, so a regional problem can never be reported as a retirement.

A transport error is called out explicitly in both: matching one would turn a network blip into an authoritative "nothing here", which is the worse failure.

## Verification

Live. `azure.subscription.iam.classicAdministrators` returns `[]` where it previously failed, and `deletedVaults` logs zero warnings while still returning its rows.

`go test ./...` is green across the provider.
