### PR TITLE
🧹 hetzner: guard the firewall rule dicts against a non-serializable value

### DIFF
--- a/providers/hetzner/resources/hetzner_firewall.go
+++ b/providers/hetzner/resources/hetzner_firewall.go
@@ -44,9 +44,21 @@ func (h *mqlHetzner) firewalls() ([]any, error) {
 	return out, nil
 }
 
-func newMqlHetznerFirewall(runtime *plugin.Runtime, fw *hcloud.Firewall) (*mqlHetznerFirewall, error) {
-	rules := make([]any, 0, len(fw.Rules))
-	for _, r := range fw.Rules {
+// firewallRuleDicts renders a firewall's rules as the dicts the rules field
+// carries.
+//
+// Every value has to be JSON-native, because the dict-to-primitive converter
+// accepts only bool/int64/float64/string/[]any/map. The port and description
+// are *string in the SDK and are dereferenced only when set, so an absent one
+// stays out of the dict rather than becoming an empty string that reads as a
+// configured value.
+//
+// These dicts feed firewallRuleOpenToInternet and through it the exposure
+// verdict, so a serialization failure here would take the reachability answer
+// with it.
+func firewallRuleDicts(rules []hcloud.FirewallRule) []any {
+	out := make([]any, 0, len(rules))
+	for _, r := range rules {
 		srcs := make([]any, 0, len(r.SourceIPs))
 		for _, ip := range r.SourceIPs {
 			srcs = append(srcs, ip.String())
@@ -67,8 +79,13 @@ func newMqlHetznerFirewall(runtime *plugin.Runtime, fw *hcloud.Firewall) (*mqlHe
 		if r.Description != nil {
 			entry["description"] = *r.Description
 		}
-		rules = append(rules, entry)
+		out = append(out, entry)
 	}
+	return out
+}
+
+func newMqlHetznerFirewall(runtime *plugin.Runtime, fw *hcloud.Firewall) (*mqlHetznerFirewall, error) {
+	rules := firewallRuleDicts(fw.Rules)
 
 	var serverIDs []int64
 	var labelSelectors []string

--- a/providers/hetzner/resources/hetzner_firewall_rules_test.go
+++ b/providers/hetzner/resources/hetzner_firewall_rules_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net"
+	"testing"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cidr is mustCIDR (hetzner_address_test.go) as a value, which is the form
+// FirewallRule.SourceIPs takes.
+func cidr(t *testing.T, s string) net.IPNet {
+	t.Helper()
+	return *mustCIDR(t, s)
+}
+
+// The firewall rule dicts are the one dict in this provider that was built
+// inline rather than through a helper, so they were never run through the llx
+// converter the way the deprecation, health-check and nameserver dicts are.
+//
+// They are also the dicts that matter most: firewallRuleOpenToInternet reads
+// them, and the server exposure verdict reads that. A value that fails to
+// serialize would take the reachability answer with it.
+func TestFirewallRuleDictsSerialize(t *testing.T) {
+	port := "80"
+	desc := "http from anywhere"
+
+	rules := []hcloud.FirewallRule{
+		{
+			Direction:   hcloud.FirewallRuleDirectionIn,
+			Protocol:    hcloud.FirewallRuleProtocolTCP,
+			SourceIPs:   []net.IPNet{cidr(t, "0.0.0.0/0"), cidr(t, "::/0")},
+			Port:        &port,
+			Description: &desc,
+		},
+		{
+			// No port and no description: both are *string in the SDK and must
+			// stay out of the dict rather than becoming empty strings.
+			Direction:      hcloud.FirewallRuleDirectionOut,
+			Protocol:       hcloud.FirewallRuleProtocolICMP,
+			DestinationIPs: []net.IPNet{cidr(t, "10.0.0.0/8")},
+		},
+	}
+
+	dicts := firewallRuleDicts(rules)
+	require.Len(t, dicts, 2)
+	requireDictArraySerializes(t, dicts)
+
+	in, ok := dicts[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "in", in["direction"])
+	assert.Equal(t, "tcp", in["protocol"])
+	assert.Equal(t, []any{"0.0.0.0/0", "::/0"}, in["sourceIps"])
+	assert.Equal(t, "80", in["port"])
+	assert.Equal(t, "http from anywhere", in["description"])
+
+	out, ok := dicts[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "out", out["direction"])
+	assert.Equal(t, []any{"10.0.0.0/8"}, out["destinationIps"])
+	assert.NotContains(t, out, "port", "an unset port must be absent, not an empty string")
+	assert.NotContains(t, out, "description", "an unset description must be absent")
+
+	// Empty rules still have to serialize, and as an empty list rather than nil.
+	empty := firewallRuleDicts(nil)
+	assert.Equal(t, []any{}, empty)
+	requireDictArraySerializes(t, empty)
+}
+
+// The dicts have to stay readable by the predicate that drives the exposure
+// verdict; this is the join the two halves meet at.
+func TestFirewallRuleDictsFeedOpenToInternet(t *testing.T) {
+	rules := firewallRuleDicts([]hcloud.FirewallRule{{
+		Direction: hcloud.FirewallRuleDirectionIn,
+		Protocol:  hcloud.FirewallRuleProtocolTCP,
+		SourceIPs: []net.IPNet{cidr(t, "0.0.0.0/0")},
+	}})
+	require.Len(t, rules, 1)
+
+	rule, ok := rules[0].(map[string]any)
+	require.True(t, ok)
+	assert.True(t, firewallRuleOpenToInternet(rule))
+
+	restricted := firewallRuleDicts([]hcloud.FirewallRule{{
+		Direction: hcloud.FirewallRuleDirectionIn,
+		Protocol:  hcloud.FirewallRuleProtocolTCP,
+		SourceIPs: []net.IPNet{cidr(t, "10.0.0.0/8")},
+	}})
+	rule, ok = restricted[0].(map[string]any)
+	require.True(t, ok)
+	assert.False(t, firewallRuleOpenToInternet(rule))
+}


### PR DESCRIPTION
Every other dict in this provider is built by a named helper and pinned by
`hetzner_dict_serialization_test.go`, which runs it through the real llx
converter:

```go
func requireDictSerializes(t *testing.T, d map[string]any) {
	res := llx.DictData(d).Result()
	require.Empty(t, res.Error, "dict must serialize through the llx dict converter")
}
```

The firewall rules were the one exception — built inline inside
`newMqlHetznerFirewall`, so they never went through it.

They are also the dicts that matter most here. `firewallRuleOpenToInternet`
reads them, and `serverFirewallIngress` and the server `exposure` verdict read
that. A value that fails to serialize does not cost one descriptive field, it
takes the reachability answer with it.

## What changed

Lifted the loop into `firewallRuleDicts` and added the guard test. Nothing about
the values changed.

**The rules are currently safe** — `Port` and `Description` are `*string` in
hcloud-go, so every value is already JSON-native. This is a regression guard,
not a fix. It matters because the dict converter accepts only
`bool/int64/float64/string/[]any/map`, and a plain `int` is not on that list:
if hcloud ever remodels `Port` as `*int`, or a new field arrives typed as
anything else, every firewall query would start failing at serialization with
nothing pointing at the cause.

Confirmed the guard actually bites by temporarily changing the port to a plain
int and re-running:

```
Error: Should be empty, but was failed to convert dict to primitive, unsupported child type: int
Messages: []dict must serialize through the llx dict converter
```

The test also covers that an absent port or description stays **out** of the
dict rather than becoming an empty string, which would read as a configured
value, and that the resulting dicts are still readable by
`firewallRuleOpenToInternet` in both the open and restricted cases — the join
where the two halves meet.

Found while auditing the provider; the same class previously shipped as real
bugs in `digitalocean` (#9366), where `[]string` and `*int32` dict values
errored at query time.
