### PR TITLE
🐛 aws: tell the two sides of a VPC peering connection apart

### DIFF
--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -819,39 +819,55 @@ func initAwsVpcPeeringConnection(runtime *plugin.Runtime, args map[string]*llx.R
 	return args, res, nil
 }
 
-func (a *mqlAwsVpcPeeringConnection) acceptorVpc() (*mqlAwsVpcPeeringConnectionPeeringVpc, error) {
-	acceptor := a.peeringConnectionCache.AccepterVpcInfo
-	if acceptor == nil {
-		a.AcceptorVpc.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
-	}
+// peeringVpcCacheKey names one side of one peering connection.
+//
+// Both sides have to appear in the key. Keying on the region and the VPC id
+// alone put the accepter and the requester of the same connection on one cache
+// entry, and a hub VPC peered several times on one entry per region.
+func peeringVpcCacheKey(peeringConnectionID, side string) string {
+	return "aws.vpc.peeringConnection.peeringVpc/" + peeringConnectionID + "/" + side
+}
+
+// peeringVpcSide builds the accepter or the requester side of this peering
+// connection from the DescribeVpcPeeringConnections result.
+func (a *mqlAwsVpcPeeringConnection) peeringVpcSide(side string, info *vpctypes.VpcPeeringConnectionVpcInfo) (*mqlAwsVpcPeeringConnectionPeeringVpc, error) {
 	ipv4 := []any{}
-	for i := range acceptor.CidrBlockSet {
-		ipv4 = append(ipv4, convert.ToValue(acceptor.CidrBlockSet[i].CidrBlock))
+	for i := range info.CidrBlockSet {
+		ipv4 = append(ipv4, convert.ToValue(info.CidrBlockSet[i].CidrBlock))
 	}
 	ipv6 := []any{}
-	for i := range acceptor.Ipv6CidrBlockSet {
-		ipv6 = append(ipv6, convert.ToValue(acceptor.Ipv6CidrBlockSet[i].Ipv6CidrBlock))
+	for i := range info.Ipv6CidrBlockSet {
+		ipv6 = append(ipv6, convert.ToValue(info.Ipv6CidrBlockSet[i].Ipv6CidrBlock))
 	}
 	var allowDns *bool
-	if acceptor.PeeringOptions != nil {
-		allowDns = acceptor.PeeringOptions.AllowDnsResolutionFromRemoteVpc
+	if info.PeeringOptions != nil {
+		allowDns = info.PeeringOptions.AllowDnsResolutionFromRemoteVpc
 	}
 	mql, err := CreateResource(a.MqlRuntime, ResourceAwsVpcPeeringConnectionPeeringVpc,
 		map[string]*llx.RawData{
+			"__id":                            llx.StringData(peeringVpcCacheKey(a.Id.Data, side)),
 			"allowDnsResolutionFromRemoteVpc": llx.BoolDataPtr(allowDns),
 			"ipv4CiderBlocks":                 llx.ArrayData(ipv4, types.String),
 			"ipv6CiderBlocks":                 llx.ArrayData(ipv6, types.String),
-			"ownerID":                         llx.StringDataPtr(acceptor.OwnerId),
+			"ownerID":                         llx.StringDataPtr(info.OwnerId),
 			"region":                          llx.StringData(a.region),
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
-	mql.(*mqlAwsVpcPeeringConnectionPeeringVpc).cacheVpcId = convert.ToValue(acceptor.VpcId)
+	res := mql.(*mqlAwsVpcPeeringConnectionPeeringVpc)
+	res.cacheVpcId = convert.ToValue(info.VpcId)
+	return res, nil
+}
 
-	return mql.(*mqlAwsVpcPeeringConnectionPeeringVpc), nil
+func (a *mqlAwsVpcPeeringConnection) acceptorVpc() (*mqlAwsVpcPeeringConnectionPeeringVpc, error) {
+	acceptor := a.peeringConnectionCache.AccepterVpcInfo
+	if acceptor == nil {
+		a.AcceptorVpc.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return a.peeringVpcSide("accepter", acceptor)
 }
 
 func (a *mqlAwsVpcPeeringConnectionPeeringVpc) vpc() (*mqlAwsVpc, error) {
@@ -869,33 +885,7 @@ func (a *mqlAwsVpcPeeringConnection) requestorVpc() (*mqlAwsVpcPeeringConnection
 		a.RequestorVpc.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	ipv4 := []any{}
-	for i := range requestor.CidrBlockSet {
-		ipv4 = append(ipv4, convert.ToValue(requestor.CidrBlockSet[i].CidrBlock))
-	}
-	ipv6 := []any{}
-	for i := range requestor.Ipv6CidrBlockSet {
-		ipv6 = append(ipv6, convert.ToValue(requestor.Ipv6CidrBlockSet[i].Ipv6CidrBlock))
-	}
-	var allowDns *bool
-	if requestor.PeeringOptions != nil {
-		allowDns = requestor.PeeringOptions.AllowDnsResolutionFromRemoteVpc
-	}
-	mql, err := CreateResource(a.MqlRuntime, ResourceAwsVpcPeeringConnectionPeeringVpc,
-		map[string]*llx.RawData{
-			"allowDnsResolutionFromRemoteVpc": llx.BoolDataPtr(allowDns),
-			"ipv4CiderBlocks":                 llx.ArrayData(ipv4, types.String),
-			"ipv6CiderBlocks":                 llx.ArrayData(ipv6, types.String),
-			"ownerID":                         llx.StringDataPtr(requestor.OwnerId),
-			"region":                          llx.StringData(a.region),
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-	mql.(*mqlAwsVpcPeeringConnectionPeeringVpc).cacheVpcId = convert.ToValue(requestor.VpcId)
-
-	return mql.(*mqlAwsVpcPeeringConnectionPeeringVpc), nil
+	return a.peeringVpcSide("requester", requestor)
 }
 
 func (a *mqlAwsVpc) flowLogs() ([]any, error) {

--- a/providers/aws/resources/aws_vpc_peering_test.go
+++ b/providers/aws/resources/aws_vpc_peering_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The accepter and the requester of one peering connection must not share a
+// cache key. They used to: the key was built from the region and the VPC id,
+// and the VPC id is empty while the generated constructor runs, so every side
+// of every connection in a region collapsed onto one entry and whichever side
+// was built second returned the first one's CIDRs.
+func TestPeeringVpcCacheKeySeparatesTheTwoSides(t *testing.T) {
+	accepter := peeringVpcCacheKey("pcx-06c03109ac23954e0", "accepter")
+	requester := peeringVpcCacheKey("pcx-06c03109ac23954e0", "requester")
+
+	require.NotEqual(t, accepter, requester,
+		"the two sides of one peering connection must have distinct cache keys")
+	assert.Equal(t, "aws.vpc.peeringConnection.peeringVpc/pcx-06c03109ac23954e0/accepter", accepter)
+	assert.Equal(t, "aws.vpc.peeringConnection.peeringVpc/pcx-06c03109ac23954e0/requester", requester)
+}
+
+// A hub VPC peered to several spokes appears once per connection. Keying on the
+// VPC id would have merged those too, so the same side of two connections has
+// to stay distinct.
+func TestPeeringVpcCacheKeySeparatesConnections(t *testing.T) {
+	first := peeringVpcCacheKey("pcx-1111111111111111a", "requester")
+	second := peeringVpcCacheKey("pcx-2222222222222222b", "requester")
+
+	assert.NotEqual(t, first, second,
+		"the same side of two peering connections must have distinct cache keys")
+}
+
+// The old key was region + VPC id, and the VPC id is "" at construction time.
+// Pin the shape that made every side collide so a regression cannot reintroduce
+// a key that ignores the connection id.
+func TestPeeringVpcCacheKeyDoesNotCollapseOnAnEmptyVpcId(t *testing.T) {
+	const region = "us-west-2"
+	oldKey := func(vpcID string) string {
+		return "aws.vpc.peeringConnection.peeringVpc/" + region + "/" + vpcID
+	}
+
+	// what the old key produced for both sides, since cacheVpcId was unset
+	assert.Equal(t, oldKey(""), oldKey(""),
+		"sanity: the old key was identical for both sides")
+
+	// the new key never depends on a value that is empty at construction
+	keys := map[string]bool{}
+	for _, side := range []string{"accepter", "requester"} {
+		for _, pcx := range []string{"pcx-aaa", "pcx-bbb"} {
+			k := peeringVpcCacheKey(pcx, side)
+			require.False(t, keys[k], "duplicate cache key %q", k)
+			keys[k] = true
+		}
+	}
+	assert.Len(t, keys, 4)
+}


### PR DESCRIPTION
`aws.vpc.peeringConnection.peeringVpc` computed its cache key from the region and
the VPC id, but the VPC id is assigned *after* `CreateResource` returns, so it is
empty while the generated constructor runs. Both sides of every peering
connection in a region therefore landed on the key
`aws.vpc.peeringConnection.peeringVpc/<region>/`.

`CreateResource` is first-wins on that key: it discards the object it just built
and returns the existing one. So the accepter and the requester of a connection
became the same object, and the post-`CreateResource` write to `cacheVpcId`
mutated that shared object — last writer wins.

Verified against a live peering connection between two VPCs:

| side | actual CIDR | reported before | reported after |
|---|---|---|---|
| requester | `10.99.0.0/16` | `10.98.0.0/16` | `10.99.0.0/16` |
| accepter | `10.98.0.0/16` | `10.98.0.0/16` | `10.98.0.0/16` |

Both sides reported the accepter's CIDR; the requester's did not appear anywhere
in the output. `requestorVpc.vpc` and `acceptorVpc.vpc` also resolved to the same
VPC. After the fix each side reports its own CIDR and its own VPC.

The key now names the connection and the side, so it cannot depend on a value
that is unset at construction time. A hub VPC peered to several spokes also gets
one entry per connection rather than one per region. The two near-identical
accessors are folded into a single `peeringVpcSide` helper.

Tests cover the pure-Go key builder: the two sides of one connection stay
distinct, the same side of two connections stays distinct, and the key never
depends on a value that is empty at construction.
