### PR TITLE
⭐ azure: expose signedIdentifiers on storage account blob containers

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1
 	github.com/cockroachdb/errors v1.14.0
 	github.com/pkg/errors v0.9.1

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -188,6 +188,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/signalr/armsignalr v1.2.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/signalr/armsignalr v1.2.0/go.mod h1:tzUx/enAY8RSmQhRq02uVZFeRJxdGYT6BqXwHiHoOcU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0 h1:PiSrjRPpkQNjrM8H0WwKMnZUdu1RGMtd/LdGKUrOo+c=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.6.0/go.mod h1:oDrbWx4ewMylP7xHivfgixbfGBT6APAwsSoHRKotnIc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v4 v4.1.0 h1:LbdgZl0olU2QZ6oPuFRfjq6oSAE+Y3afpAMTtH1O9gY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v4 v4.1.0/go.mod h1:U1yQRidgRofesJpSYiJWogdsrj24Xa0J4lR1HYb9Bd8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0 h1:IKCilT2DdxjeCXhiCIZb5hywpA1KDGKwpdA1WL20wT0=
@@ -204,6 +206,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0 h1:aMFO
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0/go.mod h1:Oct8bx+g+DXKngU7i/LzFzYt44rmLdMu4uoofIpooVo=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0 h1:mlmW46Q0B79I+Aj4azKC6xDMFN9a9SyZWESlGWYXbFs=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0/go.mod h1:PXe2h+LKcWTX9afWdZoHyODqR4fBa5boUM/8uJfZ0Jo=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 h1:qvrrnQ2mIjwY7IVlQuNB0ma43Nr74+9ZTZJ60KlmlV4=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1/go.mod h1:FkF/Az07vR3S4sBdjCuisznWfFWOD8u6Ibm/g/oyDAk=
 github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -6405,6 +6405,15 @@ private azure.subscription.storageService.account.container @defaults("id name")
   deletedTime time
   // Number of remaining days in the soft delete retention period
   remainingRetentionDays int
+  // Stored access policies on the container
+  //
+  // Each entry has `id`, `permission`, `startTime`, and `expiryTime`. A
+  // shared access signature bound to one of these policies can be revoked
+  // server-side by deleting or expiring the policy; a signature issued
+  // without one cannot be withdrawn before it expires. Empty when the
+  // container carries no policies. Read from the blob service rather than
+  // Azure Resource Manager, so it needs data access to the container.
+  signedIdentifiers() []dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -8960,6 +8960,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.container.remainingRetentionDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountContainer).GetRemainingRetentionDays()).ToDataRes(types.Int)
 	},
+	"azure.subscription.storageService.account.container.signedIdentifiers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountContainer).GetSignedIdentifiers()).ToDataRes(types.Array(types.Dict))
+	},
 	"azure.subscription.storageService.account.container.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountContainer).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -30217,6 +30220,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.container.remainingRetentionDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountContainer).RemainingRetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.container.signedIdentifiers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountContainer).SignedIdentifiers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.container.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -69276,6 +69283,7 @@ type mqlAzureSubscriptionStorageServiceAccountContainer struct {
 	Deleted                                         plugin.TValue[bool]
 	DeletedTime                                     plugin.TValue[*time.Time]
 	RemainingRetentionDays                          plugin.TValue[int64]
+	SignedIdentifiers                               plugin.TValue[[]any]
 	SystemMetadata                                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -69410,6 +69418,12 @@ func (c *mqlAzureSubscriptionStorageServiceAccountContainer) GetDeletedTime() *p
 
 func (c *mqlAzureSubscriptionStorageServiceAccountContainer) GetRemainingRetentionDays() *plugin.TValue[int64] {
 	return &c.RemainingRetentionDays
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountContainer) GetSignedIdentifiers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SignedIdentifiers, func() ([]any, error) {
+		return c.signedIdentifiers()
+	})
 }
 
 func (c *mqlAzureSubscriptionStorageServiceAccountContainer) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -6045,6 +6045,7 @@ azure.subscription.storageService.account.container.objectLevelImmutabilityEnabl
 azure.subscription.storageService.account.container.properties 9.0.1
 azure.subscription.storageService.account.container.publicAccess 11.6.1
 azure.subscription.storageService.account.container.remainingRetentionDays 11.6.2
+azure.subscription.storageService.account.container.signedIdentifiers 13.36.1
 azure.subscription.storageService.account.container.systemMetadata 13.28.1
 azure.subscription.storageService.account.container.type 9.0.1
 azure.subscription.storageService.account.containers 9.0.1

--- a/providers/azure/resources/storage_container_acl.go
+++ b/providers/azure/resources/storage_container_acl.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// blobContainerURL builds the blob service URL of a container. Both segments
+// are escaped: a storage account name cannot contain anything that needs it,
+// but a container name reaches this from ARM rather than from a literal, so it
+// is not treated as trusted path text.
+func blobContainerURL(account, containerName string) string {
+	return "https://" + url.PathEscape(account) + ".blob.core.windows.net/" + url.PathEscape(containerName)
+}
+
+// signedIdentifiersToDicts converts blob stored access policies into the same
+// dict shape the table resource already reports, so a query that spans
+// containers, queues and tables reads one set of keys.
+//
+// Times are emitted as RFC3339 strings rather than as time values because the
+// surrounding value is a dict, whose contents have to stay JSON-native.
+func signedIdentifiersToDicts(identifiers []*container.SignedIdentifier) []any {
+	res := []any{}
+	for _, si := range identifiers {
+		if si == nil {
+			continue
+		}
+		entry := map[string]any{}
+		if si.ID != nil {
+			entry["id"] = *si.ID
+		}
+		if si.AccessPolicy != nil {
+			if si.AccessPolicy.Permission != nil {
+				entry["permission"] = *si.AccessPolicy.Permission
+			}
+			if si.AccessPolicy.Start != nil {
+				entry["startTime"] = si.AccessPolicy.Start.Format(time.RFC3339)
+			}
+			if si.AccessPolicy.Expiry != nil {
+				entry["expiryTime"] = si.AccessPolicy.Expiry.Format(time.RFC3339)
+			}
+		}
+		res = append(res, entry)
+	}
+	return res
+}
+
+// isBlobDataPlaneUnreadable reports whether the error says the container's
+// access policy could not be read at all, as opposed to saying there are no
+// policies on it. Reading the policies goes through the blob service, so a
+// principal holding only Azure Resource Manager rights, or one calling into an
+// account whose firewall excludes it, is refused here even though the
+// container itself listed fine.
+func isBlobDataPlaneUnreadable(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	switch respErr.StatusCode {
+	case http.StatusForbidden, http.StatusUnauthorized, http.StatusNotFound:
+		return true
+	}
+	return false
+}
+
+// signedIdentifiers returns the container's stored access policies.
+//
+// This is a per-container call against the blob service, so it stays a
+// computed field rather than being fetched while the containers are listed: an
+// account with hundreds of containers would otherwise pay for all of them to
+// answer a query that never mentions this field.
+func (a *mqlAzureSubscriptionStorageServiceAccountContainer) signedIdentifiers() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+
+	_, accountName, err := storageAccountResourceGroup(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := container.NewClient(blobContainerURL(accountName, a.Name.Data), conn.Token(), &container.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GetAccessPolicy(context.Background(), nil)
+	if err != nil {
+		// An unreadable policy is not an absent one. Reporting the empty list
+		// here would assert that the container has no stored access policy,
+		// which is exactly the finding a policy audit acts on.
+		if isBlobDataPlaneUnreadable(err) {
+			a.SignedIdentifiers.State = plugin.StateIsNull | plugin.StateIsSet
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return signedIdentifiersToDicts(resp.SignedIdentifiers), nil
+}

--- a/providers/azure/resources/storage_container_acl.go
+++ b/providers/azure/resources/storage_container_acl.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,14 +14,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 )
-
-// blobContainerURL builds the blob service URL of a container. Both segments
-// are escaped: a storage account name cannot contain anything that needs it,
-// but a container name reaches this from ARM rather than from a literal, so it
-// is not treated as trusted path text.
-func blobContainerURL(account, containerName string) string {
-	return "https://" + url.PathEscape(account) + ".blob.core.windows.net/" + url.PathEscape(containerName)
-}
 
 // signedIdentifiersToDicts converts blob stored access policies into the same
 // dict shape the table resource already reports, so a query that spans
@@ -88,7 +79,12 @@ func (a *mqlAzureSubscriptionStorageServiceAccountContainer) signedIdentifiers()
 		return nil, err
 	}
 
-	client, err := container.NewClient(blobContainerURL(accountName, a.Name.Data), conn.Token(), &container.ClientOptions{
+	containerURL, err := azureStorageDataPlaneURL(accountName, "blob", a.Name.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := container.NewClient(containerURL, conn.Token(), &container.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {

--- a/providers/azure/resources/storage_container_acl_test.go
+++ b/providers/azure/resources/storage_container_acl_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobContainerURL(t *testing.T) {
+	assert.Equal(t,
+		"https://contoso.blob.core.windows.net/logs",
+		blobContainerURL("contoso", "logs"))
+
+	t.Run("a container name is escaped, not pasted into the path", func(t *testing.T) {
+		assert.Equal(t,
+			"https://contoso.blob.core.windows.net/logs%2F..%2Fsecrets",
+			blobContainerURL("contoso", "logs/../secrets"))
+	})
+}
+
+func TestSignedIdentifiersToDicts(t *testing.T) {
+	str := func(s string) *string { return &s }
+	ts := func(s string) *time.Time {
+		parsed, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return &parsed
+	}
+
+	t.Run("no policies is an empty list, never nil", func(t *testing.T) {
+		res := signedIdentifiersToDicts(nil)
+		require.NotNil(t, res)
+		assert.Empty(t, res)
+	})
+
+	t.Run("nil entries are skipped", func(t *testing.T) {
+		res := signedIdentifiersToDicts([]*container.SignedIdentifier{nil, nil})
+		assert.Empty(t, res)
+	})
+
+	// The keys have to match what the table resource already reports, or a
+	// query that spans containers and tables reads different keys per row.
+	t.Run("a full policy maps to the table resource's key set", func(t *testing.T) {
+		res := signedIdentifiersToDicts([]*container.SignedIdentifier{{
+			ID: str("readers"),
+			AccessPolicy: &container.AccessPolicy{
+				Permission: str("rl"),
+				Start:      ts("2026-01-02T03:04:05Z"),
+				Expiry:     ts("2027-01-02T03:04:05Z"),
+			},
+		}})
+		require.Len(t, res, 1)
+		assert.Equal(t, map[string]any{
+			"id":         "readers",
+			"permission": "rl",
+			"startTime":  "2026-01-02T03:04:05Z",
+			"expiryTime": "2027-01-02T03:04:05Z",
+		}, res[0])
+	})
+
+	t.Run("a policy with no access policy still reports its id", func(t *testing.T) {
+		res := signedIdentifiersToDicts([]*container.SignedIdentifier{{ID: str("orphan")}})
+		require.Len(t, res, 1)
+		assert.Equal(t, map[string]any{"id": "orphan"}, res[0])
+	})
+
+	t.Run("absent times are omitted, not zero-valued", func(t *testing.T) {
+		res := signedIdentifiersToDicts([]*container.SignedIdentifier{{
+			ID:           str("perm"),
+			AccessPolicy: &container.AccessPolicy{Permission: str("r")},
+		}})
+		require.Len(t, res, 1)
+		entry := res[0].(map[string]any)
+		assert.NotContains(t, entry, "startTime")
+		assert.NotContains(t, entry, "expiryTime")
+	})
+}
+
+// The regression this guards: classifying a transport failure as "unreadable"
+// would turn a network blip into a null field, and a policy that treats null as
+// "nothing to check" would pass on data that was never read.
+func TestIsBlobDataPlaneUnreadable(t *testing.T) {
+	respErr := func(code int) error {
+		return &azcore.ResponseError{StatusCode: code, RawResponse: &http.Response{StatusCode: code}}
+	}
+
+	for _, code := range []int{http.StatusForbidden, http.StatusUnauthorized, http.StatusNotFound} {
+		assert.True(t, isBlobDataPlaneUnreadable(respErr(code)), "status %d", code)
+	}
+
+	for _, code := range []int{http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable} {
+		assert.False(t, isBlobDataPlaneUnreadable(respErr(code)), "status %d", code)
+	}
+
+	assert.False(t, isBlobDataPlaneUnreadable(errors.New("connection reset by peer")))
+	assert.False(t, isBlobDataPlaneUnreadable(nil))
+}

--- a/providers/azure/resources/storage_container_acl_test.go
+++ b/providers/azure/resources/storage_container_acl_test.go
@@ -15,18 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlobContainerURL(t *testing.T) {
-	assert.Equal(t,
-		"https://contoso.blob.core.windows.net/logs",
-		blobContainerURL("contoso", "logs"))
-
-	t.Run("a container name is escaped, not pasted into the path", func(t *testing.T) {
-		assert.Equal(t,
-			"https://contoso.blob.core.windows.net/logs%2F..%2Fsecrets",
-			blobContainerURL("contoso", "logs/../secrets"))
-	})
-}
-
 func TestSignedIdentifiersToDicts(t *testing.T) {
 	str := func(s string) *string { return &s }
 	ts := func(s string) *time.Time {


### PR DESCRIPTION
Closes #10125

## What

`azure.subscription.storageService.account.container` gains
`signedIdentifiers() []dict` — the container's stored access policies, in the
same dict shape `...account.table.signedIdentifiers` already reports
(`id`, `permission`, `startTime`, `expiryTime`).

## Why

A shared access signature bound to a stored access policy can be revoked
server-side by deleting or expiring the policy. One issued ad hoc cannot be
withdrawn before it expires. Tables expose `signedIdentifiers` and file shares
expose `signedIdentifierCount`, but blob containers exposed nothing — and blob
containers are where most signature-issued access actually points.

## Not an ARM field

`armstorage.ContainerProperties` carries no signed identifiers, unlike
`TableProperties`. The value comes from **Get Container ACL** on the blob
service (`GET https://{account}.blob.core.windows.net/{container}?restype=container&comp=acl`)
via `azblob/container`. `azblob` was already in the module graph at v1.5.0;
this promotes it to a direct dependency at that same version rather than
bumping it.

Two consequences of it being a data-plane call:

- **It stays a computed field.** One call per container. Fetching it during
  `containers()` would charge an account with hundreds of containers for all of
  them to answer a query that never mentions the field.
- **Unreadable is not empty.** A principal with only ARM rights, or one outside
  the account firewall, is refused on the blob service even though the container
  listed fine. That path sets the field null (`StateIsNull | StateIsSet`) instead
  of returning `[]`, because "this container has no stored access policy" is
  exactly the finding an audit acts on and must not be manufactured out of a
  failed read. 403/401/404 are the only statuses treated that way; throttling,
  5xx and transport errors stay errors.

Note the blob-service data action (`Microsoft.Storage/storageAccounts/blobServices/containers/read`)
does not appear in `azure.permissions.json` — the extractor walks ARM client
methods, and this is not one. No ARM permission changed.

## Test plan

- `go build ./...` and `go mod tidy` clean in `providers/azure/`
- `make providers/build/azure` — codegen clean
- `go test ./resources/ -run 'TestBlobContainerURL|TestSignedIdentifiersToDicts|TestIsBlobDataPlaneUnreadable'`
  - URL construction, including that a container name is escaped rather than pasted into the path
  - dict mapping: empty list not nil, nil entries skipped, full policy against the table resource's exact key set, policy with no access policy, absent times omitted rather than zero-valued
  - error classifier: 403/401/404 unreadable; 429/500/503 and a bare transport error not
