### PR TITLE
🐛 aws: stop nesting an ARN inside a patch baseline ARN

### DIFF
--- a/providers/aws/resources/aws_ssm_documents.go
+++ b/providers/aws/resources/aws_ssm_documents.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -243,6 +244,22 @@ func (a *mqlAwsSsm) patchBaselines() ([]any, error) {
 
 const ssmPatchBaselineArnPattern = "arn:aws:ssm:%s:%s:patchbaseline/%s"
 
+// ssmPatchBaselineArn builds the ARN for a patch baseline.
+//
+// AWS-managed baselines - the ones every account has, and which an unfiltered
+// DescribePatchBaselines returns - report their BaselineId as a full ARN owned by
+// an AWS service account, not as a bare pb-* id. Wrapping that in the pattern
+// produced a doubled ARN that also claimed the caller's account owned an
+// AWS-owned baseline, and since id() returns Arn.Data it became the cache key
+// too. GetPatchBaseline documents the full ARN as the correct input for these,
+// so pass it through untouched.
+func ssmPatchBaselineArn(region, accountID, baselineID string) string {
+	if strings.HasPrefix(baselineID, "arn:") {
+		return baselineID
+	}
+	return fmt.Sprintf(ssmPatchBaselineArnPattern, region, accountID, baselineID)
+}
+
 func (a *mqlAwsSsm) getPatchBaselines(conn *connection.AwsConnection) []*jobpool.Job {
 	tasks := make([]*jobpool.Job, 0)
 	regions, err := conn.Regions()
@@ -267,7 +284,7 @@ func (a *mqlAwsSsm) getPatchBaselines(conn *connection.AwsConnection) []*jobpool
 				}
 
 				for _, pb := range resp.BaselineIdentities {
-					arn := fmt.Sprintf(ssmPatchBaselineArnPattern, region, conn.AccountId(), convert.ToValue(pb.BaselineId))
+					arn := ssmPatchBaselineArn(region, conn.AccountId(), convert.ToValue(pb.BaselineId))
 
 					mqlPB, err := CreateResource(a.MqlRuntime, "aws.ssm.patchBaseline",
 						map[string]*llx.RawData{

--- a/providers/aws/resources/aws_ssm_patchbaseline_test.go
+++ b/providers/aws/resources/aws_ssm_patchbaseline_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AWS-managed patch baselines report their BaselineId as a full ARN owned by an
+// AWS service account. Wrapping that in ssmPatchBaselineArnPattern produced a
+// doubled ARN, and because id() returns Arn.Data it became the cache key too.
+func TestSsmPatchBaselineArn(t *testing.T) {
+	const (
+		region  = "us-east-1"
+		account = "111122223333"
+	)
+
+	for _, tc := range []struct {
+		name       string
+		baselineID string
+		want       string
+	}{
+		{
+			name:       "customer baseline reports a bare id",
+			baselineID: "pb-0123456789abcdef0",
+			want:       "arn:aws:ssm:us-east-1:111122223333:patchbaseline/pb-0123456789abcdef0",
+		},
+		{
+			// The exact shape observed live: DescribePatchBaselines returns the
+			// full ARN, owned by AWS's baseline account, not the caller's.
+			name:       "AWS-managed baseline already reports an ARN",
+			baselineID: "arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0028ca011460d5eaf",
+			want:       "arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0028ca011460d5eaf",
+		},
+		{
+			name:       "a GovCloud ARN is passed through unchanged",
+			baselineID: "arn:aws-us-gov:ssm:us-gov-west-1:075727635805:patchbaseline/pb-abc",
+			want:       "arn:aws-us-gov:ssm:us-gov-west-1:075727635805:patchbaseline/pb-abc",
+		},
+		{
+			name:       "an empty id still yields the account's pattern",
+			baselineID: "",
+			want:       "arn:aws:ssm:us-east-1:111122223333:patchbaseline/",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ssmPatchBaselineArn(region, account, tc.baselineID))
+		})
+	}
+}
+
+// The doubled ARN is the specific shape to keep out. Pin it so a regression that
+// reintroduces the bare fmt.Sprintf fails here.
+func TestSsmPatchBaselineArnIsNeverDoubled(t *testing.T) {
+	awsManaged := "arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0028ca011460d5eaf"
+
+	got := ssmPatchBaselineArn("us-east-1", "111122223333", awsManaged)
+
+	assert.NotContains(t, got, "patchbaseline/arn:",
+		"an ARN must never be wrapped inside another ARN")
+	assert.Equal(t, 1, strings.Count(got, "arn:aws:ssm:"),
+		"the result must contain exactly one ARN")
+	assert.NotContains(t, got, "111122223333",
+		"an AWS-owned baseline must not be re-attributed to the caller's account")
+}

--- a/providers/aws/resources/aws_ssm_state.go
+++ b/providers/aws/resources/aws_ssm_state.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -112,7 +111,7 @@ func (a *mqlAwsSsmPatchGroup) baseline() (*mqlAwsSsmPatchBaseline, error) {
 		return nil, nil
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	arn := fmt.Sprintf(ssmPatchBaselineArnPattern, a.Region.Data, conn.AccountId(), a.BaselineId.Data)
+	arn := ssmPatchBaselineArn(a.Region.Data, conn.AccountId(), a.BaselineId.Data)
 	res, err := NewResource(a.MqlRuntime, "aws.ssm.patchBaseline",
 		map[string]*llx.RawData{"arn": llx.StringData(arn)})
 	if err != nil {


### PR DESCRIPTION
`aws.ssm.patchBaseline` wrapped every `BaselineId` in
`ssmPatchBaselineArnPattern`. AWS-managed baselines — the ones present in every
account, and which an unfiltered `DescribePatchBaselines` returns — report their
`BaselineId` as a **full ARN** owned by an AWS service account, so the result was
an ARN nested inside an ARN, attributed to the caller's account.

Observed live:

```
before  arn:aws:ssm:us-east-1:<caller>:patchbaseline/arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0028ca011460d5eaf
after   arn:aws:ssm:us-east-1:075727635805:patchbaseline/pb-0028ca011460d5eaf
```

Every AWS-managed baseline in the account was affected, and `id()` returns
`Arn.Data`, so the malformed value was the cache key as well as the user-visible
`arn`. It also asserted that the caller's account owns a baseline owned by AWS.

`GetPatchBaseline` documents the full ARN as the correct input for AWS-managed
baselines ("specify the full Amazon Resource Name (ARN) of the baseline … instead
of `pb-0e392de35e7c563b7`"), so an id that is already an ARN is now passed
through untouched. Both construction sites — the lister in `aws_ssm_documents.go`
and the `patchGroup.baseline()` reference in `aws_ssm_state.go` — go through one
helper.

Tests cover the helper: a bare `pb-*` id gets the pattern, an ARN is returned
unchanged, a GovCloud ARN survives (the pattern hardcodes the `aws` partition),
and the doubled shape is asserted absent along with the account re-attribution.
