### PR TITLE
🐛 aws: keep the RDS subnets that resolve when one is deleted

### DIFF
--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -746,21 +746,44 @@ func (a *mqlAwsRdsDbinstance) dbCluster() (*mqlAwsRdsDbcluster, error) {
 	return res.(*mqlAwsRdsDbcluster), nil
 }
 
-func (a *mqlAwsRdsDbinstance) subnets() ([]any, error) {
-	if a.cacheSubnets != nil {
-		res := []any{}
-		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-		for i := range a.cacheSubnets.Subnets {
-			subnet := a.cacheSubnets.Subnets[i]
-			sub, err := NewResource(a.MqlRuntime, ResourceAwsVpcSubnet, map[string]*llx.RawData{"arn": llx.StringData(fmt.Sprintf(subnetArnPattern, a.region, conn.AccountId(), convert.ToValue(subnet.SubnetIdentifier)))})
-			if err != nil {
-				return nil, err
-			}
-			res = append(res, sub)
+// resolveSubnetRefs turns subnet ids into aws.vpc.subnet references, skipping any
+// that cannot be resolved.
+//
+// A DB subnet group keeps listing a subnet after that subnet is deleted, so a
+// dangling reference is ordinary account state rather than a failure. Returning
+// an error on the first one threw away every reference that did resolve, and
+// because a field error renders as the value of the enclosing collection, a query
+// written as `aws.rds { instances { ... } }` lost every other field on every
+// instance as well.
+func resolveSubnetRefs(runtime *plugin.Runtime, region, accountID string, subnetIDs []string) []any {
+	res := []any{}
+	for _, id := range subnetIDs {
+		if id == "" {
+			continue
 		}
-		return res, nil
+		arn := fmt.Sprintf(subnetArnPattern, region, accountID, id)
+		sub, err := NewResource(runtime, ResourceAwsVpcSubnet,
+			map[string]*llx.RawData{"arn": llx.StringData(arn)})
+		if err != nil {
+			log.Warn().Err(err).Str("subnet", id).Str("region", region).
+				Msg("cannot resolve subnet reference, skipping it")
+			continue
+		}
+		res = append(res, sub)
 	}
-	return []any{}, nil
+	return res
+}
+
+func (a *mqlAwsRdsDbinstance) subnets() ([]any, error) {
+	if a.cacheSubnets == nil {
+		return []any{}, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	ids := make([]string, 0, len(a.cacheSubnets.Subnets))
+	for i := range a.cacheSubnets.Subnets {
+		ids = append(ids, convert.ToValue(a.cacheSubnets.Subnets[i].SubnetIdentifier))
+	}
+	return resolveSubnetRefs(a.MqlRuntime, a.region, conn.AccountId(), ids), nil
 }
 
 func (a *mqlAwsRdsDbinstance) kmsKey() (*mqlAwsKmsKey, error) {
@@ -1132,12 +1155,19 @@ func (a *mqlAwsRdsDbcluster) id() (string, error) {
 func newMqlAwsRdsCluster(runtime *plugin.Runtime, region string, accountID string, cluster rds_types.DBCluster) (*mqlAwsRdsDbcluster, error) {
 	mqlRdsDbInstances := []any{}
 	for _, instance := range cluster.DBClusterMembers {
+		memberID := convert.ToValue(instance.DBInstanceIdentifier)
 		mqlInstance, err := NewResource(runtime, ResourceAwsRdsDbinstance,
 			map[string]*llx.RawData{
-				"arn": llx.StringData(fmt.Sprintf(rdsInstanceArnPattern, region, accountID, convert.ToValue(instance.DBInstanceIdentifier))),
+				"arn": llx.StringData(fmt.Sprintf(rdsInstanceArnPattern, region, accountID, memberID)),
 			})
 		if err != nil {
-			return nil, err
+			// DescribeDBClusters reports members that DescribeDBInstances may not
+			// return - one still being created or deleted, or one filtered out
+			// because instance tags differ from the cluster's. Losing the cluster
+			// entirely over one member is far worse than losing the member.
+			log.Warn().Err(err).Str("member", memberID).Str("region", region).
+				Msg("cannot resolve rds cluster member, skipping it")
+			continue
 		}
 		mqlRdsDbInstances = append(mqlRdsDbInstances, mqlInstance)
 	}
@@ -1749,17 +1779,7 @@ func (a *mqlAwsRdsProxy) securityGroups() ([]any, error) {
 
 func (a *mqlAwsRdsProxy) subnets() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	res := []any{}
-	for _, subnetId := range a.cacheSubnetIds {
-		mqlSubnet, err := NewResource(a.MqlRuntime, "aws.vpc.subnet",
-			map[string]*llx.RawData{
-				"arn": llx.StringData(fmt.Sprintf(subnetArnPattern, a.region, conn.AccountId(), subnetId)),
-			})
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, mqlSubnet)
-	}
+	res := resolveSubnetRefs(a.MqlRuntime, a.region, conn.AccountId(), a.cacheSubnetIds)
 	return res, nil
 }
 

--- a/providers/aws/resources/aws_rds_subnet_refs_test.go
+++ b/providers/aws/resources/aws_rds_subnet_refs_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolveSubnetRefs must never return nil: a nil slice from a list accessor
+// renders as an empty array anyway, but an explicitly empty one keeps the
+// "no subnets" and "nothing resolved" cases reading the same way to callers.
+//
+// These cases reach no NewResource call, so they exercise the skip logic without
+// a runtime. Resolution itself is covered by live verification, since it is one
+// NewResource call per id.
+func TestResolveSubnetRefsWithNothingToResolve(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ids  []string
+	}{
+		{name: "nil ids", ids: nil},
+		{name: "no ids", ids: []string{}},
+		{name: "only empty ids", ids: []string{"", ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveSubnetRefs(nil, "us-east-2", "111122223333", tc.ids)
+
+			require.NotNil(t, got, "must return an empty slice rather than nil")
+			assert.Empty(t, got)
+		})
+	}
+}
+
+// An empty subnet id would build the ARN "arn:aws:ec2:<region>:<acct>:subnet/",
+// which resolves to nothing and would log a warning for every such entry. Skip
+// them before that.
+func TestResolveSubnetRefsSkipsEmptyIdsWithoutResolving(t *testing.T) {
+	// A nil runtime proves no resolution was attempted: any NewResource call
+	// would dereference it.
+	assert.NotPanics(t, func() {
+		resolveSubnetRefs(nil, "us-east-2", "111122223333", []string{"", "", ""})
+	}, "empty ids must be skipped before any resolution is attempted")
+}


### PR DESCRIPTION
One deleted subnet made `aws.rds.instances` return nothing at all.

An RDS DB subnet group keeps listing a subnet after that subnet is deleted — that
is ordinary AWS behaviour, not a failure. `subnets()` resolved each one with
`NewResource` and returned the error from the first that did not resolve, so it
discarded the subnets that did.

That alone would be a partial-data bug. What makes it total is how a field error
renders: mql replaces the value of the enclosing collection with it. Verified
live against a DB subnet group listing three subnets, two of which are deleted:

```
aws.rds.instances { arn subnets {id} }        -> per-element "Error: subnet not found", arn kept
aws.rds { instances { arn subnets {id} } }    -> ENTIRE instances value replaced by the error
```

The second form is how policies and query packs are written, so one dangling
subnet cost every field on every RDS instance in the region — the resource was
simply unauditable.

After the fix the same query returns both instances with the one subnet that
resolves, and names the deleted one in a warning:

```
! cannot resolve subnet reference, skipping it  subnet=subnet-83247ccf region=us-east-2
{"instances":[{"subnets":[{"id":"subnet-3d52e956"}],"arn":"...:db:acg-basic"}, ...]}
```

CLAUDE.md already documents log-and-continue as the convention for a typed
accessor whose resolution fails; these sites were doing the opposite. Three are
fixed here, sharing one `resolveSubnetRefs` helper:

- `aws.rds.dbinstance.subnets`
- `aws.rds.proxy.subnets`
- `newMqlAwsRdsCluster`'s member resolution — `DescribeDBClusters` reports members
  that `DescribeDBInstances` may not return (one being created or deleted, or one
  filtered out because instance tags differ from the cluster's), and losing the
  whole Aurora cluster over one member is far worse than losing the member.

**This is a sample of a wider pattern.** 110 call sites across the provider
resolve a typed reference inside a loop and `return nil, err`; only 7
log-and-continue. The rest need the same treatment where the reference can
legitimately dangle — deleted security groups on an ENI, deleted IAM roles on a
task definition, deleted VPCs on a cache subnet group — each of which the live
sweep also caught. Those are left for follow-ups rather than bundled here.

Tests cover the skip logic in the shared helper (nil, empty, and all-empty id
lists, and that an empty id is skipped before any resolution is attempted).
Resolution itself is one `NewResource` call per id and is covered by the live
verification above.
