### PR TITLE
🐛 aws: report no state transition time for a running instance

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -1338,6 +1338,36 @@ func (a *mqlAwsEc2) getInstances(conn *connection.AwsConnection) []*jobpool.Job 
 	return tasks
 }
 
+// stateTransitionReasonTime pulls the timestamp out of a StateTransitionReason
+// such as "User initiated (2026-04-05 20:44:17 GMT)".
+var stateTransitionReasonTime = regexp.MustCompile(`.*\((\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}) GMT\)`)
+
+// parseStateTransitionTime reads the transition timestamp out of an instance's
+// StateTransitionReason, or reports nil when there is none.
+//
+// A running instance has an empty StateTransitionReason - the API documents it as
+// "This might be an empty string" - so there is no timestamp to report and the
+// field has to be null. It used to be a zero time.Time handed to llx.TimeData,
+// which is a non-nil pointer, so every running instance carried a value that
+// compared as older than any real date.
+func parseStateTransitionTime(reason string) *time.Time {
+	match := stateTransitionReasonTime.FindStringSubmatch(reason)
+	if len(match) != 2 {
+		return nil
+	}
+	t, err := time.Parse(time.DateTime, match[1])
+	if err != nil {
+		// The reason named a transition but the timestamp did not parse. Keep the
+		// existing sentinel rather than null: something did happen, and we know
+		// it was in the past.
+		log.Error().Str("reason", reason).Err(err).
+			Msg("cannot parse state transition time for ec2 instance")
+		past := llx.NeverPastTime
+		return &past
+	}
+	return &t
+}
+
 func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal string) ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []any{}
@@ -1366,16 +1396,7 @@ func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal 
 			return nil, err
 		}
 
-		var stateTransitionTime time.Time
-		reg := regexp.MustCompile(`.*\((\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}) GMT\)`)
-		timeString := reg.FindStringSubmatch(convert.ToValue(instance.StateTransitionReason))
-		if len(timeString) == 2 {
-			stateTransitionTime, err = time.Parse(time.DateTime, timeString[1])
-			if err != nil {
-				log.Error().Err(err).Msg("cannot parse state transition time for ec2 instance")
-				stateTransitionTime = llx.NeverPastTime
-			}
-		}
+		stateTransitionTime := parseStateTransitionTime(convert.ToValue(instance.StateTransitionReason))
 		var detailedMonitoring string
 		if instance.Monitoring != nil {
 			detailedMonitoring = string(instance.Monitoring.State)
@@ -1409,7 +1430,7 @@ func (a *mqlAwsEc2) gatherInstanceInfo(instances []ec2types.Instance, regionVal 
 			"stateReason":        llx.MapData(stateReason, types.Any),
 			// "iamInstanceProfile":    llx.MapData(iamInstanceProfile, types.Any),
 			"stateTransitionReason": llx.StringDataPtr(instance.StateTransitionReason),
-			"stateTransitionTime":   llx.TimeData(stateTransitionTime),
+			"stateTransitionTime":   llx.TimeDataPtr(stateTransitionTime),
 			"tags":                  llx.MapData(toInterfaceMap(ec2TagsToMap(instance.Tags)), types.String),
 			"tpmSupport":            llx.StringDataPtr(instance.TpmSupport),
 			"bootMode":              llx.StringData(bootMode(string(instance.BootMode))),

--- a/providers/aws/resources/aws_ec2_state_transition_test.go
+++ b/providers/aws/resources/aws_ec2_state_transition_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestParseStateTransitionTime(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		reason string
+		want   *time.Time
+	}{
+		{
+			// The case that mattered: a running instance reports an empty reason,
+			// so there is no transition time and the field must be null. This used
+			// to yield a zero time.Time presented as a real value.
+			name:   "a running instance has no reason",
+			reason: "",
+			want:   nil,
+		},
+		{
+			name:   "a stopped instance reports the timestamp",
+			reason: "User initiated (2026-04-05 20:44:17 GMT)",
+			want:   timePtr(time.Date(2026, 4, 5, 20, 44, 17, 0, time.UTC)),
+		},
+		{
+			name:   "a terminated instance reports the same shape",
+			reason: "User initiated (2026-05-31 04:36:20 GMT)",
+			want:   timePtr(time.Date(2026, 5, 31, 4, 36, 20, 0, time.UTC)),
+		},
+		{
+			name:   "a reason with no parenthesised timestamp is null",
+			reason: "Client.InstanceInitiatedShutdown: Instance initiated shutdown",
+			want:   nil,
+		},
+		{
+			name:   "a reason in another timezone is not matched",
+			reason: "User initiated (2026-04-05 20:44:17 PST)",
+			want:   nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseStateTransitionTime(tc.reason)
+			if tc.want == nil {
+				assert.Nil(t, got, "expected a null transition time")
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tc.want.UTC(), got.UTC())
+		})
+	}
+}
+
+// A reason that names a transition but carries an unparsable timestamp keeps the
+// existing past sentinel: something did happen, so null would be wrong too.
+func TestParseStateTransitionTimeKeepsThePastSentinelOnAParseFailure(t *testing.T) {
+	got := parseStateTransitionTime("User initiated (2026-13-45 99:99:99 GMT)")
+
+	require.NotNil(t, got)
+	assert.Equal(t, llx.NeverPastTime, *got)
+}
+
+// The zero time.Time is what made this a wrong answer rather than a missing one:
+// it is a real, very old date, so `stateTransitionTime < time.now - 30*time.day`
+// was true for every running instance in the account.
+func TestZeroTimeWouldCompareAsAncient(t *testing.T) {
+	var zero time.Time
+
+	require.True(t, zero.Before(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)),
+		"the zero time is older than any real timestamp, which is why reporting "+
+			"it instead of null inverted staleness checks")
+	assert.Nil(t, parseStateTransitionTime(""),
+		"the empty reason must not produce that value")
+}


### PR DESCRIPTION
`aws.ec2.instance.stateTransitionTime` reported a value for every **running**
instance, where there is no transition time to report.

`StateTransitionReason` is documented as "This might be an empty string", and it
is empty on a running instance. The regex then found no match, the local
`time.Time` stayed at its zero value, and `llx.TimeData` took its address — a
non-nil pointer, so the zero time was published as a real timestamp instead of
null.

Observed live across 17 instances:

| state | reported before | reported after |
|---|---|---|
| running (11) | `366 days` | `null` |
| stopped (6) | correct timestamps | unchanged |

The zero `time.Time` is year 1, so it is older than any real date. Any staleness
check — `stateTransitionTime < time.now - 30*time.day` and similar — evaluated
**true** for the entire running fleet.

The parse now returns `*time.Time` and the field uses `llx.TimeDataPtr`, so no
match means null. A reason that names a transition but whose timestamp fails to
parse keeps the existing `llx.NeverPastTime` sentinel: something did happen, so
null would be wrong there too, and the failure is logged with the offending
value.

The regex also moves to package scope; it was being recompiled once per instance
inside the collection loop.

Tests cover the empty reason, both real reason shapes, a reason with no
parenthesised timestamp, a non-GMT timezone, the parse-failure sentinel, and the
zero-time comparison that made this a wrong answer rather than a missing one.
