### PR TITLE
✨ providers: add --schema-only flag to providers install (v13 backport)

### DIFF
--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -42,6 +42,7 @@ func init() {
 	resourcesProviderCmd.Flags().Bool("json", false, "Output in JSON format")
 	installProviderCmd.Flags().StringP("file", "f", "", "Install a provider via a file")
 	installProviderCmd.Flags().String("url", "", "Install a provider via a URL")
+	installProviderCmd.Flags().Bool("schema-only", false, "Install only the provider's config and resource schema, without its binary")
 	deleteProviderCmd.Flags().Bool("yes", false, "Confirm removal of all providers when using the 'all' target")
 }
 
@@ -66,21 +67,34 @@ var listProvidersCmd = &cobra.Command{
 }
 
 var installProviderCmd = &cobra.Command{
-	Use:    "install <NAME[@VERSION]>",
-	Short:  "Install or update a provider",
-	Long:   "",
+	Use:   "install <NAME[@VERSION]>",
+	Short: "Install or update a provider",
+	Long: `Install or update a provider.
+
+With --schema-only, only the provider's config and resource schema are
+installed, skipping the (much larger) binary download. That is enough to
+compile queries against the provider's resources, but not to connect to
+assets; for that, install the provider fully.`,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
+		schemaOnly, _ := cmd.Flags().GetBool("schema-only")
+
 		// Explicit installs of files will ignore version recommendations.
 		// So we just take them and roll with it.
 		path, _ := cmd.Flags().GetString("file")
 		if path != "" {
+			if schemaOnly {
+				log.Fatal().Msg("--schema-only is not supported together with --file")
+			}
 			installProviderFile(path)
 			return
 		}
 
 		url, _ := cmd.Flags().GetString("url")
 		if url != "" {
+			if schemaOnly {
+				log.Fatal().Msg("--schema-only is not supported together with --url")
+			}
 			installProviderUrl(url)
 			return
 		}
@@ -90,7 +104,7 @@ var installProviderCmd = &cobra.Command{
 		}
 
 		// if no url or file is specified, we default to installing by name from the default upstream
-		installProviderByName(args[0])
+		installProviderByName(args[0], schemaOnly)
 	},
 }
 
@@ -708,7 +722,7 @@ func updateProviders(binary string, names []string) error {
 
 // --- existing functions ---
 
-func installProviderByName(name string) {
+func installProviderByName(name string, schemaOnly bool) {
 	parts := strings.Split(name, "@")
 	if len(parts) > 2 {
 		log.Fatal().Msg("invalid provider name")
@@ -719,7 +733,11 @@ func installProviderByName(name string) {
 		// trim the v prefix, allowing users to specify both 9.0.0 and v9.0.0
 		version = strings.TrimPrefix(parts[1], "v")
 	}
-	installed, err := providers.Install(name, version)
+	install := providers.Install
+	if schemaOnly {
+		install = providers.InstallSchemaOnly
+	}
+	installed, err := install(name, version)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to install")
 	}
@@ -845,6 +863,10 @@ func printProvider(p *providers.Provider) {
 		}
 		maturity = " " + termenv.String("["+strings.ToLower(label)+"]").Foreground(color).String()
 	}
+	schemaOnly := ""
+	if p.Path != "" && !p.HasBinary {
+		schemaOnly = " " + theme.DefaultTheme.Disabled("(schema-only)")
+	}
 
-	fmt.Println("  " + name + " " + p.Version + supports + maturity)
+	fmt.Println("  " + name + " " + p.Version + supports + maturity + schemaOnly)
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -532,6 +532,93 @@ func installVersion(ctx context.Context, name string, version string) (*Provider
 	return installed[0], nil
 }
 
+// InstallSchemaOnly installs only a provider's config and resource schema,
+// without downloading the provider binary. The result is enough to compile
+// queries against the provider's resources. It is meant for workflows that
+// never start the provider; connecting to an asset requires a full install.
+func InstallSchemaOnly(name string, version string) (*Provider, error) {
+	ctx := context.Background()
+	if version == "" {
+		// if no version is specified, we default to installing the latest one
+		latestVersion, err := registry.GetLatestVersion(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		version = latestVersion
+	}
+
+	log.Info().
+		Str("version", version).
+		Msg("installing schema for provider '" + name + "'")
+	return installSchemaVersion(ctx, name, version, DefaultPath)
+}
+
+func installSchemaVersion(ctx context.Context, name string, version string, dst string) (*Provider, error) {
+	confJSON, schemaJSON, err := registry.DownloadProviderMetadata(ctx, name, version)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to install schema for "+name+"-"+version)
+	}
+
+	// Pack the two files into an in-memory tar.xz so the install goes
+	// through the same path as a full provider archive.
+	archive, err := buildTarXz(map[string][]byte{
+		name + ".json":           confJSON,
+		name + ".resources.json": schemaJSON,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	installed, err := InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: dst})
+	if err != nil {
+		return nil, err
+	}
+	if len(installed) != 1 {
+		return nil, errors.New("failed to install schema for provider " + name)
+	}
+	provider := installed[0]
+	if provider.Version != version {
+		return nil, errors.New("version for provider didn't match expected install version: expected " + version + ", installed: " + provider.Version)
+	}
+	return provider, nil
+}
+
+// buildTarXz packs the given files into an in-memory tar.xz archive.
+func buildTarXz(files map[string][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	xzWriter, err := xz.NewWriter(&buf)
+	if err != nil {
+		return nil, err
+	}
+	tarWriter := tar.NewWriter(xzWriter)
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		data := files[name]
+		header := &tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(data)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return nil, err
+		}
+		if _, err := tarWriter.Write(data); err != nil {
+			return nil, err
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		return nil, err
+	}
+	if err := xzWriter.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 // installDependencies ensures all dependencies of a provider are installed
 func installDependencies(provider *Provider, existing Providers) error {
 	// Builtins have no file-backed schema; their Schema is set at init time
@@ -712,22 +799,23 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 	log.Debug().Msg("move provider to destination")
 	providerDirs := []string{}
 	for name := range files {
-		// we only want to identify the binary and then all associated files from it
-		// NOTE: we need special handling for windows since binaries have the .exe extension
-		if !strings.HasSuffix(name, ".exe") && strings.Contains(name, ".") {
+		// Providers are identified by their schema file: every package has
+		// one, with or without a binary (schema-only installs have none).
+		if !strings.HasSuffix(name, ".resources.json") {
 			continue
 		}
-
-		providerName := name
-		if strings.HasSuffix(name, ".exe") {
-			providerName = strings.TrimSuffix(name, ".exe")
-		}
+		providerName := strings.TrimSuffix(name, ".resources.json")
 
 		if _, ok := files[providerName+".json"]; !ok {
 			return nil, errors.New("cannot find " + providerName + ".json in the archive")
 		}
-		if _, ok := files[providerName+".resources.json"]; !ok {
-			return nil, errors.New("cannot find " + providerName + ".resources.json in the archive")
+
+		// NOTE: we need special handling for windows since binaries have the .exe extension
+		binName := ""
+		if _, ok := files[providerName]; ok {
+			binName = providerName
+		} else if _, ok := files[providerName+".exe"]; ok {
+			binName = providerName + ".exe"
 		}
 
 		dstPath := filepath.Join(conf.Dst, providerName)
@@ -735,17 +823,19 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 			return nil, err
 		}
 
-		// move the binary and the associated files
-		srcBin := filepath.Join(tmpdir, name)
-		dstBin := filepath.Join(dstPath, name)
-		log.Debug().Str("src", srcBin).Str("dst", dstBin).Msg("move provider binary")
-		if err = osRetry(func() error {
-			return os.Rename(srcBin, dstBin)
-		}, maxInstallBinaryRetries); err != nil {
-			return nil, err
-		}
-		if err = os.Chmod(dstBin, 0o755); err != nil {
-			return nil, err
+		// move the binary (if any) and the associated files
+		if binName != "" {
+			srcBin := filepath.Join(tmpdir, binName)
+			dstBin := filepath.Join(dstPath, binName)
+			log.Debug().Str("src", srcBin).Str("dst", dstBin).Msg("move provider binary")
+			if err = osRetry(func() error {
+				return os.Rename(srcBin, dstBin)
+			}, maxInstallBinaryRetries); err != nil {
+				return nil, err
+			}
+			if err = os.Chmod(dstBin, 0o755); err != nil {
+				return nil, err
+			}
 		}
 
 		srcMeta := filepath.Join(tmpdir, providerName)

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -4,7 +4,9 @@
 package providers
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -128,4 +130,50 @@ func TestOsRetry_RetryableError(t *testing.T) {
 	}
 	assert.NoError(t, osRetry(testFunc, 2))
 	assert.Equal(t, 2, funcCounter)
+}
+
+func TestInstallIO(t *testing.T) {
+	confJSON := []byte(`{"Name":"testp","Version":"1.2.3"}`)
+	schemaJSON := []byte(`{"resources":{}}`)
+
+	t.Run("schema-only archive", func(t *testing.T) {
+		archive, err := buildTarXz(map[string][]byte{
+			"testp.json":           confJSON,
+			"testp.resources.json": schemaJSON,
+		})
+		require.NoError(t, err)
+
+		installed, err := InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: t.TempDir()})
+		require.NoError(t, err)
+		require.Len(t, installed, 1)
+		assert.Equal(t, "testp", installed[0].Name)
+		assert.Equal(t, "1.2.3", installed[0].Version)
+		assert.False(t, installed[0].HasBinary)
+	})
+
+	t.Run("archive with binary", func(t *testing.T) {
+		archive, err := buildTarXz(map[string][]byte{
+			"testp":                []byte(`fake-binary`),
+			"testp.json":           confJSON,
+			"testp.resources.json": schemaJSON,
+		})
+		require.NoError(t, err)
+
+		installed, err := InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: t.TempDir()})
+		require.NoError(t, err)
+		require.Len(t, installed, 1)
+		assert.Equal(t, "testp", installed[0].Name)
+		assert.True(t, installed[0].HasBinary)
+	})
+
+	t.Run("archive without config errors", func(t *testing.T) {
+		archive, err := buildTarXz(map[string][]byte{
+			"testp.resources.json": schemaJSON,
+		})
+		require.NoError(t, err)
+
+		_, err = InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: t.TempDir()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot find testp.json")
+	})
 }

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -35,6 +35,11 @@ type ProviderRegistry interface {
 
 	// DownloadProvider downloads a provider package and returns a ReadCloser for the content
 	DownloadProvider(ctx context.Context, name, version, os, arch string) (io.ReadCloser, error)
+
+	// DownloadProviderMetadata downloads only a provider's config (the
+	// contents of <name>.json) and resource schema (the contents of
+	// <name>.resources.json), without the provider binary.
+	DownloadProviderMetadata(ctx context.Context, name, version string) (confJSON []byte, schemaJSON []byte, err error)
 }
 
 // MondooProviderRegistry implements ProviderRegistry for Mondoo's provider registry
@@ -154,4 +159,62 @@ func (r *MondooProviderRegistry) DownloadProvider(ctx context.Context, name, ver
 	// Wrap with idle timeout so slow-but-active downloads succeed while
 	// truly stalled transfers are detected. Callers just read and close.
 	return httpx.NewIdleTimeoutReader(res.Body, httpx.DownloadTimeout()), nil
+}
+
+// DownloadProviderMetadata downloads only a provider's config and resource
+// schema. The registry publishes these alongside the binary archives as
+// provider.json and schema.json, so schema-only installs don't have to pull
+// the (much larger) provider binary down.
+func (r *MondooProviderRegistry) DownloadProviderMetadata(ctx context.Context, name, version string) ([]byte, []byte, error) {
+	confJSON, err := r.downloadReleaseFile(ctx, name, version, "provider.json")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	schemaJSON, err := r.downloadReleaseFile(ctx, name, version, "schema.json")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return confJSON, schemaJSON, nil
+}
+
+// downloadReleaseFile fetches a single file from a provider's release
+// directory, e.g. <base>/<name>/<version>/schema.json.
+func (r *MondooProviderRegistry) downloadReleaseFile(ctx context.Context, name, version, filename string) ([]byte, error) {
+	downloadURL, err := url.JoinPath(r.BaseURL, name, version, filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct download URL")
+	}
+
+	log.Debug().Str("url", downloadURL).Msg("downloading provider file from URL")
+
+	client, err := httpClientWithRetry()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build download request")
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to download "+filename+" for "+name+"-"+version)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		return nil, errors.New("cannot find " + filename + " for provider " + name + "-" + version + " under url " + downloadURL)
+	} else if res.StatusCode != http.StatusOK {
+		log.Debug().Str("url", downloadURL).Int("status", res.StatusCode).Msg("failed to download from URL (status code)")
+		return nil, errors.New("failed to download " + filename + " for " + name + "-" + version + ", received status code: " + res.Status)
+	}
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read "+filename+" for "+name+"-"+version)
+	}
+	return data, nil
 }

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -166,3 +166,39 @@ func TestMondooProviderRegistry_DownloadProvider(t *testing.T) {
 		assert.Contains(t, err.Error(), "cannot find provider")
 	})
 }
+
+func TestMondooProviderRegistry_DownloadProviderMetadata(t *testing.T) {
+	expectedConf := `{"Name":"aws","Version":"1.2.3"}`
+	expectedSchema := `{"resources":{}}`
+
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/aws/1.2.3/provider.json":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(expectedConf)) // nolint:errcheck
+		case "/aws/1.2.3/schema.json":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(expectedSchema)) // nolint:errcheck
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	registry := NewMondooProviderRegistry(WithBaseURL(server.URL))
+	ctx := context.Background()
+
+	t.Run("successful download", func(t *testing.T) {
+		conf, schema, err := registry.DownloadProviderMetadata(ctx, "aws", "1.2.3")
+		require.NoError(t, err)
+		assert.Equal(t, expectedConf, string(conf))
+		assert.Equal(t, expectedSchema, string(schema))
+	})
+
+	t.Run("provider not found", func(t *testing.T) {
+		_, _, err := registry.DownloadProviderMetadata(ctx, "nonexistent", "1.0.0")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot find provider.json")
+	})
+}


### PR DESCRIPTION
Backport of #9062 to the `v13` branch.

Adds a `--schema-only` flag to `providers install`, which installs a provider's schema without fetching the provider binary. Clean cherry-pick of bfbfed1d1; `go build` and `go test ./providers/` pass on the v13 base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)