### PR TITLE
🐛 aws: mark a purged codedeploy deployment null instead of returning a nil

### DIFF
--- a/providers/aws/resources/aws_codedeploy.go
+++ b/providers/aws/resources/aws_codedeploy.go
@@ -295,7 +295,18 @@ func (dg *mqlAwsCodedeployDeploymentGroup) lastSuccessfulDeployment() (*mqlAwsCo
 		dg.LastSuccessfulDeployment = plugin.TValue[*mqlAwsCodedeployDeployment]{State: plugin.StateIsSet | plugin.StateIsNull}
 		return nil, nil
 	}
-	return getDeploymentResource(dg.MqlRuntime, dg.Region.Data, &dg.ApplicationName.Data, &dg.DeploymentGroupName.Data, dg.sdkData.LastSuccessfulDeployment.DeploymentId)
+	dep, err := getDeploymentResource(dg.MqlRuntime, dg.Region.Data, &dg.ApplicationName.Data, &dg.DeploymentGroupName.Data, dg.sdkData.LastSuccessfulDeployment.DeploymentId)
+	if err != nil {
+		return nil, err
+	}
+	if dep == nil {
+		// The group still names a deployment that CodeDeploy no longer holds.
+		// Returning a typed nil with no error would leave the field set and
+		// not null, and serializing it calls MqlID on the nil receiver.
+		dg.LastSuccessfulDeployment = plugin.TValue[*mqlAwsCodedeployDeployment]{State: plugin.StateIsSet | plugin.StateIsNull}
+		return nil, nil
+	}
+	return dep, nil
 }
 
 func (dg *mqlAwsCodedeployDeploymentGroup) lastAttemptedDeployment() (*mqlAwsCodedeployDeployment, error) {
@@ -303,7 +314,18 @@ func (dg *mqlAwsCodedeployDeploymentGroup) lastAttemptedDeployment() (*mqlAwsCod
 		dg.LastAttemptedDeployment = plugin.TValue[*mqlAwsCodedeployDeployment]{State: plugin.StateIsSet | plugin.StateIsNull}
 		return nil, nil
 	}
-	return getDeploymentResource(dg.MqlRuntime, dg.Region.Data, &dg.ApplicationName.Data, &dg.DeploymentGroupName.Data, dg.sdkData.LastAttemptedDeployment.DeploymentId)
+	dep, err := getDeploymentResource(dg.MqlRuntime, dg.Region.Data, &dg.ApplicationName.Data, &dg.DeploymentGroupName.Data, dg.sdkData.LastAttemptedDeployment.DeploymentId)
+	if err != nil {
+		return nil, err
+	}
+	if dep == nil {
+		// The group still names a deployment that CodeDeploy no longer holds.
+		// Returning a typed nil with no error would leave the field set and
+		// not null, and serializing it calls MqlID on the nil receiver.
+		dg.LastAttemptedDeployment = plugin.TValue[*mqlAwsCodedeployDeployment]{State: plugin.StateIsSet | plugin.StateIsNull}
+		return nil, nil
+	}
+	return dep, nil
 }
 
 func (dg *mqlAwsCodedeployDeploymentGroup) deploymentStyle() (any, error) {

--- a/providers/aws/resources/aws_codedeploy_test.go
+++ b/providers/aws/resources/aws_codedeploy_test.go
@@ -1,0 +1,101 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	codedeploytypes "github.com/aws/aws-sdk-go-v2/service/codedeploy/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// A resource accessor that returns a typed nil with no error is not the same as
+// one that returns null. GetOrCompute stores the nil as set-and-not-null, and
+// serializing that value calls MqlID on the nil receiver. This pins the
+// mechanism the deployment accessors have to guard against.
+func TestNilResourceIsNotAValidNullValue(t *testing.T) {
+	var field plugin.TValue[*mqlAwsCodedeployDeployment]
+
+	tv := plugin.GetOrCompute(&field, func() (*mqlAwsCodedeployDeployment, error) {
+		return nil, nil
+	})
+
+	require.True(t, tv.IsSet(), "a typed nil still marks the field set")
+	require.False(t, tv.IsNull(), "and it does not mark the field null, which is the trap")
+
+	assert.Panics(t, func() {
+		tv.ToDataRes(types.Resource("aws.codedeploy.deployment"))
+	}, "serializing a set-but-nil resource dereferences the nil receiver in MqlID")
+}
+
+// The same field, marked null before the accessor returns, serializes cleanly.
+func TestNullMarkedResourceSerializes(t *testing.T) {
+	field := plugin.TValue[*mqlAwsCodedeployDeployment]{
+		State: plugin.StateIsSet | plugin.StateIsNull,
+	}
+
+	res := field.ToDataRes(types.Resource("aws.codedeploy.deployment"))
+
+	require.NotNil(t, res)
+	assert.Empty(t, res.Error)
+	require.NotNil(t, res.Data)
+	assert.Equal(t, string(types.Nil), res.Data.Type)
+}
+
+func TestDeploymentGroupLastDeploymentsWithoutAReference(t *testing.T) {
+	t.Run("no last successful deployment", func(t *testing.T) {
+		dg := &mqlAwsCodedeployDeploymentGroup{}
+		dg.sdkData = codedeploytypes.DeploymentGroupInfo{}
+
+		dep, err := dg.lastSuccessfulDeployment()
+
+		require.NoError(t, err)
+		require.Nil(t, dep)
+		assert.True(t, dg.LastSuccessfulDeployment.IsSet())
+		assert.True(t, dg.LastSuccessfulDeployment.IsNull())
+	})
+
+	t.Run("last successful deployment carries no id", func(t *testing.T) {
+		dg := &mqlAwsCodedeployDeploymentGroup{}
+		dg.sdkData = codedeploytypes.DeploymentGroupInfo{
+			LastSuccessfulDeployment: &codedeploytypes.LastDeploymentInfo{},
+		}
+
+		dep, err := dg.lastSuccessfulDeployment()
+
+		require.NoError(t, err)
+		require.Nil(t, dep)
+		assert.True(t, dg.LastSuccessfulDeployment.IsSet())
+		assert.True(t, dg.LastSuccessfulDeployment.IsNull())
+	})
+
+	t.Run("no last attempted deployment", func(t *testing.T) {
+		dg := &mqlAwsCodedeployDeploymentGroup{}
+		dg.sdkData = codedeploytypes.DeploymentGroupInfo{}
+
+		dep, err := dg.lastAttemptedDeployment()
+
+		require.NoError(t, err)
+		require.Nil(t, dep)
+		assert.True(t, dg.LastAttemptedDeployment.IsSet())
+		assert.True(t, dg.LastAttemptedDeployment.IsNull())
+	})
+
+	t.Run("last attempted deployment carries no id", func(t *testing.T) {
+		dg := &mqlAwsCodedeployDeploymentGroup{}
+		dg.sdkData = codedeploytypes.DeploymentGroupInfo{
+			LastAttemptedDeployment: &codedeploytypes.LastDeploymentInfo{},
+		}
+
+		dep, err := dg.lastAttemptedDeployment()
+
+		require.NoError(t, err)
+		require.Nil(t, dep)
+		assert.True(t, dg.LastAttemptedDeployment.IsSet())
+		assert.True(t, dg.LastAttemptedDeployment.IsNull())
+	})
+}


### PR DESCRIPTION
`lastSuccessfulDeployment` and `lastAttemptedDeployment` already handle the case
where the group names no deployment, and mark the field null for it. What they
do not handle is `getDeploymentResource` returning `(nil, nil)`, which it does
deliberately for a `DeploymentDoesNotExistException` or a response with no
`DeploymentInfo`. CodeDeploy keeps a bounded deployment history, so a group that
has not deployed in a while still names an id the API no longer resolves.

## Why a typed nil is not a null

That nil goes back to the runtime untouched, and this is where it turns into a
crash rather than an empty field:

1. `GetOrCompute` gets `(nil, nil)` and stores `TValue{Data: nil, State: StateIsSet}` — **set, and not null**. The null state is only reached via an error or an explicit assignment.
2. `ToDataRes` sees `IsSet() && !IsNull()` and takes the serialization path.
3. `resource2result` asserts the value to the `Resource` interface. **That assertion succeeds** — a nil `*mqlAwsCodedeployDeployment` still carries its type — so `ok` is true.
4. `m.MqlID()` runs `return c.__id` on the nil receiver.

One aged-out deployment takes down the provider process, not the one query.

## The fix

Mark the field null on that path, the same way the no-reference path above it
already does.

## Tests

The tests pin the mechanism rather than the symptom, so they stay meaningful if
this shape appears elsewhere:

- `TestNilResourceIsNotAValidNullValue` — a typed nil through `GetOrCompute` is set-and-not-null, and serializing it panics.
- `TestNullMarkedResourceSerializes` — the same field marked null serializes to a nil primitive with no error.
- `TestDeploymentGroupLastDeploymentsWithoutAReference` — both accessors, for a group with no last deployment and for one whose last deployment carries no id.
