### PR TITLE
🐛 aws: read a split default route as internet-reachable in subnet isPublic

### DIFF
--- a/providers/aws/resources/aws_vpc_reachability.go
+++ b/providers/aws/resources/aws_vpc_reachability.go
@@ -11,11 +11,69 @@ import "strings"
 // whose default route points at one is not reachable from the internet.
 const internetGatewayIdPrefix = "igw-"
 
-// routeIsDefault reports whether a route's destination matches every address,
-// for either address family. A default route is what carries traffic with no
-// more specific match, so it is the one that decides internet reachability.
+// routeIsDefault reports whether a single route's destination matches every
+// address, for either address family. A default route is what carries traffic
+// with no more specific match, so it is the one that decides internet
+// reachability.
+//
+// A route table can also cover every address with a pair of half-routes rather
+// than one default route, which no single destination identifies. That case is
+// routesReachInternet's, not this function's.
 func routeIsDefault(ipv4Cidr, ipv6Cidr string) bool {
 	return ipv4Cidr == "0.0.0.0/0" || ipv6Cidr == "::/0"
+}
+
+// The two halves of the split default, per address family. A pair of them
+// covers the whole address space between them and carries traffic with no more
+// specific match, exactly as a default route does, because either half is more
+// specific than the /0 it is deployed to override. Appliance vendors and VPN
+// setups use the pair for precisely that reason, so a route table that has one
+// usually has no /0 at all.
+const (
+	splitDefaultIpv4LowerHalf = "0.0.0.0/1"
+	splitDefaultIpv4UpperHalf = "128.0.0.0/1"
+	splitDefaultIpv6LowerHalf = "::/1"
+	splitDefaultIpv6UpperHalf = "8000::/1"
+)
+
+// internetRoute is one active route reduced to what reachability depends on:
+// where it sends traffic, and which destinations it sends there.
+type internetRoute struct {
+	ipv4Cidr  string
+	ipv6Cidr  string
+	gatewayId string
+}
+
+// routesReachInternet reports whether a set of active routes sends
+// unmatched traffic to an internet gateway, by a default route or by both
+// halves of a split default. Only routes that already point at an internet
+// gateway are considered, so two halves pointing at different targets do not
+// combine into one.
+func routesReachInternet(routes []internetRoute) bool {
+	var ipv4Lower, ipv4Upper, ipv6Lower, ipv6Upper bool
+
+	for _, route := range routes {
+		if !hasInternetGatewayPrefix(route.gatewayId) {
+			continue
+		}
+		if routeIsDefault(route.ipv4Cidr, route.ipv6Cidr) {
+			return true
+		}
+		switch route.ipv4Cidr {
+		case splitDefaultIpv4LowerHalf:
+			ipv4Lower = true
+		case splitDefaultIpv4UpperHalf:
+			ipv4Upper = true
+		}
+		switch route.ipv6Cidr {
+		case splitDefaultIpv6LowerHalf:
+			ipv6Lower = true
+		case splitDefaultIpv6UpperHalf:
+			ipv6Upper = true
+		}
+	}
+
+	return (ipv4Lower && ipv4Upper) || (ipv6Lower && ipv6Upper)
 }
 
 // hasInternetGatewayPrefix reports whether a route's polymorphic gatewayId names
@@ -34,7 +92,8 @@ func blockModeStopsIngress(mode string) bool {
 }
 
 // isPublic reports whether the subnet is a public subnet: one whose effective
-// route table sends a default route to an internet gateway.
+// route table sends unmatched traffic to an internet gateway, by a default
+// route or by both halves of a split default.
 //
 // The route table comes from routeTable(), which already resolves the subnet's
 // explicit association and falls back to the VPC main route table, so this
@@ -61,6 +120,8 @@ func (a *mqlAwsVpcSubnet) isPublic() (bool, error) {
 	if routes.Error != nil {
 		return false, routes.Error
 	}
+
+	active := make([]internetRoute, 0, len(routes.Data))
 	for _, r := range routes.Data {
 		route, ok := r.(*mqlAwsVpcRoutetableRoute)
 		if !ok {
@@ -82,17 +143,17 @@ func (a *mqlAwsVpcSubnet) isPublic() (bool, error) {
 		if ipv6.Error != nil {
 			return false, ipv6.Error
 		}
-		if !routeIsDefault(ipv4.Data, ipv6.Data) {
-			continue
-		}
-
 		gatewayId := route.GetGatewayId()
 		if gatewayId.Error != nil {
 			return false, gatewayId.Error
 		}
-		if hasInternetGatewayPrefix(gatewayId.Data) {
-			return true, nil
-		}
+
+		active = append(active, internetRoute{
+			ipv4Cidr:  ipv4.Data,
+			ipv6Cidr:  ipv6.Data,
+			gatewayId: gatewayId.Data,
+		})
 	}
-	return false, nil
+
+	return routesReachInternet(active), nil
 }

--- a/providers/aws/resources/aws_vpc_reachability_test.go
+++ b/providers/aws/resources/aws_vpc_reachability_test.go
@@ -15,10 +15,13 @@ func TestRouteIsDefault(t *testing.T) {
 	assert.True(t, routeIsDefault("", "::/0"))
 	assert.True(t, routeIsDefault("0.0.0.0/0", "::/0"))
 
-	// A more specific destination is not a default route, even one that looks
-	// close to the all-addresses form.
+	// A more specific destination is not a default route on its own. Half of a
+	// split default is deliberately included here: one /1 covers half the
+	// address space, and it takes the pair to carry unmatched traffic, which is
+	// routesReachInternet's decision rather than this one's.
 	assert.False(t, routeIsDefault("10.0.0.0/16", ""))
 	assert.False(t, routeIsDefault("0.0.0.0/1", ""))
+	assert.False(t, routeIsDefault("128.0.0.0/1", ""))
 	assert.False(t, routeIsDefault("", "2600:1f18::/56"))
 	assert.False(t, routeIsDefault("", ""))
 }
@@ -41,4 +44,115 @@ func TestInternetGatewayIdPrefix(t *testing.T) {
 	assert.False(t, hasInternetGatewayPrefix("vgw-0123456789abcdef0"))
 	assert.False(t, hasInternetGatewayPrefix("local"))
 	assert.False(t, hasInternetGatewayPrefix(""))
+}
+
+// TestRoutesReachInternet covers the route-set decision isPublic delegates to.
+// The split default (0.0.0.0/1 plus 128.0.0.0/1) covers every address between
+// its two halves and carries traffic with no more specific match exactly as a
+// 0.0.0.0/0 route does, so a subnet behind one is public. Only matching the
+// literal default read those subnets as private.
+func TestRoutesReachInternet(t *testing.T) {
+	const igw = "igw-0123456789abcdef0"
+
+	tests := []struct {
+		name     string
+		routes   []internetRoute
+		expected bool
+	}{
+		{
+			name:     "no routes",
+			routes:   nil,
+			expected: false,
+		},
+		{
+			name:     "default route to an internet gateway",
+			routes:   []internetRoute{{ipv4Cidr: "0.0.0.0/0", gatewayId: igw}},
+			expected: true,
+		},
+		{
+			name: "only local and more specific routes",
+			routes: []internetRoute{
+				{ipv4Cidr: "10.0.0.0/16", gatewayId: "local"},
+				{ipv4Cidr: "192.168.0.0/16", gatewayId: igw},
+			},
+			expected: false,
+		},
+		{
+			name: "split default to an internet gateway",
+			routes: []internetRoute{
+				{ipv4Cidr: "0.0.0.0/1", gatewayId: igw},
+				{ipv4Cidr: "128.0.0.0/1", gatewayId: igw},
+			},
+			expected: true,
+		},
+		{
+			name: "split default alongside local",
+			routes: []internetRoute{
+				{ipv4Cidr: "10.0.0.0/16", gatewayId: "local"},
+				{ipv4Cidr: "128.0.0.0/1", gatewayId: igw},
+				{ipv4Cidr: "0.0.0.0/1", gatewayId: igw},
+			},
+			expected: true,
+		},
+		{
+			// One half alone leaves the other half of the address space
+			// unrouted, so it does not carry unmatched traffic.
+			name:     "only the lower half",
+			routes:   []internetRoute{{ipv4Cidr: "0.0.0.0/1", gatewayId: igw}},
+			expected: false,
+		},
+		{
+			name:     "only the upper half",
+			routes:   []internetRoute{{ipv4Cidr: "128.0.0.0/1", gatewayId: igw}},
+			expected: false,
+		},
+		{
+			// Two halves that go to different targets are not one path to the
+			// internet, so they must not combine.
+			name: "halves pointing at different targets",
+			routes: []internetRoute{
+				{ipv4Cidr: "0.0.0.0/1", gatewayId: igw},
+				{ipv4Cidr: "128.0.0.0/1", gatewayId: "vgw-0123456789abcdef0"},
+			},
+			expected: false,
+		},
+		{
+			// An egress-only gateway carries outbound IPv6 only, so neither a
+			// default route nor a split default through one is reachable.
+			name: "split default to an egress-only gateway",
+			routes: []internetRoute{
+				{ipv4Cidr: "0.0.0.0/1", gatewayId: "eigw-0123456789abcdef0"},
+				{ipv4Cidr: "128.0.0.0/1", gatewayId: "eigw-0123456789abcdef0"},
+			},
+			expected: false,
+		},
+		{
+			name: "ipv6 split default to an internet gateway",
+			routes: []internetRoute{
+				{ipv6Cidr: "::/1", gatewayId: igw},
+				{ipv6Cidr: "8000::/1", gatewayId: igw},
+			},
+			expected: true,
+		},
+		{
+			name:     "ipv6 default route to an internet gateway",
+			routes:   []internetRoute{{ipv6Cidr: "::/0", gatewayId: igw}},
+			expected: true,
+		},
+		{
+			// Halves from different address families cover neither space.
+			name: "one half from each address family",
+			routes: []internetRoute{
+				{ipv4Cidr: "0.0.0.0/1", gatewayId: igw},
+				{ipv6Cidr: "8000::/1", gatewayId: igw},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, routesReachInternet(test.routes))
+		})
+	}
 }


### PR DESCRIPTION
`isPublic` decided reachability one route at a time, and `routeIsDefault`
matched only a literal `0.0.0.0/0` or `::/0`.

A route table can also cover every address with a **pair of half-routes** —
`0.0.0.0/1` and `128.0.0.0/1`. Together they carry traffic with no more
specific match exactly as a default route does, and either half is *more
specific* than the `/0` it is deployed to override, which is the whole point of
the pattern. Appliance and VPN setups use it for that reason, so a table
configured this way usually has no `/0` in it at all — and every subnet behind
one reported `isPublic: false`.

## Why not fix `routeIsDefault`

Because it isn't wrong. A single `/1` covers half the address space and
genuinely is not a default route. The fact lives at the level of the route
*set*, so `isPublic` now collects its active routes and hands them to
`routesReachInternet`, which answers for the table as a whole.

The existing assertion that `routeIsDefault("0.0.0.0/1")` is false therefore
stays — it was correct about that function, and its comment is rewritten to say
where the pair gets decided rather than implying a `/1` can never contribute to
one.

## Boundaries kept

- Only routes **already pointing at an internet gateway** are considered, so two halves aimed at different targets do not combine into a path.
- A split default through an egress-only gateway (`eigw-`) stays unreachable, same as a `/0` through one.
- Both address families are handled — `::/1` + `8000::/1` is the same trick.
- Halves from *different* families do not combine.
- Blackholed routes are still skipped, and the internet-gateway block mode still short-circuits.

## Tests

`TestRoutesReachInternet` is a table over all of the above: the literal default,
the split default, each half alone, halves at different targets, the
egress-only case, the IPv6 pair, and the mixed-family case.
