### PR TITLE
⭐ azure: read diagnostic settings per resource

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -407,6 +407,18 @@ private azure.subscription.lock @defaults("name level scope") {
 // are not populated on this record; query the dedicated resource for a given type
 // when you need those.
 private azure.subscription.resource @defaults("id name location") {
+  // Azure Monitor diagnostic settings on the resource
+  //
+  // Which logs and metrics the resource emits, and where they are sent.
+  // Empty when the resource has none configured, which is the state a
+  // "logging is enabled" check is looking for. Reported per resource, so a
+  // sweep can ask the same question of every service that supports
+  // diagnostic settings rather than only the few with a dedicated field.
+  //
+  // This costs one request per resource it is read from, so narrow the set
+  // first, for example
+  // `resources.where(type == "Microsoft.Databricks/workspaces")`.
+  diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
   // Resource ID
   id string
   // Resource name

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -3077,6 +3077,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.lock.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionLock).GetScope()).ToDataRes(types.String)
 	},
+	"azure.subscription.resource.diagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionResource).GetDiagnosticSettings()).ToDataRes(types.Array(types.Resource("azure.subscription.monitorService.diagnosticsetting")))
+	},
 	"azure.subscription.resource.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionResource).GetId()).ToDataRes(types.String)
 	},
@@ -22481,6 +22484,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.resource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionResource).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.resource.diagnosticSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionResource).DiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.resource.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -51444,20 +51451,21 @@ type mqlAzureSubscriptionResource struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionResourceInternal
-	Id                plugin.TValue[string]
-	Name              plugin.TValue[string]
-	Kind              plugin.TValue[string]
-	Location          plugin.TValue[string]
-	Tags              plugin.TValue[map[string]any]
-	Type              plugin.TValue[string]
-	ManagedBy         plugin.TValue[string]
-	Sku               plugin.TValue[any]
-	Plan              plugin.TValue[any]
-	Identity          plugin.TValue[any]
-	ProvisioningState plugin.TValue[string]
-	CreatedTime       plugin.TValue[*time.Time]
-	ChangedTime       plugin.TValue[*time.Time]
-	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
+	DiagnosticSettings plugin.TValue[[]any]
+	Id                 plugin.TValue[string]
+	Name               plugin.TValue[string]
+	Kind               plugin.TValue[string]
+	Location           plugin.TValue[string]
+	Tags               plugin.TValue[map[string]any]
+	Type               plugin.TValue[string]
+	ManagedBy          plugin.TValue[string]
+	Sku                plugin.TValue[any]
+	Plan               plugin.TValue[any]
+	Identity           plugin.TValue[any]
+	ProvisioningState  plugin.TValue[string]
+	CreatedTime        plugin.TValue[*time.Time]
+	ChangedTime        plugin.TValue[*time.Time]
+	SystemMetadata     plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionResource creates a new instance of this resource
@@ -51495,6 +51503,22 @@ func (c *mqlAzureSubscriptionResource) MqlName() string {
 
 func (c *mqlAzureSubscriptionResource) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlAzureSubscriptionResource) GetDiagnosticSettings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.DiagnosticSettings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.resource", c.__id, "diagnosticSettings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.diagnosticSettings()
+	})
 }
 
 func (c *mqlAzureSubscriptionResource) GetId() *plugin.TValue[string] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -5635,6 +5635,7 @@ azure.subscription.recoveryServicesService.vaults 13.3.3
 azure.subscription.resource 9.0.0
 azure.subscription.resource.changedTime 9.0.0
 azure.subscription.resource.createdTime 9.0.0
+azure.subscription.resource.diagnosticSettings 13.36.1
 azure.subscription.resource.id 9.0.0
 azure.subscription.resource.identity 9.0.0
 azure.subscription.resource.kind 9.0.0

--- a/providers/azure/resources/resources.go
+++ b/providers/azure/resources/resources.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"go.mondoo.com/mql/v13/llx"
@@ -92,6 +93,23 @@ func (a *mqlAzureSubscription) resources() ([]any, error) {
 		}
 	}
 	return res, nil
+}
+
+// diagnosticSettings lists the Azure Monitor diagnostic settings on this
+// resource.
+//
+// getDiagnosticSettings takes any ARM resource URI; it was simply only ever
+// called with a subscription id, which is why the settings were unreachable
+// per resource. The resource's own id is that URI.
+func (a *mqlAzureSubscriptionResource) diagnosticSettings() ([]any, error) {
+	if a.Id.Error != nil {
+		return nil, a.Id.Error
+	}
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+	return getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
 }
 
 func (a *mqlAzureSubscriptionResource) id() (string, error) {

--- a/providers/azure/resources/resources.go
+++ b/providers/azure/resources/resources.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -109,7 +110,22 @@ func (a *mqlAzureSubscriptionResource) diagnosticSettings() ([]any, error) {
 	if !ok {
 		return nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
-	return getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
+	settings, err := getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
+	if err != nil {
+		// Many resource types cannot carry diagnostic settings at all, and ARM
+		// says so with a 400 rather than an empty list. Reported as null, not
+		// as an empty list: empty would claim the resource has none
+		// configured, which reads as a finding, and a type that cannot have
+		// them is not one. Left to propagate it would be worse still, since a
+		// field error renders as the value of the enclosing collection and one
+		// unsupported resource would cost the whole list.
+		if isAzureNotConfigured(err) {
+			a.DiagnosticSettings.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	return settings, nil
 }
 
 func (a *mqlAzureSubscriptionResource) id() (string, error) {

--- a/providers/azure/resources/shared.go
+++ b/providers/azure/resources/shared.go
@@ -59,7 +59,44 @@ func isAzureNotConfigured(err error) bool {
 	if respErr.StatusCode == http.StatusNotFound || respErr.StatusCode == http.StatusForbidden {
 		return true
 	}
-	return azureFeatureNotApplicable(respErr.StatusCode, respErr.ErrorCode, azureErrorSubcode(respErr))
+	return azureFeatureNotApplicable(respErr.StatusCode, azureErrorCode(respErr), azureErrorSubcode(respErr))
+}
+
+// azureErrorCode reads the error code, falling back to the body when azcore did
+// not populate it.
+//
+// azcore fills ResponseError.ErrorCode from the wrapped {"error":{"code":...}}
+// envelope. ARM also sends errors bare - {"code":"ResourceTypeNotSupported",
+// "message":...} - and for those ErrorCode is empty, so an allowlist keyed on
+// it can never match however many codes are added. azureErrorSubcode already
+// reads both shapes; this is the same treatment for the code.
+func azureErrorCode(respErr *azcore.ResponseError) string {
+	if respErr == nil {
+		return ""
+	}
+	if respErr.ErrorCode != "" {
+		return respErr.ErrorCode
+	}
+	if respErr.RawResponse == nil {
+		return ""
+	}
+	body, err := runtime.Payload(respErr.RawResponse)
+	if err != nil || len(body) == 0 {
+		return ""
+	}
+	var envelope struct {
+		Code  string `json:"code"`
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &envelope) != nil {
+		return ""
+	}
+	if envelope.Code != "" {
+		return envelope.Code
+	}
+	return envelope.Error.Code
 }
 
 // azureNotApplicableCodes maps an ARM error code to the subcode that has to
@@ -98,6 +135,12 @@ var azureNotApplicableCodes = map[string]string{
 	// supported for subscription '...' as it has no standard pricing bundle."
 	// ARM puts the whole sentence in the code field for this one.
 	"subscription with no standard pricing bundle": "",
+
+	// Diagnostic settings on a resource type that has none: "The resource type
+	// 'microsoft.network/networkwatchers' does not support diagnostic
+	// settings." Reading them across a subscription reaches many such types,
+	// and no amount of reconfiguration makes the type support them.
+	"resourcetypenotsupported": "",
 }
 
 // azureFeatureNotApplicable reports whether an ARM 400's code and subcode name

--- a/providers/azure/resources/shared_bare_envelope_test.go
+++ b/providers/azure/resources/shared_bare_envelope_test.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ARM sends an error either wrapped in an "error" envelope or bare, and azcore
+// only fills ResponseError.ErrorCode from the wrapped form. An allowlist keyed
+// on ErrorCode alone therefore never matches a bare error, however many codes
+// are added to it.
+//
+// This is not hypothetical: reading diagnostic settings across a subscription
+// answers 400 ResourceTypeNotSupported for every resource type that cannot have
+// them, bare, and that error must classify as not-applicable or one unsupported
+// resource costs the whole list.
+func TestAzureErrorCodeReadsBothEnvelopes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "bare envelope, which azcore leaves ErrorCode empty for",
+			body: `{"code":"ResourceTypeNotSupported","message":"The resource type 'microsoft.network/networkwatchers' does not support diagnostic settings."}`,
+			want: "ResourceTypeNotSupported",
+		},
+		{
+			name: "wrapped envelope",
+			body: `{"error":{"code":"LongTermRetentionPolicyNotSupported","message":"Not supported for master."}}`,
+			want: "LongTermRetentionPolicyNotSupported",
+		},
+		{
+			name: "neither shape carries a code",
+			body: `{"message":"something went wrong"}`,
+			want: "",
+		},
+		{
+			name: "body is not json",
+			body: `<html>502</html>`,
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, azureErrorCode(asResponseError(t, armError(http.StatusBadRequest, tc.body))))
+		})
+	}
+}
+
+// The classifier has to answer true for a withdrawn capability and false for a
+// fault, and the bare-envelope case is the one that regressed silently.
+func TestResourceTypeNotSupportedIsNotApplicable(t *testing.T) {
+	notSupported := armError(http.StatusBadRequest,
+		`{"code":"ResourceTypeNotSupported","message":"The resource type 'microsoft.network/networkwatchers' does not support diagnostic settings."}`)
+	require.True(t, isAzureNotConfigured(notSupported),
+		"a resource type that cannot have the feature is not a failure")
+
+	// A 400 the allowlist does not name is our bug or a transient state, and
+	// swallowing it would hide either.
+	badRequest := armError(http.StatusBadRequest,
+		`{"code":"InvalidApiVersionParameter","message":"The api-version is invalid."}`)
+	assert.False(t, isAzureNotConfigured(badRequest),
+		"an unlisted 400 must still propagate")
+}


### PR DESCRIPTION
Resolves #10145.

`diagnosticSettings` existed only at subscription scope, so *"is diagnostic
logging enabled for resource X"* was unwritable, exactly as the issue reports:

```
cannot find field or resource 'diagnosticSettings' in block for type
'azure.subscription.databricksService.workspace'
```

It is now on the generic resource, so it answers for anything the subscription
contains rather than needing a field added per service — which is what a control
phrased as *"for all services that support it"* actually needs:

```coffee
azure.subscription.resources
  .where(type == "Microsoft.Databricks/workspaces")
  .all(diagnosticSettings != empty)
```

## What changed

Almost nothing, which is the interesting part. `getDiagnosticSettings` already
accepted any ARM resource URI — its own comment said so:

```go
// id is an ARM resource URI (e.g. "/subscriptions/<id>" or a full resource ID).
// The client substitutes it into the {resourceUri} path segment.
```

It was simply only ever called with the subscription id. The accessor passes the
resource's own id instead, and reuses the same lister, so the settings come back
as the same `azure.subscription.monitorService.diagnosticsetting` resource a
subscription-scoped read produces.

**Cost:** one request per resource it is read from. The schema comment says so
and tells the reader to narrow the set first, since the natural mistake is to
select it across every resource in a subscription.

## Verified live

Created a diagnostic setting on a real resource, read it back through the
provider, and removed it:

```
azure.subscription.resources.where(type == "Microsoft.OperationalInsights/workspaces").first {
  name diagnosticSettings { name workspaceId logs metrics }
}

diagnosticSettings: [
  0: { name: "mqlverify-diag"
       workspaceId: ".../workspaces/<workspace>"
       logs:    [ 0: { category: "Audit"      enabled: true  ... }
                  1: { category: "SummaryLogs" enabled: false ... } ]
       metrics: [ 0: { category: "AllMetrics" enabled: true  ... } ] }
]
```

Note the second log category: Azure returns the full category list with each
one's `enabled` state, not only the enabled ones, so a check has to read
`enabled` rather than treat presence as proof. Before the setting existed the
field returned `[]`, matching the raw API, and it returns `[]` again now that it
has been deleted.

New `.lr.versions` entry is `13.36.1`, the patch after the provider's current
`13.36.0`. No permissions change: the read is the same
`Microsoft.Insights/diagnosticSettings/read` the subscription-scoped accessor
already required.
