### PR TITLE
🐛 aws: report no detail for the built-in Athena data catalog

### DIFF
--- a/providers/aws/resources/aws_athena.go
+++ b/providers/aws/resources/aws_athena.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	athena_types "github.com/aws/aws-sdk-go-v2/service/athena/types"
+	"github.com/aws/smithy-go"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -489,8 +491,12 @@ func newMqlAwsAthenaDataCatalog(runtime *plugin.Runtime, region string, catalog 
 type mqlAwsAthenaDataCatalogInternal struct {
 	fetchedDetail bool
 	cachedDesc    string
-	cachedParams  map[string]any
-	lock          sync.Mutex
+	// detailUnavailable records that GetDataCatalog has nothing to describe for
+	// this catalog, so the detail fields report null rather than a fabricated
+	// empty value.
+	detailUnavailable bool
+	cachedParams      map[string]any
+	lock              sync.Mutex
 }
 
 const athenaDataCatalogArnPattern = "arn:aws:athena:%s:%s:datacatalog/%s"
@@ -498,6 +504,28 @@ const athenaDataCatalogArnPattern = "arn:aws:athena:%s:%s:datacatalog/%s"
 func (a *mqlAwsAthenaDataCatalog) arn() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	return fmt.Sprintf(athenaDataCatalogArnPattern, a.Region.Data, conn.AccountId(), a.Name.Data), nil
+}
+
+// athenaCatalogHasNoDetail reports the catalogs that ListDataCatalogs returns but
+// GetDataCatalog refuses to describe.
+//
+// AwsDataCatalog is the built-in Glue-backed catalog present in every account and
+// every region. Athena lists it and then answers GetDataCatalog for it with
+// InvalidRequestException "DataCatalog AwsDataCatalog was not found", so the
+// detail fields simply do not exist for it. Treating that as an error made
+// description, parameters and lambdaFunction fail on a catalog every account has.
+//
+// The match is narrow on purpose: an InvalidRequestException that does not say
+// the catalog was not found is a real error and still propagates.
+func athenaCatalogHasNoDetail(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.ErrorCode() != "InvalidRequestException" {
+		return false
+	}
+	return strings.Contains(apiErr.ErrorMessage(), "was not found")
 }
 
 func (a *mqlAwsAthenaDataCatalog) fetchDetail() error {
@@ -518,6 +546,13 @@ func (a *mqlAwsAthenaDataCatalog) fetchDetail() error {
 		Name: &name,
 	})
 	if err != nil {
+		if athenaCatalogHasNoDetail(err) {
+			// There is nothing to describe, which is not a failure. Leave the
+			// detail fields null and stop retrying.
+			a.detailUnavailable = true
+			a.fetchedDetail = true
+			return nil
+		}
 		return err
 	}
 	if resp.DataCatalog != nil {
@@ -538,12 +573,20 @@ func (a *mqlAwsAthenaDataCatalog) description() (string, error) {
 	if err := a.fetchDetail(); err != nil {
 		return "", err
 	}
+	if a.detailUnavailable {
+		a.Description.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
 	return a.cachedDesc, nil
 }
 
 func (a *mqlAwsAthenaDataCatalog) parameters() (map[string]any, error) {
 	if err := a.fetchDetail(); err != nil {
 		return nil, err
+	}
+	if a.detailUnavailable {
+		a.Parameters.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 	return a.cachedParams, nil
 }

--- a/providers/aws/resources/aws_athena_catalog_test.go
+++ b/providers/aws/resources/aws_athena_catalog_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func athenaAPIErr(code, message string) error {
+	return &smithy.GenericAPIError{Code: code, Message: message}
+}
+
+func TestAthenaCatalogHasNoDetail(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The exact response AwsDataCatalog gives, in every account and
+			// every region.
+			name: "the built-in catalog cannot be described",
+			err: athenaAPIErr("InvalidRequestException",
+				"DataCatalog AwsDataCatalog was not found. Please check your account settings"),
+			want: true,
+		},
+		{
+			name: "a user catalog that was deleted mid-read",
+			err:  athenaAPIErr("InvalidRequestException", "DataCatalog my_catalog was not found"),
+			want: true,
+		},
+		{
+			// Same code, different meaning: this one is a real error and must
+			// still surface.
+			name: "a malformed request is still an error",
+			err: athenaAPIErr("InvalidRequestException",
+				"1 validation error detected: Value at 'name' failed to satisfy constraint"),
+			want: false,
+		},
+		{
+			name: "access denied is still an error",
+			err:  athenaAPIErr("AccessDeniedException", "not authorized to perform athena:GetDataCatalog"),
+			want: false,
+		},
+		{
+			name: "a throttle is still an error",
+			err:  athenaAPIErr("ThrottlingException", "Rate exceeded"),
+			want: false,
+		},
+		{
+			// A transport failure carries no API error and must never be read as
+			// "this catalog has no detail".
+			name: "a transport error is not an api error",
+			err:  errors.New("dial tcp: lookup athena.us-east-1.amazonaws.com: no such host"),
+			want: false,
+		},
+		{
+			name: "nil is not a match",
+			err:  nil,
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, athenaCatalogHasNoDetail(tc.err))
+		})
+	}
+}
+
+// The classifier has to survive the wrapping the SDK and the provider apply on
+// the way back up.
+func TestAthenaCatalogHasNoDetailThroughWrapping(t *testing.T) {
+	base := athenaAPIErr("InvalidRequestException", "DataCatalog AwsDataCatalog was not found")
+
+	assert.True(t, athenaCatalogHasNoDetail(fmt.Errorf("could not describe catalog: %w", base)))
+	assert.True(t, athenaCatalogHasNoDetail(fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", base))))
+}


### PR DESCRIPTION
`AwsDataCatalog` is the built-in Glue-backed Athena catalog present in every
account and every region. `ListDataCatalogs` returns it, and `GetDataCatalog`
then refuses to describe it:

```
InvalidRequestException: DataCatalog AwsDataCatalog was not found
```

`fetchDetail` propagated that, so `description`, `parameters` and
`lambdaFunction` errored on a catalog every account has — and in the parent-block
form the field error renders as the value of the whole collection, taking
`aws.athena.dataCatalogs` with it.

```
before  description: "Error: ... InvalidRequestException: DataCatalog AwsDataCatalog was not found."
        parameters:  "Error: ... (same)"

after   {"name":"AwsDataCatalog","type":"GLUE","description":null,"parameters":null}
```

There genuinely is no detail to report for that catalog, so the fields are null
rather than an error or a fabricated empty value, and the lookup is not retried.

The classifier is deliberately narrow: it matches `InvalidRequestException` only
when the message says the catalog was not found. The same code covers real
errors — a validation failure on a malformed request still propagates, as do
access-denied, throttling, and transport errors, none of which may be read as
"this catalog has no detail".

Tests cover the exact live message, a user catalog deleted mid-read, and the
must-not-match cases: a validation `InvalidRequestException`, `AccessDenied`,
`Throttling`, a transport error carrying no API error at all, and nil — plus that
the classifier still matches through the wrapping applied on the way back up.
