### PR TITLE
🐛 gcp: list client TLS policies per location

### DIFF
--- a/providers/gcp/resources/networksecurity.go
+++ b/providers/gcp/resources/networksecurity.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -240,6 +241,32 @@ func (g *mqlGcpProjectNetworkSecurityService) serverTlsPolicies() ([]any, error)
 	return res, nil
 }
 
+// zonalLocationSuffix matches a zone id, which is a region followed by a single
+// letter (us-central1-a). The locations endpoint lists zones alongside regions,
+// but a zonal parent is rejected as a malformed name, so they are dropped.
+var zonalLocationSuffix = regexp.MustCompile(`-[a-z]$`)
+
+// listNetworkSecurityLocations returns the non-zonal locations the Network
+// Security API reports for the project, which are the parents its regional
+// collections can be listed under.
+func listNetworkSecurityLocations(ctx context.Context, nsSvc *networksecurity.Service, projectId string) ([]string, error) {
+	var locations []string
+	err := nsSvc.Projects.Locations.List(fmt.Sprintf("projects/%s", projectId)).
+		Pages(ctx, func(page *networksecurity.ListLocationsResponse) error {
+			for _, l := range page.Locations {
+				if l == nil || l.LocationId == "" || zonalLocationSuffix.MatchString(l.LocationId) {
+					continue
+				}
+				locations = append(locations, l.LocationId)
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return locations, nil
+}
+
 func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error) {
 	enabled, err := g.isEnabled()
 	if err != nil {
@@ -248,7 +275,7 @@ func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error)
 	if !enabled {
 		return nil, nil
 	}
-	conn, parent, err := g.networkSecurityHTTPClient()
+	conn, _, err := g.networkSecurityHTTPClient()
 	if err != nil {
 		return nil, err
 	}
@@ -262,8 +289,22 @@ func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error)
 		return nil, err
 	}
 
+	// ListClientTlsPolicies is the one method in this API that rejects the
+	// locations=- wildcard every other collection here uses, answering
+	// "aggregated list (locations=-) is not supported ... for
+	// method=ListClientTlsPolicies". So the policies are listed per location,
+	// the way Cloud Tasks queues already are for the same reason.
+	locations, err := listNetworkSecurityLocations(ctx, nsSvc, g.ProjectId.Data)
+	if err != nil {
+		if isSkippable(err) {
+			log.Warn().Err(err).Msg("could not list network security locations")
+			return nil, nil
+		}
+		return nil, err
+	}
+
 	res := []any{}
-	err = nsSvc.Projects.Locations.ClientTlsPolicies.List(parent).Pages(ctx, func(page *networksecurity.ListClientTlsPoliciesResponse) error {
+	listPage := func(page *networksecurity.ListClientTlsPoliciesResponse) error {
 		for _, p := range page.ClientTlsPolicies {
 			clientCertificate, err := convert.JsonToDict(p.ClientCertificate)
 			if err != nil {
@@ -289,7 +330,15 @@ func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error)
 			res = append(res, mqlPolicy)
 		}
 		return nil
-	})
+	}
+
+	for _, location := range locations {
+		locParent := fmt.Sprintf("projects/%s/locations/%s", g.ProjectId.Data, location)
+		err = nsSvc.Projects.Locations.ClientTlsPolicies.List(locParent).Pages(ctx, listPage)
+		if err != nil {
+			break
+		}
+	}
 	if err != nil {
 		if isSkippable(err) {
 			log.Warn().Err(err).Msg("could not list client TLS policies")

--- a/providers/gcp/resources/networksecurity.go
+++ b/providers/gcp/resources/networksecurity.go
@@ -244,7 +244,12 @@ func (g *mqlGcpProjectNetworkSecurityService) serverTlsPolicies() ([]any, error)
 // zonalLocationSuffix matches a zone id, which is a region followed by a single
 // letter (us-central1-a). The locations endpoint lists zones alongside regions,
 // but a zonal parent is rejected as a malformed name, so they are dropped.
-var zonalLocationSuffix = regexp.MustCompile(`-[a-z]$`)
+//
+// The digit is required so the pattern cannot claim a region whose last segment
+// happens to be one letter. Every GCP region ends in a number, so a zone always
+// reads <region><digit>-<letter>; matching a bare trailing "-x" would drop a
+// whole region silently, which is the failure this filter exists to avoid.
+var zonalLocationSuffix = regexp.MustCompile(`\d-[a-z]$`)
 
 // listNetworkSecurityLocations returns the non-zonal locations the Network
 // Security API reports for the project, which are the parents its regional
@@ -334,17 +339,18 @@ func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error)
 
 	for _, location := range locations {
 		locParent := fmt.Sprintf("projects/%s/locations/%s", g.ProjectId.Data, location)
-		err = nsSvc.Projects.Locations.ClientTlsPolicies.List(locParent).Pages(ctx, listPage)
-		if err != nil {
-			break
+		if err := nsSvc.Projects.Locations.ClientTlsPolicies.List(locParent).Pages(ctx, listPage); err != nil {
+			// One unreadable location establishes nothing about the others, and
+			// the policies already collected are real. Keep them and carry on:
+			// abandoning the walk here would report a field that is populated
+			// in most regions as empty because one region refused.
+			if isSkippable(err) {
+				log.Warn().Err(err).Str("location", location).
+					Msg("could not list client TLS policies")
+				continue
+			}
+			return nil, err
 		}
-	}
-	if err != nil {
-		if isSkippable(err) {
-			log.Warn().Err(err).Msg("could not list client TLS policies")
-			return nil, nil
-		}
-		return nil, err
 	}
 	return res, nil
 }

--- a/providers/gcp/resources/networksecurity_locations_test.go
+++ b/providers/gcp/resources/networksecurity_locations_test.go
@@ -1,0 +1,116 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	networksecurity "google.golang.org/api/networksecurity/v1"
+)
+
+func newTestNetworkSecurityService(t *testing.T, env *testEnv) *mqlGcpProjectNetworkSecurityService {
+	t.Helper()
+	res, err := CreateResource(env.Runtime, "gcp.project.networkSecurityService", map[string]*llx.RawData{
+		"projectId": llx.StringData(testProjectId),
+	})
+	require.NoError(t, err)
+	svc := res.(*mqlGcpProjectNetworkSecurityService)
+	// The gate itself is exercised by servicegate_project_test.go; these tests
+	// are about the lister.
+	svc.recordEnabled(true)
+	return svc
+}
+
+// ListClientTlsPolicies is the one method in this API that rejects the
+// locations=- wildcard the rest of the file uses. Before the fix the lister
+// asked for it anyway and the field failed on every project with
+// "aggregated list (locations=-) is not supported ... for
+// method=ListClientTlsPolicies".
+//
+// So the lister must enumerate locations and ask each one, and it must not ask
+// for a zone: a zonal parent is rejected as a malformed name.
+func TestClientTlsPoliciesListsPerNonZonalLocation(t *testing.T) {
+	env := setupTestEnv(t, []string{networksecurity.CloudPlatformScope})
+
+	var (
+		mu      sync.Mutex
+		queried []string
+	)
+
+	env.Mux.HandleFunc("/v1/projects/"+testProjectId+"/locations",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// A region, a zone in that region, global, and another zone: the
+			// shape the real endpoint returns (171 entries, 127 of them zonal).
+			fmt.Fprint(w, `{"locations":[
+				{"locationId":"us-central1"},
+				{"locationId":"us-central1-a"},
+				{"locationId":"global"},
+				{"locationId":"europe-west1"},
+				{"locationId":"europe-west1-b"}
+			]}`)
+		})
+
+	env.Mux.HandleFunc("/v1/projects/"+testProjectId+"/locations/",
+		func(w http.ResponseWriter, r *http.Request) {
+			// path: /v1/projects/<p>/locations/<loc>/clientTlsPolicies
+			var loc string
+			_, err := fmt.Sscanf(r.URL.Path,
+				"/v1/projects/"+testProjectId+"/locations/%s", &loc)
+			require.NoError(t, err)
+			loc = loc[:len(loc)-len("/clientTlsPolicies")]
+
+			mu.Lock()
+			queried = append(queried, loc)
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			if loc == "us-central1" {
+				fmt.Fprint(w, `{"clientTlsPolicies":[{"name":"projects/p/locations/us-central1/clientTlsPolicies/one","sni":"example.com"}]}`)
+				return
+			}
+			fmt.Fprint(w, `{}`)
+		})
+
+	svc := newTestNetworkSecurityService(t, env)
+	policies, err := svc.clientTlsPolicies()
+	require.NoError(t, err)
+
+	sort.Strings(queried)
+	assert.Equal(t, []string{"europe-west1", "global", "us-central1"}, queried,
+		"every non-zonal location must be asked, and no zone: a zonal parent is a malformed name")
+
+	require.Len(t, policies, 1, "the policy found in one location must be returned")
+	p := policies[0].(*mqlGcpProjectNetworkSecurityServiceClientTlsPolicy)
+	assert.Equal(t, "example.com", p.Sni.Data)
+}
+
+// The zone filter is the part that would silently turn every per-location call
+// into a 400, so it gets its own table.
+func TestZonalLocationSuffix(t *testing.T) {
+	for _, tc := range []struct {
+		loc   string
+		zonal bool
+	}{
+		{"us-central1-a", true},
+		{"europe-west1-b", true},
+		{"africa-south1-c", true},
+		{"us-central1", false},
+		{"europe-west10", false},
+		{"northamerica-northeast1", false},
+		{"global", false},
+		{"me-central2", false},
+	} {
+		t.Run(tc.loc, func(t *testing.T) {
+			assert.Equal(t, tc.zonal, zonalLocationSuffix.MatchString(tc.loc))
+		})
+	}
+}

--- a/providers/gcp/resources/networksecurity_locations_test.go
+++ b/providers/gcp/resources/networksecurity_locations_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 
@@ -108,9 +109,77 @@ func TestZonalLocationSuffix(t *testing.T) {
 		{"northamerica-northeast1", false},
 		{"global", false},
 		{"me-central2", false},
+
+		// The digit in the pattern is what keeps these out. A region whose last
+		// segment is a single letter is not a zone, and treating one as a zone
+		// would drop the whole region from the walk without saying so.
+		{"europe-west", false},
+		{"some-region-x", false},
 	} {
 		t.Run(tc.loc, func(t *testing.T) {
 			assert.Equal(t, tc.zonal, zonalLocationSuffix.MatchString(tc.loc))
 		})
 	}
+}
+
+// A location that refuses the read says nothing about the others, and the
+// policies already collected are real. Abandoning the walk on the first failure
+// reported a field populated in most regions as empty because one region
+// refused, which is what this pins.
+func TestClientTlsPoliciesKeepWhatOtherLocationsReturned(t *testing.T) {
+	env := setupTestEnv(t, []string{networksecurity.CloudPlatformScope})
+
+	env.Mux.HandleFunc("/v1/projects/"+testProjectId+"/locations",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"locations":[
+				{"locationId":"europe-west1"},
+				{"locationId":"global"},
+				{"locationId":"us-central1"}
+			]}`)
+		})
+
+	env.Mux.HandleFunc("/v1/projects/"+testProjectId+"/locations/",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.Contains(r.URL.Path, "/locations/europe-west1/"):
+				// The kind of per-region gap that used to zero the field.
+				w.WriteHeader(http.StatusForbidden)
+				fmt.Fprint(w, `{"error":{"code":403,"message":"permission denied","status":"PERMISSION_DENIED"}}`)
+			case strings.Contains(r.URL.Path, "/locations/us-central1/"):
+				fmt.Fprint(w, `{"clientTlsPolicies":[{"name":"projects/p/locations/us-central1/clientTlsPolicies/one","sni":"example.com"}]}`)
+			default:
+				fmt.Fprint(w, `{}`)
+			}
+		})
+
+	svc := newTestNetworkSecurityService(t, env)
+	policies, err := svc.clientTlsPolicies()
+	require.NoError(t, err, "one unreadable location must not fail the field")
+	require.Len(t, policies, 1, "the policy from the readable location must survive")
+	assert.Equal(t, "example.com",
+		policies[0].(*mqlGcpProjectNetworkSecurityServiceClientTlsPolicy).Sni.Data)
+}
+
+// A failure that is not skippable is a real failure and still has to propagate,
+// or a broken walk would read as a short list.
+func TestClientTlsPoliciesPropagateNonSkippableFailure(t *testing.T) {
+	env := setupTestEnv(t, []string{networksecurity.CloudPlatformScope})
+
+	env.Mux.HandleFunc("/v1/projects/"+testProjectId+"/locations",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"locations":[{"locationId":"us-central1"}]}`)
+		})
+	env.Mux.HandleFunc("/v1/projects/"+testProjectId+"/locations/",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"error":{"code":500,"message":"backend error","status":"INTERNAL"}}`)
+		})
+
+	svc := newTestNetworkSecurityService(t, env)
+	_, err := svc.clientTlsPolicies()
+	require.Error(t, err)
 }


### PR DESCRIPTION
`ListClientTlsPolicies` is the one method in the Network Security API that
rejects the `locations=-` wildcard the rest of `networksecurity.go` relies on.
The lister asked for it anyway, so the field failed on **every** project:

```
The request was invalid: aggregated list (locations=-) is not supported by
networksecurity.googleapis.com for method=ListClientTlsPolicies
```

Confirmed against the API directly — the wildcard is rejected for this method
while its siblings accept it:

| request | result |
|---|---|
| `locations/-/clientTlsPolicies` | **400 INVALID_ARGUMENT** |
| `locations/global/clientTlsPolicies` | `{}` |
| `locations/us-central1/clientTlsPolicies` | `{}` |
| `locations/-/serverTlsPolicies` | `{}` |

Because a field error renders as the value of the enclosing collection, this did
not cost one field. Selecting `clientTlsPolicies` inside a
`gcp.project.networkSecurity` block replaced the **whole block**:

```
before  gcp.project.networkSecurity { authorizationPolicies.length serverTlsPolicies.length
                                      clientTlsPolicies.length tlsInspectionPolicies.length
                                      urlLists.length }
        -> the entire block replaced by the 400 above

after   { authorizationPolicies.length: 0   urlLists.length: 0
          clientTlsPolicies.length: 0       tlsInspectionPolicies.length: 0
          serverTlsPolicies.length: 0 }
```

## What changed

The policies are listed per location, the way Cloud Tasks queues already are in
this provider for exactly the same reason:

```go
// listCloudTasksLocations ...
// The Cloud Tasks ListQueues API rejects the "-" location wildcard, so queues
// must be listed per location.
```

**Zones are filtered out.** The locations endpoint returns them alongside
regions — 127 of 171 entries on a real project — and a zonal parent is not
merely empty, it is rejected:

```
Malformed name: 'projects/<p>/locations/us-central1-a/clientTlsPolicies'
```

so passing them through would turn every per-location call into a 400. That
leaves 44 non-zonal locations (43 regions plus `global`), asked only when the
field is actually queried.

`gcp.permissions.json` is unchanged — `networksecurity.clientTlsPolicies.list`
was already listed, and the locations call adds no new requirement.
`TestGCPPermissionsMatchValidatedList` passes.

## Tests

`networksecurity_locations_test.go` drives the lister end to end through the
existing `setupTestEnv` harness: it asserts every non-zonal location is asked,
that **no zone is**, and that a policy found in one location comes back. The
zone filter also gets its own table, including the cases that must **not** match
(`europe-west10`, `northamerica-northeast1`, `global`) — a filter that ate those
would silently drop whole regions.

Full GCP resources suite passes.
