### PR TITLE
🐛 aws: nil-check the response bodies that siblings already nil-check

### DIFF
--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -599,6 +599,11 @@ func (a *mqlAwsEksNodegroup) fetchDetails() (*ekstypes.Nodegroup, error) {
 		a.fetched = true
 		return nil, err
 	}
+	if desc.Nodegroup == nil {
+		a.fetchErr = errors.New("DescribeNodegroup returned no nodegroup for " + a.Name.Data)
+		a.fetched = true
+		return nil, a.fetchErr
+	}
 	a.details = desc.Nodegroup
 	a.fetched = true
 	return desc.Nodegroup, nil
@@ -933,6 +938,11 @@ func (a *mqlAwsEksAddon) fetchDetails() (*ekstypes.Addon, error) {
 		a.fetched = true
 		return nil, err
 	}
+	if desc.Addon == nil {
+		a.fetchErr = errors.New("DescribeAddon returned no addon for " + a.Name.Data)
+		a.fetched = true
+		return nil, a.fetchErr
+	}
 	a.details = desc.Addon
 	a.fetched = true
 	return desc.Addon, nil
@@ -1126,6 +1136,11 @@ func (a *mqlAwsEksAccessEntry) fetchDetails() (*ekstypes.AccessEntry, error) {
 		a.fetched = true
 		return nil, err
 	}
+	if desc.AccessEntry == nil {
+		a.fetchErr = errors.New("DescribeAccessEntry returned no access entry for " + principalArn)
+		a.fetched = true
+		return nil, a.fetchErr
+	}
 	a.details = desc.AccessEntry
 	a.fetched = true
 	return desc.AccessEntry, nil
@@ -1298,6 +1313,11 @@ func (a *mqlAwsEksFargateProfile) fetchDetails() (*ekstypes.FargateProfile, erro
 		a.fetched = true
 		return nil, err
 	}
+	if desc.FargateProfile == nil {
+		a.fetchErr = errors.New("DescribeFargateProfile returned no profile for " + name)
+		a.fetched = true
+		return nil, a.fetchErr
+	}
 	a.details = desc.FargateProfile
 	a.fetched = true
 	return desc.FargateProfile, nil
@@ -1458,6 +1478,11 @@ func (a *mqlAwsEksPodIdentityAssociation) fetchDetails() (*ekstypes.PodIdentityA
 		a.fetchErr = err
 		a.fetched = true
 		return nil, err
+	}
+	if desc.Association == nil {
+		a.fetchErr = errors.New("DescribePodIdentityAssociation returned no association for " + assocId)
+		a.fetched = true
+		return nil, a.fetchErr
 	}
 	a.details = desc.Association
 	a.fetched = true

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -1291,6 +1291,10 @@ func (a *mqlAwsLambdaFunction) codeSigningConfig() (*mqlAwsLambdaCodeSigningConf
 		return nil, errors.Wrap(err, "could not get code signing config")
 	}
 
+	if configResp.CodeSigningConfig == nil {
+		a.CodeSigningConfig.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
 	csc := configResp.CodeSigningConfig
 
 	allowedArns := []any{}

--- a/providers/aws/resources/aws_transfer.go
+++ b/providers/aws/resources/aws_transfer.go
@@ -403,6 +403,9 @@ func (a *mqlAwsTransferConnector) fetchDetail() (*transfer.DescribeConnectorOutp
 	if err != nil {
 		return nil, err
 	}
+	if resp == nil || resp.Connector == nil {
+		return nil, errors.New("DescribeConnector returned no connector for " + connectorId)
+	}
 	a.fetched = true
 	a.descResp = resp
 	return resp, nil

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -1238,6 +1238,29 @@ func (a *mqlAwsWafAclLoggingConfiguration) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+// newEmptyWafLoggingConfiguration reports a web ACL that logs nowhere. Reading
+// that as a resource with no destinations rather than as a null keeps the
+// negative answer assertable: a null logDestinationConfigs would make a check
+// for "this ACL logs somewhere" pass without having established anything.
+func newEmptyWafLoggingConfiguration(runtime *plugin.Runtime, aclArn string) (*mqlAwsWafAclLoggingConfiguration, error) {
+	res, err := CreateResource(runtime, "aws.waf.acl.loggingConfiguration",
+		map[string]*llx.RawData{
+			"__id":                     llx.StringData(aclArn),
+			"arn":                      llx.StringData(aclArn),
+			"logDestinationConfigs":    llx.ArrayData([]any{}, types.String),
+			"managedByFirewallManager": llx.BoolData(false),
+			"redactedFields":           llx.ArrayData([]any{}, types.String),
+			"loggingFilter":            llx.DictData(nil),
+			"logScope":                 llx.StringData(""),
+			"logType":                  llx.StringData(""),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsWafAclLoggingConfiguration), nil
+}
+
 func (a *mqlAwsWafAcl) loggingConfiguration() (*mqlAwsWafAclLoggingConfiguration, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
@@ -1253,28 +1276,15 @@ func (a *mqlAwsWafAcl) loggingConfiguration() (*mqlAwsWafAclLoggingConfiguration
 		if !errors.As(err, &notFound) {
 			return nil, err
 		}
-		// No logging configuration exists — return resource with empty destinations
 		log.Debug().Str("acl", arnVal).Msg("no logging configuration found for web ACL")
-		res, createErr := CreateResource(a.MqlRuntime, "aws.waf.acl.loggingConfiguration",
-			map[string]*llx.RawData{
-				"__id":                     llx.StringData(arnVal),
-				"arn":                      llx.StringData(arnVal),
-				"logDestinationConfigs":    llx.ArrayData([]any{}, types.String),
-				"managedByFirewallManager": llx.BoolData(false),
-				"redactedFields":           llx.ArrayData([]any{}, types.String),
-				"loggingFilter":            llx.DictData(nil),
-				"logScope":                 llx.StringData(""),
-				"logType":                  llx.StringData(""),
-			},
-		)
-		if createErr != nil {
-			return nil, createErr
-		}
-		return res.(*mqlAwsWafAclLoggingConfiguration), nil
+		return newEmptyWafLoggingConfiguration(a.MqlRuntime, arnVal)
 	}
 
 	if resp.LoggingConfiguration == nil {
-		return nil, errors.New("GetLoggingConfiguration returned no configuration for " + arnVal)
+		// A 200 with no configuration in it means the same thing as the
+		// exception above, and WAF is not consistent about which one it sends.
+		log.Debug().Str("acl", arnVal).Msg("empty logging configuration returned for web ACL")
+		return newEmptyWafLoggingConfiguration(a.MqlRuntime, arnVal)
 	}
 	logConfig := resp.LoggingConfiguration
 	destinations := convert.SliceAnyToInterface(logConfig.LogDestinationConfigs)

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -132,6 +132,9 @@ func (a *mqlAwsWafAcl) fetchACLDetails() error {
 	if err != nil {
 		return err
 	}
+	if resp.WebACL == nil {
+		return errors.New("GetWebACL returned no web acl for " + a.Name.Data)
+	}
 	a.cachedManagedByFwManager = resp.WebACL.ManagedByFirewallManager
 	a.cachedRules = resp.WebACL.Rules
 	a.cachedACL = resp.WebACL
@@ -306,6 +309,9 @@ func (a *mqlAwsWafIpset) fetchIPSet() error {
 	})
 	if err != nil {
 		return err
+	}
+	if resp.IPSet == nil {
+		return errors.New("GetIPSet returned no ip set for " + a.Name.Data)
 	}
 	a.cachedAddrType = string(resp.IPSet.IPAddressVersion)
 	a.cachedAddresses = convert.SliceAnyToInterface(resp.IPSet.Addresses)
@@ -506,7 +512,14 @@ func (a *mqlAwsWafRulegroup) rules() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if ruleGroupDetails.RuleGroup == nil {
+		return nil, errors.New("GetRuleGroup returned no rule group for " + a.Name.Data)
+	}
 	for _, rule := range ruleGroupDetails.RuleGroup.Rules {
+		if rule.Name == nil {
+			log.Debug().Str("rulegroup", a.Arn.Data).Msg("skipping a rule group rule with no name")
+			continue
+		}
 		ruleID := a.Arn.Data + "/" + *rule.Name
 		mqlStatement, err := createStatementResource(a.MqlRuntime, rule.Statement, rule.Name, ruleID)
 		if err != nil {
@@ -1260,6 +1273,9 @@ func (a *mqlAwsWafAcl) loggingConfiguration() (*mqlAwsWafAclLoggingConfiguration
 		return res.(*mqlAwsWafAclLoggingConfiguration), nil
 	}
 
+	if resp.LoggingConfiguration == nil {
+		return nil, errors.New("GetLoggingConfiguration returned no configuration for " + arnVal)
+	}
 	logConfig := resp.LoggingConfiguration
 	destinations := convert.SliceAnyToInterface(logConfig.LogDestinationConfigs)
 


### PR DESCRIPTION
Nine places across four files read a field straight off an AWS response body
that the same file elsewhere admits can be absent. The SDK models these as
pointers because the service can return the envelope without the payload; a
miss panics the provider process rather than failing one query.

Each fix copies the guard its own file already uses somewhere else.

## eks — five of seven fetchers (widest blast radius)

`aws_eks.go` has seven memoized `fetchDetails()` functions. Five store `desc.X`
and hand it back without checking it, and every accessor built on them
dereferences the result immediately:

```go
ng, err := a.fetchDetails()
if err != nil { return "", err }
return convert.ToValue(ng.NodegroupArn), nil    // ng can be nil
```

There are **56** such accessors across nodegroup, addon, access entry, fargate
profile and pod identity association. The other two fetchers already do the
right thing — `mqlAwsEksInsight.fetchDetails` returns
`errors.New("DescribeInsight returned nil insight for " + a.Id.Data)`, and
`mqlAwsEksIdentityProviderConfig` returns nil with every caller checking for it.
Guarding at the fetcher fixes all 56 at once and keeps the check where the
fetch happens.

## waf — four sites

`resp.WebACL`, `resp.IPSet`, `ruleGroupDetails.RuleGroup` and
`resp.LoggingConfiguration`, while `initAwsWafAcl` in the same file opens with
`if resp.WebACL == nil || resp.WebACL.ARN == nil`. The rule loop also
dereferenced `rule.Name` to build the rule id; a rule with no name is now
skipped with a debug line rather than taking the scan down with it.

## transfer — one fetcher, a dozen readers

`fetchDetail` returns the raw `DescribeConnectorOutput` and a dozen accessors
read `resp.Connector.X` off it. The server path two hundred lines up checks
`resp == nil || resp.Server == nil` — twice.

## lambda — one site, and the odd one out

`codeSigningConfig` gets a **null** rather than an error. The function already
returns a set-and-null field for a 404 and for an empty config arn, so an empty
`GetCodeSigningConfig` body means the same thing to a caller: this function has
no code signing configuration.

## Tests

No new pure-Go logic. Every change is a nil check inside a function whose body
is one SDK call plus mapping — the case the repo's test gate scopes out.
`make providers/build/aws` reports permissions unchanged, and
`go test ./resources/` passes.
