### PR TITLE
⭐ azure: expose cross-subscription restore state on Recovery Services vaults

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -13273,6 +13273,15 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   // rather than the default paired region, which is what a data residency
   // audit needs to read.
   regionOfChoiceStatus string
+  // Cross-subscription restore state for the vault
+  //
+  // One of "Enabled", "Disabled", or "PermanentlyDisabled"; empty when the
+  // vault carries no explicit setting, which Azure treats as enabled. When
+  // restores are allowed across subscriptions, backup data held here can be
+  // recovered into a subscription that does not own the vault, so a data
+  // boundary audit reads this to confirm the restore target stays inside
+  // the owning subscription. "PermanentlyDisabled" cannot be reversed.
+  crossSubscriptionRestoreState string
   // Security settings (soft delete, immutability, enhanced security)
   securitySettings() azure.subscription.recoveryServicesService.vault.securitySettings
   // Encryption settings

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -16155,6 +16155,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.recoveryServicesService.vault.regionOfChoiceStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetRegionOfChoiceStatus()).ToDataRes(types.String)
 	},
+	"azure.subscription.recoveryServicesService.vault.crossSubscriptionRestoreState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetCrossSubscriptionRestoreState()).ToDataRes(types.String)
+	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetSecuritySettings()).ToDataRes(types.Resource("azure.subscription.recoveryServicesService.vault.securitySettings"))
 	},
@@ -40451,6 +40454,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.recoveryServicesService.vault.regionOfChoiceStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).RegionOfChoiceStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.vault.crossSubscriptionRestoreState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).CrossSubscriptionRestoreState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -94364,6 +94371,7 @@ type mqlAzureSubscriptionRecoveryServicesServiceVault struct {
 	SecureScore                         plugin.TValue[string]
 	CostManagementGranularityLevel      plugin.TValue[string]
 	RegionOfChoiceStatus                plugin.TValue[string]
+	CrossSubscriptionRestoreState       plugin.TValue[string]
 	SecuritySettings                    plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings]
 	Encryption                          plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultEncryption]
 	MonitoringSettings                  plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultMonitoringSettings]
@@ -94486,6 +94494,10 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetCostManagementGran
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetRegionOfChoiceStatus() *plugin.TValue[string] {
 	return &c.RegionOfChoiceStatus
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetCrossSubscriptionRestoreState() *plugin.TValue[string] {
+	return &c.CrossSubscriptionRestoreState
 }
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSecuritySettings() *plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -5289,6 +5289,7 @@ azure.subscription.recoveryServicesService.vault.backupPolicy.tags 13.34.1
 azure.subscription.recoveryServicesService.vault.backupPolicy.type 13.3.3
 azure.subscription.recoveryServicesService.vault.backupStorageVersion 13.3.3
 azure.subscription.recoveryServicesService.vault.costManagementGranularityLevel 13.30.1
+azure.subscription.recoveryServicesService.vault.crossSubscriptionRestoreState 13.36.1
 azure.subscription.recoveryServicesService.vault.encryption 13.3.3
 azure.subscription.recoveryServicesService.vault.encryption.id 13.3.3
 azure.subscription.recoveryServicesService.vault.encryption.infrastructureEncryption 13.3.3

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -296,6 +296,20 @@ func (a *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) systemMetadata
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
+// vaultCrossSubscriptionRestoreState reads the vault's cross-subscription
+// restore state out of the nested restore settings. Every level of the nesting
+// is optional in the ARM payload, and an absent setting is not the same as a
+// disabled one: Azure treats the absence as enabled, so it reports as empty
+// rather than being folded into "Disabled".
+func vaultCrossSubscriptionRestoreState(props *armrecoveryservices.VaultProperties) string {
+	if props == nil || props.RestoreSettings == nil ||
+		props.RestoreSettings.CrossSubscriptionRestoreSettings == nil ||
+		props.RestoreSettings.CrossSubscriptionRestoreSettings.CrossSubscriptionRestoreState == nil {
+		return ""
+	}
+	return string(*props.RestoreSettings.CrossSubscriptionRestoreSettings.CrossSubscriptionRestoreState)
+}
+
 func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vault) (*mqlAzureSubscriptionRecoveryServicesServiceVault, error) {
 	props := vault.Properties
 	if props == nil {
@@ -374,6 +388,7 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 			"secureScore":                         llx.StringData(secureScore),
 			"costManagementGranularityLevel":      llx.StringData(costManagementGranularityLevel),
 			"regionOfChoiceStatus":                llx.StringData(regionOfChoiceStatus),
+			"crossSubscriptionRestoreState":       llx.StringData(vaultCrossSubscriptionRestoreState(props)),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/recoveryservices_test.go
+++ b/providers/azure/resources/recoveryservices_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/llx"
@@ -85,4 +86,56 @@ func TestVaultChildTagsAreNullNotEmpty(t *testing.T) {
 		require.NotSame(t, llx.NilData, tags)
 		assert.Equal(t, map[string]any{"owner": "platform"}, tags.Value)
 	})
+}
+
+// The regression this guards: Azure nests the cross-subscription restore state
+// three levels deep and omits every level on a vault that was never configured
+// for it. Reading it without those guards panics; folding the absence into
+// "Disabled" would report a vault that permits cross-subscription restores as
+// one that forbids them.
+func TestVaultCrossSubscriptionRestoreState(t *testing.T) {
+	state := func(s armrecoveryservices.CrossSubscriptionRestoreState) *armrecoveryservices.CrossSubscriptionRestoreState {
+		return &s
+	}
+
+	t.Run("nil properties", func(t *testing.T) {
+		assert.Equal(t, "", vaultCrossSubscriptionRestoreState(nil))
+	})
+
+	t.Run("no restore settings", func(t *testing.T) {
+		assert.Equal(t, "", vaultCrossSubscriptionRestoreState(&armrecoveryservices.VaultProperties{}))
+	})
+
+	t.Run("no cross-subscription settings", func(t *testing.T) {
+		props := &armrecoveryservices.VaultProperties{
+			RestoreSettings: &armrecoveryservices.RestoreSettings{},
+		}
+		assert.Equal(t, "", vaultCrossSubscriptionRestoreState(props))
+	})
+
+	t.Run("settings present but state unset", func(t *testing.T) {
+		props := &armrecoveryservices.VaultProperties{
+			RestoreSettings: &armrecoveryservices.RestoreSettings{
+				CrossSubscriptionRestoreSettings: &armrecoveryservices.CrossSubscriptionRestoreSettings{},
+			},
+		}
+		assert.Equal(t, "", vaultCrossSubscriptionRestoreState(props))
+	})
+
+	for _, want := range []armrecoveryservices.CrossSubscriptionRestoreState{
+		armrecoveryservices.CrossSubscriptionRestoreStateEnabled,
+		armrecoveryservices.CrossSubscriptionRestoreStateDisabled,
+		armrecoveryservices.CrossSubscriptionRestoreStatePermanentlyDisabled,
+	} {
+		t.Run(string(want), func(t *testing.T) {
+			props := &armrecoveryservices.VaultProperties{
+				RestoreSettings: &armrecoveryservices.RestoreSettings{
+					CrossSubscriptionRestoreSettings: &armrecoveryservices.CrossSubscriptionRestoreSettings{
+						CrossSubscriptionRestoreState: state(want),
+					},
+				},
+			}
+			assert.Equal(t, string(want), vaultCrossSubscriptionRestoreState(props))
+		})
+	}
 }


### PR DESCRIPTION
Closes #10127

## What

`azure.subscription.recoveryServicesService.vault` gains a
`crossSubscriptionRestoreState` field, read from
`properties.restoreSettings.crossSubscriptionRestoreSettings.crossSubscriptionRestoreState`.
Values are `Enabled`, `Disabled`, `PermanentlyDisabled`, or empty when the vault
carries no explicit setting.

## Why

A vault's other data-protection settings are all already reachable — soft
delete, immutability, infrastructure encryption, customer-managed keys,
public network access, cross-*region* restore. Cross-*subscription* restore
was the one gap, and it is the setting that decides whether backup data held
in this vault can be recovered into a subscription that does not own it. Without
it there is no way to assert that restores stay inside the subscription boundary.

## Shape

Flat field, not a `restoreSettings` sub-resource. The ARM restore-settings group
holds exactly one scalar, so a sub-resource fails the bar in CLAUDE.md (no clear
id of its own, no nested typed refs) and would cost a generated struct and a
synthetic `__id` to reach one string.

## Absent is not disabled

Every level of the ARM nesting is optional, and Azure treats an absent setting as
enabled. The mapping therefore reports empty rather than folding the absence into
`Disabled`, which would report a vault that permits cross-subscription restores as
one that forbids them. A unit test pins each nesting level plus all three states.

## Test plan

- `go build ./...` in `providers/azure/`
- `go test ./resources/ -run TestVault` — new `TestVaultCrossSubscriptionRestoreState` covers nil props, missing restore settings, missing cross-subscription settings, unset state, and `Enabled` / `Disabled` / `PermanentlyDisabled`
- `make providers/build/azure` — codegen and permission manifest clean (no new API call, so no permission change)
