### PR TITLE
🐛 aws: make a deleted application status check tell you it is deleted

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -17523,6 +17523,14 @@ private aws.ec2.applicationStatusCheck @defaults("id protocol port aggregation")
   createdAt time
   // Time the check was last modified
   lastUpdatedAt time
+  // Time the check was deleted
+  //
+  // Null for a live check. A deleted check stays visible for a grace period
+  // after deletion, so a query that wants only the checks currently guarding an
+  // application should filter on `deletedAt == null`.
+  deletedAt time
+  // Whether the check is deleted and only visible during its grace period
+  deleted bool
   // Resource tags
   tags map[string]string
   // Current per-instance results for this check

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22778,6 +22778,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.applicationStatusCheck.lastUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2ApplicationStatusCheck).GetLastUpdatedAt()).ToDataRes(types.Time)
 	},
+	"aws.ec2.applicationStatusCheck.deletedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2ApplicationStatusCheck).GetDeletedAt()).ToDataRes(types.Time)
+	},
+	"aws.ec2.applicationStatusCheck.deleted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2ApplicationStatusCheck).GetDeleted()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.applicationStatusCheck.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2ApplicationStatusCheck).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -62410,6 +62416,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.applicationStatusCheck.lastUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2ApplicationStatusCheck).LastUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.applicationStatusCheck.deletedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2ApplicationStatusCheck).DeletedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.applicationStatusCheck.deleted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2ApplicationStatusCheck).Deleted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.applicationStatusCheck.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -150478,6 +150492,8 @@ type mqlAwsEc2ApplicationStatusCheck struct {
 	TargetTags                       plugin.TValue[map[string]any]
 	CreatedAt                        plugin.TValue[*time.Time]
 	LastUpdatedAt                    plugin.TValue[*time.Time]
+	DeletedAt                        plugin.TValue[*time.Time]
+	Deleted                          plugin.TValue[bool]
 	Tags                             plugin.TValue[map[string]any]
 	Statuses                         plugin.TValue[[]any]
 }
@@ -150593,6 +150609,14 @@ func (c *mqlAwsEc2ApplicationStatusCheck) GetCreatedAt() *plugin.TValue[*time.Ti
 
 func (c *mqlAwsEc2ApplicationStatusCheck) GetLastUpdatedAt() *plugin.TValue[*time.Time] {
 	return &c.LastUpdatedAt
+}
+
+func (c *mqlAwsEc2ApplicationStatusCheck) GetDeletedAt() *plugin.TValue[*time.Time] {
+	return &c.DeletedAt
+}
+
+func (c *mqlAwsEc2ApplicationStatusCheck) GetDeleted() *plugin.TValue[bool] {
+	return &c.Deleted
 }
 
 func (c *mqlAwsEc2ApplicationStatusCheck) GetTags() *plugin.TValue[map[string]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3276,6 +3276,8 @@ aws.ec2.allowedImagesState 13.52.2
 aws.ec2.applicationStatusCheck 13.52.2
 aws.ec2.applicationStatusCheck.aggregation 13.52.2
 aws.ec2.applicationStatusCheck.createdAt 13.52.2
+aws.ec2.applicationStatusCheck.deleted 13.53.4
+aws.ec2.applicationStatusCheck.deletedAt 13.53.4
 aws.ec2.applicationStatusCheck.deviceIndex 13.52.2
 aws.ec2.applicationStatusCheck.failureThreshold 13.52.2
 aws.ec2.applicationStatusCheck.healthCheckPaths 13.52.2

--- a/providers/aws/resources/aws_ec2_application_status_check.go
+++ b/providers/aws/resources/aws_ec2_application_status_check.go
@@ -55,8 +55,10 @@ func (a *mqlAwsEc2) getApplicationStatusChecks(conn *connection.AwsConnection) [
 			res := []any{}
 
 			// The service ships no paginator for this operation, so the token
-			// loop is manual. IncludeAll returns checks that are not currently
-			// associated with any instance, which would otherwise be invisible.
+			// loop is manual. IncludeAll adds the checks that have been deleted
+			// and are still inside their post-deletion grace period; they are
+			// reported with deleted set, so a caller can tell them from the
+			// checks currently guarding an application.
 			var nextToken *string
 			for {
 				resp, err := svc.DescribeApplicationStatusChecks(ctx, &ec2.DescribeApplicationStatusChecksInput{
@@ -136,6 +138,8 @@ func newMqlAwsEc2ApplicationStatusCheck(runtime *plugin.Runtime, region string, 
 			"targetTags":                       llx.MapData(targetTags, mqltypes.String),
 			"createdAt":                        llx.TimeDataPtr(check.CreationTime),
 			"lastUpdatedAt":                    llx.TimeDataPtr(check.LastUpdatedAt),
+			"deletedAt":                        llx.TimeDataPtr(check.DeletionTime),
+			"deleted":                          llx.BoolData(check.DeletionTime != nil),
 			"tags":                             llx.MapData(toInterfaceMap(ec2TagsToMap(check.Tags)), mqltypes.String),
 		})
 	if err != nil {

--- a/providers/aws/resources/aws_ec2_application_status_check_test.go
+++ b/providers/aws/resources/aws_ec2_application_status_check_test.go
@@ -6,7 +6,10 @@ package resources
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,4 +34,41 @@ func TestApplicationStatusInstanceNullWhenNoInstanceId(t *testing.T) {
 func TestEc2InstanceArnPattern(t *testing.T) {
 	got := fmt.Sprintf(ec2InstanceArnPattern, "us-east-1", "123456789012", "i-1234567890abcdef0")
 	assert.Equal(t, "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0", got)
+}
+
+// ===== deletion visibility =====
+
+// The lister passes IncludeAll, so the response mixes live checks with ones
+// deleted recently enough to still be inside their grace period. These pin that
+// the two are distinguishable: a live check reports deleted false and leaves
+// deletedAt null, rather than reporting a zero time that reads as a real date.
+func TestApplicationStatusCheckDeletionFields(t *testing.T) {
+	deletedAt := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+
+	t.Run("live check", func(t *testing.T) {
+		res, err := newMqlAwsEc2ApplicationStatusCheck(testRuntime(), "us-east-1",
+			ec2types.ApplicationStatusCheckResponseObject{
+				ApplicationStatusCheckId: aws.String("asc-0123456789abcdef0"),
+			})
+		require.NoError(t, err)
+
+		check := res.(*mqlAwsEc2ApplicationStatusCheck)
+		assert.False(t, check.Deleted.Data)
+		assert.True(t, check.DeletedAt.IsNull(), "a live check has no deletion time")
+	})
+
+	t.Run("deleted check inside its grace period", func(t *testing.T) {
+		res, err := newMqlAwsEc2ApplicationStatusCheck(testRuntime(), "us-east-1",
+			ec2types.ApplicationStatusCheckResponseObject{
+				ApplicationStatusCheckId: aws.String("asc-0fedcba9876543210"),
+				DeletionTime:             &deletedAt,
+			})
+		require.NoError(t, err)
+
+		check := res.(*mqlAwsEc2ApplicationStatusCheck)
+		assert.True(t, check.Deleted.Data)
+		assert.False(t, check.DeletedAt.IsNull())
+		require.NotNil(t, check.DeletedAt.Data)
+		assert.Equal(t, deletedAt, *check.DeletedAt.Data)
+	})
 }


### PR DESCRIPTION
The lister passes `IncludeAll: true`, which the SDK documents as:

> Specifies whether to include recently deleted application status checks that
> remain available during the deletion grace period. If you omit this parameter
> or set it to `false`, the response includes only active checks.

Nothing modeled `DeletionTime`, so those deleted checks arrived in
`aws.ec2.applicationStatusChecks` **indistinguishable from the live ones**. A
query counting the checks guarding an application counted checks that had
stopped guarding anything, and the count only settled once the grace period
expired.

The comment on the call said something else entirely:

```go
// IncludeAll returns checks that are not currently
// associated with any instance, which would otherwise be invisible.
```

That is not what the parameter does — which is presumably why nobody went
looking for the discriminator.

## The fix

Two fields, both straight off `ApplicationStatusCheckResponseObject`:

- **`deletedAt time`** — the deletion time, and **null** for a live check rather than the zero time, which would report 1 January year 1 as a real date.
- **`deleted bool`** — the boolean a filter actually wants, so an audit writes `.where(deleted == false)` instead of relying on null comparison. Worth having separately given MQL's three-valued logic, where a null-based filter is easy to get subtly wrong.

## Why `IncludeAll` stays

A check deleted ten minutes ago is worth being able to see — it explains a gap
in coverage that a live-only listing would silently hide. What was missing was
the ability to *tell it apart*, which is what this adds. Dropping `IncludeAll`
instead would match the AWS default but throw that visibility away; happy to
switch if you'd rather have the narrower listing.

## Generated files

`.lr.versions` entries land at `13.53.4` (next patch after the shipped
`13.53.3`). `aws.permissions.json` is unchanged — no new API calls.

## Tests

`TestApplicationStatusCheckDeletionFields` covers a live check (`deleted`
false, `deletedAt` null) and one inside its grace period (`deleted` true,
`deletedAt` carrying the time).
