### PR TITLE
🧹 ci: switch CLA action to marksalpeter/cla-assistant-action

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Mondoo CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: marksalpeter/cla-assistant-action@e980cbf75ae27b7b9d09c6b01f7c64a366cb1ccd # master, 2026-04-08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Mondoo CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # contributor-assistant/github-action is archived; using this trusted fork, pinned to a commit to avoid supply-chain risk.
         uses: marksalpeter/cla-assistant-action@e980cbf75ae27b7b9d09c6b01f7c64a366cb1ccd # master, 2026-04-08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -20,8 +20,17 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Mondoo CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # contributor-assistant/github-action is archived; using this trusted fork, pinned to a commit to avoid supply-chain risk.
-        uses: marksalpeter/cla-assistant-action@e980cbf75ae27b7b9d09c6b01f7c64a366cb1ccd # master, 2026-04-08
+        # Upstream contributor-assistant/github-action was archived in March 2026
+        # and takes no further fixes. marksalpeter/cla-assistant-action is a fork
+        # of that same SAP CLA Assistant Lite codebase and takes the identical
+        # inputs, so the swap is a drop-in.
+        #
+        # The fork publishes no tags or releases, so there is no version to pin
+        # to; the commit SHA below is the pin instead, which is what actually
+        # guards against the fork's history being rewritten under us. Re-verify
+        # the diff against upstream before advancing it.
+        # https://github.com/marksalpeter/cla-assistant-action
+        uses: marksalpeter/cla-assistant-action@e980cbf75ae27b7b9d09c6b01f7c64a366cb1ccd # master @ 2026-04-08
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Swap the CLA workflow's `uses:` from `contributor-assistant/github-action` to `marksalpeter/cla-assistant-action`, a fork of the same SAP CLA Assistant Lite codebase.
- Inputs are unchanged (`path-to-signatures`, `path-to-document`, `remote-repository-name`, `remote-organization-name`, `branch`, `allowlist`, etc. are identical between the two).
- No tags/releases exist on the fork yet, so it's pinned to the current HEAD commit SHA on `master`.

## Test plan
- [ ] Confirm the CLA Assistant check still runs on this PR and posts/updates its status comment
- [ ] Confirm `recheck` comment handling still works