### PR TITLE
🐛 aws: stop the custom model init passing a field the schema does not have

### DIFF
--- a/providers/aws/resources/aws_bedrock.go
+++ b/providers/aws/resources/aws_bedrock.go
@@ -274,19 +274,17 @@ func initAwsBedrockCustomModel(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 
 	res, err := CreateResource(runtime, "aws.bedrock.customModel",
-		map[string]*llx.RawData{
-			"__id":              llx.StringDataPtr(resp.ModelArn),
-			"modelArn":          llx.StringDataPtr(resp.ModelArn),
-			"modelName":         llx.StringDataPtr(resp.ModelName),
-			"region":            llx.StringData(region),
-			"baseModelArn":      llx.StringDataPtr(resp.BaseModelArn),
-			"customizationType": llx.StringData(string(resp.CustomizationType)),
-		})
+		bedrockCustomModelArgs(resp.ModelArn, resp.ModelName, region, resp.CustomizationType))
 	if err != nil {
 		return nil, nil, err
 	}
 	mqlCM := res.(*mqlAwsBedrockCustomModel)
 	mqlCM.cacheRegion = region
+	// The base model is not an argument: the schema exposes it as the typed
+	// baseModel accessor, which reads the ARN back off the internal cache.
+	// Seeding it here is what makes that accessor resolve on this path as well
+	// as on the listing path.
+	mqlCM.cacheBaseModelArn = convert.ToValue(resp.BaseModelArn)
 	// Seed the detail this init already fetched so the computed fields do not
 	// repeat the GetCustomModel call. CreateResource may have returned an instance
 	// already cached (and already in use) from the custom-models lister, so take
@@ -299,6 +297,21 @@ func initAwsBedrockCustomModel(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 	mqlCM.lock.Unlock()
 	return nil, mqlCM, nil
+}
+
+// bedrockCustomModelArgs maps a custom model onto the fields
+// aws.bedrock.customModel declares. Every key has to be a settable field:
+// SetAllData fails the whole resource on an unknown one, so the base model,
+// which the schema exposes through the typed baseModel accessor, is seeded on
+// the internal cache instead of passed here.
+func bedrockCustomModelArgs(modelArn, modelName *string, region string, customizationType bedrocktypes.CustomizationType) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":              llx.StringDataPtr(modelArn),
+		"modelArn":          llx.StringDataPtr(modelArn),
+		"modelName":         llx.StringDataPtr(modelName),
+		"region":            llx.StringData(region),
+		"customizationType": llx.StringData(string(customizationType)),
+	}
 }
 
 func (a *mqlAwsBedrockCustomModel) id() (string, error) {

--- a/providers/aws/resources/aws_bedrock.go
+++ b/providers/aws/resources/aws_bedrock.go
@@ -211,19 +211,13 @@ func (a *mqlAwsBedrock) getCustomModels(conn *connection.AwsConnection) []*jobpo
 
 				for _, cm := range page.ModelSummaries {
 					mqlCM, err := CreateResource(a.MqlRuntime, "aws.bedrock.customModel",
-						map[string]*llx.RawData{
-							"__id":              llx.StringDataPtr(cm.ModelArn),
-							"modelArn":          llx.StringDataPtr(cm.ModelArn),
-							"modelName":         llx.StringDataPtr(cm.ModelName),
-							"region":            llx.StringData(region),
-							"customizationType": llx.StringData(string(cm.CustomizationType)),
-						})
+						bedrockCustomModelArgs(cm.ModelArn, cm.ModelName, region, cm.CustomizationType))
 					if err != nil {
 						return nil, err
 					}
-					mqlCM.(*mqlAwsBedrockCustomModel).cacheBaseModelArn = convert.ToValue(cm.BaseModelArn)
 					mqlCMRes := mqlCM.(*mqlAwsBedrockCustomModel)
 					mqlCMRes.cacheRegion = region
+					mqlCMRes.cacheBaseModelArn = convert.ToValue(cm.BaseModelArn)
 					res = append(res, mqlCM)
 				}
 			}

--- a/providers/aws/resources/aws_bedrock_test.go
+++ b/providers/aws/resources/aws_bedrock_test.go
@@ -6,8 +6,10 @@ package resources
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnumSliceToAny(t *testing.T) {
@@ -33,4 +35,32 @@ func TestEnumSliceToAny(t *testing.T) {
 		result := enumSliceToAny(s)
 		assert.Empty(t, result)
 	})
+}
+
+// TestBedrockCustomModelArgsAreSettableFields pins every argument the custom
+// model init passes to a field the generated schema can actually set.
+// SetAllData rejects an unknown key outright, so a stale argument left behind
+// by a schema change does not degrade a field - it fails the whole resource on
+// every typed reference, because this init runs on every NewResource for the
+// type.
+func TestBedrockCustomModelArgsAreSettableFields(t *testing.T) {
+	args := bedrockCustomModelArgs(
+		aws.String("arn:aws:bedrock:us-east-1:123456789012:custom-model/anthropic.claude/abc"),
+		aws.String("tuned-claude"),
+		"us-east-1",
+		bedrocktypes.CustomizationTypeFineTuning,
+	)
+
+	require.NotEmpty(t, args)
+	for key := range args {
+		if key == "__id" {
+			continue
+		}
+		_, ok := setDataFields["aws.bedrock.customModel."+key]
+		assert.True(t, ok, "aws.bedrock.customModel has no settable field %q", key)
+	}
+
+	// The base model reaches the resource through the typed baseModel
+	// accessor, never as a raw ARN argument.
+	assert.NotContains(t, args, "baseModelArn")
 }


### PR DESCRIPTION
`initAwsBedrockCustomModel` set `args["baseModelArn"]`, but `aws.bedrock.customModel` has no such field — the schema exposes the base model as the typed `baseModel()` accessor, which reads the ARN back off the internal cache. `SetAllData` rejects an unknown key outright, so this did not degrade a field, it failed the whole resource:

```
[aws] cannot set 'baseModelArn' in resource 'aws.bedrock.customModel', field not found
```

This init is the registered `Init` for the type, so it runs on every `NewResource` for it. Every typed reference to a custom model failed — most visibly `aws.bedrock.modelCustomizationJobs { customModel { … } }`, on any account with a completed fine-tuning job. Confirmed against the generated `setDataFields` table; the test account has no custom models, so this one is verified by code rather than by run — the mechanism is identical to the backup-vault fix, which reproduced live.

## What changed

`cacheBaseModelArn` is now seeded on the resource, the way the listing path already does. That fixes the failure and also closes a cross-path gap: the init never seeded it, so even with the bad key removed `baseModel` would have resolved on the listing path and read null here. The argument map moves into `bedrockCustomModelArgs` so the regression test can assert against the map production actually builds.

## Where this came from

An audit sweep that checks every `CreateResource`/`NewResource` argument key and every `args["…"] =` assignment in an init against the generated `setDataFields` table. It found four instances of this shape across the provider, each one a typed-reference retrofit that renamed a raw `*Arn` field in the `.lr` and left the Go argument behind. Nothing in the build catches it — it compiles, lints and passes codegen. The other three are in separate PRs, and a provider-wide conformance test is worth adding once they have all landed.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `go test ./resources/ -run TestBedrockCustomModel` — new `TestBedrockCustomModelArgsAreSettableFields` pins every argument to a settable field and fails on the pre-fix map
