### PR TITLE
🐛 aws: guard the iam responses that are already treated as optional

### DIFF
--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1777,7 +1777,7 @@ func (a *mqlAwsIamPolicyversion) rawDocument() (string, error) {
 			return
 		}
 
-		if policyVersion.PolicyVersion.Document == nil {
+		if policyVersion == nil || policyVersion.PolicyVersion == nil || policyVersion.PolicyVersion.Document == nil {
 			a.rawDocErr = errors.New("could not retrieve the policy document")
 			return
 		}
@@ -1864,12 +1864,12 @@ func initAwsIamRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 			return nil, nil, err
 		}
 
+		if resp == nil || resp.Role == nil {
+			return nil, nil, fmt.Errorf("aws iam role %q not found", rolename)
+		}
 		role := resp.Role
 
-		var policyDocumentMap map[string]any
-		if role != nil {
-			policyDocumentMap = decodeIamPolicyDocument(role.AssumeRolePolicyDocument)
-		}
+		policyDocumentMap := decodeIamPolicyDocument(role.AssumeRolePolicyDocument)
 
 		args["arn"] = llx.StringDataPtr(role.Arn)
 		args["id"] = llx.StringDataPtr(role.RoleId)
@@ -2427,6 +2427,9 @@ func initAwsIamInstanceProfile(runtime *plugin.Runtime, args map[string]*llx.Raw
 			return nil, nil, err
 		}
 
+		if resp == nil || resp.InstanceProfile == nil {
+			return nil, nil, fmt.Errorf("aws iam instance profile %q not found", instanceProfileName)
+		}
 		ip := resp.InstanceProfile
 		res, err := CreateResource(runtime, ResourceAwsIamInstanceProfile, map[string]*llx.RawData{
 			"arn":                 llx.StringDataPtr(ip.Arn),


### PR DESCRIPTION
Three places in `aws_iam.go` dereference an IAM response body that the code
elsewhere already treats as optional. A miss panics the provider process rather
than failing one query.

**`initAwsIamRole`** is the clearest of the three:

```go
role := resp.Role

var policyDocumentMap map[string]any
if role != nil {                                    // <- guarded
    policyDocumentMap = decodeIamPolicyDocument(role.AssumeRolePolicyDocument)
}

args["arn"] = llx.StringDataPtr(role.Arn)           // <- and then not
args["id"] = llx.StringDataPtr(role.RoleId)
... six more
```

The guard was correct when it was written; the block below it was appended
later. A nil check reading as "this case was considered" is exactly what stops
a reviewer's eye on the lines after it.

**`initAwsIamInstanceProfile`** has the same shape with no guard at all —
`ip := resp.InstanceProfile` followed by five dereferences.

**`mqlAwsIamPolicyversion.rawDocument`** checks `PolicyVersion.Document` for nil
while dereferencing the `PolicyVersion` that holds it.

## The fix

Report the miss instead. Both inits return a not-found error, which is what the
rest of this file does rather than fall through and let the runtime build a
resource with every field unset (per CLAUDE.md's rule on init fall-through).
`rawDocument` extends its existing check to cover the container.

Because `role` can no longer be nil once the init returns, the local
`if role != nil` becomes redundant and comes out — the diff removes a nil check
and the block below it is provably safe.

## Tests

No new pure-Go logic: all three changes are guards inside functions whose body
is one SDK call plus mapping, which the repo's test gate explicitly scopes out.
`decodeIamPolicyDocument` already returns nil for a nil document, so calling it
unconditionally is safe.
