### PR TITLE
🐛 aws: stop the backup vault init passing a field the schema does not have

### DIFF
--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -229,16 +229,34 @@ func initAwsBackupVault(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, err
 	}
 
-	args["arn"] = llx.StringDataPtr(vault.BackupVaultArn)
-	args["name"] = llx.StringDataPtr(vault.BackupVaultName)
-	args["region"] = llx.StringData(region)
-	args["createdAt"] = llx.TimeDataPtr(vault.CreationDate)
-	args["encryptionKeyArn"] = llx.StringDataPtr(vault.EncryptionKeyArn)
-	args["locked"] = llx.BoolDataPtr(vault.Locked)
-	args["lockedAt"] = llx.TimeDataPtr(vault.LockDate)
-	args["maxRetentionDays"] = llx.IntDataPtr(vault.MaxRetentionDays)
-	args["minRetentionDays"] = llx.IntDataPtr(vault.MinRetentionDays)
-	return args, nil, nil
+	res, err := CreateResource(runtime, "aws.backup.vault", backupVaultArgs(vault, region))
+	if err != nil {
+		return nil, nil, err
+	}
+	// The encryption key is not an argument: the schema exposes it as the typed
+	// encryptionKey accessor, which reads the ARN back off the internal cache.
+	// Seeding it here is what makes that accessor resolve on this path as well
+	// as on the listing path.
+	res.(*mqlAwsBackupVault).cacheEncryptionKeyArn = convert.ToValue(vault.EncryptionKeyArn)
+	return nil, res, nil
+}
+
+// backupVaultArgs maps a described vault onto the fields aws.backup.vault
+// declares. Every key here has to be a settable field: SetAllData fails the
+// whole resource on an unknown one, so a field that the schema exposes through
+// a typed accessor - encryptionKey - must be seeded on the internal cache
+// instead of passed as an argument.
+func backupVaultArgs(vault *backup.DescribeBackupVaultOutput, region string) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"arn":              llx.StringDataPtr(vault.BackupVaultArn),
+		"name":             llx.StringDataPtr(vault.BackupVaultName),
+		"region":           llx.StringData(region),
+		"createdAt":        llx.TimeDataPtr(vault.CreationDate),
+		"locked":           llx.BoolDataPtr(vault.Locked),
+		"lockedAt":         llx.TimeDataPtr(vault.LockDate),
+		"maxRetentionDays": llx.IntDataPtr(vault.MaxRetentionDays),
+		"minRetentionDays": llx.IntDataPtr(vault.MinRetentionDays),
+	}
 }
 
 // newMqlBackupRecoveryPoint builds a recovery point resource. Both the vault

--- a/providers/aws/resources/aws_backups_test.go
+++ b/providers/aws/resources/aws_backups_test.go
@@ -6,6 +6,8 @@ package resources
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,4 +56,27 @@ func TestBackupVaultNameFromArn(t *testing.T) {
 			assert.Equal(t, test.wantRegion, region)
 		})
 	}
+}
+
+// TestBackupVaultArgsAreSettableFields pins every argument the vault init
+// passes to a field the generated schema can actually set. SetAllData rejects
+// an unknown key outright, so a stale argument left behind by a schema change
+// does not degrade a field - it fails the whole resource, on every lookup.
+func TestBackupVaultArgsAreSettableFields(t *testing.T) {
+	args := backupVaultArgs(&backup.DescribeBackupVaultOutput{
+		BackupVaultArn:   aws.String("arn:aws:backup:us-east-1:123456789012:backup-vault:Default"),
+		BackupVaultName:  aws.String("Default"),
+		EncryptionKeyArn: aws.String("arn:aws:kms:us-east-1:123456789012:key/abc"),
+		Locked:           aws.Bool(true),
+	}, "us-east-1")
+
+	require.NotEmpty(t, args)
+	for key := range args {
+		_, ok := setDataFields["aws.backup.vault."+key]
+		assert.True(t, ok, "aws.backup.vault has no settable field %q", key)
+	}
+
+	// The encryption key reaches the resource through the typed encryptionKey
+	// accessor, never as a raw ARN argument.
+	assert.NotContains(t, args, "encryptionKeyArn")
 }


### PR DESCRIPTION
`initAwsBackupVault` set `args["encryptionKeyArn"]`, but `aws.backup.vault` has no such field — the schema exposes the key as the typed `encryptionKey()` accessor. `SetAllData` rejects an unknown key outright, so this did not degrade a field, it failed the whole resource.

Reproduced against a live account with an empty vault:

```
$ mql run aws -c 'aws.backup.vault(arn: "arn:aws:backup:us-east-1:…:backup-vault:probe").name'
rpc error: code = Unknown desc = [aws] cannot set 'encryptionKeyArn' in resource 'aws.backup.vault', field not found
aws.backup.vault.name: no data available
```

Every path that resolves a single vault was affected:

- `aws.backup.vault(arn: …)` and `aws.backup.vault(name:, region:)`
- `aws.backup.scanJob.vault`
- `aws.backup.accessPoint.vault`
- `aws.backup.plan.rules.copyActions.destinationVault`

The listing path (`aws.backup.vaults`) builds its arguments separately and was unaffected, which is why this went unnoticed.

## What changed

The init now builds the resource itself and seeds `cacheEncryptionKeyArn` on it, the way the listing path already does. That fixes the failure and also closes a cross-path gap: `encryptionKey` previously resolved on the listing path and would have read null on every other one.

The argument map moves into `backupVaultArgs` so the regression test can assert against the map production actually builds.

## Where this came from

An audit sweep that checks every `CreateResource`/`NewResource` argument key and every `args["…"] =` assignment in an init against the generated `setDataFields` table. It found four instances of this shape across the provider, each one a typed-reference retrofit that renamed the raw `*Arn` field in the `.lr` and left the Go argument behind. Nothing in the build catches it — it compiles, lints and passes codegen. The other three are in separate PRs, and a provider-wide conformance test is worth adding once they have all landed.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `go test ./resources/ -run TestBackupVault` — new `TestBackupVaultArgsAreSettableFields` pins every argument to a settable field and fails on the pre-fix map
- [x] Live: `aws.backup.vault(arn: …)` now resolves instead of erroring
