### PR TITLE
⭐ digitalocean: expose organization teams

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -98,6 +98,8 @@ digitalocean {
   secrets() []digitalocean.secret
   // Account billing balance and month-to-date usage
   billing() digitalocean.billing
+  // Teams belonging to the organization the token is scoped to
+  teams() []digitalocean.team
 }
 
 // DigitalOcean account
@@ -1796,6 +1798,36 @@ digitalocean.cdn @defaults("id origin") {
   customDomain string
   // Time the resource was created
   createdAt time
+}
+
+// DigitalOcean organization team
+//
+// Team within a DigitalOcean organization, which is the boundary
+// resources and access are divided along. The `memberCount` field
+// reports how many people the team carries, `status` distinguishes a
+// team that has joined the organization from one still pending, and
+// `joinedOrganizationAt` dates the join. Teams are only visible to a
+// token scoped to an organization; a token scoped to a plain account
+// reports none. The DigitalOcean API exposes no per-member listing, so
+// individual members and the roles they hold are not queryable.
+digitalocean.team @defaults("name status memberCount") {
+  // Unique identifier for the team
+  id int
+  // Universal unique identifier for the team
+  uuid string
+  // Human-readable name for the team
+  name string
+  // Email address associated with the team
+  email string
+  // Number of members on the team
+  memberCount int
+  // Team's membership status within the organization
+  //
+  // Either "joined" for a team that is part of the organization, or
+  // "pending" for one that has been invited and has not accepted.
+  status string
+  // Time the team joined the organization
+  joinedOrganizationAt time
 }
 
 // DigitalOcean tag

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -61,6 +61,7 @@ const (
 	ResourceDigitaloceanAlertPolicy                                     string = "digitalocean.alertPolicy"
 	ResourceDigitaloceanUptimeCheck                                     string = "digitalocean.uptimeCheck"
 	ResourceDigitaloceanCdn                                             string = "digitalocean.cdn"
+	ResourceDigitaloceanTeam                                            string = "digitalocean.team"
 	ResourceDigitaloceanTag                                             string = "digitalocean.tag"
 	ResourceDigitaloceanSpacesKey                                       string = "digitalocean.spacesKey"
 	ResourceDigitaloceanSpacesBucket                                    string = "digitalocean.spacesBucket"
@@ -286,6 +287,10 @@ func init() {
 		"digitalocean.cdn": {
 			// to override args, implement: initDigitaloceanCdn(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDigitaloceanCdn,
+		},
+		"digitalocean.team": {
+			// to override args, implement: initDigitaloceanTeam(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDigitaloceanTeam,
 		},
 		"digitalocean.tag": {
 			// to override args, implement: initDigitaloceanTag(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -634,6 +639,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.billing": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitalocean).GetBilling()).ToDataRes(types.Resource("digitalocean.billing"))
+	},
+	"digitalocean.teams": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitalocean).GetTeams()).ToDataRes(types.Array(types.Resource("digitalocean.team")))
 	},
 	"digitalocean.account.email": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanAccount).GetEmail()).ToDataRes(types.String)
@@ -2164,6 +2172,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.cdn.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanCdn).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"digitalocean.team.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanTeam).GetId()).ToDataRes(types.Int)
+	},
+	"digitalocean.team.uuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanTeam).GetUuid()).ToDataRes(types.String)
+	},
+	"digitalocean.team.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanTeam).GetName()).ToDataRes(types.String)
+	},
+	"digitalocean.team.email": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanTeam).GetEmail()).ToDataRes(types.String)
+	},
+	"digitalocean.team.memberCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanTeam).GetMemberCount()).ToDataRes(types.Int)
+	},
+	"digitalocean.team.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanTeam).GetStatus()).ToDataRes(types.String)
+	},
+	"digitalocean.team.joinedOrganizationAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanTeam).GetJoinedOrganizationAt()).ToDataRes(types.Time)
 	},
 	"digitalocean.tag.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanTag).GetName()).ToDataRes(types.String)
@@ -3712,6 +3741,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.billing": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitalocean).Billing, ok = plugin.RawToTValue[*mqlDigitaloceanBilling](v.Value, v.Error)
+		return
+	},
+	"digitalocean.teams": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitalocean).Teams, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.account.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5930,6 +5963,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanCdn).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"digitalocean.team.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).__id, ok = v.Value.(string)
+		return
+	},
+	"digitalocean.team.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).Id, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.team.uuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).Uuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.team.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.team.email": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).Email, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.team.memberCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).MemberCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.team.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.team.joinedOrganizationAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanTeam).JoinedOrganizationAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
 	"digitalocean.tag.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanTag).__id, ok = v.Value.(string)
 		return
@@ -7994,6 +8059,7 @@ type mqlDigitalocean struct {
 	PartnerAttachments    plugin.TValue[[]any]
 	Secrets               plugin.TValue[[]any]
 	Billing               plugin.TValue[*mqlDigitaloceanBilling]
+	Teams                 plugin.TValue[[]any]
 }
 
 // createDigitalocean creates a new instance of this resource
@@ -8654,6 +8720,22 @@ func (c *mqlDigitalocean) GetBilling() *plugin.TValue[*mqlDigitaloceanBilling] {
 		}
 
 		return c.billing()
+	})
+}
+
+func (c *mqlDigitalocean) GetTeams() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Teams, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean", c.__id, "teams")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.teams()
 	})
 }
 
@@ -14003,6 +14085,85 @@ func (c *mqlDigitaloceanCdn) GetCustomDomain() *plugin.TValue[string] {
 
 func (c *mqlDigitaloceanCdn) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+// mqlDigitaloceanTeam for the digitalocean.team resource
+type mqlDigitaloceanTeam struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDigitaloceanTeamInternal it will be used here
+	Id                   plugin.TValue[int64]
+	Uuid                 plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	Email                plugin.TValue[string]
+	MemberCount          plugin.TValue[int64]
+	Status               plugin.TValue[string]
+	JoinedOrganizationAt plugin.TValue[*time.Time]
+}
+
+// createDigitaloceanTeam creates a new instance of this resource
+func createDigitaloceanTeam(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDigitaloceanTeam{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("digitalocean.team", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDigitaloceanTeam) MqlName() string {
+	return "digitalocean.team"
+}
+
+func (c *mqlDigitaloceanTeam) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDigitaloceanTeam) GetId() *plugin.TValue[int64] {
+	return &c.Id
+}
+
+func (c *mqlDigitaloceanTeam) GetUuid() *plugin.TValue[string] {
+	return &c.Uuid
+}
+
+func (c *mqlDigitaloceanTeam) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlDigitaloceanTeam) GetEmail() *plugin.TValue[string] {
+	return &c.Email
+}
+
+func (c *mqlDigitaloceanTeam) GetMemberCount() *plugin.TValue[int64] {
+	return &c.MemberCount
+}
+
+func (c *mqlDigitaloceanTeam) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlDigitaloceanTeam) GetJoinedOrganizationAt() *plugin.TValue[*time.Time] {
+	return &c.JoinedOrganizationAt
 }
 
 // mqlDigitaloceanTag for the digitalocean.tag resource

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -1010,6 +1010,15 @@ digitalocean.tag 13.0.1
 digitalocean.tag.name 13.0.1
 digitalocean.tag.resourceCount 13.0.1
 digitalocean.tags 13.0.1
+digitalocean.team 13.15.3
+digitalocean.team.email 13.15.3
+digitalocean.team.id 13.15.3
+digitalocean.team.joinedOrganizationAt 13.15.3
+digitalocean.team.memberCount 13.15.3
+digitalocean.team.name 13.15.3
+digitalocean.team.status 13.15.3
+digitalocean.team.uuid 13.15.3
+digitalocean.teams 13.15.3
 digitalocean.uptimeCheck 13.0.1
 digitalocean.uptimeCheck.enabled 13.0.1
 digitalocean.uptimeCheck.id 13.0.1

--- a/providers/digitalocean/resources/digitalocean_organizations.go
+++ b/providers/digitalocean/resources/digitalocean_organizations.go
@@ -18,6 +18,16 @@ import (
 // the client's own NewRequest/Do. That keeps the token, the rate limiter and
 // the error decoding the rest of the provider relies on, rather than standing
 // up a second HTTP client beside them.
+//
+// This endpoint is not paginated, so there is deliberately no paginate() call
+// here. DigitalOcean's published spec declares no page or per_page parameter on
+// it, and its response body is a bare {"teams": [...]} with none of the
+// pagination and meta members every paginated endpoint carries. A loop would
+// also be dead code rather than a safety net: godo fills Response.Links from
+// the body's links key, so a body that never has one always reports the first
+// page as the last. That is how the scan-findings loop in #9366 silently
+// truncated. If DigitalOcean ever paginates this, it has to be driven off the
+// returned slice length instead.
 const organizationTeamsPath = "v2/organizations/teams"
 
 type organizationTeam struct {

--- a/providers/digitalocean/resources/digitalocean_organizations.go
+++ b/providers/digitalocean/resources/digitalocean_organizations.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/digitalocean/godo"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+)
+
+// godo does not wrap the Organizations endpoints, so the request goes through
+// the client's own NewRequest/Do. That keeps the token, the rate limiter and
+// the error decoding the rest of the provider relies on, rather than standing
+// up a second HTTP client beside them.
+const organizationTeamsPath = "v2/organizations/teams"
+
+type organizationTeam struct {
+	ID                   uint64 `json:"id"`
+	UUID                 string `json:"uuid"`
+	Name                 string `json:"name"`
+	Email                string `json:"email"`
+	MemberCount          uint64 `json:"member_count"`
+	Status               string `json:"status"`
+	JoinedOrganizationAt string `json:"joined_organization_at"`
+}
+
+type organizationTeamsRoot struct {
+	Teams []organizationTeam `json:"teams"`
+}
+
+// noOrganizationContext reports the answers that mean this token has no
+// organization to enumerate, rather than that the read failed.
+//
+// The endpoint "must be called in an organization context", so a token scoped
+// to a plain account is not a failure to report: it is an account with no
+// teams. A 401 is deliberately excluded, since a rejected token is a real
+// problem and must not be laundered into an empty list.
+func noOrganizationContext(err error) bool {
+	var er *godo.ErrorResponse
+	if !errors.As(err, &er) || er.Response == nil {
+		return false
+	}
+	switch er.Response.StatusCode {
+	case http.StatusForbidden, http.StatusNotFound, http.StatusPreconditionFailed:
+		return true
+	}
+	return false
+}
+
+func (r *mqlDigitaloceanTeam) id() (string, error) {
+	return resourceID("digitalocean.team", r.Uuid.Data)
+}
+
+func (r *mqlDigitalocean) teams() ([]interface{}, error) {
+	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
+	client := conn.Client()
+	ctx := context.Background()
+
+	req, err := client.NewRequest(ctx, http.MethodGet, organizationTeamsPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	root := new(organizationTeamsRoot)
+	if _, err := client.Do(ctx, req, root); err != nil {
+		if noOrganizationContext(err) {
+			log.Debug().Err(err).Msg("digitalocean> token is not scoped to an organization; reporting no teams")
+			return []interface{}{}, nil
+		}
+		return nil, err
+	}
+
+	all := make([]interface{}, 0, len(root.Teams))
+	for i := range root.Teams {
+		t := root.Teams[i]
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.team", map[string]*llx.RawData{
+			"id":                   llx.IntData(int64(t.ID)),
+			"uuid":                 llx.StringData(t.UUID),
+			"name":                 llx.StringData(t.Name),
+			"email":                llx.StringData(t.Email),
+			"memberCount":          llx.IntData(int64(t.MemberCount)),
+			"status":               llx.StringData(t.Status),
+			"joinedOrganizationAt": llx.TimeDataPtr(parseDoTime(t.JoinedOrganizationAt)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, res)
+	}
+	return all, nil
+}

--- a/providers/digitalocean/resources/digitalocean_organizations_test.go
+++ b/providers/digitalocean/resources/digitalocean_organizations_test.go
@@ -1,0 +1,62 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+)
+
+func doErr(status int) error {
+	return &godo.ErrorResponse{
+		Response: &http.Response{StatusCode: status},
+		Message:  http.StatusText(status),
+	}
+}
+
+// The teams endpoint must be called in an organization context, so a token
+// scoped to a plain account has no teams to enumerate rather than a failed
+// read. A rejected token is a different thing entirely and must not be
+// laundered into an empty list.
+func TestNoOrganizationContext(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"forbidden means no organization", doErr(http.StatusForbidden), true},
+		{"not found means no organization", doErr(http.StatusNotFound), true},
+		{"precondition failed means no organization", doErr(http.StatusPreconditionFailed), true},
+
+		{"an unauthorized token is a real problem", doErr(http.StatusUnauthorized), false},
+		{"a rate limit is transient", doErr(http.StatusTooManyRequests), false},
+		{"a service fault is a real failure", doErr(http.StatusInternalServerError), false},
+		{"a transport error carries no status", errors.New("dial tcp: no such host"), false},
+		{"nil is not a match", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, noOrganizationContext(tc.err))
+		})
+	}
+}
+
+// The error travels back up through the client, so the classifier has to see
+// through wrapping.
+func TestNoOrganizationContextThroughWrapping(t *testing.T) {
+	assert.True(t, noOrganizationContext(
+		fmt.Errorf("listing teams: %w", doErr(http.StatusForbidden))))
+	assert.False(t, noOrganizationContext(
+		fmt.Errorf("listing teams: %w", doErr(http.StatusUnauthorized))))
+}
+
+// A godo ErrorResponse with no underlying HTTP response must not be treated as
+// an absent organization, since nothing established that.
+func TestNoOrganizationContextWithoutResponse(t *testing.T) {
+	assert.False(t, noOrganizationContext(&godo.ErrorResponse{Message: "boom"}))
+}


### PR DESCRIPTION
Addresses the team/role gap in #10114, and reports what the API does not make
possible for the other three.

DigitalOcean divides resources and access along **teams**, and nothing in the
provider modelled them. `digitalocean.teams` now lists them:

```
digitalocean.teams { name status memberCount joinedOrganizationAt }
```

| field | |
|---|---|
| `id`, `uuid` | team identifiers |
| `name`, `email` | display name and the address the team is reachable at |
| `memberCount` | how many people the team carries |
| `status` | `joined`, or `pending` for an invited team that has not accepted |
| `joinedOrganizationAt` | when the team joined the organization |

## Implementation notes

godo does not wrap the Organizations endpoints, so the request goes through the
client's own `NewRequest`/`Do` rather than a second HTTP client beside it. That
keeps the token, the rate limiter, and the error decoding the rest of the
provider already relies on.

The endpoint has to be called in an organization context, so a token scoped to
a plain account has no teams to enumerate rather than a failed read: **403, 404
and 412 report an empty list**. A **401 is deliberately excluded** — a rejected
token is a real problem and must not be laundered into an empty list. That
classifier is unit-tested in both directions, including through error wrapping
and for a godo `ErrorResponse` carrying no HTTP response.

## On the rest of #10114

Checked against DigitalOcean's published OpenAPI spec (`DigitalOcean-public.v2.yaml`,
fetched 2026-08-18) rather than godo, since godo can lag the API. Three of the
four gaps are not implementable, because the facts are not exposed:

- **API tokens / PATs** — there is no `/v2/account/tokens`. The only paths under
  `/v2/account` are `/v2/account`, `/v2/account/keys` and
  `/v2/account/keys/{id}`, and the only `tokens` endpoints in the entire spec
  belong to dedicated inference. Token name, scopes, and legacy-vs-scoped are
  not readable through the public API.
- **DOKS log forwarding** — no log-forwarding path or field exists anywhere
  under `/v2/kubernetes`. Log-destination schemas exist only for App Platform
  and managed databases; the latter already ships as `database.logsinks`.
- **`sshKey` created / last-used** — the `sshKeys` schema is exactly
  `{id, fingerprint, public_key, name}`. There is no timestamp of any kind, so
  the provider already exposes every field the API returns.

**Per-member roles remain unavailable even here.** The Organizations API has
only two endpoints — create a team and list teams — with no member listing. The
role enum (`member`, `biller`, `billing viewer`, `resource viewer`, `modifier`,
and `owner`, which cannot be invited) appears only in the *create-invitation
request*, never in a readable membership list. So this gives team inventory and
member counts, not who holds which role. The schema comment says so rather than
leaving the reader to infer it.

## Not verified live

No `DIGITALOCEAN_TOKEN` was available, so the field mapping is taken from the
published spec and the degradation path is unverified against a real account.
The specific status DigitalOcean returns for a non-organization token is the
part most worth confirming: the fix treats 403/404/412 alike, so it is correct
whichever of them comes back, but which one actually does is unconfirmed.
