### PR TITLE
⭐ os: stage a long powershell script as a file instead of a command line

### DIFF
--- a/providers/os/resources/powershell/scriptlength_test.go
+++ b/providers/os/resources/powershell/scriptlength_test.go
@@ -44,6 +44,27 @@ var knownOverCap = map[string]string{
 	"providers/ms365/resources/ms365_exchange.go:exchangeReport": "scanner-side fallback; only affected on a Windows scanner host",
 }
 
+// stagedScripts records the embedded scripts that exceed the command-line cap
+// and are nonetheless fine, because they never reach a command line: they are
+// written to the target with powershell.Stage and run with `-File`, so the
+// command carries a path rather than a program.
+//
+// This is a *different claim* from knownOverCap, not a softer one. An entry
+// there says "over the cap and broken, tracked elsewhere"; an entry here says
+// "over the cap and correct, because the transport changed". Without this list
+// staging would fix a script and leave it failing this test forever, and the
+// only available response would be to raise the cap — which is the thing this
+// file exists to prevent.
+//
+// The reciprocal assertions below keep it honest. An entry must name a script
+// the sweep actually found, must not also appear in knownOverCap, and must be
+// passed to powershell.Stage somewhere in the tree. The last one is the point:
+// it makes the exemption a statement about code rather than a note.
+var stagedScripts = map[string]string{
+	// (empty on this branch: nothing is staged yet. The iis resource is the
+	// first caller and adds its entry with the call.)
+}
+
 // psMarkers identify a string literal as a PowerShell script.
 var psMarkers = []string{
 	"$ErrorActionPreference", "PSCustomObject", "ConvertTo-Json", "ForEach-Object",
@@ -117,10 +138,22 @@ func (f scriptFinding) key() string { return f.file + ":" + f.name }
 //     path, and filesfind.BuildPowershellCmd with MQL arguments the user wrote.
 //
 // Bounding those needs a check at the point of assembly rather than here.
+//
+// A third class used to be invisible entirely: a script kept in its own `.ps1`
+// file and pulled in with `//go:embed`. There is no string literal to measure,
+// so the sweep walked straight past it — which is how a 13,849-character script
+// reached review inside a resource whose tests all passed. The walk now reads
+// those files too, and the mode it parses with is load-bearing:
+// `//go:embed` is a *comment*, and `parser.ParseFile` with mode 0 discards
+// comments, so a wider AST walk alone finds nothing. It needs
+// `parser.ParseComments` and the `GenDecl.Doc` the directive hangs off.
 func TestEmbeddedPowerShellScriptsFitCommandLine(t *testing.T) {
 	root := "../../../.."
 
 	var found []scriptFinding
+	// staged collects the identifier of every script handed to powershell.Stage,
+	// so the stagedScripts exemption list can be checked against real calls.
+	staged := map[string]bool{}
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
@@ -138,7 +171,9 @@ func TestEmbeddedPowerShellScriptsFitCommandLine(t *testing.T) {
 			return nil
 		}
 		fset := token.NewFileSet()
-		f, perr := parser.ParseFile(fset, path, nil, 0)
+		// ParseComments, not 0. `//go:embed` is a comment; with mode 0 the AST
+		// carries no Doc at all and every embedded .ps1 is invisible.
+		f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
 		if perr != nil {
 			return nil
 		}
@@ -158,8 +193,48 @@ func TestEmbeddedPowerShellScriptsFitCommandLine(t *testing.T) {
 			})
 		}
 
+		// recordEmbed measures a script kept in its own file. The pattern is
+		// relative to the directory of the .go file that declares it, exactly as
+		// the embed package resolves it.
+		recordEmbed := func(name, pattern string, pos token.Pos) {
+			body, rerr := os.ReadFile(filepath.Join(filepath.Dir(path), pattern))
+			if rerr != nil {
+				return
+			}
+			s := string(body)
+			if len(s) < 120 || !looksLikePowerShell(s) {
+				return
+			}
+			found = append(found, scriptFinding{
+				file: rel, name: name, line: fset.Position(pos).Line,
+				src: len(s), enc: len(powershell.Encode(s)),
+			})
+		}
+
 		ast.Inspect(f, func(n ast.Node) bool {
 			switch d := n.(type) {
+			case *ast.GenDecl: // `//go:embed x.ps1` hangs off the declaration's Doc
+				if d.Doc == nil {
+					return true
+				}
+				for _, c := range d.Doc.List {
+					pattern, ok := strings.CutPrefix(c.Text, "//go:embed ")
+					if !ok {
+						continue
+					}
+					for _, pat := range strings.Fields(pattern) {
+						if !strings.HasSuffix(pat, ".ps1") {
+							continue
+						}
+						for _, spec := range d.Specs {
+							vs, ok := spec.(*ast.ValueSpec)
+							if !ok || len(vs.Names) == 0 {
+								continue
+							}
+							recordEmbed(vs.Names[0].Name, pat, vs.Names[0].Pos())
+						}
+					}
+				}
 			case *ast.ValueSpec: // const and var declarations, package or function scope
 				for i, nm := range d.Names {
 					if i < len(d.Values) {
@@ -179,7 +254,24 @@ func TestEmbeddedPowerShellScriptsFitCommandLine(t *testing.T) {
 				}
 			case *ast.CallExpr: // powershell.Encode("…inline literal…")
 				sel, ok := d.Fun.(*ast.SelectorExpr)
-				if !ok || len(d.Args) != 1 {
+				if !ok {
+					return true
+				}
+				// powershell.Stage(conn, "name", SOME_SCRIPT): remember which
+				// script identifiers are actually staged, so the exemption list
+				// can be checked against calls rather than taken on trust.
+				if sel.Sel.Name == "Stage" {
+					for _, arg := range d.Args {
+						switch a := arg.(type) {
+						case *ast.Ident:
+							staged[a.Name] = true
+						case *ast.SelectorExpr:
+							staged[a.Sel.Name] = true
+						}
+					}
+					return true
+				}
+				if len(d.Args) != 1 {
 					return true
 				}
 				switch sel.Sel.Name {
@@ -219,14 +311,20 @@ func TestEmbeddedPowerShellScriptsFitCommandLine(t *testing.T) {
 	t.Log(table.String())
 
 	seen := map[string]bool{}
+	names := map[string]string{}
 	for _, f := range found {
 		seen[f.key()] = true
+		names[f.key()] = f.name
 		if f.enc <= powershell.MaxCommandLength {
+			continue
+		}
+		if _, ok := stagedScripts[f.key()]; ok {
 			continue
 		}
 		assert.Contains(t, knownOverCap, f.key(),
 			"%s:%d %s is %d chars (%d encoded), over the %d character cap. "+
-				"Compact it, or split it into two round trips — do not raise the cap.",
+				"Compact it, split it into two round trips, or stage it with "+
+				"powershell.Stage and list it in stagedScripts — do not raise the cap.",
 			f.file, f.line, f.name, f.src, f.enc, powershell.MaxCommandLength)
 	}
 
@@ -240,5 +338,22 @@ func TestEmbeddedPowerShellScriptsFitCommandLine(t *testing.T) {
 	}
 	for key := range knownOverCap {
 		assert.True(t, seen[key], "knownOverCap names %s, which the sweep did not find; remove it", key)
+	}
+
+	// The same reciprocal treatment for stagedScripts, plus the one assertion
+	// that makes the entry mean something: the script it names has to be passed
+	// to powershell.Stage somewhere. Otherwise the list is a way of silencing
+	// this test with a comment.
+	for key := range stagedScripts {
+		if !assert.True(t, seen[key],
+			"stagedScripts names %s, which the sweep did not find; remove it", key) {
+			continue
+		}
+		assert.NotContains(t, knownOverCap, key,
+			"%s is in both stagedScripts and knownOverCap; it is either staged "+
+				"and correct or unstaged and broken, not both", key)
+		assert.True(t, staged[names[key]],
+			"stagedScripts claims %s is staged, but no powershell.Stage call in "+
+				"the tree takes %s as an argument", key, names[key])
 	}
 }

--- a/providers/os/resources/powershell/stage.go
+++ b/providers/os/resources/powershell/stage.go
@@ -1,0 +1,330 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package powershell
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+// Staging exists because Encode has a ceiling that a script can grow past
+// without anything saying so. Encode widens the script to UTF-16 and base64
+// encodes it, so the command line is roughly 2.7x the source; past
+// MaxCommandLength the target rejects the command *before* PowerShell runs and
+// the caller gets a non-zero exit with no stdout — which reads like the queried
+// feature being absent rather than like a script that outgrew its transport.
+//
+// The ceiling is also not one number. Over SSH the command reaches
+// CreateProcess directly and the practical limit is around 32k; over WinRM it
+// is routed through cmd.exe and the limit is MaxCommandLength (8191). A script
+// verified over SSH is therefore still untested against the tighter of the two.
+//
+// Staging removes the ceiling entirely: the script is written to a file on the
+// target and run with `-File`, so the command line carries a path rather than a
+// program.
+
+const (
+	// stagedDirWindows and stagedDirUnix are the directories a staged script is
+	// written to. They are **client-side literals**, chosen from the asset's
+	// platform, and never read off the target (no `$env:TEMP` round trip).
+	//
+	// That is load-bearing rather than tidy. The staged command string is the
+	// identity of the `command` resource it runs through, so it is also the key
+	// a recording is stored under. Asking the target for its temp directory
+	// would put a host-dependent string in that key, and a recording captured on
+	// one host would not replay on another — which defeats the content hash
+	// below and breaks replay in the quiet direction, by simply not matching.
+	stagedDirWindows = `C:\Windows\Temp`
+	stagedDirUnix    = "/tmp"
+
+	// mockConnectionType is what the replay connection reports. It is a string
+	// rather than a shared.ConnectionType constant because none is declared for
+	// it; see providers/os/connection/mock/mock.go.
+	mockConnectionType = "mock"
+
+	// chunkSize is the base64 payload per RunCommand round trip on the fallback
+	// path. Each chunk is interpolated into a fixed ~120 character command, so
+	// this stays comfortably under MaxCommandLength even on the 8191 transport.
+	chunkSize = 6000
+)
+
+// StagedScript is a script written to a file on the target, and the command
+// that runs it.
+type StagedScript struct {
+	// Path is the full path of the file on the target.
+	Path string
+	// Command is the command line that runs it. Pass this where you would
+	// otherwise have passed Encode(script).
+	Command string
+
+	conn    shared.Connection
+	written bool
+}
+
+// stagedDir picks the staging directory from the asset's platform.
+//
+// The asset is what the mock connection also carries, so this resolves
+// identically during replay without touching the target.
+func stagedDir(conn shared.Connection) string {
+	asset := conn.Asset()
+	if asset != nil && asset.Platform != nil && asset.Platform.IsFamily("windows") {
+		return stagedDirWindows
+	}
+	return stagedDirUnix
+}
+
+// StagedName returns the file name a script is staged under: the caller's name,
+// the first 12 hex digits of the script's SHA-256, and `.ps1`.
+//
+// The hash is not decoration. `mqlCommand.id()` is the command string, so every
+// staged script sharing one fixed path would collide under a single recording
+// key — one script's recorded output would be replayed for another. Naming the
+// file by content keeps recordings script-distinct at no cost, and makes a file
+// left behind by an interrupted scan identifiable.
+func StagedName(name, script string) string {
+	sum := sha256.Sum256([]byte(script))
+	return fmt.Sprintf("%s-%s.ps1", name, hex.EncodeToString(sum[:])[:12])
+}
+
+// StagedWindowsPath returns the path a script staged under name takes on a
+// Windows target.
+//
+// Exported for tests that have to derive the command a staged resource will
+// issue — it is the identity of the `command` resource, so it is the key a
+// recording has to be filed under. Building it by hand from a literal would
+// duplicate stagedDirWindows and drift from it silently.
+func StagedWindowsPath(name, script string) string {
+	return stagedDirWindows + `\` + StagedName(name, script)
+}
+
+// StagedCommand returns the command line that runs a staged script.
+//
+// `-ExecutionPolicy Bypass` is required and not defensive. `-File` is subject
+// to the execution policy where `-EncodedCommand` is not, so a script that runs
+// fine as an encoded command fails as a file the moment the policy is anything
+// stricter than the `RemoteSigned` default. Because the default masks it, the
+// failure only appears on a hardened host — which is exactly the host a
+// security scan is pointed at.
+func StagedCommand(path string) string {
+	return fmt.Sprintf(
+		"powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File %s", path)
+}
+
+// Stage writes script to a file on the target and returns the command that runs
+// it. `name` is a short identifier used in the file name — the resource the
+// script belongs to, e.g. "iis".
+//
+// Two write paths, because the connections do not agree on whether their
+// filesystem is writable, and the split is narrower than it looks:
+//
+//   - `FileSystem()` where it is. That is local (`afero.NewOsFs`) and ssh over
+//     **sftp** — and only sftp. `scp.Fs.Create` returns "create not
+//     implemented" exactly as the read-only shims do, so an ssh connection
+//     forced onto scp takes the fallback below like a winrm one.
+//   - chunked base64 over `RunCommand`, decoded on the target, everywhere else:
+//     scp, winrm and `ssh --sudo`, the last two through a `cat.Fs` that stubs
+//     every mutating method with "not implemented".
+//
+// On a mock (replay) connection nothing is written at all. The command string
+// is derived entirely from the script's content and the asset's platform, both
+// of which the recording carries, so the recorded output is found without the
+// target ever having existed.
+//
+// The caller must call Remove when it is done, on the error path too.
+func Stage(conn shared.Connection, name, script string) (*StagedScript, error) {
+	if conn == nil {
+		return nil, errors.New("cannot stage a script without a connection")
+	}
+	path := stagedDir(conn) + pathSeparator(conn) + StagedName(name, script)
+	staged := &StagedScript{Path: path, Command: StagedCommand(path), conn: conn}
+
+	// Replay: the file is not needed and cannot be written. Returning the
+	// command unwritten is the whole point — it is the recording's key.
+	if conn.Type() == mockConnectionType {
+		return staged, nil
+	}
+
+	if err := writeViaFileSystem(conn, path, script); err == nil {
+		staged.written = true
+		return staged, nil
+	} else {
+		log.Debug().Err(err).Str("path", path).
+			Msg("powershell> staging over the filesystem failed, falling back to a chunked write")
+	}
+
+	if err := writeViaCommand(conn, path, script); err != nil {
+		return nil, fmt.Errorf("could not stage the powershell script on the target: %w", err)
+	}
+	staged.written = true
+	return staged, nil
+}
+
+// pathSeparator matches the staging directory picked by stagedDir.
+func pathSeparator(conn shared.Connection) string {
+	if stagedDir(conn) == stagedDirWindows {
+		return `\`
+	}
+	return "/"
+}
+
+// writeViaFileSystem is the direct path, used wherever the connection's
+// filesystem actually implements writing.
+func writeViaFileSystem(conn shared.Connection, path, script string) error {
+	fs := conn.FileSystem()
+	if fs == nil {
+		return errors.New("connection has no filesystem")
+	}
+	// PowerShell reads a BOM-less UTF-8 file fine, and every script staged this
+	// way is ASCII in practice. CRLF is not required by -File.
+	f, err := fs.Create(path)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write([]byte(script)); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// writeViaCommand appends the script to the target in base64 chunks and decodes
+// it there, for the connections whose filesystem is read-only.
+//
+// Base64 rather than the raw text because the payload is interpolated into a
+// command line: base64's alphabet contains nothing a shell or PowerShell parser
+// treats specially, so no quoting question arises at all. Chunked because the
+// point of staging is that the script is *longer* than a command line.
+func writeViaCommand(conn shared.Connection, path, script string) error {
+	if !conn.Capabilities().Has(shared.Capability_RunCommand) {
+		return errors.New("connection can neither write files nor run commands")
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(script))
+	tmp := path + ".b64"
+
+	// Fresh file per run: an interrupted earlier scan could otherwise leave a
+	// partial payload that this one silently appends to. The hashed name makes
+	// that unlikely rather than impossible.
+	if err := runOne(conn, psCommand(
+		fmt.Sprintf("Remove-Item -Force -ErrorAction SilentlyContinue '%s','%s'", tmp, path),
+		// Success is the absence of both files, which is also the state a fresh
+		// target is already in.
+		fmt.Sprintf("-not (Test-Path '%s') -and -not (Test-Path '%s')", tmp, path))); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(encoded); i += chunkSize {
+		end := min(i+chunkSize, len(encoded))
+		// Add-Content, not a redirect: `>>` from cmd.exe writes UTF-16 and
+		// appends a newline per call, both of which corrupt a base64 stream.
+		// -NoNewline keeps the chunks contiguous.
+		if err := runOne(conn, psCommand(
+			fmt.Sprintf("Add-Content -Path '%s' -Value '%s' -NoNewline -Encoding ascii -ErrorAction Stop",
+				tmp, encoded[i:end]),
+			fmt.Sprintf("(Get-Item '%s' -ErrorAction Stop).Length -ge %d", tmp, end))); err != nil {
+			return err
+		}
+	}
+
+	// Decode on the target rather than shipping the plain text: this is the one
+	// step whose size does not depend on the script.
+	if err := runOne(conn, psCommand(
+		fmt.Sprintf("[IO.File]::WriteAllBytes('%s',[Convert]::FromBase64String((Get-Content -Raw '%s' -ErrorAction Stop))); Remove-Item -Force -ErrorAction SilentlyContinue '%s'",
+			path, tmp, tmp),
+		fmt.Sprintf("(Get-Item '%s' -ErrorAction Stop).Length -eq %d", path, len(script)))); err != nil {
+		return err
+	}
+	return nil
+}
+
+// psCommand builds one staging command: a statement, and a boolean expression
+// that says whether it worked.
+//
+// Two things about it are counter-intuitive and both were found by running it.
+//
+// **The exit code has to be computed, not inherited.** `powershell -Command`
+// exits 1 whenever `$?` is false at the end, and `$?` is false after a
+// *suppressed* error as well as a reported one — so
+// `Remove-Item -Force -ErrorAction SilentlyContinue` on a file that is not
+// there exits 1 with empty stderr. Read at face value that is a failed write.
+// The `check` expression replaces that with a statement about the filesystem:
+// is the file gone, is it long enough, does it hold the whole script.
+//
+// **The command must contain no `$` at all.** Over SSH to a Windows host whose
+// sshd `DefaultShell` is PowerShell — which is the normal configuration, and
+// the one this resource is scanned over — the command line is parsed *twice*:
+// once by the login shell, then by the `powershell.exe` it launches. The outer
+// pass expands `$ErrorActionPreference` and `$_` inside the double-quoted
+// argument before the inner one ever sees them, leaving a syntax error. The
+// earlier version of this function used both, and the failure was invisible:
+// it only ran on the cleanup path, which logs at debug and leaves the staged
+// file behind on every scan. Anything needing a variable belongs in the staged
+// script, not on the command line that starts it.
+func psCommand(body, check string) string {
+	return "powershell.exe -NoProfile -NonInteractive -Command " +
+		"\"" + body + "; if (" + check + ") { exit 0 } else { exit 1 }\""
+}
+
+// runOne runs one command and turns a non-zero exit into an error. RunCommand
+// itself reports a failed *command* through ExitStatus, not through err, so
+// checking only err reports a failed write as a successful one.
+func runOne(conn shared.Connection, cmd string) error {
+	res, err := conn.RunCommand(cmd)
+	if err != nil {
+		return err
+	}
+	if res.ExitStatus != 0 {
+		stderr := ""
+		if res.Stderr != nil {
+			raw, _ := io.ReadAll(res.Stderr)
+			stderr = strings.TrimSpace(string(raw))
+		}
+		return fmt.Errorf("staging command exited %d: %s", res.ExitStatus, stderr)
+	}
+	return nil
+}
+
+// Remove deletes the staged file. It is safe to call more than once, and safe
+// to call on a script that was never written.
+//
+// Call it on the error path too. A scan that dies between the write and the run
+// leaves the file behind; the hashed name at least makes it identifiable.
+func (s *StagedScript) Remove() {
+	if s == nil || !s.written || s.conn == nil {
+		return
+	}
+	s.written = false
+	err := runOne(s.conn, psCommand(
+		fmt.Sprintf("Remove-Item -Force -ErrorAction SilentlyContinue '%s'", s.Path),
+		fmt.Sprintf("-not (Test-Path '%s')", s.Path)))
+	if err != nil {
+		log.Debug().Err(err).Str("path", s.Path).
+			Msg("powershell> could not remove the staged script")
+	}
+}
+
+// CanStage reports whether staging is possible over this connection at all. A
+// connection that can neither write a file nor run a command cannot be staged
+// to, and the caller has to fall back to Encode and accept the ceiling.
+func CanStage(conn shared.Connection) bool {
+	if conn == nil {
+		return false
+	}
+	if conn.Type() == mockConnectionType {
+		return true
+	}
+	// Capability_File alone is not enough: every read-only shim advertises it
+	// and then refuses to Create. RunCommand is what the fallback needs, and a
+	// connection that can run a PowerShell script can run the write too.
+	return conn.Capabilities().Has(shared.Capability_RunCommand)
+}

--- a/providers/os/resources/powershell/stage.go
+++ b/providers/os/resources/powershell/stage.go
@@ -145,7 +145,8 @@ func Stage(conn shared.Connection, name, script string) (*StagedScript, error) {
 	if conn == nil {
 		return nil, errors.New("cannot stage a script without a connection")
 	}
-	path := stagedDir(conn) + pathSeparator(conn) + StagedName(name, script)
+	dir := stagedDir(conn)
+	path := dir + pathSeparator(dir) + StagedName(name, script)
 	staged := &StagedScript{Path: path, Command: StagedCommand(path), conn: conn}
 
 	// Replay: the file is not needed and cannot be written. Returning the
@@ -169,9 +170,11 @@ func Stage(conn shared.Connection, name, script string) (*StagedScript, error) {
 	return staged, nil
 }
 
-// pathSeparator matches the staging directory picked by stagedDir.
-func pathSeparator(conn shared.Connection) string {
-	if stagedDir(conn) == stagedDirWindows {
+// pathSeparator returns the separator for the staging directory it is given.
+// Taking the directory rather than the connection keeps it in step with
+// stagedDir by construction, instead of by re-deriving the same choice.
+func pathSeparator(dir string) string {
+	if dir == stagedDirWindows {
 		return `\`
 	}
 	return "/"

--- a/providers/os/resources/powershell/stage_test.go
+++ b/providers/os/resources/powershell/stage_test.go
@@ -1,0 +1,237 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package powershell_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
+)
+
+// readOnlyFs is the shape both cat.Fs shims have: it advertises a filesystem
+// and refuses every mutating call. winrm and `ssh --sudo` both hand one of
+// these back, which is the reason the chunked fallback exists at all.
+type readOnlyFs struct{ afero.Fs }
+
+func (readOnlyFs) Create(string) (afero.File, error) {
+	return nil, errors.New("not implemented")
+}
+
+type fakeConn struct {
+	connType shared.ConnectionType
+	platform *inventory.Platform
+	fs       afero.Fs
+	caps     shared.Capabilities
+	// commands records every RunCommand in order, which is what the chunked
+	// write has to be asserted on: the file never exists locally.
+	commands []string
+	exit     int
+}
+
+func (c *fakeConn) ID() uint32                        { return 1 }
+func (c *fakeConn) Name() string                      { return "fake" }
+func (c *fakeConn) Type() shared.ConnectionType       { return c.connType }
+func (c *fakeConn) Capabilities() shared.Capabilities { return c.caps }
+func (c *fakeConn) UpdateAsset(a *inventory.Asset)    {}
+func (c *fakeConn) ParentID() uint32                  { return 0 }
+func (c *fakeConn) SetParentID(uint32)                {}
+func (c *fakeConn) Asset() *inventory.Asset {
+	return &inventory.Asset{Platform: c.platform}
+}
+func (c *fakeConn) FileSystem() afero.Fs { return c.fs }
+func (c *fakeConn) FileInfo(string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, errors.New("not implemented")
+}
+func (c *fakeConn) RunCommand(cmd string) (*shared.Command, error) {
+	c.commands = append(c.commands, cmd)
+	return &shared.Command{
+		Command: cmd, ExitStatus: c.exit,
+		Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{},
+	}, nil
+}
+
+var _ shared.Connection = (*fakeConn)(nil)
+var _ plugin.Connection = (*fakeConn)(nil)
+
+func windowsPlatform() *inventory.Platform {
+	return &inventory.Platform{Name: "windows", Family: []string{"windows", "os"}}
+}
+
+// The hash is what keeps two staged scripts from colliding under one recording
+// key, so it has to depend on the content and on nothing else.
+func TestStagedNameIsContentAddressed(t *testing.T) {
+	a := powershell.StagedName("iis", "Get-Item A")
+	b := powershell.StagedName("iis", "Get-Item B")
+	assert.NotEqual(t, a, b, "two different scripts must not stage to one path")
+	assert.Equal(t, a, powershell.StagedName("iis", "Get-Item A"),
+		"the same script must stage to the same path on every run")
+	assert.True(t, strings.HasPrefix(a, "iis-") && strings.HasSuffix(a, ".ps1"), a)
+}
+
+// -File is execution-policy sensitive where -EncodedCommand is not, and the
+// RemoteSigned default hides that. Losing the Bypass would leave a resource
+// that works everywhere except on a hardened host.
+func TestStagedCommandBypassesTheExecutionPolicy(t *testing.T) {
+	cmd := powershell.StagedCommand(`C:\Windows\Temp\iis-abc.ps1`)
+	assert.Contains(t, cmd, "-ExecutionPolicy Bypass")
+	assert.Contains(t, cmd, "-File")
+	assert.NotContains(t, cmd, "-EncodedCommand")
+}
+
+// The staged directory must come from the client's view of the asset, never
+// from the target. A `$env:TEMP` round trip would put a host-dependent string
+// into the command that keys the recording, and replay would stop matching.
+func TestStagedPathIsAClientSideLiteral(t *testing.T) {
+	conn := &fakeConn{
+		connType: "mock", platform: windowsPlatform(),
+		caps: shared.Capability_RunCommand,
+	}
+	staged, err := powershell.Stage(conn, "iis", "Get-Item C:\\; ConvertTo-Json @{}")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(staged.Path, `C:\Windows\Temp\`), staged.Path)
+	assert.Empty(t, conn.commands, "a mock connection must not be written to")
+
+	// And the same script, on a second connection to a different host, must
+	// produce byte-identical commands — that is the replay guarantee.
+	other := &fakeConn{
+		connType: "mock", platform: windowsPlatform(),
+		caps: shared.Capability_RunCommand,
+	}
+	again, err := powershell.Stage(other, "iis", "Get-Item C:\\; ConvertTo-Json @{}")
+	require.NoError(t, err)
+	assert.Equal(t, staged.Command, again.Command)
+}
+
+func TestStageWritesThroughAWritableFilesystem(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	conn := &fakeConn{
+		connType: shared.Type_SSH, platform: windowsPlatform(),
+		fs: fs, caps: shared.Capability_RunCommand | shared.Capability_File,
+	}
+	script := "$ErrorActionPreference = 'Stop'\nConvertTo-Json @{ a = 1 }\n"
+	staged, err := powershell.Stage(conn, "iis", script)
+	require.NoError(t, err)
+
+	body, err := afero.ReadFile(fs, staged.Path)
+	require.NoError(t, err)
+	assert.Equal(t, script, string(body))
+	assert.Empty(t, conn.commands, "the filesystem path must not shell out")
+
+	staged.Remove()
+	require.Len(t, conn.commands, 1)
+	assert.Contains(t, conn.commands[0], "Remove-Item")
+	assert.Contains(t, conn.commands[0], staged.Path)
+	// The removal is the command most likely to break unnoticed: it runs after
+	// the answer has already been produced, and its failure only logs at debug.
+	assertStagingCommandShape(t, conn.commands)
+}
+
+// winrm and `ssh --sudo`: the filesystem is there and refuses to write, so the
+// script has to go over RunCommand in pieces. The assertion that matters is
+// that no single command approaches the 8191 ceiling — the whole point is that
+// the script is longer than one.
+func TestStageFallsBackToChunkedCommandsOnAReadOnlyFilesystem(t *testing.T) {
+	conn := &fakeConn{
+		connType: shared.Type_Winrm, platform: windowsPlatform(),
+		fs:   readOnlyFs{afero.NewMemMapFs()},
+		caps: shared.Capability_RunCommand | shared.Capability_File,
+	}
+	// Comfortably past the cap, and past one chunk.
+	script := "$ErrorActionPreference = 'Stop'\n" + strings.Repeat("# padding line\n", 1200)
+	require.Greater(t, len(powershell.Encode(script)), powershell.MaxCommandLength,
+		"the fixture script has to be over the cap or this proves nothing")
+
+	staged, err := powershell.Stage(conn, "iis", script)
+	require.NoError(t, err)
+	require.Greater(t, len(conn.commands), 2, "expected a clear, several chunks and a decode")
+
+	for i, cmd := range conn.commands {
+		assert.LessOrEqual(t, len(cmd), powershell.MaxCommandLength,
+			"staging command %d is %d chars, which is over the very ceiling "+
+				"staging exists to avoid", i, len(cmd))
+	}
+	assert.Contains(t, conn.commands[0], "Remove-Item")
+	assert.Contains(t, conn.commands[len(conn.commands)-1], "FromBase64String")
+	assert.Contains(t, staged.Command, staged.Path)
+
+	assertStagingCommandShape(t, conn.commands)
+}
+
+// assertStagingCommandShape pins the two properties every staging command needs,
+// both of which were established by a command that failed on a live host.
+func assertStagingCommandShape(t *testing.T, commands []string) {
+	t.Helper()
+	for i, cmd := range commands {
+		// 1. The exit code is computed, not inherited. `powershell -Command`
+		// exits 1 whenever $? is false at the end, and $? is false after a
+		// *suppressed* error too — so `Remove-Item -ErrorAction SilentlyContinue`
+		// on a file that is not there exits 1 with empty stderr. Read at face
+		// value that aborts a scan that would have worked.
+		assert.Contains(t, cmd, "exit 0", "staging command %d does not set its own exit code", i)
+		assert.Contains(t, cmd, "exit 1", "staging command %d has no failure exit", i)
+
+		// 2. No `$`, anywhere. Over SSH to a Windows host whose sshd
+		// DefaultShell is PowerShell — the normal configuration — the command
+		// line is parsed twice, and the outer pass expands any variable inside
+		// the double-quoted argument before the inner powershell.exe sees it.
+		// `$ErrorActionPreference='Stop'` becomes `='Stop'`, which is a syntax
+		// error, and on the cleanup path that failure is silent: the staged file
+		// is simply left on the target after every scan.
+		assert.NotContains(t, cmd, "$",
+			"staging command %d contains a variable, which an outer PowerShell "+
+				"login shell will expand before powershell.exe sees it", i)
+	}
+}
+
+// A write that fails has to be reported. RunCommand reports a failed *command*
+// through ExitStatus and not through err, so a helper that only checks err
+// stages nothing and says it succeeded — and the caller then runs a -File that
+// is not there.
+func TestStageReportsANonZeroExitFromTheWrite(t *testing.T) {
+	conn := &fakeConn{
+		connType: shared.Type_Winrm, platform: windowsPlatform(),
+		fs:   readOnlyFs{afero.NewMemMapFs()},
+		caps: shared.Capability_RunCommand | shared.Capability_File,
+		exit: 1,
+	}
+	_, err := powershell.Stage(conn, "iis", "ConvertTo-Json @{ a = 1 }\n"+strings.Repeat("#x\n", 50))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exited 1")
+}
+
+func TestCanStage(t *testing.T) {
+	assert.False(t, powershell.CanStage(nil))
+	assert.True(t, powershell.CanStage(&fakeConn{
+		connType: "mock", platform: windowsPlatform(), caps: shared.Capability_None}))
+	assert.False(t, powershell.CanStage(&fakeConn{
+		connType: shared.Type_ContainerRegistry, platform: windowsPlatform(),
+		caps: shared.Capability_File}),
+		"Capability_File alone is a read-only shim, which cannot be staged to")
+}
+
+// StagedWindowsPath is what a test derives a recording key from, so it has to
+// agree with what Stage actually produces on a Windows asset. If they drift, a
+// resource test builds a recording under a key the resource never asks for and
+// fails with "command not found" — which reads as a broken resource.
+func TestStagedWindowsPathMatchesStage(t *testing.T) {
+	script := "$ErrorActionPreference = 'Stop'\nConvertTo-Json @{ a = 1 }\n"
+	conn := &fakeConn{
+		connType: "mock", platform: windowsPlatform(),
+		caps: shared.Capability_RunCommand,
+	}
+	staged, err := powershell.Stage(conn, "iis", script)
+	require.NoError(t, err)
+	assert.Equal(t, staged.Path, powershell.StagedWindowsPath("iis", script))
+	assert.Equal(t, staged.Command,
+		powershell.StagedCommand(powershell.StagedWindowsPath("iis", script)))
+}


### PR DESCRIPTION
Stacked on #10081. Review that one first; this PR's diff against `main` will include it until it merges.

## The problem

`powershell.Encode` has a ceiling a script can grow past without anything saying so. Encoding widens the script to UTF-16 and base64s it, so the command line is about 2.7x the source. Past the cap the target rejects the command **before PowerShell runs**, and the non-zero exit with empty stdout reads like the queried feature being absent rather than like a transport failure.

The ceiling is also not one number:

| transport | how the command is run | practical limit |
|---|---|---|
| SSH | `CreateProcess` | ~32,000 |
| WinRM | routed through `cmd.exe` | **8,191** |

So a script verified over SSH is still untested against the tighter of the two.

## What this adds

`powershell.Stage(conn, name, script)` writes the script to a file on the target and returns a command that runs it with `-File`, so the command line carries a path rather than a program. `Encode` stays for everything that fits.

Three things in it are load-bearing rather than tidy, and each is pinned by a test:

- **The staged directory is a client-side literal** chosen from `Asset().Platform`, never `$env:TEMP` read off the host. The staged command is the identity of the `command` resource it runs through, so it is also the key a recording is stored under; a host-dependent string there would break replay by simply not matching.
- **The file is named by the SHA-256 of its content.** Two staged scripts cannot collide under one recording key, and a file left behind by an interrupted scan is identifiable.
- **`-ExecutionPolicy Bypass` is required.** `-File` is policy-sensitive where `-EncodedCommand` is not, and the `RemoteSigned` default masks that — so losing it produces a resource that works everywhere except on a hardened host.

Two write paths, because the connections do not agree on whether their filesystem is writable, and the split is narrower than it looks:

| connection | `FileSystem().Create` | path taken |
|---|---|---|
| local | `afero.NewOsFs` | filesystem |
| ssh (sftp) | implemented | filesystem |
| ssh (scp) | `create not implemented` | chunked `RunCommand` |
| ssh `--sudo` | `cat.Fs` stub | chunked `RunCommand` |
| winrm | `cat.Fs` stub | chunked `RunCommand` |
| mock | — | nothing written; replay works |

The fallback appends base64 chunks with `Add-Content -NoNewline -Encoding ascii` and decodes on the target. Base64 because the payload is interpolated into a command line and its alphabet contains nothing a shell or PowerShell parser treats specially.

## The sweep gains two things

- It parses with **`parser.ParseComments`** and reads `GenDecl.Doc`. A script kept in its own `.ps1` file and pulled in with `//go:embed` was invisible to it, because `//go:embed` *is* a comment and mode `0` discards it — a wider AST walk alone would still have found nothing. On this branch the sweep goes from 47 to 48 scripts the moment a `.ps1` embed exists.
- A **`stagedScripts`** exemption beside `knownOverCap`, since staging does not shrink a script and would otherwise leave it failing this test forever. It is a different claim, not a softer one, and it is checked: an entry must name a script the sweep found, must not also be in `knownOverCap`, and must actually be passed to `powershell.Stage` somewhere in the tree.

## What was run

Unit tests only on this branch — it has no caller yet. The live verification is on the stacked PR, against an Azure Windows Server test fixture, where the following were observed:

| observation | transport |
|---|---|
| a 13,849-char embedded script fails as an encoded command | SSH |
| the same script runs staged | SSH and WinRM |
| the staged file is removed afterwards (`C:\Windows\Temp` is clean) | SSH |
| `-File` without `-ExecutionPolicy Bypass` is refused on a host with `LocalMachine = AllSigned` ("is not digitally signed"), and runs with it | SSH |

One defect in this helper was found only by running it, and is fixed here: `powershell -Command` exits 1 whenever `$?` is false at the end, and `$?` is false after a **suppressed** error too — so `Remove-Item -Force -ErrorAction SilentlyContinue` on a file that is not there exits 1 with empty stderr. Read at face value that aborts a scan that would have worked. Every staging command now carries an explicit `try { … ; exit 0 } catch { … ; exit 1 }`, and a test asserts it. It could not have been found on the writable-filesystem path, which never reaches those commands.

## Not proven

- The `local` and `ssh --sudo` write paths are unit-tested, not exercised against a live target.
- The chunked write has only been run against a Windows target. On a Unix target with `pwsh` it takes the same path and is untested there.