### PR TITLE
🐛 azure: count public load balancer reachability in a VM's exposure verdict

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -3780,11 +3780,27 @@ private azure.subscription.networkService.securityrule @defaults("id name") {
 private azure.subscription.networkService.exposure {
   // Whether the resource is reachable from the public internet
   //
-  // True when the resource has a public IP AND the effective NSG chain admits
-  // inbound traffic from any source. False when either signal is absent.
+  // True when internet traffic can arrive at the resource AND the effective NSG
+  // chain admits inbound traffic from any source. Traffic can arrive either
+  // because the resource holds a public IP itself, or because a public load
+  // balancer forwards to it, so this is hasPublicIp or behindPublicLoadBalancer
+  // combined with securityGroupAllowsIngress. Check securityGroupsEvaluated
+  // before trusting a false.
   internetReachable bool
   // Whether the resource has at least one public IP address assigned
+  //
+  // A public IP on the resource's own network interfaces. False on a resource
+  // reached only through a load balancer, which is the common topology.
   hasPublicIp bool
+  // Whether a public load balancer forwards internet traffic to the resource
+  //
+  // True when a load balancer with a public frontend IP has a rule bound to that
+  // frontend, pointing at a backend the resource's network interface is a member
+  // of. Both load balancing rules and inbound NAT rules count, and a NAT rule
+  // bound straight to one IP configuration counts as well. This is the way
+  // Azure's reference architectures expose a virtual machine, with the public IP
+  // on the load balancer and only a private address on the machine.
+  behindPublicLoadBalancer bool
   // Whether the effective NSG chain (NIC and subnet NSGs, resolved by priority) admits inbound traffic from any internet source
   //
   // A resource whose network interfaces have no NSG attached at all admits

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -6387,6 +6387,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.exposure.hasPublicIp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetHasPublicIp()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.networkService.exposure.behindPublicLoadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetBehindPublicLoadBalancer()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.networkService.exposure.securityGroupAllowsIngress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceExposure).GetSecurityGroupAllowsIngress()).ToDataRes(types.Bool)
 	},
@@ -26293,6 +26296,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.exposure.hasPublicIp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceExposure).HasPublicIp, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.exposure.behindPublicLoadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceExposure).BehindPublicLoadBalancer, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.exposure.securityGroupAllowsIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -60422,6 +60429,7 @@ type mqlAzureSubscriptionNetworkServiceExposure struct {
 	// optional: if you define mqlAzureSubscriptionNetworkServiceExposureInternal it will be used here
 	InternetReachable          plugin.TValue[bool]
 	HasPublicIp                plugin.TValue[bool]
+	BehindPublicLoadBalancer   plugin.TValue[bool]
 	SecurityGroupAllowsIngress plugin.TValue[bool]
 	SecurityGroupsEvaluated    plugin.TValue[bool]
 	OpenIngressRules           plugin.TValue[[]any]
@@ -60465,6 +60473,10 @@ func (c *mqlAzureSubscriptionNetworkServiceExposure) GetInternetReachable() *plu
 
 func (c *mqlAzureSubscriptionNetworkServiceExposure) GetHasPublicIp() *plugin.TValue[bool] {
 	return &c.HasPublicIp
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceExposure) GetBehindPublicLoadBalancer() *plugin.TValue[bool] {
+	return &c.BehindPublicLoadBalancer
 }
 
 func (c *mqlAzureSubscriptionNetworkServiceExposure) GetSecurityGroupAllowsIngress() *plugin.TValue[bool] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3915,6 +3915,7 @@ azure.subscription.networkService.ddosProtectionPlan.type 13.3.3
 azure.subscription.networkService.ddosProtectionPlan.virtualNetworks 13.3.3
 azure.subscription.networkService.ddosProtectionPlans 13.3.3
 azure.subscription.networkService.exposure 13.20.1
+azure.subscription.networkService.exposure.behindPublicLoadBalancer 13.36.1
 azure.subscription.networkService.exposure.hasPublicIp 13.20.1
 azure.subscription.networkService.exposure.internetReachable 13.20.1
 azure.subscription.networkService.exposure.openIngressRules 13.20.1

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -563,12 +563,26 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 		}
 	}
 
-	internetReachable := hasPublicIp && securityGroupAllowsIngress
+	// The other way in. Azure's own reference architectures put the public IP on a
+	// load balancer frontend and leave the machine's interface with a private
+	// address only, so reading public IPs off the interfaces alone reports the
+	// recommended topology as closed.
+	behindPublicLb, err := a.behindPublicLoadBalancer(nics.Data)
+	if err != nil {
+		// One unreadable listing must not turn into "closed". Drop the signal,
+		// mark the verdict provisional, and say why.
+		logLoadBalancerLookupFailure(a.Id.Data, err)
+		behindPublicLb = false
+		allEvaluated = false
+	}
+
+	internetReachable := (hasPublicIp || behindPublicLb) && securityGroupAllowsIngress
 
 	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceExposure, map[string]*llx.RawData{
 		"__id":                       llx.StringData("azure.subscription.computeService.vm/" + a.Id.Data + "/exposure"),
 		"internetReachable":          llx.BoolData(internetReachable),
 		"hasPublicIp":                llx.BoolData(hasPublicIp),
+		"behindPublicLoadBalancer":   llx.BoolData(behindPublicLb),
 		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),
 		"securityGroupsEvaluated":    llx.BoolData(allEvaluated),
 		"openIngressRules":           llx.ArrayData(openRules, types.Dict),

--- a/providers/azure/resources/azure_exposure_loadbalancer.go
+++ b/providers/azure/resources/azure_exposure_loadbalancer.go
@@ -1,0 +1,226 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// lowerSet folds a list of ARM resource ids for comparison. ARM resource ids are
+// case-insensitive, and which casing a caller sees depends on which API returned
+// the id, so every id comparison here goes through this.
+func lowerSet(ids []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id = strings.ToLower(strings.TrimSpace(id)); id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	return set
+}
+
+// subResourceID reads the id off an ARM sub-resource reference, or "" when either
+// the reference or the id is absent.
+func subResourceID(ref *network.SubResource) string {
+	if ref == nil || ref.ID == nil {
+		return ""
+	}
+	return *ref.ID
+}
+
+// publicFrontendIDs returns the load balancer's frontend configurations that have
+// a public IP address, folded for comparison.
+//
+// A frontend with a private IP is an internal load balancer's, and traffic
+// arriving through it is not from the internet.
+func publicFrontendIDs(props *network.LoadBalancerPropertiesFormat) map[string]struct{} {
+	if props == nil {
+		return nil
+	}
+	var ids []string
+	for _, frontend := range props.FrontendIPConfigurations {
+		if frontend == nil || frontend.ID == nil || frontend.Properties == nil {
+			continue
+		}
+		if frontend.Properties.PublicIPAddress != nil {
+			ids = append(ids, *frontend.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return lowerSet(ids)
+}
+
+// internetForwardedIPConfigIDs returns the interface IP configurations this load
+// balancer forwards internet traffic to, folded for comparison.
+//
+// Three things all have to hold, and each is checked rather than assumed:
+// a frontend with a public IP, a rule bound to that frontend, and a backend the
+// rule points at that the IP configuration is a member of. A public frontend with
+// no rule forwards nothing; a rule on a private frontend forwards traffic that did
+// not come from the internet.
+//
+// Inbound NAT rules are read two ways because ARM supports both: a rule bound to
+// one IP configuration directly, and a rule bound to a backend pool.
+func internetForwardedIPConfigIDs(props *network.LoadBalancerPropertiesFormat) map[string]struct{} {
+	publicFrontends := publicFrontendIDs(props)
+	if len(publicFrontends) == 0 {
+		return nil
+	}
+
+	isPublicFrontend := func(ref *network.SubResource) bool {
+		id := strings.ToLower(subResourceID(ref))
+		if id == "" {
+			return false
+		}
+		_, ok := publicFrontends[id]
+		return ok
+	}
+
+	forwarded := map[string]struct{}{}
+	pools := map[string]struct{}{}
+
+	for _, rule := range props.LoadBalancingRules {
+		if rule == nil || rule.Properties == nil || !isPublicFrontend(rule.Properties.FrontendIPConfiguration) {
+			continue
+		}
+		if id := strings.ToLower(subResourceID(rule.Properties.BackendAddressPool)); id != "" {
+			pools[id] = struct{}{}
+		}
+		for _, pool := range rule.Properties.BackendAddressPools {
+			if id := strings.ToLower(subResourceID(pool)); id != "" {
+				pools[id] = struct{}{}
+			}
+		}
+	}
+
+	for _, rule := range props.InboundNatRules {
+		if rule == nil || rule.Properties == nil || !isPublicFrontend(rule.Properties.FrontendIPConfiguration) {
+			continue
+		}
+		if id := strings.ToLower(subResourceID(rule.Properties.BackendAddressPool)); id != "" {
+			pools[id] = struct{}{}
+		}
+		// A NAT rule can name one IP configuration instead of a pool, which is
+		// how a single-VM RDP or SSH forward is written.
+		if cfg := rule.Properties.BackendIPConfiguration; cfg != nil && cfg.ID != nil {
+			if id := strings.ToLower(*cfg.ID); id != "" {
+				forwarded[id] = struct{}{}
+			}
+		}
+	}
+
+	for _, pool := range props.BackendAddressPools {
+		if pool == nil || pool.ID == nil || pool.Properties == nil {
+			continue
+		}
+		if _, ok := pools[strings.ToLower(*pool.ID)]; !ok {
+			continue
+		}
+		for _, cfg := range pool.Properties.BackendIPConfigurations {
+			if cfg == nil || cfg.ID == nil {
+				continue
+			}
+			if id := strings.ToLower(*cfg.ID); id != "" {
+				forwarded[id] = struct{}{}
+			}
+		}
+	}
+
+	if len(forwarded) == 0 {
+		return nil
+	}
+	return forwarded
+}
+
+// anyIPConfigForwarded reports whether any of the given interface IP
+// configurations is one a public frontend of any of these load balancers forwards
+// to.
+func anyIPConfigForwarded(loadBalancerProps []*network.LoadBalancerPropertiesFormat, ipConfigIDs []string) bool {
+	wanted := lowerSet(ipConfigIDs)
+	if len(wanted) == 0 {
+		return false
+	}
+	for _, props := range loadBalancerProps {
+		for id := range internetForwardedIPConfigIDs(props) {
+			if _, ok := wanted[id]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// vmNicIPConfigIDs collects the ids of the IP configurations on a VM's network
+// interfaces, read from the raw configurations already cached on each interface.
+func vmNicIPConfigIDs(nics []any) []string {
+	var ids []string
+	for _, n := range nics {
+		nic, ok := n.(*mqlAzureSubscriptionNetworkServiceInterface)
+		if !ok {
+			continue
+		}
+		for _, ipConfig := range nic.cacheIPConfigurations {
+			if ipConfig != nil && ipConfig.ID != nil {
+				ids = append(ids, *ipConfig.ID)
+			}
+		}
+	}
+	return ids
+}
+
+// behindPublicLoadBalancer reports whether a public load balancer forwards
+// internet traffic to any of these network interfaces.
+//
+// This is the other way a virtual machine is reachable from the internet, and the
+// one Azure's own reference architectures use: the public IP sits on the load
+// balancer's frontend and the machine's interface holds only a private address, so
+// reading public IPs off the interfaces alone reports a reachable machine as
+// closed.
+//
+// The load balancers are read through the network service resource, so the listing
+// is fetched once for the whole scan rather than once per machine.
+func (a *mqlAzureSubscriptionComputeServiceVm) behindPublicLoadBalancer(nics []any) (bool, error) {
+	ipConfigIDs := vmNicIPConfigIDs(nics)
+	if len(ipConfigIDs) == 0 {
+		return false, nil
+	}
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return false, err
+	}
+	svc, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkService, map[string]*llx.RawData{
+		"subscriptionId": llx.StringData(resourceID.SubscriptionID),
+	})
+	if err != nil {
+		return false, err
+	}
+	loadBalancers := svc.(*mqlAzureSubscriptionNetworkService).GetLoadBalancers()
+	if loadBalancers.Error != nil {
+		return false, loadBalancers.Error
+	}
+
+	props := make([]*network.LoadBalancerPropertiesFormat, 0, len(loadBalancers.Data))
+	for _, lb := range loadBalancers.Data {
+		mqlLB, ok := lb.(*mqlAzureSubscriptionNetworkServiceLoadBalancer)
+		if !ok {
+			continue
+		}
+		props = append(props, mqlLB.cacheProperties)
+	}
+	return anyIPConfigForwarded(props, ipConfigIDs), nil
+}
+
+// logLoadBalancerLookupFailure records why the load balancer signal is missing.
+// The verdict stays provisional rather than claiming the machine is closed.
+func logLoadBalancerLookupFailure(vmID string, err error) {
+	log.Warn().Err(err).Str("vm", vmID).
+		Msg("could not read load balancers while evaluating exposure")
+}

--- a/providers/azure/resources/azure_exposure_loadbalancer_test.go
+++ b/providers/azure/resources/azure_exposure_loadbalancer_test.go
@@ -1,0 +1,235 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	network "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	lbID              = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/lb"
+	publicFrontendID  = lbID + "/frontendIPConfigurations/public"
+	privateFrontendID = lbID + "/frontendIPConfigurations/internal"
+	backendPool       = lbID + "/backendAddressPools/pool"
+	otherPool         = lbID + "/backendAddressPools/other"
+	vmIPConfig        = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/vm-nic/ipConfigurations/internal"
+	otherIPConfg      = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/other-nic/ipConfigurations/internal"
+)
+
+func sub(id string) *network.SubResource { return &network.SubResource{ID: &id} }
+
+func frontend(id string, public bool) *network.FrontendIPConfiguration {
+	props := &network.FrontendIPConfigurationPropertiesFormat{}
+	if public {
+		props.PublicIPAddress = &network.PublicIPAddress{ID: strPtr("/…/publicIPAddresses/pip")}
+	} else {
+		props.PrivateIPAddress = strPtr("10.0.0.9")
+	}
+	return &network.FrontendIPConfiguration{ID: &id, Properties: props}
+}
+
+func pool(id string, memberIPConfigIDs ...string) *network.BackendAddressPool {
+	members := make([]*network.InterfaceIPConfiguration, 0, len(memberIPConfigIDs))
+	for _, member := range memberIPConfigIDs {
+		members = append(members, &network.InterfaceIPConfiguration{ID: strPtr(member)})
+	}
+	return &network.BackendAddressPool{
+		ID:         &id,
+		Properties: &network.BackendAddressPoolPropertiesFormat{BackendIPConfigurations: members},
+	}
+}
+
+func lbRule(frontendID, poolID string) *network.LoadBalancingRule {
+	return &network.LoadBalancingRule{
+		Properties: &network.LoadBalancingRulePropertiesFormat{
+			FrontendIPConfiguration: sub(frontendID),
+			BackendAddressPool:      sub(poolID),
+		},
+	}
+}
+
+// The defect: exposure read public IPs off the machine's own network interfaces
+// only. Azure's reference architectures put the public IP on a load balancer
+// frontend and leave the interface with a private address, so the recommended
+// topology reported internetReachable false on a machine reachable from the
+// internet -- a verdict that fails open.
+func TestInternetForwardedIPConfigIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		props *network.LoadBalancerPropertiesFormat
+		want  []string
+	}{
+		{
+			name: "a public frontend, a rule, and a pool the machine is in",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
+				LoadBalancingRules:       []*network.LoadBalancingRule{lbRule(publicFrontendID, backendPool)},
+				BackendAddressPools:      []*network.BackendAddressPool{pool(backendPool, vmIPConfig, otherIPConfg)},
+			},
+			want: []string{vmIPConfig, otherIPConfg},
+		},
+		{
+			// An internal load balancer. Traffic through it did not come from the
+			// internet, so nothing it forwards to is exposed by it.
+			name: "an internal load balancer forwards nothing from the internet",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(privateFrontendID, false)},
+				LoadBalancingRules:       []*network.LoadBalancingRule{lbRule(privateFrontendID, backendPool)},
+				BackendAddressPools:      []*network.BackendAddressPool{pool(backendPool, vmIPConfig)},
+			},
+		},
+		{
+			// A public IP with nothing bound to it reaches nothing. This is why
+			// the rule is checked rather than assumed from the frontend.
+			name: "a public frontend with no rule",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
+				BackendAddressPools:      []*network.BackendAddressPool{pool(backendPool, vmIPConfig)},
+			},
+		},
+		{
+			// Both frontends exist, but the rule is on the private one.
+			name: "a rule on the private frontend of a mixed load balancer",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{
+					frontend(publicFrontendID, true), frontend(privateFrontendID, false),
+				},
+				LoadBalancingRules:  []*network.LoadBalancingRule{lbRule(privateFrontendID, backendPool)},
+				BackendAddressPools: []*network.BackendAddressPool{pool(backendPool, vmIPConfig)},
+			},
+		},
+		{
+			// Only the pool the public rule points at counts.
+			name: "another pool on the same load balancer is not forwarded",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
+				LoadBalancingRules:       []*network.LoadBalancingRule{lbRule(publicFrontendID, backendPool)},
+				BackendAddressPools: []*network.BackendAddressPool{
+					pool(backendPool, vmIPConfig), pool(otherPool, otherIPConfg),
+				},
+			},
+			want: []string{vmIPConfig},
+		},
+		{
+			// How a single-machine SSH or RDP forward is written: the NAT rule
+			// names the IP configuration directly, with no pool at all.
+			name: "an inbound NAT rule bound straight to one ip configuration",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
+				InboundNatRules: []*network.InboundNatRule{{
+					Properties: &network.InboundNatRulePropertiesFormat{
+						FrontendIPConfiguration: sub(publicFrontendID),
+						BackendIPConfiguration:  &network.InterfaceIPConfiguration{ID: strPtr(vmIPConfig)},
+					},
+				}},
+			},
+			want: []string{vmIPConfig},
+		},
+		{
+			name: "an inbound NAT rule bound to a pool",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
+				InboundNatRules: []*network.InboundNatRule{{
+					Properties: &network.InboundNatRulePropertiesFormat{
+						FrontendIPConfiguration: sub(publicFrontendID),
+						BackendAddressPool:      sub(backendPool),
+					},
+				}},
+				BackendAddressPools: []*network.BackendAddressPool{pool(backendPool, vmIPConfig)},
+			},
+			want: []string{vmIPConfig},
+		},
+		{
+			name: "a NAT rule on the private frontend",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(privateFrontendID, false)},
+				InboundNatRules: []*network.InboundNatRule{{
+					Properties: &network.InboundNatRulePropertiesFormat{
+						FrontendIPConfiguration: sub(privateFrontendID),
+						BackendIPConfiguration:  &network.InterfaceIPConfiguration{ID: strPtr(vmIPConfig)},
+					},
+				}},
+			},
+		},
+		{
+			// ARM resource ids are case-insensitive, and which casing a caller
+			// sees depends on which API returned the id.
+			name: "ids match across casings",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
+				LoadBalancingRules: []*network.LoadBalancingRule{
+					lbRule(strings.ToUpper(publicFrontendID), strings.ToUpper(backendPool)),
+				},
+				BackendAddressPools: []*network.BackendAddressPool{pool(backendPool, vmIPConfig)},
+			},
+			want: []string{vmIPConfig},
+		},
+		{name: "no properties at all", props: nil},
+		{name: "an empty load balancer", props: &network.LoadBalancerPropertiesFormat{}},
+		{
+			name: "nil elements everywhere",
+			props: &network.LoadBalancerPropertiesFormat{
+				FrontendIPConfigurations: []*network.FrontendIPConfiguration{nil, frontend(publicFrontendID, true)},
+				LoadBalancingRules:       []*network.LoadBalancingRule{nil, lbRule(publicFrontendID, backendPool)},
+				InboundNatRules:          []*network.InboundNatRule{nil},
+				BackendAddressPools:      []*network.BackendAddressPool{nil, pool(backendPool, vmIPConfig)},
+			},
+			want: []string{vmIPConfig},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got map[string]struct{}
+			require.NotPanics(t, func() { got = internetForwardedIPConfigIDs(tc.props) })
+			assert.Len(t, got, len(tc.want))
+			for _, want := range tc.want {
+				_, ok := got[strings.ToLower(want)]
+				assert.True(t, ok, "expected %q to be forwarded", want)
+			}
+		})
+	}
+}
+
+func TestAnyIPConfigForwarded(t *testing.T) {
+	exposed := &network.LoadBalancerPropertiesFormat{
+		FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
+		LoadBalancingRules:       []*network.LoadBalancingRule{lbRule(publicFrontendID, backendPool)},
+		BackendAddressPools:      []*network.BackendAddressPool{pool(backendPool, vmIPConfig)},
+	}
+	internal := &network.LoadBalancerPropertiesFormat{
+		FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(privateFrontendID, false)},
+		LoadBalancingRules:       []*network.LoadBalancingRule{lbRule(privateFrontendID, backendPool)},
+		BackendAddressPools:      []*network.BackendAddressPool{pool(backendPool, vmIPConfig)},
+	}
+
+	all := []*network.LoadBalancerPropertiesFormat{internal, exposed}
+	assert.True(t, anyIPConfigForwarded(all, []string{vmIPConfig}),
+		"one public load balancer among several is enough")
+	assert.False(t, anyIPConfigForwarded(all, []string{otherIPConfg}),
+		"a machine in no forwarded pool is not exposed by these")
+	assert.False(t, anyIPConfigForwarded([]*network.LoadBalancerPropertiesFormat{internal}, []string{vmIPConfig}))
+
+	assert.False(t, anyIPConfigForwarded(all, nil), "a machine with no ip configurations")
+	assert.False(t, anyIPConfigForwarded(nil, []string{vmIPConfig}), "no load balancers in the subscription")
+	assert.False(t, anyIPConfigForwarded([]*network.LoadBalancerPropertiesFormat{nil}, []string{vmIPConfig}))
+}
+
+func TestSubResourceID(t *testing.T) {
+	assert.Equal(t, "/an/id", subResourceID(sub("/an/id")))
+	assert.Equal(t, "", subResourceID(nil))
+	assert.Equal(t, "", subResourceID(&network.SubResource{}))
+}
+
+func TestLowerSet(t *testing.T) {
+	set := lowerSet([]string{"/A/B", "  /c/d  ", "", "   ", "/a/b"})
+	assert.Len(t, set, 2, "folded and deduplicated, blanks dropped")
+	_, ok := set["/a/b"]
+	assert.True(t, ok)
+	_, ok = set["/c/d"]
+	assert.True(t, ok)
+}

--- a/providers/azure/resources/azure_exposure_loadbalancer_test.go
+++ b/providers/azure/resources/azure_exposure_loadbalancer_test.go
@@ -19,7 +19,7 @@ const (
 	backendPool       = lbID + "/backendAddressPools/pool"
 	otherPool         = lbID + "/backendAddressPools/other"
 	vmIPConfig        = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/vm-nic/ipConfigurations/internal"
-	otherIPConfg      = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/other-nic/ipConfigurations/internal"
+	otherIPConfig     = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/other-nic/ipConfigurations/internal"
 )
 
 func sub(id string) *network.SubResource { return &network.SubResource{ID: &id} }
@@ -70,9 +70,9 @@ func TestInternetForwardedIPConfigIDs(t *testing.T) {
 			props: &network.LoadBalancerPropertiesFormat{
 				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
 				LoadBalancingRules:       []*network.LoadBalancingRule{lbRule(publicFrontendID, backendPool)},
-				BackendAddressPools:      []*network.BackendAddressPool{pool(backendPool, vmIPConfig, otherIPConfg)},
+				BackendAddressPools:      []*network.BackendAddressPool{pool(backendPool, vmIPConfig, otherIPConfig)},
 			},
-			want: []string{vmIPConfig, otherIPConfg},
+			want: []string{vmIPConfig, otherIPConfig},
 		},
 		{
 			// An internal load balancer. Traffic through it did not come from the
@@ -111,7 +111,7 @@ func TestInternetForwardedIPConfigIDs(t *testing.T) {
 				FrontendIPConfigurations: []*network.FrontendIPConfiguration{frontend(publicFrontendID, true)},
 				LoadBalancingRules:       []*network.LoadBalancingRule{lbRule(publicFrontendID, backendPool)},
 				BackendAddressPools: []*network.BackendAddressPool{
-					pool(backendPool, vmIPConfig), pool(otherPool, otherIPConfg),
+					pool(backendPool, vmIPConfig), pool(otherPool, otherIPConfig),
 				},
 			},
 			want: []string{vmIPConfig},
@@ -210,7 +210,7 @@ func TestAnyIPConfigForwarded(t *testing.T) {
 	all := []*network.LoadBalancerPropertiesFormat{internal, exposed}
 	assert.True(t, anyIPConfigForwarded(all, []string{vmIPConfig}),
 		"one public load balancer among several is enough")
-	assert.False(t, anyIPConfigForwarded(all, []string{otherIPConfg}),
+	assert.False(t, anyIPConfigForwarded(all, []string{otherIPConfig}),
 		"a machine in no forwarded pool is not exposed by these")
 	assert.False(t, anyIPConfigForwarded([]*network.LoadBalancerPropertiesFormat{internal}, []string{vmIPConfig}))
 


### PR DESCRIPTION
A VM reachable from the internet through a public load balancer reported `internetReachable: false`. The verdict **failed open**, which is the dangerous direction for this field.

## The defect

```go
internetReachable := hasPublicIp && securityGroupAllowsIngress
```

…where `hasPublicIp` comes from walking the VM's **own NIC ip-configs** for a `PublicIPAddress`. Azure's reference architectures put the public IP on a **load balancer frontend** and leave the machine's interface with a private address only — so the recommended topology was the one that read as closed.

## The fix

`behindPublicLoadBalancer` is the missing signal:

```go
internetReachable := (hasPublicIp || behindPublicLoadBalancer) && securityGroupAllowsIngress
```

Three things must hold for the load balancer signal, and **each is checked rather than assumed**:

1. a frontend with a **public** IP — a private frontend is an internal load balancer, and traffic through it did not come from the internet;
2. a **rule bound to that frontend** — a public IP with nothing bound to it forwards nothing;
3. a **backend the machine's IP configuration is a member of**.

Both load balancing rules and inbound NAT rules count, and a NAT rule bound straight to one IP configuration counts as well — that is how a single-machine SSH or RDP forward is written, with no pool at all.

`hasPublicIp` keeps its meaning (a public IP on the resource's own interfaces) and its doc now says so, including that it reads false on a resource reached only through a load balancer.

**Cost and failure handling.** The load balancers are read through the network service resource, so the listing is fetched once for the whole scan rather than once per machine. If it cannot be read, the signal is dropped **and** `securityGroupsEvaluated` goes false — so an unreadable listing makes the verdict provisional instead of quietly becoming "closed".

## Verification — live, end to end

Built the exact failing topology on a real VM: a public Standard load balancer with a load balancing rule on its public frontend, the VM's NIC ip-config in the backend pool, the VM's **own public IP detached**, and an NSG rule admitting the Internet.

```
$ az network lb address-pool show … --query "backendIPConfigurations[].id"
/subscriptions/…/networkInterfaces/…-nic-1/ipConfigurations/internal
```

**Before** (pre-fix provider, same infrastructure) — an internet-reachable VM reported closed:

```
exposure: { internetReachable: false,  hasPublicIp: false,  securityGroupAllowsIngress: true }
```

**After**:

```
exposure: { internetReachable: true,   hasPublicIp: false,  behindPublicLoadBalancer: true,
            securityGroupAllowsIngress: true,  securityGroupsEvaluated: true }
```

Only the provider differed between those two runs.

Everything provisioned for the test was removed — NSG rule deleted, public IP re-attached, NIC removed from the pool, load balancer and its public IP deleted — verified against the owning services (no tagged resources, no load balancers, the two original public IPs and the one original NSG rule intact), and the subscription's original verdict confirmed unchanged.

## Tests

`azure_exposure_loadbalancer_test.go` tables `internetForwardedIPConfigIDs` against the SDK types. The cases that matter are the ones that must **not** report exposure, since each guards one of the three conditions:

- an internal load balancer (private frontend);
- a public frontend with **no rule**;
- a rule on the private frontend of a **mixed** load balancer that also has a public one;
- another pool on the same load balancer that the public rule does not point at;
- a NAT rule on the private frontend.

And the ones that must: a public frontend + rule + pool; a NAT rule bound straight to one ip-config; a NAT rule bound to a pool; ids matching **across casings** (ARM ids are case-insensitive and the casing depends on which API returned them); and nil elements at every level, since a panic in an accessor kills the whole scan.

`TestAnyIPConfigForwarded` covers one public load balancer among several, a machine in no forwarded pool, no load balancers at all, and a machine with no ip-configs.

`.lr.versions` entry at `13.36.1`. `go test ./...` is green across the provider.
