### PR TITLE
🐛 aws: reject a regions filter the account cannot scan

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -14,6 +14,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -362,27 +363,53 @@ func CheckIam(cfg aws.Config) (*sts.GetCallerIdentityOutput, error) {
 	}
 }
 
-func (h *AwsConnection) Regions() ([]string, error) {
-	// check cache for regions list, return if exists
-	c, ok := h.clientcache.Load("_regions")
-	if ok {
-		log.Debug().Msg("use regions from cache")
-		return c.Data.([]string), nil
+// normalizeRegionFilter trims and de-duplicates the regions filter.
+//
+// The filter is split on commas without trimming, so `regions=us-east-1, us-west-2`
+// yields " us-west-2" with a leading space, and a trailing comma yields "". An
+// empty entry is worse than useless: the client treats an empty region as "use
+// the configured one", so it silently scans the default region a second time.
+func normalizeRegionFilter(regions []string) []string {
+	out := make([]string, 0, len(regions))
+	seen := make(map[string]struct{}, len(regions))
+	for _, region := range regions {
+		region = strings.TrimSpace(region)
+		if region == "" {
+			continue
+		}
+		if _, dup := seen[region]; dup {
+			continue
+		}
+		seen[region] = struct{}{}
+		out = append(out, region)
 	}
+	return out
+}
 
-	// include filters have precedence over exclude filters. in any normal situation they should be mutually exclusive.
-	regionLimits := h.Filters.General.Regions
-	if len(regionLimits) > 0 {
-		log.Debug().Interface("regions", regionLimits).Msg("using region limits")
-		// cache the regions as part of the provider instance
-		h.clientcache.Store("_regions", &CacheEntry{Data: regionLimits})
-		return regionLimits, nil
+// unknownRegions reports which requested regions the account does not have
+// enabled, preserving the order they were given in.
+func unknownRegions(requested, enabled []string) []string {
+	have := make(map[string]struct{}, len(enabled))
+	for _, region := range enabled {
+		have[region] = struct{}{}
 	}
-	// if no cache, get regions using ec2 client (using the ssm list global regions does not give the same list)
-	log.Debug().Msg("no region cache or region limits found. fetching regions")
-	regions := []string{}
+	unknown := []string{}
+	for _, region := range requested {
+		if _, ok := have[region]; !ok {
+			unknown = append(unknown, region)
+		}
+	}
+	return unknown
+}
+
+// discoverEnabledRegions lists the regions this account has enabled.
+//
+// allowFallback controls whether a failed DescribeRegions escalates to the
+// slower routes (Account list-regions, then the public regional table plus a
+// per-region access probe). They are worth it when the answer decides the whole
+// scan's scope, and not worth it when the caller has already named its regions.
+func (h *AwsConnection) discoverEnabledRegions(ctx context.Context, allowFallback bool) ([]string, error) {
 	svc := h.Ec2(h.cfg.Region)
-	ctx := context.Background()
 
 	// DescribeRegions works to get the list of enabled regions for the account ( each account of organization)
 	// but this does not mean the respective service endpoint is available in that region. They will timeout instead of failing fast
@@ -391,22 +418,66 @@ func (h *AwsConnection) Regions() ([]string, error) {
 	res, err := svc.DescribeRegions(ctx, &ec2.DescribeRegionsInput{})
 	if err != nil {
 		log.Warn().Err(err).Msg("unable to describe regions")
+		if !allowFallback {
+			return nil, err
+		}
 		// when we can't use `DescribeRegions` we will fallback to:
 		// 1. Account list-regions
 		// 2. Public regional table + region access verification
 		enabledRegions, fallbackErr := h.fallbackGetEnabledRegions(ctx)
 		if fallbackErr != nil {
 			log.Warn().Err(fallbackErr).Msg("unable to list regions from fallback options")
-			return regions, err
+			return nil, err
 		}
-		regions = enabledRegions
-	} else {
-		for _, region := range res.Regions {
-			if region.RegionName == nil {
-				continue
-			}
-			regions = append(regions, *region.RegionName)
+		return enabledRegions, nil
+	}
+
+	regions := []string{}
+	for _, region := range res.Regions {
+		if region.RegionName == nil {
+			continue
 		}
+		regions = append(regions, *region.RegionName)
+	}
+	return regions, nil
+}
+
+func (h *AwsConnection) Regions() ([]string, error) {
+	// check cache for regions list, return if exists
+	c, ok := h.clientcache.Load("_regions")
+	if ok {
+		log.Debug().Msg("use regions from cache")
+		return c.Data.([]string), nil
+	}
+
+	ctx := context.Background()
+
+	// include filters have precedence over exclude filters. in any normal situation they should be mutually exclusive.
+	if regionLimits := normalizeRegionFilter(h.Filters.General.Regions); len(regionLimits) > 0 {
+		// A region name that the account does not have enabled resolves to no
+		// endpoint at all, and every lister then classifies the resulting DNS
+		// miss as "this service is absent here". Left unchecked, a typo makes the
+		// whole scan report zero resources and exit successfully. Skip the
+		// expensive fallback here: it costs a probe per region, and the caller
+		// has already told us which regions it wants.
+		enabled, err := h.discoverEnabledRegions(ctx, false)
+		if err != nil {
+			log.Warn().Err(err).Strs("regions", regionLimits).
+				Msg("cannot check the regions filter against the account's enabled regions")
+		} else if unknown := unknownRegions(regionLimits, enabled); len(unknown) > 0 {
+			return nil, fmt.Errorf("regions filter names %d region(s) this account does not have enabled: %s",
+				len(unknown), strings.Join(unknown, ", "))
+		}
+		log.Debug().Strs("regions", regionLimits).Msg("using region limits")
+		// cache the regions as part of the provider instance
+		h.clientcache.Store("_regions", &CacheEntry{Data: regionLimits})
+		return regionLimits, nil
+	}
+	// if no cache, get regions using ec2 client (using the ssm list global regions does not give the same list)
+	log.Debug().Msg("no region cache or region limits found. fetching regions")
+	regions, err := h.discoverEnabledRegions(ctx, true)
+	if err != nil {
+		return []string{}, err
 	}
 
 	// ensure excluded regions are discarded

--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -462,8 +462,12 @@ func (h *AwsConnection) Regions() ([]string, error) {
 		// has already told us which regions it wants.
 		enabled, err := h.discoverEnabledRegions(ctx, false)
 		if err != nil {
+			// Degrading to a no-op is the safe direction - refusing to scan
+			// because we could not read the region list would be worse. Say
+			// plainly that the filter was taken as given, so this is not mistaken
+			// for a filter that passed the check.
 			log.Warn().Err(err).Strs("regions", regionLimits).
-				Msg("cannot check the regions filter against the account's enabled regions")
+				Msg("could not list the account's enabled regions, accepting the regions filter unchecked; a misspelled region will report no resources")
 		} else if unknown := unknownRegions(regionLimits, enabled); len(unknown) > 0 {
 			return nil, fmt.Errorf("regions filter names %d region(s) this account does not have enabled: %s",
 				len(unknown), strings.Join(unknown, ", "))

--- a/providers/aws/connection/regions_filter_test.go
+++ b/providers/aws/connection/regions_filter_test.go
@@ -1,0 +1,126 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeRegionFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "nothing to normalize",
+			in:   []string{"us-east-1", "us-west-2"},
+			want: []string{"us-east-1", "us-west-2"},
+		},
+		{
+			// `--filters regions=us-east-1, us-west-2` is split on the comma with
+			// no trimming, so the second entry keeps its leading space and
+			// resolves to no endpoint at all.
+			name: "a space after the comma",
+			in:   []string{"us-east-1", " us-west-2"},
+			want: []string{"us-east-1", "us-west-2"},
+		},
+		{
+			// A trailing comma yields "", and an empty region means "use the
+			// configured one", so the default region would be scanned twice.
+			name: "a trailing comma",
+			in:   []string{"us-east-1", ""},
+			want: []string{"us-east-1"},
+		},
+		{
+			name: "duplicates collapse",
+			in:   []string{"us-east-1", "us-east-1", " us-east-1 "},
+			want: []string{"us-east-1"},
+		},
+		{
+			name: "tabs and surrounding space",
+			in:   []string{"\tus-east-1 ", " eu-central-1"},
+			want: []string{"us-east-1", "eu-central-1"},
+		},
+		{
+			name: "nothing but empties",
+			in:   []string{"", "  ", "\t"},
+			want: []string{},
+		},
+		{
+			name: "no filter at all",
+			in:   nil,
+			want: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeRegionFilter(tc.in))
+		})
+	}
+}
+
+func TestUnknownRegions(t *testing.T) {
+	enabled := []string{"us-east-1", "us-east-2", "us-west-2", "eu-central-1"}
+
+	for _, tc := range []struct {
+		name      string
+		requested []string
+		want      []string
+	}{
+		{
+			name:      "every requested region is enabled",
+			requested: []string{"us-east-1", "eu-central-1"},
+			want:      []string{},
+		},
+		{
+			// The case that returned an empty account with exit 0.
+			name:      "a region that does not exist",
+			requested: []string{"us-east-99"},
+			want:      []string{"us-east-99"},
+		},
+		{
+			name:      "a transposed region name",
+			requested: []string{"eu-wets-1"},
+			want:      []string{"eu-wets-1"},
+		},
+		{
+			name:      "a real region the account has not enabled",
+			requested: []string{"us-east-1", "ap-south-2"},
+			want:      []string{"ap-south-2"},
+		},
+		{
+			name:      "several unknown, reported in the order given",
+			requested: []string{"zz-top-1", "us-east-1", "aa-bottom-2"},
+			want:      []string{"zz-top-1", "aa-bottom-2"},
+		},
+		{
+			name:      "region names are case sensitive, as AWS treats them",
+			requested: []string{"US-EAST-1"},
+			want:      []string{"US-EAST-1"},
+		},
+		{
+			name:      "nothing requested",
+			requested: []string{},
+			want:      []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, unknownRegions(tc.requested, enabled))
+		})
+	}
+}
+
+// If the account's region list cannot be read there is nothing to check against,
+// and every requested region has to be accepted rather than rejected.
+func TestUnknownRegionsWithNoEnabledListRejectsEverything(t *testing.T) {
+	// unknownRegions itself reports all of them; Regions() is what decides not to
+	// call it when the enabled list could not be determined. Pin the raw
+	// behaviour so that decision stays deliberate.
+	got := unknownRegions([]string{"us-east-1"}, nil)
+	assert.Equal(t, []string{"us-east-1"}, got,
+		"with no enabled list everything looks unknown, which is why the caller "+
+			"must skip the check rather than pass an empty list")
+}


### PR DESCRIPTION
A typo in `--filters regions=` turned a whole account into "no findings", quietly
and with a successful exit code.

The filter was taken verbatim: no trimming, no de-duplication, and no check
against the account's enabled regions. Every lister then fanned out to a region
name that resolves to no endpoint, the DNS miss was classified as
`dispositionEmpty` ("this service is absent here"), and the scan reported zero
resources everywhere.

```
before  mql run aws --filters regions=us-east-99 -c 'aws.s3.buckets.length'
        [{"aws.s3.buckets.length":0}]          exit 0

after   [{"aws.s3.buckets.length":{"error":"regions filter names 1 region(s)
        this account does not have enabled: us-east-99"}}]
```

`eu-wets-1` behaves the same way, so shape-checking would not have caught either;
the requested regions have to be intersected with the account's real list.

Two adjacent problems fixed with it. The filter is split on commas without
trimming, so `regions=us-east-1, us-west-2` kept a leading space on the second
entry and silently dropped that region. And a trailing comma produced an empty
entry, which `regionalClient` reads as "use the configured region" — so the
default region was scanned twice.

Notes on the shape of the fix:

- Validation deliberately does **not** escalate to the slow fallback (Account
  list-regions, then the public regional table plus a per-region access probe).
  That path costs a probe per region and exists to decide the scan's whole scope;
  when the caller has already named its regions it is not worth paying. A failed
  `DescribeRegions` there warns and accepts the filter rather than refusing to
  scan, so an account that restricts regions *because* it cannot call
  `DescribeRegions` still works.
- The region-discovery block is extracted into `discoverEnabledRegions` so both
  paths share it instead of one inlining it.

Tests cover both pure functions: trimming, the trailing-comma empty, duplicate
collapsing, tabs; and unknown-region detection for a non-existent region, a
transposed name, a real region the account has not enabled, ordering with several
unknowns, and case sensitivity. One test pins why the caller must skip the check
rather than pass an empty enabled list — against nothing, everything looks
unknown.
