### PR TITLE
🐛 aws: stop dereferencing an absent config compliance recorded time

### DIFF
--- a/providers/aws/resources/aws_config.go
+++ b/providers/aws/resources/aws_config.go
@@ -669,6 +669,17 @@ func (a *mqlAwsConfigDeliverychannel) snsTopic() (*mqlAwsSnsTopic, error) {
 	return res.(*mqlAwsSnsTopic), nil
 }
 
+// configComplianceDetailID builds the cache key for a compliance detail. Every
+// component of it is optional in the API response, including the recorded time,
+// which is why the time is read through a nil check rather than dereferenced.
+func configComplianceDetailID(ruleArn, resourceType, resourceID string, resultRecordedTime *time.Time) string {
+	var recordedNanos int64
+	if resultRecordedTime != nil {
+		recordedNanos = resultRecordedTime.UnixNano()
+	}
+	return fmt.Sprintf("%s/complianceDetail/%s/%s/%d", ruleArn, resourceType, resourceID, recordedNanos)
+}
+
 func (a *mqlAwsConfigRule) complianceDetails() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	ruleName := a.Name.Data
@@ -703,7 +714,7 @@ func (a *mqlAwsConfigRule) complianceDetails() ([]any, error) {
 
 			mqlDetail, err := CreateResource(a.MqlRuntime, "aws.config.rule.complianceDetail",
 				map[string]*llx.RawData{
-					"__id":               llx.StringData(fmt.Sprintf("%s/complianceDetail/%s/%s/%d", a.Arn.Data, resourceType, resourceId, eval.ResultRecordedTime.UnixNano())),
+					"__id":               llx.StringData(configComplianceDetailID(a.Arn.Data, resourceType, resourceId, eval.ResultRecordedTime)),
 					"resourceType":       llx.StringData(resourceType),
 					"resourceId":         llx.StringData(resourceId),
 					"complianceType":     llx.StringData(string(eval.ComplianceType)),

--- a/providers/aws/resources/aws_config_test.go
+++ b/providers/aws/resources/aws_config_test.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigComplianceDetailID(t *testing.T) {
+	recorded := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name               string
+		ruleArn            string
+		resourceType       string
+		resourceID         string
+		resultRecordedTime *time.Time
+		expected           string
+	}{
+		{
+			name:               "recorded time present",
+			ruleArn:            "arn:aws:config:us-east-1:000000000000:config-rule/config-rule-abcdef",
+			resourceType:       "AWS::EC2::Instance",
+			resourceID:         "i-0123456789abcdef0",
+			resultRecordedTime: &recorded,
+			expected:           "arn:aws:config:us-east-1:000000000000:config-rule/config-rule-abcdef/complianceDetail/AWS::EC2::Instance/i-0123456789abcdef0/1787140800000000000",
+		},
+		{
+			// GetComplianceDetailsByConfigRule leaves ResultRecordedTime unset for
+			// an evaluation that has not been recorded yet. Reading it must not
+			// panic, and the key must stay stable across calls.
+			name:               "recorded time absent",
+			ruleArn:            "arn:aws:config:us-east-1:000000000000:config-rule/config-rule-abcdef",
+			resourceType:       "AWS::EC2::Instance",
+			resourceID:         "i-0123456789abcdef0",
+			resultRecordedTime: nil,
+			expected:           "arn:aws:config:us-east-1:000000000000:config-rule/config-rule-abcdef/complianceDetail/AWS::EC2::Instance/i-0123456789abcdef0/0",
+		},
+		{
+			// The evaluation result identifier is optional too, so both the type
+			// and the id can reach the key empty.
+			name:               "resource type and id absent",
+			ruleArn:            "arn:aws:config:us-east-1:000000000000:config-rule/config-rule-abcdef",
+			resourceType:       "",
+			resourceID:         "",
+			resultRecordedTime: nil,
+			expected:           "arn:aws:config:us-east-1:000000000000:config-rule/config-rule-abcdef/complianceDetail///0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected,
+				configComplianceDetailID(test.ruleArn, test.resourceType, test.resourceID, test.resultRecordedTime))
+		})
+	}
+}
+
+func TestConfigComplianceDetailIDIsDistinctPerResource(t *testing.T) {
+	// Two resources evaluated by the same rule with no recorded time must still
+	// land on different cache keys, or one would overwrite the other.
+	arn := "arn:aws:config:us-east-1:000000000000:config-rule/config-rule-abcdef"
+	first := configComplianceDetailID(arn, "AWS::EC2::Instance", "i-aaaaaaaaaaaaaaaaa", nil)
+	second := configComplianceDetailID(arn, "AWS::EC2::Instance", "i-bbbbbbbbbbbbbbbbb", nil)
+	assert.NotEqual(t, first, second)
+}


### PR DESCRIPTION
The cache key for `aws.config.rule.complianceDetail` reads
`eval.ResultRecordedTime.UnixNano()` directly. `ResultRecordedTime` is a
`*time.Time`, and `GetComplianceDetailsByConfigRule` leaves it unset for an
evaluation that has not been recorded yet, so that call panics the provider
process.

The line reads as safe, which is why it survived review. Three lines below it,
`llx.TimeDataPtr(eval.ResultRecordedTime)` handles the same pointer correctly,
and every other optional in the loop is guarded: the evaluation result
identifier, the qualifier, the annotation, the ordering timestamp. The
dereference hides inside the `%d` of a format string, where `time.Time`'s
`UnixNano()` has a **value receiver**, so Go inserts the deref silently and
nothing in the expression looks like one.

## The fix

Move the key into `configComplianceDetailID`, which reads the time through a
nil check and contributes a zero when it is absent. The key stays stable across
calls for the same evaluation, and two resources evaluated by the same rule
still land on distinct keys with no recorded time.

## Tests

`TestConfigComplianceDetailID` covers the recorded time present, absent, and an
evaluation whose identifier gave neither a resource type nor an id.
`TestConfigComplianceDetailIDIsDistinctPerResource` pins that the absent-time
key does not collapse two resources onto one cache entry.
