### PR TITLE
🐛 aws: count NotAction, NotResource and service wildcards as iam wildcards

### DIFF
--- a/providers/aws/resources/aws_iam_policy_statement.go
+++ b/providers/aws/resources/aws_iam_policy_statement.go
@@ -117,11 +117,21 @@ func (a *mqlAwsIamPolicy) statements() ([]any, error) {
 	return defaultVersion.statements()
 }
 
-// anyWildcardResource reports whether any element is the all-resources
-// wildcard `*`.
+// anyWildcardResource reports whether any element covers a service's whole
+// resource namespace — the global `*`, or an ARN whose resource part is a bare
+// wildcard such as `arn:aws:s3:::*`, which names every bucket in the account.
+// This is the same `:*` test anyWildcardAction applies to actions.
+//
+// A path wildcard under a named resource (`arn:aws:s3:::my-bucket/*`, every
+// object in one bucket) is scoped to that resource and deliberately does not
+// match — it is what a correctly written bucket policy looks like.
 func anyWildcardResource(resources []any) bool {
 	for _, r := range resources {
-		if s, ok := r.(string); ok && s == "*" {
+		s, ok := r.(string)
+		if !ok {
+			continue
+		}
+		if s == "*" || strings.HasSuffix(s, ":*") {
 			return true
 		}
 	}
@@ -143,9 +153,22 @@ func anyWildcardAction(actions []any) bool {
 	return false
 }
 
-// hasWildcardResource reports whether any resource the statement applies to is
-// the all-resources wildcard `*`.
+// hasWildcardResource reports whether the statement applies to every resource:
+// through a wildcard in Resource, or through any NotResource at all.
+//
+// NotResource inverts the set. `{"Effect":"Allow","NotResource":["arn:...:my-secret"]}`
+// applies to every resource except the one named, which is broader than any
+// wildcard the statement could have written out, so the exclusion list only has
+// to be non-empty. hasPublicPrincipal reads NotPrincipal the same way.
 func (a *mqlAwsIamPolicyStatement) hasWildcardResource() (bool, error) {
+	notResources := a.GetNotResources()
+	if notResources.Error != nil {
+		return false, notResources.Error
+	}
+	if len(notResources.Data) > 0 {
+		return true, nil
+	}
+
 	resources := a.GetResources()
 	if resources.Error != nil {
 		return false, resources.Error
@@ -153,9 +176,23 @@ func (a *mqlAwsIamPolicyStatement) hasWildcardResource() (bool, error) {
 	return anyWildcardResource(resources.Data), nil
 }
 
-// hasWildcardAction reports whether any action grants service-wide or global
-// access — the global `*` action or a service-wide wildcard such as `s3:*`.
+// hasWildcardAction reports whether the statement grants service-wide or global
+// access: the global `*` action, a service-wide wildcard such as `s3:*`, or any
+// NotAction at all.
+//
+// NotAction inverts the set the same way NotResource does.
+// `{"Effect":"Allow","NotAction":["iam:*"]}` grants every action in AWS except
+// the IAM ones, which is near-administrator and read as no wildcard at all
+// while only Action was consulted.
 func (a *mqlAwsIamPolicyStatement) hasWildcardAction() (bool, error) {
+	notActions := a.GetNotActions()
+	if notActions.Error != nil {
+		return false, notActions.Error
+	}
+	if len(notActions.Data) > 0 {
+		return true, nil
+	}
+
 	actions := a.GetActions()
 	if actions.Error != nil {
 		return false, actions.Error

--- a/providers/aws/resources/aws_iam_policy_statement_test.go
+++ b/providers/aws/resources/aws_iam_policy_statement_test.go
@@ -192,3 +192,144 @@ func TestStatementsAllowPublicNegatedCondition(t *testing.T) {
 		})
 	}
 }
+
+// setStrings builds a resolved list field, as setString does for scalars.
+func setStrings(v ...string) plugin.TValue[[]any] {
+	data := make([]any, 0, len(v))
+	for _, s := range v {
+		data = append(data, s)
+	}
+	return plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet}
+}
+
+// A NotAction or NotResource inverts the set the statement applies to, so an
+// exclusion list only has to be non-empty to be broader than any wildcard the
+// statement could have written out. hasPublicPrincipal already reads
+// NotPrincipal this way.
+func TestPolicyStatementWildcardsThroughNegatedFields(t *testing.T) {
+	t.Run("action", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			actions    []string
+			notActions []string
+			want       bool
+		}{
+			{"specific actions", []string{"s3:GetObject"}, nil, false},
+			{"global wildcard action", []string{"*"}, nil, true},
+			{"service wildcard action", []string{"s3:*"}, nil, true},
+			{
+				// Every action in AWS except the IAM ones: near-administrator,
+				// and reported as no wildcard while only Action was consulted.
+				name:       "not action",
+				actions:    nil,
+				notActions: []string{"iam:*"},
+				want:       true,
+			},
+			{"not action with a specific exclusion", nil, []string{"s3:DeleteBucket"}, true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				stmt := &mqlAwsIamPolicyStatement{
+					Actions:    setStrings(tt.actions...),
+					NotActions: setStrings(tt.notActions...),
+				}
+				got, err := stmt.hasWildcardAction()
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			})
+		}
+	})
+
+	t.Run("resource", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			resources    []string
+			notResources []string
+			want         bool
+		}{
+			{"specific resources", []string{"arn:aws:s3:::my-bucket"}, nil, false},
+			{"global wildcard resource", []string{"*"}, nil, true},
+			{"service namespace wildcard resource", []string{"arn:aws:s3:::*"}, nil, true},
+			{
+				// Every resource except the one named, which no written-out
+				// wildcard could exceed.
+				name:         "not resource",
+				resources:    nil,
+				notResources: []string{"arn:aws:secretsmanager:us-east-1:000000000000:secret:prod"},
+				want:         true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				stmt := &mqlAwsIamPolicyStatement{
+					Resources:    setStrings(tt.resources...),
+					NotResources: setStrings(tt.notResources...),
+				}
+				got, err := stmt.hasWildcardResource()
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			})
+		}
+	})
+}
+
+// statementsAllowWildcard is what hasWildcardAllow reports, so the negated
+// fields have to reach it through an Allow and stay out of it through a Deny.
+func TestStatementsAllowWildcardWithNegatedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		stmt *mqlAwsIamPolicyStatement
+		want bool
+	}{
+		{
+			name: "allow with not action",
+			stmt: &mqlAwsIamPolicyStatement{
+				Effect:     setString("Allow"),
+				Actions:    setStrings(),
+				NotActions: setStrings("iam:*"),
+				Resources:  setStrings("arn:aws:s3:::my-bucket"),
+			},
+			want: true,
+		},
+		{
+			// A Deny that excludes a set is a guardrail, not a grant.
+			name: "deny with not action",
+			stmt: &mqlAwsIamPolicyStatement{
+				Effect:     setString("Deny"),
+				Actions:    setStrings(),
+				NotActions: setStrings("iam:*"),
+				Resources:  setStrings("arn:aws:s3:::my-bucket"),
+			},
+			want: false,
+		},
+		{
+			name: "allow with not resource",
+			stmt: &mqlAwsIamPolicyStatement{
+				Effect:       setString("Allow"),
+				Actions:      setStrings("s3:GetObject"),
+				NotActions:   setStrings(),
+				Resources:    setStrings(),
+				NotResources: setStrings("arn:aws:s3:::my-bucket"),
+			},
+			want: true,
+		},
+		{
+			name: "allow with neither",
+			stmt: &mqlAwsIamPolicyStatement{
+				Effect:       setString("Allow"),
+				Actions:      setStrings("s3:GetObject"),
+				NotActions:   setStrings(),
+				Resources:    setStrings("arn:aws:s3:::my-bucket"),
+				NotResources: setStrings(),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := statementsAllowWildcard([]any{tt.stmt})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/providers/aws/resources/aws_policy_helpers_test.go
+++ b/providers/aws/resources/aws_policy_helpers_test.go
@@ -17,8 +17,21 @@ import (
 
 func TestAnyWildcardResource(t *testing.T) {
 	assert.True(t, anyWildcardResource([]any{"arn:aws:s3:::bucket", "*"}))
+
+	// A service namespace wildcard names every resource of that kind in the
+	// account - every bucket, every secret - which is as broad as `*` within
+	// the service. This is the same `:*` test anyWildcardAction applies.
+	assert.True(t, anyWildcardResource([]any{"arn:aws:s3:::*"}))
+	assert.True(t, anyWildcardResource([]any{"arn:aws:secretsmanager:us-east-1:000000000000:secret:*"}))
+	assert.True(t, anyWildcardResource([]any{"arn:aws:s3:::bucket", "arn:aws:s3:::*"}))
+
+	// A path wildcard under a named resource is every object in one bucket,
+	// which is scoped to that bucket and is what a correct bucket policy looks
+	// like.
 	assert.False(t, anyWildcardResource([]any{"arn:aws:s3:::bucket/*"}))
+	assert.False(t, anyWildcardResource([]any{"arn:aws:s3:::bucket"}))
 	assert.False(t, anyWildcardResource([]any{}))
+	assert.False(t, anyWildcardResource([]any{42}))
 }
 
 func TestAnyWildcardAction(t *testing.T) {

--- a/providers/aws/resources/aws_policy_helpers_test.go
+++ b/providers/aws/resources/aws_policy_helpers_test.go
@@ -25,6 +25,10 @@ func TestAnyWildcardResource(t *testing.T) {
 	assert.True(t, anyWildcardResource([]any{"arn:aws:secretsmanager:us-east-1:000000000000:secret:*"}))
 	assert.True(t, anyWildcardResource([]any{"arn:aws:s3:::bucket", "arn:aws:s3:::*"}))
 
+	// An ARN that wildcards the account as well as the resource is broader
+	// still, not narrower, so it matches for the same reason.
+	assert.True(t, anyWildcardResource([]any{"arn:aws:iam::*:*"}))
+
 	// A path wildcard under a named resource is every object in one bucket,
 	// which is scoped to that bucket and is what a correct bucket policy looks
 	// like.


### PR DESCRIPTION
Two ways an IAM statement grants broadly went unreported by
`hasWildcardAction` / `hasWildcardResource`, so `hasWildcardAllow` returned
`false` on policies that are about as wide as a policy gets. Both live in the
same two functions, so they are fixed together rather than as two PRs editing
the same lines.

## 1. `NotAction` / `NotResource` were ignored

These fields invert the set the statement applies to:

```json
{"Effect": "Allow", "NotAction": ["iam:*"], "Resource": "*"}
```

That grants **every action in AWS except the IAM ones** — near-administrator —
and reported `hasWildcardAllow: false`, because only `Action` was consulted.

An exclusion list is broader than any wildcard the statement could have written
out, so its presence alone is enough. That is exactly the reading the sibling
`hasPublicPrincipal` already applies to `NotPrincipal`, and both fields are
already modeled in the schema (`notActions`, `notResources`) — nothing new to
fetch.

## 2. `anyWildcardResource` matched only a bare `*`

So `arn:aws:s3:::*` — every bucket in the account — read as scoped. Its sibling
`anyWildcardAction` has always handled the `:*` form; the two now agree.

### What deliberately still does not match

`arn:aws:s3:::my-bucket/*` is every object in **one** bucket. It is scoped to
that resource and is what a correctly written bucket policy looks like, so
matching it would fire on nearly every legitimate S3 policy. The existing test
in `aws_policy_helpers_test.go` already pinned that case and still passes — I
extended that test rather than adding a second one.

## Tests

- `TestAnyWildcardResource` (existing, extended): the `:*` form on S3 and Secrets Manager, mixed with specific ARNs, and the `/*` non-match kept.
- `TestPolicyStatementWildcardsThroughNegatedFields`: both predicates across specific / global-wildcard / service-wildcard / negated-field inputs.
- `TestStatementsAllowWildcardWithNegatedFields`: that the negated fields reach `hasWildcardAllow` through an `Allow` and stay out of it through a `Deny` — a `Deny` that excludes a set is a guardrail, not a grant.
