### PR TITLE
⭐ ms365: expose the Entra device registration policy

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -2264,6 +2264,35 @@ microsoft.policies {
   crossTenantAccessPolicy() microsoft.crossTenantAccessPolicyDefault
   // Tenant-wide default app management policy
   defaultAppManagementPolicy() microsoft.defaultAppManagementPolicy
+  // Device registration and join settings for the tenant
+  deviceRegistrationPolicy() microsoft.deviceRegistrationPolicy
+}
+
+// Entra device registration policy
+//
+// The tenant's device settings: who may join or register a device, whether
+// multifactor authentication is required to do so, how many devices a user
+// may hold, and whether the local administrator password solution is on.
+// `multiFactorAuthConfiguration` is the setting behind "Require Multifactor
+// Authentication to register or join devices with Microsoft Entra".
+private microsoft.deviceRegistrationPolicy @defaults("multiFactorAuthConfiguration userDeviceQuota") {
+  // Policy identifier
+  id string
+  // Policy display name
+  displayName string
+  // Policy description
+  description string
+  // Whether multifactor authentication is required to register or join a device
+  //
+  // Either "required" or "notRequired". Null when the tenant reports no
+  // value, which is not the same as not requiring it.
+  multiFactorAuthConfiguration string
+  // Maximum number of devices a single user may register or join
+  //
+  // 0 means the tenant permits none. Null when unreported.
+  userDeviceQuota int
+  // Whether the Windows local administrator password solution is enabled
+  localAdminPasswordEnabled bool
 }
 
 // Tenant Default App Management Policy

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -100,6 +100,7 @@ const (
 	ResourceMicrosoftSecurityInformationProtection                                                       string = "microsoft.security.informationProtection"
 	ResourceMicrosoftSecurityInformationProtectionSensitivityLabel                                       string = "microsoft.security.informationProtection.sensitivityLabel"
 	ResourceMicrosoftPolicies                                                                            string = "microsoft.policies"
+	ResourceMicrosoftDeviceRegistrationPolicy                                                            string = "microsoft.deviceRegistrationPolicy"
 	ResourceMicrosoftDefaultAppManagementPolicy                                                          string = "microsoft.defaultAppManagementPolicy"
 	ResourceMicrosoftDefaultAppManagementPolicyAppManagementConfiguration                                string = "microsoft.defaultAppManagementPolicy.appManagementConfiguration"
 	ResourceMicrosoftExternalIdentitiesPolicy                                                            string = "microsoft.externalIdentitiesPolicy"
@@ -539,6 +540,10 @@ func init() {
 		"microsoft.policies": {
 			// to override args, implement: initMicrosoftPolicies(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMicrosoftPolicies,
+		},
+		"microsoft.deviceRegistrationPolicy": {
+			// to override args, implement: initMicrosoftDeviceRegistrationPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftDeviceRegistrationPolicy,
 		},
 		"microsoft.defaultAppManagementPolicy": {
 			Init:   initMicrosoftDefaultAppManagementPolicy,
@@ -2952,6 +2957,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.policies.defaultAppManagementPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftPolicies).GetDefaultAppManagementPolicy()).ToDataRes(types.Resource("microsoft.defaultAppManagementPolicy"))
+	},
+	"microsoft.policies.deviceRegistrationPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftPolicies).GetDeviceRegistrationPolicy()).ToDataRes(types.Resource("microsoft.deviceRegistrationPolicy"))
+	},
+	"microsoft.deviceRegistrationPolicy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDeviceRegistrationPolicy).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.deviceRegistrationPolicy.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDeviceRegistrationPolicy).GetDisplayName()).ToDataRes(types.String)
+	},
+	"microsoft.deviceRegistrationPolicy.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDeviceRegistrationPolicy).GetDescription()).ToDataRes(types.String)
+	},
+	"microsoft.deviceRegistrationPolicy.multiFactorAuthConfiguration": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDeviceRegistrationPolicy).GetMultiFactorAuthConfiguration()).ToDataRes(types.String)
+	},
+	"microsoft.deviceRegistrationPolicy.userDeviceQuota": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDeviceRegistrationPolicy).GetUserDeviceQuota()).ToDataRes(types.Int)
+	},
+	"microsoft.deviceRegistrationPolicy.localAdminPasswordEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDeviceRegistrationPolicy).GetLocalAdminPasswordEnabled()).ToDataRes(types.Bool)
 	},
 	"microsoft.defaultAppManagementPolicy.displayName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftDefaultAppManagementPolicy).GetDisplayName()).ToDataRes(types.String)
@@ -8608,6 +8634,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.policies.defaultAppManagementPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftPolicies).DefaultAppManagementPolicy, ok = plugin.RawToTValue[*mqlMicrosoftDefaultAppManagementPolicy](v.Value, v.Error)
+		return
+	},
+	"microsoft.policies.deviceRegistrationPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftPolicies).DeviceRegistrationPolicy, ok = plugin.RawToTValue[*mqlMicrosoftDeviceRegistrationPolicy](v.Value, v.Error)
+		return
+	},
+	"microsoft.deviceRegistrationPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDeviceRegistrationPolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.deviceRegistrationPolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDeviceRegistrationPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.deviceRegistrationPolicy.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDeviceRegistrationPolicy).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.deviceRegistrationPolicy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDeviceRegistrationPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.deviceRegistrationPolicy.multiFactorAuthConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDeviceRegistrationPolicy).MultiFactorAuthConfiguration, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.deviceRegistrationPolicy.userDeviceQuota": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDeviceRegistrationPolicy).UserDeviceQuota, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"microsoft.deviceRegistrationPolicy.localAdminPasswordEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDeviceRegistrationPolicy).LocalAdminPasswordEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"microsoft.defaultAppManagementPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20145,6 +20203,7 @@ type mqlMicrosoftPolicies struct {
 	ExternalIdentitiesPolicy                  plugin.TValue[*mqlMicrosoftExternalIdentitiesPolicy]
 	CrossTenantAccessPolicy                   plugin.TValue[*mqlMicrosoftCrossTenantAccessPolicyDefault]
 	DefaultAppManagementPolicy                plugin.TValue[*mqlMicrosoftDefaultAppManagementPolicy]
+	DeviceRegistrationPolicy                  plugin.TValue[*mqlMicrosoftDeviceRegistrationPolicy]
 }
 
 // createMicrosoftPolicies creates a new instance of this resource
@@ -20297,6 +20356,91 @@ func (c *mqlMicrosoftPolicies) GetDefaultAppManagementPolicy() *plugin.TValue[*m
 
 		return c.defaultAppManagementPolicy()
 	})
+}
+
+func (c *mqlMicrosoftPolicies) GetDeviceRegistrationPolicy() *plugin.TValue[*mqlMicrosoftDeviceRegistrationPolicy] {
+	return plugin.GetOrCompute[*mqlMicrosoftDeviceRegistrationPolicy](&c.DeviceRegistrationPolicy, func() (*mqlMicrosoftDeviceRegistrationPolicy, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft.policies", c.__id, "deviceRegistrationPolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMicrosoftDeviceRegistrationPolicy), nil
+			}
+		}
+
+		return c.deviceRegistrationPolicy()
+	})
+}
+
+// mqlMicrosoftDeviceRegistrationPolicy for the microsoft.deviceRegistrationPolicy resource
+type mqlMicrosoftDeviceRegistrationPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftDeviceRegistrationPolicyInternal it will be used here
+	Id                           plugin.TValue[string]
+	DisplayName                  plugin.TValue[string]
+	Description                  plugin.TValue[string]
+	MultiFactorAuthConfiguration plugin.TValue[string]
+	UserDeviceQuota              plugin.TValue[int64]
+	LocalAdminPasswordEnabled    plugin.TValue[bool]
+}
+
+// createMicrosoftDeviceRegistrationPolicy creates a new instance of this resource
+func createMicrosoftDeviceRegistrationPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftDeviceRegistrationPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.deviceRegistrationPolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) MqlName() string {
+	return "microsoft.deviceRegistrationPolicy"
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) GetMultiFactorAuthConfiguration() *plugin.TValue[string] {
+	return &c.MultiFactorAuthConfiguration
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) GetUserDeviceQuota() *plugin.TValue[int64] {
+	return &c.UserDeviceQuota
+}
+
+func (c *mqlMicrosoftDeviceRegistrationPolicy) GetLocalAdminPasswordEnabled() *plugin.TValue[bool] {
+	return &c.LocalAdminPasswordEnabled
 }
 
 // mqlMicrosoftDefaultAppManagementPolicy for the microsoft.defaultAppManagementPolicy resource

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -278,6 +278,13 @@ microsoft.device.profileType 11.2.1
 microsoft.device.registrationDateTime 11.1.21
 microsoft.device.systemLabels 11.1.21
 microsoft.device.trustType 11.1.21
+microsoft.deviceRegistrationPolicy 13.12.1
+microsoft.deviceRegistrationPolicy.description 13.12.1
+microsoft.deviceRegistrationPolicy.displayName 13.12.1
+microsoft.deviceRegistrationPolicy.id 13.12.1
+microsoft.deviceRegistrationPolicy.localAdminPasswordEnabled 13.12.1
+microsoft.deviceRegistrationPolicy.multiFactorAuthConfiguration 13.12.1
+microsoft.deviceRegistrationPolicy.userDeviceQuota 13.12.1
 microsoft.devicemanagement 9.0.0
 microsoft.devicemanagement.appProtectionPolicies 13.3.1
 microsoft.devicemanagement.appProtectionPolicy 13.3.1
@@ -826,6 +833,7 @@ microsoft.policies.authorizationPolicy 9.0.0
 microsoft.policies.consentPolicySettings 9.0.0
 microsoft.policies.crossTenantAccessPolicy 9.0.0
 microsoft.policies.defaultAppManagementPolicy 13.5.1
+microsoft.policies.deviceRegistrationPolicy 13.12.1
 microsoft.policies.externalIdentitiesPolicy 11.1.43
 microsoft.policies.identitySecurityDefaultsEnforcementPolicy 9.0.0
 microsoft.policies.permissionGrantPolicies 9.0.0

--- a/providers/ms365/resources/policies.go
+++ b/providers/ms365/resources/policies.go
@@ -386,6 +386,54 @@ func (a *mqlMicrosoftPolicies) externalIdentitiesPolicy() (*mqlMicrosoftExternal
 	return mqlPolicy.(*mqlMicrosoftExternalIdentitiesPolicy), nil
 }
 
+// deviceRegistrationPolicy reports the tenant's Entra device settings.
+//
+// Only the scalars are reported. Graph also models azureADJoin and
+// azureADRegistration here, but both came back empty against a live tenant and
+// the cause was not established, so they are left out rather than shipped as a
+// field that reads "this policy names nobody" whatever the truth is.
+func (a *mqlMicrosoftPolicies) deviceRegistrationPolicy() (*mqlMicrosoftDeviceRegistrationPolicy, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return nil, err
+	}
+	policy, err := graphClient.Policies().DeviceRegistrationPolicy().Get(context.Background(), nil)
+	if err != nil {
+		return nil, transformError(err)
+	}
+	if policy == nil {
+		return nil, fmt.Errorf("device registration policy not found")
+	}
+
+	var mfaConfiguration *string
+	if v := policy.GetMultiFactorAuthConfiguration(); v != nil {
+		s := v.String()
+		mfaConfiguration = &s
+	}
+
+	var localAdminPasswordEnabled *bool
+	if lap := policy.GetLocalAdminPassword(); lap != nil {
+		localAdminPasswordEnabled = lap.GetIsEnabled()
+	}
+
+	mqlPolicy, err := CreateResource(a.MqlRuntime, ResourceMicrosoftDeviceRegistrationPolicy,
+		map[string]*llx.RawData{
+			"__id":                         llx.StringDataPtr(policy.GetId()),
+			"id":                           llx.StringDataPtr(policy.GetId()),
+			"displayName":                  llx.StringDataPtr(policy.GetDisplayName()),
+			"description":                  llx.StringDataPtr(policy.GetDescription()),
+			"multiFactorAuthConfiguration": llx.StringDataPtr(mfaConfiguration),
+			"userDeviceQuota":              llx.IntDataPtr(policy.GetUserDeviceQuota()),
+			"localAdminPasswordEnabled":    llx.BoolDataPtr(localAdminPasswordEnabled),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return mqlPolicy.(*mqlMicrosoftDeviceRegistrationPolicy), nil
+}
+
 func initMicrosoftExternalIdentitiesPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	// Create the parent policies resource and call its method
 	policiesResource, err := CreateResource(runtime, ResourceMicrosoftPolicies, map[string]*llx.RawData{})


### PR DESCRIPTION
Resolves #10151.

`microsoft.policies` covered authorization, authentication methods, cross-tenant access and external identities, but not `deviceRegistrationPolicy` — so the Entra **Device settings** were unreachable, including whether multifactor authentication is required to register or join a device.

```coffee
microsoft.policies.deviceRegistrationPolicy.multiFactorAuthConfiguration == "required"
```

## Verified live

Against a real tenant:

```
microsoft.policies.deviceRegistrationPolicy:
  multiFactorAuthConfiguration="notRequired"  userDeviceQuota=50
```

That tenant does **not** require MFA to join, so the control would correctly fail on it — which is a more useful verification than a tenant that happens to pass.

## What is deliberately not here

Graph also models `azureADJoin` and `azureADRegistration` on this policy, and the issue asks for them. **I left them out.** Both rendered as `{}` against the live tenant, and I could not account for it: the Kiota getters do not survive `convert.JsonToDict` (the generated models keep values in a backing store, so there is nothing for the encoder to see), and building the dict by hand from the getters still produced an empty object.

Since an empty dict there reads as *"this policy names nobody"* whether or not that is true, shipping it would be the stub-data failure — a field that looks answered and is not. Worth a follow-up to establish whether the tenant genuinely reports no block, the app needs a broader Graph scope, or the beta endpoint carries them.

`localAdminPassword` is reported as the single `localAdminPasswordEnabled` bool it actually contains, rather than a wrapper object.

New `.lr.versions` entries are `13.12.1`, the patch after the provider's current `13.12.0`.