### PR TITLE
⭐ azure: report the interface IP configurations allocated in a subnet

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -3014,7 +3014,20 @@ azure.subscription.networkService.subnet @defaults("id name addressPrefix") {
   privateEndpoints() []azure.subscription.networkService.privateEndpoint
   // IP allocations reserving address space in the subnet
   ipAllocations() []azure.subscription.networkService.ipAllocation
-  // List of IP configurations for the subnet
+  // Network interface IP configurations allocated in the subnet
+  //
+  // The interface IP configurations holding an address from this subnet, which
+  // is what occupies a subnet's address space in practice: virtual machine
+  // interfaces, private endpoint interfaces, and load balancer backend members.
+  // Each one resolves its public IP address and application security groups, so
+  // a path from the subnet to what is actually reachable in it can be followed.
+  // Empty on a subnet no interface has an address in, such as a gateway subnet.
+  interfaceIpConfigurations() []azure.subscription.networkService.interface.ipConfiguration
+  // Virtual network gateway IP configurations in the subnet
+  //
+  // Only the gateway IP configurations, which is what a gateway subnet holds.
+  // Empty on an ordinary workload subnet: the addresses there belong to network
+  // interfaces, and interfaceIpConfigurations reports those.
   ipConfigurations() []azure.subscription.networkService.virtualNetworkGateway.ipConfig
 }
 

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -5646,6 +5646,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.subnet.ipAllocations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSubnet).GetIpAllocations()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.ipAllocation")))
 	},
+	"azure.subscription.networkService.subnet.interfaceIpConfigurations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSubnet).GetInterfaceIpConfigurations()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.interface.ipConfiguration")))
+	},
 	"azure.subscription.networkService.subnet.ipConfigurations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSubnet).GetIpConfigurations()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.virtualNetworkGateway.ipConfig")))
 	},
@@ -25213,6 +25216,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.subnet.ipAllocations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSubnet).IpAllocations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.subnet.interfaceIpConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSubnet).InterfaceIpConfigurations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.subnet.ipConfigurations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -57593,6 +57600,7 @@ type mqlAzureSubscriptionNetworkServiceSubnet struct {
 	NatGateway                        plugin.TValue[*mqlAzureSubscriptionNetworkServiceNatGateway]
 	PrivateEndpoints                  plugin.TValue[[]any]
 	IpAllocations                     plugin.TValue[[]any]
+	InterfaceIpConfigurations         plugin.TValue[[]any]
 	IpConfigurations                  plugin.TValue[[]any]
 }
 
@@ -57778,6 +57786,22 @@ func (c *mqlAzureSubscriptionNetworkServiceSubnet) GetIpAllocations() *plugin.TV
 		}
 
 		return c.ipAllocations()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSubnet) GetInterfaceIpConfigurations() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InterfaceIpConfigurations, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.subnet", c.__id, "interfaceIpConfigurations")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.interfaceIpConfigurations()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -4629,6 +4629,7 @@ azure.subscription.networkService.subnet.delegation.serviceName 13.12.2
 azure.subscription.networkService.subnet.delegations 13.12.2
 azure.subscription.networkService.subnet.etag 9.0.8
 azure.subscription.networkService.subnet.id 9.0.8
+azure.subscription.networkService.subnet.interfaceIpConfigurations 13.36.1
 azure.subscription.networkService.subnet.ipAllocations 13.25.1
 azure.subscription.networkService.subnet.ipConfigurations 9.0.10
 azure.subscription.networkService.subnet.name 9.0.8

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -5022,6 +5022,11 @@ func azureSubnetToMql(runtime *plugin.Runtime, subnet network.Subnet) (*mqlAzure
 			}
 		}
 		mqlSubnet.cacheIPAllocationIDs = azureNetworkSubResourceIDs(subnet.Properties.IPAllocations)
+		for _, ipConfig := range subnet.Properties.IPConfigurations {
+			if ipConfig != nil && ipConfig.ID != nil {
+				mqlSubnet.cacheIPConfigurationIDs = append(mqlSubnet.cacheIPConfigurationIDs, *ipConfig.ID)
+			}
+		}
 	}
 	return mqlSubnet, nil
 }
@@ -5031,6 +5036,85 @@ type mqlAzureSubscriptionNetworkServiceSubnetInternal struct {
 	cacheRouteTableID           string
 	cachePrivateEndpointIDs     []string
 	cacheIPAllocationIDs        []string
+	cacheIPConfigurationIDs     []string
+}
+
+// subnetIPConfigIDSet lowercases a subnet's ipConfigurations ids so they can be
+// matched against the same ids as the owning resource reports them.
+//
+// ARM upper-cases these inside the subnet --
+// .../networkInterfaces/MY-NIC/ipConfigurations/INTERNAL -- while the interface
+// itself reports the identical id in the casing it was created with, so a direct
+// comparison finds nothing. ARM resource ids are case-insensitive, so folding both
+// sides is the correct comparison rather than a workaround.
+func subnetIPConfigIDSet(ids []string) map[string]struct{} {
+	if len(ids) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id = strings.ToLower(strings.TrimSpace(id)); id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	return set
+}
+
+// interfaceIpConfigurations resolves the network interface IP configurations that
+// hold an address from this subnet.
+//
+// A subnet's properties.ipConfigurations is where ARM reports them, and in
+// practice it is almost entirely interface configurations: virtual machine
+// interfaces, private endpoint interfaces, load balancer backend members. Nothing
+// exposed them, because the only accessor over that list matched virtual network
+// gateway configurations, which exist on a gateway subnet and nowhere else.
+//
+// Resolved by walking the interface list rather than fetching per id: there is no
+// API for an IP configuration on its own, and the interfaces are fetched once for
+// the whole scan.
+func (a *mqlAzureSubscriptionNetworkServiceSubnet) interfaceIpConfigurations() ([]any, error) {
+	wanted := subnetIPConfigIDSet(a.cacheIPConfigurationIDs)
+	res := []any{}
+	if len(wanted) == 0 {
+		return res, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	svc, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService", map[string]*llx.RawData{
+		"subscriptionId": llx.StringData(conn.SubId()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	interfaces := svc.(*mqlAzureSubscriptionNetworkService).GetInterfaces()
+	if interfaces.Error != nil {
+		return nil, interfaces.Error
+	}
+
+	for _, iface := range interfaces.Data {
+		mqlIface, ok := iface.(*mqlAzureSubscriptionNetworkServiceInterface)
+		if !ok {
+			continue
+		}
+		ipConfigs := mqlIface.GetIpConfigs()
+		if ipConfigs.Error != nil {
+			// One unreadable interface should not hide every address in the
+			// subnet; the rest are still reported.
+			log.Warn().Err(ipConfigs.Error).Str("interface", mqlIface.Id.Data).
+				Msg("could not read ip configurations while resolving a subnet's")
+			continue
+		}
+		for _, ipConfig := range ipConfigs.Data {
+			mqlIPConfig, ok := ipConfig.(*mqlAzureSubscriptionNetworkServiceInterfaceIpConfiguration)
+			if !ok {
+				continue
+			}
+			if _, ok := wanted[strings.ToLower(mqlIPConfig.Id.Data)]; ok {
+				res = append(res, mqlIPConfig)
+			}
+		}
+	}
+	return res, nil
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceSubnet) privateEndpoints() ([]any, error) {

--- a/providers/azure/resources/network_subnet_ipconfig_test.go
+++ b/providers/azure/resources/network_subnet_ipconfig_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ARM reports a subnet's ipConfigurations ids upper-cased, while the owning
+// interface reports the identical id in the casing it was created with. Matching
+// them directly finds nothing, which is why a subnet whose addresses are all held
+// by network interfaces reported none of them.
+//
+// These are the exact shapes observed live: the subnet's copy is upper-cased
+// through the resource group and interface name, the interface's copy is not.
+const (
+	subnetCopyOfIPConfigID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SECURITY-TEAM-RESOURCES/" +
+		"providers/Microsoft.Network/networkInterfaces/SECURITY-TEAM-NIC-1/ipConfigurations/INTERNAL"
+	interfaceCopyOfIPConfigID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Security-Team-resources/" +
+		"providers/Microsoft.Network/networkInterfaces/Security-Team-nic-1/ipConfigurations/internal"
+)
+
+func TestSubnetIPConfigIDSetFoldsCase(t *testing.T) {
+	set := subnetIPConfigIDSet([]string{subnetCopyOfIPConfigID})
+	require.Len(t, set, 1)
+
+	// The property the accessor relies on: the interface's own casing matches.
+	_, ok := set[strings.ToLower(interfaceCopyOfIPConfigID)]
+	assert.True(t, ok, "the same id in either casing must match")
+
+	// And the pre-fix comparison does not, which is the bug.
+	assert.NotEqual(t, subnetCopyOfIPConfigID, interfaceCopyOfIPConfigID,
+		"a direct string comparison is what failed")
+}
+
+func TestSubnetIPConfigIDSet(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ids  []string
+		want int
+	}{
+		{name: "several ids", ids: []string{"/a/IPCONFIGURATIONS/one", "/b/ipConfigurations/two"}, want: 2},
+		{
+			// Two casings of one id are one id: ARM resource ids are
+			// case-insensitive, so folding must also deduplicate.
+			name: "the same id twice in different casing",
+			ids:  []string{subnetCopyOfIPConfigID, interfaceCopyOfIPConfigID},
+			want: 1,
+		},
+		{name: "blank entries are dropped", ids: []string{"", "   ", "/a/ipConfigurations/one"}, want: 1},
+		{name: "surrounding whitespace is trimmed", ids: []string{"  /a/ipConfigurations/one  "}, want: 1},
+		{name: "nothing at all", ids: nil, want: 0},
+		{name: "only blanks", ids: []string{"", " "}, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Len(t, subnetIPConfigIDSet(tc.ids), tc.want)
+		})
+	}
+}
+
+func TestSubnetIPConfigIDSetLookupIsLowerCased(t *testing.T) {
+	set := subnetIPConfigIDSet([]string{"/a/ipConfigurations/MixedCase"})
+	for _, probe := range []string{
+		"/a/ipconfigurations/mixedcase",
+		strings.ToLower("/A/IPCONFIGURATIONS/MIXEDCASE"),
+	} {
+		_, ok := set[probe]
+		assert.True(t, ok, "lookup with %q must hit", probe)
+	}
+
+	// A caller who forgets to fold its own side gets no match, so the accessor
+	// has to lower-case what it probes with -- pinned so that stays true.
+	_, ok := set["/a/ipConfigurations/MixedCase"]
+	assert.False(t, ok, "the set holds folded keys only")
+}
+
+// A subnet with no ipConfigurations must report an empty list rather than null:
+// a gateway subnet, or one nothing has an address in yet, is a normal state and a
+// query should be able to assert on its length.
+func TestSubnetWithNoIPConfigurationsReportsEmpty(t *testing.T) {
+	subnet := &mqlAzureSubscriptionNetworkServiceSubnet{MqlRuntime: cacheIDTestRuntime()}
+	got, err := subnet.interfaceIpConfigurations()
+	require.NoError(t, err)
+	assert.NotNil(t, got, "empty, not null")
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
`subnet.ipConfigurations` returned **zero on every subnet that had addresses in it**.

## What ARM actually reports

A subnet's `properties.ipConfigurations` is where ARM lists what occupies its address space, and in practice that is almost entirely **network interface** configurations. Live, on three different subnets:

```
$ az network vnet subnet list … --query "[].ipConfigurations[].id"
/subscriptions/…/providers/Microsoft.Network/networkInterfaces/SECURITY-TEAM-NIC-1/ipConfigurations/INTERNAL
/subscriptions/…/providers/Microsoft.Network/networkInterfaces/…-PRIVATEENDPOINT….NIC…/ipConfigurations/PRIVATEENDPOINTIPCONFIG…
```

Virtual machine interfaces, private endpoint interfaces, load balancer backend members. **Nothing exposed them.**

## Why the existing field is not the fix

`ipConfigurations()` is typed `[]azure.subscription.networkService.virtualNetworkGateway.ipConfig` and matches only gateway configurations — which exist on a gateway subnet and nowhere else. It is not *wrong*, and its type is shipped, so it cannot start returning interface configurations. But its doc read *"List of IP configurations for the subnet"*, so a subnet reporting none looked like an empty subnet rather than one whose addresses the schema could not reach.

Measured on one subscription: **5 of 7 subnets hold interface configurations, and every one reported zero.**

## The fix

`interfaceIpConfigurations()`, typed as `azure.subscription.networkService.interface.ipConfiguration` — which already carries `subnet()`, `publicIpAddress()`, and `applicationSecurityGroups()`. The schema had that edge only in the child→parent direction; this adds the direction that answers *what is reachable in this subnet*.

`ipConfigurations` keeps its behaviour and gets a doc that says what it returns.

### Two implementation notes

**Resolved through the interface list, not per id.** There is no API for an IP configuration on its own, and the interfaces are fetched once for the whole scan, so this adds no API calls beyond the ones a subnet query already makes. One unreadable interface is logged and skipped rather than hiding every other address in the subnet.

**The matching folds case on both sides.** ARM upper-cases these ids *inside the subnet* while the owning interface reports them in the casing they were created with:

```
subnet's copy:    …/resourceGroups/SECURITY-TEAM-RESOURCES/…/networkInterfaces/SECURITY-TEAM-NIC-1/ipConfigurations/INTERNAL
interface's copy: …/resourceGroups/Security-Team-resources/…/networkInterfaces/Security-Team-nic-1/ipConfigurations/internal
```

A direct comparison finds nothing. ARM resource ids are case-insensitive, so folding is the correct comparison rather than a workaround — and folding must also deduplicate, which the tests pin.

## Verification

Live. Three subnets holding 2, 1, and 1 interface configurations report exactly those with their private addresses — matching `az` — while `ipConfigurations` stays 0 because none is a gateway subnet:

```
subnets: [
  0: { name: "…-subnet-storage1Endpoint",  ipConfigurations.length: 0
       interfaceIpConfigurations: [ { privateIpAddress: "10.0.1.5", name: "privateEndpointIpConfig.…" }
                                    { privateIpAddress: "10.0.1.4", name: "privateEndpointIpConfig.…" } ] }
  1: { name: "…-subnet-storage3Endpoint",  ipConfigurations.length: 0
       interfaceIpConfigurations: [ { privateIpAddress: "10.0.1.4", name: "privateEndpointIpConfig.…" } ] }
]
```

## Tests

`network_subnet_ipconfig_test.go` uses the **exact casings observed live** as fixtures:

- `TestSubnetIPConfigIDSetFoldsCase` — the two real ids match after folding, and asserts the direct string comparison does **not**, which is the bug.
- `TestSubnetIPConfigIDSet` — several ids, the same id twice in different casing collapsing to one, blanks dropped, whitespace trimmed, nil.
- `TestSubnetIPConfigIDSetLookupIsLowerCased` — the set holds folded keys only, pinning that the accessor must fold what it probes with.
- `TestSubnetWithNoIPConfigurationsReportsEmpty` — a gateway subnet, or one nothing has an address in yet, reports empty rather than null so a query can assert on length.

`.lr.versions` entry at `13.36.1`. `go test ./...` is green across the provider.
