### PR TITLE
🐛 azure: guard the nil slice elements that would crash a whole scan

### DIFF
--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -298,62 +298,12 @@ func (a *mqlAzureSubscriptionMonitorServiceActivityLog) alerts() ([]any, error) 
 		if err != nil {
 			return nil, err
 		}
-		type mqlAlertAction struct {
-			ActionGroupId     string            `json:"actionGroupId"`
-			WebhookProperties map[string]string `json:"webhookProperties"`
-		}
-
-		type mqlAlertLeafCondition struct {
-			FieldName   string   `json:"fieldName"`
-			Equals      string   `json:"equals"`
-			ContainsAny []string `json:"containsAny"`
-		}
-
-		type mqlAlertCondition struct {
-			FieldName   string                  `json:"fieldName"`
-			Equals      string                  `json:"equals"`
-			ContainsAny []string                `json:"containsAny"`
-			AnyOf       []mqlAlertLeafCondition `json:"anyOf"`
-		}
-
 		for _, entry := range page.Value {
 			if entry == nil || entry.Properties == nil {
 				continue
 			}
-			actions := []mqlAlertAction{}
-			conditions := []mqlAlertCondition{}
-
-			if entry.Properties.Actions != nil {
-				for _, act := range entry.Properties.Actions.ActionGroups {
-					mqlAction := mqlAlertAction{
-						ActionGroupId:     convert.ToValue(act.ActionGroupID),
-						WebhookProperties: convert.PtrMapStrToStr(act.WebhookProperties),
-					}
-					actions = append(actions, mqlAction)
-				}
-			}
-			var allOf []*monitor.AlertRuleAnyOfOrLeafCondition
-			if entry.Properties.Condition != nil {
-				allOf = entry.Properties.Condition.AllOf
-			}
-			for _, cond := range allOf {
-				anyOf := []mqlAlertLeafCondition{}
-				for _, leaf := range cond.AnyOf {
-					mqlAnyOfLeaf := mqlAlertLeafCondition{
-						FieldName:   convert.ToValue(leaf.Field),
-						Equals:      convert.ToValue(leaf.Equals),
-						ContainsAny: azureStrPtrsToStr(leaf.ContainsAny),
-					}
-					anyOf = append(anyOf, mqlAnyOfLeaf)
-				}
-				mqlCondition := mqlAlertCondition{
-					FieldName:   convert.ToValue(cond.Field),
-					Equals:      convert.ToValue(cond.Equals),
-					ContainsAny: azureStrPtrsToStr(cond.ContainsAny),
-					AnyOf:       anyOf,
-				}
-				conditions = append(conditions, mqlCondition)
-			}
+			actions := alertActions(entry.Properties.Actions)
+			conditions := alertConditions(entry.Properties.Condition)
 
 			actionsDict := []any{}
 			for _, a := range actions {
@@ -395,6 +345,84 @@ func (a *mqlAzureSubscriptionMonitorServiceActivityLog) alerts() ([]any, error) 
 		}
 	}
 	return res, nil
+}
+
+// The flattened shapes an activity-log alert's actions and conditions are
+// reported as. They were declared inside the pager loop, which is why nothing
+// could test them.
+type (
+	mqlAlertAction struct {
+		ActionGroupId     string            `json:"actionGroupId"`
+		WebhookProperties map[string]string `json:"webhookProperties"`
+	}
+
+	mqlAlertLeafCondition struct {
+		FieldName   string   `json:"fieldName"`
+		Equals      string   `json:"equals"`
+		ContainsAny []string `json:"containsAny"`
+	}
+
+	mqlAlertCondition struct {
+		FieldName   string                  `json:"fieldName"`
+		Equals      string                  `json:"equals"`
+		ContainsAny []string                `json:"containsAny"`
+		AnyOf       []mqlAlertLeafCondition `json:"anyOf"`
+	}
+)
+
+// alertActions flattens an activity-log alert's action groups.
+//
+// ARM models each element as an optional pointer. A nil one panics on the first
+// field read, and a panic in a provider accessor is unrecoverable: the executor
+// runs query blocks in goroutines, so it takes down the whole scan rather than
+// the one alert rule.
+func alertActions(actions *monitor.ActionList) []mqlAlertAction {
+	res := []mqlAlertAction{}
+	if actions == nil {
+		return res
+	}
+	for _, act := range actions.ActionGroups {
+		if act == nil {
+			continue
+		}
+		res = append(res, mqlAlertAction{
+			ActionGroupId:     convert.ToValue(act.ActionGroupID),
+			WebhookProperties: convert.PtrMapStrToStr(act.WebhookProperties),
+		})
+	}
+	return res
+}
+
+// alertConditions flattens an activity-log alert's condition tree, skipping nil
+// elements at both levels for the same reason as alertActions.
+func alertConditions(condition *monitor.AlertRuleAllOfCondition) []mqlAlertCondition {
+	res := []mqlAlertCondition{}
+	if condition == nil {
+		return res
+	}
+	for _, cond := range condition.AllOf {
+		if cond == nil {
+			continue
+		}
+		anyOf := []mqlAlertLeafCondition{}
+		for _, leaf := range cond.AnyOf {
+			if leaf == nil {
+				continue
+			}
+			anyOf = append(anyOf, mqlAlertLeafCondition{
+				FieldName:   convert.ToValue(leaf.Field),
+				Equals:      convert.ToValue(leaf.Equals),
+				ContainsAny: azureStrPtrsToStr(leaf.ContainsAny),
+			})
+		}
+		res = append(res, mqlAlertCondition{
+			FieldName:   convert.ToValue(cond.Field),
+			Equals:      convert.ToValue(cond.Equals),
+			ContainsAny: azureStrPtrsToStr(cond.ContainsAny),
+			AnyOf:       anyOf,
+		})
+	}
+	return res
 }
 
 type mqlAzureSubscriptionMonitorServiceActionGroupInternal struct {

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -1792,6 +1792,12 @@ func mqlBgpSettingsFromSdk(runtime *plugin.Runtime, parentId string, bgp *networ
 	bgpSettingsId := parentId + "/bgpSettings"
 	bgpPeeringAddresses := []any{}
 	for i, bpa := range bgp.BgpPeeringAddresses {
+		// ARM models every element of this slice as an optional pointer. A nil
+		// one panics on the first field read, and a panic here kills the scan
+		// rather than this gateway.
+		if bpa == nil {
+			continue
+		}
 		bpaId := fmt.Sprintf("%s/%s/%d", bgpSettingsId, "bgpPeeringAddresses", i)
 		mqlBpa, err := CreateResource(runtime, "azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringAddress",
 			map[string]*llx.RawData{
@@ -5622,6 +5628,13 @@ func azureSecurityRuleToMql(runtime *plugin.Runtime, secRule network.SecurityRul
 
 	if secRule.Properties != nil && secRule.Properties.DestinationPortRanges != nil {
 		for _, r := range secRule.Properties.DestinationPortRanges {
+			// The same slice is walked again below with a nil guard. Without one
+			// here a nil element panics, and a panic in an accessor is
+			// unrecoverable: the executor runs blocks in goroutines, so it takes
+			// down the whole scan rather than this one rule.
+			if r == nil {
+				continue
+			}
 			dPortRange := parseAzureSecurityRulePortRange(*r)
 			for i := range dPortRange {
 				destinationPortRange = append(destinationPortRange, map[string]any{

--- a/providers/azure/resources/nil_element_test.go
+++ b/providers/azure/resources/nil_element_test.go
@@ -1,0 +1,154 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	monitor "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A panic in a provider accessor is unrecoverable: the executor evaluates query
+// blocks in goroutines, so a nil element in one ARM response takes down the
+// entire scan rather than the one resource that carried it. Each conversion below
+// walked a slice of optional pointers without a guard, and each had a guarded
+// sibling walking the same kind of data -- so the guard was an omission, not a
+// judgement that the element could not be nil.
+
+// azureSecurityRuleToMql walked Properties.DestinationPortRanges twice: once
+// bare, to expand each range into from/to ports, and once with an `if p != nil`
+// guard to report the raw strings. The unguarded walk came first.
+func TestSecurityRuleTolerateNilPortRange(t *testing.T) {
+	rule := network.SecurityRule{
+		ID:   strPtr("/subscriptions/sub/…/securityRules/allow-web"),
+		Name: strPtr("allow-web"),
+		Properties: &network.SecurityRulePropertiesFormat{
+			DestinationPortRanges: []*string{strPtr("80"), nil, strPtr("443-8443")},
+		},
+	}
+
+	var res *mqlAzureSubscriptionNetworkServiceSecurityrule
+	require.NotPanics(t, func() {
+		var err error
+		res, err = azureSecurityRuleToMql(cacheIDTestRuntime(), rule)
+		require.NoError(t, err)
+	})
+	require.NotNil(t, res)
+
+	// The nil is skipped, and the surrounding entries survive it -- dropping the
+	// whole rule would be as wrong as crashing.
+	assert.Equal(t, []any{"80", "443-8443"}, res.DestinationPortRanges.Data)
+	require.Len(t, res.DestinationPortRange.Data, 2, "80, then 443-8443 expanded")
+}
+
+func TestSecurityRuleWithNoPortRanges(t *testing.T) {
+	require.NotPanics(t, func() {
+		res, err := azureSecurityRuleToMql(cacheIDTestRuntime(), network.SecurityRule{
+			ID:         strPtr("/subscriptions/sub/…/securityRules/empty"),
+			Properties: &network.SecurityRulePropertiesFormat{},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+
+	// No properties at all, which ARM sends for a rule mid-provision.
+	require.NotPanics(t, func() {
+		res, err := azureSecurityRuleToMql(cacheIDTestRuntime(), network.SecurityRule{
+			ID: strPtr("/subscriptions/sub/…/securityRules/bare"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+}
+
+// mqlBgpSettingsFromSdk read each peering address's fields with no nil check.
+func TestBgpSettingsTolerateNilPeeringAddress(t *testing.T) {
+	bgp := &network.BgpSettings{
+		Asn: func() *int64 { v := int64(65515); return &v }(),
+		BgpPeeringAddresses: []*network.IPConfigurationBgpPeeringAddress{
+			{
+				IPConfigurationID:    strPtr("/…/ipConfigurations/default"),
+				CustomBgpIPAddresses: []*string{strPtr("169.254.21.5")},
+			},
+			nil,
+		},
+	}
+
+	var res *mqlAzureSubscriptionNetworkServiceBgpSettings
+	require.NotPanics(t, func() {
+		var err error
+		res, err = mqlBgpSettingsFromSdk(cacheIDTestRuntime(), "/subscriptions/sub/…/virtualNetworkGateways/gw", bgp)
+		require.NoError(t, err)
+	})
+	require.NotNil(t, res)
+	assert.Len(t, res.BgpPeeringAddressesConfig.Data, 1, "the nil element is skipped, the real one is kept")
+	assert.Equal(t, int64(65515), res.Asn.Data)
+}
+
+func TestBgpSettingsWithNoPeeringAddresses(t *testing.T) {
+	require.NotPanics(t, func() {
+		res, err := mqlBgpSettingsFromSdk(cacheIDTestRuntime(), "/subscriptions/sub/…/virtualNetworkGateways/gw",
+			&network.BgpSettings{})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.Empty(t, res.BgpPeeringAddressesConfig.Data)
+	})
+}
+
+// The activity-log alert flattening was declared inside the pager loop, which is
+// both why it had no nil guards and why nothing could test it. It is now two
+// package-level functions.
+func TestAlertActionsTolerateNilActionGroup(t *testing.T) {
+	actions := &monitor.ActionList{
+		ActionGroups: []*monitor.ActivityLogAlertActionGroup{
+			{ActionGroupID: strPtr("/…/actionGroups/oncall")},
+			nil,
+			{ActionGroupID: strPtr("/…/actionGroups/security")},
+		},
+	}
+
+	var got []mqlAlertAction
+	require.NotPanics(t, func() { got = alertActions(actions) })
+	require.Len(t, got, 2)
+	assert.Equal(t, "/…/actionGroups/oncall", got[0].ActionGroupId)
+	assert.Equal(t, "/…/actionGroups/security", got[1].ActionGroupId)
+
+	// Non-nil so a query can assert on length without a null guard.
+	assert.NotNil(t, alertActions(nil))
+	assert.Empty(t, alertActions(nil))
+	assert.Empty(t, alertActions(&monitor.ActionList{}))
+}
+
+func TestAlertConditionsTolerateNilAtBothLevels(t *testing.T) {
+	condition := &monitor.AlertRuleAllOfCondition{
+		AllOf: []*monitor.AlertRuleAnyOfOrLeafCondition{
+			{
+				Field:  strPtr("category"),
+				Equals: strPtr("Administrative"),
+			},
+			nil,
+			{
+				AnyOf: []*monitor.AlertRuleLeafCondition{
+					{Field: strPtr("operationName"), Equals: strPtr("Microsoft.Sql/servers/write")},
+					nil,
+				},
+			},
+		},
+	}
+
+	var got []mqlAlertCondition
+	require.NotPanics(t, func() { got = alertConditions(condition) })
+	require.Len(t, got, 2, "the nil top-level condition is skipped")
+	assert.Equal(t, "category", got[0].FieldName)
+	assert.Equal(t, "Administrative", got[0].Equals)
+	require.Len(t, got[1].AnyOf, 1, "the nil leaf is skipped, the real one is kept")
+	assert.Equal(t, "operationName", got[1].AnyOf[0].FieldName)
+
+	assert.NotNil(t, alertConditions(nil))
+	assert.Empty(t, alertConditions(nil))
+	assert.Empty(t, alertConditions(&monitor.AlertRuleAllOfCondition{}))
+}


### PR DESCRIPTION
Three conversions walked a slice of ARM's optional pointers and read fields off each element without checking for nil.

**A panic in a provider accessor is not recoverable.** The executor evaluates query blocks in goroutines, so one nil element in one ARM response takes down the **entire scan**, not the resource that carried it.

## The three sites

Each had a **guarded sibling walking the same kind of data**, so the missing check was an omission rather than a judgement that the element could not be nil:

| site | what it read | the sibling that already guards |
|---|---|---|
| `network.go` `azureSecurityRuleToMql` | `*r` on each `DestinationPortRanges` element | the *second* walk of the same slice, 40 lines later, has `if p != nil` |
| `network.go` `mqlBgpSettingsFromSdk` | four fields off each peering address | the enclosing accessor guards `BgpSettings` itself |
| `monitor.go` activity-log alerts | action groups, and the condition tree at both levels | `entry == nil \|\| entry.Properties == nil` in the same loop |

The security-rule one is the sharpest: the same slice is walked twice, and the **unguarded walk runs first**.

## The monitor extraction

That conversion was declared *inside the pager loop* — types and all — which is both why it had no guards and why nothing could test it. It also re-declared three struct types on every page.

It is now `alertActions` and `alertConditions` at package level, with the flattened shapes beside them. Both return non-nil empties so a query can assert on length without a null guard. No behaviour change beyond the guards: verified live that the activity-log alerts return identical output.

## Tests

`nil_element_test.go` covers all three, plus the empty and absent shapes. **Every `TolerateNil` test panics against the unguarded code**, which is what makes them worth keeping:

```
--- FAIL: TestSecurityRuleTolerateNilPortRange
        Panic value:	runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestBgpSettingsTolerateNilPeeringAddress
        Panic value:	runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestAlertActionsTolerateNilActionGroup
        Panic value:	runtime error: invalid memory address or nil pointer dereference
--- FAIL: TestAlertConditionsTolerateNilAtBothLevels
        Panic value:	runtime error: invalid memory address or nil pointer dereference
```

They also assert the surrounding entries **survive** the nil rather than the whole collection being dropped — silently losing a rule would be as wrong as crashing. `TestAlertConditionsTolerateNilAtBothLevels` puts a nil at the top level *and* inside a nested `anyOf`, since only one of the two guards would otherwise be exercised.

## Verification

Live: the security-rule and activity-log alert paths return the same data as before the change.

```
securityRules: [ 0: { name: "…", destinationPortRanges: [], destinationPortRange: [ 0: { fromPort: "2222", toPort: "2222" } ] } ]

conditions: [ 0: { fieldName: "category", equals: "Administrative", anyOf: [] }
              1: { fieldName: "operationName", equals: "Microsoft.Sql/servers/write", anyOf: [] } ]
```

`go test ./...` is green across the provider.
