### PR TITLE
🐛 aws: give every instance block device its own cache key

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1349,6 +1349,8 @@ func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal 
 			}
 			mqlInstanceDevice, err := CreateResource(a.MqlRuntime, ResourceAwsEc2InstanceDevice,
 				map[string]*llx.RawData{
+					"__id": llx.StringData(instanceDeviceCacheKey(regionVal,
+						convert.ToValue(instance.InstanceId), convert.ToValue(device.DeviceName))),
 					"deleteOnTermination": llx.BoolData(convert.ToValue(device.Ebs.DeleteOnTermination)),
 					"status":              llx.StringData(string(device.Ebs.Status)),
 					"deviceName":          llx.StringData(convert.ToValue(device.DeviceName)),
@@ -2354,6 +2356,19 @@ type mqlAwsEc2InstanceDeviceInternal struct {
 	region        string
 }
 
+// instanceDeviceCacheKey identifies one block device mapping.
+//
+// A device is identified by the instance it is attached to and its name in that
+// instance. The volume id is not usable here: it lives on the Internal struct,
+// which is only populated after the generated constructor has already computed
+// the cache key from it.
+func instanceDeviceCacheKey(region, instanceID, deviceName string) string {
+	return region + "/" + instanceID + "/" + deviceName
+}
+
+// id is a fallback only. gatherInstanceInfo passes an explicit "__id", which
+// wins, because cacheVolumeId is still empty while the generated constructor
+// runs and every device would otherwise share one cache entry.
 func (a *mqlAwsEc2InstanceDevice) id() (string, error) {
 	return a.cacheVolumeId, nil
 }

--- a/providers/aws/resources/aws_ec2_instance_device_test.go
+++ b/providers/aws/resources/aws_ec2_instance_device_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every block device mapping used to share one cache key. id() returns
+// cacheVolumeId, which is assigned only after CreateResource has already
+// computed the key from it, so the key was "" for every device in the account.
+// CreateResource is first-wins, so the first device seen anywhere was returned
+// for every device everywhere.
+func TestInstanceDeviceCacheKeySeparatesDevicesOnOneInstance(t *testing.T) {
+	root := instanceDeviceCacheKey("us-east-1", "i-05ff4488b72b3a050", "/dev/xvda")
+	extra := instanceDeviceCacheKey("us-east-1", "i-05ff4488b72b3a050", "/dev/sdf")
+
+	require.NotEqual(t, root, extra,
+		"two devices on one instance must have distinct cache keys")
+	assert.Equal(t, "us-east-1/i-05ff4488b72b3a050//dev/xvda", root)
+}
+
+// Two instances that both have a /dev/xvda are the ordinary case, and they must
+// not collapse into one another.
+func TestInstanceDeviceCacheKeySeparatesInstances(t *testing.T) {
+	first := instanceDeviceCacheKey("us-east-1", "i-05ff4488b72b3a050", "/dev/xvda")
+	second := instanceDeviceCacheKey("us-east-1", "i-085611f4927f5091e", "/dev/xvda")
+
+	assert.NotEqual(t, first, second,
+		"the same device name on two instances must have distinct cache keys")
+}
+
+// The same instance id cannot appear in two regions, but the region is part of
+// the key so a device can never be resolved against the wrong regional client.
+func TestInstanceDeviceCacheKeyIncludesRegion(t *testing.T) {
+	east := instanceDeviceCacheKey("us-east-1", "i-abc", "/dev/xvda")
+	west := instanceDeviceCacheKey("us-west-2", "i-abc", "/dev/xvda")
+
+	assert.NotEqual(t, east, west)
+}
+
+// A whole fleet's worth of devices must produce a whole fleet's worth of keys.
+// Under the old scheme this set had exactly one member.
+func TestInstanceDeviceCacheKeysAreUniquePerDevice(t *testing.T) {
+	type dev struct{ region, instance, name string }
+	devices := []dev{
+		{"us-east-1", "i-05ff4488b72b3a050", "/dev/xvda"},
+		{"us-east-1", "i-05ff4488b72b3a050", "/dev/sdf"},
+		{"us-east-1", "i-085611f4927f5091e", "/dev/sda1"},
+		{"us-east-1", "i-085611f4927f5091e", "/dev/sdb"},
+		{"us-west-2", "i-0dd81acba6ed990d7", "/dev/xvda"},
+	}
+
+	keys := map[string]bool{}
+	for _, d := range devices {
+		k := instanceDeviceCacheKey(d.region, d.instance, d.name)
+		require.False(t, keys[k], "duplicate cache key %q for %+v", k, d)
+		keys[k] = true
+	}
+	assert.Len(t, keys, len(devices))
+}
+
+// An instance id or device name AWS did not return must not silently merge two
+// devices; the key still varies by whatever is known.
+func TestInstanceDeviceCacheKeyWithMissingParts(t *testing.T) {
+	assert.NotEqual(t,
+		instanceDeviceCacheKey("us-east-1", "", "/dev/xvda"),
+		instanceDeviceCacheKey("us-east-1", "", "/dev/sdf"))
+	assert.NotEqual(t,
+		instanceDeviceCacheKey("us-east-1", "i-abc", ""),
+		instanceDeviceCacheKey("us-east-1", "i-def", ""))
+}


### PR DESCRIPTION
`aws.ec2.instance.device` had no explicit `__id`, so the generated constructor
fell back to `id()`, which returns `cacheVolumeId` — a field assigned only *after*
`CreateResource` returns. Every block device mapping in the account was therefore
built with the cache key `aws.ec2.instance.device\x00`.

`CreateResource` is first-wins on that key, so the first device seen anywhere was
returned for every device everywhere, and the post-create writes to
`cacheVolumeId`/`region` mutated that one shared object. Because
`gatherInstanceInfo` runs per region concurrently, those writes also raced.

Verified against two live instances:

| instance | actual devices | reported before | reported after |
|---|---|---|---|
| A | `/dev/xvda`, `/dev/sdf` | `/dev/xvda`, `/dev/xvda` | `/dev/xvda`, `/dev/sdf` |
| B | `/dev/sda1`, `/dev/sdb` | `/dev/xvda`, `/dev/xvda` | `/dev/sda1`, `/dev/sdb` |

Instance B has no `/dev/xvda` at all — the device names it reported were
fabricated. Every one of the four `deviceMappings.volume` entries also resolved
to the same volume (the last one written to the shared object), which belongs to
only one of the two instances.

`deleteOnTermination` and `status` are read from the wrong device the same way,
so "every attached volume is deleted on termination" was being answered from one
arbitrary device in the account.

A device is identified by its instance and its name within that instance, so the
key is now `<region>/<instanceId>/<deviceName>`, passed explicitly. `id()` is
kept as a fallback with a comment recording why it cannot be relied on.

Tests cover the pure-Go key builder: two devices on one instance, the same device
name on two instances, the region component, a fleet-sized uniqueness sweep, and
the missing-component cases.
