### PR TITLE
🐛 azure: set every private-endpoint connection-state field, so an empty one is not a provider bug

### DIFF
--- a/providers/azure/resources/private_endpoint_connections.go
+++ b/providers/azure/resources/private_endpoint_connections.go
@@ -72,6 +72,24 @@ func newPrivateLinkServiceConnectionState(runtime *plugin.Runtime, connectionID 
 		})
 }
 
+// dictStringPtr returns a pointer to the string at key, and nil when the key is
+// absent or holds something other than a string.
+//
+// It keeps two different answers apart. A key ARM never sent is unknown, and
+// reads as null. A key ARM sent as "" is a value it reported, and reads as the
+// empty string.
+func dictStringPtr(m map[string]any, key string) *string {
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	return &s
+}
+
 func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (plugin.Resource, error) {
 	dict, err := convert.JsonToDict(entry)
 	if err != nil {
@@ -146,21 +164,15 @@ func azurePrivateEndpointConnectionToMql(runtime *plugin.Runtime, entry any) (pl
 			args["provisioningState"] = llx.StringData(provState)
 		}
 		if cs, ok := props["privateLinkServiceConnectionState"].(map[string]any); ok && cs != nil {
-			// Derive a unique cache key from the parent connection so multiple
-			// connection states never collide on an empty __id.
-			stateArgs := map[string]*llx.RawData{
-				"__id": llx.StringData(id + "/privateLinkServiceConnectionState"),
-			}
-			if v, _ := cs["actionsRequired"].(string); v != "" {
-				stateArgs["actionsRequired"] = llx.StringData(v)
-			}
-			if v, _ := cs["description"].(string); v != "" {
-				stateArgs["description"] = llx.StringData(v)
-			}
-			if v, _ := cs["status"].(string); v != "" {
-				stateArgs["status"] = llx.StringData(v)
-			}
-			stateRes, err := CreateResource(runtime, ResourceAzureSubscriptionPrivateEndpointConnectionConnectionState, stateArgs)
+			// Through the same helper the per-SDK callers use. Building the args
+			// here instead is what left an absent field unset rather than null:
+			// a key that never lands in args crosses the plugin boundary as an
+			// empty DataRes. actionsRequired is the one that showed it, because
+			// a connection needing no action is the normal case.
+			stateRes, err := newPrivateLinkServiceConnectionState(runtime, id,
+				dictStringPtr(cs, "actionsRequired"),
+				dictStringPtr(cs, "description"),
+				dictStringPtr(cs, "status"))
 			if err != nil {
 				return nil, err
 			}

--- a/providers/azure/resources/private_endpoint_connections_test.go
+++ b/providers/azure/resources/private_endpoint_connections_test.go
@@ -1,0 +1,163 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestDictStringPtr(t *testing.T) {
+	m := map[string]any{
+		"present": "value",
+		"empty":   "",
+		"number":  42,
+		"null":    nil,
+		"object":  map[string]any{"a": "b"},
+	}
+
+	got := dictStringPtr(m, "present")
+	require.NotNil(t, got)
+	assert.Equal(t, "value", *got)
+
+	// The distinction the helper exists for: ARM reporting "" is a value it
+	// reported, and must not be confused with a key it never sent.
+	got = dictStringPtr(m, "empty")
+	require.NotNil(t, got, `an explicit "" is a reported value, not an absence`)
+	assert.Equal(t, "", *got)
+
+	assert.Nil(t, dictStringPtr(m, "absent"), "a key ARM never sent is unknown")
+	assert.Nil(t, dictStringPtr(m, "number"))
+	assert.Nil(t, dictStringPtr(m, "null"))
+	assert.Nil(t, dictStringPtr(m, "object"))
+	assert.Nil(t, dictStringPtr(nil, "anything"))
+}
+
+// pecEntry is the JSON shape every Azure SDK uses for a private endpoint
+// connection, which is why the converter goes through a dict rather than a
+// per-SDK type.
+func pecEntry(id string, connectionState map[string]any) map[string]any {
+	return map[string]any{
+		"id":   id,
+		"name": "conn",
+		"type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+		"properties": map[string]any{
+			"privateEndpoint":                   map[string]any{"id": "/subscriptions/sub/…/privateEndpoints/pe"},
+			"privateLinkServiceConnectionState": connectionState,
+			"provisioningState":                 "Succeeded",
+		},
+	}
+}
+
+func connectionStateOf(t *testing.T, entry map[string]any) *mqlAzureSubscriptionPrivateEndpointConnectionConnectionState {
+	t.Helper()
+	res, err := azurePrivateEndpointConnectionToMql(cacheIDTestRuntime(), entry)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	conn := res.(*mqlAzureSubscriptionPrivateEndpointConnection)
+	require.True(t, conn.PrivateLinkServiceConnectionState.State&plugin.StateIsSet != 0,
+		"the connection state field must be set")
+	require.NotNil(t, conn.PrivateLinkServiceConnectionState.Data)
+	return conn.PrivateLinkServiceConnectionState.Data
+}
+
+// The defect: this path built the state's args by hand and only added a key when
+// the value was non-empty, so an absent field stayed UNSET rather than null. An
+// unset TValue crosses the plugin boundary as an empty DataRes and surfaces
+// client-side as "primitive with no type information, coercing to null", once per
+// field with nothing naming which field it was.
+//
+// actionsRequired is what exposed it, because a connection needing no action is
+// the normal case -- so the normal case was the broken one.
+func TestPrivateEndpointConnectionStateFieldsAreAlwaysSet(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state map[string]any
+	}{
+		{
+			// What ARM sends for an approved connection that needs nothing.
+			name:  "only status is reported",
+			state: map[string]any{"status": "Approved"},
+		},
+		{
+			name:  "an empty connection state object",
+			state: map[string]any{},
+		},
+		{
+			name:  "status and description but no actionsRequired",
+			state: map[string]any{"status": "Pending", "description": "Awaiting approval"},
+		},
+		{
+			name:  "every field reported",
+			state: map[string]any{"status": "Approved", "description": "Auto-approved", "actionsRequired": "None"},
+		},
+		{
+			name:  "fields reported as empty strings",
+			state: map[string]any{"status": "", "description": "", "actionsRequired": ""},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := connectionStateOf(t, pecEntry("/subscriptions/sub/…/privateEndpointConnections/conn", tc.state))
+
+			for name, field := range map[string]plugin.TValue[string]{
+				"actionsRequired": state.ActionsRequired,
+				"description":     state.Description,
+				"status":          state.Status,
+			} {
+				assert.NotZero(t, field.State&plugin.StateIsSet,
+					"%s must be set -- unset is what surfaces as an unattributed null", name)
+			}
+		})
+	}
+}
+
+// An absent field must read as null, and a reported one must keep its value.
+func TestPrivateEndpointConnectionStateDistinguishesAbsentFromEmpty(t *testing.T) {
+	absent := connectionStateOf(t, pecEntry("/subscriptions/sub/…/privateEndpointConnections/a",
+		map[string]any{"status": "Approved"}))
+	assert.NotZero(t, absent.ActionsRequired.State&plugin.StateIsNull,
+		"a field ARM never sent must be null, not an empty string")
+	assert.Equal(t, "Approved", absent.Status.Data)
+
+	reported := connectionStateOf(t, pecEntry("/subscriptions/sub/…/privateEndpointConnections/b",
+		map[string]any{"status": "Approved", "actionsRequired": ""}))
+	assert.Zero(t, reported.ActionsRequired.State&plugin.StateIsNull,
+		`a field ARM reported as "" must not be null`)
+	assert.Equal(t, "", reported.ActionsRequired.Data)
+}
+
+// The state has no identity of its own, so it is keyed off the parent connection.
+// Without that, every state in a scan collides and each connection reports
+// whichever one resolved first.
+func TestPrivateEndpointConnectionStatesAreKeyedByParent(t *testing.T) {
+	runtime := cacheIDTestRuntime()
+	mk := func(id, status string) *mqlAzureSubscriptionPrivateEndpointConnectionConnectionState {
+		res, err := azurePrivateEndpointConnectionToMql(runtime,
+			pecEntry(id, map[string]any{"status": status}))
+		require.NoError(t, err)
+		conn := res.(*mqlAzureSubscriptionPrivateEndpointConnection)
+		return conn.PrivateLinkServiceConnectionState.Data
+	}
+
+	approved := mk("/subscriptions/sub/…/privateEndpointConnections/approved", "Approved")
+	rejected := mk("/subscriptions/sub/…/privateEndpointConnections/rejected", "Rejected")
+
+	assert.NotEqual(t, approved.MqlID(), rejected.MqlID())
+	// The failure this guards: the rejected connection reporting Approved.
+	assert.Equal(t, "Rejected", rejected.Status.Data)
+	assert.Equal(t, "Approved", approved.Status.Data)
+}
+
+// A connection with no id has no stable cache key, so it is skipped rather than
+// letting several of them collide on an empty one.
+func TestPrivateEndpointConnectionWithoutIdIsSkipped(t *testing.T) {
+	res, err := azurePrivateEndpointConnectionToMql(cacheIDTestRuntime(),
+		pecEntry("", map[string]any{"status": "Approved"}))
+	require.NoError(t, err)
+	assert.Nil(t, res)
+}


### PR DESCRIPTION
A private endpoint connection whose state field ARM reports as `""` made the scan emit a **provider bug** diagnostic.

## The defect

`private_endpoint_connections.go` is the shared converter every service's private endpoint connections go through. It built the connection-state args by hand, adding a key only when the value was non-empty:

```go
if v, _ := cs["description"].(string); v != "" {
    stateArgs["description"] = llx.StringData(v)
}
```

A field ARM reports as an empty string never landed in `args`, so its `TValue` stayed **unset** rather than null. An unset field crosses the plugin boundary as an empty `DataRes`, once per field per connection.

The file **already had a helper for exactly this**, and its doc comment says why:

> `newPrivateLinkServiceConnectionState` … *All three fields are set unconditionally so an absent value reads as null rather than staying unset.*

The generic path duplicated the work instead of calling it, and the duplicate lost that property. It now calls the helper.

`dictStringPtr` keeps apart two answers the old guard collapsed into one: a key ARM **never sent** is unknown and reads as null; a key ARM **sent as `""`** is a value it reported and reads as the empty string.

## Verification

Live, on a SQL server, using a **manual** private endpoint request — which is where ARM reports `description` as an empty string:

```
$ az rest --method get --url ".../privateEndpointConnections?api-version=2021-11-01" \
    --query "value[].properties.privateLinkServiceConnectionState"
[
  { "actionsRequired": "None", "description": "Auto-approved", "status": "Approved" },
  { "actionsRequired": "None", "description": "",              "status": "Pending"  }   ← the shape that broke
]
```

**Before** — the field reads null, and the scan reports itself as buggy:

```
x provider returned no data and no error for a field; the field was never set on the resource
  (provider bug) field=description id=…/privateEndpointConnections/…/privateLinkServiceConnectionState
  resource=azure.subscription.privateEndpointConnection.connectionState
x llx: encountered a primitive with no type information, coercing to null

  1: { privateLinkServiceConnectionState: { description: null, status: "Pending", actionsRequired: "None" } }
```

**After** — the reported value survives and the scan is clean:

```
  1: { privateLinkServiceConnectionState: { description: "", status: "Pending", actionsRequired: "None" } }
```

Both endpoints created for this were deleted afterwards, confirmed against the owning service rather than the tagging API: the resource group lists only the three pre-existing storage endpoints, and the SQL server reports `length(value) == 0` connections.

## Tests

`private_endpoint_connections_test.go` drives the converter through the same dict shape every Azure SDK produces:

- `TestPrivateEndpointConnectionStateFieldsAreAlwaysSet` — all three fields set for every state shape ARM sends, including the normal *"only status is reported"* case, an empty state object, and fields reported as `""`.
- `TestPrivateEndpointConnectionStateDistinguishesAbsentFromEmpty` — absent reads null, `""` does not.
- `TestPrivateEndpointConnectionStatesAreKeyedByParent` — the state has no identity of its own, so a shared cache key would make the rejected connection report `Approved`; asserts the value, not just the id.
- `TestPrivateEndpointConnectionWithoutIdIsSkipped`, `TestDictStringPtr`.

Confirmed the tests fail against the pre-fix code — including the case that matters most, the one ARM sends normally:

```
--- FAIL: TestPrivateEndpointConnectionStateFieldsAreAlwaysSet/only_status_is_reported
    Messages: actionsRequired must be set -- unset is what surfaces as an unattributed null
    Messages: description must be set -- unset is what surfaces as an unattributed null
--- FAIL: …/an_empty_connection_state_object
--- FAIL: …/status_and_description_but_no_actionsRequired
--- FAIL: …/fields_reported_as_empty_strings
```

`go test ./...` is green across the provider.
