### PR TITLE
⭐ azure: expose signedIdentifiers on storage account queues

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1
 	github.com/cockroachdb/errors v1.14.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -200,6 +200,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0 h1:aMFO
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0/go.mod h1:Oct8bx+g+DXKngU7i/LzFzYt44rmLdMu4uoofIpooVo=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 h1:qvrrnQ2mIjwY7IVlQuNB0ma43Nr74+9ZTZJ60KlmlV4=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1/go.mod h1:FkF/Az07vR3S4sBdjCuisznWfFWOD8u6Ibm/g/oyDAk=
 github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
 github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -6066,6 +6066,15 @@ private azure.subscription.storageService.account.queue @defaults("id name") {
   metadata map[string]string
   // Approximate number of messages in the queue
   approximateMessageCount() int
+  // Stored access policies on the queue
+  //
+  // Each entry has `id`, `permission`, `startTime`, and `expiryTime`. A
+  // shared access signature bound to one of these policies can be revoked
+  // server-side by deleting or expiring the policy; a signature issued
+  // without one cannot be withdrawn before it expires. Empty when the
+  // queue carries no policies. Read from the queue service rather than
+  // Azure Resource Manager, so it needs data access to the queue.
+  signedIdentifiers() []dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -8598,6 +8598,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.queue.approximateMessageCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetApproximateMessageCount()).ToDataRes(types.Int)
 	},
+	"azure.subscription.storageService.account.queue.signedIdentifiers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetSignedIdentifiers()).ToDataRes(types.Array(types.Dict))
+	},
 	"azure.subscription.storageService.account.queue.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -29475,6 +29478,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.queue.approximateMessageCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).ApproximateMessageCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.queue.signedIdentifiers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).SignedIdentifiers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.queue.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -67477,6 +67484,7 @@ type mqlAzureSubscriptionStorageServiceAccountQueue struct {
 	Name                    plugin.TValue[string]
 	Metadata                plugin.TValue[map[string]any]
 	ApproximateMessageCount plugin.TValue[int64]
+	SignedIdentifiers       plugin.TValue[[]any]
 	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -67532,6 +67540,12 @@ func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetMetadata() *plugin.T
 func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetApproximateMessageCount() *plugin.TValue[int64] {
 	return plugin.GetOrCompute[int64](&c.ApproximateMessageCount, func() (int64, error) {
 		return c.approximateMessageCount()
+	})
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetSignedIdentifiers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SignedIdentifiers, func() ([]any, error) {
+		return c.signedIdentifiers()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -6168,6 +6168,7 @@ azure.subscription.storageService.account.queue.approximateMessageCount 13.10.2
 azure.subscription.storageService.account.queue.id 13.10.2
 azure.subscription.storageService.account.queue.metadata 13.10.2
 azure.subscription.storageService.account.queue.name 13.10.2
+azure.subscription.storageService.account.queue.signedIdentifiers 13.36.1
 azure.subscription.storageService.account.queue.systemMetadata 13.28.1
 azure.subscription.storageService.account.queueProperties 9.0.1
 azure.subscription.storageService.account.queues 13.10.2

--- a/providers/azure/resources/storage_dataplane_url.go
+++ b/providers/azure/resources/storage_dataplane_url.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+)
+
+// azureStorageAccountNameRe is Azure's storage account naming rule: 3 to 24
+// characters, lowercase letters and digits only.
+var azureStorageAccountNameRe = regexp.MustCompile(`^[a-z0-9]{3,24}$`)
+
+// azureStorageDataPlaneURL builds the URL of one object in a storage account's
+// data plane: a container on the blob service, a queue on the queue service.
+//
+// The two halves are handled differently because they land in different parts
+// of the URL. The object name is a path segment, so it is percent-escaped. The
+// account name is part of the host, where percent-escaping does not apply: a
+// name carrying a "/" would not be encoded away, it would change which host the
+// request is sent to. So the account name is validated against Azure's naming
+// rule instead of escaped, and a name that fails is an error rather than a URL.
+// In practice it always passes, since it is read back out of an ARM resource
+// ID, but the URL is only safe to build because that is checked rather than
+// assumed.
+func azureStorageDataPlaneURL(account, service, name string) (string, error) {
+	if !azureStorageAccountNameRe.MatchString(account) {
+		return "", fmt.Errorf("%q is not a valid Azure storage account name", account)
+	}
+	return "https://" + account + "." + service + ".core.windows.net/" + url.PathEscape(name), nil
+}

--- a/providers/azure/resources/storage_dataplane_url_test.go
+++ b/providers/azure/resources/storage_dataplane_url_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureStorageDataPlaneURL(t *testing.T) {
+	t.Run("account, service and object become host and path", func(t *testing.T) {
+		blob, err := azureStorageDataPlaneURL("contoso", "blob", "logs")
+		require.NoError(t, err)
+		assert.Equal(t, "https://contoso.blob.core.windows.net/logs", blob)
+
+		queue, err := azureStorageDataPlaneURL("contoso", "queue", "orders")
+		require.NoError(t, err)
+		assert.Equal(t, "https://contoso.queue.core.windows.net/orders", queue)
+	})
+
+	t.Run("the object name is escaped, not pasted into the path", func(t *testing.T) {
+		got, err := azureStorageDataPlaneURL("contoso", "blob", "logs/../secrets")
+		require.NoError(t, err)
+		assert.Equal(t, "https://contoso.blob.core.windows.net/logs%2F..%2Fsecrets", got)
+	})
+
+	// The regression this guards: the account name lands in the host, where
+	// percent-escaping does not apply. Escaping it there would look like a
+	// defence and not be one -- a name carrying a "/" is not encoded away, it
+	// moves the request to a different host. Rejecting the name is the defence.
+	t.Run("an account name that is not a valid account name is refused", func(t *testing.T) {
+		for _, account := range []string{
+			"",
+			"ab",                              // shorter than the 3 character minimum
+			"averyverylongstorageaccountname", // longer than the 24 character maximum
+			"Contoso",                         // uppercase is not allowed
+			"contoso-logs",                    // hyphens are not allowed
+			"evil/../attacker",                // would relocate the host
+			"attacker.example.com",            // would relocate the host
+			"contoso ",                        // trailing space
+		} {
+			_, err := azureStorageDataPlaneURL(account, "blob", "logs")
+			assert.Error(t, err, "account %q", account)
+		}
+	})
+
+	t.Run("the shortest and longest legal account names are accepted", func(t *testing.T) {
+		shortest, err := azureStorageDataPlaneURL("abc", "blob", "logs")
+		require.NoError(t, err)
+		assert.Equal(t, "https://abc.blob.core.windows.net/logs", shortest)
+
+		longest, err := azureStorageDataPlaneURL("abcdefghij0123456789wxyz", "blob", "logs")
+		require.NoError(t, err)
+		assert.Equal(t, "https://abcdefghij0123456789wxyz.blob.core.windows.net/logs", longest)
+	})
+}

--- a/providers/azure/resources/storage_queue_acl.go
+++ b/providers/azure/resources/storage_queue_acl.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,14 +14,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 )
-
-// storageQueueURL builds the queue service URL of a queue. Both segments are
-// escaped: a storage account name cannot contain anything that needs it, but a
-// queue name reaches this from ARM rather than from a literal, so it is not
-// treated as trusted path text.
-func storageQueueURL(account, queueName string) string {
-	return "https://" + url.PathEscape(account) + ".queue.core.windows.net/" + url.PathEscape(queueName)
-}
 
 // queueSignedIdentifiersToDicts converts queue stored access policies into the
 // same dict shape the table resource already reports, so a query that spans
@@ -88,7 +79,12 @@ func (a *mqlAzureSubscriptionStorageServiceAccountQueue) signedIdentifiers() ([]
 		return nil, err
 	}
 
-	client, err := azqueue.NewQueueClient(storageQueueURL(accountName, a.Name.Data), conn.Token(), &azqueue.ClientOptions{
+	queueURL, err := azureStorageDataPlaneURL(accountName, "queue", a.Name.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := azqueue.NewQueueClient(queueURL, conn.Token(), &azqueue.ClientOptions{
 		ClientOptions: conn.ClientOptions(),
 	})
 	if err != nil {

--- a/providers/azure/resources/storage_queue_acl.go
+++ b/providers/azure/resources/storage_queue_acl.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// storageQueueURL builds the queue service URL of a queue. Both segments are
+// escaped: a storage account name cannot contain anything that needs it, but a
+// queue name reaches this from ARM rather than from a literal, so it is not
+// treated as trusted path text.
+func storageQueueURL(account, queueName string) string {
+	return "https://" + url.PathEscape(account) + ".queue.core.windows.net/" + url.PathEscape(queueName)
+}
+
+// queueSignedIdentifiersToDicts converts queue stored access policies into the
+// same dict shape the table resource already reports, so a query that spans
+// queues and tables reads one set of keys.
+//
+// Times are emitted as RFC3339 strings rather than as time values because the
+// surrounding value is a dict, whose contents have to stay JSON-native.
+func queueSignedIdentifiersToDicts(identifiers []*azqueue.SignedIdentifier) []any {
+	res := []any{}
+	for _, si := range identifiers {
+		if si == nil {
+			continue
+		}
+		entry := map[string]any{}
+		if si.ID != nil {
+			entry["id"] = *si.ID
+		}
+		if si.AccessPolicy != nil {
+			if si.AccessPolicy.Permission != nil {
+				entry["permission"] = *si.AccessPolicy.Permission
+			}
+			if si.AccessPolicy.Start != nil {
+				entry["startTime"] = si.AccessPolicy.Start.Format(time.RFC3339)
+			}
+			if si.AccessPolicy.Expiry != nil {
+				entry["expiryTime"] = si.AccessPolicy.Expiry.Format(time.RFC3339)
+			}
+		}
+		res = append(res, entry)
+	}
+	return res
+}
+
+// isQueueDataPlaneUnreadable reports whether the error says the queue's access
+// policy could not be read at all, as opposed to saying there are no policies
+// on it. Reading the policies goes through the queue service, so a principal
+// holding only Azure Resource Manager rights, or one calling into an account
+// whose firewall excludes it, is refused here even though the queue itself
+// listed fine.
+func isQueueDataPlaneUnreadable(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	switch respErr.StatusCode {
+	case http.StatusForbidden, http.StatusUnauthorized, http.StatusNotFound:
+		return true
+	}
+	return false
+}
+
+// signedIdentifiers returns the queue's stored access policies.
+//
+// This is a per-queue call against the queue service, so it stays a computed
+// field rather than being fetched while the queues are listed: an account with
+// many queues would otherwise pay for all of them to answer a query that never
+// mentions this field.
+func (a *mqlAzureSubscriptionStorageServiceAccountQueue) signedIdentifiers() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+
+	_, accountName, err := storageAccountResourceGroup(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := azqueue.NewQueueClient(storageQueueURL(accountName, a.Name.Data), conn.Token(), &azqueue.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GetAccessPolicy(context.Background(), nil)
+	if err != nil {
+		// An unreadable policy is not an absent one. Reporting the empty list
+		// here would assert that the queue has no stored access policy, which
+		// is exactly the finding a policy audit acts on.
+		if isQueueDataPlaneUnreadable(err) {
+			a.SignedIdentifiers.State = plugin.StateIsNull | plugin.StateIsSet
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return queueSignedIdentifiersToDicts(resp.SignedIdentifiers), nil
+}

--- a/providers/azure/resources/storage_queue_acl_test.go
+++ b/providers/azure/resources/storage_queue_acl_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageQueueURL(t *testing.T) {
+	assert.Equal(t,
+		"https://contoso.queue.core.windows.net/orders",
+		storageQueueURL("contoso", "orders"))
+
+	t.Run("a queue name is escaped, not pasted into the path", func(t *testing.T) {
+		assert.Equal(t,
+			"https://contoso.queue.core.windows.net/orders%2F..%2Fsecrets",
+			storageQueueURL("contoso", "orders/../secrets"))
+	})
+}
+
+func TestQueueSignedIdentifiersToDicts(t *testing.T) {
+	str := func(s string) *string { return &s }
+	ts := func(s string) *time.Time {
+		parsed, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return &parsed
+	}
+
+	t.Run("no policies is an empty list, never nil", func(t *testing.T) {
+		res := queueSignedIdentifiersToDicts(nil)
+		require.NotNil(t, res)
+		assert.Empty(t, res)
+	})
+
+	t.Run("nil entries are skipped", func(t *testing.T) {
+		res := queueSignedIdentifiersToDicts([]*azqueue.SignedIdentifier{nil, nil})
+		assert.Empty(t, res)
+	})
+
+	// The keys have to match what the table resource already reports, or a
+	// query that spans queues and tables reads different keys per row.
+	t.Run("a full policy maps to the table resource's key set", func(t *testing.T) {
+		res := queueSignedIdentifiersToDicts([]*azqueue.SignedIdentifier{{
+			ID: str("processors"),
+			AccessPolicy: &azqueue.AccessPolicy{
+				Permission: str("rap"),
+				Start:      ts("2026-01-02T03:04:05Z"),
+				Expiry:     ts("2027-01-02T03:04:05Z"),
+			},
+		}})
+		require.Len(t, res, 1)
+		assert.Equal(t, map[string]any{
+			"id":         "processors",
+			"permission": "rap",
+			"startTime":  "2026-01-02T03:04:05Z",
+			"expiryTime": "2027-01-02T03:04:05Z",
+		}, res[0])
+	})
+
+	t.Run("a policy with no access policy still reports its id", func(t *testing.T) {
+		res := queueSignedIdentifiersToDicts([]*azqueue.SignedIdentifier{{ID: str("orphan")}})
+		require.Len(t, res, 1)
+		assert.Equal(t, map[string]any{"id": "orphan"}, res[0])
+	})
+
+	t.Run("absent times are omitted, not zero-valued", func(t *testing.T) {
+		res := queueSignedIdentifiersToDicts([]*azqueue.SignedIdentifier{{
+			ID:           str("perm"),
+			AccessPolicy: &azqueue.AccessPolicy{Permission: str("r")},
+		}})
+		require.Len(t, res, 1)
+		entry := res[0].(map[string]any)
+		assert.NotContains(t, entry, "startTime")
+		assert.NotContains(t, entry, "expiryTime")
+	})
+}
+
+// The regression this guards: classifying a transport failure as "unreadable"
+// would turn a network blip into a null field, and a policy that treats null as
+// "nothing to check" would pass on data that was never read.
+func TestIsQueueDataPlaneUnreadable(t *testing.T) {
+	respErr := func(code int) error {
+		return &azcore.ResponseError{StatusCode: code, RawResponse: &http.Response{StatusCode: code}}
+	}
+
+	for _, code := range []int{http.StatusForbidden, http.StatusUnauthorized, http.StatusNotFound} {
+		assert.True(t, isQueueDataPlaneUnreadable(respErr(code)), "status %d", code)
+	}
+
+	for _, code := range []int{http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable} {
+		assert.False(t, isQueueDataPlaneUnreadable(respErr(code)), "status %d", code)
+	}
+
+	assert.False(t, isQueueDataPlaneUnreadable(errors.New("connection reset by peer")))
+	assert.False(t, isQueueDataPlaneUnreadable(nil))
+}

--- a/providers/azure/resources/storage_queue_acl_test.go
+++ b/providers/azure/resources/storage_queue_acl_test.go
@@ -15,18 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStorageQueueURL(t *testing.T) {
-	assert.Equal(t,
-		"https://contoso.queue.core.windows.net/orders",
-		storageQueueURL("contoso", "orders"))
-
-	t.Run("a queue name is escaped, not pasted into the path", func(t *testing.T) {
-		assert.Equal(t,
-			"https://contoso.queue.core.windows.net/orders%2F..%2Fsecrets",
-			storageQueueURL("contoso", "orders/../secrets"))
-	})
-}
-
 func TestQueueSignedIdentifiersToDicts(t *testing.T) {
 	str := func(s string) *string { return &s }
 	ts := func(s string) *time.Time {


### PR DESCRIPTION
Closes #10126

## What

`azure.subscription.storageService.account.queue` gains
`signedIdentifiers() []dict` — the queue's stored access policies, in the same
dict shape `...account.table.signedIdentifiers` already reports
(`id`, `permission`, `startTime`, `expiryTime`).

## Why

A shared access signature bound to a stored access policy can be revoked
server-side by deleting or expiring the policy. One issued ad hoc cannot be
withdrawn before it expires. The queue resource exposed only
`approximateMessageCount`, `id`, `metadata`, `name` and `systemMetadata`, so
that difference was unassertable for queues while tables and file shares both
reached theirs.

## Not an ARM field

`armstorage.QueueProperties` carries only `Metadata` and
`ApproximateMessageCount`. The value comes from **Get Queue ACL** on the queue
service (`GET https://{account}.queue.core.windows.net/{queue}?comp=acl`) via
the `azqueue` SDK, added at v1.0.1.

Two consequences of it being a data-plane call:

- **It stays a computed field.** One call per queue. Fetching it during
  `queues()` would charge an account with many queues for all of them to answer
  a query that never mentions the field.
- **Unreadable is not empty.** A principal with only ARM rights, or one outside
  the account firewall, is refused on the queue service even though the queue
  listed fine. That path sets the field null (`StateIsNull | StateIsSet`) instead
  of returning `[]`, because "this queue has no stored access policy" is exactly
  the finding an audit acts on and must not be manufactured out of a failed read.
  403/401/404 are the only statuses treated that way; throttling, 5xx and
  transport errors stay errors.

Note the queue-service data action does not appear in `azure.permissions.json` —
the extractor walks ARM client methods, and this is not one. No ARM permission
changed.

Companion to #10129 (blob containers); filed and shipped separately because they
are different data-plane endpoints and different SDKs.

## Test plan

- `go build ./...` and `go mod tidy` clean in `providers/azure/`
- `make providers/build/azure` — codegen clean
- `go test ./resources/ -run 'TestStorageQueueURL|TestQueueSignedIdentifiersToDicts|TestIsQueueDataPlaneUnreadable'`
  - URL construction, including that a queue name is escaped rather than pasted into the path
  - dict mapping: empty list not nil, nil entries skipped, full policy against the table resource's exact key set, policy with no access policy, absent times omitted rather than zero-valued
  - error classifier: 403/401/404 unreadable; 429/500/503 and a bare transport error not
