### PR TITLE
🐛 aws: make the patch baseline detail fields reachable

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -26473,31 +26473,31 @@ private aws.ssm.patchBaseline @defaults("id name operatingSystem") {
   // auto-approved), `complianceLevel` (severity assigned to patches the rule approves),
   // `enableNonSecurity` (whether non-security updates are included), and `patchFilters`
   // (a list of `key`/`values` filters selecting the patches the rule applies to).
-  approvalRules []dict
+  approvalRules() []dict
   // List of explicitly approved patches
-  approvedPatches []string
+  approvedPatches() []string
   // Compliance level for approved patches: CRITICAL, HIGH, MEDIUM, LOW, INFORMATIONAL, UNSPECIFIED
-  approvedPatchesComplianceLevel string
+  approvedPatchesComplianceLevel() string
   // List of explicitly rejected patches
-  rejectedPatches []string
+  rejectedPatches() []string
   // Action for rejected patches: ALLOW_AS_DEPENDENCY or BLOCK
-  rejectedPatchesAction string
+  rejectedPatchesAction() string
   // Global filters for the patch baseline
   //
   // Filters applied to every patch before the approval rules run. Each entry has `key`
   // (the filter attribute, for example `PRODUCT`, `CLASSIFICATION`, or `SEVERITY`) and
   // `values` (the matching values).
-  globalFilters []dict
+  globalFilters() []dict
   // Patch sources
   //
   // Alternate patch repositories for non-default operating systems. Each entry has `name`
   // (the source name), `products` (the products it applies to), and `configuration` (the
   // repository configuration, for example a yum or apt source definition).
-  sources []dict
+  sources() []dict
   // Creation date
-  createdAt time
+  createdAt() time
   // Last modified date
-  modifiedAt time
+  modifiedAt() time
   // Whether approved patches include non-security updates (Linux baselines)
   approvedPatchesEnableNonSecurity() bool
   // Compliance status reported when security patches are available but not yet approved

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -185121,39 +185121,57 @@ func (c *mqlAwsSsmPatchBaseline) GetIsDefault() *plugin.TValue[bool] {
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetApprovalRules() *plugin.TValue[[]any] {
-	return &c.ApprovalRules
+	return plugin.GetOrCompute[[]any](&c.ApprovalRules, func() ([]any, error) {
+		return c.approvalRules()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetApprovedPatches() *plugin.TValue[[]any] {
-	return &c.ApprovedPatches
+	return plugin.GetOrCompute[[]any](&c.ApprovedPatches, func() ([]any, error) {
+		return c.approvedPatches()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetApprovedPatchesComplianceLevel() *plugin.TValue[string] {
-	return &c.ApprovedPatchesComplianceLevel
+	return plugin.GetOrCompute[string](&c.ApprovedPatchesComplianceLevel, func() (string, error) {
+		return c.approvedPatchesComplianceLevel()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetRejectedPatches() *plugin.TValue[[]any] {
-	return &c.RejectedPatches
+	return plugin.GetOrCompute[[]any](&c.RejectedPatches, func() ([]any, error) {
+		return c.rejectedPatches()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetRejectedPatchesAction() *plugin.TValue[string] {
-	return &c.RejectedPatchesAction
+	return plugin.GetOrCompute[string](&c.RejectedPatchesAction, func() (string, error) {
+		return c.rejectedPatchesAction()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetGlobalFilters() *plugin.TValue[[]any] {
-	return &c.GlobalFilters
+	return plugin.GetOrCompute[[]any](&c.GlobalFilters, func() ([]any, error) {
+		return c.globalFilters()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetSources() *plugin.TValue[[]any] {
-	return &c.Sources
+	return plugin.GetOrCompute[[]any](&c.Sources, func() ([]any, error) {
+		return c.sources()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetCreatedAt() *plugin.TValue[*time.Time] {
-	return &c.CreatedAt
+	return plugin.GetOrCompute[*time.Time](&c.CreatedAt, func() (*time.Time, error) {
+		return c.createdAt()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetModifiedAt() *plugin.TValue[*time.Time] {
-	return &c.ModifiedAt
+	return plugin.GetOrCompute[*time.Time](&c.ModifiedAt, func() (*time.Time, error) {
+		return c.modifiedAt()
+	})
 }
 
 func (c *mqlAwsSsmPatchBaseline) GetApprovedPatchesEnableNonSecurity() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws_ssm_documents.go
+++ b/providers/aws/resources/aws_ssm_documents.go
@@ -319,6 +319,40 @@ func (a *mqlAwsSsmPatchBaseline) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+// ssmPatchApprovalRules maps a baseline's approval rules into dicts.
+//
+// Every value has to be JSON-native: dict2primitive rejects a *int32 or a
+// *bool outright, so leaving the SDK pointers in place fails the whole field
+// at query time rather than degrading it.
+func ssmPatchApprovalRules(rules *types.PatchRuleGroup) []any {
+	approvalRules := []any{}
+	if rules == nil {
+		return approvalRules
+	}
+	for _, rule := range rules.PatchRules {
+		patchFilters := []any{}
+		if rule.PatchFilterGroup != nil {
+			for _, pf := range rule.PatchFilterGroup.PatchFilters {
+				vals := make([]any, 0, len(pf.Values))
+				for _, v := range pf.Values {
+					vals = append(vals, v)
+				}
+				patchFilters = append(patchFilters, map[string]any{
+					"key":    string(pf.Key),
+					"values": vals,
+				})
+			}
+		}
+		approvalRules = append(approvalRules, map[string]any{
+			"approveAfterDays":  int64(convert.ToValue(rule.ApproveAfterDays)),
+			"complianceLevel":   string(rule.ComplianceLevel),
+			"enableNonSecurity": convert.ToValue(rule.EnableNonSecurity),
+			"patchFilters":      patchFilters,
+		})
+	}
+	return approvalRules
+}
+
 func (a *mqlAwsSsmPatchBaseline) fetchDetails() error {
 	if a.fetched {
 		return a.fetchErr
@@ -343,31 +377,7 @@ func (a *mqlAwsSsmPatchBaseline) fetchDetails() error {
 		return err
 	}
 
-	// Approval rules
-	approvalRules := []any{}
-	if resp.ApprovalRules != nil {
-		for _, rule := range resp.ApprovalRules.PatchRules {
-			patchFilters := []any{}
-			if rule.PatchFilterGroup != nil {
-				for _, pf := range rule.PatchFilterGroup.PatchFilters {
-					vals := make([]any, 0, len(pf.Values))
-					for _, v := range pf.Values {
-						vals = append(vals, v)
-					}
-					patchFilters = append(patchFilters, map[string]any{
-						"key":    string(pf.Key),
-						"values": vals,
-					})
-				}
-			}
-			approvalRules = append(approvalRules, map[string]any{
-				"approveAfterDays":  rule.ApproveAfterDays,
-				"complianceLevel":   string(rule.ComplianceLevel),
-				"enableNonSecurity": rule.EnableNonSecurity,
-				"patchFilters":      patchFilters,
-			})
-		}
-	}
+	approvalRules := ssmPatchApprovalRules(resp.ApprovalRules)
 
 	// Global filters
 	globalFilters := []any{}

--- a/providers/aws/resources/aws_ssm_patchbaseline_test.go
+++ b/providers/aws/resources/aws_ssm_patchbaseline_test.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // AWS-managed patch baselines report their BaselineId as a full ARN owned by an
@@ -66,4 +69,68 @@ func TestSsmPatchBaselineArnIsNeverDoubled(t *testing.T) {
 		"the result must contain exactly one ARN")
 	assert.NotContains(t, got, "111122223333",
 		"an AWS-owned baseline must not be re-attributed to the caller's account")
+}
+
+// TestSsmPatchApprovalRulesAreDictSerializable pins the approval-rule dict to
+// JSON-native values. dict2primitive accepts only bool, int64, float64,
+// string, []any, map[string]any and nil, so leaving the SDK's *int32 and *bool
+// in place fails the whole field at query time rather than degrading it.
+func TestSsmPatchApprovalRulesAreDictSerializable(t *testing.T) {
+	rules := ssmPatchApprovalRules(&types.PatchRuleGroup{
+		PatchRules: []types.PatchRule{
+			{
+				ApproveAfterDays:  aws.Int32(7),
+				EnableNonSecurity: aws.Bool(true),
+				ComplianceLevel:   types.PatchComplianceLevelCritical,
+				PatchFilterGroup: &types.PatchFilterGroup{
+					PatchFilters: []types.PatchFilter{
+						{Key: types.PatchFilterKeyClassification, Values: []string{"Security"}},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, rules, 1)
+	rule, ok := rules[0].(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, int64(7), rule["approveAfterDays"])
+	assert.Equal(t, true, rule["enableNonSecurity"])
+	assert.Equal(t, "CRITICAL", rule["complianceLevel"])
+	assertDictSerializable(t, rule)
+}
+
+// TestSsmPatchApprovalRulesAbsentPointers covers a baseline whose rules omit
+// the optional members, and the nil rule group itself.
+func TestSsmPatchApprovalRulesAbsentPointers(t *testing.T) {
+	assert.Equal(t, []any{}, ssmPatchApprovalRules(nil))
+
+	rules := ssmPatchApprovalRules(&types.PatchRuleGroup{
+		PatchRules: []types.PatchRule{{}},
+	})
+	require.Len(t, rules, 1)
+	rule := rules[0].(map[string]any)
+	assert.Equal(t, int64(0), rule["approveAfterDays"])
+	assert.Equal(t, false, rule["enableNonSecurity"])
+	assertDictSerializable(t, rule)
+}
+
+// assertDictSerializable walks a dict value and fails on any type the llx dict
+// conversion does not accept.
+func assertDictSerializable(t *testing.T, v any) {
+	t.Helper()
+	switch val := v.(type) {
+	case nil, bool, int64, float64, string:
+	case []any:
+		for _, item := range val {
+			assertDictSerializable(t, item)
+		}
+	case map[string]any:
+		for _, item := range val {
+			assertDictSerializable(t, item)
+		}
+	default:
+		t.Fatalf("dict carries a value of type %T, which dict2primitive rejects", v)
+	}
 }


### PR DESCRIPTION
Nine fields on `aws.ssm.patchBaseline` were declared as **plain** schema fields but populated only by `fetchDetails()`, which nothing ever called.

A plain field's generated getter is `return &c.Field` with no `GetOrCompute`, so the hand-written `approvalRules()`, `sources()`, `createdAt()` and the rest were **dead code** — and the listing path never passes those keys either. Every one read `null` on every account, and the ~90 lines of `GetPatchBaseline` behind them never ran. The runtime says so directly:

```
$ mql run aws -c 'aws.ssm.patchBaselines.first { name approvedPatchesComplianceLevel createdAt sources }'
x provider returned no data and no error for a field; the field was never set
  on the resource (provider bug) field=createdAt …
aws.ssm.patchBaselines.first: {
  name: "AWS-AmazonLinux2022DefaultPatchBaseline"
  approvedPatchesComplianceLevel: null
  createdAt: null
  sources: null
}
```

Affected: `approvalRules`, `approvedPatches`, `approvedPatchesComplianceLevel`, `rejectedPatches`, `rejectedPatchesAction`, `globalFilters`, `sources`, `createdAt`, `modifiedAt`. Every account has AWS-managed baselines — 17 in `us-east-1` on the test account — so every account saw this, and patch-approval posture was entirely unqueryable.

## What changed

Declare the nine as computed in the `.lr` and regenerate. That is all the Go side was already written for.

Two things fall out of making the code reachable:

- **The approval-rule dicts carried the SDK's `*int32` and `*bool` straight through.** `dict2primitive` accepts only JSON-native values, so `approvalRules` would have failed at query time the moment it started resolving — the dead code was hiding a second bug. Both are converted now, and the mapping moved into `ssmPatchApprovalRules` so it can be tested.
- The unused-method lint on this file goes quiet (it was flagging all nine).

`.lr.versions` is unchanged: the field names are the same, only their kind changed.

## Live verification

Same query, after:

```
approvalRules: [
  0: {
    approveAfterDays: 7
    complianceLevel: "CRITICAL"
    enableNonSecurity: false
    patchFilters: [ { key: "CLASSIFICATION", values: ["Security"] },
                    { key: "SEVERITY", values: ["Critical","Important"] } ]
  }
  …
]
createdAt: 2018-06-21 02:27:05.252 -0700 PDT
sources: []
approvedPatchesComplianceLevel: "UNSPECIFIED"
```

## Test plan

- [x] `./mqlr generate providers/aws/resources/aws.lr --dist providers/aws/resources`
- [x] `go build ./...` in `providers/aws`
- [x] `go test ./resources/ -run TestSsmPatch` — two new tests: `TestSsmPatchApprovalRulesAreDictSerializable` walks the dict and fails on any type `dict2primitive` rejects, `TestSsmPatchApprovalRulesAbsentPointers` covers the nil rule group and absent optional members
- [x] Live against a real account (above)
