### PR TITLE
🐛 aws: keep the CloudTrail trails when a referenced role is deleted

### DIFF
--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -218,7 +218,13 @@ func (a *mqlAwsCloudtrailTrail) snsTopic() (*mqlAwsSnsTopic, error) {
 		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.trailCache.SnsTopicARN)},
 	)
 	if err != nil {
-		return nil, err
+		// A trail keeps naming a topic after the topic is deleted. Report the
+		// reference as null rather than failing the field, which would render as
+		// the value of the whole trails collection.
+		log.Warn().Err(err).Str("topic", convert.ToValue(a.trailCache.SnsTopicARN)).
+			Msg("cannot resolve the trail's sns topic")
+		a.SnsTopic.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 	return mqlTopic.(*mqlAwsSnsTopic), nil
 }
@@ -232,7 +238,11 @@ func (a *mqlAwsCloudtrailTrail) cloudWatchLogsRole() (*mqlAwsIamRole, error) {
 		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.trailCache.CloudWatchLogsRoleArn)},
 	)
 	if err != nil {
-		return nil, err
+		// A trail keeps naming its delivery role after the role is deleted.
+		log.Warn().Err(err).Str("role", convert.ToValue(a.trailCache.CloudWatchLogsRoleArn)).
+			Msg("cannot resolve the trail's cloudwatch logs role")
+		a.CloudWatchLogsRole.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 	return mqlRole.(*mqlAwsIamRole), nil
 }
@@ -905,7 +915,12 @@ func (a *mqlAwsCloudtrailEventDataStore) federationRole() (*mqlAwsIamRole, error
 			"arn": llx.StringDataPtr(detail.FederationRoleArn),
 		})
 	if err != nil {
-		return nil, err
+		// An event data store keeps naming its federation role after the role is
+		// deleted.
+		log.Warn().Err(err).Str("role", convert.ToValue(detail.FederationRoleArn)).
+			Msg("cannot resolve the event data store's federation role")
+		a.FederationRole.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 	return mqlRole.(*mqlAwsIamRole), nil
 }

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 
+	"github.com/aws/smithy-go"
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -209,6 +210,36 @@ func (a *mqlAwsCloudtrail) getTrails(conn *connection.AwsConnection) []*jobpool.
 	return tasks
 }
 
+// referencedResourceUnavailable reports an error that a retry will not change:
+// the referenced resource is gone, or this caller may not read it.
+//
+// A trail keeps naming a role, topic, bucket, log group or key after that target
+// is deleted, and a scan may legitimately lack permission to read it. Both are
+// permanent for this scan, so the reference is reported as null rather than
+// failing the field - which, because a field error renders as the value of the
+// enclosing collection, would cost the caller every trail.
+//
+// A throttle, a 5xx or a network failure is deliberately excluded. There the
+// target may well exist and simply could not be resolved right now, so reporting
+// null would assert an absence that was never established.
+func referencedResourceUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if Is400AccessDeniedError(err) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "NoSuchEntity", "NotFound", "NotFoundException", "ResourceNotFoundException":
+		return true
+	}
+	return false
+}
+
 func (a *mqlAwsCloudtrailTrail) snsTopic() (*mqlAwsSnsTopic, error) {
 	if a.trailCache.SnsTopicARN == nil || *a.trailCache.SnsTopicARN == "" {
 		a.SnsTopic.State = plugin.StateIsSet | plugin.StateIsNull
@@ -218,9 +249,9 @@ func (a *mqlAwsCloudtrailTrail) snsTopic() (*mqlAwsSnsTopic, error) {
 		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.trailCache.SnsTopicARN)},
 	)
 	if err != nil {
-		// A trail keeps naming a topic after the topic is deleted. Report the
-		// reference as null rather than failing the field, which would render as
-		// the value of the whole trails collection.
+		if !referencedResourceUnavailable(err) {
+			return nil, err
+		}
 		log.Warn().Err(err).Str("topic", convert.ToValue(a.trailCache.SnsTopicARN)).
 			Msg("cannot resolve the trail's sns topic")
 		a.SnsTopic.State = plugin.StateIsSet | plugin.StateIsNull
@@ -238,7 +269,9 @@ func (a *mqlAwsCloudtrailTrail) cloudWatchLogsRole() (*mqlAwsIamRole, error) {
 		map[string]*llx.RawData{"arn": llx.StringDataPtr(a.trailCache.CloudWatchLogsRoleArn)},
 	)
 	if err != nil {
-		// A trail keeps naming its delivery role after the role is deleted.
+		if !referencedResourceUnavailable(err) {
+			return nil, err
+		}
 		log.Warn().Err(err).Str("role", convert.ToValue(a.trailCache.CloudWatchLogsRoleArn)).
 			Msg("cannot resolve the trail's cloudwatch logs role")
 		a.CloudWatchLogsRole.State = plugin.StateIsSet | plugin.StateIsNull
@@ -254,9 +287,12 @@ func (a *mqlAwsCloudtrailTrail) s3bucket() (*mqlAwsS3Bucket, error) {
 		)
 		if err == nil {
 			return mqlBucket.(*mqlAwsS3Bucket), nil
-		} else {
-			log.Error().Err(err).Msg("cannot get s3 bucket")
 		}
+		if !referencedResourceUnavailable(err) {
+			return nil, err
+		}
+		log.Warn().Err(err).Str("bucket", convert.ToValue(a.trailCache.S3BucketName)).
+			Msg("cannot resolve the trail's s3 bucket")
 	}
 	a.S3bucket.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil
@@ -269,9 +305,12 @@ func (a *mqlAwsCloudtrailTrail) logGroup() (*mqlAwsCloudwatchLoggroup, error) {
 		)
 		if err == nil {
 			return mqlLoggroup.(*mqlAwsCloudwatchLoggroup), nil
-		} else {
-			log.Error().Err(err).Msg("cannot get log group")
 		}
+		if !referencedResourceUnavailable(err) {
+			return nil, err
+		}
+		log.Warn().Err(err).Str("logGroup", convert.ToValue(a.trailCache.CloudWatchLogsLogGroupArn)).
+			Msg("cannot resolve the trail's log group")
 	}
 	a.LogGroup.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil
@@ -285,9 +324,12 @@ func (a *mqlAwsCloudtrailTrail) kmsKey() (*mqlAwsKmsKey, error) {
 		)
 		if err == nil {
 			return mqlKeyResource.(*mqlAwsKmsKey), nil
-		} else {
-			log.Error().Err(err).Msg("could not create KMS key resource")
 		}
+		if !referencedResourceUnavailable(err) {
+			return nil, err
+		}
+		log.Warn().Err(err).Str("key", convert.ToValue(a.trailCache.KmsKeyId)).
+			Msg("cannot resolve the trail's kms key")
 	}
 	a.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil
@@ -915,8 +957,9 @@ func (a *mqlAwsCloudtrailEventDataStore) federationRole() (*mqlAwsIamRole, error
 			"arn": llx.StringDataPtr(detail.FederationRoleArn),
 		})
 	if err != nil {
-		// An event data store keeps naming its federation role after the role is
-		// deleted.
+		if !referencedResourceUnavailable(err) {
+			return nil, err
+		}
 		log.Warn().Err(err).Str("role", convert.ToValue(detail.FederationRoleArn)).
 			Msg("cannot resolve the event data store's federation role")
 		a.FederationRole.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/aws/resources/aws_cloudtrail_refs_test.go
+++ b/providers/aws/resources/aws_cloudtrail_refs_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+)
+
+// trailDeniedErr builds the 403 shape Is400AccessDeniedError matches. apiErr
+// itself is the shared helper from aws_disposition_test.go.
+func trailDeniedErr() error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: 403}},
+			Err:      apiErr("AccessDenied", "not authorized to perform iam:GetRole"),
+		},
+	}
+}
+
+func TestReferencedResourceUnavailable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The case this fix exists for: a trail keeps naming a role that has
+			// been deleted.
+			name: "deleted iam role",
+			err:  apiErr("NoSuchEntity", "The role with name CloudTrailRoleForCloudWatchLogs cannot be found."),
+			want: true,
+		},
+		{
+			name: "deleted sns topic",
+			err:  apiErr("NotFoundException", "Topic does not exist"),
+			want: true,
+		},
+		{
+			name: "deleted log group",
+			err:  apiErr("ResourceNotFoundException", "The specified log group does not exist"),
+			want: true,
+		},
+		{
+			name: "not found",
+			err:  apiErr("NotFound", "not found"),
+			want: true,
+		},
+		{
+			name: "access denied is permanent for this scan",
+			err:  trailDeniedErr(),
+			want: true,
+		},
+
+		// Everything below may resolve on a retry, so reporting the reference as
+		// null would assert an absence that was never established.
+		{
+			name: "throttling must not look like an absent reference",
+			err:  apiErr("ThrottlingException", "Rate exceeded"),
+			want: false,
+		},
+		{
+			name: "a service fault must not look like an absent reference",
+			err:  apiErr("InternalFailure", "internal service error"),
+			want: false,
+		},
+		{
+			name: "a network failure carries no api error",
+			err:  errors.New("dial tcp: lookup iam.amazonaws.com: no such host"),
+			want: false,
+		},
+		{
+			name: "retry exhaustion must not look like an absent reference",
+			err:  errors.New("exceeded maximum number of attempts, 3, request send failed"),
+			want: false,
+		},
+		{
+			name: "nil is not a match",
+			err:  nil,
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, referencedResourceUnavailable(tc.err))
+		})
+	}
+}
+
+// The error travels back through NewResource and the init, so the classifier has
+// to see through wrapping.
+func TestReferencedResourceUnavailableThroughWrapping(t *testing.T) {
+	gone := apiErr("NoSuchEntity", "The role cannot be found")
+	assert.True(t, referencedResourceUnavailable(
+		fmt.Errorf("could not resolve reference: %w", gone)))
+
+	transient := apiErr("ThrottlingException", "Rate exceeded")
+	assert.False(t, referencedResourceUnavailable(
+		fmt.Errorf("could not resolve reference: %w", transient)))
+}


### PR DESCRIPTION
A CloudTrail trail keeps naming its CloudWatch Logs delivery role after that role
is deleted — ordinary account state, not a failure. `cloudWatchLogsRole`
propagated the resulting `NoSuchEntity`, and because a field error renders as the
value of the enclosing collection, `aws.cloudtrail.trails` returned nothing:

```
before  aws.cloudtrail { trails { name cloudWatchLogsRole { arn } } }
        -> the whole trails value replaced by
           "operation error IAM: GetRole ... NoSuchEntity: The role with name
            CloudTrailRoleForCloudWatchLogs cannot be found."

after   {"trails":[{"name":"organizational-trail","cloudWatchLogsRole":null,
                    "kmsKey":{"arn":"..."},"s3bucket":{"name":"..."}}]}
```

CloudTrail is the resource an audit reaches for first, so losing it entirely to
one deleted role is expensive.

**Not every failure is an absent reference.** Three accessors in this file
(`s3bucket`, `logGroup`, `kmsKey`) already degraded, but they degraded on *any*
error — so a throttle or a 5xx also reported the reference as null, asserting an
absence that was never established. All six accessors now classify first:

- **gone or unreadable** — `NoSuchEntity`, `NotFound`, `NotFoundException`,
  `ResourceNotFoundException`, or access denied. Permanent for this scan, so the
  reference is null and the trail survives.
- **anything else** — throttling, a service fault, a network failure, retry
  exhaustion. The target may well exist and simply could not be resolved right
  now, so the error propagates rather than being laundered into "no role".

Six accessors covered: `trail.cloudWatchLogsRole` (confirmed live),
`trail.snsTopic`, `trail.s3bucket`, `trail.logGroup`, `trail.kmsKey`, and
`eventDataStore.federationRole`. Each logs the unresolvable ARN at warn level so
the reference is visible rather than silently dropped.

Tests cover the classifier across both directions: the four not-found codes and
the 403 access-denied shape must degrade; throttling, an internal service fault, a
DNS failure, retry exhaustion and nil must not — plus that the classification
survives the wrapping applied on the way back through `NewResource`. Verified live
afterwards that the deleted role still degrades to null while the trail's KMS key
and S3 bucket resolve normally, so narrowing the rule did not reintroduce the
original failure.
