### PR TITLE
🧹 azure: drop a stray blank line in the subscription accessor list

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -255,7 +255,6 @@ azure.subscription @defaults ("name") {
   dataBox() azure.subscription.dataBoxService
   // Azure NetApp Files resources in the subscription
   netApp() azure.subscription.netAppService
-
   // Azure Elastic SAN resources in the subscription
   elasticSan() azure.subscription.elasticSanService
   // Azure Functions resources in the subscription


### PR DESCRIPTION
The service accessors on `azure.subscription` run comment/accessor with no blank lines between them — `recoveryServices`, `dataProtection`, `dataBox`, `functions`, `serviceBus`, `eventHub` and the rest are all packed. One blank line crept in after `netApp()` during a rebase, which reads as a section break where there is none.

Schema-only whitespace. The generator ignores blank lines, so `make providers/build/azure` produces no diff in `azure.lr.go`, `azure.lr.versions` or `azure.permissions.json` — the commit is the one line and nothing else.

Companion to #10154, which fixed the same class between top-level resource blocks. Worth noting the two conventions are opposite: blocks are separated by a blank line, fields inside a block are not.