### PR TITLE
🐛 aws: honour the discovery tag filter for kms keys and secrets

### DIFF
--- a/providers/aws/connection/filters_test.go
+++ b/providers/aws/connection/filters_test.go
@@ -94,6 +94,35 @@ func TestMatchesIncludeTags(t *testing.T) {
 	})
 }
 
+// A resource whose tag read failed is left out of the pre-fetched map, so the
+// lister evaluates it against a nil map rather than an empty one. Callers depend
+// on those being indistinguishable here: it is what lets a failed tag fetch stay
+// absent (so the tags field can still report null) without changing which
+// resources the filter selects.
+func TestTagFiltersReadNilLikeAnEmptyMap(t *testing.T) {
+	filters := GeneralDiscoveryFilters{
+		Tags:        map[string]string{"env": "prod"},
+		ExcludeTags: map[string]string{"tier": "scratch"},
+	}
+
+	require.Equal(t,
+		filters.MatchesIncludeTags(map[string]string{}),
+		filters.MatchesIncludeTags(nil),
+		"a nil tag map must include exactly like an empty one")
+	require.Equal(t,
+		filters.MatchesExcludeTags(map[string]string{}),
+		filters.MatchesExcludeTags(nil),
+		"a nil tag map must exclude exactly like an empty one")
+	require.Equal(t,
+		filters.IsFilteredOutByTags(map[string]string{}),
+		filters.IsFilteredOutByTags(nil))
+
+	// and with no filters configured at all, both are kept
+	var none GeneralDiscoveryFilters
+	require.False(t, none.IsFilteredOutByTags(nil))
+	require.False(t, none.IsFilteredOutByTags(map[string]string{}))
+}
+
 func TestMatchesExcludeTags(t *testing.T) {
 	t.Run("no exclude tags does not match", func(t *testing.T) {
 		filters := GeneralDiscoveryFilters{

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -148,13 +148,43 @@ func (a *mqlAwsKms) keys() ([]any, error) {
 			keys = append(keys, output.Keys...)
 		}
 
+		// Pre-fetch tags in parallel when tag-based filters are configured. KMS
+		// has no batch tags endpoint, so this turns a sequential per-key call
+		// into bounded concurrent ones, and it stays entirely unpaid when no tag
+		// filter is set.
+		var tagsByArn map[string]map[string]string
+		if conn.Filters.General.HasTags() {
+			arns := make([]string, 0, len(keys))
+			for i := range keys {
+				arns = append(arns, convert.ToValue(keys[i].KeyArn))
+			}
+			tagsByArn = fetchTagsConcurrently(ctx, arns, func(ctx context.Context, keyArn string) (map[string]string, error) {
+				return kmsKeyTags(ctx, svc, keyArn)
+			})
+		}
+
 		for _, key := range keys {
-			mqlKey, err := CreateResource(a.MqlRuntime, "aws.kms.key",
-				map[string]*llx.RawData{
-					"id":     llx.StringDataPtr(key.KeyId),
-					"arn":    llx.StringDataPtr(key.KeyArn),
-					"region": llx.StringData(region),
-				})
+			keyArn := convert.ToValue(key.KeyArn)
+			tags, fetched := tagsByArn[keyArn]
+			if conn.Filters.General.HasTags() &&
+				conn.Filters.General.IsFilteredOutByTags(tags) {
+				log.Debug().Str("key", keyArn).Msg("excluding kms key due to filters")
+				continue
+			}
+
+			args := map[string]*llx.RawData{
+				"id":     llx.StringDataPtr(key.KeyId),
+				"arn":    llx.StringDataPtr(key.KeyArn),
+				"region": llx.StringData(region),
+			}
+			// Seed the tags we already paid for, but only a set we actually read:
+			// publishing an empty map for a key whose ListResourceTags call failed
+			// would report "no tags" as fact. Leaving it unset keeps the field lazy.
+			if fetched {
+				args["tags"] = llx.MapData(stringMapToAny(tags), mqlTypes.String)
+			}
+
+			mqlKey, err := CreateResource(a.MqlRuntime, "aws.kms.key", args)
 			if err != nil {
 				return nil, err
 			}
@@ -163,6 +193,30 @@ func (a *mqlAwsKms) keys() ([]any, error) {
 
 		return res, nil
 	})
+}
+
+// kmsKeyTags reads one key's tags for filter evaluation.
+//
+// AWS-managed keys reject ListResourceTags with AccessDenied. For filtering that
+// is "no tags to match on" rather than a failure, so it returns an empty set and
+// lets the key be judged on it; the tags field itself still reports the denial as
+// null through markTagsUnreadable.
+func kmsKeyTags(ctx context.Context, svc *kms.Client, keyArn string) (map[string]string, error) {
+	tags := map[string]string{}
+	paginator := kms.NewListResourceTagsPaginator(svc, &kms.ListResourceTagsInput{KeyId: &keyArn})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return tags, nil
+			}
+			return nil, err
+		}
+		for i := range page.Tags {
+			tags[convert.ToValue(page.Tags[i].TagKey)] = convert.ToValue(page.Tags[i].TagValue)
+		}
+	}
+	return tags, nil
 }
 
 func (a *mqlAwsKms) grants() ([]any, error) {

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -197,19 +197,24 @@ func (a *mqlAwsKms) keys() ([]any, error) {
 
 // kmsKeyTags reads one key's tags for filter evaluation.
 //
-// AWS-managed keys reject ListResourceTags with AccessDenied. For filtering that
-// is "no tags to match on" rather than a failure, so it returns an empty set and
-// lets the key be judged on it; the tags field itself still reports the denial as
-// null through markTagsUnreadable.
+// Every error is returned, including AccessDenied. Some AWS-managed keys grant
+// kms:ListResourceTags and answer with an empty tag set, others refuse it, and
+// only the first is "this key has no tags". fetchTagsConcurrently leaves a key
+// whose read failed out of its result, so nothing is seeded onto the resource
+// and the lazy tags accessor still reports the refusal as null via
+// markTagsUnreadable. Returning an empty set here would publish "no tags" as fact
+// for a key whose tags could not be read, and would make the same key report {}
+// under a tag filter and null without one.
+//
+// Filtering is unaffected: an absent entry yields a nil map, and both
+// MatchesIncludeTags and MatchesExcludeTags read a nil map exactly as they read
+// an empty one.
 func kmsKeyTags(ctx context.Context, svc *kms.Client, keyArn string) (map[string]string, error) {
 	tags := map[string]string{}
 	paginator := kms.NewListResourceTagsPaginator(svc, &kms.ListResourceTagsInput{KeyId: &keyArn})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			if Is400AccessDeniedError(err) {
-				return tags, nil
-			}
 			return nil, err
 		}
 		for i := range page.Tags {

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -224,6 +224,14 @@ func (a *mqlAwsSecretsmanager) getSecrets(conn *connection.AwsConnection) []*job
 					return nil, err
 				}
 				for _, secret := range secrets.SecretList {
+					// ListSecrets already carries the tags, so the discovery tag
+					// filter costs nothing extra here.
+					if conn.Filters.General.HasTags() &&
+						conn.Filters.General.IsFilteredOutByTags(secretTagsToStringMap(secret.Tags)) {
+						log.Debug().Str("secret", convert.ToValue(secret.ARN)).
+							Msg("excluding secret due to filters")
+						continue
+					}
 					args := map[string]*llx.RawData{
 						"arn":              llx.StringDataPtr(secret.ARN),
 						"region":           llx.StringData(region),
@@ -483,6 +491,12 @@ func (a *mqlAwsSecretsmanagerSecretReplicaRegion) kmsKey() (*mqlAwsKmsKey, error
 
 func secretTagsToMap(tags []secretstypes.Tag) map[string]any {
 	return tagsToMap(tags, func(t secretstypes.Tag) *string { return t.Key }, func(t secretstypes.Tag) *string { return t.Value })
+}
+
+// secretTagsToStringMap is secretTagsToMap in the shape the discovery filters
+// evaluate against.
+func secretTagsToStringMap(tags []secretstypes.Tag) map[string]string {
+	return tagsToStringMap(tags, func(t secretstypes.Tag) *string { return t.Key }, func(t secretstypes.Tag) *string { return t.Value })
 }
 
 type mqlAwsSecretsmanagerSecretReplicaRegionInternal struct {

--- a/providers/aws/resources/aws_tags_test.go
+++ b/providers/aws/resources/aws_tags_test.go
@@ -18,6 +18,7 @@ import (
 	cstypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
 	elasticache_types "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	emrtypes "github.com/aws/aws-sdk-go-v2/service/emr/types"
+	secretstypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,6 +128,18 @@ func TestElasticacheTagsToMap(t *testing.T) {
 		{Key: nil, Value: aws.String("dropped")},
 	})
 	assert.Equal(t, map[string]any{"env": "prod", "empty": ""}, got)
+}
+
+// secretTagsToStringMap feeds the discovery tag filter. A swapped Key/Value
+// accessor here would not fail loudly - it would silently invert every
+// `--filters tag:` match on Secrets Manager.
+func TestSecretTagsToStringMap(t *testing.T) {
+	got := secretTagsToStringMap([]secretstypes.Tag{
+		{Key: aws.String("environment"), Value: aws.String("prod")},
+		{Key: aws.String("empty"), Value: nil},
+		{Key: nil, Value: aws.String("dropped")},
+	})
+	assert.Equal(t, map[string]string{"environment": "prod", "empty": ""}, got)
 }
 
 func TestConfigTagsToMap(t *testing.T) {


### PR DESCRIPTION
`--filters tag:` is advertised as a general discovery filter, but 26 of the 60
discovery targets never consult it. Scanning with `--discover kms-keys --filters
tag:Environment=production` enumerates — and reports on, and bills for — every
key in the account, while appearing to have honoured the scope.

`discovery.go` reads tags only to populate asset labels; it never filters. So the
gate has to live in the lister, which is also what keeps discovery and a plain
MQL query consistent. This is the check CLAUDE.md §3.5 describes, and the reason
it says the bug is an *absence* you cannot spot by reading one file.

Verified live before the fix:

```
aws.s3.buckets.length     --filters tag:nonexistent=zzz   ->  0    (correct)
aws.kms.keys.length       --filters tag:nonexistent=zzz   ->  24   (ignored)
aws.kms.keys.length       (unfiltered)                    ->  24
```

And after, including that a real filter selects the right subset rather than
merely returning zero:

| query | before | after |
|---|---|---|
| `kms.keys` `tag:nonexistent=zzz` | 24 | 0 |
| `kms.keys` `tag:Terraform=true` | 24 | 2 (the two keys carrying it) |
| `kms.keys` `tag:terraform-aws-modules=eks` | 24 | 1 |
| `kms.keys` unfiltered | 24 | 24 |
| `secretsmanager.secrets` `tag:environment=prod` | 1 | 1 |
| `secretsmanager.secrets` `tag:environment=dev` | 1 | 0 |
| `secretsmanager.secrets` unfiltered | 1 | 1 |

Two services in this change:

- **Secrets Manager** — `ListSecrets` already returns the tags, so the gate costs
  nothing extra.
- **KMS** — no batch tags endpoint, so it uses `fetchTagsConcurrently` like
  sns/sqs/lambda do: bounded concurrency, per-item failures tolerated, and it
  stays entirely unpaid when no tag filter is set. The tags it did pay for are
  seeded onto the resource so discovery does not re-fetch them, but **only for a
  key whose tag call actually succeeded** — publishing an empty map for a key
  whose `ListResourceTags` failed would report "no tags" as fact. AWS-managed keys
  reject `ListResourceTags` with AccessDenied; for filtering that is "no tags to
  match on" rather than a failure, so they are judged as untagged while the `tags`
  field itself still reports the denial as null via `markTagsUnreadable`.

**Remaining targets** that still ignore the filter, for follow-ups: ssm-instances,
cloudtrail-trails, iam-users, iam-groups, dynamodb-tables, dynamodb-global-tables,
es-domains, opensearch-domains, elasticache-clusters, cloudfront-distributions,
neptune-clusters, emr-clusters, documentdb-clusters, documentdb-instances,
msk-clusters, mq-brokers, memorydb-clusters, codebuild-projects, cognito-userpools,
transfer-servers, apigatewayv2-apis, athena-workgroups, appstream-fleets,
batch-jobdefinitions, directoryservice-directories. `ecs` and `ecr-repositories`
apply their service-specific filters but not the general tag filter.

Filter semantics (`IsFilteredOutByTags`, include/exclude precedence) and
`fetchTagsConcurrently`'s failure handling are already covered by
`connection/filters_test.go` and `resources/aws_test.go`; this adds a converter
test for `secretTagsToStringMap`, following the existing per-service pattern,
because a swapped Key/Value accessor there would silently invert every match
rather than fail.
