### PR TITLE
🐛 aws: resolve the cognito userPool reference by the arn its init accepts

### DIFF
--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -80,7 +80,7 @@ func (a *mqlAwsCognito) getUserPools(conn *connection.AwsConnection) []*jobpool.
 				}
 
 				for _, pool := range resp.UserPools {
-					poolArn := "arn:aws:cognito-idp:" + region + ":" + conn.AccountId() + ":userpool/" + convert.ToValue(pool.Id)
+					poolArn := cognitoUserPoolArn(region, conn.AccountId(), convert.ToValue(pool.Id))
 
 					mqlPool, err := CreateResource(a.MqlRuntime, "aws.cognito.userPool",
 						map[string]*llx.RawData{
@@ -109,6 +109,13 @@ func (a *mqlAwsCognito) getUserPools(conn *connection.AwsConnection) []*jobpool.
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+// cognitoUserPoolArn builds a user pool's ARN, which is also its __id. The
+// listing path and the reference resolver share it so both agree on the cache
+// key.
+func cognitoUserPoolArn(region, accountID, userPoolId string) string {
+	return "arn:aws:cognito-idp:" + region + ":" + accountID + ":userpool/" + userPoolId
 }
 
 func initAwsCognitoUserPool(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -743,18 +750,19 @@ func (a *mqlAwsCognitoUserPoolClient) id() (string, error) {
 	return a.UserPoolId.Data + "/" + a.ClientId.Data, nil
 }
 
-// resolveCognitoUserPool returns the lazy user-pool reference for a
-// sub-resource keyed by region+userPoolId. The user pool list creates
-// each pool with `__id = ARN`, so the NewResource call must pass the
-// same ARN — without it the lookup misses the cache and there's no init
-// to backfill the rest of the user-pool fields.
+// resolveCognitoUserPool returns the user-pool reference for a sub-resource
+// keyed by region+userPoolId.
+//
+// It passes the ARN and nothing else. That is the one argument
+// initAwsCognitoUserPool accepts, and the ARN is also the pool's __id, so a
+// pool the listing path already built is served from the cache and one reached
+// on its own is fetched and fully populated by the init.
 func resolveCognitoUserPool(runtime *plugin.Runtime, region, userPoolId string) (*mqlAwsCognitoUserPool, error) {
 	conn := runtime.Connection.(*connection.AwsConnection)
-	poolArn := "arn:aws:cognito-idp:" + region + ":" + conn.AccountId() + ":userpool/" + userPoolId
+	poolArn := cognitoUserPoolArn(region, conn.AccountId(), userPoolId)
 	mqlPool, err := NewResource(runtime, "aws.cognito.userPool",
 		map[string]*llx.RawData{
-			"__id": llx.StringData(poolArn),
-			"id":   llx.StringData(userPoolId),
+			"arn": llx.StringData(poolArn),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/aws/resources/aws_cognito_test.go
+++ b/providers/aws/resources/aws_cognito_test.go
@@ -1,0 +1,19 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCognitoUserPoolArn pins the ARN shape the listing path and the reference
+// resolver share. It is also the pool's __id, so the two have to agree or a
+// sub-resource's userPool reference misses the cache and re-fetches.
+func TestCognitoUserPoolArn(t *testing.T) {
+	assert.Equal(t,
+		"arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_AbCdEf",
+		cognitoUserPoolArn("us-east-1", "123456789012", "us-east-1_AbCdEf"))
+}


### PR DESCRIPTION
`resolveCognitoUserPool` called `NewResource` with `{__id, id}`. That is two args, so it does not trip `initAwsCognitoUserPool`'s `len(args) > 2` fast path, and the init's next check is:

```go
if args["arn"] == nil {
    return nil, nil, errors.New("arn required to fetch cognito user pool")
}
```

So every sub-resource's `userPool` back-reference failed outright — all three the schema exposes:

- `aws.cognito.userPool.client.userPool`
- `aws.cognito.userPool.domain.userPool`
- `aws.cognito.userPool.identityProvider.userPool`

## What changed

Pass the ARN. It is the one argument the init accepts, and it is also the pool's `__id`, so a pool the listing path already built is served straight from the cache and one reached on its own is fetched and fully populated by the init.

The resolver's comment asserted there was "no init to backfill the rest of the user-pool fields" — there is one, and it does exactly that, including pre-seeding the `DescribeUserPool` cache so the computed fields don't cost a second call. Comment corrected.

The ARN now has a single builder (`cognitoUserPoolArn`) shared by the listing path and the resolver, so the two cannot disagree about the cache key.

## Where this came from

An audit pass over the provider. This is the same family as the four schema/Go mismatches in #10185–#10188: a reference that looks right, compiles, and fails on every call at runtime.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `go test ./resources/ -run TestCognito` — new `TestCognitoUserPoolArn` pins the shared ARN shape
- [ ] Live verification pending — the test account has no Cognito user pools
