### PR TITLE
🐛 aws: stop dereferencing the cache cluster id on the path that logs it

### DIFF
--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -101,6 +101,21 @@ type mqlAwsElasticacheClusterInternal struct {
 	region                  string
 }
 
+// elasticacheSecurityGroupArns builds the security group arns for a cache
+// cluster, skipping any membership the API reports without an id. Every value
+// it reads is optional, including the cluster id it logs the skip with.
+func elasticacheSecurityGroupArns(region, accountID string, cluster elasticache_types.CacheCluster) []string {
+	sgs := []string{}
+	for _, sg := range cluster.SecurityGroups {
+		if sg.SecurityGroupId == nil {
+			log.Debug().Msgf("elasticache>newMqlAwsElasticacheCluster>missing security group id for cluster %s", convert.ToValue(cluster.CacheClusterId))
+			continue
+		}
+		sgs = append(sgs, NewSecurityGroupArn(region, accountID, convert.ToValue(sg.SecurityGroupId)))
+	}
+	return sgs
+}
+
 func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, accountID string, cluster elasticache_types.CacheCluster) (*mqlAwsElasticacheCluster, error) {
 	cacheNodes := []any{}
 	for i := range cluster.CacheNodes {
@@ -131,14 +146,7 @@ func newMqlAwsElasticacheCluster(runtime *plugin.Runtime, region string, account
 		configurationEndpointPort = int64(convert.ToValue(cluster.ConfigurationEndpoint.Port))
 	}
 
-	sgs := []string{}
-	for _, sg := range cluster.SecurityGroups {
-		if sg.SecurityGroupId == nil {
-			log.Debug().Msgf("elasticache>newMqlAwsElasticacheCluster>missing security group id for cluster %s", *cluster.CacheClusterId)
-			continue
-		}
-		sgs = append(sgs, NewSecurityGroupArn(region, accountID, convert.ToValue(sg.SecurityGroupId)))
-	}
+	sgs := elasticacheSecurityGroupArns(region, accountID, cluster)
 
 	resource, err := CreateResource(runtime, "aws.elasticache.cluster",
 		map[string]*llx.RawData{

--- a/providers/aws/resources/aws_elasticache_test.go
+++ b/providers/aws/resources/aws_elasticache_test.go
@@ -6,6 +6,8 @@ package resources
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	elasticache_types "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,4 +38,73 @@ func TestElasticacheClusterKmsKey(t *testing.T) {
 		assert.True(t, c.KmsKey.IsNull())
 		assert.True(t, c.KmsKey.IsSet())
 	})
+}
+
+// TestElasticacheSecurityGroupArns covers the branch that skips a security
+// group membership the API reports without an id. That branch logs the cluster
+// id, which is itself optional, and it is the path a partially populated
+// cluster record is most likely to take. jobpool runs the lister with no panic
+// recovery, so a deref here kills the provider process rather than one query.
+func TestElasticacheSecurityGroupArns(t *testing.T) {
+	const (
+		region    = "us-east-1"
+		accountID = "000000000000"
+	)
+
+	sgID := func(id string) elasticache_types.SecurityGroupMembership {
+		return elasticache_types.SecurityGroupMembership{SecurityGroupId: &id}
+	}
+
+	tests := []struct {
+		name     string
+		cluster  elasticache_types.CacheCluster
+		expected []string
+	}{
+		{
+			name:     "no security groups",
+			cluster:  elasticache_types.CacheCluster{},
+			expected: []string{},
+		},
+		{
+			name: "all memberships carry an id",
+			cluster: elasticache_types.CacheCluster{
+				CacheClusterId: aws.String("my-cluster"),
+				SecurityGroups: []elasticache_types.SecurityGroupMembership{
+					sgID("sg-0123456789abcdef0"),
+					sgID("sg-0fedcba9876543210"),
+				},
+			},
+			expected: []string{
+				"arn:aws:ec2:us-east-1:000000000000:security-group/sg-0123456789abcdef0",
+				"arn:aws:ec2:us-east-1:000000000000:security-group/sg-0fedcba9876543210",
+			},
+		},
+		{
+			name: "membership without an id is skipped",
+			cluster: elasticache_types.CacheCluster{
+				CacheClusterId: aws.String("my-cluster"),
+				SecurityGroups: []elasticache_types.SecurityGroupMembership{
+					{},
+					sgID("sg-0123456789abcdef0"),
+				},
+			},
+			expected: []string{"arn:aws:ec2:us-east-1:000000000000:security-group/sg-0123456789abcdef0"},
+		},
+		{
+			// The skip path logs the cluster id, so an absent one must not be
+			// dereferenced to report the skip.
+			name: "membership without an id on a cluster without an id",
+			cluster: elasticache_types.CacheCluster{
+				SecurityGroups: []elasticache_types.SecurityGroupMembership{{}},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected,
+				elasticacheSecurityGroupArns(region, accountID, test.cluster))
+		})
+	}
 }


### PR DESCRIPTION
`newMqlAwsElasticacheCluster` reads every optional on the cluster through
`llx.*DataPtr` or `convert.ToValue` — roughly thirty of them — with exactly one
exception:

```go
if sg.SecurityGroupId == nil {
    log.Debug().Msgf("...missing security group id for cluster %s", *cluster.CacheClusterId)
    continue
}
```

That is the wrong place to make the exception. The branch only runs on a record
the API returned incompletely, which is precisely the record most likely to be
missing its other optionals too — so the dereference fires on the shape it was
least tested against, and only there.

The blast radius is the whole scan. The elasticache lister runs under
`jobpool`, which has no panic recovery of its own the way `perRegion`'s
`callRegion` does, so this takes down the provider process rather than failing
one region.

## The fix

Read the id through `convert.ToValue` like everything else in the function, and
pull the loop into `elasticacheSecurityGroupArns` so the skip branch is
reachable from a test.

## Tests

`TestElasticacheSecurityGroupArns` covers no security groups, all memberships
carrying an id, a membership without an id, and a membership without an id on a
cluster that also has no id. Against the old body that last case panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
  resources.elasticacheSecurityGroupArns
    providers/aws/resources/aws_elasticache.go:111
```
