### PR TITLE
⚡ fetch the provider version manifest once per hour, not once per provider start

### DIFF
--- a/providers/registry.go
+++ b/providers/registry.go
@@ -10,10 +10,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/utils/httpx"
+	"golang.org/x/sync/singleflight"
 )
 
 var DefaultUpdatesURL = "https://releases.mondoo.com"
@@ -42,9 +45,51 @@ type ProviderRegistry interface {
 	DownloadProviderMetadata(ctx context.Context, name, version string) (confJSON []byte, schemaJSON []byte, err error)
 }
 
+const (
+	// How long a fetched latest.json is reused. Providers are started per
+	// asset -- the coordinator shuts an idle one down when an asset's runtime
+	// is removed, and the next asset starts it again -- so without this the
+	// same 3.6KB file was fetched once per provider start: 170 blocking
+	// requests and ~17s on a measured 169-asset scan, scaling linearly.
+	//
+	// An hour matches the existing UpdateProvidersConfig.RefreshInterval
+	// default. The file changes a few times a week.
+	defaultLatestVersionsTTL = time.Hour
+
+	// A failed fetch is remembered only briefly. Long enough that an offline
+	// scan does not repeat the retry storm for every provider start, short
+	// enough that a transient blip recovers within the same run.
+	failedLatestVersionsTTL = time.Minute
+)
+
 // MondooProviderRegistry implements ProviderRegistry for Mondoo's provider registry
 type MondooProviderRegistry struct {
 	BaseURL string
+
+	// CacheTTL is how long a fetched latest.json is reused. Zero means
+	// defaultLatestVersionsTTL.
+	CacheTTL time.Duration
+
+	mu        sync.Mutex
+	cached    *ProviderVersions
+	cachedErr error
+	cachedAt  time.Time
+
+	// group collapses concurrent fetches into one. Provider starts overlap, so
+	// without it every concurrent caller misses the cache and fetches its own
+	// copy.
+	group singleflight.Group
+
+	// now is swapped in tests so cache expiry can be exercised without
+	// sleeping. Nil means time.Now.
+	now func() time.Time
+}
+
+// WithCacheTTL sets how long a fetched latest.json is reused.
+func WithCacheTTL(ttl time.Duration) MondooProviderRegistryOption {
+	return func(r *MondooProviderRegistry) {
+		r.CacheTTL = ttl
+	}
 }
 
 // MondooProviderRegistryOption defines a function type for configuring MondooProviderRegistry
@@ -75,40 +120,127 @@ func LatestVersion(ctx context.Context, name string) (string, error) {
 	return registry.GetLatestVersion(ctx, name)
 }
 
-// GetLatestVersion fetches the latest version for the given provider name
-func (r *MondooProviderRegistry) GetLatestVersion(ctx context.Context, name string) (string, error) {
+func (r *MondooProviderRegistry) clock() time.Time {
+	if r.now != nil {
+		return r.now()
+	}
+	return time.Now()
+}
+
+func (r *MondooProviderRegistry) ttl() time.Duration {
+	if r.CacheTTL > 0 {
+		return r.CacheTTL
+	}
+	return defaultLatestVersionsTTL
+}
+
+// cachedVersions returns the memoized document and whether it is still valid.
+// A remembered failure is returned as such, so callers see the same error
+// rather than each re-running the request behind it.
+func (r *MondooProviderRegistry) cachedVersions() (*ProviderVersions, error, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.cachedAt.IsZero() {
+		return nil, nil, false
+	}
+	ttl := r.ttl()
+	if r.cachedErr != nil {
+		ttl = failedLatestVersionsTTL
+	}
+	if r.clock().Sub(r.cachedAt) >= ttl {
+		return nil, nil, false
+	}
+	return r.cached, r.cachedErr, true
+}
+
+func (r *MondooProviderRegistry) storeVersions(v *ProviderVersions, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cached, r.cachedErr, r.cachedAt = v, err, r.clock()
+}
+
+// FlushVersionCache drops the memoized latest.json. Exported for tests and for
+// callers that need to force a fresh read.
+func (r *MondooProviderRegistry) FlushVersionCache() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cached, r.cachedErr, r.cachedAt = nil, nil, time.Time{}
+}
+
+// latestVersions returns the whole latest.json document, fetching it at most
+// once per TTL.
+//
+// The document is memoized rather than the per-provider version: one file
+// lists every provider, so a scan touching aws, os and core answers all three
+// from a single request instead of three identical ones.
+func (r *MondooProviderRegistry) latestVersions(ctx context.Context) (*ProviderVersions, error) {
+	if v, err, ok := r.cachedVersions(); ok {
+		return v, err
+	}
+
+	res, err, _ := r.group.Do("latest.json", func() (any, error) {
+		// another caller may have completed while this one waited on the group
+		if v, cerr, ok := r.cachedVersions(); ok {
+			return v, cerr
+		}
+		v, ferr := r.fetchLatestVersions(ctx)
+		r.storeVersions(v, ferr)
+		return v, ferr
+	})
+	if err != nil {
+		return nil, err
+	}
+	versions, _ := res.(*ProviderVersions)
+	return versions, nil
+}
+
+func (r *MondooProviderRegistry) fetchLatestVersions(ctx context.Context) (*ProviderVersions, error) {
 	client, err := httpClientWithRetry()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	latestURL, err := url.JoinPath(r.BaseURL, "latest.json")
 	if err != nil {
-		return "", errors.Wrap(err, "failed to construct latest version URL")
+		return nil, errors.Wrap(err, "failed to construct latest version URL")
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestURL, nil)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to build latest version request")
+		return nil, errors.Wrap(err, "failed to build latest version request")
 	}
 
 	res, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer res.Body.Close()
 
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Debug().Err(err).Msg("reading latest.json failed")
-		return "", errors.New("failed to read response from upstream provider versions")
+		return nil, errors.New("failed to read response from upstream provider versions")
 	}
 
 	var upstreamVersions ProviderVersions
 	err = json.Unmarshal(data, &upstreamVersions)
 	if err != nil {
 		log.Debug().Err(err).Msg("parsing latest.json failed")
-		return "", errors.New("failed to parse response from upstream provider versions")
+		return nil, errors.New("failed to parse response from upstream provider versions")
+	}
+
+	return &upstreamVersions, nil
+}
+
+// GetLatestVersion fetches the latest version for the given provider name
+func (r *MondooProviderRegistry) GetLatestVersion(ctx context.Context, name string) (string, error) {
+	upstreamVersions, err := r.latestVersions(ctx)
+	if err != nil {
+		return "", err
+	}
+	if upstreamVersions == nil {
+		return "", errors.New("cannot determine latest version of provider '" + name + "'")
 	}
 
 	var latestVersion string

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -9,7 +9,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -201,4 +204,166 @@ func TestMondooProviderRegistry_DownloadProviderMetadata(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot find provider.json")
 	})
+}
+
+// latestJSONServer serves latest.json and counts how many times it is asked.
+func latestJSONServer(t *testing.T, hits *int64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/latest.json" {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt64(hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ProviderVersions{Providers: []ProviderVersion{
+			{Name: "aws", Version: "1.2.3"},
+			{Name: "os", Version: "2.0.0"},
+			{Name: "core", Version: "3.0.0"},
+		}})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The reason this cache exists. Providers are started per asset -- the
+// coordinator shuts an idle provider down when an asset's runtime is removed
+// and the next asset starts it again -- so this used to be one blocking
+// request per provider start: 170 of them on a measured 169-asset scan.
+func TestGetLatestVersionFetchesOncePerTTL(t *testing.T) {
+	var hits int64
+	reg := NewMondooProviderRegistry(WithBaseURL(latestJSONServer(t, &hits).URL))
+
+	for i := 0; i < 50; i++ {
+		v, err := reg.GetLatestVersion(context.Background(), "aws")
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3", v)
+	}
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits), "latest.json should be fetched once")
+}
+
+// One file lists every provider, so a scan touching several answers all of
+// them from a single request rather than one identical request each.
+func TestGetLatestVersionSharesOneFetchAcrossProviders(t *testing.T) {
+	var hits int64
+	reg := NewMondooProviderRegistry(WithBaseURL(latestJSONServer(t, &hits).URL))
+
+	for name, want := range map[string]string{"aws": "1.2.3", "os": "2.0.0", "core": "3.0.0"} {
+		v, err := reg.GetLatestVersion(context.Background(), name)
+		require.NoError(t, err)
+		assert.Equal(t, want, v)
+	}
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits))
+}
+
+// Provider starts overlap, so without single-flighting every concurrent
+// caller misses the cache and fetches its own copy.
+func TestGetLatestVersionCollapsesConcurrentFetches(t *testing.T) {
+	var hits int64
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		<-release // hold the first request open so the rest pile up behind it
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ProviderVersions{Providers: []ProviderVersion{{Name: "aws", Version: "1.2.3"}}})
+	}))
+	defer srv.Close()
+	reg := NewMondooProviderRegistry(WithBaseURL(srv.URL))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v, err := reg.GetLatestVersion(context.Background(), "aws")
+			assert.NoError(t, err)
+			assert.Equal(t, "1.2.3", v)
+		}()
+	}
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits), "concurrent callers should share one fetch")
+}
+
+// The cache is a TTL, not a permanent memo: a long-running process must pick
+// up a newly published provider without being restarted.
+func TestGetLatestVersionRefetchesAfterTTL(t *testing.T) {
+	var hits int64
+	reg := NewMondooProviderRegistry(WithBaseURL(latestJSONServer(t, &hits).URL))
+
+	now := time.Now()
+	reg.now = func() time.Time { return now }
+
+	_, err := reg.GetLatestVersion(context.Background(), "aws")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits))
+
+	now = now.Add(defaultLatestVersionsTTL - time.Second) // still inside the window
+	_, err = reg.GetLatestVersion(context.Background(), "aws")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits), "must not refetch before the TTL expires")
+
+	now = now.Add(2 * time.Second) // now past it
+	_, err = reg.GetLatestVersion(context.Background(), "aws")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&hits), "must refetch once the TTL expires")
+}
+
+// An offline scan must not repeat the request for every provider start, but a
+// transient failure has to recover within the same run -- so failures are
+// remembered on a much shorter TTL than successes.
+func TestGetLatestVersionCachesFailuresBriefly(t *testing.T) {
+	var hits int64
+	var broken atomic.Bool
+	broken.Store(true)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if broken.Load() {
+			// malformed rather than a 5xx: the retrying client would otherwise
+			// turn one logical failure into several requests
+			_, _ = w.Write([]byte("{not json"))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ProviderVersions{Providers: []ProviderVersion{{Name: "aws", Version: "1.2.3"}}})
+	}))
+	defer srv.Close()
+	reg := NewMondooProviderRegistry(WithBaseURL(srv.URL))
+
+	now := time.Now()
+	reg.now = func() time.Time { return now }
+
+	for i := 0; i < 5; i++ {
+		_, err := reg.GetLatestVersion(context.Background(), "aws")
+		require.Error(t, err)
+	}
+	assert.Equal(t, int64(1), atomic.LoadInt64(&hits), "a failure must not be retried by every caller")
+
+	// the failure TTL is short, so the run recovers on its own
+	broken.Store(false)
+	now = now.Add(failedLatestVersionsTTL + time.Second)
+	v, err := reg.GetLatestVersion(context.Background(), "aws")
+	require.NoError(t, err)
+	assert.Equal(t, "1.2.3", v)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&hits))
+
+	// a success must not then be re-fetched on the short failure TTL
+	now = now.Add(2 * failedLatestVersionsTTL)
+	_, err = reg.GetLatestVersion(context.Background(), "aws")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&hits), "a success is held for the full TTL")
+}
+
+func TestFlushVersionCacheForcesRefetch(t *testing.T) {
+	var hits int64
+	reg := NewMondooProviderRegistry(WithBaseURL(latestJSONServer(t, &hits).URL))
+
+	_, err := reg.GetLatestVersion(context.Background(), "aws")
+	require.NoError(t, err)
+	reg.FlushVersionCache()
+	_, err = reg.GetLatestVersion(context.Background(), "aws")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), atomic.LoadInt64(&hits))
 }


### PR DESCRIPTION
Closes #10000.

Every provider start performs a **blocking** `GET https://releases.mondoo.com/providers/latest.json`. Providers are started per asset — `coordinator.RemoveRuntime` shuts an idle provider down when an asset's runtime is removed, and the next asset starts it again — so a scan fetches the same 3.6KB file once per provider start. The measured 169-asset scan in the issue spent **170 requests and ~17s** of blocking wall-clock on a file that changes a few times a week, scaling linearly with asset count.

## Measured, end to end

Built `cnspec` against this tree via a `go.work`, with provider `conf.json` mtimes aged so the broken throttle could not mask the effect (the steady state the issue describes):

| | update checks reaching the registry | actual HTTP fetches |
|---|---|---|
| before | 10 | **10** |
| after | 10 | **1** |

Same assets, same 10 checks — the check still runs per provider start, it just answers from memory.

## What changed

Confined to `providers/registry.go`:

- **Memoizes the parsed `ProviderVersions` document**, not a per-provider version. One file lists every provider, so a scan touching `aws`, `os` and `core` answers all three from one request instead of three identical ones.
- **1-hour TTL** (`defaultLatestVersionsTTL`, matching the existing `UpdateProvidersConfig.RefreshInterval` default), overridable with `WithCacheTTL`. Not a permanent memo — a long-running process still picks up a newly published provider.
- **`singleflight`**, because provider starts overlap and without it every concurrent caller misses the cache and fetches its own copy. Already a direct dependency, so no `go.mod` change.
- **Failures cached for 60s only**, so an offline scan doesn't repeat the retry storm for every provider start but a transient failure still recovers inside the same run.
- `FlushVersionCache()` for tests and forced refreshes.

## Why not fix the mtime throttle instead

The issue proposes re-arming the throttle by calling `os.Chtimes` on the up-to-date path. That bug is real — `os.Chtimes` appears in exactly one place, after a successful install, so once `conf.json` is older than an hour every start re-fetches forever — but the memo makes it moot within a process, and it fixes something the mtime approach cannot: the mtime is *per provider*, so a scan touching three providers still paid three fetches of the same file.

**Deliberately left in place:** the memo lives for the process, so each `cnspec scan` invocation still pays exactly one fetch. Making the hourly window span invocations needs on-disk state, which is what the mtime was reaching for. That felt like a separate decision rather than something to fold in here.

## Tests

Six new, in `providers/registry_test.go`: fetch-once-per-TTL, one fetch shared across providers, concurrent collapse, refetch after expiry, failure cached briefly then recovering, and flush. Expiry is driven by an injectable clock rather than sleeps. Verified load-bearing — defeating the memo fails four of them — and `go test -race ./providers/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)