### PR TITLE
🐛 azure: close the effective-NSG response body the poll loop leaves behind

### DIFF
--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -385,6 +385,64 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() (
 	return res, nil
 }
 
+// azureAsyncPollInterval is how long to wait between polls of a long-running
+// ARM operation. A variable so tests do not have to sleep through it.
+var azureAsyncPollInterval = 2 * time.Second
+
+// drainAndClose reads a response body to EOF and closes it, which is what
+// returns the connection to the pool. Closing without draining makes net/http
+// discard the connection instead of reusing it.
+func drainAndClose(body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
+}
+
+// pollAzureAsyncOperation follows the Location header of a 202 Accepted response
+// until the operation reports its result, and returns that final response with
+// its body still open for the caller to read and close.
+//
+// Every response the loop moves past is drained and closed here, on the success
+// path and on every error path. That used to be a leak: the caller's
+// `defer httpResp.Body.Close()` evaluates httpResp.Body when the defer statement
+// runs rather than when the function returns, so it bound the very first
+// response, which the loop had already closed on its way past, and the final
+// response -- the one actually decoded -- was never closed at all. Azure answers
+// 202 for any NIC attached to a running VM, so this fired on the success path,
+// once per interface.
+func pollAzureAsyncOperation(ctx context.Context, client *http.Client, resp *http.Response, bearer string) (*http.Response, error) {
+	for resp.StatusCode == http.StatusAccepted {
+		loc := resp.Header.Get("Location")
+		if loc == "" {
+			drainAndClose(resp.Body)
+			return nil, errors.New("azure long-running operation returned 202 without a Location header")
+		}
+		select {
+		case <-ctx.Done():
+			drainAndClose(resp.Body)
+			return nil, ctx.Err()
+		case <-time.After(azureAsyncPollInterval):
+		}
+		pollReq, err := http.NewRequestWithContext(ctx, http.MethodGet, loc, nil)
+		if err != nil {
+			drainAndClose(resp.Body)
+			return nil, err
+		}
+		pollReq.Header.Set("Authorization", "Bearer "+bearer)
+		pollReq.Header.Set("Accept", "application/json")
+		next, err := client.Do(pollReq)
+		if err != nil {
+			drainAndClose(resp.Body)
+			return nil, err
+		}
+		drainAndClose(resp.Body)
+		resp = next
+	}
+	return resp, nil
+}
+
 // fetchEffectiveNsgGroups computes the effective NSGs on this NIC, one group per
 // NSG in the effective chain. Azure only computes effective rules for NICs
 // attached to a running VM; for detached or stopped NICs the API returns
@@ -434,37 +492,17 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) fetchEffectiveNsgGroups() 
 	if err != nil {
 		return nil, false, err
 	}
-	defer httpResp.Body.Close()
 
 	// 202 Accepted → poll the Location header until the result is ready. We don't
 	// fall back to Azure-AsyncOperation: that endpoint returns a status envelope
 	// (`{"status": "InProgress"|"Succeeded"|"Failed"}`), not the effective-rules
 	// payload, so a 200 from it would just be the loop exiting onto the wrong body.
-	for httpResp.StatusCode == http.StatusAccepted {
-		loc := httpResp.Header.Get("Location")
-		if loc == "" {
-			io.Copy(io.Discard, httpResp.Body)
-			return nil, false, fmt.Errorf("effective NSG list returned 202 without a Location header")
-		}
-		// Sleep a beat then poll.
-		select {
-		case <-ctx.Done():
-			return nil, false, ctx.Err()
-		case <-time.After(2 * time.Second):
-		}
-		pollReq, perr := http.NewRequestWithContext(ctx, http.MethodGet, loc, nil)
-		if perr != nil {
-			return nil, false, perr
-		}
-		pollReq.Header.Set("Authorization", "Bearer "+tok.Token)
-		pollReq.Header.Set("Accept", "application/json")
-		newResp, perr := httpClient.Do(pollReq)
-		if perr != nil {
-			return nil, false, perr
-		}
-		httpResp.Body.Close()
-		httpResp = newResp
+	httpResp, err = pollAzureAsyncOperation(ctx, httpClient, httpResp, tok.Token)
+	if err != nil {
+		return nil, false, err
 	}
+	// Deferred after the poll, so it binds the body actually being read below.
+	defer drainAndClose(httpResp.Body)
 
 	if httpResp.StatusCode == http.StatusBadRequest ||
 		httpResp.StatusCode == http.StatusNotFound ||

--- a/providers/azure/resources/network_asyncpoll_test.go
+++ b/providers/azure/resources/network_asyncpoll_test.go
@@ -1,0 +1,289 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingBody wraps a response body so a test can see whether the caller closed
+// it. A leaked body is invisible in the returned data -- the only way to catch it
+// is to watch the close.
+type countingBody struct {
+	io.ReadCloser
+	closed *atomic.Int32
+}
+
+func (c countingBody) Close() error {
+	c.closed.Add(1)
+	return c.ReadCloser.Close()
+}
+
+// bodyTracker wraps a RoundTripper and records one close counter per response, in
+// the order the responses came back.
+type bodyTracker struct {
+	rt       http.RoundTripper
+	mu       sync.Mutex
+	counters []*atomic.Int32
+}
+
+func (b *bodyTracker) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := b.rt.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	counter := &atomic.Int32{}
+	b.mu.Lock()
+	b.counters = append(b.counters, counter)
+	b.mu.Unlock()
+	resp.Body = countingBody{ReadCloser: resp.Body, closed: counter}
+	return resp, nil
+}
+
+func (b *bodyTracker) closes() []int32 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]int32, 0, len(b.counters))
+	for _, c := range b.counters {
+		out = append(out, c.Load())
+	}
+	return out
+}
+
+func trackedClient(t *testing.T) (*http.Client, *bodyTracker) {
+	t.Helper()
+	tracker := &bodyTracker{rt: http.DefaultTransport}
+	return &http.Client{Transport: tracker, Timeout: 10 * time.Second}, tracker
+}
+
+// pollTestSetup shortens the poll interval so a test does not sleep through the
+// production two seconds.
+func pollTestSetup(t *testing.T) {
+	t.Helper()
+	original := azureAsyncPollInterval
+	azureAsyncPollInterval = time.Millisecond
+	t.Cleanup(func() { azureAsyncPollInterval = original })
+}
+
+// The defect: the caller's `defer httpResp.Body.Close()` evaluated httpResp.Body
+// at the defer statement, binding the FIRST response. The loop then reassigned
+// httpResp, so the final response -- the one actually decoded -- was never closed.
+// Azure answers 202 for any NIC on a running VM, so this leaked once per
+// interface on the success path.
+func TestPollAzureAsyncOperationClosesEveryIntermediateBody(t *testing.T) {
+	pollTestSetup(t)
+
+	var hits atomic.Int32
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch hits.Add(1) {
+		case 1, 2:
+			// Two rounds of "still working", as a slow operation gives.
+			w.Header().Set("Location", srv.URL+"/poll")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"status":"InProgress"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		}
+	}))
+	defer srv.Close()
+
+	client, tracker := trackedClient(t)
+	first, err := client.Post(srv.URL, "application/json", nil)
+	require.NoError(t, err)
+
+	final, err := pollAzureAsyncOperation(context.Background(), client, first, "token")
+	require.NoError(t, err)
+	require.NotNil(t, final)
+	assert.Equal(t, http.StatusOK, final.StatusCode)
+
+	closes := tracker.closes()
+	require.Len(t, closes, 3, "two 202s then the result")
+	assert.Equal(t, int32(1), closes[0], "the first 202 body must be closed")
+	assert.Equal(t, int32(1), closes[1], "the second 202 body must be closed")
+	assert.Equal(t, int32(0), closes[2], "the final body is handed back open for the caller to read")
+
+	// The caller's deferred drainAndClose is what closes the last one.
+	body, err := io.ReadAll(final.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"value":[]}`, string(body))
+	drainAndClose(final.Body)
+	assert.Equal(t, int32(1), tracker.closes()[2])
+}
+
+// A response that is already final must be returned untouched, still open.
+func TestPollAzureAsyncOperationPassesThroughANonAcceptedResponse(t *testing.T) {
+	pollTestSetup(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"value":[]}`))
+	}))
+	defer srv.Close()
+
+	client, tracker := trackedClient(t)
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+
+	final, err := pollAzureAsyncOperation(context.Background(), client, resp, "token")
+	require.NoError(t, err)
+	assert.Same(t, resp, final)
+	assert.Equal(t, []int32{0}, tracker.closes(), "nothing to close yet")
+}
+
+// Every error path must close the body it is abandoning. These leaked too: the
+// caller's deferred close was bound to a body the loop had already closed.
+func TestPollAzureAsyncOperationClosesTheBodyOnEveryErrorPath(t *testing.T) {
+	t.Run("202 with no Location header", func(t *testing.T) {
+		pollTestSetup(t)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"status":"InProgress"}`))
+		}))
+		defer srv.Close()
+
+		client, tracker := trackedClient(t)
+		resp, err := client.Post(srv.URL, "application/json", nil)
+		require.NoError(t, err)
+
+		final, err := pollAzureAsyncOperation(context.Background(), client, resp, "token")
+		require.Error(t, err)
+		assert.Nil(t, final)
+		assert.Contains(t, err.Error(), "without a Location header")
+		assert.Equal(t, []int32{1}, tracker.closes())
+	})
+
+	t.Run("the context is cancelled mid-poll", func(t *testing.T) {
+		pollTestSetup(t)
+		var srv *httptest.Server
+		srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Location", srv.URL+"/poll")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"status":"InProgress"}`))
+		}))
+		defer srv.Close()
+
+		client, tracker := trackedClient(t)
+		resp, err := client.Post(srv.URL, "application/json", nil)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		final, err := pollAzureAsyncOperation(ctx, client, resp, "token")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
+		assert.Nil(t, final)
+		assert.Equal(t, []int32{1}, tracker.closes(), "the abandoned body must still be closed")
+	})
+
+	t.Run("the poll request itself fails", func(t *testing.T) {
+		pollTestSetup(t)
+		// Point Location at a closed listener so the poll cannot connect.
+		dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		deadURL := dead.URL
+		dead.Close()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Location", deadURL+"/poll")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"status":"InProgress"}`))
+		}))
+		defer srv.Close()
+
+		client, tracker := trackedClient(t)
+		resp, err := client.Post(srv.URL, "application/json", nil)
+		require.NoError(t, err)
+
+		final, err := pollAzureAsyncOperation(context.Background(), client, resp, "token")
+		require.Error(t, err)
+		assert.Nil(t, final)
+		assert.Equal(t, []int32{1}, tracker.closes())
+	})
+}
+
+// The poll carries the bearer token, or ARM answers 401 and the loop never ends.
+func TestPollAzureAsyncOperationAuthenticatesEachPoll(t *testing.T) {
+	pollTestSetup(t)
+
+	var authHeaders []string
+	var mu sync.Mutex
+	var hits atomic.Int32
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			mu.Lock()
+			authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+			mu.Unlock()
+		}
+		if hits.Add(1) == 1 {
+			w.Header().Set("Location", srv.URL+"/poll")
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, _ := trackedClient(t)
+	resp, err := client.Post(srv.URL, "application/json", nil)
+	require.NoError(t, err)
+
+	final, err := pollAzureAsyncOperation(context.Background(), client, resp, "secret-token")
+	require.NoError(t, err)
+	drainAndClose(final.Body)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, authHeaders, 1)
+	assert.Equal(t, "Bearer secret-token", authHeaders[0])
+}
+
+func TestDrainAndCloseToleratesANilBody(t *testing.T) {
+	assert.NotPanics(t, func() { drainAndClose(nil) })
+}
+
+// The Go semantics the leak rested on, pinned so the shape is not reintroduced:
+// a deferred method call evaluates its receiver where the DEFER STATEMENT is, not
+// where the function returns. `defer resp.Body.Close()` before a loop that
+// reassigns resp therefore closes the response the loop started with and never
+// the one it ended on -- which reads as correct and leaks every time.
+func TestDeferBindsItsReceiverAtTheDeferStatement(t *testing.T) {
+	firstClosed, lastClosed := &atomic.Int32{}, &atomic.Int32{}
+	emptyBody := func(counter *atomic.Int32) countingBody {
+		return countingBody{ReadCloser: io.NopCloser(http.NoBody), closed: counter}
+	}
+
+	func() {
+		body := emptyBody(firstClosed)
+		defer body.Close() // binds THIS body, not whatever body ends up being
+		body = emptyBody(lastClosed)
+		_ = body
+	}()
+
+	assert.Equal(t, int32(1), firstClosed.Load(), "the deferred close hit the original")
+	assert.Equal(t, int32(0), lastClosed.Load(), "and never the reassignment: that is the leak")
+
+	// Wrapping in a closure defers the evaluation instead, which is the other way
+	// to write it correctly when the variable must be reassigned.
+	reassignedClosed := &atomic.Int32{}
+	func() {
+		body := emptyBody(firstClosed)
+		defer func() { body.Close() }()
+		body = emptyBody(reassignedClosed)
+		_ = body
+	}()
+	assert.Equal(t, int32(1), reassignedClosed.Load(), "the closure sees the latest value")
+}


### PR DESCRIPTION
The effective-NSG call leaked one response body **per network interface**, on the success path.

## The defect

`fetchEffectiveNsgGroups` guarded its response like this, before a loop that reassigns the variable:

```go
httpResp, err := httpClient.Do(req)
defer httpResp.Body.Close()          // ← binds THIS body

for httpResp.StatusCode == http.StatusAccepted {
    …
    httpResp.Body.Close()
    httpResp = newResp               // ← the deferred close no longer refers to this
}
…
json.NewDecoder(httpResp.Body).Decode(&payload)   // decoded, never closed
```

A deferred **method call** evaluates its receiver where the `defer` *statement* is, not where the function returns. So the deferred close bound the very first response — which the loop had already closed explicitly on its way past — and the final response, the one actually decoded, was never closed at all. Every error path inside the loop returned the same way, abandoning the response it was holding.

**This is the success path, not an edge case.** Azure answers 202 for the effective-NSG call on any NIC attached to a running VM, and the call runs once per interface.

## The fix

The poll is now `pollAzureAsyncOperation`. It drains and closes every response it moves past — on the success path and on all four error paths — and returns the final one open for its caller. The caller defers the close *after* the poll, where it binds the response being read.

Draining before closing is what returns the connection to the pool; closing an unread body makes `net/http` discard the connection instead of reusing it.

Extracting it also made it **testable**, which it was not while inline in an accessor that needs a live Azure connection. The poll interval moved behind a variable so tests do not sleep through the production two seconds.

## Tests

`network_asyncpoll_test.go` drives the loop against `httptest` with a `RoundTripper` that wraps every response body in a close counter — a leaked body is invisible in the returned data, so watching the close is the only way to catch it.

- `TestPollAzureAsyncOperationClosesEveryIntermediateBody` — two 202s then the result; asserts the first two bodies are closed **once each**, the final one is handed back **open**, and that the caller's `drainAndClose` is what closes it.
- `TestPollAzureAsyncOperationClosesTheBodyOnEveryErrorPath` — a 202 with no `Location`, a cancelled context, and a poll request that cannot connect; each must close the body it abandons.
- `TestPollAzureAsyncOperationPassesThroughANonAcceptedResponse` — an already-final response is returned untouched and still open.
- `TestPollAzureAsyncOperationAuthenticatesEachPoll` — the bearer token rides along, or ARM 401s and the loop never ends.
- `TestDeferBindsItsReceiverAtTheDeferStatement` — pins the **Go semantics the bug rested on**: a deferred method call binds the receiver at the defer statement, so the original is closed and the reassignment never is. It also shows the closure form that behaves correctly. This is the thing a future reader would get wrong again.

## Verification

Live. A NIC attached to a running VM — the 202 path — reports its effective rules, and detached private-endpoint NICs still degrade with a warning rather than failing the interface list:

```
! effective security rules unavailable for NIC nic=…storage2-privateendpoint… status=400
azure.subscription.network.interfaces.where: [
  0: { name: "…-nic-1", effectiveSecurityRules.length: 7 }
]
```

`go test ./...` and `go vet ./...` are clean across the provider.
