### PR TITLE
🐛 aws: report the credential report's root entry as having no IAM user

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2410,6 +2410,9 @@ private aws.iam.usercredentialreportentry @defaults("arn") {
   passwordNextRotation() time
 
   // IAM user
+  //
+  // Null for the root account entry, which always appears in the report but has
+  // no IAM user behind it. Use isRoot to select that entry.
   user() aws.iam.user
   // Time when user was created
   createdAt() time

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1017,9 +1017,14 @@ func (a *mqlAwsIamUsercredentialreportentry) user() (*mqlAwsIamUser, error) {
 		log.Info().Msgf("could not retrieve key")
 		return nil, errors.New("could not read the credentials report")
 	}
-	// handle special case for the root account since that user does not exist
+	// The root account always appears in the credential report but has no IAM
+	// user behind it, so there is nothing to resolve. That is a null, not a
+	// failure: reporting an error here made the whole credentialReport
+	// collection error out, because a field error renders as the value of the
+	// enclosing collection. Use isRoot to select the entry.
 	if props["user"] == "<root_account>" {
-		return nil, errors.New("root user does not exist")
+		a.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	userName, ok := props["user"].(string)

--- a/providers/aws/resources/aws_iam_credential_report_test.go
+++ b/providers/aws/resources/aws_iam_credential_report_test.go
@@ -1,0 +1,80 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func reportEntry(props map[string]any) *mqlAwsIamUsercredentialreportentry {
+	return &mqlAwsIamUsercredentialreportentry{
+		Properties: plugin.TValue[map[string]any]{Data: props, State: plugin.StateIsSet},
+	}
+}
+
+// The root account is always in the credential report and never has an IAM user
+// behind it, so `user` is null. It used to return an error, and because a field
+// error renders as the value of the enclosing collection, that error took the
+// whole credentialReport with it - making every root-MFA and key-rotation check
+// unrunnable on every account.
+func TestCredentialReportRootEntryReportsNoUser(t *testing.T) {
+	entry := reportEntry(map[string]any{"user": "<root_account>"})
+
+	got, err := entry.user()
+
+	require.NoError(t, err, "the root entry is expected, not a failure")
+	assert.Nil(t, got)
+	assert.NotZero(t, entry.User.State&plugin.StateIsSet, "the field must be marked resolved")
+	assert.NotZero(t, entry.User.State&plugin.StateIsNull, "the field must be marked null")
+}
+
+// isRoot is how a caller selects that entry, so it has to agree with the branch
+// user() takes.
+func TestCredentialReportIsRootAgreesWithTheUserBranch(t *testing.T) {
+	root := reportEntry(map[string]any{"user": "<root_account>"})
+	isRoot, err := root.isRoot()
+	require.NoError(t, err)
+	assert.True(t, isRoot)
+
+	human := reportEntry(map[string]any{"user": "andre"})
+	isRoot, err = human.isRoot()
+	require.NoError(t, err)
+	assert.False(t, isRoot)
+}
+
+// A report we could not read at all is still an error: that is a genuine failure
+// rather than an entry with nothing to resolve.
+func TestCredentialReportUnreadableReportStillErrors(t *testing.T) {
+	entry := reportEntry(nil)
+
+	_, err := entry.user()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not read the credentials report")
+}
+
+// An entry whose user column is missing or not a string is malformed input, not
+// the root account, and must not be quietly treated as null.
+func TestCredentialReportMalformedUserStillErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		props map[string]any
+	}{
+		{name: "no user column", props: map[string]any{"arn": "arn:aws:iam::1:user/x"}},
+		{name: "user is not a string", props: map[string]any{"user": 42}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := reportEntry(tc.props)
+
+			_, err := entry.user()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no user")
+		})
+	}
+}


### PR DESCRIPTION
`aws.iam.credentialReport` returned nothing at all on every AWS account.

The root account always appears in the credential report as `<root_account>`, and
there is no IAM user behind it. The `user` accessor recognised that — the comment
reads *"handle special case for the root account since that user does not
exist"* — and then returned an error, which is the opposite of handling it.

Because a field error renders as the value of the enclosing collection, the whole
report went with it:

```
before  aws.iam { credentialReport { arn user } }
        -> the entire credentialReport value replaced by "root user does not exist"

after   [{"arn":"...:root","user":null},
         {"arn":"...:user/andre","user":{"name":"andre", ...}}, ...]
```

Every root-MFA, password-policy, and key-rotation check reads this resource, so
all of them were unrunnable. The resource already models the entry as legitimate
via `isRoot`, so null is the answer the schema implies; the `.lr` comment now says
so explicitly.

Only the root branch changes. An unreadable report and a malformed `user` column
still error, because those are genuine failures rather than an entry with nothing
to resolve.

Tests construct the entry directly — the root branch returns before any
`NewResource` call, so no runtime is needed — and cover the root entry (null, with
both state bits set), that `isRoot` agrees with the branch `user()` takes, and
that the unreadable-report and malformed-user paths still error.
