### PR TITLE
🐛 digitalocean: stop reporting an unread Spaces bucket as a clean one

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -1869,33 +1869,74 @@ digitalocean.spacesBucket @defaults("name region encryptionEnabled versioningSta
   // and `hasWildcardPolicy`, which read the bucket ACL and policy
   // directly.
   publicAccessBlocked bool
-  // Whether the bucket ACL grants READ to the AllUsers group (anonymous read)
+  // Whether the bucket ACL grants READ to the AllUsers group
+  //
+  // Anonymous read. Null when the bucket ACL could not be read, either
+  // because the credentials are not allowed to read it or because the
+  // service does not implement the call, so an unread ACL is not
+  // mistaken for one that grants nothing.
   publicReadAcl bool
-  // Whether the bucket ACL grants WRITE to the AllUsers group (anonymous write, should always be false)
+  // Whether the bucket ACL grants WRITE to the AllUsers group
+  //
+  // Anonymous write, which should always be false. Null when the bucket
+  // ACL could not be read.
   publicWriteAcl bool
-  // Whether the bucket ACL grants READ to the AuthenticatedUsers group (any DO/AWS-compatible account can list)
+  // Whether the bucket ACL grants READ to the AuthenticatedUsers group
+  //
+  // That group covers every account on the platform rather than only this
+  // one, so such a grant lets any DigitalOcean or S3-compatible account
+  // list the bucket. Null when the bucket ACL could not be read.
   authenticatedReadAcl bool
-  // Raw ACL grants (each entry: granteeType, granteeUri, granteeDisplayName, permission)
+  // Raw ACL grants
+  //
+  // Each entry: granteeType, granteeUri, granteeDisplayName, permission.
+  // Null when the bucket ACL could not be read, as distinct from an empty
+  // list, which means the ACL was read and carries no grants.
   aclGrants []dict
   // Whether server-side encryption is configured on the bucket
+  //
+  // False when the service answered that nothing is configured, which is a
+  // real answer. Null when the encryption configuration could not be read
+  // at all, so an unread bucket is not reported as unencrypted.
   encryptionEnabled bool
-  // Default encryption algorithm ("AES256" or "aws:kms"); empty when encryption is not configured
+  // Default encryption algorithm
+  //
+  // Either "AES256" or "aws:kms". Empty when encryption is not configured,
+  // and null when the encryption configuration could not be read.
   encryptionAlgorithm string
   // KMS key id used for default encryption when `encryptionAlgorithm` is "aws:kms"
+  //
+  // Null when the encryption configuration could not be read.
   encryptionKmsKeyId string
-  // Versioning state ("Enabled", "Suspended"); empty when versioning has never been configured
+  // Versioning state
+  //
+  // Either "Enabled" or "Suspended", and empty when versioning has never
+  // been configured. Null when the versioning configuration could not be
+  // read, so an unread bucket is not reported as unversioned.
   versioningStatus string
   // Whether MFA delete is required for permanent version deletion
+  //
+  // Null when the versioning configuration could not be read.
   mfaDeleteEnabled bool
-  // Bucket policy JSON document; nil when no policy is set
+  // Bucket policy JSON document
+  //
+  // Null when no policy is set, and also when the policy could not be
+  // read. Use `hasWildcardPolicy`, which reports null in the second case
+  // rather than answering as though the policy were absent.
   policy dict
   // CORS rules configured on the bucket
   //
-  // Each entry: allowedHeaders, allowedMethods, allowedOrigins, exposeHeaders, maxAgeSeconds, id.
+  // Each entry: allowedHeaders, allowedMethods, allowedOrigins,
+  // exposeHeaders, maxAgeSeconds, id. Null when the CORS configuration
+  // could not be read, as distinct from an empty list, which means it was
+  // read and no rules are set.
   corsRules []dict
   // Lifecycle rules configured on the bucket
   //
-  // Each entry: id, status, prefix, expirationDays, noncurrentVersionExpirationDays, abortIncompleteMultipartUploadDays.
+  // Each entry: id, status, prefix, expirationDays,
+  // noncurrentVersionExpirationDays, abortIncompleteMultipartUploadDays.
+  // Null when the lifecycle configuration could not be read, as distinct
+  // from an empty list.
   lifecycleRules []dict
   // Whether the bucket's contents are reachable by anyone on the internet
   //
@@ -1906,13 +1947,20 @@ digitalocean.spacesBucket @defaults("name region encryptionEnabled versioningSta
   // public. Spaces has no block-public-access control to override those
   // grants, so on DigitalOcean the verdict rests on the ACL and the
   // policy alone.
+  //
+  // A grant that was read and is public settles the verdict as true
+  // whatever else could not be read. When nothing read says public but
+  // the ACL or the policy could not be read, the verdict is null rather
+  // than false, because clearing the bucket would rest on an answer
+  // nobody gave.
   isPublic() bool
   // Whether the bucket policy allows the wildcard principal
   //
   // True when any Allow statement in the bucket policy names "*" as its
   // principal, which grants the action to every requester. This describes
   // the policy alone; isPublic combines it with the ACL grants to say
-  // whether the bucket is actually reachable.
+  // whether the bucket is actually reachable. Null when the policy could
+  // not be read, which is not the same as a bucket that has no policy.
   hasWildcardPolicy() bool
 }
 

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -14127,7 +14127,7 @@ func (c *mqlDigitaloceanSpacesKey) GetCreatedAt() *plugin.TValue[*time.Time] {
 type mqlDigitaloceanSpacesBucket struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDigitaloceanSpacesBucketInternal it will be used here
+	mqlDigitaloceanSpacesBucketInternal
 	Name                 plugin.TValue[string]
 	Region               plugin.TValue[string]
 	CreatedAt            plugin.TValue[*time.Time]

--- a/providers/digitalocean/resources/digitalocean_exposure.go
+++ b/providers/digitalocean/resources/digitalocean_exposure.go
@@ -359,6 +359,11 @@ func (b *mqlDigitaloceanSpacesBucket) hasWildcardPolicy() (bool, error) {
 	if policy.Error != nil {
 		return false, policy.Error
 	}
+	// A policy that was never read is not a policy that grants nothing.
+	if !b.policyRead {
+		b.HasWildcardPolicy.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
 	return spacesPolicyGrantsWildcard(policy.Data), nil
 }
 
@@ -400,7 +405,27 @@ func (b *mqlDigitaloceanSpacesBucket) isPublic() (bool, error) {
 		return false, wildcardPolicy.Error
 	}
 
-	return publicRead.Data || publicWrite.Data || authenticatedRead.Data || wildcardPolicy.Data, nil
+	// Any grant that was actually read and is public settles it, whatever else
+	// could not be read.
+	signals := []*plugin.TValue[bool]{publicRead, publicWrite, authenticatedRead, wildcardPolicy}
+	unknown := false
+	for _, s := range signals {
+		if s.State&plugin.StateIsNull != 0 {
+			unknown = true
+			continue
+		}
+		if s.Data {
+			return true, nil
+		}
+	}
+
+	// Nothing read said public, but something was not read. Reporting false
+	// here would clear the bucket on the strength of an answer nobody gave.
+	if unknown {
+		b.IsPublic.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+	return false, nil
 }
 
 // isPublic reports whether anyone on the internet can invoke the action: it is

--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -42,6 +42,14 @@ const regionConcurrency = 5
 // the main win.
 const bucketConcurrency = 8
 
+// mqlDigitaloceanSpacesBucketInternal carries whether the bucket policy was
+// actually read. The policy field is null both when the bucket has no policy
+// and when the call to fetch it never succeeded, and only the first of those
+// lets hasWildcardPolicy answer false.
+type mqlDigitaloceanSpacesBucketInternal struct {
+	policyRead bool
+}
+
 func (r *mqlDigitaloceanSpacesBucket) id() (string, error) {
 	return "digitalocean.spacesBucket/" + r.Region.Data + "/" + r.Name.Data, nil
 }
@@ -236,9 +244,29 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 		return nil, err
 	}
 
-	publicReadAcl, publicWriteAcl, authenticatedReadAcl := false, false, false
-	aclGrants := []interface{}{}
+	// Each block below keeps three outcomes apart, the same way
+	// publicAccessBlockedValue already does for the block-public-access call:
+	//
+	//   read succeeded            -> report what it said
+	//   read succeeded, unset     -> report the absence, which is a real answer
+	//   read did not happen       -> report null
+	//
+	// The third case is the one worth being careful about. Spaces implements a
+	// subset of S3 and answers 501 on the calls it does not have, and a token
+	// may simply not be allowed to read a bucket. Letting the zero value stand
+	// there turns "nothing was read" into "nothing is configured": a bucket
+	// whose ACL could not be read would report no public grants, and isPublic
+	// would clear it on the strength of a read that never happened.
+
+	var (
+		publicReadAcl        *bool
+		publicWriteAcl       *bool
+		authenticatedReadAcl *bool
+		aclGrants            []interface{} // nil means the ACL was not read
+	)
 	if acl, err := client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: aws.String(name)}); err == nil {
+		grants := []interface{}{}
+		publicRead, publicWrite, authenticatedRead := false, false, false
 		for _, g := range acl.Grants {
 			perm := string(g.Permission)
 			grantee := g.Grantee
@@ -248,7 +276,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 				ty = string(grantee.Type)
 				display = aws.ToString(grantee.DisplayName)
 			}
-			aclGrants = append(aclGrants, map[string]interface{}{
+			grants = append(grants, map[string]interface{}{
 				"granteeType":        ty,
 				"granteeUri":         uri,
 				"granteeDisplayName": display,
@@ -256,56 +284,77 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 			})
 			if uri == "http://acs.amazonaws.com/groups/global/AllUsers" {
 				if perm == "READ" || perm == "FULL_CONTROL" {
-					publicReadAcl = true
+					publicRead = true
 				}
 				if perm == "WRITE" || perm == "FULL_CONTROL" {
-					publicWriteAcl = true
+					publicWrite = true
 				}
 			}
 			if uri == "http://acs.amazonaws.com/groups/global/AuthenticatedUsers" {
 				if perm == "READ" || perm == "FULL_CONTROL" {
-					authenticatedReadAcl = true
+					authenticatedRead = true
 				}
 			}
 		}
-	} else if isAccessDenied(err) {
-		log.Warn().Err(err).Str("bucket", name).Msg("digitalocean> ACL access denied; bucket reported with no grants — audit results may be incomplete")
-	} else if isUnsupportedOperation(err) {
-		// The grants feed publicReadAcl, authenticatedReadAcl and isPublic, so a
-		// bucket reported with none reads as "not public". Say so when the read
-		// did not happen, rather than letting the absence pass for a finding.
-		log.Warn().Err(err).Str("bucket", name).Msg("digitalocean> ACL API not implemented; bucket reported with no grants — audit results may be incomplete")
+		aclGrants = grants
+		publicReadAcl, publicWriteAcl, authenticatedReadAcl = &publicRead, &publicWrite, &authenticatedRead
+	} else if isAccessDenied(err) || isUnsupportedOperation(err) {
+		log.Warn().Err(err).Str("bucket", name).
+			Msg("digitalocean> bucket ACL could not be read; its grants and public-ACL flags are reported as null")
 	} else {
 		return nil, err
 	}
 
-	encryptionEnabled := false
-	encryptionAlgorithm := ""
-	encryptionKmsKeyId := ""
+	var (
+		encryptionEnabled   *bool
+		encryptionAlgorithm *string
+		encryptionKmsKeyId  *string
+	)
 	if enc, err := client.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{Bucket: aws.String(name)}); err == nil {
+		enabled, algorithm, kmsKeyId := false, "", ""
 		if enc.ServerSideEncryptionConfiguration != nil && len(enc.ServerSideEncryptionConfiguration.Rules) > 0 {
 			rule := enc.ServerSideEncryptionConfiguration.Rules[0]
 			if rule.ApplyServerSideEncryptionByDefault != nil {
-				encryptionEnabled = true
-				encryptionAlgorithm = string(rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
-				encryptionKmsKeyId = aws.ToString(rule.ApplyServerSideEncryptionByDefault.KMSMasterKeyID)
+				enabled = true
+				algorithm = string(rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm)
+				kmsKeyId = aws.ToString(rule.ApplyServerSideEncryptionByDefault.KMSMasterKeyID)
 			}
 		}
-	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
+		encryptionEnabled, encryptionAlgorithm, encryptionKmsKeyId = &enabled, &algorithm, &kmsKeyId
+	} else if isNoSuchConfiguration(err) {
+		// The service answered, and the answer is that nothing is configured.
+		// Default encryption really is off.
+		notEncrypted, none := false, ""
+		encryptionEnabled, encryptionAlgorithm, encryptionKmsKeyId = &notEncrypted, &none, &none
+	} else if isUnsupportedOperation(err) {
+		log.Warn().Err(err).Str("bucket", name).
+			Msg("digitalocean> bucket encryption could not be read; it is reported as null")
+	} else {
 		return nil, err
 	}
 
-	versioningStatus := ""
-	mfaDeleteEnabled := false
+	var (
+		versioningStatus *string
+		mfaDeleteEnabled *bool
+	)
 	if v, err := client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(name)}); err == nil {
-		versioningStatus = string(v.Status)
-		mfaDeleteEnabled = v.MFADelete == s3types.MFADeleteStatusEnabled
-	} else if !isAccessDenied(err) && !isUnsupportedOperation(err) {
+		status := string(v.Status)
+		mfaDelete := v.MFADelete == s3types.MFADeleteStatusEnabled
+		versioningStatus, mfaDeleteEnabled = &status, &mfaDelete
+	} else if isAccessDenied(err) || isUnsupportedOperation(err) {
+		log.Warn().Err(err).Str("bucket", name).
+			Msg("digitalocean> bucket versioning could not be read; it is reported as null")
+	} else {
 		return nil, err
 	}
 
+	// policyRead separates "this bucket has no policy" from "the policy was
+	// never read". Both leave policy null, but only the first lets
+	// hasWildcardPolicy answer false.
 	var policyDict interface{}
+	policyRead := false
 	if p, err := client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: aws.String(name)}); err == nil {
+		policyRead = true
 		raw := aws.ToString(p.Policy)
 		if raw != "" {
 			var parsed interface{}
@@ -315,46 +364,72 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 				policyDict = raw
 			}
 		}
-	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
+	} else if isNoSuchConfiguration(err) {
+		policyRead = true
+	} else if isUnsupportedOperation(err) {
+		log.Warn().Err(err).Str("bucket", name).
+			Msg("digitalocean> bucket policy could not be read; it is reported as null")
+	} else {
 		return nil, err
 	}
 
-	corsRules := []interface{}{}
+	var corsRules []interface{} // nil means the CORS configuration was not read
 	if c, err := client.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: aws.String(name)}); err == nil {
+		corsRules = []interface{}{}
 		for _, rule := range c.CORSRules {
 			corsRules = append(corsRules, spacesCorsRuleDict(rule))
 		}
-	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
+	} else if isNoSuchConfiguration(err) {
+		corsRules = []interface{}{}
+	} else if !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
-	lifecycleRules := []interface{}{}
+	var lifecycleRules []interface{} // nil means the lifecycle rules were not read
 	if l, err := client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(name)}); err == nil {
+		lifecycleRules = []interface{}{}
 		for _, rule := range l.Rules {
 			lifecycleRules = append(lifecycleRules, spacesLifecycleRuleDict(rule))
 		}
-	} else if !isNoSuchConfiguration(err) && !isUnsupportedOperation(err) {
+	} else if isNoSuchConfiguration(err) {
+		lifecycleRules = []interface{}{}
+	} else if !isUnsupportedOperation(err) {
 		return nil, err
 	}
 
-	return CreateResource(runtime, "digitalocean.spacesBucket", map[string]*llx.RawData{
+	res, err := CreateResource(runtime, "digitalocean.spacesBucket", map[string]*llx.RawData{
 		"name":                 llx.StringData(name),
 		"region":               llx.StringData(region),
 		"createdAt":            llx.TimeDataPtr(createdAt),
 		"publicAccessBlocked":  llx.BoolDataPtr(publicAccessBlocked),
-		"publicReadAcl":        llx.BoolData(publicReadAcl),
-		"publicWriteAcl":       llx.BoolData(publicWriteAcl),
-		"authenticatedReadAcl": llx.BoolData(authenticatedReadAcl),
-		"aclGrants":            llx.ArrayData(aclGrants, types.Dict),
-		"encryptionEnabled":    llx.BoolData(encryptionEnabled),
-		"encryptionAlgorithm":  llx.StringData(encryptionAlgorithm),
-		"encryptionKmsKeyId":   llx.StringData(encryptionKmsKeyId),
-		"versioningStatus":     llx.StringData(versioningStatus),
-		"mfaDeleteEnabled":     llx.BoolData(mfaDeleteEnabled),
+		"publicReadAcl":        llx.BoolDataPtr(publicReadAcl),
+		"publicWriteAcl":       llx.BoolDataPtr(publicWriteAcl),
+		"authenticatedReadAcl": llx.BoolDataPtr(authenticatedReadAcl),
+		"aclGrants":            dictListData(aclGrants),
+		"encryptionEnabled":    llx.BoolDataPtr(encryptionEnabled),
+		"encryptionAlgorithm":  llx.StringDataPtr(encryptionAlgorithm),
+		"encryptionKmsKeyId":   llx.StringDataPtr(encryptionKmsKeyId),
+		"versioningStatus":     llx.StringDataPtr(versioningStatus),
+		"mfaDeleteEnabled":     llx.BoolDataPtr(mfaDeleteEnabled),
 		"policy":               llx.DictData(policyDict),
-		"corsRules":            llx.ArrayData(corsRules, types.Dict),
-		"lifecycleRules":       llx.ArrayData(lifecycleRules, types.Dict),
+		"corsRules":            dictListData(corsRules),
+		"lifecycleRules":       dictListData(lifecycleRules),
 	})
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlDigitaloceanSpacesBucket).policyRead = policyRead
+	return res, nil
+}
+
+// dictListData renders a dict list that was never read as null rather than as
+// an empty list, so "nothing came back" cannot be mistaken for "there is
+// nothing".
+func dictListData(v []interface{}) *llx.RawData {
+	if v == nil {
+		return llx.NilData
+	}
+	return llx.ArrayData(v, types.Dict)
 }
 
 // spacesCorsRuleDict builds the dict for one CORS rule. dict values must

--- a/providers/digitalocean/resources/digitalocean_spaces_unread_test.go
+++ b/providers/digitalocean/resources/digitalocean_spaces_unread_test.go
@@ -1,0 +1,173 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// boolRead is a bool field the API actually answered.
+func boolRead(v bool) plugin.TValue[bool] {
+	return plugin.TValue[bool]{Data: v, State: plugin.StateIsSet}
+}
+
+// boolUnread is a bool field whose read never happened: null, not false.
+func boolUnread() plugin.TValue[bool] {
+	return plugin.TValue[bool]{State: plugin.StateIsSet | plugin.StateIsNull}
+}
+
+func TestDictListData(t *testing.T) {
+	// A list that was never read must not render as an empty list, or
+	// "nothing came back" reads as "there is nothing".
+	assert.Equal(t, llx.NilData, dictListData(nil))
+
+	read := dictListData([]interface{}{})
+	assert.NotEqual(t, llx.NilData, read)
+	assert.Equal(t, types.Array(types.Dict), read.Type)
+	assert.Equal(t, []interface{}{}, read.Value)
+}
+
+// hasWildcardPolicy has to separate a bucket with no policy from a bucket whose
+// policy was never read. Both leave the policy field null.
+func TestHasWildcardPolicyNullWhenPolicyUnread(t *testing.T) {
+	t.Run("policy read and absent is a real answer", func(t *testing.T) {
+		b := &mqlDigitaloceanSpacesBucket{}
+		b.policyRead = true
+		b.Policy = plugin.TValue[any]{State: plugin.StateIsSet | plugin.StateIsNull}
+
+		got := b.GetHasWildcardPolicy()
+		assert.Zero(t, got.State&plugin.StateIsNull, "a bucket with no policy should answer false, not null")
+		assert.False(t, got.Data)
+	})
+
+	t.Run("policy never read is unknown", func(t *testing.T) {
+		b := &mqlDigitaloceanSpacesBucket{}
+		b.policyRead = false
+		b.Policy = plugin.TValue[any]{State: plugin.StateIsSet | plugin.StateIsNull}
+
+		got := b.GetHasWildcardPolicy()
+		assert.NotZero(t, got.State&plugin.StateIsNull, "an unread policy must not answer false")
+	})
+}
+
+// isPublic used to be a plain OR over four booleans that were left at false
+// whenever their read failed, so a bucket whose ACL and policy could not be
+// read reported "not reachable by anyone on the internet" having read neither.
+func TestSpacesBucketIsPublicThreeValued(t *testing.T) {
+	wildcardPolicy := map[string]any{
+		"Statement": []any{
+			map[string]any{"Effect": "Allow", "Principal": "*", "Action": "s3:GetObject"},
+		},
+	}
+	ownerPolicy := map[string]any{
+		"Statement": []any{
+			map[string]any{"Effect": "Allow", "Principal": map[string]any{"AWS": "acct-1"}, "Action": "s3:GetObject"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		publicRead plugin.TValue[bool]
+		publicWt   plugin.TValue[bool]
+		authRead   plugin.TValue[bool]
+		policy     any
+		policyRead bool
+		wantNull   bool
+		want       bool
+	}{
+		{
+			name:       "everything read and nothing is public",
+			publicRead: boolRead(false), publicWt: boolRead(false), authRead: boolRead(false),
+			policy: ownerPolicy, policyRead: true,
+			want: false,
+		},
+		{
+			name:       "an anonymous read grant is public",
+			publicRead: boolRead(true), publicWt: boolRead(false), authRead: boolRead(false),
+			policy: ownerPolicy, policyRead: true,
+			want: true,
+		},
+		{
+			name:       "an authenticated-users grant is public",
+			publicRead: boolRead(false), publicWt: boolRead(false), authRead: boolRead(true),
+			policy: ownerPolicy, policyRead: true,
+			want: true,
+		},
+		{
+			name:       "a wildcard policy is public",
+			publicRead: boolRead(false), publicWt: boolRead(false), authRead: boolRead(false),
+			policy: wildcardPolicy, policyRead: true,
+			want: true,
+		},
+
+		// The cases this test exists for.
+		{
+			name:       "an unread acl is unknown, not clear",
+			publicRead: boolUnread(), publicWt: boolUnread(), authRead: boolUnread(),
+			policy: ownerPolicy, policyRead: true,
+			wantNull: true,
+		},
+		{
+			name:       "an unread policy is unknown, not clear",
+			publicRead: boolRead(false), publicWt: boolRead(false), authRead: boolRead(false),
+			policy: nil, policyRead: false,
+			wantNull: true,
+		},
+		{
+			name:       "nothing read at all is unknown",
+			publicRead: boolUnread(), publicWt: boolUnread(), authRead: boolUnread(),
+			policy: nil, policyRead: false,
+			wantNull: true,
+		},
+		{
+			// A grant that was read and is public settles it regardless of what
+			// else could not be read: unknown must not mask a known exposure.
+			name:       "a read public grant outweighs an unread policy",
+			publicRead: boolRead(true), publicWt: boolUnread(), authRead: boolUnread(),
+			policy: nil, policyRead: false,
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &mqlDigitaloceanSpacesBucket{}
+			b.PublicAccessBlocked = plugin.TValue[bool]{State: plugin.StateIsSet | plugin.StateIsNull}
+			b.PublicReadAcl = tc.publicRead
+			b.PublicWriteAcl = tc.publicWt
+			b.AuthenticatedReadAcl = tc.authRead
+			b.policyRead = tc.policyRead
+			if tc.policy == nil {
+				b.Policy = plugin.TValue[any]{State: plugin.StateIsSet | plugin.StateIsNull}
+			} else {
+				b.Policy = plugin.TValue[any]{Data: tc.policy, State: plugin.StateIsSet}
+			}
+
+			got := b.GetIsPublic()
+			if tc.wantNull {
+				assert.NotZero(t, got.State&plugin.StateIsNull,
+					"verdict must be null when a signal was never read")
+				return
+			}
+			assert.Zero(t, got.State&plugin.StateIsNull, "verdict should not be null here")
+			assert.Equal(t, tc.want, got.Data)
+		})
+	}
+}
+
+// A fully blocked bucket short-circuits before the ACL is consulted. Spaces
+// never reports this, but the branch is shared with S3-compatible services
+// that do.
+func TestSpacesBucketPublicAccessBlockedShortCircuits(t *testing.T) {
+	b := &mqlDigitaloceanSpacesBucket{}
+	b.PublicAccessBlocked = boolRead(true)
+	b.PublicReadAcl = boolRead(true)
+
+	got := b.GetIsPublic()
+	assert.Zero(t, got.State&plugin.StateIsNull)
+	assert.False(t, got.Data)
+}


### PR DESCRIPTION
`newSpacesBucket` tolerates a failed sub-read so that one unsupported call
cannot kill the whole bucket listing. That part is right, and #9748 exists
because it wasn't always. What it *also* did was let each tolerated call's zero
value stand as a reported fact.

Spaces implements a subset of S3 and answers 501 on the calls it doesn't have,
and a Spaces key may simply not be permitted to read a given bucket. In either
case the bucket came back looking clean:

| field | reported when the read never happened |
|---|---|
| `publicReadAcl` / `publicWriteAcl` / `authenticatedReadAcl` | `false` |
| `aclGrants` | `[]` |
| `encryptionEnabled` | `false` |
| `versioningStatus` | `""` |
| `mfaDeleteEnabled` | `false` |

`isPublic` is a plain OR over four of those booleans, so a bucket whose ACL and
policy could not be read answered **"not reachable by anyone on the internet"**
on the strength of two reads that never happened. `encryptionEnabled` and
`versioningStatus` are both in `@defaults`, so the manufactured values print on
every bucket listing.

This is the same defect #9808 fixed for `publicAccessBlocked`, which became null
when the read did not happen. That fix stopped at the one field; its four
neighbours in the same constructor kept manufacturing posture.

## What changed

Each block now keeps three outcomes apart, the way `publicAccessBlockedValue`
already did:

- **read succeeded** → report what it said
- **read succeeded, nothing configured** → report the absence, which is a real
  answer (a bucket that reports no encryption config really is unencrypted)
- **read did not happen** → null

The distinction matters per call: `NoSuchBucketPolicy` means there is genuinely
no policy, while a 501 means nobody looked. `hasWildcardPolicy` could not tell
those apart before, because both leave `policy` null — it now reads a
`policyRead` flag off the resource's Internal struct and reports null in the
second case.

`isPublic` becomes three-valued with it. A grant that **was** read and is public
still settles the verdict as `true` whatever else could not be read, so unknown
never masks a known exposure; only when nothing read says public *and* something
was not read does the verdict go null.

Lists follow the same rule: `aclGrants`, `corsRules` and `lifecycleRules` are
null when unread and `[]` when read and empty, so "nothing came back" is no
longer indistinguishable from "there is nothing".

No schema fields were added or removed — the affected fields were already
declared `bool`/`string`/`[]dict` and simply gain a null state, so
`.lr.versions` is unchanged. The doc comments now state the null semantics per
field.

## Tests

`digitalocean_spaces_unread_test.go` covers `isPublic` across all three values
(including that a read public grant outweighs an unread policy),
`hasWildcardPolicy` for no-policy vs unread-policy, and `dictListData` for the
null-vs-empty list distinction.

Verified the tests catch the bug by reverting `isPublic`/`hasWildcardPolicy` to
their two-valued form and re-running: exactly the four unknown-state cases fail
and every positive case still passes, so the tests pin the new behaviour rather
than merely exercising it.

Full provider suite passes.

## Not verified live

No `DIGITALOCEAN_TOKEN` was available for this change, so which specific calls
Spaces answers 501 on is taken from the existing `isUnsupportedOperation`
handling rather than re-confirmed against an account. The fix does not depend on
that: whichever call fails, its zero value is no longer reported as a fact. The
access-denied path is reachable regardless of service support.
