### PR TITLE
🐛 aws: make the workdocs users lister able to return data

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.53.1",
-  "generated_at": "2026-08-16T17:48:34+02:00",
+  "version": "13.53.3",
+  "generated_at": "2026-08-19T11:52:57-07:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -2631,6 +2631,12 @@
       "service": "ds",
       "action": "DescribeDirectories",
       "source_file": "aws_directoryservice.go"
+    },
+    {
+      "permission": "ds:DescribeDirectories",
+      "service": "ds",
+      "action": "DescribeDirectories",
+      "source_file": "aws_workdocs.go"
     },
     {
       "permission": "ds:ListTagsForResource",

--- a/providers/aws/resources/aws_workdocs.go
+++ b/providers/aws/resources/aws_workdocs.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
 	"github.com/aws/aws-sdk-go-v2/service/workdocs"
 	workdocstypes "github.com/aws/aws-sdk-go-v2/service/workdocs/types"
 	"github.com/rs/zerolog/log"
@@ -79,70 +80,96 @@ func (a *mqlAwsWorkdocs) getUsers(conn *connection.AwsConnection) []*jobpool.Job
 
 	for _, region := range regions {
 		f := func() (jobpool.JobResult, error) {
-			svc := conn.WorkDocs(region)
 			ctx := context.Background()
 			res := []any{}
 
-			params := &workdocs.DescribeUsersInput{
-				Fields:  aws.String("STORAGE_METADATA"),
-				Include: workdocstypes.UserFilterTypeAll,
+			// DescribeUsers is scoped to one WorkDocs organization, and under
+			// SigV4 the API requires it: without an organizationId (or explicit
+			// userIds) it answers ValidationException. A WorkDocs organization
+			// is a registered Directory Service directory, so the directory ids
+			// in this region are the organizations to enumerate.
+			orgIds, err := workdocsOrganizationIds(ctx, conn, region)
+			if err != nil {
+				return nil, err
 			}
-			paginator := workdocs.NewDescribeUsersPaginator(svc, params)
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
-				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS WorkDocs API")
-						return res, nil
-					}
-					if isBadRequestError(err) {
-						log.Warn().Str("region", region).Msg("AWS WorkDocs not enabled in region")
-						return res, nil
-					}
-					return nil, err
-				}
-				for _, user := range page.Users {
-					var storageAllocatedInBytes int64
-					var storageUtilizedInBytes int64
-					var storageType string
-					if user.Storage != nil {
-						if user.Storage.StorageUtilizedInBytes != nil {
-							storageUtilizedInBytes = *user.Storage.StorageUtilizedInBytes
-						}
-						if user.Storage.StorageRule != nil {
-							if user.Storage.StorageRule.StorageAllocatedInBytes != nil {
-								storageAllocatedInBytes = *user.Storage.StorageRule.StorageAllocatedInBytes
-							}
-							storageType = string(user.Storage.StorageRule.StorageType)
-						}
-					}
 
-					mqlUser, err := CreateResource(a.MqlRuntime, "aws.workdocs.user",
-						map[string]*llx.RawData{
-							"id":                      llx.StringDataPtr(user.Id),
-							"username":                llx.StringDataPtr(user.Username),
-							"emailAddress":            llx.StringDataPtr(user.EmailAddress),
-							"givenName":               llx.StringDataPtr(user.GivenName),
-							"surname":                 llx.StringDataPtr(user.Surname),
-							"status":                  llx.StringData(string(user.Status)),
-							"userType":                llx.StringData(string(user.Type)),
-							"createdTimestamp":        llx.TimeDataPtr(user.CreatedTimestamp),
-							"modifiedTimestamp":       llx.TimeDataPtr(user.ModifiedTimestamp),
-							"timeZoneId":              llx.StringDataPtr(user.TimeZoneId),
-							"locale":                  llx.StringData(string(user.Locale)),
-							"organizationId":          llx.StringDataPtr(user.OrganizationId),
-							"storageAllocatedInBytes": llx.IntData(storageAllocatedInBytes),
-							"storageUtilizedInBytes":  llx.IntData(storageUtilizedInBytes),
-							"storageType":             llx.StringData(storageType),
-							"recycleBinFolderId":      llx.StringDataPtr(user.RecycleBinFolderId),
-							"rootFolderId":            llx.StringDataPtr(user.RootFolderId),
-							"region":                  llx.StringData(region),
-						},
-					)
+			svc := conn.WorkDocs(region)
+			for _, orgId := range orgIds {
+				params := &workdocs.DescribeUsersInput{
+					OrganizationId: aws.String(orgId),
+					Fields:         aws.String("STORAGE_METADATA"),
+					Include:        workdocstypes.UserFilterTypeAll,
+				}
+				paginator := workdocs.NewDescribeUsersPaginator(svc, params)
+				for paginator.HasMorePages() {
+					page, err := paginator.NextPage(ctx)
 					if err != nil {
+						// The SDK declares WorkDocs regionalized with a
+						// {region} endpoint template but ships endpoints for
+						// only a handful of regions, so elsewhere the
+						// synthesized host does not resolve. That is not a
+						// failure to read the account, it means there is
+						// nothing here.
+						if IsServiceNotAvailableInRegionError(err) {
+							log.Debug().Str("region", region).Msg("AWS WorkDocs is not available in region")
+							return res, nil
+						}
+						if Is400AccessDeniedError(err) {
+							log.Warn().Str("region", region).Msg("error accessing region for AWS WorkDocs API")
+							return res, nil
+						}
+						// A directory that is not registered with WorkDocs is
+						// not an error, it simply hosts no WorkDocs users.
+						if isBadRequestError(err) || isResourceNotFoundError(err) {
+							log.Debug().Str("region", region).Str("organizationId", orgId).
+								Msg("directory is not a WorkDocs organization")
+							break
+						}
 						return nil, err
 					}
-					res = append(res, mqlUser)
+					for _, user := range page.Users {
+						var storageAllocatedInBytes int64
+						var storageUtilizedInBytes int64
+						var storageType string
+						if user.Storage != nil {
+							if user.Storage.StorageUtilizedInBytes != nil {
+								storageUtilizedInBytes = *user.Storage.StorageUtilizedInBytes
+							}
+							if user.Storage.StorageRule != nil {
+								if user.Storage.StorageRule.StorageAllocatedInBytes != nil {
+									storageAllocatedInBytes = *user.Storage.StorageRule.StorageAllocatedInBytes
+								}
+								storageType = string(user.Storage.StorageRule.StorageType)
+							}
+						}
+
+						mqlUser, err := CreateResource(a.MqlRuntime, "aws.workdocs.user",
+							map[string]*llx.RawData{
+								"id":                      llx.StringDataPtr(user.Id),
+								"username":                llx.StringDataPtr(user.Username),
+								"emailAddress":            llx.StringDataPtr(user.EmailAddress),
+								"givenName":               llx.StringDataPtr(user.GivenName),
+								"surname":                 llx.StringDataPtr(user.Surname),
+								"status":                  llx.StringData(string(user.Status)),
+								"userType":                llx.StringData(string(user.Type)),
+								"createdTimestamp":        llx.TimeDataPtr(user.CreatedTimestamp),
+								"modifiedTimestamp":       llx.TimeDataPtr(user.ModifiedTimestamp),
+								"timeZoneId":              llx.StringDataPtr(user.TimeZoneId),
+								"locale":                  llx.StringData(string(user.Locale)),
+								"organizationId":          llx.StringDataPtr(user.OrganizationId),
+								"storageAllocatedInBytes": llx.IntData(storageAllocatedInBytes),
+								"storageUtilizedInBytes":  llx.IntData(storageUtilizedInBytes),
+								"storageType":             llx.StringData(storageType),
+								"recycleBinFolderId":      llx.StringDataPtr(user.RecycleBinFolderId),
+								"rootFolderId":            llx.StringDataPtr(user.RootFolderId),
+								"region":                  llx.StringData(region),
+							},
+						)
+						if err != nil {
+							return nil, err
+						}
+						res = append(res, mqlUser)
+					}
 				}
 			}
 			return jobpool.JobResult(res), nil
@@ -150,6 +177,35 @@ func (a *mqlAwsWorkdocs) getUsers(conn *connection.AwsConnection) []*jobpool.Job
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
+}
+
+// workdocsOrganizationIds lists the WorkDocs organizations in a region.
+//
+// A WorkDocs organization is an AWS Directory Service directory that has been
+// registered with WorkDocs, and its organization id is the directory id. The
+// WorkDocs API itself offers no way to enumerate them, so the directories are
+// the candidate set; the ones that are not registered simply return no users.
+func workdocsOrganizationIds(ctx context.Context, conn *connection.AwsConnection, region string) ([]string, error) {
+	svc := conn.DirectoryService(region)
+	ids := []string{}
+
+	paginator := directoryservice.NewDescribeDirectoriesPaginator(svc, &directoryservice.DescribeDirectoriesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+				log.Debug().Str("region", region).Msg("cannot list directories to resolve WorkDocs organizations")
+				return nil, nil
+			}
+			return nil, err
+		}
+		for _, dir := range page.DirectoryDescriptions {
+			if id := convert.ToValue(dir.DirectoryId); id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids, nil
 }
 
 // rootFolder fetches the user's root folder via GetFolder. The folder id alone

--- a/providers/aws/resources/aws_workdocs.go
+++ b/providers/aws/resources/aws_workdocs.go
@@ -92,6 +92,9 @@ func (a *mqlAwsWorkdocs) getUsers(conn *connection.AwsConnection) []*jobpool.Job
 			if err != nil {
 				return nil, err
 			}
+			if len(orgIds) == 0 {
+				return res, nil
+			}
 
 			svc := conn.WorkDocs(region)
 			for _, orgId := range orgIds {
@@ -114,9 +117,15 @@ func (a *mqlAwsWorkdocs) getUsers(conn *connection.AwsConnection) []*jobpool.Job
 							log.Debug().Str("region", region).Msg("AWS WorkDocs is not available in region")
 							return res, nil
 						}
+						// A denial is a fact about one organization, not about
+						// the region: a policy can scope WorkDocs access to
+						// some directories and not others. Move on to the next
+						// organization rather than dropping the users already
+						// read from the ones that did answer.
 						if Is400AccessDeniedError(err) {
-							log.Warn().Str("region", region).Msg("error accessing region for AWS WorkDocs API")
-							return res, nil
+							log.Warn().Str("region", region).Str("organizationId", orgId).
+								Msg("error accessing WorkDocs organization")
+							break
 						}
 						// A directory that is not registered with WorkDocs is
 						// not an error, it simply hosts no WorkDocs users.


### PR DESCRIPTION
`aws.workdocs.users` errored on **every** account, for two independent reasons.

**1. The API call was malformed.** `DescribeUsers` was called with neither an `organizationId` nor `userIds`. Under SigV4 the API requires one of them, so in the handful of regions where WorkDocs exists:

```
operation error WorkDocs: DescribeUsers, https response error StatusCode: 400,
api error ValidationException: SigV4 request should contain either organizationId or userIds.
```

**2. There was no region guard at all.** The SDK declares WorkDocs regionalized with a `{region}` endpoint template but ships endpoints for only a few regions, so every other region failed below the API layer:

```
dial tcp: lookup workdocs.ap-south-1.amazonaws.com: no such host
```

Neither `Is400AccessDeniedError` nor `isBadRequestError` matches a transport failure, and the jobpool collector is all-or-nothing — so one unreachable region sank the whole query. `folders` and `documents` both derive from `users`, so the entire subtree was unreachable.

## What changed

A WorkDocs organization is a Directory Service directory registered with WorkDocs, and its organization id **is** the directory id. The WorkDocs API offers no way to enumerate them — the vendored SDK (`workdocs@v1.33.6`) has no `DescribeInstances` — so the directories in the region are the candidate set, and `DescribeUsers` runs once per organization. A directory that is not registered with WorkDocs simply hosts no WorkDocs users, which is a result rather than an error, so those are skipped quietly.

`IsServiceNotAvailableInRegionError` is added alongside, so a region with no WorkDocs endpoint contributes nothing instead of failing the account.

`aws.permissions.json` picks up `ds:DescribeDirectories` for the new call.

## Live verification

Before:

```
$ mql run aws -c 'aws.workdocs.users.length'
… ValidationException: SigV4 request should contain either organizationId or userIds.
… dial tcp: lookup workdocs.ap-south-1.amazonaws.com: no such host
aws.workdocs.users.length: no data available
```

After, same account:

```
$ mql run aws -c 'aws.workdocs.users.length'
aws.workdocs.users.length: 0
```

## Worth a decision

The test account has no Directory Service directories, so this proves the failure is gone but not that users come back on a populated org — that needs an account with a WorkDocs site. Flagging two things for the team:

- Whether `aws.workdocs.*` should be kept at all. It has been unable to return data since it shipped, which suggests nothing depends on it.
- If it stays, the folder and document paths deserve the same region guard; they inherit the fix through `users` today but call WorkDocs directly elsewhere.

## Test plan

- [x] `go build ./...` and `go vet ./resources/` in `providers/aws`
- [x] Live against a real account (above)
- [ ] Users returned from a populated WorkDocs organization — needs an account with a registered directory
