### PR TITLE
🧹 azure: restore the blank line between two .lr resource blocks

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -18900,6 +18900,7 @@ azure.subscription.dataBoxService.job @defaults("id name status transferType") {
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
+
 // Encryption settings of an Azure NetApp Files account
 //
 // Which key protects the account's data at rest, and which identity is used
@@ -19161,6 +19162,7 @@ private azure.subscription.netAppService.account.capacityPool.volume.exportPolic
   // Whether matching clients get read-write access under Kerberos krb5p
   kerberos5pReadWrite bool
 }
+
 // Snapshot of an Azure file share
 //
 // Point-in-time copy of a file share's contents, taken under the


### PR DESCRIPTION
Two resource blocks in `azure.lr` lost the blank line that separates every other top-level block in the file, so a closing brace runs straight into the next doc-comment:

```
  systemMetadata() azure.subscription.systemData
}
// Encryption settings of an Azure NetApp Files account
```

Both seams are where a new service landed next to one that merged around the same time, so the separator fell in the join rather than in either change.

Schema-only whitespace. The generator ignores blank lines, so `make providers/build/azure` produces no diff in `azure.lr.go`, `azure.lr.versions` or `azure.permissions.json` — the commit is the two lines and nothing else.