### PR TITLE
🐛 digitalocean: do not panic when a lookup returns no object

### DIFF
--- a/providers/digitalocean/resources/digitalocean_assets.go
+++ b/providers/digitalocean/resources/digitalocean_assets.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/digitalocean/godo"
@@ -241,6 +242,13 @@ func initDigitaloceanFirewall(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if err != nil {
 		return nil, nil, err
 	}
+	// godo returns the decoded root's field directly, so a 200 whose body
+	// carries no firewall yields a nil object with a nil error. Building the
+	// resource from it dereferences nil and panics the provider, which takes
+	// down the whole scan rather than this one resource.
+	if fw == nil {
+		return nil, nil, fmt.Errorf("digitalocean.firewall with id %q not found", id)
+	}
 	res, err := newMqlFirewall(runtime, fw)
 	if err != nil {
 		return nil, nil, err
@@ -357,6 +365,11 @@ func initDigitaloceanLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.
 	lb, _, err := conn.Client().LoadBalancers.Get(context.Background(), id)
 	if err != nil {
 		return nil, nil, err
+	}
+	// A nil object alongside a nil error, as above: report it as not found
+	// rather than dereferencing it in the arg builder.
+	if lb == nil {
+		return nil, nil, fmt.Errorf("digitalocean.loadBalancer with id %q not found", id)
 	}
 	res, err := newMqlLoadBalancer(runtime, lb)
 	if err != nil {
@@ -530,6 +543,10 @@ func initDigitaloceanKubernetesCluster(runtime *plugin.Runtime, args map[string]
 	c, _, err := conn.Client().Kubernetes.Get(context.Background(), id)
 	if err != nil {
 		return nil, nil, err
+	}
+	// A nil object alongside a nil error, as above.
+	if c == nil {
+		return nil, nil, fmt.Errorf("digitalocean.kubernetes.cluster with id %q not found", id)
 	}
 	res, err := newMqlKubernetesCluster(runtime, c)
 	if err != nil {

--- a/providers/digitalocean/resources/digitalocean_gradientai.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -283,6 +284,13 @@ func initDigitaloceanGradientaiAgent(runtime *plugin.Runtime, args map[string]*l
 	agent, _, err := conn.Client().GradientAI.GetAgent(context.Background(), uuid)
 	if err != nil {
 		return nil, nil, err
+	}
+	// GetAgent returns the decoded root's field, so a 200 carrying no agent
+	// yields a nil agent and a nil error. Passing it on hands the runtime a
+	// typed nil, which is not == nil once widened to plugin.Resource: the
+	// runtime accepts it and panics reading its id.
+	if agent == nil {
+		return nil, nil, fmt.Errorf("digitalocean.gradientai.agent with uuid %q not found", uuid)
 	}
 	res, err := newMqlGradientaiAgent(runtime, agent)
 	if err != nil {

--- a/providers/digitalocean/resources/digitalocean_init_notfound_test.go
+++ b/providers/digitalocean/resources/digitalocean_init_notfound_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+)
+
+// emptyBodyRuntime points a real connection at a server that answers every
+// request 200 with an empty JSON object.
+//
+// That is the shape these tests exist for. godo's Get methods end in
+// `return root.X, resp, err`, so a 200 whose body carries no "firewall" /
+// "load_balancer" / "kubernetes_cluster" / "agent" key decodes to a nil object
+// and a nil error. The caller sees success and a nil pointer.
+func emptyBodyRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("DIGITALOCEAN_TOKEN", "test-token")
+	conn, err := connection.NewDigitaloceanConnection(0, &inventory.Asset{},
+		&inventory.Config{Options: map[string]string{}})
+	require.NoError(t, err)
+
+	base, err := url.Parse(srv.URL + "/")
+	require.NoError(t, err)
+	conn.Client().BaseURL = base
+
+	return &plugin.Runtime{Connection: conn}
+}
+
+// Each init used to hand the fetched object straight to its constructor.
+//
+// For the firewall, load balancer and cluster that dereferences nil in the arg
+// builder. For the GradientAI agent the constructor returns a nil
+// *mqlDigitaloceanGradientaiAgent, which is not == nil once widened to
+// plugin.Resource, so the runtime accepts it and panics reading its id.
+//
+// Either way the provider panics, and a provider panic takes down the whole
+// scan rather than the one resource that triggered it. A not-found error is
+// what the caller should get instead.
+func TestInitReportsNotFoundInsteadOfPanicking(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		init func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+		args map[string]*llx.RawData
+		want string
+	}{
+		{
+			name: "firewall",
+			init: initDigitaloceanFirewall,
+			args: map[string]*llx.RawData{"id": llx.StringData("fw-1")},
+			want: `digitalocean.firewall with id "fw-1" not found`,
+		},
+		{
+			name: "load balancer",
+			init: initDigitaloceanLoadBalancer,
+			args: map[string]*llx.RawData{"id": llx.StringData("lb-1")},
+			want: `digitalocean.loadBalancer with id "lb-1" not found`,
+		},
+		{
+			name: "kubernetes cluster",
+			init: initDigitaloceanKubernetesCluster,
+			args: map[string]*llx.RawData{"id": llx.StringData("k8s-1")},
+			want: `digitalocean.kubernetes.cluster with id "k8s-1" not found`,
+		},
+		{
+			name: "gradientai agent",
+			init: initDigitaloceanGradientaiAgent,
+			args: map[string]*llx.RawData{"uuid": llx.StringData("agent-1")},
+			want: `digitalocean.gradientai.agent with uuid "agent-1" not found`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := emptyBodyRuntime(t)
+
+			require.NotPanics(t, func() {
+				_, res, err := tc.init(runtime, tc.args)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.want)
+
+				// The resource must be absent as an interface, not merely a nil
+				// pointer inside one: a typed nil satisfies `res != nil` and is
+				// exactly what the runtime would go on to panic reading.
+				assert.True(t, res == nil, "init returned a non-nil plugin.Resource alongside an error")
+			})
+		})
+	}
+}


### PR DESCRIPTION
godo's `Get` methods end in `return root.X, resp, err`, so a 200 response whose
body carries no object decodes to a **nil pointer alongside a nil error**. Four
single-resource inits handed that result straight to their constructor without
checking it.

The two failure modes differ, and the second is the quieter one:

| init | what happens today |
|---|---|
| `digitalocean.firewall` | `firewallArgs` dereferences `fw.Tags` → nil pointer panic |
| `digitalocean.loadBalancer` | `loadBalancerArgs` dereferences `lb.Tags` → nil pointer panic |
| `digitalocean.kubernetes.cluster` | `kubernetesClusterArgs` dereferences `c.Tags` → nil pointer panic |
| `digitalocean.gradientai.agent` | **no error at all** — returns a nil `*mqlDigitaloceanGradientaiAgent` |

That last one is the interesting case. A nil `*mqlDigitaloceanGradientaiAgent`
is not `== nil` once widened to `plugin.Resource`, so the init looks like it
succeeded, the runtime accepts the resource, and the panic lands later in
`MqlID()` reading `c.__id` off a nil receiver — with nothing left to point at
the init that produced it.

A provider runs as a separate gRPC subprocess, so either panic takes down the
**whole scan**, not just the resource that triggered it. Each init now reports
the object as not found, which is what the caller of a by-id lookup should get:

```
digitalocean.firewall with id "fw-1" not found
```

## Tests

`digitalocean_init_notfound_test.go` points a real connection at an httptest
server that answers every request `200 {}` — the exact shape that produces the
nil-object-with-nil-error — and asserts each init returns a not-found error
without panicking. It also asserts the returned `plugin.Resource` is `== nil`
as an interface, not merely a nil pointer inside one, since a typed nil is
precisely what the runtime would go on to panic reading.

Verified the tests actually catch the bug by disabling the four guards and
re-running: the firewall, load balancer and cluster cases fail with
`invalid memory address or nil pointer dereference`, and the GradientAI agent
case fails with `An error is expected but got nil` — each reproducing its own
failure mode rather than a shared one.

Full provider suite passes.
