### PR TITLE
⭐ azure: expose private endpoint connections on Databricks workspaces

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1812,6 +1812,14 @@ private azure.subscription.databricksService {
 // and the Compliance Security Profile posture. The requiredNsgRules value
 // selects which network security group rules the data plane relies on.
 azure.subscription.databricksService.workspace @defaults("id name location publicNetworkAccess") {
+  // Private endpoint connections on the workspace
+  //
+  // Connections created against the workspace's private link resources.
+  // A workspace reached over a private endpoint has at least one whose
+  // `privateLinkServiceConnectionState.status` is Approved. Note this is
+  // separate from `publicNetworkAccess`: a workspace can carry an approved
+  // connection and still answer on its public endpoint.
+  privateEndpointConnections() []azure.subscription.privateEndpointConnection
   // Workspace ID
   id string
   // Workspace name

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -4500,6 +4500,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.databricksService.workspaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDatabricksService).GetWorkspaces()).ToDataRes(types.Array(types.Resource("azure.subscription.databricksService.workspace")))
 	},
+	"azure.subscription.databricksService.workspace.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
+	},
 	"azure.subscription.databricksService.workspace.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).GetId()).ToDataRes(types.String)
 	},
@@ -24438,6 +24441,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.databricksService.workspace.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.databricksService.workspace.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDatabricksServiceWorkspace).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.databricksService.workspace.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -55571,6 +55578,7 @@ type mqlAzureSubscriptionDatabricksServiceWorkspace struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionDatabricksServiceWorkspaceInternal
+	PrivateEndpointConnections      plugin.TValue[[]any]
 	Id                              plugin.TValue[string]
 	Name                            plugin.TValue[string]
 	Location                        plugin.TValue[string]
@@ -55647,6 +55655,22 @@ func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) MqlName() string {
 
 func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetPrivateEndpointConnections() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PrivateEndpointConnections, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.databricksService.workspace", c.__id, "privateEndpointConnections")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.privateEndpointConnections()
+	})
 }
 
 func (c *mqlAzureSubscriptionDatabricksServiceWorkspace) GetId() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2371,6 +2371,7 @@ azure.subscription.databricksService.workspace.managedServicesKeySource 13.5.1
 azure.subscription.databricksService.workspace.managedServicesKeyVaultUri 13.5.1
 azure.subscription.databricksService.workspace.managedServicesKeyVersion 13.5.1
 azure.subscription.databricksService.workspace.name 11.4.25
+azure.subscription.databricksService.workspace.privateEndpointConnections 13.36.1
 azure.subscription.databricksService.workspace.properties 11.4.25
 azure.subscription.databricksService.workspace.provisioningState 13.5.1
 azure.subscription.databricksService.workspace.publicNetworkAccess 13.5.1

--- a/providers/azure/resources/databricks.go
+++ b/providers/azure/resources/databricks.go
@@ -284,12 +284,29 @@ func databricksWorkspaceToMql(runtime *plugin.Runtime, workspace *armdatabricks.
 		return nil, err
 	}
 	mqlWorkspace.cacheSystemData = sysData
+	if workspace.Properties != nil {
+		mqlWorkspace.cachePrivateEndpointConnections = workspace.Properties.PrivateEndpointConnections
+	}
 
 	return mqlWorkspace, nil
 }
 
 type mqlAzureSubscriptionDatabricksServiceWorkspaceInternal struct {
-	cacheSystemData any
+	cacheSystemData                 any
+	cachePrivateEndpointConnections []*armdatabricks.PrivateEndpointConnection
+}
+
+// privateEndpointConnections reports the connections created against the
+// workspace's private link resources.
+//
+// The list arrives with the workspace, so this reads what was already fetched
+// rather than issuing a request of its own. The values go through the shared
+// converter every other azure resource uses, which normalizes the SDK type
+// through a dict, so the workspace's connections are the same resource shape a
+// storage account's or a key vault's are and a fleet-wide query over
+// privateEndpointConnections stays comparable.
+func (a *mqlAzureSubscriptionDatabricksServiceWorkspace) privateEndpointConnections() ([]any, error) {
+	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
 }
 
 func (a *mqlAzureSubscriptionDatabricksServiceWorkspace) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {


### PR DESCRIPTION
Resolves #10146.

A Databricks workspace could not be asserted to be reached over a private
endpoint, and there was no workaround: the shared
`azure.subscription.privateEndpointConnection` resource exists but is reachable
only through an owner, and there is no subscription-level list to filter by
resource id.

```coffee
azure.subscription.databricks.workspaces.all(
  privateEndpointConnections.any(privateLinkServiceConnectionState.status == "Approved")
)
```

## What changed

Three lines of behaviour. `WorkspaceProperties.PrivateEndpointConnections` is
already in the payload the workspace listing returns, so the accessor reads what
was fetched rather than issuing a request of its own, and hands it to
`azurePrivateEndpointConnectionsToMql` — the shared converter roughly 40 other
azure resources already use.

That last part is the point of doing it this way rather than modelling a
Databricks-specific connection type: the converter normalizes each SDK's
connection through a dict, so a fleet-wide query over
`privateEndpointConnections` covers Databricks on the same terms as storage
accounts, key vaults and SQL servers instead of needing a per-service shape.

The schema comment notes the distinction that actually catches people: this is
separate from `publicNetworkAccess`, and a workspace can carry an approved
private connection while still answering on its public endpoint.

New `.lr.versions` entry is `13.36.1`, the patch after the provider's current
`13.36.0`.

## Verification

Built, generated cleanly, full azure suite passes, and the field compiles and
resolves to the shared resource type:

```
- azure.subscription.databricksService.workspace
  - privateEndpointConnections  type=[]azure.subscription.privateEndpointConnection
```

**Not exercised against a real connection.** The subscription available to me has
no Databricks workspaces, and its three private endpoints belong to resource
types that carry their own connection model rather than the shared one, so I
could not drive this exact path with live data. What that leaves untested is the
three-line hand-off; the decode itself is the shared converter, already
exercised in production by every other resource that uses it.
