### PR TITLE
🐛 hetzner: survive the datacenters API being withdrawn

### DIFF
--- a/providers/hetzner/resources/helpers.go
+++ b/providers/hetzner/resources/helpers.go
@@ -43,6 +43,26 @@ func translateHcloudError(err error) error {
 	return err
 }
 
+// isRemovedAPIEndpoint reports the answer Hetzner gives once an endpoint has
+// been withdrawn: HTTP 410 with the deprecated_api_endpoint code.
+//
+// This is deliberately not folded into translateHcloudError, which answers a
+// different question. A collection that 404s is genuinely empty, because the
+// product is not provisioned for the project. A withdrawn endpoint establishes
+// nothing at all: there may well be resources, there is simply no longer any
+// way to ask. Reporting those as an empty list would be the same false claim
+// as reporting a denial that way.
+func isRemovedAPIEndpoint(err error) bool {
+	if err == nil {
+		return false
+	}
+	var hErr hcloud.Error
+	if errors.As(err, &hErr) {
+		return hErr.Code == hcloud.ErrorDeprecatedAPIEndpoint
+	}
+	return false
+}
+
 func conn(runtime *plugin.Runtime) *connection.HetznerConnection {
 	return runtime.Connection.(*connection.HetznerConnection)
 }

--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -48,7 +48,13 @@ hetzner {
   // Locations (Hetzner regions)
   locations() []hetzner.location
   // Datacenters within locations
-  datacenters() []hetzner.datacenter
+  //
+  // Deprecated in favor of locations, and of serverType.locations for
+  // where a given server type can be provisioned. Hetzner withdrew the
+  // datacenters API after 2026-10-01, so this reports null from that
+  // date on: the endpoint answers that the functionality was removed,
+  // which establishes nothing about what the project holds.
+  datacenters() @maturity("deprecated") []hetzner.datacenter
   // Storage Boxes (managed backup/file storage)
   storageBoxes() []hetzner.storageBox
   // Storage Box types (storage tiers)
@@ -861,13 +867,18 @@ private hetzner.location @defaults("id name city") {
 
 // Hetzner Cloud datacenter
 //
+// Deprecated in favor of hetzner.location, and of
+// hetzner.serverType.locations for where a given server type can be
+// provisioned. Hetzner withdrew the datacenters API after 2026-10-01
+// and requests to it now report that the functionality was removed, so
+// nothing here can be read from that date on.
+//
 // A single datacenter within a Hetzner location, identified by a slug
 // such as fsn1-dc14. Select one by its numeric id, for example
 // hetzner.datacenter(id: 4). Reports the location it belongs to, the
 // server types it supports, which of those are currently available for
-// new servers, and which are open for migration, so you can plan
-// placement and capacity.
-private hetzner.datacenter @defaults("id name") {
+// new servers, and which are open for migration.
+private hetzner.datacenter @defaults("id name") @maturity("deprecated") {
   init(id? int)
   // Datacenter ID
   id int
@@ -878,11 +889,21 @@ private hetzner.datacenter @defaults("id name") {
   // Location of the datacenter
   location() hetzner.location
   // Server types supported in this datacenter
-  supportedServerTypes() []hetzner.serverType
+  //
+  // Deprecated in favor of serverType.locations, whose available field
+  // carries the same fact per location. Hetzner stopped returning the
+  // datacenter server-type lists after 2026-10-01.
+  supportedServerTypes() @maturity("deprecated") []hetzner.serverType
   // Server types currently available for new servers in this datacenter
-  availableServerTypes() []hetzner.serverType
+  //
+  // Deprecated in favor of serverType.locations, whose available and
+  // recommended fields carry the same facts per location.
+  availableServerTypes() @maturity("deprecated") []hetzner.serverType
   // Server types available for migration into this datacenter
-  serverTypesAvailableForMigration() []hetzner.serverType
+  //
+  // Deprecated in favor of serverType.locations. Hetzner stopped
+  // returning the datacenter server-type lists after 2026-10-01.
+  serverTypesAvailableForMigration() @maturity("deprecated") []hetzner.serverType
 }
 
 // Hetzner Cloud Storage Box (managed backup/file storage)

--- a/providers/hetzner/resources/hetzner_datacenter.go
+++ b/providers/hetzner/resources/hetzner_datacenter.go
@@ -28,6 +28,14 @@ func (h *mqlHetzner) datacenters() ([]any, error) {
 		return c.Client().Datacenter.List(ctx(), hcloud.DatacenterListOpts{ListOpts: opts})
 	})
 	if err != nil {
+		// Hetzner withdrew GET /v1/datacenters after 2026-10-01. Report the
+		// field as null rather than as an error that would take the whole
+		// value with it, and rather than as an empty list, which would claim
+		// the project has no datacenters when in truth none can be read.
+		if isRemovedAPIEndpoint(err) {
+			h.Datacenters.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	out := make([]any, 0, len(items))
@@ -66,6 +74,14 @@ func initHetznerDatacenter(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 	dc, _, err := conn(runtime).Client().Datacenter.GetByID(ctx(), id)
 	if err != nil {
+		// An init has to produce a resource or an error, so unlike the list
+		// accessor it cannot report the withdrawal as null. Say what happened
+		// and what replaced it instead of surfacing a bare 410.
+		if isRemovedAPIEndpoint(err) {
+			return nil, nil, fmt.Errorf(
+				"hetzner withdrew the datacenters API after 2026-10-01; use hetzner.locations, "+
+					"and hetzner.serverType.locations for where a server type can be provisioned (id %d)", id)
+		}
 		return nil, nil, err
 	}
 	if dc == nil {

--- a/providers/hetzner/resources/hetzner_datacenter_removed_test.go
+++ b/providers/hetzner/resources/hetzner_datacenter_removed_test.go
@@ -1,0 +1,145 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/hetzner/connection"
+)
+
+func TestIsRemovedAPIEndpoint(t *testing.T) {
+	// The answer Hetzner gives for a withdrawn endpoint. GET /v1/datacenters
+	// answers this way after 2026-10-01.
+	t.Run("a withdrawn endpoint is recognized", func(t *testing.T) {
+		err := hcloud.Error{Code: hcloud.ErrorDeprecatedAPIEndpoint, Message: "removed"}
+		assert.True(t, isRemovedAPIEndpoint(err))
+	})
+
+	t.Run("through wrapping", func(t *testing.T) {
+		err := fmt.Errorf("listing datacenters: %w",
+			hcloud.Error{Code: hcloud.ErrorDeprecatedAPIEndpoint, Message: "removed"})
+		assert.True(t, isRemovedAPIEndpoint(err))
+	})
+
+	// Everything below is a different situation and must not be reported as a
+	// withdrawn endpoint, or a real failure would be laundered into a null.
+	for _, code := range []hcloud.ErrorCode{
+		hcloud.ErrorCodeNotFound,
+		hcloud.ErrorCodeUnauthorized,
+		hcloud.ErrorCodeForbidden,
+		hcloud.ErrorCodeRateLimitExceeded,
+		hcloud.ErrorCodeServerError,
+	} {
+		t.Run(string(code)+" is not a withdrawal", func(t *testing.T) {
+			assert.False(t, isRemovedAPIEndpoint(hcloud.Error{Code: code}))
+		})
+	}
+
+	t.Run("a transport error carries no hcloud code", func(t *testing.T) {
+		assert.False(t, isRemovedAPIEndpoint(errors.New("dial tcp: no such host")))
+	})
+
+	t.Run("nil is not a match", func(t *testing.T) {
+		assert.False(t, isRemovedAPIEndpoint(nil))
+	})
+}
+
+// paginate is the only path a list reaches the accessor through, so the
+// withdrawal has to survive it. If translateHcloudError ever swallowed this
+// code the way it swallows a 404, paginate would report an empty list and the
+// null branch in datacenters() would be unreachable.
+func TestRemovedEndpointSurvivesPaginate(t *testing.T) {
+	removed := hcloud.Error{Code: hcloud.ErrorDeprecatedAPIEndpoint, Message: "removed"}
+	_, err := paginate(func(hcloud.ListOpts) ([]*hcloud.Datacenter, *hcloud.Response, error) {
+		return nil, nil, removed
+	})
+	require.Error(t, err, "a withdrawn endpoint must not be reported as an empty list")
+	assert.True(t, isRemovedAPIEndpoint(err))
+
+	// Contrast: a 404 collection genuinely is empty, and still is.
+	out, err := paginate(func(hcloud.ListOpts) ([]*hcloud.Datacenter, *hcloud.Response, error) {
+		return nil, nil, hcloud.Error{Code: hcloud.ErrorCodeNotFound}
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+// hetznerRuntime points a real connection at a test server.
+func hetznerRuntime(t *testing.T, h http.HandlerFunc) *plugin.Runtime {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	conn, err := connection.NewHetznerConnection(0, &inventory.Asset{}, &inventory.Config{
+		Options: map[string]string{
+			connection.OPTION_TOKEN:    "test-token",
+			connection.OPTION_ENDPOINT: srv.URL,
+		},
+	})
+	require.NoError(t, err)
+	return &plugin.Runtime{Connection: conn}
+}
+
+// The response Hetzner serves for the withdrawn datacenters endpoint.
+const removedEndpointBody = `{"error":{"code":"deprecated_api_endpoint","message":"The API functionality was removed"}}`
+
+// After 2026-10-01 the datacenters endpoint is gone. The field must read null,
+// not an empty list: an empty list would claim the project has no datacenters,
+// when in truth none can be read any more.
+func TestDatacentersReadNullOnceWithdrawn(t *testing.T) {
+	runtime := hetznerRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(removedEndpointBody))
+	})
+
+	h := &mqlHetzner{MqlRuntime: runtime}
+	out, err := h.datacenters()
+	require.NoError(t, err, "a withdrawn endpoint should not fail the field")
+	assert.Nil(t, out)
+	assert.NotZero(t, h.Datacenters.State&plugin.StateIsNull,
+		"the field must be null, not an empty list")
+}
+
+// A failure that is not the withdrawal still has to propagate, or an outage
+// would read as "no datacenters".
+func TestDatacentersPropagateOtherFailures(t *testing.T) {
+	runtime := hetznerRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":"unauthorized","message":"bad token"}}`))
+	})
+
+	h := &mqlHetzner{MqlRuntime: runtime}
+	_, err := h.datacenters()
+	require.Error(t, err)
+	assert.Zero(t, h.Datacenters.State&plugin.StateIsNull)
+}
+
+// The init cannot report null, so it has to say what happened and name the
+// replacement rather than surfacing a bare 410.
+func TestDatacenterInitExplainsWithdrawal(t *testing.T) {
+	runtime := hetznerRuntime(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGone)
+		_, _ = w.Write([]byte(removedEndpointBody))
+	})
+
+	_, res, err := initHetznerDatacenter(runtime, map[string]*llx.RawData{"id": llx.IntData(4)})
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "withdrew the datacenters API")
+	assert.Contains(t, err.Error(), "hetzner.serverType.locations")
+}


### PR DESCRIPTION
Hetzner withdrew `GET /v1/datacenters` and `GET /v1/datacenters/{id}` **after
2026-10-01**. Requests now answer HTTP 410 with the `deprecated_api_endpoint`
code, and hcloud-go marks the entire `Datacenter` family deprecated as of
v2.47.0:

```go
// hcloud/datacenter.go
// Deprecated: [DatacenterClient.List] is deprecated and will be removed after the 2026-10-01.
// Deprecated: [Datacenter.ServerTypes] is deprecated and will not be returned after 2026-10-01.
```

The provider still calls both endpoints — `hetzner.datacenters()` via
`Datacenter.List`, and `initHetznerDatacenter` via `Datacenter.GetByID` — and
neither handled the withdrawal. From that date the field fails with a bare:

```
The API functionality was removed (deprecated_api_endpoint)
```

which tells the reader nothing about what replaced it. (That string is not
speculation — it is what the pre-fix code produces in the regression test.)

## What changed

**`datacenters()` reports null when the endpoint is gone.** Not an empty list:
that would claim the project has no datacenters, when in truth none can be read
any more. This is the same distinction `translateHcloudError` already draws
between a 404 collection — genuinely empty, the product is not provisioned —
and a denial, which establishes nothing. So the withdrawal is classified
separately by a new `isRemovedAPIEndpoint` rather than folded into the existing
helper, and the comment says why.

**The init names the replacement.** An init has to produce a resource or an
error, so it cannot report null. It now says what happened and where to go:

```
hetzner withdrew the datacenters API after 2026-10-01; use hetzner.locations,
and hetzner.serverType.locations for where a server type can be provisioned (id 4)
```

**The schema marks the surface deprecated** — the `datacenters` accessor, the
`hetzner.datacenter` resource, and its three server-type lists — pointing at
`hetzner.locations` and `hetzner.serverType.locations`. That replacement already
exists in this provider: `hetzner.serverType.location` carries `available` and
`recommended`, which is exactly what the datacenter server-type lists reported.

No `.lr.versions` change and no codegen diff — a deprecation marker alters
neither.

## Tests

`hetzner_datacenter_removed_test.go` covers:

- the classifier both ways — the withdrawal code, through error wrapping, and
  that not-found / unauthorized / forbidden / rate-limited / server-error /
  transport-error / nil are **not** treated as a withdrawal
- that the withdrawal **survives `paginate`** — if `translateHcloudError` ever
  swallowed this code the way it swallows a 404, `paginate` would report an
  empty list and the null branch would be unreachable
- end to end against an `httptest` server serving the real 410 body, via a real
  connection using the existing `endpoint` config option: the field reads null,
  an unauthorized response still propagates as an error, and the init returns
  the explanatory message

Verified the tests catch the bug by removing both guards and re-running: the
null-degradation and init-message tests fail (the latter showing the bare
`deprecated_api_endpoint` string above), while the propagate-other-failures test
correctly still passes.

Full provider suite passes.

## Not verified live

No `HCLOUD_TOKEN` was available for this change. The 410 path is exercised
against a test server reproducing the documented response rather than against
the real endpoint — which today still answers normally, since the removal date
has not yet passed.
