### PR TITLE
⚡ github: resolve a repository's special files from the files field

### DIFF
--- a/.claude/skills/provider-api-call-dedup/SKILL.md
+++ b/.claude/skills/provider-api-call-dedup/SKILL.md
@@ -50,17 +50,21 @@ or a client for another asset. In three of five providers audited this was the
 single largest source of waste, and in every one of those the static passes came
 back clean. See *The class the classifiers cannot see*.
 
-**Worked examples, with numbers.** Seven providers have been through this work.
+**Worked examples, with numbers.** Eight providers have been through this work.
 What each one's defect turned out to be, what the fix measured, and what the
 test environment could *not* exercise are recorded per provider in
 [`docs/provider-scan-performance.md`](../../../docs/provider-scan-performance.md).
-Read it before starting a new provider: the third and fourth classes above were
-both discovered there rather than reasoned out, the per-provider notes say which
-class bit which provider, and the *What is not covered* sections are the honest
-record of where each audit stopped. It is also the precedent for how to report
-this work — every claim tied to a measurement, and the one change that reduced
-calls without improving wall-clock (vSphere) filed as a draft rather than sold
-as a win.
+
+Read it before starting a new provider. The third and fourth classes above were
+discovered there rather than reasoned out, as was a fifth that no classifier
+finds: **two different fields issuing one identical request**. No amount of cache
+sharing fixes that one, because each field is computed correctly and exactly
+once -- the duplication is below the resource layer, where only the URL is
+visible. The per-provider notes say which class bit which provider, and the
+*What is not covered* sections are the honest record of where each audit
+stopped. It is also the precedent for how to report this work: every claim tied
+to a measurement, and the one change that reduced calls without improving
+wall-clock (vSphere) filed as a draft rather than sold as a win.
 
 ## The parent-child cache model
 

--- a/docs/provider-scan-performance.md
+++ b/docs/provider-scan-performance.md
@@ -3,11 +3,11 @@
 Work to remove redundant API calls from cloud provider scans. Same data, same
 scores, far fewer requests — which matters most where APIs throttle.
 
-Status: **Azure, AWS, GCP, GitLab, Okta and ms365 all merged to main**, and
-backported to the **v13** release branch. **vSphere is in draft** (#10049)
-pending a decision — it is the one change with no measured user-visible benefit.
-Each provider has a *What is not covered* note where a test environment could
-not exercise everything.
+Status: **Azure, AWS, GCP, GitLab, Okta and ms365 all merged to main**, with
+Okta and ms365 also backported to the **v13** release branch. **GitHub is in
+review**. **vSphere is in draft** (#10049) pending a decision — it is the one
+change with no measured user-visible benefit. Each provider has a *What is not
+covered* note where a test environment could not exercise everything.
 
 ---
 
@@ -22,6 +22,7 @@ not exercise everything.
 | **ms365** (worst-path query) | 123s | **24s** | **−80%** |
 | **ms365** (registration details) | 58 calls | **10** | **−83%** |
 | **Okta** | 7 calls | **3** | **−57%** |
+| **GitHub** | 1,291 calls | **1,049** | **−18.7%** |
 
 AWS was measured end to end on a 169-asset scan and GCP on a 71-asset project,
 both with server policies. Azure was measured per change on a live subscription,
@@ -37,9 +38,9 @@ by running the fixed build twice and confirming byte-identical scores.
 
 ---
 
-## Three root causes
+## Four root causes
 
-All three come from shared machinery, so they recur in every provider.
+All four come from shared machinery, so they recur in every provider.
 
 **1. The resource cache is per connection.** Every discovered asset gets its own
 runtime. Unless a provider opts in, data belonging to a subscription or account
@@ -57,6 +58,14 @@ run while an EC2 instance was being scanned, adopt the instance's ARN, and call
 `DescribeSecret` with it. The call fails, failures are not cached, so it retries
 per referrer. This was the largest single cause in AWS and was invisible in
 normal output — it surfaces only in a request trace.
+
+**4. Two fields, one request.** The cache stores resolved values *per field*,
+and nothing in it knows that two different fields issue the same HTTP request.
+Each field is computed exactly once, correctly, and the API is still asked
+twice. This is not a caching failure and no amount of cache sharing fixes it:
+the duplication lives below the resource layer, where only the request URL is
+visible. GitHub is the worked example — `files` read the repository root and
+`findSpecialFiles` read the same directory as `"."`.
 
 ---
 
@@ -322,6 +331,80 @@ The test org has **8 users, 2 groups and 0 applications**. The six
 per-application accessors never executed and the per-user fan-out was too small
 to stress, so "otherwise clean" is a weaker claim here than for GitLab, where 36
 projects exercised the fan-out properly.
+
+## GitHub
+
+**1,291 → 1,049 calls (−18.7%)** on the mondoohq organization, 226 repositories,
+both runs stopped at the same 97 asset blocks. The 159 redundant calls went to
+**zero**, and 404s fell from 375 to 289.
+
+This is the worked example of root cause 4, and it is the one provider where the
+resource cache was working perfectly and the duplication happened anyway.
+
+`repository.files` reads the repository root. `findSpecialFiles`, which resolves
+`securityFile`, `supportFile` and `codeOfConductFile`, read the same directory as
+`"."`. Those normalize to the identical request. Scanning an organization paid
+it twice per repository: once while the organization asset resolved the
+repository, once while that repository was scanned as its own asset.
+
+The cache could not help, and this was verified rather than assumed. Discovery
+sets `WithParentConnectionId`, so a repository asset inherits the organization's
+`runtime.Resources`; instrumenting the resource showed **the same
+`github.repository` object, at the same address, serving both assets**. Across
+226 repositories: zero resolved to more than one instance, and
+`findSpecialFiles` never ran twice. Both fields computed exactly once. The cache
+stores values per field, so two fields wanting one request is simply outside
+what it can see.
+
+The fix reads the root from the `files` field instead of fetching it, so
+whichever caller arrives second reuses the cached field, and reaches `.github`
+by descending through its entry in that listing rather than requesting it
+outright. That second part was unplanned and turned out to be the larger win: a
+repository with no `.github` directory now costs **no request at all**, where
+before it bought a 404. That is the 86 vanished 404s.
+
+| | before | after |
+|---|---|---|
+| root `contents/` | 321 for 226 repos | **226** |
+| `contents/.github` | 290 for 226 repos | **140** |
+| redundant calls | 159 | **0** |
+
+An earlier attempt cached directory listings in the connection layer with
+single-flighting. It also reached zero redundancy but only −12.0%, because it
+still paid the `.github` 404s, and it cost ~205 lines and a new dependency
+against 68 net lines and none. It is recorded here because it is the fix that
+generalizes: it holds under parallel scanning, where the field approach does not
+(see below).
+
+**Correctness:** all 13,480 per-check score tuples identical, none missing.
+
+### What is not covered
+
+The field approach relies on GitHub scans running **sequentially**, which they
+currently do. `GetOrCompute` (`providers-sdk/v1/plugin/runtime.go:263`) checks
+`IsSet` and computes with no lock between the two, so under `--parallelism > 1`
+two assets could resolve `files` on the same shared resource at once and both
+fetch. That degrades to an occasional duplicate, never to wrong data, and it is
+the same exposure as **server#18630**. Fixing that guard upstream would make the
+field approach airtight and benefit every provider.
+
+No repository in the measured organization keeps a `SECURITY.md`,
+`SUPPORT.md` or `CODE_OF_CONDUCT.md` **inside `.github/`** — a code search across
+the org returns zero. The descent path is therefore the one part of the change
+with no measurement behind it, and carries unit tests instead. The positive root
+path was confirmed live against `mondoohq/.github`, which returns all three with
+their real uppercase names.
+
+`allFiles` never ran in either scan: no policy in the bundle asks for it. It is
+backed by the Git Trees API rather than `contents/`, so it neither benefits from
+nor contributes to this change. Serving `files` and the special files from one
+recursive tree call would cut 2–3 requests per repository to 1, but it changes
+which API backs a shipped field and would truncate on large repositories, so it
+belongs in its own change.
+
+The scan was stopped at 97 of 227 assets, so the percentage is measured at 43%
+completion. The redundancy share grew with completion, so a full scan would have
+saved somewhat more.
 
 ## vSphere — in draft, undecided
 

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -2180,15 +2180,58 @@ type mqlGithubRepositoryInternal struct {
 	findSpecialFilesOnceFunc func() error
 }
 
-func (g *mqlGithubRepository) findSpecialFiles() error {
-	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
+// claimSpecialFiles assigns any of the wanted files present in a directory
+// listing, recording what it matched in found so a later directory cannot
+// override an earlier one.
+//
+// Entries are the same github.file resources the files field hands out, so a
+// special file and its entry in that listing are one resource rather than two
+// views of it.
+func claimSpecialFiles(entries []any, wanted map[string]*plugin.TValue[*mqlGithubFile], found map[string]struct{}) {
+	for i := range entries {
+		file, ok := entries[i].(*mqlGithubFile)
+		if !ok || file == nil || file.Type.Error != nil || file.Name.Error != nil {
+			continue
+		}
+		if file.Type.Data != "file" {
+			continue
+		}
 
+		// found is keyed lowercase; probe it the same way, otherwise which copy
+		// of a file wins depends on how the second one happens to be
+		// capitalized.
+		name := strings.ToLower(file.Name.Data)
+		if _, ok := found[name]; ok {
+			continue
+		}
+		if v, ok := wanted[name]; ok && v != nil {
+			(*v) = plugin.TValue[*mqlGithubFile]{Data: file, State: plugin.StateIsSet, Error: nil}
+			found[name] = struct{}{}
+		}
+	}
+}
+
+// githubDirEntry returns the named subdirectory of a listing, or nil when the
+// listing has no such directory. Looking before descending is what keeps a
+// repository without a .github directory from paying for a 404.
+func githubDirEntry(entries []any, name string) *mqlGithubFile {
+	for i := range entries {
+		dir, ok := entries[i].(*mqlGithubFile)
+		if !ok || dir == nil || dir.Type.Error != nil || dir.Name.Error != nil {
+			continue
+		}
+		if dir.Type.Data == "dir" && dir.Name.Data == name {
+			return dir
+		}
+	}
+	return nil
+}
+
+func (g *mqlGithubRepository) findSpecialFiles() error {
 	ownerLogin, repoName, err := repoOwnerAndName(g)
 	if err != nil {
 		return err
 	}
-
-	specialDirectories := []string{".", ".github"}
 
 	specialFilesCaseInsensitive := map[string]*plugin.TValue[*mqlGithubFile]{
 		"code_of_conduct.md": &g.CodeOfConductFile,
@@ -2197,41 +2240,28 @@ func (g *mqlGithubRepository) findSpecialFiles() error {
 	}
 	foundFiles := map[string]struct{}{}
 
-	for _, dir := range specialDirectories {
-		if len(foundFiles) == len(specialFilesCaseInsensitive) {
-			break
-		}
-		_, dirContent, _, err := conn.Client().Repositories.GetContents(conn.Context(), ownerLogin, repoName, dir, &github.RepositoryContentGetOptions{})
-		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				continue
-			}
-			return err
-		}
+	// The repository root, read through the files field rather than fetched
+	// here, so the listing is resolved once per repository however it is
+	// reached: asking for securityFile and asking for files are the same
+	// request, and whichever arrives second reuses the cached field. That holds
+	// across assets too, because a repository scanned as its own asset shares
+	// the organization's resource cache and so the same resource.
+	root := g.GetFiles()
+	if root.Error != nil {
+		return root.Error
+	}
+	claimSpecialFiles(root.Data, specialFilesCaseInsensitive, foundFiles)
 
-		for i := range dirContent {
-			if dirContent[i].GetType() != "file" {
-				continue
+	// .github, only when the root did not already answer everything. Descending
+	// through the entry means the listing comes from that directory's own files
+	// field, shared with any policy that walks into .github itself.
+	if len(foundFiles) < len(specialFilesCaseInsensitive) {
+		if dir := githubDirEntry(root.Data, ".github"); dir != nil {
+			sub := dir.GetFiles()
+			if sub.Error != nil {
+				return sub.Error
 			}
-
-			// foundFiles is keyed lowercase; probe it the same way, otherwise
-			// which copy of a file wins depends on how the second one happens
-			// to be capitalized.
-			name := strings.ToLower(dirContent[i].GetName())
-			if _, ok := foundFiles[name]; ok {
-				continue
-			}
-			if _, ok := specialFilesCaseInsensitive[name]; ok {
-				v := specialFilesCaseInsensitive[name]
-				if v != nil {
-					file, err := newMqlGithubFile(g.MqlRuntime, ownerLogin, repoName, dirContent[i])
-					if err != nil {
-						return err
-					}
-					(*v) = plugin.TValue[*mqlGithubFile]{Data: file, State: plugin.StateIsSet, Error: nil}
-				}
-				foundFiles[name] = struct{}{}
-			}
+			claimSpecialFiles(sub.Data, specialFilesCaseInsensitive, foundFiles)
 		}
 	}
 

--- a/providers/github/resources/github_special_files_test.go
+++ b/providers/github/resources/github_special_files_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func ghFile(name, fileType string) *mqlGithubFile {
+	return &mqlGithubFile{
+		Name: plugin.TValue[string]{Data: name, State: plugin.StateIsSet},
+		Type: plugin.TValue[string]{Data: fileType, State: plugin.StateIsSet},
+	}
+}
+
+func wantedFiles() (map[string]*plugin.TValue[*mqlGithubFile], *mqlGithubRepository) {
+	repo := &mqlGithubRepository{}
+	return map[string]*plugin.TValue[*mqlGithubFile]{
+		"code_of_conduct.md": &repo.CodeOfConductFile,
+		"support.md":         &repo.SupportFile,
+		"security.md":        &repo.SecurityFile,
+	}, repo
+}
+
+// GitHub accepts these files under any capitalization, so matching has to be
+// case-insensitive -- mondoohq/.github ships them fully uppercased.
+func TestClaimSpecialFilesIsCaseInsensitive(t *testing.T) {
+	wanted, repo := wantedFiles()
+	found := map[string]struct{}{}
+
+	claimSpecialFiles([]any{
+		ghFile("README.md", "file"),
+		ghFile("SECURITY.md", "file"),
+		ghFile("Code_Of_Conduct.md", "file"),
+	}, wanted, found)
+
+	require.NotNil(t, repo.SecurityFile.Data)
+	assert.Equal(t, "SECURITY.md", repo.SecurityFile.Data.Name.Data)
+	require.NotNil(t, repo.CodeOfConductFile.Data)
+	assert.Equal(t, "Code_Of_Conduct.md", repo.CodeOfConductFile.Data.Name.Data)
+	assert.Nil(t, repo.SupportFile.Data, "support.md is absent and must not be claimed")
+}
+
+// A directory named security.md would otherwise be reported as the security
+// policy, and a file resource for a directory has no content to read.
+func TestClaimSpecialFilesIgnoresDirectories(t *testing.T) {
+	wanted, repo := wantedFiles()
+	claimSpecialFiles([]any{ghFile("security.md", "dir")}, wanted, map[string]struct{}{})
+	assert.Nil(t, repo.SecurityFile.Data)
+}
+
+// The root wins over .github: it is scanned first, and a file already claimed
+// there must survive a second listing that also contains one.
+func TestClaimSpecialFilesKeepsTheFirstMatch(t *testing.T) {
+	wanted, repo := wantedFiles()
+	found := map[string]struct{}{}
+
+	claimSpecialFiles([]any{ghFile("SECURITY.md", "file")}, wanted, found)
+	root := repo.SecurityFile.Data
+	require.NotNil(t, root)
+
+	// a later directory offering its own copy must not displace it
+	claimSpecialFiles([]any{ghFile("security.md", "file")}, wanted, found)
+	assert.Same(t, root, repo.SecurityFile.Data, "the root copy must win")
+}
+
+// Entries arrive as []any straight off a field, so a nil or foreign element
+// must be skipped rather than panic the scan.
+func TestClaimSpecialFilesToleratesBadEntries(t *testing.T) {
+	wanted, repo := wantedFiles()
+	assert.NotPanics(t, func() {
+		claimSpecialFiles([]any{
+			nil,
+			"not a file resource",
+			(*mqlGithubFile)(nil),
+			&mqlGithubFile{Name: plugin.TValue[string]{Error: assert.AnError}},
+			ghFile("SECURITY.md", "file"),
+		}, wanted, map[string]struct{}{})
+	})
+	require.NotNil(t, repo.SecurityFile.Data)
+}
+
+// The descent only happens when the directory is really there; that is what
+// replaces an unconditional request that answered 404 on most repositories.
+func TestGithubDirEntry(t *testing.T) {
+	entries := []any{
+		ghFile("README.md", "file"),
+		ghFile(".github", "dir"),
+		ghFile("docs", "dir"),
+	}
+	got := githubDirEntry(entries, ".github")
+	require.NotNil(t, got)
+	assert.Equal(t, ".github", got.Name.Data)
+
+	assert.Nil(t, githubDirEntry(entries, ".circleci"), "absent directory must not be descended into")
+	// a *file* named .github is not a directory to walk
+	assert.Nil(t, githubDirEntry([]any{ghFile(".github", "file")}, ".github"))
+	assert.Nil(t, githubDirEntry(nil, ".github"))
+}


### PR DESCRIPTION
`repository.files` reads the repository root. `findSpecialFiles`, which resolves `securityFile`, `supportFile` and `codeOfConductFile`, read the same directory as `"."`. Those normalize to the identical request, so scanning an organization paid it twice per repository: once while the organization asset resolved the repository, once while that repository was scanned as its own asset.

## The cache was not the problem

This one is worth stating precisely, because the obvious diagnosis is wrong. Discovery sets `WithParentConnectionId`, so a repository asset inherits the organization's `runtime.Resources`. Instrumenting the resource showed **the same `github.repository` object, at the same address, serving both assets**:

```
repo mondoohq/cosmo:
  during asset mondoohq         findSpecialFiles  res=0x2ecdde4c1b08  resmap=0x2ecdde1197a0
  during asset mondoohq/cosmo   files             res=0x2ecdde4c1b08  resmap=0x2ecdde1197a0
```

Across 226 repositories: **zero** resolved to more than one instance, and `findSpecialFiles` **never** ran twice. Both fields computed exactly once, correctly. The cache stores values per field, and nothing in it knows two different fields issue one identical GET — the duplication lives below the resource layer, where only the URL is visible.

## The fix

The root now comes from the `files` field rather than a fetch of its own, so whichever caller arrives second reuses the cached field. `.github` is reached by descending through its entry in that listing instead of being requested outright — so a repository with no `.github` directory costs **no request at all**, where before it bought a 404. That second part was unplanned and is the larger win.

## Measured

mondoohq, 226 repositories, both runs stopped at the same 97 asset blocks:

| | before | after |
|---|---|---|
| total API calls | 1,291 | **1,049 (−18.7%)** |
| redundant calls | 159 | **0** |
| root `contents/` | 321 for 226 repos | **226** |
| `contents/.github` | 290 for 226 repos | **140** |
| 404s | 375 | **289** |

**Correctness:** all 13,480 per-check score tuples identical, none missing.

## An alternative that was tried and rejected

A connection-level cache of directory listings with single-flighting. It also reached zero redundancy, but only −12.0% — it still paid the `.github` 404s — and cost ~205 lines plus a new dependency against 68 net lines and none. It is described in the docs commit because it is the version that generalizes: it holds under parallel scanning, where this one does not.

## Limitations, stated plainly

- **Relies on GitHub scans running sequentially**, which they currently do. `GetOrCompute` (`providers-sdk/v1/plugin/runtime.go:263`) checks `IsSet` and computes with no lock between, so under `--parallelism > 1` two assets could resolve `files` concurrently and both fetch. Degrades to an occasional duplicate, never to wrong data — same exposure as mondoohq/server#18630.
- **The `.github` descent has no measurement behind it.** No repository in the measured org keeps `SECURITY.md`/`SUPPORT.md`/`CODE_OF_CONDUCT.md` under `.github/` (code search returns zero), so that path carries unit tests instead. The positive root path was confirmed live against `mondoohq/.github`, which returns all three with their real uppercase names.
- Measured at 43% completion (97 of 227 assets); redundancy share grew with completion, so a full scan would save somewhat more.

## Tests

`claimSpecialFiles` and `githubDirEntry` are split out so the logic is testable without a runtime: case-insensitive matching, directories named like files, root-wins-over-`.github`, nil/foreign entries, and descend-only-when-present.

## Also in this PR

`docs/provider-scan-performance.md` gains a GitHub section and a fourth root cause — *two fields, one request* — since this is the first case where cache sharing was verifiably working and the duplication happened regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)