### PR TITLE
⭐ aws: expose nested virtualization on WorkSpaces

### DIFF
--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/athena v1.60.6
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.72.1
 	github.com/aws/aws-sdk-go-v2/service/backup v1.60.2
-	github.com/aws/aws-sdk-go-v2/service/batch v1.68.6
+	github.com/aws/aws-sdk-go-v2/service/batch v1.68.7
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.6
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.58.6
 	github.com/aws/aws-sdk-go-v2/service/bedrockagentcorecontrol v1.57.0
@@ -55,7 +55,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/drs v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.16.7
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.3
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.2
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.3
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.60.6
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.90.2
@@ -125,7 +125,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.25.7
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.5
 	github.com/aws/aws-sdk-go-v2/service/workdocs v1.33.6
-	github.com/aws/aws-sdk-go-v2/service/workspaces v1.73.3
+	github.com/aws/aws-sdk-go-v2/service/workspaces v1.74.0
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.42.6
 	github.com/aws/smithy-go v1.27.8
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -151,8 +151,8 @@ github.com/aws/aws-sdk-go-v2/service/autoscaling v1.72.1 h1:dphKqIDUM4m9Lz6rPgTJ
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.72.1/go.mod h1:GAUQKj/AD0M/V2yO652a6BOJiLhsLKZ+jQ7bFfbZDDk=
 github.com/aws/aws-sdk-go-v2/service/backup v1.60.2 h1:b3QwmC6vV20LLbUGedok6UlOe45HgnW7C93MThgk0P4=
 github.com/aws/aws-sdk-go-v2/service/backup v1.60.2/go.mod h1:zMHhtRP9145uUJxHZM7yURy5/d/mn837hyVWBSz5RaM=
-github.com/aws/aws-sdk-go-v2/service/batch v1.68.6 h1:3aFJ6Red2kQBAfrii5c4bq9fqnQSVxE96gVTjSaOiCs=
-github.com/aws/aws-sdk-go-v2/service/batch v1.68.6/go.mod h1:S7Qaws+9V1PsynezOZJjEqPNKcdk2Ht5bU9c3z0LYn0=
+github.com/aws/aws-sdk-go-v2/service/batch v1.68.7 h1:bECyc0PEYH1fSQSgVaCznfY7918YhYd75yOEwrco1Z0=
+github.com/aws/aws-sdk-go-v2/service/batch v1.68.7/go.mod h1:S7Qaws+9V1PsynezOZJjEqPNKcdk2Ht5bU9c3z0LYn0=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.6 h1:VZxz2SILULvluRU9g92ZDCdqToTPw/xPXDqtJ47ng2U=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.6/go.mod h1:E4BGQ5oTXmgMZhHavHrix+6rzp3nfjHt82P7mWtEzqs=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.58.6 h1:vWoZhFXHKDQSIh7Ok6uMVz4EApp0hNOft2hdrPal/p8=
@@ -213,8 +213,8 @@ github.com/aws/aws-sdk-go-v2/service/dsql v1.16.7 h1:Wzzkh3nQ9Aa991147DUPACgeIgK
 github.com/aws/aws-sdk-go-v2/service/dsql v1.16.7/go.mod h1:0tJ7LOipeFsPBpbgSznKw6snZoWz8mCo6LWvf5a2okU=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.3 h1:cVfESNZmZ8L9TkOeNo6u/eNR0ZphBuS1J2GjLBLmEdA=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.63.3/go.mod h1:n9exrC9k5S+0t6X6LQKHcv7ap1jAEAHY2Sbqhu9mS34=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.2 h1:jcHDG5dFHYfpGUfEKmBbG8XtJHcJinqLpiIsjz2c4Uw=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.2/go.mod h1:0YYJ+4BAgeIkRucGTesOdWnVnxhodrwWo6+lJ6Wmndg=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.3 h1:D/jnJv0FOeJKpRguRNC4tptuJ7y1yYYk/dKVTPmHQJs=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.321.3/go.mod h1:0YYJ+4BAgeIkRucGTesOdWnVnxhodrwWo6+lJ6Wmndg=
 github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.35.6 h1:lI5GKBn2wlW6sno1xOT/kWM5fwYjPFk8LrAgFR62koI=
 github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.35.6/go.mod h1:PchrTj09ZwmTP7gKSffuJljlpWJZBsx83rQ4u8fQrFo=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.60.6 h1:RbjO6G1wu+q43r0322sDABXi9vq/YZp254BBKAeLtRI=
@@ -371,8 +371,8 @@ github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.5 h1:ZeVYPSvHINjXaLnnspyhbm9jZ1
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.77.5/go.mod h1:Do1edZBjPihnT/0A7Msu4ozdmf5HfpcZ0edTaqNxhoQ=
 github.com/aws/aws-sdk-go-v2/service/workdocs v1.33.6 h1:VEbVyIGPUp3f8HlVUpuoAN0Lxf6xkDsqJSwlgBzeXC0=
 github.com/aws/aws-sdk-go-v2/service/workdocs v1.33.6/go.mod h1:BMAWaTktXwt0Dy/SEOIOIAgubdw6ALRZzNaDBiFk5rY=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.73.3 h1:GmLebyRVCdRAYNNS0Yqiy5+CmVqsDNUJ3Cp4y6UxMrQ=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.73.3/go.mod h1:2+a7hL3zlcGLM9d9NFGRRnHk7EYJ4hZlkRZ+31UFxis=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.74.0 h1:rRfn5efSFN59wL1lhv02WyF9nmz83p53GtOTS0OqBOw=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.74.0/go.mod h1:2+a7hL3zlcGLM9d9NFGRRnHk7EYJ4hZlkRZ+31UFxis=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.42.6 h1:XXT1uUXCwDcuyKjTCyT/2+UpY4Nv6EP0joYeHWLWcVA=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.42.6/go.mod h1:BR+gFQzTXWTq83mvtafCmGxf6Nu45kxAGVyGxWqv6UE=
 github.com/aws/smithy-go v1.27.8 h1:FR0dxZfIlV7Z8eh2iHfIofdunw382XsDV3Mxt9nUvRY=

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -22865,6 +22865,12 @@ private aws.workspaces.workspace @defaults("workspaceId userName state region") 
   rootVolumeEncryptionEnabled bool
   // Whether the user volume is encrypted
   userVolumeEncryptionEnabled bool
+  // Whether nested virtualization is enabled
+  //
+  // Null when the WorkSpace type does not report the setting. Nested
+  // virtualization lets a user run a hypervisor inside the desktop,
+  // which widens the guest isolation boundary.
+  nestedVirtualizationEnabled bool
   // KMS key ARN for volume encryption
   volumeEncryptionKey string
   // Error code if in error state

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -28424,6 +28424,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.workspaces.workspace.userVolumeEncryptionEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetUserVolumeEncryptionEnabled()).ToDataRes(types.Bool)
 	},
+	"aws.workspaces.workspace.nestedVirtualizationEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWorkspacesWorkspace).GetNestedVirtualizationEnabled()).ToDataRes(types.Bool)
+	},
 	"aws.workspaces.workspace.volumeEncryptionKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWorkspacesWorkspace).GetVolumeEncryptionKey()).ToDataRes(types.String)
 	},
@@ -70580,6 +70583,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.workspaces.workspace.userVolumeEncryptionEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWorkspacesWorkspace).UserVolumeEncryptionEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.workspaces.workspace.nestedVirtualizationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWorkspacesWorkspace).NestedVirtualizationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.workspaces.workspace.volumeEncryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -170958,6 +170965,7 @@ type mqlAwsWorkspacesWorkspace struct {
 	State                            plugin.TValue[string]
 	RootVolumeEncryptionEnabled      plugin.TValue[bool]
 	UserVolumeEncryptionEnabled      plugin.TValue[bool]
+	NestedVirtualizationEnabled      plugin.TValue[bool]
 	VolumeEncryptionKey              plugin.TValue[string]
 	ErrorCode                        plugin.TValue[string]
 	ErrorMessage                     plugin.TValue[string]
@@ -171078,6 +171086,10 @@ func (c *mqlAwsWorkspacesWorkspace) GetRootVolumeEncryptionEnabled() *plugin.TVa
 
 func (c *mqlAwsWorkspacesWorkspace) GetUserVolumeEncryptionEnabled() *plugin.TValue[bool] {
 	return &c.UserVolumeEncryptionEnabled
+}
+
+func (c *mqlAwsWorkspacesWorkspace) GetNestedVirtualizationEnabled() *plugin.TValue[bool] {
+	return &c.NestedVirtualizationEnabled
 }
 
 func (c *mqlAwsWorkspacesWorkspace) GetVolumeEncryptionKey() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -11270,6 +11270,7 @@ aws.workspaces.workspace.errorCode 11.16.1
 aws.workspaces.workspace.errorMessage 11.16.1
 aws.workspaces.workspace.ipAddress 11.16.1
 aws.workspaces.workspace.lastKnownUserConnectionTimestamp 11.16.1
+aws.workspaces.workspace.nestedVirtualizationEnabled 13.53.4
 aws.workspaces.workspace.region 11.16.1
 aws.workspaces.workspace.rootVolumeEncryptionEnabled 11.16.1
 aws.workspaces.workspace.securityGroups 11.16.1

--- a/providers/aws/resources/aws_workspaces.go
+++ b/providers/aws/resources/aws_workspaces.go
@@ -305,6 +305,15 @@ func newMqlAwsWorkspacesWorkspace(runtime *plugin.Runtime, region string, ws wor
 		workspaceId = *ws.WorkspaceId
 	}
 
+	// WorkspaceProperties is absent on some responses, and nested
+	// virtualization is only reported for the WorkSpace types that support
+	// it. Leaving the pointer nil keeps the field null in both cases: a
+	// false would claim we looked and the feature was switched off.
+	var nestedVirtualizationEnabled *bool
+	if ws.WorkspaceProperties != nil {
+		nestedVirtualizationEnabled = ws.WorkspaceProperties.NestedVirtualizationEnabled
+	}
+
 	resource, err := CreateResource(runtime, "aws.workspaces.workspace",
 		map[string]*llx.RawData{
 			"__id":                        llx.StringData("aws.workspaces.workspace/" + region + "/" + workspaceId),
@@ -317,6 +326,7 @@ func newMqlAwsWorkspacesWorkspace(runtime *plugin.Runtime, region string, ws wor
 			"state":                       llx.StringData(string(ws.State)),
 			"rootVolumeEncryptionEnabled": llx.BoolDataPtr(ws.RootVolumeEncryptionEnabled),
 			"userVolumeEncryptionEnabled": llx.BoolDataPtr(ws.UserVolumeEncryptionEnabled),
+			"nestedVirtualizationEnabled": llx.BoolDataPtr(nestedVirtualizationEnabled),
 			"volumeEncryptionKey":         llx.StringDataPtr(ws.VolumeEncryptionKey),
 			"errorCode":                   llx.StringDataPtr(ws.ErrorCode),
 			"errorMessage":                llx.StringDataPtr(ws.ErrorMessage),


### PR DESCRIPTION
Adds `aws.workspaces.workspace.nestedVirtualizationEnabled`, reported by
the `workspaces` SDK from v1.74.0. Nested virtualization lets a user run
a hypervisor inside the desktop, which widens the guest isolation
boundary, and there was previously no way to ask which WorkSpaces have
it turned on.

The value rides the `DescribeWorkspaces` response the lister already
issues, so this costs no additional API call and `aws.permissions.json`
is unchanged.

Null, not false, when the setting is absent. `WorkspaceProperties` is
missing from some responses and the flag is only reported for the
WorkSpace types that support nested virtualization; a `false` in those
cases would claim we looked and found the feature switched off.

SDK bumps carried here:

| module | from | to |
|---|---|---|
| github.com/aws/aws-sdk-go-v2/service/workspaces | v1.73.3 | v1.74.0 |
| github.com/aws/aws-sdk-go-v2/service/ec2 | v1.321.2 | v1.321.3 |
| github.com/aws/aws-sdk-go-v2/service/batch | v1.68.6 | v1.68.7 |

The `ec2` and `batch` bumps are patch releases with no reachable change;
they are here rather than in the combined dependency PR only because
this PR already touches the aws module.

`aws.permissions.json` was left alone on purpose: rebuilding it produces
only a version-stamp change (13.53.1 -> 13.53.3) left over from an
earlier commit, with no change to the permission list itself.

Not verified against a live AWS account. The claims above rest on the
SDK source, the compiler, and the provider's unit tests.


