### PR TITLE
🐛 gcp: do not fail a project block when Dataflow is not enabled

### DIFF
--- a/providers/gcp/resources/dataflow.go
+++ b/providers/gcp/resources/dataflow.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -95,6 +96,15 @@ func (g *mqlGcpProjectDataflowService) jobs() ([]any, error) {
 		}
 		return nil
 	}); err != nil {
+		// Dataflow is not enabled on most projects, and an unused API answers
+		// 403 "has not been used ... or it is disabled" rather than with an
+		// empty list. Left to propagate, that error renders as the value of the
+		// enclosing collection, so selecting jobs inside a gcp.project block
+		// costs every other field in it.
+		if isSkippable(err) {
+			log.Warn().Err(err).Msg("could not list dataflow jobs")
+			return nil, nil
+		}
 		return nil, err
 	}
 	return res, nil


### PR DESCRIPTION
Every other service collection in this provider either gates on service
enablement (`isEnabled()` / `serviceEnabled()`) or tolerates the error a
disabled API returns (`isSkippable`). `dataflow.jobs` did neither, so on a
project that has not turned Dataflow on it propagated a raw:

```
403: Dataflow API has not been used in project <p> before or it is disabled.
     ... "reason": "SERVICE_DISABLED"
```

Dataflow is off by default, so this fires on most projects. And because a field
error renders as the value of the enclosing collection, it did not cost one
field — it took every other field selected alongside it.

Found by live sweep: of the 115 APIs enabled on the test project, Dataflow was
not one, and it was the only ungated collection that surfaced an error rather
than an empty list.

## What changed

The List error now goes through `isSkippable`, the helper the rest of the
provider already uses for exactly this (it matches `SERVICE_DISABLED`, 403 and
404), and logs what was skipped rather than dropping it silently.

Verified live on a project without the API enabled:

```
before  gcp.project { dataflow.jobs.length ... }
        -> the whole block replaced by the 403

after   ! could not list dataflow jobs  error="... reason: SERVICE_DISABLED ..."
        gcp.project: {
          compute.networks.length: 1
          dataflow.jobs.length: 0
          kms.keyrings.length: 10
        }
```

No new test: the change is one call to `isSkippable`, whose classification is
already covered by `errors_test.go`, and the enclosing lister is a thin wrapper
around the SDK call.

## Related, not fixed here

`dataflow.jobs` was the collection that failed on this project, but it is not
the only ungated one. Auditing every `gcp.project.*Service` list accessor,
**59** neither gate on enablement nor tolerate a skippable error — concentrated
in `vertexai.go` (25) and `monitoring.go` (7). They did not surface here only
because those APIs happen to be enabled on the test project; on a project
without them, each would fail the same way.

Worth a follow-up sweep, and possibly an AST ratchet alongside the existing
`TestNoBareGetEnabledDataGate` and `TestNoStringifiedAPIErrors` guards so new
collections cannot reintroduce it. Happy to take that on separately rather than
bundle 59 files into this fix.
