### PR TITLE
🐛 aws: report a log group that never expires as null retention, not zero

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -10765,7 +10765,19 @@ private aws.cloudwatch.loggroup @defaults("arn") {
   // When the log group was created
   createdAt time
   // Number of days to retain the log events in the specified log group
+  //
+  // Null when the log group never expires its events, which is what CloudWatch
+  // reports by returning no retention at all, and null again when the group
+  // lives in another account and its retention could not be read. A retention
+  // audit should treat null as "no expiry set" rather than compare it as a
+  // number: `retentionInDays >= 365` excludes exactly the groups that keep
+  // their logs forever.
   retentionInDays int
+  // Whether the log group keeps its events forever
+  //
+  // True when CloudWatch reports no retention on the group. Null when the
+  // retention could not be read, so an unread group is not reported as either.
+  neverExpires bool
   // Tags for the log group
   tags() map[string]string
   // CloudFormation stack that manages this log group, if any

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -16025,6 +16025,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.cloudwatch.loggroup.retentionInDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroup).GetRetentionInDays()).ToDataRes(types.Int)
 	},
+	"aws.cloudwatch.loggroup.neverExpires": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsCloudwatchLoggroup).GetNeverExpires()).ToDataRes(types.Bool)
+	},
 	"aws.cloudwatch.loggroup.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsCloudwatchLoggroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -52670,6 +52673,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.cloudwatch.loggroup.retentionInDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsCloudwatchLoggroup).RetentionInDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.cloudwatch.loggroup.neverExpires": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsCloudwatchLoggroup).NeverExpires, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.cloudwatch.loggroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -126268,6 +126275,7 @@ type mqlAwsCloudwatchLoggroup struct {
 	Region                    plugin.TValue[string]
 	CreatedAt                 plugin.TValue[*time.Time]
 	RetentionInDays           plugin.TValue[int64]
+	NeverExpires              plugin.TValue[bool]
 	Tags                      plugin.TValue[map[string]any]
 	CloudformationStack       plugin.TValue[*mqlAwsCloudformationStack]
 	ManagedBy                 plugin.TValue[string]
@@ -126399,6 +126407,10 @@ func (c *mqlAwsCloudwatchLoggroup) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlAwsCloudwatchLoggroup) GetRetentionInDays() *plugin.TValue[int64] {
 	return &c.RetentionInDays
+}
+
+func (c *mqlAwsCloudwatchLoggroup) GetNeverExpires() *plugin.TValue[bool] {
+	return &c.NeverExpires
 }
 
 func (c *mqlAwsCloudwatchLoggroup) GetTags() *plugin.TValue[map[string]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -2104,6 +2104,7 @@ aws.cloudwatch.loggroup.metricsfilter.metrics 11.15.2
 aws.cloudwatch.loggroup.metricsfilter.monitoredEventNames 13.33.2
 aws.cloudwatch.loggroup.metricsfilter.monitoredEventSources 13.33.2
 aws.cloudwatch.loggroup.name 11.15.2
+aws.cloudwatch.loggroup.neverExpires 13.53.4
 aws.cloudwatch.loggroup.region 11.15.2
 aws.cloudwatch.loggroup.resourcePolicy 13.26.3
 aws.cloudwatch.loggroup.retentionInDays 11.15.2

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -664,7 +664,13 @@ func buildLogGroupResource(runtime *plugin.Runtime, region string, loggroup clou
 	args["arn"] = llx.StringDataPtr(loggroup.Arn)
 	args["name"] = llx.StringDataPtr(loggroup.LogGroupName)
 	args["region"] = llx.StringData(region)
-	args["retentionInDays"] = llx.IntDataDefault(loggroup.RetentionInDays, 0)
+	// CloudWatch signals "never expire" by returning no retention at all.
+	// Defaulting that to 0 made the strongest retention read as the weakest, so
+	// `retentionInDays >= 365` excluded exactly the groups that keep their logs
+	// forever. Null is the honest reading, and neverExpires is what a filter
+	// can assert on directly.
+	args["retentionInDays"] = llx.IntDataPtr(loggroup.RetentionInDays)
+	args["neverExpires"] = llx.BoolData(loggroup.RetentionInDays == nil)
 	args["createdAt"] = llx.TimeDataPtr(int64MillisToTime(loggroup.CreationTime))
 	args["dataProtectionStatus"] = llx.StringData(string(loggroup.DataProtectionStatus))
 	args["deletionProtectionEnabled"] = llx.BoolDataPtr(loggroup.DeletionProtectionEnabled)
@@ -801,8 +807,12 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 		}
 		args["name"] = llx.StringData(groupName)
 		args["region"] = llx.StringData(grpRegion)
-		args["retentionInDays"] = llx.IntData(-1)
-		args["storedBytes"] = llx.IntData(-1)
+		// Nothing about this group was read, so neither field has a value to
+		// report. -1 was a second sentinel for the same field, which arithmetic
+		// accepts as silently as 0 did.
+		args["retentionInDays"] = llx.NilData
+		args["neverExpires"] = llx.NilData
+		args["storedBytes"] = llx.NilData
 		args["dataProtectionStatus"] = llx.StringData("")
 		args["deletionProtectionEnabled"] = llx.BoolData(false)
 		args["logGroupClass"] = llx.StringData("")

--- a/providers/aws/resources/aws_cloudwatch_test.go
+++ b/providers/aws/resources/aws_cloudwatch_test.go
@@ -6,7 +6,10 @@ package resources
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseLogGroupArn(t *testing.T) {
@@ -67,4 +70,36 @@ func TestParseLogGroupArn(t *testing.T) {
 			assert.Equal(t, tt.expectGroup, groupName)
 		})
 	}
+}
+
+// TestBuildLogGroupResourceRetention pins how a log group reports its
+// retention. CloudWatch signals "never expire" by returning no retention at
+// all, so defaulting that to 0 put the strongest retention at the bottom of
+// any numeric comparison: `retentionInDays >= 365` excluded exactly the groups
+// that keep their logs forever.
+func TestBuildLogGroupResourceRetention(t *testing.T) {
+	t.Run("a group with a retention reports it", func(t *testing.T) {
+		lg, err := buildLogGroupResource(testRuntime(), "us-east-1", cloudwatchlogstypes.LogGroup{
+			Arn:             aws.String("arn:aws:logs:us-east-1:000000000000:log-group:/aws/lambda/fn:*"),
+			LogGroupName:    aws.String("/aws/lambda/fn"),
+			RetentionInDays: aws.Int32(365),
+		})
+		require.NoError(t, err)
+
+		assert.False(t, lg.RetentionInDays.IsNull())
+		assert.Equal(t, int64(365), lg.RetentionInDays.Data)
+		assert.False(t, lg.NeverExpires.Data)
+	})
+
+	t.Run("a group that never expires reports null, not zero", func(t *testing.T) {
+		lg, err := buildLogGroupResource(testRuntime(), "us-east-1", cloudwatchlogstypes.LogGroup{
+			Arn:          aws.String("arn:aws:logs:us-east-1:000000000000:log-group:/aws/lambda/forever:*"),
+			LogGroupName: aws.String("/aws/lambda/forever"),
+		})
+		require.NoError(t, err)
+
+		assert.True(t, lg.RetentionInDays.IsNull(),
+			"no retention means no expiry, which is not a retention of zero days")
+		assert.True(t, lg.NeverExpires.Data)
+	})
 }


### PR DESCRIPTION
CloudWatch signals "these events never expire" by returning **no retention** on
the log group. `buildLogGroupResource` turned that into `0`:

```go
args["retentionInDays"] = llx.IntDataDefault(loggroup.RetentionInDays, 0)
```

So the strongest retention in the account sorted below the weakest, and the
obvious audit query excluded exactly the groups it was looking for:

```
aws.cloudwatch.logGroups.where(retentionInDays >= 365)
```

`0` is not a value CloudWatch can return, either — valid retentions start at 1
day — so it was only ever a sentinel, and one that arithmetic accepts as
silently as a real answer.

## Two sentinels, one field

The cross-account placeholder path used a **second** sentinel for the same
field, meaning something different again:

```go
args["retentionInDays"] = llx.IntData(-1)   // group is in another account, nothing was read
args["storedBytes"]     = llx.IntData(-1)
```

Two sentinels on one int, neither distinguishable from a real answer.

## The fix

- **`retentionInDays`** is **null** when CloudWatch reports no retention, and null again on the cross-account placeholder. Both are honestly "no number to report". `storedBytes` on the placeholder goes null for the same reason.
- **`neverExpires bool`** is new, and carries the case that has a positive answer. A filter says `neverExpires` directly rather than comparing against null — which matters here, because MQL's three-valued logic makes a null-based filter easy to get subtly wrong.

The name matches the existing `neverExpires` on `aws.cloudhsm.backup`.

## Compatibility

`retentionInDays` keeps its type (`int`) and its `.lr.versions` entry — this
changes which *value* an absent retention maps to, from a sentinel to null. A
query that compared it numerically was getting a wrong answer for those groups
before; it now gets null instead of a misleading `0`.

Nothing else in the provider reads `RetentionInDays`, and no query pack in
`content/` references it.

## Tests

`TestBuildLogGroupResourceRetention` covers a group with a retention (value
present, `neverExpires` false) and one without (retention **null**, not zero,
`neverExpires` true).
