### PR TITLE
🐛 aws: read the lambda lookup args as values, not as their display form

### DIFF
--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -327,8 +327,16 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 		if regionArg == nil {
 			return nil, nil, errors.New("region required to fetch lambda function")
 		}
+		// Read the values, not their display form: RawData.String() renders a
+		// string wrapped in quote characters, which would go straight into the
+		// composed ARN and match nothing.
+		name, _ := nameArg.Value.(string)
+		regionVal, _ := regionArg.Value.(string)
+		if name == "" || regionVal == "" {
+			return nil, nil, errors.New("name and region required to fetch lambda function")
+		}
 		conn := runtime.Connection.(*connection.AwsConnection)
-		arnVal = getLambdaArn(nameArg.String(), regionArg.String(), conn.AccountId())
+		arnVal = getLambdaArn(name, regionVal, conn.AccountId())
 		if arnVal == "" {
 			return nil, nil, errors.New("arn required to fetch lambda function")
 		}

--- a/providers/aws/resources/aws_lambda_test.go
+++ b/providers/aws/resources/aws_lambda_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 )
 
 func TestGetLambdaArn(t *testing.T) {
@@ -48,4 +49,22 @@ func TestLambdaFunctionRole(t *testing.T) {
 		assert.True(t, fn.Role.IsNull())
 		assert.True(t, fn.Role.IsSet())
 	})
+}
+
+// TestGetLambdaArnFromRawDataArgs pins the ARN a name-and-region lookup
+// composes from its init arguments. RawData.String() is the display form and
+// wraps a string in quote characters, so reading an argument that way puts the
+// quotes inside the ARN and the lookup can never match a real function.
+func TestGetLambdaArnFromRawDataArgs(t *testing.T) {
+	nameArg := llx.StringData("my-function")
+	regionArg := llx.StringData("us-east-1")
+
+	// The display form is what the bug used.
+	assert.Equal(t, `"my-function"`, nameArg.String())
+
+	name, _ := nameArg.Value.(string)
+	region, _ := regionArg.Value.(string)
+	assert.Equal(t,
+		"arn:aws:lambda:us-east-1:123456789012:function:my-function",
+		getLambdaArn(name, region, "123456789012"))
 }


### PR DESCRIPTION
`initAwsLambdaFunction` composed the function ARN from `nameArg.String()` and `regionArg.String()`. `RawData.String()` is the *display* form — for a string it returns the value wrapped in quote characters (`llx/rawdata.go:160`):

```go
case types.String:
    return "\"" + value.(string) + "\""
```

So `aws.lambda.function(name: "my-fn", region: "us-east-1")` built:

```
arn:aws:lambda:"us-east-1":<account>:function:"my-fn"
```

The targeted `GetFunction` went to a region that does not exist, and the list-scan fallback compared that string against real ARNs and never matched — so the lookup always ended in `lambda function does not exist`, on every account, for every function. `len(args) == 2` there, so the `len(args) > 2` fast path does not shield it either.

## What changed

Read the values with the comma-ok form, which is what the same function already does for the `arn` argument six lines further down, and reject an empty name or region explicitly rather than composing a malformed ARN.

This was the only `.String()` on an init argument anywhere in the provider — a grep for the pattern comes back with one hit.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `go test ./resources/ -run 'TestGetLambdaArn|TestLambdaFunctionRole'` — existing tests still pass; new `TestGetLambdaArnFromRawDataArgs` pins the composed ARN and asserts the display form is the quoted one, so the old code fails it
