### PR TITLE
🐛 llx: escape error values in JSON output

### DIFF
--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -120,7 +120,18 @@ func refMapJSON(typ types.Type, data map[string]any, codeID string, bundle *Code
 
 		val := v.(*RawData)
 		if val.Error != nil {
-			buf.WriteString(PrettyPrintString("Error: " + val.Error.Error()))
+			// PrettyPrintString un-escapes \n and \t back into real control
+			// characters, which is what the terminal printer wants and what JSON
+			// forbids inside a string (RFC 8259 section 7). Multi-line errors are
+			// routine here - a multierror renders as "N errors occurred:\n\t* ..."
+			// whenever more than one element of a collection fails - so using it
+			// made the whole document unparseable. Encode the error the same way
+			// every other string in this writer is encoded.
+			str, err := string2json("Error: " + val.Error.Error())
+			if err != nil {
+				return err
+			}
+			buf.WriteString(str)
 		} else {
 			err = rawDataJSON(val.Type, val.Value, k, bundle, buf)
 			if err != nil {

--- a/llx/rawdata_json_test.go
+++ b/llx/rawdata_json_test.go
@@ -6,6 +6,7 @@ package llx
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -160,5 +161,74 @@ func TestRawDataJson_refMapJSON_collidingLabels(t *testing.T) {
 			}
 			require.Equal(t, len(tc.data), len(seen), "every entry must be present in JSON: %s", buf.String())
 		})
+	}
+}
+
+// An error value used to be written with PrettyPrintString, which un-escapes \n
+// and \t back into real control characters. JSON forbids those inside a string
+// (RFC 8259 section 7), so any multi-line error made the whole document
+// unparseable - and multi-line is the common case, since a multierror renders as
+// "N errors occurred:\n\t* ..." whenever more than one element of a collection
+// fails.
+func TestRawDataJson_errorValuesAreEscaped(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "single line error",
+			err:  errors.New("operation error IAM: GetRole, NoSuchEntity"),
+		},
+		{
+			// The shape a multierror produces, which is what broke this.
+			name: "multierror with newline and tab",
+			err:  errors.New("2 errors occurred:\n\t* subnet not found\n\t* role not found"),
+		},
+		{
+			name: "carriage return",
+			err:  errors.New("line one\rline two"),
+		},
+		{
+			name: "embedded quotes and backslashes",
+			err:  errors.New(`the role "x\y" cannot be found`),
+		},
+		{
+			name: "other control characters",
+			err:  errors.New("bell\x07 and null-ish\x1f"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := &CodeBundle{Labels: &Labels{Labels: map[string]string{"e": "thing"}}}
+			data := map[string]any{"e": &RawData{Type: types.String, Error: tc.err}}
+
+			var buf bytes.Buffer
+			require.NoError(t, refMapJSON(types.Block, data, "", bundle, &buf))
+			require.True(t, json.Valid(buf.Bytes()),
+				"output is not valid JSON: %q", buf.String())
+
+			// the message must survive intact, not just be escaped away
+			var out map[string]string
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+			require.Equal(t, "Error: "+tc.err.Error(), out["thing"])
+		})
+	}
+}
+
+// Guard the specific byte-level rule: no raw control character may appear in the
+// output, whatever the error contains.
+func TestRawDataJson_errorValuesCarryNoRawControlBytes(t *testing.T) {
+	bundle := &CodeBundle{Labels: &Labels{Labels: map[string]string{"e": "thing"}}}
+	data := map[string]any{
+		"e": &RawData{Type: types.String, Error: errors.New("a\n\tb\rc")},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, refMapJSON(types.Block, data, "", bundle, &buf))
+
+	for i, b := range buf.Bytes() {
+		require.Greater(t, b, byte(0x1f),
+			"raw control byte %#x at offset %d in %q", b, i, buf.String())
 	}
 }


### PR DESCRIPTION
`mql run -j` emitted **invalid JSON** whenever a field carried a multi-line error,
which made the whole document unparseable for any consumer.

`rawDataJSON` wrote error values with `PrettyPrintString`, which deliberately
un-escapes `\n` and `\t` back into real control characters. That is exactly right
for the terminal printer — the other three callers are terminal printers and are
untouched — but JSON forbids unescaped control characters inside a string
(RFC 8259 §7). Every other string in this writer already goes through
`string2json`; the error path was the one exception.

Multi-line errors are not an edge case. A multierror renders as
`"N errors occurred:\n\t* ..."`, which is what you get whenever more than one
element of a collection fails — a routine outcome for any cloud query touching
several resources.

Found while auditing the AWS provider. Reproduced with a CloudTrail query where
two references fail:

```
before  $ mql run aws -j -c 'aws.cloudtrail { trails { cloudWatchLogsRole { arn } kmsKey { arn } } }'
        raw control bytes in payload: [0x09, 0x0a]
        json.loads -> Invalid control character at line 1 column 55

after   raw control bytes in payload: []
        json.loads -> valid
```

Tests assert the output is valid JSON and that the message survives intact
(escaped, not stripped) for a single-line error, a multierror carrying `\n` and
`\t`, a carriage return, embedded quotes and backslashes, and assorted other
control characters — plus a byte-level check that no raw control byte reaches the
output at all. The multi-line cases fail against the previous implementation and
the single-line ones pass either way, so the tests discriminate rather than merely
cover.
