### PR TITLE
🐛 aws: paginate the direct connect listers instead of truncating at 100

### DIFF
--- a/providers/aws/resources/aws_directconnect.go
+++ b/providers/aws/resources/aws_directconnect.go
@@ -57,6 +57,31 @@ func (a *mqlAwsDirectconnect) connections() ([]any, error) {
 	return res, nil
 }
 
+// walkPages drives a NextToken-paginated Direct Connect operation. fetch is
+// called once per page with the token for that page (nil for the first) and
+// returns the token the service handed back.
+//
+// The walk stops when the service stops handing back a token, and also when it
+// hands back the token it was just given. Direct Connect ships no paginator for
+// these operations, so the loop is hand-written, and a service that echoes the
+// request token would otherwise re-collect the same page forever.
+func walkPages(fetch func(nextToken *string) (*string, error)) error {
+	var token *string
+	for {
+		next, err := fetch(token)
+		if err != nil {
+			return err
+		}
+		if next == nil || *next == "" {
+			return nil
+		}
+		if token != nil && *next == *token {
+			return nil
+		}
+		token = next
+	}
+}
+
 func (a *mqlAwsDirectconnect) getConnections(conn *connection.AwsConnection) []*jobpool.Job {
 	tasks := make([]*jobpool.Job, 0)
 	regions, err := conn.Regions()
@@ -67,42 +92,54 @@ func (a *mqlAwsDirectconnect) getConnections(conn *connection.AwsConnection) []*
 		f := func() (jobpool.JobResult, error) {
 			svc := conn.DirectConnect(region)
 			res := []any{}
-			// DescribeConnections is not paginated; it returns every connection
-			// homed in the region in one response.
-			resp, err := svc.DescribeConnections(context.Background(), &directconnect.DescribeConnectionsInput{})
-			if err != nil {
-				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
-					log.Debug().Str("region", region).Msg("skipping direct connect connections for region")
-					return res, nil
-				}
-				return nil, err
-			}
-			for _, dcConn := range resp.Connections {
-				mqlDcConn, err := CreateResource(a.MqlRuntime, ResourceAwsDirectconnectConnection,
-					map[string]*llx.RawData{
-						"id":                   llx.StringDataPtr(dcConn.ConnectionId),
-						"name":                 llx.StringDataPtr(dcConn.ConnectionName),
-						"state":                llx.StringData(string(dcConn.ConnectionState)),
-						"location":             llx.StringDataPtr(dcConn.Location),
-						"bandwidth":            llx.StringDataPtr(dcConn.Bandwidth),
-						"vlan":                 llx.IntData(int64(dcConn.Vlan)),
-						"region":               llx.StringData(region),
-						"ownerAccount":         llx.StringDataPtr(dcConn.OwnerAccount),
-						"partnerName":          llx.StringDataPtr(dcConn.PartnerName),
-						"providerName":         llx.StringDataPtr(dcConn.ProviderName),
-						"macSecCapable":        llx.BoolDataPtr(dcConn.MacSecCapable),
-						"encryptionMode":       llx.StringDataPtr(dcConn.EncryptionMode),
-						"portEncryptionStatus": llx.StringDataPtr(dcConn.PortEncryptionStatus),
-						"jumboFrameCapable":    llx.BoolDataPtr(dcConn.JumboFrameCapable),
-						"hasLogicalRedundancy": llx.StringData(string(dcConn.HasLogicalRedundancy)),
-						"lagId":                llx.StringDataPtr(dcConn.LagId),
-						"awsDevice":            llx.StringDataPtr(dcConn.AwsDeviceV2),
-						"tags":                 llx.MapData(directConnectTagsToMap(dcConn.Tags), types.String),
-					})
+			// DescribeConnections caps a page at 100 and pages with NextToken.
+			skipRegion := false
+			err := walkPages(func(nextToken *string) (*string, error) {
+				resp, err := svc.DescribeConnections(context.Background(), &directconnect.DescribeConnectionsInput{
+					NextToken: nextToken,
+				})
 				if err != nil {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+						log.Debug().Str("region", region).Msg("skipping direct connect connections for region")
+						skipRegion = true
+						return nil, nil
+					}
 					return nil, err
 				}
-				res = append(res, mqlDcConn)
+				for _, dcConn := range resp.Connections {
+					mqlDcConn, err := CreateResource(a.MqlRuntime, ResourceAwsDirectconnectConnection,
+						map[string]*llx.RawData{
+							"id":                   llx.StringDataPtr(dcConn.ConnectionId),
+							"name":                 llx.StringDataPtr(dcConn.ConnectionName),
+							"state":                llx.StringData(string(dcConn.ConnectionState)),
+							"location":             llx.StringDataPtr(dcConn.Location),
+							"bandwidth":            llx.StringDataPtr(dcConn.Bandwidth),
+							"vlan":                 llx.IntData(int64(dcConn.Vlan)),
+							"region":               llx.StringData(region),
+							"ownerAccount":         llx.StringDataPtr(dcConn.OwnerAccount),
+							"partnerName":          llx.StringDataPtr(dcConn.PartnerName),
+							"providerName":         llx.StringDataPtr(dcConn.ProviderName),
+							"macSecCapable":        llx.BoolDataPtr(dcConn.MacSecCapable),
+							"encryptionMode":       llx.StringDataPtr(dcConn.EncryptionMode),
+							"portEncryptionStatus": llx.StringDataPtr(dcConn.PortEncryptionStatus),
+							"jumboFrameCapable":    llx.BoolDataPtr(dcConn.JumboFrameCapable),
+							"hasLogicalRedundancy": llx.StringData(string(dcConn.HasLogicalRedundancy)),
+							"lagId":                llx.StringDataPtr(dcConn.LagId),
+							"awsDevice":            llx.StringDataPtr(dcConn.AwsDeviceV2),
+							"tags":                 llx.MapData(directConnectTagsToMap(dcConn.Tags), types.String),
+						})
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlDcConn)
+				}
+				return resp.NextToken, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			if skipRegion {
+				return jobpool.JobResult([]any{}), nil
 			}
 			return jobpool.JobResult(res), nil
 		}
@@ -135,20 +172,35 @@ func (a *mqlAwsDirectconnect) getVirtualInterfaces(conn *connection.AwsConnectio
 		f := func() (jobpool.JobResult, error) {
 			svc := conn.DirectConnect(region)
 			res := []any{}
-			resp, err := svc.DescribeVirtualInterfaces(context.Background(), &directconnect.DescribeVirtualInterfacesInput{})
-			if err != nil {
-				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
-					log.Debug().Str("region", region).Msg("skipping direct connect virtual interfaces for region")
-					return res, nil
-				}
-				return nil, err
-			}
-			for _, vif := range resp.VirtualInterfaces {
-				mqlVif, err := newMqlAwsDirectconnectVirtualInterface(a.MqlRuntime, region, vif)
+			// DescribeVirtualInterfaces caps a page at 100 and pages with
+			// NextToken, and ships no paginator either.
+			skipRegion := false
+			err := walkPages(func(nextToken *string) (*string, error) {
+				resp, err := svc.DescribeVirtualInterfaces(context.Background(), &directconnect.DescribeVirtualInterfacesInput{
+					NextToken: nextToken,
+				})
 				if err != nil {
+					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+						log.Debug().Str("region", region).Msg("skipping direct connect virtual interfaces for region")
+						skipRegion = true
+						return nil, nil
+					}
 					return nil, err
 				}
-				res = append(res, mqlVif)
+				for _, vif := range resp.VirtualInterfaces {
+					mqlVif, err := newMqlAwsDirectconnectVirtualInterface(a.MqlRuntime, region, vif)
+					if err != nil {
+						return nil, err
+					}
+					res = append(res, mqlVif)
+				}
+				return resp.NextToken, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			if skipRegion {
+				return jobpool.JobResult([]any{}), nil
 			}
 			return jobpool.JobResult(res), nil
 		}

--- a/providers/aws/resources/aws_directconnect_test.go
+++ b/providers/aws/resources/aws_directconnect_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalkPages(t *testing.T) {
+	t.Run("a single page ends the walk", func(t *testing.T) {
+		var seen []*string
+		err := walkPages(func(nextToken *string) (*string, error) {
+			seen = append(seen, nextToken)
+			return nil, nil
+		})
+		require.NoError(t, err)
+		require.Len(t, seen, 1)
+		assert.Nil(t, seen[0], "the first page is requested with no token")
+	})
+
+	t.Run("every page is visited in order", func(t *testing.T) {
+		tokens := []*string{aws.String("page2"), aws.String("page3"), nil}
+		var seen []string
+		call := 0
+
+		err := walkPages(func(nextToken *string) (*string, error) {
+			seen = append(seen, aws.ToString(nextToken))
+			next := tokens[call]
+			call++
+			return next, nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"", "page2", "page3"}, seen)
+	})
+
+	t.Run("an empty token ends the walk", func(t *testing.T) {
+		calls := 0
+		err := walkPages(func(nextToken *string) (*string, error) {
+			calls++
+			return aws.String(""), nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls, "an empty token means no more pages, not another page")
+	})
+
+	t.Run("a repeated token ends the walk", func(t *testing.T) {
+		// A service that echoes back the token it was given would otherwise
+		// re-collect the same page forever. The guard has to hold whether or
+		// not the caller notices, so the walk must terminate on its own.
+		calls := 0
+		err := walkPages(func(nextToken *string) (*string, error) {
+			calls++
+			require.Less(t, calls, 10, "the walk did not terminate on a repeated token")
+			return aws.String("stuck"), nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, calls, "the first page, then the page that repeated its token")
+	})
+
+	t.Run("an error stops the walk and propagates", func(t *testing.T) {
+		boom := errors.New("throttled")
+		calls := 0
+
+		err := walkPages(func(nextToken *string) (*string, error) {
+			calls++
+			if calls == 2 {
+				return nil, boom
+			}
+			return aws.String("page2"), nil
+		})
+
+		require.ErrorIs(t, err, boom)
+		assert.Equal(t, 2, calls, "no page is fetched after the failure")
+	})
+}


### PR DESCRIPTION
Both Direct Connect listers made a **single unpaginated call**, under a comment
asserting that was correct:

```go
// DescribeConnections is not paginated; it returns every connection
// homed in the region in one response.
resp, err := svc.DescribeConnections(ctx, &directconnect.DescribeConnectionsInput{})
```

The SDK says otherwise. Both `DescribeConnections` and
`DescribeVirtualInterfaces` carry `NextToken` on input *and* output, and both
document the cap:

```go
// If MaxResults is given a value larger than 100, only 100 results are returned.
MaxResults *int32
NextToken *string
```

An account past 100 silently loses everything after the first page — no error,
nothing in the log to suggest the list is short.

## It propagates into the cross-references

`virtualInterface.connection()` and `connection.virtualInterfaces()` resolve by
filtering these same shared lists. So a virtual interface whose connection fell
off the end reports a **null connection**, and a connection reports only the
subset of its interfaces that made the cut — a wrong answer rather than a
missing one. Both are fixed by fixing the listers; neither needed a change of
its own.

## `walkPages`

The page walk is extracted so the two listers share one implementation and it
can be tested without a live client. It also stops when the service hands back
**the token it was just given**: no paginator ships for these operations, so
nothing upstream would catch a service that echoes the request token, and a
hand-written loop would re-collect the same page forever.

## Tests

`TestWalkPages` covers the single-page case, multi-page ordering (asserting the
first page is requested with no token), an empty-string token, an error
propagating and stopping the walk, and the stuck-cursor case — which asserts
termination rather than trusting it.
