### PR TITLE
⭐ azure: expose the Defender for Servers plan components

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -10482,6 +10482,28 @@ private azure.subscription.cloudDefenderService.defenderForServers @defaults("en
   resourcesCoverageStatus string
   // Name of the vulnerability management tool in use
   vulnerabilityManagementToolName string
+  // Components offered under the plan and whether each is turned on
+  //
+  // The plan is billed as a whole but its capabilities are switched
+  // individually, so a subscription on the Standard tier can still have File
+  // Integrity Monitoring or agentless scanning turned off. Select a component
+  // by name, for example
+  // `extensions.where(name == "FileIntegrityMonitoring")`.
+  extensions() []azure.subscription.cloudDefenderService.defenderForServers.extension
+}
+
+// Microsoft Defender for Servers extension
+private azure.subscription.cloudDefenderService.defenderForServers.extension {
+  // Extension name
+  name string
+  // Whether the extension is enabled
+  isEnabled bool
+  // Additional extension properties
+  additionalProperties dict
+  // Status code of the enablement/disablement operation (Succeeded or Failed)
+  operationStatusCode string
+  // Status message of the enablement/disablement operation
+  operationStatusMessage string
 }
 
 // Microsoft Defender for App Service

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -301,6 +301,7 @@ const (
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderCSPM                                           string = "azure.subscription.cloudDefenderService.defenderCSPM"
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension                                  string = "azure.subscription.cloudDefenderService.defenderCSPM.extension"
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderForServers                                     string = "azure.subscription.cloudDefenderService.defenderForServers"
+	ResourceAzureSubscriptionCloudDefenderServiceDefenderForServersExtension                            string = "azure.subscription.cloudDefenderService.defenderForServers.extension"
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderForAppServices                                 string = "azure.subscription.cloudDefenderService.defenderForAppServices"
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderForSqlServersOnMachines                        string = "azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines"
 	ResourceAzureSubscriptionCloudDefenderServiceDefenderForSqlDatabases                                string = "azure.subscription.cloudDefenderService.defenderForSqlDatabases"
@@ -1685,6 +1686,10 @@ func init() {
 		"azure.subscription.cloudDefenderService.defenderForServers": {
 			// to override args, implement: initAzureSubscriptionCloudDefenderServiceDefenderForServers(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionCloudDefenderServiceDefenderForServers,
+		},
+		"azure.subscription.cloudDefenderService.defenderForServers.extension": {
+			// to override args, implement: initAzureSubscriptionCloudDefenderServiceDefenderForServersExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionCloudDefenderServiceDefenderForServersExtension,
 		},
 		"azure.subscription.cloudDefenderService.defenderForAppServices": {
 			// to override args, implement: initAzureSubscriptionCloudDefenderServiceDefenderForAppServices(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -13419,6 +13424,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cloudDefenderService.defenderForServers.vulnerabilityManagementToolName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers).GetVulnerabilityManagementToolName()).ToDataRes(types.String)
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extensions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers).GetExtensions()).ToDataRes(types.Array(types.Resource("azure.subscription.cloudDefenderService.defenderForServers.extension")))
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.isEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).GetIsEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.additionalProperties": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).GetAdditionalProperties()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.operationStatusCode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).GetOperationStatusCode()).ToDataRes(types.String)
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.operationStatusMessage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).GetOperationStatusMessage()).ToDataRes(types.String)
 	},
 	"azure.subscription.cloudDefenderService.defenderForAppServices.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices).GetSubscriptionId()).ToDataRes(types.String)
@@ -37069,6 +37092,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cloudDefenderService.defenderForServers.vulnerabilityManagementToolName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers).VulnerabilityManagementToolName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extensions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers).Extensions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.isEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).IsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.additionalProperties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).AdditionalProperties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.operationStatusCode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).OperationStatusCode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.defenderForServers.extension.operationStatusMessage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension).OperationStatusMessage, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.defenderForAppServices.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -86093,7 +86144,7 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderCSPMExtension) GetOpera
 type mqlAzureSubscriptionCloudDefenderServiceDefenderForServers struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceDefenderForServersInternal it will be used here
+	mqlAzureSubscriptionCloudDefenderServiceDefenderForServersInternal
 	SubscriptionId                  plugin.TValue[string]
 	Enabled                         plugin.TValue[bool]
 	PricingTier                     plugin.TValue[string]
@@ -86107,6 +86158,7 @@ type mqlAzureSubscriptionCloudDefenderServiceDefenderForServers struct {
 	ReplacedBy                      plugin.TValue[[]any]
 	ResourcesCoverageStatus         plugin.TValue[string]
 	VulnerabilityManagementToolName plugin.TValue[string]
+	Extensions                      plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionCloudDefenderServiceDefenderForServers creates a new instance of this resource
@@ -86196,6 +86248,91 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServers) GetResource
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServers) GetVulnerabilityManagementToolName() *plugin.TValue[string] {
 	return &c.VulnerabilityManagementToolName
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServers) GetExtensions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Extensions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService.defenderForServers", c.__id, "extensions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.extensions()
+	})
+}
+
+// mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension for the azure.subscription.cloudDefenderService.defenderForServers.extension resource
+type mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtensionInternal it will be used here
+	Name                   plugin.TValue[string]
+	IsEnabled              plugin.TValue[bool]
+	AdditionalProperties   plugin.TValue[any]
+	OperationStatusCode    plugin.TValue[string]
+	OperationStatusMessage plugin.TValue[string]
+}
+
+// createAzureSubscriptionCloudDefenderServiceDefenderForServersExtension creates a new instance of this resource
+func createAzureSubscriptionCloudDefenderServiceDefenderForServersExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.cloudDefenderService.defenderForServers.extension", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) MqlName() string {
+	return "azure.subscription.cloudDefenderService.defenderForServers.extension"
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) GetIsEnabled() *plugin.TValue[bool] {
+	return &c.IsEnabled
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) GetAdditionalProperties() *plugin.TValue[any] {
+	return &c.AdditionalProperties
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) GetOperationStatusCode() *plugin.TValue[string] {
+	return &c.OperationStatusCode
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) GetOperationStatusMessage() *plugin.TValue[string] {
+	return &c.OperationStatusMessage
 }
 
 // mqlAzureSubscriptionCloudDefenderServiceDefenderForAppServices for the azure.subscription.cloudDefenderService.defenderForAppServices resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -814,6 +814,13 @@ azure.subscription.cloudDefenderService.defenderForServers.deprecated 11.6.1
 azure.subscription.cloudDefenderService.defenderForServers.enabled 11.6.1
 azure.subscription.cloudDefenderService.defenderForServers.enablementTime 11.6.1
 azure.subscription.cloudDefenderService.defenderForServers.enforce 11.6.1
+azure.subscription.cloudDefenderService.defenderForServers.extension 13.36.1
+azure.subscription.cloudDefenderService.defenderForServers.extension.additionalProperties 13.36.1
+azure.subscription.cloudDefenderService.defenderForServers.extension.isEnabled 13.36.1
+azure.subscription.cloudDefenderService.defenderForServers.extension.name 13.36.1
+azure.subscription.cloudDefenderService.defenderForServers.extension.operationStatusCode 13.36.1
+azure.subscription.cloudDefenderService.defenderForServers.extension.operationStatusMessage 13.36.1
+azure.subscription.cloudDefenderService.defenderForServers.extensions 13.36.1
 azure.subscription.cloudDefenderService.defenderForServers.freeTrialRemainingTime 11.6.1
 azure.subscription.cloudDefenderService.defenderForServers.inherited 11.6.1
 azure.subscription.cloudDefenderService.defenderForServers.inheritedFrom 11.6.1

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -250,7 +250,66 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscr
 	if err != nil {
 		return nil, err
 	}
-	return resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers), nil
+	mqlServers := resource.(*mqlAzureSubscriptionCloudDefenderServiceDefenderForServers)
+	// The pricing response already carries the extensions, so prime the cache
+	// rather than making extensions() fetch the same thing again.
+	var rawExtensions []*security.Extension
+	if vmPricing.Properties != nil {
+		rawExtensions = vmPricing.Properties.Extensions
+	}
+	mqlServers.rawExtensionsOnce.Do(func() {
+		mqlServers.rawExtensions = rawExtensions
+	})
+	return mqlServers, nil
+}
+
+type mqlAzureSubscriptionCloudDefenderServiceDefenderForServersInternal struct {
+	rawExtensionsOnce sync.Once
+	rawExtensions     []*security.Extension
+	rawExtensionsErr  error
+}
+
+// fetchRawExtensions returns the extension list from the VirtualMachines
+// pricing endpoint, resolved once. The parent forServers() primes it from the
+// response it already has; reaching the resource by its own type name falls
+// back to the API.
+func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForServers) fetchRawExtensions() ([]*security.Extension, error) {
+	a.rawExtensionsOnce.Do(func() {
+		conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		subId := a.SubscriptionId.Data
+		clientFactory, err := armsecurity.NewClientFactory(subId, conn.Token(), &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			a.rawExtensionsErr = err
+			return
+		}
+		resp, err := clientFactory.NewPricingsClient().Get(context.Background(),
+			fmt.Sprintf("subscriptions/%s", subId), "VirtualMachines",
+			&security.PricingsClientGetOptions{})
+		if err != nil {
+			a.rawExtensionsErr = err
+			return
+		}
+		if resp.Properties != nil {
+			a.rawExtensions = resp.Properties.Extensions
+		}
+	})
+	return a.rawExtensions, a.rawExtensionsErr
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForServers) extensions() ([]any, error) {
+	exts, err := a.fetchRawExtensions()
+	if err != nil {
+		return nil, err
+	}
+	return buildExtensionResources(a.MqlRuntime, exts,
+		ResourceAzureSubscriptionCloudDefenderServiceDefenderForServersExtension,
+		ResourceAzureSubscriptionCloudDefenderServiceDefenderForServers+"/"+a.SubscriptionId.Data)
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderServiceDefenderForServersExtension) id() (string, error) {
+	return a.__id, nil
 }
 
 // simpleDefenderDict serializes a typed Defender pricing resource's `enabled`


### PR DESCRIPTION
Resolves #10147.

`defenderForServers` reported the plan (`enabled`, `pricingTier`, `subPlan`, …)
but not its extension components, so per-component status could not be asserted.

That distinction is the point: the plan is billed as a whole but its
capabilities are switched **individually**, so a subscription sitting on the
Standard tier can still have File Integrity Monitoring or agentless scanning
turned off — and nothing in the schema showed it.

```coffee
azure.subscription.cloudDefender.forServers.extensions
  .where(name == "FileIntegrityMonitoring")
  .all(isEnabled == true)
```

Confirmed against the ARM reference rather than assumed: the `Microsoft.Security/pricings`
extension list documents `FileIntegrityMonitoring` as *"Available for
VirtualMachines plan (P2 sub plan)"*, alongside `AgentlessVmScanning` and
`MdeDesignatedSubscription` on the same plan. So the extensions genuinely ride
on the plan this resource models.

## What changed

Both plans come from the same pricings API and the response carries `extensions`
for each, so this reuses the shape `defenderForContainers` already has — same
field set on the extension resource, and the same `buildExtensionResources`
helper, rather than a second implementation of it.

The pricing response `forServers()` already fetches carries the extensions, so
the cache is primed from it and the accessor costs no extra request in the
common path. Reaching the resource by its own type name
(`azure.subscription.cloudDefenderService.defenderForServers.extensions`) falls
back to the API, which keeps both construction paths returning the same thing —
the failure mode where one path silently reports an empty list.

New `.lr.versions` entries are `13.36.1`, the patch after the provider's current
`13.36.0`.

## Not verified live

No Azure subscription was available in this session, so the field mapping comes
from the ARM reference and the sibling implementation rather than from a real
response. The extension decode is the existing helper, already exercised by the
containers path, so the untested surface is the one pricing call and its cache
priming.

## Related issues in the same batch, deliberately not bundled here

#10148 asks for a `defenderForIot` plan. I did **not** implement it: the
`Microsoft.Security/pricings` reference lists no IoT plan, and Defender for IoT
has moved to site/device licensing rather than a subscription pricing tier. That
needs confirmation against a real subscription before a resource is added —
guessing the pricing name ships a field that errors on every account. Left a
note on the issue.
