### PR TITLE
🐛 aws: stop the recovery point constructor passing fields the schema does not have

### DIFF
--- a/providers/aws/resources/aws_backups.go
+++ b/providers/aws/resources/aws_backups.go
@@ -267,20 +267,36 @@ func newMqlBackupRecoveryPoint(runtime *plugin.Runtime, rp backuptypes.RecoveryP
 	if err != nil {
 		return nil, err
 	}
-	return CreateResource(runtime, "aws.backup.vaultRecoveryPoint",
-		map[string]*llx.RawData{
-			"arn":                  llx.StringDataPtr(rp.RecoveryPointArn),
-			"completionDate":       llx.TimeDataPtr(rp.CompletionDate),
-			"createdAt":            llx.TimeDataPtr(rp.CreationDate),
-			"createdBy":            llx.MapData(createdBy, types.String),
-			"encryptionKeyArn":     llx.StringDataPtr(rp.EncryptionKeyArn),
-			"iamRoleArn":           llx.StringDataPtr(rp.IamRoleArn),
-			"isEncrypted":          llx.BoolData(rp.IsEncrypted),
-			"resourceType":         llx.StringDataPtr(rp.ResourceType),
-			"status":               llx.StringData(string(rp.Status)),
-			"sourceResourceArn":    llx.StringDataPtr(rp.ResourceArn),
-			"sourceBackupVaultArn": llx.StringDataPtr(rp.SourceBackupVaultArn),
-		})
+	res, err := CreateResource(runtime, "aws.backup.vaultRecoveryPoint",
+		backupRecoveryPointArgs(rp, createdBy))
+	if err != nil {
+		return nil, err
+	}
+	// The KMS key and the IAM role are not arguments: the schema exposes both
+	// as typed accessors, which read the ARNs back off the internal cache.
+	mqlRP := res.(*mqlAwsBackupVaultRecoveryPoint)
+	mqlRP.cacheEncryptionKeyArn = convert.ToValue(rp.EncryptionKeyArn)
+	mqlRP.cacheIamRoleArn = convert.ToValue(rp.IamRoleArn)
+	return mqlRP, nil
+}
+
+// backupRecoveryPointArgs maps a recovery point onto the fields
+// aws.backup.vaultRecoveryPoint declares. Every key has to be a settable
+// field: SetAllData fails the whole resource on an unknown one, so the two
+// ARNs the schema exposes through typed accessors - encryptionKey and iamRole
+// - are seeded on the internal cache instead of passed here.
+func backupRecoveryPointArgs(rp backuptypes.RecoveryPointByBackupVault, createdBy map[string]any) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"arn":                  llx.StringDataPtr(rp.RecoveryPointArn),
+		"completionDate":       llx.TimeDataPtr(rp.CompletionDate),
+		"createdAt":            llx.TimeDataPtr(rp.CreationDate),
+		"createdBy":            llx.MapData(createdBy, types.String),
+		"isEncrypted":          llx.BoolData(rp.IsEncrypted),
+		"resourceType":         llx.StringDataPtr(rp.ResourceType),
+		"status":               llx.StringData(string(rp.Status)),
+		"sourceResourceArn":    llx.StringDataPtr(rp.ResourceArn),
+		"sourceBackupVaultArn": llx.StringDataPtr(rp.SourceBackupVaultArn),
+	}
 }
 
 func (a *mqlAwsBackupVault) recoveryPoints() ([]any, error) {

--- a/providers/aws/resources/aws_backups_test.go
+++ b/providers/aws/resources/aws_backups_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/backup"
+	backuptypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,4 +80,29 @@ func TestBackupVaultArgsAreSettableFields(t *testing.T) {
 	// The encryption key reaches the resource through the typed encryptionKey
 	// accessor, never as a raw ARN argument.
 	assert.NotContains(t, args, "encryptionKeyArn")
+}
+
+// TestBackupRecoveryPointArgsAreSettableFields pins every argument the
+// recovery point constructor passes to a field the generated schema can
+// actually set. SetAllData rejects an unknown key outright, so a stale
+// argument left behind by a schema change fails the whole resource - and this
+// constructor is on both the listing path and the per-recovery-point describe.
+func TestBackupRecoveryPointArgsAreSettableFields(t *testing.T) {
+	args := backupRecoveryPointArgs(backuptypes.RecoveryPointByBackupVault{
+		RecoveryPointArn: aws.String("arn:aws:backup:us-east-1:123456789012:recovery-point:abc"),
+		EncryptionKeyArn: aws.String("arn:aws:kms:us-east-1:123456789012:key/abc"),
+		IamRoleArn:       aws.String("arn:aws:iam::123456789012:role/service-role/AWSBackupDefaultServiceRole"),
+		IsEncrypted:      true,
+	}, map[string]any{})
+
+	require.NotEmpty(t, args)
+	for key := range args {
+		_, ok := setDataFields["aws.backup.vaultRecoveryPoint."+key]
+		assert.True(t, ok, "aws.backup.vaultRecoveryPoint has no settable field %q", key)
+	}
+
+	// Both ARNs reach the resource through typed accessors, never as raw
+	// arguments.
+	assert.NotContains(t, args, "encryptionKeyArn")
+	assert.NotContains(t, args, "iamRoleArn")
 }


### PR DESCRIPTION
`newMqlBackupRecoveryPoint` set `args["encryptionKeyArn"]` and `args["iamRoleArn"]`, but `aws.backup.vaultRecoveryPoint` has neither field — the schema exposes both as the typed `encryptionKey()` and `iamRole()` accessors, which read the ARNs back off the internal cache. `SetAllData` rejects an unknown key outright, so this did not degrade a field, it failed the whole resource:

```
[aws] cannot set 'encryptionKeyArn' in resource 'aws.backup.vaultRecoveryPoint', field not found
```

Both the vault listing and the per-recovery-point describe feed through this constructor, so `aws.backup.vaults { recoveryPoints }` failed on any account that has a recovery point, and so did every targeted lookup. Confirmed against the generated `setDataFields` table; the test account has no recovery points, so unlike the sibling vault fix this one is verified by code rather than by run — the mechanism is identical.

## What changed

The two ARNs are seeded on the internal cache after construction, which is what `encryptionKey()` and `iamRole()` already read. The argument map moves into `backupRecoveryPointArgs` so the regression test can assert against the map production actually builds.

## Where this came from

An audit sweep that checks every `CreateResource`/`NewResource` argument key and every `args["…"] =` assignment in an init against the generated `setDataFields` table. It found four instances of this shape across the provider, each one a typed-reference retrofit that renamed a raw `*Arn` field in the `.lr` and left the Go argument behind. Nothing in the build catches it — it compiles, lints and passes codegen. The other three are in separate PRs, and a provider-wide conformance test is worth adding once they have all landed.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `go test ./resources/ -run TestBackupRecoveryPoint` — new `TestBackupRecoveryPointArgsAreSettableFields` pins every argument to a settable field and fails on the pre-fix map
