### PR TITLE
🐛 aws: resolve a KMS alias instead of building an invalid key ARN

### DIFF
--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -233,9 +233,7 @@ func (a *mqlAwsDynamodbExport) kmsKey() (*mqlAwsKmsKey, error) {
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	mqlKey, err := NewResource(a.MqlRuntime, "aws.kms.key",
-		map[string]*llx.RawData{
-			"arn": llx.StringData(fmt.Sprintf(kmsKeyArnPattern, a.region, conn.AccountId(), convert.ToValue(exp.S3SseKmsKeyId))),
-		})
+		kmsKeyRefArgs(a.region, conn.AccountId(), convert.ToValue(exp.S3SseKmsKeyId)))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -68,6 +68,30 @@ func NormalizeKmsKeyRef(s, region, accountId string) (arn.ARN, error) {
 	}, nil
 }
 
+// kmsKeyRefArgs builds the NewResource arguments for a reference to a KMS key.
+//
+// Services report their key in several shapes: a full key ARN, a full alias ARN,
+// a bare key id, or a bare alias such as "alias/aws/sqs" - which is what SQS and
+// SSM Parameter Store return for a resource encrypted with the service's default
+// key. initAwsKmsKey normalizes all of them, so a reference already in one of
+// those forms is passed through untouched.
+//
+// Only a bare key id is wrapped in kmsKeyArnPattern, because neither the region
+// nor the account is recoverable from the id alone. Wrapping unconditionally
+// produced "arn:aws:kms:<region>:<account>:key/alias/aws/sqs", which is not a KMS
+// ARN, and DescribeKey rejected it with "Invalid keyId alias/aws/sqs" - so the
+// key reference errored for every default-encrypted queue and parameter.
+func kmsKeyRefArgs(region, accountID, keyRef string) map[string]*llx.RawData {
+	ref := keyRef
+	if !strings.HasPrefix(ref, "arn:") && !strings.HasPrefix(ref, kmsAliasResourcePrefix) {
+		ref = fmt.Sprintf(kmsKeyArnPattern, region, accountID, ref)
+	}
+	return map[string]*llx.RawData{
+		"arn":    llx.StringData(ref),
+		"region": llx.StringData(region),
+	}
+}
+
 func isKmsKeyID(s string) bool {
 	return isUUIDKeyID(s) || isMultiRegionKeyID(s)
 }

--- a/providers/aws/resources/aws_kms_keyref_test.go
+++ b/providers/aws/resources/aws_kms_keyref_test.go
@@ -1,0 +1,92 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func kmsRef(t *testing.T, region, account, keyRef string) (string, string) {
+	t.Helper()
+	args := kmsKeyRefArgs(region, account, keyRef)
+	require.Contains(t, args, "arn")
+	require.Contains(t, args, "region", "the init needs the region to resolve an alias")
+	return args["arn"].Value.(string), args["region"].Value.(string)
+}
+
+func TestKmsKeyRefArgs(t *testing.T) {
+	const (
+		region  = "us-east-1"
+		account = "111122223333"
+	)
+
+	for _, tc := range []struct {
+		name    string
+		keyRef  string
+		wantArn string
+	}{
+		{
+			// The shape that was broken: SQS and SSM Parameter Store report the
+			// service default key as a bare alias, and wrapping it produced
+			// "...:key/alias/aws/sqs", which DescribeKey rejects.
+			name:    "bare alias is passed through",
+			keyRef:  "alias/aws/sqs",
+			wantArn: "alias/aws/sqs",
+		},
+		{
+			name:    "customer alias is passed through",
+			keyRef:  "alias/my-app",
+			wantArn: "alias/my-app",
+		},
+		{
+			name:    "bare key id gets the region and account it cannot carry",
+			keyRef:  "5fcdd4f3-26dc-40c8-a3cb-02007dfb8996",
+			wantArn: "arn:aws:kms:us-east-1:111122223333:key/5fcdd4f3-26dc-40c8-a3cb-02007dfb8996",
+		},
+		{
+			name:    "multi-region key id gets the pattern too",
+			keyRef:  "mrk-1234567890abcdef1234567890abcdef",
+			wantArn: "arn:aws:kms:us-east-1:111122223333:key/mrk-1234567890abcdef1234567890abcdef",
+		},
+		{
+			name:    "full key arn is passed through",
+			keyRef:  "arn:aws:kms:eu-west-1:999988887777:key/5fcdd4f3-26dc-40c8-a3cb-02007dfb8996",
+			wantArn: "arn:aws:kms:eu-west-1:999988887777:key/5fcdd4f3-26dc-40c8-a3cb-02007dfb8996",
+		},
+		{
+			name:    "full alias arn is passed through",
+			keyRef:  "arn:aws:kms:eu-west-1:999988887777:alias/aws/sqs",
+			wantArn: "arn:aws:kms:eu-west-1:999988887777:alias/aws/sqs",
+		},
+		{
+			name:    "a GovCloud arn keeps its partition",
+			keyRef:  "arn:aws-us-gov:kms:us-gov-west-1:999988887777:key/abc",
+			wantArn: "arn:aws-us-gov:kms:us-gov-west-1:999988887777:key/abc",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotArn, gotRegion := kmsRef(t, region, account, tc.keyRef)
+			assert.Equal(t, tc.wantArn, gotArn)
+			assert.Equal(t, region, gotRegion)
+		})
+	}
+}
+
+// Pin the specific malformed shape this fixes, so a regression that reintroduces
+// the unconditional wrap fails here.
+func TestKmsKeyRefArgsNeverNestsAnAliasUnderKey(t *testing.T) {
+	for _, alias := range []string{
+		"alias/aws/sqs",
+		"alias/aws/ssm",
+		"alias/aws/dynamodb",
+		"arn:aws:kms:us-east-1:111122223333:alias/aws/s3",
+	} {
+		gotArn, _ := kmsRef(t, "us-east-1", "111122223333", alias)
+		assert.NotContains(t, gotArn, ":key/alias/",
+			"an alias must never be wrapped as a key resource")
+	}
+}

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -439,14 +438,9 @@ func (a *mqlAwsSecretsmanagerSecretVersion) kmsKeys() ([]any, error) {
 		if keyID == "DefaultEncryptionKey" {
 			continue
 		}
-		// KmsKeyIds may already be full ARNs or bare key ids; build an ARN from
-		// the version's region + account only when it isn't one already.
-		arnStr := keyID
-		if !strings.HasPrefix(keyID, "arn:") {
-			arnStr = fmt.Sprintf(kmsKeyArnPattern, a.region, a.accountID, keyID)
-		}
+		// KmsKeyIds may be full ARNs, bare key ids, or aliases.
 		mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
-			map[string]*llx.RawData{"arn": llx.StringData(arnStr)})
+			kmsKeyRefArgs(a.region, a.accountID, keyID))
 		if err != nil {
 			return nil, err
 		}

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -269,9 +269,7 @@ func (a *mqlAwsSqsQueue) kmsKey() (*mqlAwsKmsKey, error) {
 	id := atts["KmsMasterKeyId"]
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	mqlKey, err := NewResource(a.MqlRuntime, "aws.kms.key",
-		map[string]*llx.RawData{
-			"arn": llx.StringData(fmt.Sprintf(kmsKeyArnPattern, a.Region.Data, conn.AccountId(), id)),
-		})
+		kmsKeyRefArgs(a.Region.Data, conn.AccountId(), id))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/aws/resources/aws_ssm.go
+++ b/providers/aws/resources/aws_ssm.go
@@ -152,9 +152,7 @@ func (a *mqlAwsSsmParameter) kmsKey() (*mqlAwsKmsKey, error) {
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	mqlKey, err := NewResource(a.MqlRuntime, "aws.kms.key",
-		map[string]*llx.RawData{
-			"arn": llx.StringData(fmt.Sprintf(kmsKeyArnPattern, a.region, conn.AccountId(), convert.ToValue(a.parameterCache.KeyId))),
-		})
+		kmsKeyRefArgs(a.region, conn.AccountId(), convert.ToValue(a.parameterCache.KeyId)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`aws.sqs.queue.kmsKey` errored on every queue encrypted with the SQS default key,
which is the ordinary configuration.

SQS reports `KmsMasterKeyId` as an **alias** (`alias/aws/sqs`), not a key id. The
accessor wrapped it in `kmsKeyArnPattern` (`arn:aws:kms:%s:%s:key/%s`), producing

```
arn:aws:kms:us-east-1:<account>:key/alias/aws/sqs
```

which is not a KMS ARN. `initAwsKmsKey` could not take its alias branch — the
resource part is `key/alias/...`, not `alias/...` — and `DescribeKey` rejected it:

```
before  kmsKey: 1 error occurred:
        * KMS: DescribeKey ... NotFoundException: Invalid keyId alias/aws/sqs

after   kmsKey: {"arn":"arn:aws:kms:us-east-1:<acct>:key/0f4d7c60-...","keyManager":"AWS"}
```

The resolved key matches `aws kms describe-key --key-id alias/aws/sqs` exactly.

`initAwsKmsKey` already normalizes a full key ARN, a full alias ARN, a bare key
id, **and** a bare alias, so the fix is to stop pre-wrapping and let it do that.
Only a bare key id still gets the pattern, because neither the region nor the
account is recoverable from the id alone. The region is passed alongside, since
the init needs it to resolve an alias.

Four call sites had the same exposure and now share one `kmsKeyRefArgs` helper:

- `aws.sqs.queue.kmsKey` — confirmed broken live (alias)
- `aws.ssm.parameter.kmsKey` — `ParameterMetadata.KeyId` is documented as *"The
  **alias** of the KMS key used to encrypt the parameter"*, so every
  default-encrypted `SecureString` hits it
- `aws.dynamodb.export.kmsKey` — `S3SseKmsKeyId` accepts an id, ARN, alias name or
  alias ARN
- `aws.secretsmanager.secret.version` — handled ARNs but not aliases

`aws_kinesis.go` already resolved aliases explicitly and is left alone.

Tests cover the builder across all six reference shapes (bare alias, customer
alias, bare key id, multi-region key id, full key ARN, full alias ARN, GovCloud
partition), that the region is always passed, and a dedicated case pinning that an
alias is never nested under `key/`.
