### PR TITLE
🐛 aws: look up a secret's cloudformation stack in the secret's own region

### DIFF
--- a/providers/aws/resources/aws_managed_by.go
+++ b/providers/aws/resources/aws_managed_by.go
@@ -303,7 +303,10 @@ func (a *mqlAwsSecretsmanagerSecret) managedBy() (string, error) {
 }
 
 func (a *mqlAwsSecretsmanagerSecret) cloudformationStack() (*mqlAwsCloudformationStack, error) {
-	return cloudformationStackFromResourceTags(a.MqlRuntime, a.GetPrimaryRegion().Data, a.GetTags(), &a.CloudformationStack)
+	// region, not primaryRegion: AWS returns primaryRegion only for a secret
+	// replicated to other regions, so for every other secret it is empty and
+	// the stack was looked for in the connection's default region.
+	return cloudformationStackFromResourceTags(a.MqlRuntime, a.Region.Data, a.GetTags(), &a.CloudformationStack)
 }
 
 func (a *mqlAwsEmrCluster) managedBy() (string, error) {


### PR DESCRIPTION
`aws.secretsmanager.secret.cloudformationStack` passed `GetPrimaryRegion()` as
the region to search for the managing stack.

The schema documents what that field actually is, on the line directly above
it:

```
// Primary region of the secret
primaryRegion string
```
```
// Region the secret lives in
//
// Distinct from `primaryRegion`, which AWS only returns for secrets that are
// replicated to other Regions and is empty for every other secret.
region string
```

So for every secret that is not cross-region replicated — nearly all of them —
that argument is `""`. An empty region sends the stack lookup to the
connection's default region, and the field reads **null** on a secret that is
demonstrably CloudFormation-managed.

In a single-region account the two regions coincide, which is why this went
unnoticed.

## The fix

Pass `Region` — the secret's own region, and what **all 26** sibling
`cloudformationStack()` accessors in this file pass.

The one other exception, `aws.emr.cluster`, parses the region out of the ARN
because EMR clusters carry no `region` field. That is deliberate and stays as
it is.

## Tests

No new pure-Go logic — this is a one-argument correction, and the resolver it
feeds (`cloudformationStackForTags`) needs a live runtime to observe. Verifying
it means querying a CloudFormation-managed secret outside the connection's
default region and seeing the stack resolve.
