### PR TITLE
⭐ alicloud: expose RDS SQL Explorer, TDE key and running parameters

### DIFF
--- a/providers/alicloud/resources/alicloud.lr
+++ b/providers/alicloud/resources/alicloud.lr
@@ -2238,6 +2238,41 @@ alicloud.rds.instance {
   sslExpireTime() time
   // Whether Transparent Data Encryption (TDE) is enabled for the instance
   tdeEnabled() bool
+  // Key generation method used for Transparent Data Encryption
+  //
+  // One of Aliyun_Generate_Key (the key is generated and held by Alibaba
+  // Cloud), Customer_Provided_Key (the key is one you supply through Key
+  // Management Service), or Unknown. Empty when TDE is disabled or the engine
+  // does not report a mode.
+  tdeMode() string
+  // Key Management Service key that protects the instance under TDE
+  //
+  // Null when TDE is disabled, when the instance is encrypted with a key
+  // Alibaba Cloud generated and holds, or when the key can no longer be read.
+  // Traverse to the key to see its rotation state, deletion protection, and
+  // who is allowed to use it.
+  tdeEncryptionKey() alicloud.kms.key
+  // Whether SQL Explorer collects the statements executed against the instance
+  //
+  // SQL Explorer (also called SQL audit) records each statement the instance
+  // executes, which is what makes after-the-fact review of database activity
+  // possible. False when the feature was never switched on, when it has been
+  // switched off, or when the engine does not offer it.
+  sqlAuditEnabled() bool
+  // Days that SQL Explorer retains the statements it collects
+  //
+  // Zero when SQL Explorer is switched off or the instance reports no
+  // retention setting. Configurable values are 30, 180, and 365 days.
+  sqlAuditRetentionDays() int
+  // Running parameter values of the instance, keyed by parameter name
+  //
+  // The values in effect on the running instance, so a check reads
+  // parameters["log_connections"] without a nested traversal. Parameters
+  // changed but not yet applied are not reflected here. For a PostgreSQL
+  // instance this carries the log_connections, log_disconnections, and
+  // log_duration settings that decide what the database records about the
+  // sessions that connect to it.
+  parameters() map[string]string
   // IP address whitelist
   //
   // The IP addresses and CIDR blocks allowed to connect to the instance. A

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -2561,6 +2561,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"alicloud.rds.instance.tdeEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRdsInstance).GetTdeEnabled()).ToDataRes(types.Bool)
 	},
+	"alicloud.rds.instance.tdeMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRdsInstance).GetTdeMode()).ToDataRes(types.String)
+	},
+	"alicloud.rds.instance.tdeEncryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRdsInstance).GetTdeEncryptionKey()).ToDataRes(types.Resource("alicloud.kms.key"))
+	},
+	"alicloud.rds.instance.sqlAuditEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRdsInstance).GetSqlAuditEnabled()).ToDataRes(types.Bool)
+	},
+	"alicloud.rds.instance.sqlAuditRetentionDays": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRdsInstance).GetSqlAuditRetentionDays()).ToDataRes(types.Int)
+	},
+	"alicloud.rds.instance.parameters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAlicloudRdsInstance).GetParameters()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"alicloud.rds.instance.securityIPList": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAlicloudRdsInstance).GetSecurityIPList()).ToDataRes(types.Array(types.String))
 	},
@@ -8633,6 +8648,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"alicloud.rds.instance.tdeEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAlicloudRdsInstance).TdeEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"alicloud.rds.instance.tdeMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRdsInstance).TdeMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"alicloud.rds.instance.tdeEncryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRdsInstance).TdeEncryptionKey, ok = plugin.RawToTValue[*mqlAlicloudKmsKey](v.Value, v.Error)
+		return
+	},
+	"alicloud.rds.instance.sqlAuditEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRdsInstance).SqlAuditEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"alicloud.rds.instance.sqlAuditRetentionDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRdsInstance).SqlAuditRetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"alicloud.rds.instance.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAlicloudRdsInstance).Parameters, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"alicloud.rds.instance.securityIPList": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19476,6 +19511,11 @@ type mqlAlicloudRdsInstance struct {
 	SslEnabled              plugin.TValue[bool]
 	SslExpireTime           plugin.TValue[*time.Time]
 	TdeEnabled              plugin.TValue[bool]
+	TdeMode                 plugin.TValue[string]
+	TdeEncryptionKey        plugin.TValue[*mqlAlicloudKmsKey]
+	SqlAuditEnabled         plugin.TValue[bool]
+	SqlAuditRetentionDays   plugin.TValue[int64]
+	Parameters              plugin.TValue[map[string]any]
 	SecurityIPList          plugin.TValue[[]any]
 	SecurityGroups          plugin.TValue[[]any]
 	BlueGreenDeploymentName plugin.TValue[string]
@@ -19708,6 +19748,46 @@ func (c *mqlAlicloudRdsInstance) GetSslExpireTime() *plugin.TValue[*time.Time] {
 func (c *mqlAlicloudRdsInstance) GetTdeEnabled() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.TdeEnabled, func() (bool, error) {
 		return c.tdeEnabled()
+	})
+}
+
+func (c *mqlAlicloudRdsInstance) GetTdeMode() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.TdeMode, func() (string, error) {
+		return c.tdeMode()
+	})
+}
+
+func (c *mqlAlicloudRdsInstance) GetTdeEncryptionKey() *plugin.TValue[*mqlAlicloudKmsKey] {
+	return plugin.GetOrCompute[*mqlAlicloudKmsKey](&c.TdeEncryptionKey, func() (*mqlAlicloudKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("alicloud.rds.instance", c.__id, "tdeEncryptionKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAlicloudKmsKey), nil
+			}
+		}
+
+		return c.tdeEncryptionKey()
+	})
+}
+
+func (c *mqlAlicloudRdsInstance) GetSqlAuditEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SqlAuditEnabled, func() (bool, error) {
+		return c.sqlAuditEnabled()
+	})
+}
+
+func (c *mqlAlicloudRdsInstance) GetSqlAuditRetentionDays() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.SqlAuditRetentionDays, func() (int64, error) {
+		return c.sqlAuditRetentionDays()
+	})
+}
+
+func (c *mqlAlicloudRdsInstance) GetParameters() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Parameters, func() (map[string]any, error) {
+		return c.parameters()
 	})
 }
 

--- a/providers/alicloud/resources/alicloud.lr.versions
+++ b/providers/alicloud/resources/alicloud.lr.versions
@@ -1320,6 +1320,7 @@ alicloud.rds.instance.instanceNetworkType 13.0.0
 alicloud.rds.instance.lockMode 13.0.0
 alicloud.rds.instance.lockReason 13.0.0
 alicloud.rds.instance.masterInstance 13.0.0
+alicloud.rds.instance.parameters 13.5.1
 alicloud.rds.instance.payType 13.0.0
 alicloud.rds.instance.port 13.0.0
 alicloud.rds.instance.readOnlyStatus 13.4.1
@@ -1328,10 +1329,14 @@ alicloud.rds.instance.resourceGroup 13.3.2
 alicloud.rds.instance.resourceGroupId 13.0.0
 alicloud.rds.instance.securityGroups 13.2.5
 alicloud.rds.instance.securityIPList 13.0.0
+alicloud.rds.instance.sqlAuditEnabled 13.5.1
+alicloud.rds.instance.sqlAuditRetentionDays 13.5.1
 alicloud.rds.instance.sslEnabled 13.0.0
 alicloud.rds.instance.sslExpireTime 13.0.0
 alicloud.rds.instance.tags 13.0.0
 alicloud.rds.instance.tdeEnabled 13.0.0
+alicloud.rds.instance.tdeEncryptionKey 13.5.1
+alicloud.rds.instance.tdeMode 13.5.1
 alicloud.rds.instance.vectorSupportStatus 13.4.1
 alicloud.rds.instance.vpc 13.0.0
 alicloud.rds.instance.vswitch 13.0.0

--- a/providers/alicloud/resources/rds.go
+++ b/providers/alicloud/resources/rds.go
@@ -31,6 +31,55 @@ func rdsParseTime(s *string) *time.Time {
 	return &t
 }
 
+// rdsStatusEnabled reports whether an RDS on/off status string means on. The
+// RDS APIs are not consistent about the spelling: TDE reports Enabled, SQL
+// Explorer reports Enable, and both have been seen with surrounding space.
+// Anything else, including a nil or empty value, counts as off so a "must be
+// enabled" check fails rather than passing on a value nobody recognised.
+func rdsStatusEnabled(status *string) bool {
+	if status == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(*status)) {
+	case "enable", "enabled":
+		return true
+	default:
+		return false
+	}
+}
+
+// rdsRetentionDays converts the SQL Explorer retention window, which the API
+// returns as a string, to a day count. An absent or unparseable value is 0,
+// which fails a minimum-retention check rather than satisfying it.
+func rdsRetentionDays(configValue *string) int64 {
+	if configValue == nil {
+		return 0
+	}
+	days, err := strconv.Atoi(strings.TrimSpace(*configValue))
+	if err != nil || days < 0 {
+		return 0
+	}
+	return int64(days)
+}
+
+// rdsRunningParameters flattens the running parameter list into a name-keyed
+// map. It reads RunningParameters, the values in effect on the instance, and
+// not ConfigParameters, which also carries changes that have not been applied
+// yet and would report a setting as active before the instance restarts.
+func rdsRunningParameters(body *rdsclient.DescribeParametersResponseBody) map[string]any {
+	res := map[string]any{}
+	if body == nil || body.RunningParameters == nil {
+		return res
+	}
+	for _, param := range body.RunningParameters.DBInstanceParameter {
+		if param == nil || param.ParameterName == nil || *param.ParameterName == "" {
+			continue
+		}
+		res[*param.ParameterName] = tea.StringValue(param.ParameterValue)
+	}
+	return res
+}
+
 func (r *mqlAlicloudRds) id() (string, error) {
 	return "alicloud.rds", nil
 }
@@ -51,6 +100,10 @@ type mqlAlicloudRdsInstanceInternal struct {
 	sslLock sync.Mutex
 	sslDone bool
 	ssl     *rdsclient.DescribeDBInstanceSSLResponseBody
+
+	tdeLock sync.Mutex
+	tdeDone bool
+	tde     *rdsclient.DescribeDBInstanceTDEResponseBody
 }
 
 func (r *mqlAlicloudRds) instances() ([]any, error) {
@@ -409,19 +462,125 @@ func (r *mqlAlicloudRdsInstance) sslExpireTime() (*time.Time, error) {
 	return rdsParseTime(ssl.SSLExpireTime), nil
 }
 
+// fetchTDE lazily loads the per-instance DescribeDBInstanceTDE detail and
+// caches it, so the TDE status, the key generation mode and the customer key
+// share a single call. Returns nil when the call fails or returns no detail, so
+// callers fall back to their safe default: encryption reads as off rather than
+// on, which fails an encryption check instead of passing it vacuously.
+func (r *mqlAlicloudRdsInstance) fetchTDE() *rdsclient.DescribeDBInstanceTDEResponseBody {
+	r.tdeLock.Lock()
+	defer r.tdeLock.Unlock()
+	if r.tdeDone {
+		return r.tde
+	}
+	r.tdeDone = true
+
+	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RdsClient(r.region)
+	if err != nil {
+		return nil
+	}
+	resp, err := client.DescribeDBInstanceTDE(&rdsclient.DescribeDBInstanceTDERequest{
+		DBInstanceId: tea.String(r.instanceId),
+	})
+	if err != nil || resp == nil || resp.Body == nil {
+		return nil
+	}
+	r.tde = resp.Body
+	return r.tde
+}
+
 func (r *mqlAlicloudRdsInstance) tdeEnabled() (bool, error) {
+	tde := r.fetchTDE()
+	if tde == nil {
+		return false, nil
+	}
+	return rdsStatusEnabled(tde.TDEStatus), nil
+}
+
+func (r *mqlAlicloudRdsInstance) tdeMode() (string, error) {
+	tde := r.fetchTDE()
+	if tde == nil {
+		return "", nil
+	}
+	return tea.StringValue(tde.TDEMode), nil
+}
+
+// tdeEncryptionKey resolves the customer key protecting the instance. It is
+// null whenever the instance is not encrypted with a key of its own: TDE off,
+// or on with a key Alibaba Cloud generated and holds, in which case the API
+// reports no EncryptionKey at all.
+func (r *mqlAlicloudRdsInstance) tdeEncryptionKey() (*mqlAlicloudKmsKey, error) {
+	tde := r.fetchTDE()
+	if tde == nil || tea.StringValue(tde.EncryptionKey) == "" {
+		r.TdeEncryptionKey.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	key, err := resolveKmsKey(r.MqlRuntime, r.cacheRegion, tea.StringValue(tde.EncryptionKey))
+	if err != nil || key == nil {
+		r.TdeEncryptionKey.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return key, nil
+}
+
+// sqlAuditEnabled reports whether SQL Explorer is collecting statements. A
+// failed read returns false so an "auditing is on" check fails rather than
+// passing on an instance nobody could read.
+func (r *mqlAlicloudRdsInstance) sqlAuditEnabled() (bool, error) {
 	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
 	client, err := conn.RdsClient(r.region)
 	if err != nil {
 		return false, nil
 	}
-	resp, err := client.DescribeDBInstanceTDE(&rdsclient.DescribeDBInstanceTDERequest{
+	resp, err := client.DescribeSQLCollectorPolicy(&rdsclient.DescribeSQLCollectorPolicyRequest{
 		DBInstanceId: tea.String(r.instanceId),
 	})
-	if err != nil || resp == nil || resp.Body == nil || resp.Body.TDEStatus == nil {
+	if err != nil || resp == nil || resp.Body == nil {
 		return false, nil
 	}
-	return strings.EqualFold(strings.TrimSpace(*resp.Body.TDEStatus), "Enabled"), nil
+	return rdsStatusEnabled(resp.Body.SQLCollectorStatus), nil
+}
+
+// sqlAuditRetentionDays reads the retention window from
+// DescribeSQLCollectorRetention rather than the DescribeSQLCollectorPolicy
+// StoragePeriod field, which the API documents as reserved and leaves at 0.
+func (r *mqlAlicloudRdsInstance) sqlAuditRetentionDays() (int64, error) {
+	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RdsClient(r.region)
+	if err != nil {
+		return 0, nil
+	}
+	resp, err := client.DescribeSQLCollectorRetention(&rdsclient.DescribeSQLCollectorRetentionRequest{
+		DBInstanceId: tea.String(r.instanceId),
+	})
+	if err != nil || resp == nil || resp.Body == nil {
+		return 0, nil
+	}
+	return rdsRetentionDays(resp.Body.ConfigValue), nil
+}
+
+// parameters returns the parameter values in effect on the running instance,
+// keyed by parameter name. A fetch error is propagated rather than reported as
+// an empty map: an empty map reads as "the parameter is unset", which is a
+// legitimate answer, and would let a check on log_connections pass judgement on
+// an instance whose parameters were never read.
+func (r *mqlAlicloudRdsInstance) parameters() (map[string]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
+	client, err := conn.RdsClient(r.region)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.DescribeParameters(&rdsclient.DescribeParametersRequest{
+		DBInstanceId: tea.String(r.instanceId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return map[string]any{}, nil
+	}
+	return rdsRunningParameters(resp.Body), nil
 }
 
 func (r *mqlAlicloudRdsInstance) securityIPList() ([]any, error) {

--- a/providers/alicloud/resources/rds_test.go
+++ b/providers/alicloud/resources/rds_test.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	rdsclient "github.com/alibabacloud-go/rds-20140815/v16/client"
+	tea "github.com/alibabacloud-go/tea/tea"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRdsStatusEnabled covers the on/off classifier shared by the TDE and SQL
+// Explorer readers. The two APIs spell the same state differently (Enabled vs
+// Enable), and every unrecognised value has to read as off: a status that
+// silently became true would report encryption or auditing on an instance that
+// has neither.
+func TestRdsStatusEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status *string
+		want   bool
+	}{
+		{"nil is off", nil, false},
+		{"empty is off", tea.String(""), false},
+		{"TDE spelling", tea.String("Enabled"), true},
+		{"SQL Explorer spelling", tea.String("Enable"), true},
+		{"lowercase", tea.String("enabled"), true},
+		{"surrounding space", tea.String("  Enable  "), true},
+		{"disabled", tea.String("Disabled"), false},
+		{"disable", tea.String("Disable"), false},
+		{"unrecognised value is off", tea.String("Pending"), false},
+		{"substring must not match", tea.String("NotEnabled"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, rdsStatusEnabled(tc.status))
+		})
+	}
+}
+
+// TestRdsRetentionDays covers the string-to-days conversion for the SQL
+// Explorer retention window. Anything unreadable must land on 0, which fails a
+// minimum-retention assertion rather than satisfying it with a made-up number.
+func TestRdsRetentionDays(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value *string
+		want  int64
+	}{
+		{"nil is zero", nil, 0},
+		{"empty is zero", tea.String(""), 0},
+		{"garbage is zero", tea.String("forever"), 0},
+		{"negative is zero", tea.String("-1"), 0},
+		{"thirty days", tea.String("30"), 30},
+		{"surrounding space", tea.String(" 365 "), 365},
+		{"six months", tea.String("180"), 180},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, rdsRetentionDays(tc.value))
+		})
+	}
+}
+
+// TestRdsRunningParameters covers the parameter map build. It must read the
+// running parameters and not the configured ones: a parameter changed but not
+// yet applied is not in effect, and reporting it would say a PostgreSQL
+// instance is logging connections before the restart that makes it true.
+func TestRdsRunningParameters(t *testing.T) {
+	param := func(name, value string) *rdsclient.DescribeParametersResponseBodyRunningParametersDBInstanceParameter {
+		return &rdsclient.DescribeParametersResponseBodyRunningParametersDBInstanceParameter{
+			ParameterName:  tea.String(name),
+			ParameterValue: tea.String(value),
+		}
+	}
+
+	t.Run("nil body is an empty map, not nil", func(t *testing.T) {
+		assert.Equal(t, map[string]any{}, rdsRunningParameters(nil))
+	})
+
+	t.Run("no running parameters is an empty map", func(t *testing.T) {
+		assert.Equal(t, map[string]any{}, rdsRunningParameters(&rdsclient.DescribeParametersResponseBody{}))
+	})
+
+	t.Run("running parameters are keyed by name", func(t *testing.T) {
+		got := rdsRunningParameters(&rdsclient.DescribeParametersResponseBody{
+			RunningParameters: &rdsclient.DescribeParametersResponseBodyRunningParameters{
+				DBInstanceParameter: []*rdsclient.DescribeParametersResponseBodyRunningParametersDBInstanceParameter{
+					param("log_connections", "on"),
+					param("log_disconnections", "off"),
+					param("log_duration", "on"),
+				},
+			},
+		})
+		assert.Equal(t, map[string]any{
+			"log_connections":    "on",
+			"log_disconnections": "off",
+			"log_duration":       "on",
+		}, got)
+	})
+
+	t.Run("nil and unnamed entries are dropped", func(t *testing.T) {
+		got := rdsRunningParameters(&rdsclient.DescribeParametersResponseBody{
+			RunningParameters: &rdsclient.DescribeParametersResponseBodyRunningParameters{
+				DBInstanceParameter: []*rdsclient.DescribeParametersResponseBodyRunningParametersDBInstanceParameter{
+					nil,
+					{ParameterName: tea.String("")},
+					{ParameterName: nil, ParameterValue: tea.String("on")},
+					param("log_duration", "on"),
+				},
+			},
+		})
+		assert.Equal(t, map[string]any{"log_duration": "on"}, got)
+	})
+
+	t.Run("a parameter with no value reports empty, not missing", func(t *testing.T) {
+		got := rdsRunningParameters(&rdsclient.DescribeParametersResponseBody{
+			RunningParameters: &rdsclient.DescribeParametersResponseBodyRunningParameters{
+				DBInstanceParameter: []*rdsclient.DescribeParametersResponseBodyRunningParametersDBInstanceParameter{
+					{ParameterName: tea.String("log_statement")},
+				},
+			},
+		})
+		assert.Equal(t, map[string]any{"log_statement": ""}, got)
+	})
+
+	t.Run("configured-but-unapplied parameters are not reported", func(t *testing.T) {
+		got := rdsRunningParameters(&rdsclient.DescribeParametersResponseBody{
+			ConfigParameters: &rdsclient.DescribeParametersResponseBodyConfigParameters{
+				DBInstanceParameter: []*rdsclient.DescribeParametersResponseBodyConfigParametersDBInstanceParameter{
+					{ParameterName: tea.String("log_connections"), ParameterValue: tea.String("on")},
+				},
+			},
+		})
+		assert.Equal(t, map[string]any{}, got)
+	})
+}


### PR DESCRIPTION
Closes #10171

`alicloud.rds.instance` carries 41 fields but could not answer three questions about a database instance's audit and encryption posture:

- **SQL Explorer** (SQL audit) state and retention — no field at all.
- **Which key** protects the instance under TDE. `tdeEnabled` is a bare bool, so "TDE is on" was assertable but "TDE uses a key we own" was not.
- **Instance parameters** — no field, so no PostgreSQL `log_*` setting was readable.

## What this adds

Five fields on `alicloud.rds.instance`, all reading APIs the already-vendored `rds-20140815/v16` client carries. No new dependency.

| field | source | notes |
|---|---|---|
| `tdeMode() string` | `DescribeDBInstanceTDE` | `Aliyun_Generate_Key` / `Customer_Provided_Key` / `Unknown` |
| `tdeEncryptionKey() alicloud.kms.key` | `DescribeDBInstanceTDE` | null when TDE is off or the key is Alibaba-generated |
| `sqlAuditEnabled() bool` | `DescribeSQLCollectorPolicy` | |
| `sqlAuditRetentionDays() int` | `DescribeSQLCollectorRetention` | |
| `parameters() map[string]string` | `DescribeParameters` | running values, keyed by name |

```coffee
alicloud.rds.instances.where(engine == "PostgreSQL") {
  dbInstanceId
  sqlAuditEnabled
  sqlAuditRetentionDays
  parameters["log_connections"]
  parameters["log_disconnections"]
  parameters["log_duration"]
}

alicloud.rds.instances.where(tdeEnabled) {
  tdeMode
  tdeEncryptionKey { keyId keyState creator }
}
```

## Three decisions worth reviewing

**`tdeEncryptionKey` is a typed reference, not a `tdeKeyId` string.** `DescribeDBInstanceTDE` returns a KMS key id, and `alicloud.kms.key` is already modelled with an `initAlicloudKmsKey` that seven other resources reach through `resolveKmsKey`. Shipping the raw id would have been a duplicate of a modelled resource and a breaking change to undo later.

**`tdeMode` states customer-managed-key directly.** The alternative — inferring it from whether `EncryptionKey` came back non-empty — makes a policy derive something the API already reports as an enum.

**Retention comes from `DescribeSQLCollectorRetention`, not `DescribeSQLCollectorPolicy.StoragePeriod`.** The SDK documents `StoragePeriod` as "a reserved parameter" and it returns `0`; reading it would have reported every instance as having no retention.

`tdeEnabled` previously made its own `DescribeDBInstanceTDE` call. It now shares one memoized fetch with `tdeMode` and `tdeEncryptionKey`, so three fields cost one call instead of three.

## Error direction

Every new boolean and count fails **closed**: an unreadable instance reports `sqlAuditEnabled == false` and `sqlAuditRetentionDays == 0`, so a "must be enabled" check fails rather than passing vacuously.

`parameters` is the exception and deliberately **propagates** its error. An empty map is a legitimate answer there, so swallowing the error would let `parameters["log_connections"]` return null on an instance nobody could read — indistinguishable from a genuinely unset parameter. Same reasoning as the existing `securityIPList`.

## Verification

```
go build ./...                          ok
go test ./...                           ok  (23 new subtests)
./mqlr generate ... (twice)             no drift
make providers/build/alicloud           ok
gofmt -l / typos                        clean
```

New unit tests cover the parts where a bug would be silent rather than loud:

- `rdsStatusEnabled` — the two APIs spell the same state differently (`Enabled` vs `Enable`); every unrecognised value reads as off, and `NotEnabled` must not match as a substring.
- `rdsRetentionDays` — nil / empty / non-numeric / negative all land on `0`, not on an invented number.
- `rdsRunningParameters` — reads `RunningParameters`, **not** `ConfigParameters`. A parameter changed but not yet applied is not in effect, and reporting it would say an instance is logging connections before the restart that makes it true. There is an explicit test asserting a `ConfigParameters`-only payload yields an empty map.

**Not live-verified.** There are no Alibaba Cloud credentials on this machine, so no field here has been read from a real RDS instance. Live verification is owed for the whole alicloud provider and is batched into a single `provider-verification` run; this PR should be part of that batch before it is trusted. The fields most likely to need correcting against a live account are `sqlAuditRetentionDays` (the `ConfigValue` units are documented but unconfirmed) and `tdeMode` on engines other than MySQL.
