### PR TITLE
🐛 aws: stop the firehose lister passing a field the schema does not have

### DIFF
--- a/providers/aws/resources/aws_kinesis.go
+++ b/providers/aws/resources/aws_kinesis.go
@@ -701,11 +701,6 @@ type mqlAwsKinesisFirehoseDeliveryStreamInternal struct {
 }
 
 func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region string, stream *firehose_types.DeliveryStreamDescription) (*mqlAwsKinesisFirehoseDeliveryStream, error) {
-	encryption, err := convert.JsonToDict(stream.DeliveryStreamEncryptionConfiguration)
-	if err != nil {
-		return nil, err
-	}
-
 	kinesisStreamArn := ""
 	if stream.Source != nil && stream.Source.KinesisStreamSourceDescription != nil &&
 		stream.Source.KinesisStreamSourceDescription.KinesisStreamARN != nil {
@@ -713,17 +708,7 @@ func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region stri
 	}
 
 	resource, err := CreateResource(runtime, "aws.kinesis.firehoseDeliveryStream",
-		map[string]*llx.RawData{
-			"__id":               llx.StringDataPtr(stream.DeliveryStreamARN),
-			"arn":                llx.StringDataPtr(stream.DeliveryStreamARN),
-			"name":               llx.StringDataPtr(stream.DeliveryStreamName),
-			"status":             llx.StringData(string(stream.DeliveryStreamStatus)),
-			"deliveryStreamType": llx.StringData(string(stream.DeliveryStreamType)),
-			"encryption":         llx.DictData(encryption),
-			"createdAt":          llx.TimeDataPtr(stream.CreateTimestamp),
-			"lastUpdatedAt":      llx.TimeDataPtr(stream.LastUpdateTimestamp),
-			"region":             llx.StringData(region),
-		})
+		firehoseDeliveryStreamArgs(stream, region))
 	if err != nil {
 		return nil, err
 	}
@@ -733,6 +718,25 @@ func newMqlAwsKinesisFirehoseDeliveryStream(runtime *plugin.Runtime, region stri
 	mqlStream.cacheEncryption = stream.DeliveryStreamEncryptionConfiguration
 	mqlStream.cacheKinesisStreamArn = kinesisStreamArn
 	return mqlStream, nil
+}
+
+// firehoseDeliveryStreamArgs maps a delivery stream onto the fields
+// aws.kinesis.firehoseDeliveryStream declares. Every key has to be a settable
+// field: SetAllData fails the whole resource on an unknown one, so the
+// encryption configuration, which the schema exposes through the typed
+// serverSideEncryption accessor, is seeded on the internal cache instead of
+// passed here.
+func firehoseDeliveryStreamArgs(stream *firehose_types.DeliveryStreamDescription, region string) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":               llx.StringDataPtr(stream.DeliveryStreamARN),
+		"arn":                llx.StringDataPtr(stream.DeliveryStreamARN),
+		"name":               llx.StringDataPtr(stream.DeliveryStreamName),
+		"status":             llx.StringData(string(stream.DeliveryStreamStatus)),
+		"deliveryStreamType": llx.StringData(string(stream.DeliveryStreamType)),
+		"createdAt":          llx.TimeDataPtr(stream.CreateTimestamp),
+		"lastUpdatedAt":      llx.TimeDataPtr(stream.LastUpdateTimestamp),
+		"region":             llx.StringData(region),
+	}
 }
 
 func (a *mqlAwsKinesisFirehoseDeliveryStream) serverSideEncryption() (*mqlAwsKinesisFirehoseDeliveryStreamEncryption, error) {

--- a/providers/aws/resources/aws_kinesis_test.go
+++ b/providers/aws/resources/aws_kinesis_test.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	firehose_types "github.com/aws/aws-sdk-go-v2/service/firehose/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFirehoseDeliveryStreamArgsAreSettableFields pins every argument the
+// delivery stream constructor passes to a field the generated schema can
+// actually set. SetAllData rejects an unknown key outright, so a stale
+// argument left behind by a schema change does not degrade a field - it fails
+// the whole lister, on any account that has a delivery stream.
+func TestFirehoseDeliveryStreamArgsAreSettableFields(t *testing.T) {
+	args := firehoseDeliveryStreamArgs(&firehose_types.DeliveryStreamDescription{
+		DeliveryStreamARN:  aws.String("arn:aws:firehose:us-east-1:123456789012:deliverystream/logs"),
+		DeliveryStreamName: aws.String("logs"),
+		DeliveryStreamEncryptionConfiguration: &firehose_types.DeliveryStreamEncryptionConfiguration{
+			Status: firehose_types.DeliveryStreamEncryptionStatusEnabled,
+		},
+	}, "us-east-1")
+
+	require.NotEmpty(t, args)
+	for key := range args {
+		if key == "__id" {
+			continue
+		}
+		_, ok := setDataFields["aws.kinesis.firehoseDeliveryStream."+key]
+		assert.True(t, ok, "aws.kinesis.firehoseDeliveryStream has no settable field %q", key)
+	}
+
+	// The encryption configuration reaches the resource through the typed
+	// serverSideEncryption accessor, never as a raw dict argument.
+	assert.NotContains(t, args, "encryption")
+}


### PR DESCRIPTION
`newMqlAwsKinesisFirehoseDeliveryStream` set `args["encryption"]`, but `aws.kinesis.firehoseDeliveryStream` has no such field — the schema exposes the encryption configuration as the typed `serverSideEncryption()` accessor, which reads it back off the internal cache. `SetAllData` rejects an unknown key outright, so this did not degrade a field, it failed the whole resource:

```
[aws] cannot set 'encryption' in resource 'aws.kinesis.firehoseDeliveryStream', field not found
```

Every account with a delivery stream got an error from `aws.kinesis.firehoseDeliveryStreams`, so an encryption-at-rest check over them could never run. Confirmed against the generated `setDataFields` table; the test account has no delivery streams, so this one is verified by code rather than by run — the mechanism is identical to the backup-vault fix, which reproduced live.

## What changed

`cacheEncryption` was already seeded three lines further down and `serverSideEncryption()` already reads it, so the argument — and the `convert.JsonToDict` call that fed it — were dead weight on top of being wrong. Both are gone. The argument map moves into `firehoseDeliveryStreamArgs` so the regression test can assert against the map production actually builds.

## Where this came from

An audit sweep that checks every `CreateResource`/`NewResource` argument key and every `args["…"] =` assignment in an init against the generated `setDataFields` table. It found four instances of this shape across the provider, each one a typed-reference retrofit that renamed a raw field in the `.lr` and left the Go argument behind. Nothing in the build catches it — it compiles, lints and passes codegen. The other three are in separate PRs, and a provider-wide conformance test is worth adding once they have all landed.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `go test ./resources/ -run TestFirehose` — new `TestFirehoseDeliveryStreamArgsAreSettableFields` pins every argument to a settable field and fails on the pre-fix map
