### PR TITLE
🧹 providers: refresh SDK dependencies

### DIFF
--- a/providers/alicloud/go.mod
+++ b/providers/alicloud/go.mod
@@ -12,14 +12,14 @@ require (
 	github.com/alibabacloud-go/cloudsso-20210515 v1.6.2
 	github.com/alibabacloud-go/config-20200907/v4 v4.2.3
 	github.com/alibabacloud-go/cr-20181201/v3 v3.2.2
-	github.com/alibabacloud-go/cs-20151215/v8 v8.0.4
+	github.com/alibabacloud-go/cs-20151215/v8 v8.1.0
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.2.4
 	github.com/alibabacloud-go/ddoscoo-20200101/v5 v5.0.2
 	github.com/alibabacloud-go/dds-20151201/v10 v10.4.2
 	github.com/alibabacloud-go/ecs-20140526/v7 v7.9.5
 	github.com/alibabacloud-go/elasticsearch-20170613/v6 v6.3.3
 	github.com/alibabacloud-go/ess-20220222/v2 v2.13.3
-	github.com/alibabacloud-go/fc-20230330/v4 v4.7.9
+	github.com/alibabacloud-go/fc-20230330/v4 v4.8.1
 	github.com/alibabacloud-go/kms-20160120/v4 v4.2.0
 	github.com/alibabacloud-go/nas-20170626/v4 v4.7.0
 	github.com/alibabacloud-go/nlb-20220430/v4 v4.1.3
@@ -36,7 +36,7 @@ require (
 	github.com/alibabacloud-go/vpc-20160428/v7 v7.2.5
 	github.com/alibabacloud-go/waf-openapi-20211001/v7 v7.8.4
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.3
-	github.com/aliyun/credentials-go v1.4.12
+	github.com/aliyun/credentials-go v1.4.13
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.0
 	go.mondoo.com/mql/v13 v13.34.1

--- a/providers/alicloud/go.sum
+++ b/providers/alicloud/go.sum
@@ -57,8 +57,8 @@ github.com/alibabacloud-go/config-20200907/v4 v4.2.3 h1:2pc+g0xLJIZySTbGHIcO+SgO
 github.com/alibabacloud-go/config-20200907/v4 v4.2.3/go.mod h1:676adIwzf0Vv49S7EbnLgx15yypR6ksoZBmGRC+SoMs=
 github.com/alibabacloud-go/cr-20181201/v3 v3.2.2 h1:FVb9x96nzfYYGY1TiqGeGIJ94hiV3rMDYJj450xcgew=
 github.com/alibabacloud-go/cr-20181201/v3 v3.2.2/go.mod h1:n6rgkvIRrWimA7ZDk/amBIcxjw0lXF8tL+NKdMjSDW4=
-github.com/alibabacloud-go/cs-20151215/v8 v8.0.4 h1:yt4OLEgGWxyFIziBJtd4M2QGF5Sievr+92u/FZNTYXg=
-github.com/alibabacloud-go/cs-20151215/v8 v8.0.4/go.mod h1:BCwaxkn50Fg/j7jcVtamSy1GjXIVTpbWc8ihEnOcgwY=
+github.com/alibabacloud-go/cs-20151215/v8 v8.1.0 h1:8G2i98quaWIoj0RGkaRzlt80JHbyKbt/EpcgbnUo/Xc=
+github.com/alibabacloud-go/cs-20151215/v8 v8.1.0/go.mod h1:BCwaxkn50Fg/j7jcVtamSy1GjXIVTpbWc8ihEnOcgwY=
 github.com/alibabacloud-go/darabonba-array v0.1.0 h1:vR8s7b1fWAQIjEjWnuF0JiKsCvclSRTfDzZHTYqfufY=
 github.com/alibabacloud-go/darabonba-array v0.1.0/go.mod h1:BLKxr0brnggqOJPqT09DFJ8g3fsDshapUD3C3aOEFaI=
 github.com/alibabacloud-go/darabonba-encode-util v0.0.2 h1:1uJGrbsGEVqWcWxrS9MyC2NG0Ax+GpOM5gtupki31XE=
@@ -93,8 +93,8 @@ github.com/alibabacloud-go/endpoint-util v1.1.0 h1:r/4D3VSw888XGaeNpP994zDUaxdgT
 github.com/alibabacloud-go/endpoint-util v1.1.0/go.mod h1:O5FuCALmCKs2Ff7JFJMudHs0I5EBgecXXxZRyswlEjE=
 github.com/alibabacloud-go/ess-20220222/v2 v2.13.3 h1:VafOjNLGZtRn62lzvu9NlXG7/hEBqKBENqXNv1z5VmU=
 github.com/alibabacloud-go/ess-20220222/v2 v2.13.3/go.mod h1:yPi7k7mC7NL6RO9zS1QTPjDBB/gZoqUBTePVoT8Yf04=
-github.com/alibabacloud-go/fc-20230330/v4 v4.7.9 h1:YQOm9qRkWDszkuBSJwVjIzwdh2nflnLaQDUqSekdS2Y=
-github.com/alibabacloud-go/fc-20230330/v4 v4.7.9/go.mod h1:b58LH0Xv8fl9PlaWpVx26cEpBLTcY4q536X0GCz/BGc=
+github.com/alibabacloud-go/fc-20230330/v4 v4.8.1 h1:SqD3FYIFUx2bfqz1wI4dUi9FQ27WW79iRQF24qWlMHc=
+github.com/alibabacloud-go/fc-20230330/v4 v4.8.1/go.mod h1:b58LH0Xv8fl9PlaWpVx26cEpBLTcY4q536X0GCz/BGc=
 github.com/alibabacloud-go/kms-20160120/v4 v4.2.0 h1:ntXWBE1hAXfgimTbrehkDj1KejCGS1FE9qZosOBvM+0=
 github.com/alibabacloud-go/kms-20160120/v4 v4.2.0/go.mod h1:trxe0VW1zZuKEks3hjrggEXbBuMHuS/Li6e9M5A8q0w=
 github.com/alibabacloud-go/nas-20170626/v4 v4.7.0 h1:eukUfWdXfoGoNRTbqk6cwAshJFT6/rNwBlZyh/pdy88=
@@ -157,8 +157,8 @@ github.com/aliyun/credentials-go v1.3.1/go.mod h1:8jKYhQuDawt8x2+fusqa1Y6mPxemTs
 github.com/aliyun/credentials-go v1.3.6/go.mod h1:1LxUuX7L5YrZUWzBrRyk0SwSdH4OmPrib8NVePL3fxM=
 github.com/aliyun/credentials-go v1.3.10/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
 github.com/aliyun/credentials-go v1.4.5/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
-github.com/aliyun/credentials-go v1.4.12 h1:7D8eXGotNwthZuUEgAMgBoqxmIHwfaPVwW+/04LIJSQ=
-github.com/aliyun/credentials-go v1.4.12/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
+github.com/aliyun/credentials-go v1.4.13 h1:alJaUIolzjrw0sZjOTwYpI34Djqo3MJJh4q+yqMah7Q=
+github.com/aliyun/credentials-go v1.4.13/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
 github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9dedlWa0OhD30=
 github.com/anchore/go-struct-converter v0.1.0/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=

--- a/providers/databricks/go.mod
+++ b/providers/databricks/go.mod
@@ -5,7 +5,7 @@ replace go.mondoo.com/mql/v13 => ../..
 go 1.26.6
 
 require (
-	github.com/databricks/databricks-sdk-go v0.173.0
+	github.com/databricks/databricks-sdk-go v0.175.0
 	github.com/stretchr/testify v1.12.0
 	go.mondoo.com/mql/v13 v13.34.1
 )

--- a/providers/databricks/go.sum
+++ b/providers/databricks/go.sum
@@ -120,8 +120,8 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.7.0 h1:s0Y3ITPy6sQn5xt54DuYvTF8hu134ooYLUb58DX/HjE=
 github.com/cyphar/filepath-securejoin v0.7.0/go.mod h1:ymLGms/u3BYaviIiuKFnUx8EkQEZeK6cInNoAPJA3o4=
-github.com/databricks/databricks-sdk-go v0.173.0 h1:ob/1OAnSZHChTYnw0p2R2EOMV0uXRp0gmq7z2NIyEpU=
-github.com/databricks/databricks-sdk-go v0.173.0/go.mod h1:udBw6nxkaqa0fgPQ7ZW1kGFkltQncYx+qFJeVFmxtz8=
+github.com/databricks/databricks-sdk-go v0.175.0 h1:XJKS5dqV23fADlEgo/PTYo74+lhzR8sUXJZv8qoNr50=
+github.com/databricks/databricks-sdk-go v0.175.0/go.mod h1:udBw6nxkaqa0fgPQ7ZW1kGFkltQncYx+qFJeVFmxtz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/providers/dropbox/go.mod
+++ b/providers/dropbox/go.mod
@@ -6,7 +6,7 @@ go 1.26.6
 
 require (
 	github.com/cockroachdb/errors v1.14.0
-	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0
+	github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.1
 	github.com/rs/zerolog v1.35.1
 	go.mondoo.com/mql/v13 v13.34.1
 )

--- a/providers/dropbox/go.sum
+++ b/providers/dropbox/go.sum
@@ -128,8 +128,8 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0 h1:LWwNAeoGaMbNkbaa/0wlNc01SeT0JtISyTZOr4iLeXU=
-github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.0/go.mod h1:gDXhl0OElhzYoDsYWHr1RXjpxjGeLzEvjYzH7sZV73k=
+github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.1 h1:NS9fm6KmJTN2J6YzF70QrZ0tMPYOrs+GL9uPVI0K9Ug=
+github.com/dropbox/dropbox-sdk-go-unofficial/v6 v6.6.1/go.mod h1:gDXhl0OElhzYoDsYWHr1RXjpxjGeLzEvjYzH7sZV73k=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=

--- a/providers/oci/go.mod
+++ b/providers/oci/go.mod
@@ -5,7 +5,7 @@ go 1.26.6
 replace go.mondoo.com/mql/v13 => ../..
 
 require (
-	github.com/oracle/oci-go-sdk/v65 v65.123.1
+	github.com/oracle/oci-go-sdk/v65 v65.123.2
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.0
 	go.mondoo.com/mql/v13 v13.34.1

--- a/providers/oci/go.sum
+++ b/providers/oci/go.sum
@@ -326,8 +326,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/oracle/oci-go-sdk/v65 v65.123.1 h1:UE8xEOuF++LnrnvQDcn4gbviD9N4ZFGOFrV8tW2bHbU=
-github.com/oracle/oci-go-sdk/v65 v65.123.1/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
+github.com/oracle/oci-go-sdk/v65 v65.123.2 h1:Xg/OEjuj+xNkJKgjTVDG9R5rq7oxKIKHWIeNFZd9etU=
+github.com/oracle/oci-go-sdk/v65 v65.123.2/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
 github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
 github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.2 h1:TFiHlzUkT67s6UkelHmK6s1INKVUG7nlKYiWWDTITGI=

--- a/providers/stackit/go.mod
+++ b/providers/stackit/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/authorization v0.15.3
 	github.com/stackitcloud/stackit-sdk-go/services/certificates v1.9.1
 	github.com/stackitcloud/stackit-sdk-go/services/dns v0.22.1
-	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.14.0
+	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.14.1
 	github.com/stackitcloud/stackit-sdk-go/services/kms v1.13.0
 	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.15.1
 	github.com/stackitcloud/stackit-sdk-go/services/logme v1.3.0

--- a/providers/stackit/go.sum
+++ b/providers/stackit/go.sum
@@ -412,8 +412,8 @@ github.com/stackitcloud/stackit-sdk-go/services/certificates v1.9.1 h1:tf9+nPZ/1
 github.com/stackitcloud/stackit-sdk-go/services/certificates v1.9.1/go.mod h1:eJpB3/pukz+KzVPVHQ4g3DVtQkxGga18VbFBhq9ugdY=
 github.com/stackitcloud/stackit-sdk-go/services/dns v0.22.1 h1:vC0GpKVKH1Tce9VNyZTMWbheyGGS9a9GZWv6H5/z4Ek=
 github.com/stackitcloud/stackit-sdk-go/services/dns v0.22.1/go.mod h1:FiYSv3D9rzgEVzi8Mpq5oYZBosrasa5uUYqVdEIbM1U=
-github.com/stackitcloud/stackit-sdk-go/services/iaas v1.14.0 h1:oT8MPM4nEV/5O09+4SBmo+sT1nuxSyA6YWmK+pdNQog=
-github.com/stackitcloud/stackit-sdk-go/services/iaas v1.14.0/go.mod h1:gkUAQcOPukQQhER997HZe50WQK9JblwFc4O9PHExVQo=
+github.com/stackitcloud/stackit-sdk-go/services/iaas v1.14.1 h1:P8XhOi8TLA7NbLHhxU8dCJjgQpha/65agos3pI59+vw=
+github.com/stackitcloud/stackit-sdk-go/services/iaas v1.14.1/go.mod h1:/QpOsaCOQjwGgQqG8y9xXqryp25AfkorPjInX9xIeOU=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.13.0 h1:4S9gcTlijtvlF8wYZR5anbQ98oIP2+fIaEsvBXluux4=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.13.0/go.mod h1:pVaCmb1ZHAPGVRlSlBlVOjThp9Tb2sX9+nRX0M+d1KU=
 github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.15.1 h1:+NT2okD80TlFNDTKSgaEvV/o7LevTrATqcDL0r4nuhU=


### PR DESCRIPTION
Routine dependency refresh for the five providers whose upgrade is a
version bump with no code change. Each module was built and tested as
its own Go module; none of these bumps crosses a major.

| provider | module | from | to |
|---|---|---|---|
| oci | github.com/oracle/oci-go-sdk/v65 | v65.123.1 | v65.123.2 |
| alicloud | github.com/alibabacloud-go/cs-20151215/v8 | v8.0.4 | v8.1.0 |
| alicloud | github.com/alibabacloud-go/fc-20230330/v4 | v4.7.9 | v4.8.1 |
| alicloud | github.com/aliyun/credentials-go | v1.4.12 | v1.4.13 |
| stackit | github.com/stackitcloud/stackit-sdk-go/services/iaas | v1.14.0 | v1.14.1 |
| dropbox | github.com/dropbox/dropbox-sdk-go-unofficial/v6 | v6.6.0 | v6.6.1 |
| databricks | github.com/databricks/databricks-sdk-go | v0.173.0 | v0.175.0 |

No `.lr` schema changes, so no `.lr.versions` entries and no provider
version bumps.


