### PR TITLE
🐛 azure: give the root asset an identity instead of a blank entry

### DIFF
--- a/providers/azure/provider/detect_test.go
+++ b/providers/azure/provider/detect_test.go
@@ -87,6 +87,20 @@ func TestApplyAzureSubscriptionIdentityDoesNotOverwriteExistingIdentity(t *testi
 	assert.Equal(t, []string{testPlatformID}, asset.PlatformIds)
 }
 
+// A name the caller supplied via --asset-name survives detect. Naming the root
+// asset here runs after cnspec has already applied --asset-name, so an
+// unconditional write makes that flag a no-op for every Azure scan.
+func TestApplyAzureSubscriptionIdentityKeepsARequestedName(t *testing.T) {
+	asset := &inventory.Asset{Name: "prod-billing-account"}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
+
+	assert.Equal(t, "prod-billing-account", asset.Name, "a name already set is left alone")
+
+	// The rest of the identity is still stamped on.
+	assert.Equal(t, []string{testPlatformID}, asset.PlatformIds)
+	assert.Equal(t, testSubID, asset.Labels[resources.SubscriptionLabel])
+}
+
 // detect returns without touching the asset when there is no single subscription
 // to be: the caller named several, or none, and discovery enumerates them.
 func TestDetectLeavesAMultiSubscriptionConnectionAlone(t *testing.T) {

--- a/providers/azure/provider/detect_test.go
+++ b/providers/azure/provider/detect_test.go
@@ -1,0 +1,102 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/azure/resources"
+)
+
+const (
+	testSubID     = "00000000-0000-0000-0000-000000000000"
+	testTenantID  = "11111111-1111-1111-1111-111111111111"
+	testPlatformI = "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + testSubID
+)
+
+// detect used to be a bare `return nil`, so the root asset -- the one the caller
+// connected as, before any discovery -- reached the client with no platform, no
+// name, and no platform id. Every Azure scan carried one blank entry, and
+// `--discover none` produced nothing but the blank entry.
+func TestApplyAzureSubscriptionIdentity(t *testing.T) {
+	asset := &inventory.Asset{}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "Production")
+
+	require.NotNil(t, asset.Platform, "a blank platform is the defect")
+	assert.Equal(t, "azure", asset.Platform.Name)
+	assert.Equal(t, []string{"azure", testTenantID, testSubID, "account"},
+		asset.Platform.TechnologyUrlSegments)
+
+	assert.Equal(t, []string{testPlatformI}, asset.PlatformIds)
+	assert.Equal(t, testPlatformI, asset.Id)
+	assert.Equal(t, "Azure subscription Production", asset.Name)
+	assert.Equal(t, testSubID, asset.Labels[resources.SubscriptionLabel])
+}
+
+// The whole point is that the same subscription reads the same whether it arrived
+// as the root asset or as one discovery found, so the shape has to match
+// subToAsset's: the same platform id, the same name prefix, the same label.
+func TestApplyAzureSubscriptionIdentityMatchesDiscoveryShape(t *testing.T) {
+	asset := &inventory.Asset{}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "Production")
+
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/azure/subscriptions/"+testSubID, asset.Id,
+		"the platform id format discovery uses")
+	assert.Equal(t, asset.Id, asset.PlatformIds[0], "id and platform id agree")
+	assert.Equal(t, "azure.mondoo.com/subscription", resources.SubscriptionLabel,
+		"the label key discovery sets")
+}
+
+func TestApplyAzureSubscriptionIdentityFallbacks(t *testing.T) {
+	t.Run("no display name falls back to the id", func(t *testing.T) {
+		// Reached when the subscription lookup fails, or when ARM omits
+		// displayName -- which it does for deleted, disabled, and cross-tenant
+		// subscriptions. A scan must not fail over a display name.
+		asset := &inventory.Asset{}
+		applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "")
+		assert.Equal(t, "Azure subscription "+testSubID, asset.Name)
+	})
+
+	t.Run("no tenant id is reported as unknown", func(t *testing.T) {
+		// The tenant is only known when the caller passed --tenant-id.
+		asset := &inventory.Asset{}
+		applyAzureSubscriptionIdentity(asset, testSubID, "", testPlatformI, "Production")
+		assert.Equal(t, []string{"azure", "unknown", testSubID, "account"},
+			asset.Platform.TechnologyUrlSegments)
+	})
+}
+
+// An asset that already carries an id or a label keeps them: those came from
+// whoever built the asset, and this only fills in what is missing.
+func TestApplyAzureSubscriptionIdentityDoesNotOverwriteExistingIdentity(t *testing.T) {
+	asset := &inventory.Asset{
+		Id:     "//some/other/id",
+		Labels: map[string]string{resources.SubscriptionLabel: "someone-elses-sub", "env": "prod"},
+	}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "Production")
+
+	assert.Equal(t, "//some/other/id", asset.Id, "an id already set is left alone")
+	assert.Equal(t, "someone-elses-sub", asset.Labels[resources.SubscriptionLabel])
+	assert.Equal(t, "prod", asset.Labels["env"], "unrelated labels survive")
+
+	// The platform ids still report what this connection actually is.
+	assert.Equal(t, []string{testPlatformI}, asset.PlatformIds)
+}
+
+// detect returns without touching the asset when there is no single subscription
+// to be: the caller named several, or none, and discovery enumerates them.
+func TestDetectLeavesAMultiSubscriptionConnectionAlone(t *testing.T) {
+	s := &Service{}
+	asset := &inventory.Asset{}
+
+	// A nil connection is not an *AzureConnection, which is the same branch a
+	// snapshot connection takes -- those are detected by the os provider.
+	require.NoError(t, s.detect(asset, nil))
+	assert.Nil(t, asset.Platform)
+	assert.Empty(t, asset.Name)
+	assert.Empty(t, asset.PlatformIds)
+}

--- a/providers/azure/provider/detect_test.go
+++ b/providers/azure/provider/detect_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	testSubID     = "00000000-0000-0000-0000-000000000000"
-	testTenantID  = "11111111-1111-1111-1111-111111111111"
-	testPlatformI = "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + testSubID
+	testSubID      = "00000000-0000-0000-0000-000000000000"
+	testTenantID   = "11111111-1111-1111-1111-111111111111"
+	testPlatformID = "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + testSubID
 )
 
 // detect used to be a bare `return nil`, so the root asset -- the one the caller
@@ -24,15 +24,15 @@ const (
 // `--discover none` produced nothing but the blank entry.
 func TestApplyAzureSubscriptionIdentity(t *testing.T) {
 	asset := &inventory.Asset{}
-	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "Production")
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
 
 	require.NotNil(t, asset.Platform, "a blank platform is the defect")
 	assert.Equal(t, "azure", asset.Platform.Name)
 	assert.Equal(t, []string{"azure", testTenantID, testSubID, "account"},
 		asset.Platform.TechnologyUrlSegments)
 
-	assert.Equal(t, []string{testPlatformI}, asset.PlatformIds)
-	assert.Equal(t, testPlatformI, asset.Id)
+	assert.Equal(t, []string{testPlatformID}, asset.PlatformIds)
+	assert.Equal(t, testPlatformID, asset.Id)
 	assert.Equal(t, "Azure subscription Production", asset.Name)
 	assert.Equal(t, testSubID, asset.Labels[resources.SubscriptionLabel])
 }
@@ -42,7 +42,7 @@ func TestApplyAzureSubscriptionIdentity(t *testing.T) {
 // subToAsset's: the same platform id, the same name prefix, the same label.
 func TestApplyAzureSubscriptionIdentityMatchesDiscoveryShape(t *testing.T) {
 	asset := &inventory.Asset{}
-	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "Production")
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
 
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/azure/subscriptions/"+testSubID, asset.Id,
 		"the platform id format discovery uses")
@@ -57,14 +57,14 @@ func TestApplyAzureSubscriptionIdentityFallbacks(t *testing.T) {
 		// displayName -- which it does for deleted, disabled, and cross-tenant
 		// subscriptions. A scan must not fail over a display name.
 		asset := &inventory.Asset{}
-		applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "")
+		applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "")
 		assert.Equal(t, "Azure subscription "+testSubID, asset.Name)
 	})
 
 	t.Run("no tenant id is reported as unknown", func(t *testing.T) {
 		// The tenant is only known when the caller passed --tenant-id.
 		asset := &inventory.Asset{}
-		applyAzureSubscriptionIdentity(asset, testSubID, "", testPlatformI, "Production")
+		applyAzureSubscriptionIdentity(asset, testSubID, "", testPlatformID, "Production")
 		assert.Equal(t, []string{"azure", "unknown", testSubID, "account"},
 			asset.Platform.TechnologyUrlSegments)
 	})
@@ -77,14 +77,14 @@ func TestApplyAzureSubscriptionIdentityDoesNotOverwriteExistingIdentity(t *testi
 		Id:     "//some/other/id",
 		Labels: map[string]string{resources.SubscriptionLabel: "someone-elses-sub", "env": "prod"},
 	}
-	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformI, "Production")
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
 
 	assert.Equal(t, "//some/other/id", asset.Id, "an id already set is left alone")
 	assert.Equal(t, "someone-elses-sub", asset.Labels[resources.SubscriptionLabel])
 	assert.Equal(t, "prod", asset.Labels["env"], "unrelated labels survive")
 
 	// The platform ids still report what this connection actually is.
-	assert.Equal(t, []string{testPlatformI}, asset.PlatformIds)
+	assert.Equal(t, []string{testPlatformID}, asset.PlatformIds)
 }
 
 // detect returns without touching the asset when there is no single subscription

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -367,10 +367,15 @@ func applyAzureSubscriptionIdentity(asset *inventory.Asset, subID, tenantID, pla
 		asset.Labels[resources.SubscriptionLabel] = subID
 	}
 
-	if displayName == "" {
-		displayName = subID
+	// Only name an asset that has no name. A caller who passed --asset-name
+	// has already named this asset, and detect running afterwards must not
+	// take that back; the sibling fields above guard for the same reason.
+	if asset.Name == "" {
+		if displayName == "" {
+			displayName = subID
+		}
+		asset.Name = "Azure subscription " + displayName
 	}
-	asset.Name = "Azure subscription " + displayName
 }
 
 // azureSubscriptionDisplayName reads the connected subscription's display name,

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -300,8 +303,96 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	return runtime.Connection.(shared.AzureConnection), nil
 }
 
+// detect gives the root asset -- the one the caller connected as, before any
+// discovery -- the identity a discovered subscription gets from subToAsset.
+//
+// It used to be a bare `return nil`, so that asset reached the client with no
+// platform, no name, and no platform id: every Azure scan carried one blank
+// entry, and `--discover none` produced nothing but the blank entry. The
+// resources were queryable the whole time, because the connection knows which
+// subscription it is on; only the asset's own identity was missing.
+//
+// A connection with no subscription is left alone deliberately. That is the
+// caller who named several subscriptions or none, where discovery enumerates
+// them and there is no single subscription for the root asset to be.
 func (s *Service) detect(asset *inventory.Asset, conn shared.AzureConnection) error {
+	azureConn, ok := conn.(*connection.AzureConnection)
+	if !ok {
+		// A snapshot connection is handed to the os provider, which detects it.
+		return nil
+	}
+
+	subID := azureConn.SubId()
+	if subID == "" {
+		return nil
+	}
+
+	var tenantID string
+	if conf := azureConn.Config(); conf != nil {
+		tenantID = conf.Options[connection.OptionTenantID]
+	}
+
+	applyAzureSubscriptionIdentity(asset, subID, tenantID, azureConn.PlatformId(),
+		azureSubscriptionDisplayName(azureConn))
 	return nil
+}
+
+// applyAzureSubscriptionIdentity stamps a subscription's identity onto an asset,
+// in the shape subToAsset gives a discovered subscription, so the same
+// subscription reads the same whichever way it arrived.
+//
+// displayName may be empty, in which case the id names the asset. That is also
+// what subToAsset does for a subscription whose displayName ARM omits, and it is
+// the right outcome here too: a scan should not fail because the asset could only
+// be named by its id.
+func applyAzureSubscriptionIdentity(asset *inventory.Asset, subID, tenantID, platformID, displayName string) {
+	if tenantID == "" {
+		tenantID = "unknown"
+	}
+
+	platform := &inventory.Platform{
+		TechnologyUrlSegments: []string{"azure", tenantID, subID, "account"},
+	}
+	resources.PlatformByName("azure").Apply(platform)
+
+	asset.Platform = platform
+	asset.PlatformIds = []string{platformID}
+	if asset.Id == "" {
+		asset.Id = platformID
+	}
+	if asset.Labels == nil {
+		asset.Labels = map[string]string{}
+	}
+	if _, ok := asset.Labels[resources.SubscriptionLabel]; !ok {
+		asset.Labels[resources.SubscriptionLabel] = subID
+	}
+
+	if displayName == "" {
+		displayName = subID
+	}
+	asset.Name = "Azure subscription " + displayName
+}
+
+// azureSubscriptionDisplayName reads the connected subscription's display name,
+// and returns "" when it cannot be read. Logged rather than returned: a scan
+// should not fail because the asset could only be named by its id.
+func azureSubscriptionDisplayName(conn *connection.AzureConnection) string {
+	client, err := subscriptions.NewClient(conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		log.Debug().Err(err).Msg("could not build the subscriptions client to name the asset")
+		return ""
+	}
+	resp, err := client.Get(context.Background(), conn.SubId(), nil)
+	if err != nil {
+		log.Debug().Err(err).Msg("could not read the subscription to name the asset")
+		return ""
+	}
+	if resp.DisplayName == nil {
+		return ""
+	}
+	return *resp.DisplayName
 }
 
 func (s *Service) discover(conn shared.AzureConnection) (*inventory.Inventory, error) {


### PR DESCRIPTION
Every Azure scan carried one blank asset, and `--discover none` produced **nothing but** the blank asset.

## The defect

```go
func (s *Service) detect(asset *inventory.Asset, conn shared.AzureConnection) error {
	return nil
}
```

So the root asset — the one the caller connected as, before any discovery — reached the client with no platform, no name, and no platform ids. Live, before:

```
$ mql run azure --subscription … --discover none -c 'asset { name platform ids }'
asset: {
  platform: ""
  ids: []
  name: ""
}
```

The resources were queryable the whole time, because the connection knows which subscription it is on. Only the asset's *own identity* was missing — which is what names it in a report, keys it upstream, and lets `PlatformIds` resolve it.

## The fix

`detect` now stamps the identity `subToAsset` gives a **discovered** subscription, so the same subscription reads the same whichever way it arrived:

| | root asset (before) | root asset (now) | discovered (`subToAsset`) |
|---|---|---|---|
| `Platform` | nil | `azure` | `azure` |
| `TechnologyUrlSegments` | — | `azure/<tenant>/<sub>/account` | same |
| `PlatformIds` | `[]` | `//platformid.api.mondoo.app/runtime/azure/subscriptions/<sub>` | same |
| `Name` | `""` | `Azure subscription <displayName>` | same |
| `Labels` | — | `azure.mondoo.com/subscription: <sub>` | same |

After:

```
asset: {
  platform: "azure"
  ids: [ 0: "//platformid.api.mondoo.app/runtime/azure/subscriptions/…" ]
  name: "Azure subscription …"
}
```

### Deliberate non-actions

- **An asset that already has an id or that label keeps them.** Those came from whoever built the asset; this only fills in what is missing.
- **A connection with no subscription is left alone.** That is the caller who named several subscriptions or none — discovery enumerates them, and there is no single subscription for the root asset to *be*.
- **A snapshot connection is left alone**, since the os provider detects those.

### Cost

The display name costs one `GET` on the subscription. If it cannot be read — and ARM omits `displayName` for deleted, disabled, and cross-tenant subscriptions projected in by Lighthouse — the id names the asset, which is the same fallback `subToAsset` uses. A scan must not fail because the asset could only be named by its id.

That lookup duplicates the one `initAzureSubscription` makes when a query touches `azure.subscription`. Caching it on the connection would remove the duplicate; that is a separate cleanup, not folded in here.

## Tests

The identity shaping is a pure function (`applyAzureSubscriptionIdentity`), separated from the network call precisely so it can be tested:

- `TestApplyAzureSubscriptionIdentity` — the full shape, including that `Platform` is **not nil**, which is the defect.
- `TestApplyAzureSubscriptionIdentityMatchesDiscoveryShape` — pins the platform-id format and the label key against discovery's, since agreement between the two paths is the whole point.
- `TestApplyAzureSubscriptionIdentityFallbacks` — no display name falls back to the id; no tenant id reports `unknown`.
- `TestApplyAzureSubscriptionIdentityDoesNotOverwriteExistingIdentity` — an existing id and label survive, unrelated labels survive, and `PlatformIds` still reports what this connection is.
- `TestDetectLeavesAMultiSubscriptionConnectionAlone` — the non-`*AzureConnection` branch (the same one a snapshot takes) touches nothing.

`go test ./...` is green across the provider.
