### PR TITLE
🐛 aws: stop macieCoverage panicking on a bucket Macie does not track

### DIFF
--- a/providers/aws/resources/aws_macie.go
+++ b/providers/aws/resources/aws_macie.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -548,6 +550,17 @@ func (a *mqlAwsMacieClassificationJob) buckets() ([]any, error) {
 // aws.macie.bucket — DescribeBuckets coverage
 // ============================================================================
 
+// errMacieBucketNotCovered reports a bucket that Macie does not hold in its
+// inventory, either because Macie is not enabled in the region or because the
+// bucket is outside the monitored set. macieCoverage turns it into a null field,
+// which is what the schema promises; any other error is a real failure.
+//
+// The init has to answer with an error rather than no resource: returning
+// (args, nil, nil) makes the runtime build the resource from the partial args,
+// leaving every field unset rather than null, and every such husk shares one
+// cache key because its arn is never set.
+var errMacieBucketNotCovered = errors.New("bucket is not in Macie's inventory")
+
 func initAwsMacieBucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if args["name"] == nil && args["arn"] == nil {
 		return args, nil, nil
@@ -561,7 +574,7 @@ func initAwsMacieBucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		arnVal := args["arn"].Value.(string)
 		parts := strings.SplitN(arnVal, ":::", 2)
 		if len(parts) != 2 {
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("%q is not an s3 bucket arn", arnVal)
 		}
 		bucketName = parts[1]
 	}
@@ -588,12 +601,15 @@ func initAwsMacieBucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 				return args, res, nil
 			}
 		}
-		return args, nil, nil
+		return args, nil, errMacieBucketNotCovered
 	}
 
 	res, err := describeMacieBucket(runtime, conn, region, bucketName)
 	if err != nil {
 		return args, nil, err
+	}
+	if res == nil {
+		return args, nil, errMacieBucketNotCovered
 	}
 	return args, res, nil
 }
@@ -787,6 +803,10 @@ func (a *mqlAwsS3Bucket) macieCoverage() (*mqlAwsMacieBucket, error) {
 		"region": llx.StringData(region),
 	})
 	if err != nil {
+		if errors.Is(err, errMacieBucketNotCovered) {
+			a.MacieCoverage.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return mqlBucket.(*mqlAwsMacieBucket), nil

--- a/providers/aws/resources/aws_macie_bucket_init_test.go
+++ b/providers/aws/resources/aws_macie_bucket_init_test.go
@@ -1,0 +1,68 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// A nil *mqlAwsMacieBucket assigned to a plugin.Resource interface is NOT nil.
+// That is the whole bug: describeMacieBucket returns a typed nil for a bucket
+// outside Macie's inventory, initAwsMacieBucket used to hand it straight back,
+// and NewResource's `if res != nil` guard then called MqlID() on a nil receiver.
+//
+// This test documents the Go semantics the fix depends on, so a future refactor
+// that reintroduces `return args, res, nil` fails here first.
+func TestTypedNilResourceIsNotNilAsAnInterface(t *testing.T) {
+	var concrete *mqlAwsMacieBucket // nil pointer
+
+	var iface plugin.Resource = concrete
+
+	require.Nil(t, concrete, "the concrete pointer is nil")
+
+	// Compare with Go's own operator, which is what NewResource does. Note that
+	// testify's assert.NotNil uses reflection and would report this as nil,
+	// disagreeing with the language - which is exactly how the bug hid.
+	assert.True(t, iface != nil,
+		"an interface holding a nil *mqlAwsMacieBucket is not nil - this is why "+
+			"NewResource's `if res != nil` guard passed and MqlID() panicked")
+
+	// Prove the deref actually panics, so the guard is load-bearing rather than
+	// defensive.
+	assert.Panics(t, func() { _ = iface.MqlID() },
+		"calling MqlID() on the typed nil must panic")
+}
+
+// Guarding on the concrete pointer before widening to the interface is what
+// makes the difference. This is the shape the fix uses.
+func TestGuardingTheConcretePointerYieldsATrueNilInterface(t *testing.T) {
+	var concrete *mqlAwsMacieBucket
+
+	var iface plugin.Resource
+	if concrete != nil {
+		iface = concrete
+	}
+
+	assert.True(t, iface == nil, "guarding on the concrete pointer keeps the interface nil")
+}
+
+// The not-covered case has to be distinguishable from a real failure, because
+// macieCoverage turns one into a null field and must propagate the other.
+func TestMacieBucketNotCoveredIsDistinguishable(t *testing.T) {
+	assert.True(t, errors.Is(errMacieBucketNotCovered, errMacieBucketNotCovered))
+
+	// survives wrapping, which is how it travels back through NewResource
+	wrapped := fmt.Errorf("aws.macie.bucket lookup: %w", errMacieBucketNotCovered)
+	assert.True(t, errors.Is(wrapped, errMacieBucketNotCovered))
+
+	// a genuine failure must not be mistaken for it
+	assert.False(t, errors.Is(errors.New("AccessDeniedException"), errMacieBucketNotCovered))
+	assert.False(t, errors.Is(fmt.Errorf("macie2 throttled"), errMacieBucketNotCovered))
+}


### PR DESCRIPTION
`aws.s3.buckets { macieCoverage }` panicked the provider on any account where a
bucket is not in Macie's inventory — which is every account that has not enabled
Macie, plus every bucket outside the monitored set in accounts that have.

`describeMacieBucket` returns `(*mqlAwsMacieBucket, error)` and answers a
not-covered bucket with `nil, nil`. That nil is a **typed** nil, and
`initAwsMacieBucket` returned it directly into the `plugin.Resource` interface.
An interface holding a nil pointer of a known type is not `== nil`, so
`NewResource`'s `if res != nil` guard passed and `res.MqlID()` dereferenced a nil
receiver:

```
(*mqlAwsMacieBucket).MqlID(...)        aws.lr.go:113179
NewResource(...)                       aws.lr.go:4924
(*mqlAwsS3Bucket).macieCoverage(...)   aws_macie.go:785
```

The recovered panic surfaced as an error for the whole `buckets` collection, so
selecting `macieCoverage` cost the entire S3 query. The sibling region-loop path
ten lines above already guarded on the concrete pointer, which is what makes this
a slip rather than a convention.

Returning no resource and no error would have traded the panic for a husk: the
runtime builds the resource from the partial args, leaving every field unset
rather than null, and since `arn` is never set every such husk shares one cache
key. The schema is explicit that null is the right answer here — *"Null when
Macie is not enabled in the bucket's region or the bucket is outside Macie's
monitored set"* — so the init now reports a sentinel error and `macieCoverage`
turns that one error into a null field while propagating everything else.

An unparsable bucket ARN now returns a not-found error too, instead of falling
through to the same husk.

Verified live: `aws.s3.buckets { name macieCoverage { name sensitivityScore } }`
errored with the panic before and reports `macieCoverage: null` for every bucket
after.

Tests pin the Go semantics the fix rests on — that a typed nil in an interface is
not nil, that `MqlID()` on it panics, that guarding the concrete pointer yields a
true nil interface — and that the sentinel survives wrapping without matching an
ordinary failure.
