### PR TITLE
🐛 aws: read cloudtrail advanced selectors through the resource field

### DIFF
--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -432,14 +432,35 @@ const (
 	eventCategoryManagement            = "Management"
 )
 
-// containsFold reports whether values holds s, ignoring case.
-func containsFold(values []string, s string) bool {
+// containsFold reports whether values holds s, ignoring case. The elements are
+// the runtime's []any form of a string list.
+func containsFold(values []any, s string) bool {
 	for _, v := range values {
-		if strings.EqualFold(v, s) {
+		if str, ok := v.(string); ok && strings.EqualFold(str, s) {
 			return true
 		}
 	}
 	return false
+}
+
+// fieldSelectorConstrains reports whether a field selector places any condition
+// on its field. Every match kind counts: a NotEquals or a prefix match narrows
+// the selector just as an Equals does.
+func fieldSelectorConstrains(fs *mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector) (bool, error) {
+	for _, get := range []func() *plugin.TValue[[]any]{
+		fs.GetEquals, fs.GetNotEquals,
+		fs.GetStartsWith, fs.GetNotStartsWith,
+		fs.GetEndsWith, fs.GetNotEndsWith,
+	} {
+		values := get()
+		if values.Error != nil {
+			return false, values.Error
+		}
+		if len(values.Data) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // advancedSelectorsCaptureAllManagementEvents reports whether a set of advanced
@@ -448,34 +469,55 @@ func containsFold(values []string, s string) bool {
 // An advanced selector says what it captures through its field selectors rather
 // than through a readWriteType enum: it selects management events with
 // `eventCategory Equals ["Management"]`, and it captures both directions unless
-// it also constrains `readOnly`, which narrows it to one of them. A selector
-// that constrains readOnly in any way - Equals, NotEquals or a prefix match -
-// therefore does not capture all management events on its own.
-func advancedSelectorsCaptureAllManagementEvents(selectors []types.AdvancedEventSelector) bool {
-	for _, sel := range selectors {
+// it also constrains `readOnly`, which narrows it to one of them.
+func advancedSelectorsCaptureAllManagementEvents(selectors []any) (bool, error) {
+	for _, raw := range selectors {
+		sel, ok := raw.(*mqlAwsCloudtrailTrailAdvancedEventSelector)
+		if !ok {
+			continue
+		}
+
+		fieldSelectors := sel.GetFieldSelectors()
+		if fieldSelectors.Error != nil {
+			return false, fieldSelectors.Error
+		}
+
 		selectsManagement := false
 		restrictsReadOnly := false
 
-		for _, fs := range sel.FieldSelectors {
-			field := convert.ToValue(fs.Field)
+		for _, rawFs := range fieldSelectors.Data {
+			fs, ok := rawFs.(*mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector)
+			if !ok {
+				continue
+			}
+			field := fs.GetField()
+			if field.Error != nil {
+				return false, field.Error
+			}
+
 			switch {
-			case strings.EqualFold(field, advancedSelectorFieldEventCategory):
-				if containsFold(fs.Equals, eventCategoryManagement) {
+			case strings.EqualFold(field.Data, advancedSelectorFieldEventCategory):
+				equals := fs.GetEquals()
+				if equals.Error != nil {
+					return false, equals.Error
+				}
+				if containsFold(equals.Data, eventCategoryManagement) {
 					selectsManagement = true
 				}
-			case strings.EqualFold(field, advancedSelectorFieldReadOnly):
-				restrictsReadOnly = restrictsReadOnly ||
-					len(fs.Equals) > 0 || len(fs.NotEquals) > 0 ||
-					len(fs.StartsWith) > 0 || len(fs.NotStartsWith) > 0 ||
-					len(fs.EndsWith) > 0 || len(fs.NotEndsWith) > 0
+			case strings.EqualFold(field.Data, advancedSelectorFieldReadOnly):
+				constrains, err := fieldSelectorConstrains(fs)
+				if err != nil {
+					return false, err
+				}
+				restrictsReadOnly = restrictsReadOnly || constrains
 			}
 		}
 
 		if selectsManagement && !restrictsReadOnly {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // capturesAllManagementEvents reports whether the trail logs management events
@@ -511,11 +553,11 @@ func (a *mqlAwsCloudtrailTrail) capturesAllManagementEvents() (bool, error) {
 		}
 	}
 
-	resp, err := a.getEventSelectorsData()
-	if err != nil {
-		return false, err
+	advanced := a.GetAdvancedEventSelectors()
+	if advanced.Error != nil {
+		return false, advanced.Error
 	}
-	return advancedSelectorsCaptureAllManagementEvents(resp.AdvancedEventSelectors), nil
+	return advancedSelectorsCaptureAllManagementEvents(advanced.Data)
 }
 
 func (a *mqlAwsCloudtrailTrail) eventSelectorEntries() ([]any, error) {

--- a/providers/aws/resources/aws_cloudtrail_test.go
+++ b/providers/aws/resources/aws_cloudtrail_test.go
@@ -6,13 +6,57 @@ package resources
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
-func fieldSelector(field string, equals ...string) types.AdvancedFieldSelector {
-	return types.AdvancedFieldSelector{Field: aws.String(field), Equals: equals}
+// setAnyList builds a resolved list field so a resource method can be exercised
+// without a runtime: GetOrCompute returns a set value without calling compute.
+func setAnyList(values ...string) plugin.TValue[[]any] {
+	data := make([]any, 0, len(values))
+	for _, v := range values {
+		data = append(data, v)
+	}
+	return plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet}
+}
+
+// equalsSelector builds a field selector matching field against values.
+func equalsSelector(field string, values ...string) *mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector {
+	fs := &mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector{}
+	fs.Field = plugin.TValue[string]{Data: field, State: plugin.StateIsSet}
+	fs.Equals = setAnyList(values...)
+	fs.NotEquals = setAnyList()
+	fs.StartsWith = setAnyList()
+	fs.NotStartsWith = setAnyList()
+	fs.EndsWith = setAnyList()
+	fs.NotEndsWith = setAnyList()
+	return fs
+}
+
+// notEqualsSelector builds a field selector excluding values from field.
+func notEqualsSelector(field string, values ...string) *mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector {
+	fs := equalsSelector(field)
+	fs.NotEquals = setAnyList(values...)
+	return fs
+}
+
+func advancedSelector(fieldSelectors ...*mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector) *mqlAwsCloudtrailTrailAdvancedEventSelector {
+	data := make([]any, 0, len(fieldSelectors))
+	for _, fs := range fieldSelectors {
+		data = append(data, fs)
+	}
+	sel := &mqlAwsCloudtrailTrailAdvancedEventSelector{}
+	sel.FieldSelectors = plugin.TValue[[]any]{Data: data, State: plugin.StateIsSet}
+	return sel
+}
+
+func advancedSelectors(sels ...*mqlAwsCloudtrailTrailAdvancedEventSelector) []any {
+	data := make([]any, 0, len(sels))
+	for _, s := range sels {
+		data = append(data, s)
+	}
+	return data
 }
 
 // TestAdvancedSelectorsCaptureAllManagementEvents covers the mechanism a trail
@@ -24,7 +68,7 @@ func fieldSelector(field string, equals ...string) types.AdvancedFieldSelector {
 func TestAdvancedSelectorsCaptureAllManagementEvents(t *testing.T) {
 	tests := []struct {
 		name      string
-		selectors []types.AdvancedEventSelector
+		selectors []any
 		expected  bool
 	}{
 		{
@@ -35,117 +79,138 @@ func TestAdvancedSelectorsCaptureAllManagementEvents(t *testing.T) {
 		{
 			// The shape both CloudFormation and Terraform emit for a trail that
 			// logs all management events.
-			name: "management with no readOnly constraint",
-			selectors: []types.AdvancedEventSelector{{
-				Name:           aws.String("Management events"),
-				FieldSelectors: []types.AdvancedFieldSelector{fieldSelector("eventCategory", "Management")},
-			}},
-			expected: true,
+			name:      "management with no readOnly constraint",
+			selectors: advancedSelectors(advancedSelector(equalsSelector("eventCategory", "Management"))),
+			expected:  true,
 		},
 		{
 			name: "management restricted to read events",
-			selectors: []types.AdvancedEventSelector{{
-				FieldSelectors: []types.AdvancedFieldSelector{
-					fieldSelector("eventCategory", "Management"),
-					fieldSelector("readOnly", "true"),
-				},
-			}},
+			selectors: advancedSelectors(advancedSelector(
+				equalsSelector("eventCategory", "Management"),
+				equalsSelector("readOnly", "true"),
+			)),
 			expected: false,
 		},
 		{
 			name: "management restricted to write events",
-			selectors: []types.AdvancedEventSelector{{
-				FieldSelectors: []types.AdvancedFieldSelector{
-					fieldSelector("eventCategory", "Management"),
-					fieldSelector("readOnly", "false"),
-				},
-			}},
+			selectors: advancedSelectors(advancedSelector(
+				equalsSelector("eventCategory", "Management"),
+				equalsSelector("readOnly", "false"),
+			)),
 			expected: false,
 		},
 		{
 			// NotEquals narrows the selector just as Equals does, so it is not
 			// capturing both directions either.
 			name: "management with a negated readOnly constraint",
-			selectors: []types.AdvancedEventSelector{{
-				FieldSelectors: []types.AdvancedFieldSelector{
-					fieldSelector("eventCategory", "Management"),
-					{Field: aws.String("readOnly"), NotEquals: []string{"true"}},
-				},
-			}},
+			selectors: advancedSelectors(advancedSelector(
+				equalsSelector("eventCategory", "Management"),
+				notEqualsSelector("readOnly", "true"),
+			)),
 			expected: false,
 		},
 		{
 			name: "data events only",
-			selectors: []types.AdvancedEventSelector{{
-				FieldSelectors: []types.AdvancedFieldSelector{
-					fieldSelector("eventCategory", "Data"),
-					fieldSelector("resources.type", "AWS::S3::Object"),
-				},
-			}},
+			selectors: advancedSelectors(advancedSelector(
+				equalsSelector("eventCategory", "Data"),
+				equalsSelector("resources.type", "AWS::S3::Object"),
+			)),
 			expected: false,
 		},
 		{
 			// A trail commonly carries several selectors; one that qualifies is
 			// enough, and it must be found even when it is not the first.
 			name: "a qualifying selector alongside a data selector",
-			selectors: []types.AdvancedEventSelector{
-				{FieldSelectors: []types.AdvancedFieldSelector{
-					fieldSelector("eventCategory", "Data"),
-					fieldSelector("resources.type", "AWS::S3::Object"),
-				}},
-				{FieldSelectors: []types.AdvancedFieldSelector{fieldSelector("eventCategory", "Management")}},
-			},
+			selectors: advancedSelectors(
+				advancedSelector(
+					equalsSelector("eventCategory", "Data"),
+					equalsSelector("resources.type", "AWS::S3::Object"),
+				),
+				advancedSelector(equalsSelector("eventCategory", "Management")),
+			),
 			expected: true,
 		},
 		{
 			name: "read-only and write-only management selectors do not combine",
-			selectors: []types.AdvancedEventSelector{
-				{FieldSelectors: []types.AdvancedFieldSelector{
-					fieldSelector("eventCategory", "Management"),
-					fieldSelector("readOnly", "true"),
-				}},
-				{FieldSelectors: []types.AdvancedFieldSelector{
-					fieldSelector("eventCategory", "Management"),
-					fieldSelector("readOnly", "false"),
-				}},
-			},
+			selectors: advancedSelectors(
+				advancedSelector(
+					equalsSelector("eventCategory", "Management"),
+					equalsSelector("readOnly", "true"),
+				),
+				advancedSelector(
+					equalsSelector("eventCategory", "Management"),
+					equalsSelector("readOnly", "false"),
+				),
+			),
 			expected: false,
 		},
 		{
-			name: "field name in a different case",
-			selectors: []types.AdvancedEventSelector{{
-				FieldSelectors: []types.AdvancedFieldSelector{fieldSelector("eventcategory", "management")},
-			}},
-			expected: true,
+			name:      "field name in a different case",
+			selectors: advancedSelectors(advancedSelector(equalsSelector("eventcategory", "management"))),
+			expected:  true,
 		},
 		{
 			// A selector with no field selectors at all selects nothing this
 			// predicate can vouch for.
 			name:      "selector with no field selectors",
-			selectors: []types.AdvancedEventSelector{{Name: aws.String("empty")}},
+			selectors: advancedSelectors(advancedSelector()),
 			expected:  false,
 		},
 		{
-			// An absent Field must not be read as matching either name.
-			name: "field selector with no field name",
-			selectors: []types.AdvancedEventSelector{{
-				FieldSelectors: []types.AdvancedFieldSelector{{Equals: []string{"Management"}}},
-			}},
-			expected: false,
+			// An empty field name must not be read as matching either name.
+			name:      "field selector with no field name",
+			selectors: advancedSelectors(advancedSelector(equalsSelector("", "Management"))),
+			expected:  false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected,
-				advancedSelectorsCaptureAllManagementEvents(test.selectors))
+			got, err := advancedSelectorsCaptureAllManagementEvents(test.selectors)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestFieldSelectorConstrains(t *testing.T) {
+	t.Run("no condition at all", func(t *testing.T) {
+		got, err := fieldSelectorConstrains(equalsSelector("readOnly"))
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	// Every match kind narrows the selector, so every one of them counts.
+	for _, tc := range []struct {
+		name string
+		fs   *mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector
+	}{
+		{"equals", equalsSelector("readOnly", "true")},
+		{"notEquals", notEqualsSelector("readOnly", "true")},
+		{"startsWith", func() *mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector {
+			fs := equalsSelector("readOnly")
+			fs.StartsWith = setAnyList("t")
+			return fs
+		}()},
+		{"endsWith", func() *mqlAwsCloudtrailTrailAdvancedEventSelectorFieldSelector {
+			fs := equalsSelector("readOnly")
+			fs.EndsWith = setAnyList("e")
+			return fs
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fieldSelectorConstrains(tc.fs)
+			require.NoError(t, err)
+			assert.True(t, got)
 		})
 	}
 }
 
 func TestContainsFold(t *testing.T) {
-	assert.True(t, containsFold([]string{"Data", "Management"}, "Management"))
-	assert.True(t, containsFold([]string{"management"}, "Management"))
-	assert.False(t, containsFold([]string{"Data"}, "Management"))
+	assert.True(t, containsFold([]any{"Data", "Management"}, "Management"))
+	assert.True(t, containsFold([]any{"management"}, "Management"))
+	assert.False(t, containsFold([]any{"Data"}, "Management"))
 	assert.False(t, containsFold(nil, "Management"))
+	// A non-string element is not a match and must not panic.
+	assert.False(t, containsFold([]any{42}, "Management"))
 }

--- a/providers/aws/resources/aws_cloudtrail_trail_test.go
+++ b/providers/aws/resources/aws_cloudtrail_trail_test.go
@@ -18,6 +18,9 @@ func TestCapturesAllManagementEvents(t *testing.T) {
 		sel.ReadWriteType = plugin.TValue[string]{Data: readWriteType, State: plugin.StateIsSet}
 		return sel
 	}
+	// A trail uses classic or advanced selectors, never both, so these trails
+	// carry an empty advanced set. capturesAllManagementEvents consults both,
+	// and leaving the field unset would send it to the API for the answer.
 	trail := func(sels ...*mqlAwsCloudtrailTrailEventSelector) *mqlAwsCloudtrailTrail {
 		entries := make([]any, len(sels))
 		for i, s := range sels {
@@ -25,6 +28,7 @@ func TestCapturesAllManagementEvents(t *testing.T) {
 		}
 		tr := &mqlAwsCloudtrailTrail{}
 		tr.EventSelectorEntries = plugin.TValue[[]any]{Data: entries, State: plugin.StateIsSet}
+		tr.AdvancedEventSelectors = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
 		return tr
 	}
 
@@ -46,4 +50,19 @@ func TestCapturesAllManagementEvents(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+
+	// A trail configured through CloudFormation or Terraform has no classic
+	// selectors at all, and the answer has to come from the advanced ones.
+	t.Run("advanced selectors with no classic selectors", func(t *testing.T) {
+		tr := &mqlAwsCloudtrailTrail{}
+		tr.EventSelectorEntries = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+		tr.AdvancedEventSelectors = plugin.TValue[[]any]{
+			Data:  advancedSelectors(advancedSelector(equalsSelector("eventCategory", "Management"))),
+			State: plugin.StateIsSet,
+		}
+
+		got, err := tr.capturesAllManagementEvents()
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
 }


### PR DESCRIPTION
Fixes the `go-test-providers` failure introduced by #10202.

```
=== FAIL: resources TestCapturesAllManagementEvents/management_but_write_only
panic: runtime error: invalid memory address or nil pointer dereference
  resources.(*mqlAwsCloudtrailTrail).getEventSelectorsData
    providers/aws/resources/aws_cloudtrail.go:410
  resources.(*mqlAwsCloudtrailTrail).capturesAllManagementEvents
    providers/aws/resources/aws_cloudtrail.go:514
```

## What went wrong

#10202 taught `capturesAllManagementEvents` about advanced event selectors, but
read them off the **raw `GetEventSelectors` response** while the classic half
reads through the **resource field** `GetEventSelectorEntries()`.

`TestCapturesAllManagementEvents` builds a trail with its classic entries
pre-set and no runtime — exactly what a resource-level unit test should be able
to do — and the new branch went looking for a connection that was never there.

## It was wrong beyond the test

`GetAdvancedEventSelectors` is a resource field, so going around it skips two
things that field does: the resource cache, and the recording lookup
(`FieldResourceFromRecording`). A replayed scan would have gone to the network
for an answer the recording already held.

## The fix

Read both halves the same way. `advancedSelectorsCaptureAllManagementEvents`
now works over the field-selector resources rather than SDK structs, so the
predicate is uniform and every path goes through the runtime's own caching.

`fieldSelectorConstrains` is split out and checks **every** match kind, so a
`NotEquals` or a prefix match on `readOnly` narrows the selector just as an
`Equals` does.

## Tests

- The existing test now states its advanced set as **empty** rather than leaving it unset — which is what a trail using classic selectors actually has, and stops an unset field from sending the predicate to the API.
- It gains a case for the reverse: advanced selectors with **no** classic ones, the shape this whole change exists for.
- The table from #10202 is rebuilt over resources, and `TestFieldSelectorConstrains` covers each match kind.
