### PR TITLE
🐛 aws: decide elb enforcesTls from the encrypted protocols, not the plaintext ones

### DIFF
--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -1520,7 +1520,9 @@ func (a *mqlAwsElbTargetgroup) ipTargets() ([]any, error) {
 }
 
 // enforcesTls reports whether every listener terminates an encrypted protocol —
-// i.e. no plaintext HTTP, TCP, or UDP listener accepts traffic. It reads
+// HTTPS or TLS on an ALB/NLB, SSL on a classic load balancer. Any other
+// protocol counts as plaintext, including GENEVE and a listener whose protocol
+// could not be read, so an unrecognized listener never reads as secure. It reads
 // listenerDescriptions, which covers both classic ELBs (where the protocol is
 // nested under "Listener") and ALB/NLB load balancers (top-level "Protocol"), so
 // a classic HTTP load balancer is not missed. A load balancer with no listeners

--- a/providers/aws/resources/aws_exposure.go
+++ b/providers/aws/resources/aws_exposure.go
@@ -14,12 +14,19 @@ func viewerPolicyEnforcesHttps(policy string) bool {
 
 // listenerProtocolIsPlaintext reports whether a load balancer listener protocol
 // carries traffic without transport encryption.
+//
+// The encrypted protocols are the closed set, so they are what gets listed:
+// HTTPS and TLS on ALB and NLB, SSL on a classic load balancer. Everything else
+// is plaintext, which is the safe direction for a value this predicate has not
+// seen before. Listing the plaintext names instead would have reported GENEVE -
+// the unencrypted Gateway Load Balancer tunnel - as encrypted, along with any
+// protocol AWS adds later and any value the description did not parse.
 func listenerProtocolIsPlaintext(protocol string) bool {
 	switch strings.ToUpper(protocol) {
-	case "HTTP", "TCP", "UDP", "TCP_UDP":
-		return true
-	default:
+	case "HTTPS", "TLS", "SSL":
 		return false
+	default:
+		return true
 	}
 }
 

--- a/providers/aws/resources/aws_exposure_test.go
+++ b/providers/aws/resources/aws_exposure_test.go
@@ -18,12 +18,25 @@ func TestViewerPolicyEnforcesHttps(t *testing.T) {
 }
 
 func TestListenerProtocolIsPlaintext(t *testing.T) {
+	// The encrypted protocols are the closed set: HTTPS and TLS on ALB and NLB,
+	// SSL on a classic load balancer.
+	for _, p := range []string{"HTTPS", "TLS", "SSL", "https", "tls", "ssl"} {
+		assert.False(t, listenerProtocolIsPlaintext(p), p)
+	}
+
 	for _, p := range []string{"HTTP", "TCP", "UDP", "TCP_UDP", "http", "tcp"} {
 		assert.True(t, listenerProtocolIsPlaintext(p), p)
 	}
-	for _, p := range []string{"HTTPS", "TLS", "https", "tls", ""} {
-		assert.False(t, listenerProtocolIsPlaintext(p), p)
-	}
+
+	// GENEVE is the Gateway Load Balancer tunnel and carries traffic in the
+	// clear. The schema enumerates it, so it is not a hypothetical value.
+	assert.True(t, listenerProtocolIsPlaintext("GENEVE"))
+
+	// A protocol this predicate has not seen, and a listener whose description
+	// did not parse, both have to fail toward plaintext. Reporting an unread
+	// listener as encrypted is the answer that lets a finding through.
+	assert.True(t, listenerProtocolIsPlaintext("QUIC"))
+	assert.True(t, listenerProtocolIsPlaintext(""))
 }
 
 func TestListenerDescriptionProtocol(t *testing.T) {


### PR DESCRIPTION
`listenerProtocolIsPlaintext` listed the *insecure* protocols — HTTP, TCP, UDP,
TCP_UDP — and returned `false` for everything else. In a predicate that feeds
`enforcesTls`, that puts every value it has not seen on the **secure** side of
the boundary.

Three things land there today:

- **GENEVE** — the Gateway Load Balancer tunnel. It is unencrypted, and it is a value `aws.lr` itself enumerates in the listener protocol comment, so it is not hypothetical.
- **Any protocol AWS adds later** starts out reported as encrypted.
- **`""`** — `listenerDescriptionProtocol` returns the empty string when a description matches neither the ALB/NLB nor the classic-ELB shape. A listener that failed to parse and a TLS listener were reporting identically.

## The fix

Enumerate the encrypted set instead: `HTTPS` and `TLS` on ALB/NLB, `SSL` on a
classic load balancer. That set is closed and small, so both novelty and parse
failure land on "not proven encrypted" — the direction a security predicate has
to fail in.

## What this changes for users

A load balancer with a GENEVE listener, an unrecognized protocol, or an
unparseable listener description flips from `enforcesTls: true` to `false`.
That is the correction, not a regression.

A load balancer with **no listeners at all** still enforces TLS vacuously —
nothing accepts traffic. That behaviour is unchanged and separately documented
at `aws_elb.go:1055`.

## Tests

`TestListenerProtocolIsPlaintext` previously asserted `""` as not-plaintext; it
now asserts the opposite, alongside `GENEVE` and an unknown protocol, and pins
`SSL` on the encrypted side.
