### PR TITLE
🐛 aws: read advanced event selectors in cloudtrail capturesAllManagementEvents

### DIFF
--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -422,15 +422,82 @@ func (a *mqlAwsCloudtrailTrail) getEventSelectorsData() (*cloudtrail.GetEventSel
 	return resp, nil
 }
 
-// capturesAllManagementEvents reports whether any event selector logs
-// management events for both read and write events (readWriteType "All").
+// Advanced event selector field names, and the event category that carries
+// management events. CloudTrail documents these as case-sensitive, but they are
+// compared case-insensitively here so a hand-written trail definition that
+// differs in case is not read as selecting nothing.
+const (
+	advancedSelectorFieldEventCategory = "eventCategory"
+	advancedSelectorFieldReadOnly      = "readOnly"
+	eventCategoryManagement            = "Management"
+)
+
+// containsFold reports whether values holds s, ignoring case.
+func containsFold(values []string, s string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// advancedSelectorsCaptureAllManagementEvents reports whether a set of advanced
+// event selectors logs management events for both reads and writes.
+//
+// An advanced selector says what it captures through its field selectors rather
+// than through a readWriteType enum: it selects management events with
+// `eventCategory Equals ["Management"]`, and it captures both directions unless
+// it also constrains `readOnly`, which narrows it to one of them. A selector
+// that constrains readOnly in any way - Equals, NotEquals or a prefix match -
+// therefore does not capture all management events on its own.
+func advancedSelectorsCaptureAllManagementEvents(selectors []types.AdvancedEventSelector) bool {
+	for _, sel := range selectors {
+		selectsManagement := false
+		restrictsReadOnly := false
+
+		for _, fs := range sel.FieldSelectors {
+			field := convert.ToValue(fs.Field)
+			switch {
+			case strings.EqualFold(field, advancedSelectorFieldEventCategory):
+				if containsFold(fs.Equals, eventCategoryManagement) {
+					selectsManagement = true
+				}
+			case strings.EqualFold(field, advancedSelectorFieldReadOnly):
+				restrictsReadOnly = restrictsReadOnly ||
+					len(fs.Equals) > 0 || len(fs.NotEquals) > 0 ||
+					len(fs.StartsWith) > 0 || len(fs.NotStartsWith) > 0 ||
+					len(fs.EndsWith) > 0 || len(fs.NotEndsWith) > 0
+			}
+		}
+
+		if selectsManagement && !restrictsReadOnly {
+			return true
+		}
+	}
+	return false
+}
+
+// capturesAllManagementEvents reports whether the trail logs management events
+// for both reads and writes.
+//
+// A trail configures that through one of two mutually exclusive mechanisms, and
+// GetEventSelectors returns whichever one the trail uses. Classic event
+// selectors say it with includeManagementEvents plus readWriteType "All";
+// advanced event selectors say it with field selectors, and are what
+// CloudFormation and Terraform produce. Reading only the classic ones reported
+// false for every trail configured the modern way, which is a false positive on
+// a compliant trail.
 func (a *mqlAwsCloudtrailTrail) capturesAllManagementEvents() (bool, error) {
 	entries := a.GetEventSelectorEntries()
 	if entries.Error != nil {
 		return false, entries.Error
 	}
 	for _, e := range entries.Data {
-		sel := e.(*mqlAwsCloudtrailTrailEventSelector)
+		sel, ok := e.(*mqlAwsCloudtrailTrailEventSelector)
+		if !ok {
+			continue
+		}
 		mgmt := sel.GetIncludeManagementEvents()
 		if mgmt.Error != nil {
 			return false, mgmt.Error
@@ -443,7 +510,12 @@ func (a *mqlAwsCloudtrailTrail) capturesAllManagementEvents() (bool, error) {
 			return true, nil
 		}
 	}
-	return false, nil
+
+	resp, err := a.getEventSelectorsData()
+	if err != nil {
+		return false, err
+	}
+	return advancedSelectorsCaptureAllManagementEvents(resp.AdvancedEventSelectors), nil
 }
 
 func (a *mqlAwsCloudtrailTrail) eventSelectorEntries() ([]any, error) {

--- a/providers/aws/resources/aws_cloudtrail_test.go
+++ b/providers/aws/resources/aws_cloudtrail_test.go
@@ -1,0 +1,151 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func fieldSelector(field string, equals ...string) types.AdvancedFieldSelector {
+	return types.AdvancedFieldSelector{Field: aws.String(field), Equals: equals}
+}
+
+// TestAdvancedSelectorsCaptureAllManagementEvents covers the mechanism a trail
+// configured through CloudFormation or Terraform uses. An advanced selector
+// says what it captures through its field selectors rather than through a
+// readWriteType enum: eventCategory Equals ["Management"] selects management
+// events, and the selector captures both reads and writes unless it also
+// constrains readOnly.
+func TestAdvancedSelectorsCaptureAllManagementEvents(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors []types.AdvancedEventSelector
+		expected  bool
+	}{
+		{
+			name:      "no advanced selectors",
+			selectors: nil,
+			expected:  false,
+		},
+		{
+			// The shape both CloudFormation and Terraform emit for a trail that
+			// logs all management events.
+			name: "management with no readOnly constraint",
+			selectors: []types.AdvancedEventSelector{{
+				Name:           aws.String("Management events"),
+				FieldSelectors: []types.AdvancedFieldSelector{fieldSelector("eventCategory", "Management")},
+			}},
+			expected: true,
+		},
+		{
+			name: "management restricted to read events",
+			selectors: []types.AdvancedEventSelector{{
+				FieldSelectors: []types.AdvancedFieldSelector{
+					fieldSelector("eventCategory", "Management"),
+					fieldSelector("readOnly", "true"),
+				},
+			}},
+			expected: false,
+		},
+		{
+			name: "management restricted to write events",
+			selectors: []types.AdvancedEventSelector{{
+				FieldSelectors: []types.AdvancedFieldSelector{
+					fieldSelector("eventCategory", "Management"),
+					fieldSelector("readOnly", "false"),
+				},
+			}},
+			expected: false,
+		},
+		{
+			// NotEquals narrows the selector just as Equals does, so it is not
+			// capturing both directions either.
+			name: "management with a negated readOnly constraint",
+			selectors: []types.AdvancedEventSelector{{
+				FieldSelectors: []types.AdvancedFieldSelector{
+					fieldSelector("eventCategory", "Management"),
+					{Field: aws.String("readOnly"), NotEquals: []string{"true"}},
+				},
+			}},
+			expected: false,
+		},
+		{
+			name: "data events only",
+			selectors: []types.AdvancedEventSelector{{
+				FieldSelectors: []types.AdvancedFieldSelector{
+					fieldSelector("eventCategory", "Data"),
+					fieldSelector("resources.type", "AWS::S3::Object"),
+				},
+			}},
+			expected: false,
+		},
+		{
+			// A trail commonly carries several selectors; one that qualifies is
+			// enough, and it must be found even when it is not the first.
+			name: "a qualifying selector alongside a data selector",
+			selectors: []types.AdvancedEventSelector{
+				{FieldSelectors: []types.AdvancedFieldSelector{
+					fieldSelector("eventCategory", "Data"),
+					fieldSelector("resources.type", "AWS::S3::Object"),
+				}},
+				{FieldSelectors: []types.AdvancedFieldSelector{fieldSelector("eventCategory", "Management")}},
+			},
+			expected: true,
+		},
+		{
+			name: "read-only and write-only management selectors do not combine",
+			selectors: []types.AdvancedEventSelector{
+				{FieldSelectors: []types.AdvancedFieldSelector{
+					fieldSelector("eventCategory", "Management"),
+					fieldSelector("readOnly", "true"),
+				}},
+				{FieldSelectors: []types.AdvancedFieldSelector{
+					fieldSelector("eventCategory", "Management"),
+					fieldSelector("readOnly", "false"),
+				}},
+			},
+			expected: false,
+		},
+		{
+			name: "field name in a different case",
+			selectors: []types.AdvancedEventSelector{{
+				FieldSelectors: []types.AdvancedFieldSelector{fieldSelector("eventcategory", "management")},
+			}},
+			expected: true,
+		},
+		{
+			// A selector with no field selectors at all selects nothing this
+			// predicate can vouch for.
+			name:      "selector with no field selectors",
+			selectors: []types.AdvancedEventSelector{{Name: aws.String("empty")}},
+			expected:  false,
+		},
+		{
+			// An absent Field must not be read as matching either name.
+			name: "field selector with no field name",
+			selectors: []types.AdvancedEventSelector{{
+				FieldSelectors: []types.AdvancedFieldSelector{{Equals: []string{"Management"}}},
+			}},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected,
+				advancedSelectorsCaptureAllManagementEvents(test.selectors))
+		})
+	}
+}
+
+func TestContainsFold(t *testing.T) {
+	assert.True(t, containsFold([]string{"Data", "Management"}, "Management"))
+	assert.True(t, containsFold([]string{"management"}, "Management"))
+	assert.False(t, containsFold([]string{"Data"}, "Management"))
+	assert.False(t, containsFold(nil, "Management"))
+}


### PR DESCRIPTION
A trail declares that it logs all management events through one of **two
mutually exclusive mechanisms**, and `GetEventSelectors` returns whichever one
the trail actually uses:

- **Classic event selectors** — `IncludeManagementEvents: true` plus `ReadWriteType: "All"`.
- **Advanced event selectors** — field selectors, and what CloudFormation and Terraform emit. Most trails managed as code use these.

`capturesAllManagementEvents` read only the classic list. For a trail
configured the modern way that list comes back **empty**, so the predicate
returned `false` on a trail that logs precisely what is being asked about — a
false positive on a compliant trail, which is the direction that costs the most
to chase down.

## What qualifies as an advanced selector that captures all management events

An advanced selector states what it captures through its field selectors rather
than through an enum. It qualifies when it:

1. selects `eventCategory Equals ["Management"]`, and
2. does **not** also constrain `readOnly`, since constraining that narrows it to reads or to writes.

Details that the tests pin:

- **Any** `readOnly` constraint disqualifies, not just `Equals` — a `NotEquals` or a prefix match narrows it just as much.
- A read-only selector and a write-only selector **do not add up** to one that covers both.
- A qualifying selector is found even when it is not the first in the list (trails commonly carry a data-events selector too).
- Field names compare case-insensitively, so a hand-written trail definition differing in case is not read as selecting nothing.
- A field selector with no `Field` set matches neither name.

## Cost

None. `advancedEventSelectors` was already modeled and reads from the same
cached `GetEventSelectors` response, so this adds no API calls.

## Tests

`TestAdvancedSelectorsCaptureAllManagementEvents` is a table over all of the
above, plus `TestContainsFold` for the case-insensitive membership helper.
