### PR TITLE
🐛 aws: pick the EBS root volume by RootDeviceName, not by guessing

### DIFF
--- a/providers/aws/connection/awsec2ebsconn/setup.go
+++ b/providers/aws/connection/awsec2ebsconn/setup.go
@@ -6,6 +6,7 @@ package awsec2ebsconn
 import (
 	"context"
 	"math/rand"
+	"slices"
 	"strings"
 	"time"
 
@@ -148,20 +149,62 @@ func (c *AwsEbsConnection) GetVolumeInfoForInstance(ctx context.Context, instanc
 	return awsec2ebstypes.VolumeInfo{}, errors.New("no volume id found for instance")
 }
 
+// conventionalRootDeviceNames are the device names AWS gives a root volume on
+// the standard AMIs. They are only consulted when the instance does not report
+// a RootDeviceName of its own, which should not happen for an EBS-backed
+// instance.
+var conventionalRootDeviceNames = []string{"/dev/xvda", "/dev/sda1"}
+
+// GetVolumeInfoForInstance returns the EBS volume backing an instance's root
+// device, or nil when it cannot be identified.
+//
+// The instance says which device is the root one, in RootDeviceName, so match
+// on that. The device name was previously guessed with a substring test for
+// "xvda" or "sda1", which was wrong in both directions: an AMI whose root
+// device is neither found nothing, and because "xvda" is a substring of
+// "xvda1" a *data* volume at /dev/xvda1 could be picked ahead of the real root
+// at /dev/xvda. That second case is the dangerous one - the scan reports the
+// wrong filesystem's operating system and packages, and nothing errors.
+//
+// Returning nil is better than guessing: the caller turns it into "no volume
+// id found for instance", which names the problem, where a wrong volume does
+// not.
 func GetVolumeInfoForInstance(instanceinfo *types.Instance) *string {
-	if len(instanceinfo.BlockDeviceMappings) == 1 {
-		return instanceinfo.BlockDeviceMappings[0].Ebs.VolumeId
+	if instanceinfo == nil {
+		return nil
 	}
-	if len(instanceinfo.BlockDeviceMappings) > 1 {
-		for bi := range instanceinfo.BlockDeviceMappings {
-			log.Info().Interface("device", *instanceinfo.BlockDeviceMappings[bi].DeviceName).Msg("found instance block devices")
-			// todo: revisit this. this works for the standard ec2 instance setup, but no guarantees outside of that..
-			if strings.Contains(*instanceinfo.BlockDeviceMappings[bi].DeviceName, "xvda") { // xvda is the root volume
-				return instanceinfo.BlockDeviceMappings[bi].Ebs.VolumeId
+
+	// An instance-store mapping carries no EBS volume, so it is not a
+	// candidate and dereferencing it would panic.
+	ebsMappings := make([]types.InstanceBlockDeviceMapping, 0, len(instanceinfo.BlockDeviceMappings))
+	for i := range instanceinfo.BlockDeviceMappings {
+		mapping := instanceinfo.BlockDeviceMappings[i]
+		if mapping.Ebs == nil || mapping.Ebs.VolumeId == nil {
+			continue
+		}
+		log.Debug().Str("device", aws.ToString(mapping.DeviceName)).Msg("found instance block device")
+		ebsMappings = append(ebsMappings, mapping)
+	}
+	if len(ebsMappings) == 0 {
+		return nil
+	}
+
+	if rootDeviceName := aws.ToString(instanceinfo.RootDeviceName); rootDeviceName != "" {
+		for i := range ebsMappings {
+			if aws.ToString(ebsMappings[i].DeviceName) == rootDeviceName {
+				return ebsMappings[i].Ebs.VolumeId
 			}
-			if strings.Contains(*instanceinfo.BlockDeviceMappings[bi].DeviceName, "sda1") {
-				return instanceinfo.BlockDeviceMappings[bi].Ebs.VolumeId
-			}
+		}
+	}
+
+	// No RootDeviceName to match on. A single EBS volume is unambiguous.
+	if len(ebsMappings) == 1 {
+		return ebsMappings[0].Ebs.VolumeId
+	}
+
+	for i := range ebsMappings {
+		if slices.Contains(conventionalRootDeviceNames, aws.ToString(ebsMappings[i].DeviceName)) {
+			return ebsMappings[i].Ebs.VolumeId
 		}
 	}
 	return nil

--- a/providers/aws/connection/awsec2ebsconn/setup.go
+++ b/providers/aws/connection/awsec2ebsconn/setup.go
@@ -197,7 +197,9 @@ func GetVolumeInfoForInstance(instanceinfo *types.Instance) *string {
 		}
 	}
 
-	// No RootDeviceName to match on. A single EBS volume is unambiguous.
+	// Either the instance reported no RootDeviceName, or it named a device
+	// that carries no EBS volume. A single EBS volume is unambiguous in
+	// both cases.
 	if len(ebsMappings) == 1 {
 		return ebsMappings[0].Ebs.VolumeId
 	}

--- a/providers/aws/connection/awsec2ebsconn/setup_unit_test.go
+++ b/providers/aws/connection/awsec2ebsconn/setup_unit_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,4 +19,129 @@ func TestNewVolumeAttachmentLoc(t *testing.T) {
 	loc1 := newVolumeAttachmentLoc()
 	require.Equal(t, len(loc1), 8)
 	require.Equal(t, strings.HasPrefix(loc1, "/dev/sd"), true)
+}
+
+func ebsMapping(device, volumeID string) types.InstanceBlockDeviceMapping {
+	return types.InstanceBlockDeviceMapping{
+		DeviceName: aws.String(device),
+		Ebs:        &types.EbsInstanceBlockDevice{VolumeId: aws.String(volumeID)},
+	}
+}
+
+func TestGetVolumeInfoForInstance(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *types.Instance
+		want     string // "" means no volume identified
+	}{
+		{
+			name: "root device is matched exactly, not by substring",
+			// The regression: /dev/xvda1 is a data volume, and "xvda" is a
+			// substring of it, so the old code returned vol-data for an
+			// instance whose root is /dev/xvda. That scans the wrong
+			// filesystem and reports the wrong OS with no error.
+			instance: &types.Instance{
+				RootDeviceName: aws.String("/dev/xvda"),
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					ebsMapping("/dev/xvda1", "vol-data"),
+					ebsMapping("/dev/xvda", "vol-root"),
+				},
+			},
+			want: "vol-root",
+		},
+		{
+			name: "root device outside the conventional names is found",
+			instance: &types.Instance{
+				RootDeviceName: aws.String("/dev/xvdb"),
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					ebsMapping("/dev/xvda", "vol-data"),
+					ebsMapping("/dev/xvdb", "vol-root"),
+				},
+			},
+			want: "vol-root",
+		},
+		{
+			name: "sda1 root",
+			instance: &types.Instance{
+				RootDeviceName: aws.String("/dev/sda1"),
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					ebsMapping("/dev/sda1", "vol-root"),
+					ebsMapping("/dev/sdf", "vol-data"),
+				},
+			},
+			want: "vol-root",
+		},
+		{
+			name: "single volume, no root device name",
+			instance: &types.Instance{
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					ebsMapping("/dev/xvdz", "vol-only"),
+				},
+			},
+			want: "vol-only",
+		},
+		{
+			name: "no root device name falls back to a conventional name",
+			instance: &types.Instance{
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					ebsMapping("/dev/sdf", "vol-data"),
+					ebsMapping("/dev/xvda", "vol-root"),
+				},
+			},
+			want: "vol-root",
+		},
+		{
+			name: "no root device name and nothing conventional is not a guess",
+			instance: &types.Instance{
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					ebsMapping("/dev/sdf", "vol-a"),
+					ebsMapping("/dev/sdg", "vol-b"),
+				},
+			},
+			want: "",
+		},
+		{
+			name: "instance-store mapping carries no volume and is skipped",
+			instance: &types.Instance{
+				RootDeviceName: aws.String("/dev/xvda"),
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					{DeviceName: aws.String("/dev/xvdb")}, // Ebs is nil
+					ebsMapping("/dev/xvda", "vol-root"),
+				},
+			},
+			want: "vol-root",
+		},
+		{
+			name: "only instance-store mappings",
+			instance: &types.Instance{
+				RootDeviceName: aws.String("/dev/xvda"),
+				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+					{DeviceName: aws.String("/dev/xvda")},
+				},
+			},
+			want: "",
+		},
+		{
+			name:     "no mappings",
+			instance: &types.Instance{RootDeviceName: aws.String("/dev/xvda")},
+			want:     "",
+		},
+		{
+			name:     "nil instance",
+			instance: nil,
+			want:     "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := GetVolumeInfoForInstance(test.instance)
+			if test.want == "" {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, test.want, *got)
+		})
+	}
 }


### PR DESCRIPTION
`GetVolumeInfoForInstance` guessed which block device was the root one with a substring test, under a `todo` admitting it made no guarantees outside the standard setup:

```go
// todo: revisit this. this works for the standard ec2 instance setup, but no guarantees outside of that..
if strings.Contains(*instanceinfo.BlockDeviceMappings[bi].DeviceName, "xvda") { // xvda is the root volume
```

The instance already reports the answer: `types.Instance.RootDeviceName`.

The guess was wrong in **both** directions:

- An AMI whose root device is neither `xvda` nor `sda1` found nothing, and the scan failed with `no volume id found for instance`.
- `"xvda"` is a substring of `"xvda1"`. An instance with a data volume at `/dev/xvda1` and its root at `/dev/xvda` got **the data volume**, because that mapping came first. The scan then reports that filesystem's operating system and packages as the instance's — and nothing errors. That is the dangerous one: a wrong answer that looks like a right one.

## What changed

Match `RootDeviceName` exactly. Where the instance reports no root device, a single EBS mapping is unambiguous, and only then are the conventional names consulted — by exact match, not substring. When none of that identifies a volume, return nil and let the caller say so, which names the problem where a wrong volume does not.

Mappings with no EBS volume are skipped on the way. An instance-store mapping has a nil `Ebs`, and both the single-mapping and multi-mapping paths dereferenced it.

## The test fails three ways against the old code

`GetVolumeInfoForInstance` is a pure function over an SDK type, so it takes a plain table test. Stashing the fix and re-running it:

```
--- FAIL: TestGetVolumeInfoForInstance/root_device_is_matched_exactly,_not_by_substring
            expected: "vol-root"
            actual  : "vol-data"
--- FAIL: TestGetVolumeInfoForInstance/root_device_outside_the_conventional_names_is_found
            expected: "vol-root"
            actual  : "vol-data"
--- FAIL: TestGetVolumeInfoForInstance/only_instance-store_mappings
panic: runtime error: invalid memory address or nil pointer dereference
```

Ten cases in total, covering both conventional roots, a non-conventional root, the single-volume and no-root-device fallbacks, the deliberate no-guess case, instance-store mappings, and nil input.

## Where this came from

The AWS provider audit. It is one of several findings in `awsec2ebsconn/`; the rest of that file's problems are still open and worth taking together, in rough order of cost:

- **`DeleteSnapshot` appears nowhere in `providers/`** — every EBS scan that creates a snapshot leaks it permanently.
- The snapshot-completion wait loop declares a `timeout` counter, compares it, and never increments it, so a snapshot in `error` state polls forever.
- `Close()` deletes any *target* volume carrying the `createdBy=Mondoo` tag, including one the customer owns or one leaked by an earlier scan.

## Test plan

- [x] `go build ./...` in `providers/aws`
- [x] `go test ./connection/awsec2ebsconn/` — 10 new cases pass; verified they fail on the pre-fix code (above)
- [ ] Live EBS scan against a multi-volume instance — needs an instance provisioned with a data volume at `/dev/xvda1`
