### PR TITLE
🐛 aws: list waf across every region and both scopes

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -860,7 +860,11 @@ aws.waf {
   ipSets() []aws.waf.ipset
   // List of WAF regex pattern sets
   regexPatternSets() []aws.waf.regexPatternSet
-  // Scope either REGIONAL or CLOUDFRONT
+  // Scope the resources are listed for
+  //
+  // Either REGIONAL or CLOUDFRONT. Empty when no scope was given, which lists
+  // both: CloudFront web ACLs live only in us-east-1, while regional ones are
+  // per-region, so neither scope on its own describes an account's WAF estate.
   scope string
 }
 
@@ -904,6 +908,13 @@ private aws.waf.acl @defaults("name") {
   rules() []aws.waf.rule
   // Scope either REGIONAL or CLOUDFRONT
   scope string
+  // Region the resource lives in
+  //
+  // us-east-1 for a CLOUDFRONT-scoped resource, which is where WAF keeps
+  // them regardless of where the distribution serves from. The resource's
+  // own region for a REGIONAL one, and the region every detail call about
+  // it has to be made in.
+  region string
   // Logging configuration for the ACL
   loggingConfiguration() aws.waf.acl.loggingConfiguration
   // ARNs of resources associated with this web ACL
@@ -937,6 +948,13 @@ private aws.waf.rulegroup @defaults("name") {
   rules() []aws.waf.rule
   // Scope either REGIONAL or CLOUDFRONT
   scope string
+  // Region the resource lives in
+  //
+  // us-east-1 for a CLOUDFRONT-scoped resource, which is where WAF keeps
+  // them regardless of where the distribution serves from. The resource's
+  // own region for a REGIONAL one, and the region every detail call about
+  // it has to be made in.
+  region string
   // Tags on the rule group
   tags() map[string]string
 }
@@ -1360,6 +1378,13 @@ private aws.waf.ipset @defaults("name") {
   id string
   // Scope: REGIONAL or CLOUDFRONT
   scope string
+  // Region the resource lives in
+  //
+  // us-east-1 for a CLOUDFRONT-scoped resource, which is where WAF keeps
+  // them regardless of where the distribution serves from. The resource's
+  // own region for a REGIONAL one, and the region every detail call about
+  // it has to be made in.
+  region string
   // Name of the IP set
   name string
   // Description of the IP set
@@ -1384,6 +1409,13 @@ private aws.waf.regexPatternSet @defaults("name") {
   id string
   // Scope: REGIONAL or CLOUDFRONT
   scope string
+  // Region the resource lives in
+  //
+  // us-east-1 for a CLOUDFRONT-scoped resource, which is where WAF keeps
+  // them regardless of where the distribution serves from. The resource's
+  // own region for a REGIONAL one, and the region every detail call about
+  // it has to be made in.
+  region string
   // Name of the regex pattern set
   name string
   // Description of the regex pattern set

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5735,6 +5735,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.waf.acl.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafAcl).GetScope()).ToDataRes(types.String)
 	},
+	"aws.waf.acl.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafAcl).GetRegion()).ToDataRes(types.String)
+	},
 	"aws.waf.acl.loggingConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafAcl).GetLoggingConfiguration()).ToDataRes(types.Resource("aws.waf.acl.loggingConfiguration"))
 	},
@@ -5764,6 +5767,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.waf.rulegroup.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRulegroup).GetScope()).ToDataRes(types.String)
+	},
+	"aws.waf.rulegroup.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafRulegroup).GetRegion()).ToDataRes(types.String)
 	},
 	"aws.waf.rulegroup.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRulegroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -6197,6 +6203,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.waf.ipset.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafIpset).GetScope()).ToDataRes(types.String)
 	},
+	"aws.waf.ipset.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafIpset).GetRegion()).ToDataRes(types.String)
+	},
 	"aws.waf.ipset.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafIpset).GetName()).ToDataRes(types.String)
 	},
@@ -6220,6 +6229,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.waf.regexPatternSet.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRegexPatternSet).GetScope()).ToDataRes(types.String)
+	},
+	"aws.waf.regexPatternSet.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafRegexPatternSet).GetRegion()).ToDataRes(types.String)
 	},
 	"aws.waf.regexPatternSet.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRegexPatternSet).GetName()).ToDataRes(types.String)
@@ -37536,6 +37548,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWafAcl).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.waf.acl.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafAcl).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.waf.acl.loggingConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafAcl).LoggingConfiguration, ok = plugin.RawToTValue[*mqlAwsWafAclLoggingConfiguration](v.Value, v.Error)
 		return
@@ -37578,6 +37594,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.waf.rulegroup.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRulegroup).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.waf.rulegroup.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafRulegroup).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.waf.rulegroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -38280,6 +38300,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWafIpset).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.waf.ipset.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafIpset).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"aws.waf.ipset.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafIpset).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -38314,6 +38338,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.waf.regexPatternSet.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRegexPatternSet).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.waf.regexPatternSet.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafRegexPatternSet).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.waf.regexPatternSet.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -85303,6 +85331,7 @@ type mqlAwsWafAcl struct {
 	LabelNamespace           plugin.TValue[string]
 	Rules                    plugin.TValue[[]any]
 	Scope                    plugin.TValue[string]
+	Region                   plugin.TValue[string]
 	LoggingConfiguration     plugin.TValue[*mqlAwsWafAclLoggingConfiguration]
 	AssociatedResources      plugin.TValue[[]any]
 	AssociatedLoadBalancers  plugin.TValue[[]any]
@@ -85418,6 +85447,10 @@ func (c *mqlAwsWafAcl) GetScope() *plugin.TValue[string] {
 	return &c.Scope
 }
 
+func (c *mqlAwsWafAcl) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
 func (c *mqlAwsWafAcl) GetLoggingConfiguration() *plugin.TValue[*mqlAwsWafAclLoggingConfiguration] {
 	return plugin.GetOrCompute[*mqlAwsWafAclLoggingConfiguration](&c.LoggingConfiguration, func() (*mqlAwsWafAclLoggingConfiguration, error) {
 		if c.MqlRuntime.HasRecording {
@@ -85473,6 +85506,7 @@ type mqlAwsWafRulegroup struct {
 	Description plugin.TValue[string]
 	Rules       plugin.TValue[[]any]
 	Scope       plugin.TValue[string]
+	Region      plugin.TValue[string]
 	Tags        plugin.TValue[map[string]any]
 }
 
@@ -85547,6 +85581,10 @@ func (c *mqlAwsWafRulegroup) GetRules() *plugin.TValue[[]any] {
 
 func (c *mqlAwsWafRulegroup) GetScope() *plugin.TValue[string] {
 	return &c.Scope
+}
+
+func (c *mqlAwsWafRulegroup) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 func (c *mqlAwsWafRulegroup) GetTags() *plugin.TValue[map[string]any] {
@@ -87573,6 +87611,7 @@ type mqlAwsWafIpset struct {
 	Arn         plugin.TValue[string]
 	Id          plugin.TValue[string]
 	Scope       plugin.TValue[string]
+	Region      plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
 	AddressType plugin.TValue[string]
@@ -87629,6 +87668,10 @@ func (c *mqlAwsWafIpset) GetScope() *plugin.TValue[string] {
 	return &c.Scope
 }
 
+func (c *mqlAwsWafIpset) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
 func (c *mqlAwsWafIpset) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -87663,6 +87706,7 @@ type mqlAwsWafRegexPatternSet struct {
 	Arn                plugin.TValue[string]
 	Id                 plugin.TValue[string]
 	Scope              plugin.TValue[string]
+	Region             plugin.TValue[string]
 	Name               plugin.TValue[string]
 	Description        plugin.TValue[string]
 	RegularExpressions plugin.TValue[[]any]
@@ -87716,6 +87760,10 @@ func (c *mqlAwsWafRegexPatternSet) GetId() *plugin.TValue[string] {
 
 func (c *mqlAwsWafRegexPatternSet) GetScope() *plugin.TValue[string] {
 	return &c.Scope
+}
+
+func (c *mqlAwsWafRegexPatternSet) GetRegion() *plugin.TValue[string] {
+	return &c.Region
 }
 
 func (c *mqlAwsWafRegexPatternSet) GetName() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -10950,6 +10950,7 @@ aws.waf.acl.loggingConfiguration.managedByFirewallManager 11.16.1
 aws.waf.acl.loggingConfiguration.redactedFields 11.16.1
 aws.waf.acl.managedByFirewallManager 11.15.2
 aws.waf.acl.name 11.15.2
+aws.waf.acl.region 13.53.4
 aws.waf.acl.rules 11.15.2
 aws.waf.acl.scope 11.15.2
 aws.waf.acl.tags 13.49.1
@@ -10964,6 +10965,7 @@ aws.waf.ipset.arn 11.15.2
 aws.waf.ipset.description 11.15.2
 aws.waf.ipset.id 11.15.2
 aws.waf.ipset.name 11.15.2
+aws.waf.ipset.region 13.53.4
 aws.waf.ipset.scope 11.15.2
 aws.waf.ipset.tags 13.49.1
 aws.waf.regexPatternSet 11.16.1
@@ -10971,6 +10973,7 @@ aws.waf.regexPatternSet.arn 11.16.1
 aws.waf.regexPatternSet.description 11.16.1
 aws.waf.regexPatternSet.id 11.16.1
 aws.waf.regexPatternSet.name 11.16.1
+aws.waf.regexPatternSet.region 13.53.4
 aws.waf.regexPatternSet.regularExpressions 11.16.1
 aws.waf.regexPatternSet.scope 11.16.1
 aws.waf.regexPatternSet.tags 13.49.1
@@ -11146,6 +11149,7 @@ aws.waf.rulegroup.arn 11.15.2
 aws.waf.rulegroup.description 11.15.2
 aws.waf.rulegroup.id 11.15.2
 aws.waf.rulegroup.name 11.15.2
+aws.waf.rulegroup.region 13.53.4
 aws.waf.rulegroup.rules 11.15.2
 aws.waf.rulegroup.scope 11.15.2
 aws.waf.rulegroup.tags 13.49.1

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
 	waftypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 	"github.com/google/uuid"
@@ -21,13 +20,36 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
-// wafRegionForScope returns the region to use for WAF API calls.
-// CLOUDFRONT-scoped resources must use us-east-1; REGIONAL uses the default.
-func wafRegionForScope(scope string) string {
-	if scope == "CLOUDFRONT" {
-		return "us-east-1"
+const (
+	wafScopeCloudfront = "CLOUDFRONT"
+	wafScopeRegional   = "REGIONAL"
+
+	// WAF keeps every CLOUDFRONT-scoped resource in us-east-1, whatever regions
+	// the distribution serves from.
+	wafCloudfrontRegion = "us-east-1"
+)
+
+// wafScopesFor returns the scopes to list for. An explicit scope lists only
+// itself; no scope lists both, because CloudFront and regional web ACLs are
+// separate estates and neither on its own describes an account's WAF posture.
+func wafScopesFor(scope string) []string {
+	switch scope {
+	case wafScopeCloudfront, wafScopeRegional:
+		return []string{scope}
+	default:
+		return []string{wafScopeCloudfront, wafScopeRegional}
 	}
-	return ""
+}
+
+// wafRegionsFor returns the regions a scope has to be queried in. CLOUDFRONT
+// lives in one region; REGIONAL is per-region, so it takes the connection's
+// whole region list - querying only the default region reported an empty WAF
+// estate for every account whose ACLs live anywhere else.
+func wafRegionsFor(conn *connection.AwsConnection, scope string) ([]string, error) {
+	if scope == wafScopeCloudfront {
+		return []string{wafCloudfrontRegion}, nil
+	}
+	return conn.Regions()
 }
 
 // id includes the scope: aws.waf is parameterized on it, so a constant key made
@@ -37,13 +59,13 @@ func (a *mqlAwsWaf) id() (string, error) {
 	return "aws.waf/" + a.Scope.Data, nil
 }
 
-// wafTagsForArn lists the tags on a WAF resource, resolving the WAF endpoint
-// from the resource's scope. A missing wafv2:ListTagsForResource permission is
-// reported as errTagsUnreadable, which each caller turns into a null tags
-// field rather than an empty one.
-func wafTagsForArn(runtime *plugin.Runtime, scope, arn string) (map[string]any, error) {
+// wafTagsForArn lists the tags on a WAF resource in the region that holds it.
+// A missing wafv2:ListTagsForResource permission is reported as
+// errTagsUnreadable, which each caller turns into a null tags field rather than
+// an empty one.
+func wafTagsForArn(runtime *plugin.Runtime, region, arn string) (map[string]any, error) {
 	conn := runtime.Connection.(*connection.AwsConnection)
-	svc := conn.Wafv2(wafRegionForScope(scope))
+	svc := conn.Wafv2(region)
 	ctx := context.Background()
 
 	tags := map[string]any{}
@@ -79,22 +101,22 @@ func wafTagsForArn(runtime *plugin.Runtime, scope, arn string) (map[string]any, 
 }
 
 func (a *mqlAwsWafAcl) tags() (map[string]any, error) {
-	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsWafRulegroup) tags() (map[string]any, error) {
-	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsWafIpset) tags() (map[string]any, error) {
-	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
 func (a *mqlAwsWafRegexPatternSet) tags() (map[string]any, error) {
-	tags, err := wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+	tags, err := wafTagsForArn(a.MqlRuntime, a.Region.Data, a.Arn.Data)
 	return tagsOrUnreadable(&a.Tags, tags, err)
 }
 
@@ -121,7 +143,7 @@ func (a *mqlAwsWafAcl) fetchACLDetails() error {
 	}
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Wafv2(wafRegionForScope(a.Scope.Data))
+	svc := conn.Wafv2(a.Region.Data)
 	ctx := context.Background()
 
 	resp, err := svc.GetWebACL(ctx, &wafv2.GetWebACLInput{
@@ -299,7 +321,7 @@ func (a *mqlAwsWafIpset) fetchIPSet() error {
 	}
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Wafv2(wafRegionForScope(a.Scope.Data))
+	svc := conn.Wafv2(a.Region.Data)
 	ctx := context.Background()
 
 	resp, err := svc.GetIPSet(ctx, &wafv2.GetIPSetInput{
@@ -338,57 +360,98 @@ func initAwsWaf(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 		return args, nil, nil
 	}
 
+	// No scope means both. Defaulting to CLOUDFRONT reported an empty WAF
+	// estate for every account whose web ACLs are regional, which is most of
+	// them, and said nothing about having only looked at one half.
 	scope := ""
 	if x, ok := args["scope"]; ok {
-		scope = x.Value.(string)
-	} else {
-		scope = "CLOUDFRONT"
+		scope, _ = x.Value.(string)
 	}
 	args["scope"] = llx.StringData(scope)
 
-	log.Debug().Msgf("AWS WAF using scope: %s", scope)
+	log.Debug().Str("scope", scope).Msg("aws waf scope")
 
 	return args, nil, nil
+}
+
+// wafAcross runs fn once for every scope and region in play and concatenates
+// the results. CLOUDFRONT contributes one region; REGIONAL contributes the
+// connection's whole region list. forRegions does the per-region work, so a
+// region where WAF is unavailable contributes nothing, a region the caller may
+// not read is recorded as a coverage gap, and one bad region does not discard
+// the rest.
+//
+// A scope that fails outright does not discard the other one either: the error
+// is only returned when neither scope produced anything.
+func wafAcross(conn *connection.AwsConnection, scope string,
+	fn func(ctx context.Context, scope, region string) ([]any, error),
+) ([]any, error) {
+	res := []any{}
+	var firstErr error
+
+	for _, s := range wafScopesFor(scope) {
+		regions, err := wafRegionsFor(conn, s)
+		if err != nil {
+			return nil, err
+		}
+
+		items, err := forRegions(conn, "wafv2", regions,
+			func(ctx context.Context, region string) ([]any, error) {
+				return fn(ctx, s, region)
+			})
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		res = append(res, items...)
+	}
+
+	if firstErr != nil && len(res) == 0 {
+		return nil, firstErr
+	}
+	return res, nil
 }
 
 func (a *mqlAwsWaf) acls() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	scopeString := a.Scope.Data
-	svc := conn.Wafv2(wafRegionForScope(scopeString))
-	ctx := context.Background()
-	acls := []any{}
-	nextMarker := aws.String("No-Marker-to-begin-with")
-	scope := waftypes.Scope(scopeString)
-	params := &wafv2.ListWebACLsInput{Scope: scope}
-	for nextMarker != nil {
-		aclsRes, err := svc.ListWebACLs(ctx, params)
-		if err != nil {
-			return nil, err
-		}
-		nextMarker = aclsRes.NextMarker
-		if aclsRes.NextMarker != nil {
-			params.NextMarker = nextMarker
-		}
-
-		for _, acl := range aclsRes.WebACLs {
-			mqlAcl, err := CreateResource(a.MqlRuntime, "aws.waf.acl",
-				map[string]*llx.RawData{
-					"__id":        llx.StringDataPtr(acl.ARN),
-					"id":          llx.StringDataPtr(acl.Id),
-					"scope":       llx.StringData(scopeString),
-					"arn":         llx.StringDataPtr(acl.ARN),
-					"name":        llx.StringDataPtr(acl.Name),
-					"description": llx.StringDataPtr(acl.Description),
-				},
-			)
+	return wafAcross(conn, a.Scope.Data, func(ctx context.Context, scope, region string) ([]any, error) {
+		svc := conn.Wafv2(region)
+		acls := []any{}
+		params := &wafv2.ListWebACLsInput{Scope: waftypes.Scope(scope)}
+		for {
+			aclsRes, err := svc.ListWebACLs(ctx, params)
 			if err != nil {
 				return nil, err
 			}
-			acls = append(acls, mqlAcl)
+
+			for _, acl := range aclsRes.WebACLs {
+				mqlAcl, err := CreateResource(a.MqlRuntime, "aws.waf.acl",
+					map[string]*llx.RawData{
+						"__id":        llx.StringDataPtr(acl.ARN),
+						"id":          llx.StringDataPtr(acl.Id),
+						"scope":       llx.StringData(scope),
+						"region":      llx.StringData(region),
+						"arn":         llx.StringDataPtr(acl.ARN),
+						"name":        llx.StringDataPtr(acl.Name),
+						"description": llx.StringDataPtr(acl.Description),
+					},
+				)
+				if err != nil {
+					return nil, err
+				}
+				acls = append(acls, mqlAcl)
+			}
+
+			if aclsRes.NextMarker == nil {
+				break
+			}
+			params.NextMarker = aclsRes.NextMarker
 		}
-	}
-	return acls, nil
+		return acls, nil
+	})
 }
 
 func (a *mqlAwsWafRuleStatementSqlimatchstatement) id() (string, error) {
@@ -498,10 +561,9 @@ func (a *mqlAwsWafRuleFieldtomatchJa3fingerprint) id() (string, error) {
 func (a *mqlAwsWafRulegroup) rules() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	scopeString := a.Scope.Data
-	scope := waftypes.Scope(scopeString)
+	scope := waftypes.Scope(a.Scope.Data)
 	ctx := context.Background()
-	svc := conn.Wafv2(wafRegionForScope(scopeString))
+	svc := conn.Wafv2(a.Region.Data)
 	rules := []any{}
 	params := &wafv2.GetRuleGroupInput{
 		Id:    &a.Id.Data,
@@ -553,81 +615,81 @@ func (a *mqlAwsWafRulegroup) rules() ([]any, error) {
 func (a *mqlAwsWaf) ruleGroups() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	scopeString := a.Scope.Data
-	svc := conn.Wafv2(wafRegionForScope(scopeString))
-	ctx := context.Background()
-	acls := []any{}
-	nextMarker := aws.String("No-Marker-to-begin-with")
-	scope := waftypes.Scope(scopeString)
-	params := &wafv2.ListRuleGroupsInput{Scope: scope}
-	for nextMarker != nil {
-		aclsRes, err := svc.ListRuleGroups(ctx, params)
-		if err != nil {
-			return nil, err
-		}
-		nextMarker = aclsRes.NextMarker
-		if aclsRes.NextMarker != nil {
-			params.NextMarker = nextMarker
-		}
-
-		for _, ruleGroup := range aclsRes.RuleGroups {
-			mqlRuleGroup, err := CreateResource(a.MqlRuntime, "aws.waf.rulegroup",
-				map[string]*llx.RawData{
-					"__id":        llx.StringDataPtr(ruleGroup.ARN),
-					"id":          llx.StringDataPtr(ruleGroup.Id),
-					"arn":         llx.StringDataPtr(ruleGroup.ARN),
-					"name":        llx.StringDataPtr(ruleGroup.Name),
-					"description": llx.StringDataPtr(ruleGroup.Description),
-					"scope":       llx.StringData(scopeString),
-				},
-			)
+	return wafAcross(conn, a.Scope.Data, func(ctx context.Context, scope, region string) ([]any, error) {
+		svc := conn.Wafv2(region)
+		res := []any{}
+		params := &wafv2.ListRuleGroupsInput{Scope: waftypes.Scope(scope)}
+		for {
+			listRes, err := svc.ListRuleGroups(ctx, params)
 			if err != nil {
 				return nil, err
 			}
-			acls = append(acls, mqlRuleGroup)
+
+			for _, ruleGroup := range listRes.RuleGroups {
+				mqlRes, err := CreateResource(a.MqlRuntime, "aws.waf.rulegroup",
+					map[string]*llx.RawData{
+						"__id":        llx.StringDataPtr(ruleGroup.ARN),
+						"id":          llx.StringDataPtr(ruleGroup.Id),
+						"arn":         llx.StringDataPtr(ruleGroup.ARN),
+						"name":        llx.StringDataPtr(ruleGroup.Name),
+						"description": llx.StringDataPtr(ruleGroup.Description),
+						"scope":       llx.StringData(scope),
+						"region":      llx.StringData(region),
+					},
+				)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, mqlRes)
+			}
+
+			if listRes.NextMarker == nil {
+				break
+			}
+			params.NextMarker = listRes.NextMarker
 		}
-	}
-	return acls, nil
+		return res, nil
+	})
 }
 
 func (a *mqlAwsWaf) ipSets() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	scopeString := a.Scope.Data
-	svc := conn.Wafv2(wafRegionForScope(scopeString))
-	ctx := context.Background()
-	acls := []any{}
-	nextMarker := aws.String("No-Marker-to-begin-with")
-	scope := waftypes.Scope(scopeString)
-	params := &wafv2.ListIPSetsInput{Scope: scope}
-	for nextMarker != nil {
-		aclsRes, err := svc.ListIPSets(ctx, params)
-		if err != nil {
-			return nil, err
-		}
-		nextMarker = aclsRes.NextMarker
-		if aclsRes.NextMarker != nil {
-			params.NextMarker = nextMarker
-		}
-
-		for _, ipset := range aclsRes.IPSets {
-			mqlIPSet, err := CreateResource(a.MqlRuntime, "aws.waf.ipset",
-				map[string]*llx.RawData{
-					"__id":        llx.StringDataPtr(ipset.ARN),
-					"id":          llx.StringDataPtr(ipset.Id),
-					"arn":         llx.StringDataPtr(ipset.ARN),
-					"name":        llx.StringDataPtr(ipset.Name),
-					"description": llx.StringDataPtr(ipset.Description),
-					"scope":       llx.StringData(scopeString),
-				},
-			)
+	return wafAcross(conn, a.Scope.Data, func(ctx context.Context, scope, region string) ([]any, error) {
+		svc := conn.Wafv2(region)
+		res := []any{}
+		params := &wafv2.ListIPSetsInput{Scope: waftypes.Scope(scope)}
+		for {
+			listRes, err := svc.ListIPSets(ctx, params)
 			if err != nil {
 				return nil, err
 			}
-			acls = append(acls, mqlIPSet)
+
+			for _, ipset := range listRes.IPSets {
+				mqlRes, err := CreateResource(a.MqlRuntime, "aws.waf.ipset",
+					map[string]*llx.RawData{
+						"__id":        llx.StringDataPtr(ipset.ARN),
+						"id":          llx.StringDataPtr(ipset.Id),
+						"arn":         llx.StringDataPtr(ipset.ARN),
+						"name":        llx.StringDataPtr(ipset.Name),
+						"description": llx.StringDataPtr(ipset.Description),
+						"scope":       llx.StringData(scope),
+						"region":      llx.StringData(region),
+					},
+				)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, mqlRes)
+			}
+
+			if listRes.NextMarker == nil {
+				break
+			}
+			params.NextMarker = listRes.NextMarker
 		}
-	}
-	return acls, nil
+		return res, nil
+	})
 }
 
 func (a *mqlAwsWafAcl) rules() ([]any, error) {
@@ -1179,59 +1241,60 @@ func (a *mqlAwsWafRegexPatternSet) id() (string, error) {
 func (a *mqlAwsWaf) regexPatternSets() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	scopeString := a.Scope.Data
-	svc := conn.Wafv2(wafRegionForScope(scopeString))
-	ctx := context.Background()
-	res := []any{}
-	nextMarker := aws.String("No-Marker-to-begin-with")
-	scope := waftypes.Scope(scopeString)
-	params := &wafv2.ListRegexPatternSetsInput{Scope: scope}
-	for nextMarker != nil {
-		setsRes, err := svc.ListRegexPatternSets(ctx, params)
-		if err != nil {
-			return nil, err
-		}
-		nextMarker = setsRes.NextMarker
-		if setsRes.NextMarker != nil {
-			params.NextMarker = nextMarker
-		}
-
-		for _, summary := range setsRes.RegexPatternSets {
-			getParams := &wafv2.GetRegexPatternSetInput{
-				Id:    summary.Id,
-				Name:  summary.Name,
-				Scope: scope,
-			}
-			details, err := svc.GetRegexPatternSet(ctx, getParams)
+	return wafAcross(conn, a.Scope.Data, func(ctx context.Context, scopeString, region string) ([]any, error) {
+		svc := conn.Wafv2(region)
+		scope := waftypes.Scope(scopeString)
+		res := []any{}
+		params := &wafv2.ListRegexPatternSetsInput{Scope: scope}
+		for {
+			setsRes, err := svc.ListRegexPatternSets(ctx, params)
 			if err != nil {
 				return nil, err
 			}
-			regexes := []any{}
-			if details.RegexPatternSet != nil {
-				for _, r := range details.RegexPatternSet.RegularExpressionList {
-					if r.RegexString != nil {
-						regexes = append(regexes, *r.RegexString)
+
+			for _, summary := range setsRes.RegexPatternSets {
+				getParams := &wafv2.GetRegexPatternSetInput{
+					Id:    summary.Id,
+					Name:  summary.Name,
+					Scope: scope,
+				}
+				details, err := svc.GetRegexPatternSet(ctx, getParams)
+				if err != nil {
+					return nil, err
+				}
+				regexes := []any{}
+				if details.RegexPatternSet != nil {
+					for _, r := range details.RegexPatternSet.RegularExpressionList {
+						if r.RegexString != nil {
+							regexes = append(regexes, *r.RegexString)
+						}
 					}
 				}
+				mqlSet, err := CreateResource(a.MqlRuntime, "aws.waf.regexPatternSet",
+					map[string]*llx.RawData{
+						"__id":               llx.StringDataPtr(summary.ARN),
+						"id":                 llx.StringDataPtr(summary.Id),
+						"arn":                llx.StringDataPtr(summary.ARN),
+						"name":               llx.StringDataPtr(summary.Name),
+						"description":        llx.StringDataPtr(summary.Description),
+						"scope":              llx.StringData(scopeString),
+						"region":             llx.StringData(region),
+						"regularExpressions": llx.ArrayData(regexes, types.String),
+					},
+				)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, mqlSet)
 			}
-			mqlSet, err := CreateResource(a.MqlRuntime, "aws.waf.regexPatternSet",
-				map[string]*llx.RawData{
-					"__id":               llx.StringDataPtr(summary.ARN),
-					"id":                 llx.StringDataPtr(summary.Id),
-					"arn":                llx.StringDataPtr(summary.ARN),
-					"name":               llx.StringDataPtr(summary.Name),
-					"description":        llx.StringDataPtr(summary.Description),
-					"scope":              llx.StringData(scopeString),
-					"regularExpressions": llx.ArrayData(regexes, types.String),
-				},
-			)
-			if err != nil {
-				return nil, err
+
+			if setsRes.NextMarker == nil {
+				break
 			}
-			res = append(res, mqlSet)
+			params.NextMarker = setsRes.NextMarker
 		}
-	}
-	return res, nil
+		return res, nil
+	})
 }
 
 func (a *mqlAwsWafAclLoggingConfiguration) id() (string, error) {
@@ -1264,7 +1327,7 @@ func newEmptyWafLoggingConfiguration(runtime *plugin.Runtime, aclArn string) (*m
 func (a *mqlAwsWafAcl) loggingConfiguration() (*mqlAwsWafAclLoggingConfiguration, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	svc := conn.Wafv2(wafRegionForScope(a.Scope.Data))
+	svc := conn.Wafv2(a.Region.Data)
 	ctx := context.Background()
 
 	arnVal := a.Arn.Data
@@ -1327,11 +1390,11 @@ func (a *mqlAwsWafAcl) associatedResources() ([]any, error) {
 
 	// ListResourcesForWebACL only supports REGIONAL scope ACLs.
 	// CLOUDFRONT ACLs are associated via CloudFront distributions, not this API.
-	if scopeString == "CLOUDFRONT" {
+	if scopeString == wafScopeCloudfront {
 		return []any{}, nil
 	}
 
-	svc := conn.Wafv2(wafRegionForScope(scopeString))
+	svc := conn.Wafv2(a.Region.Data)
 	ctx := context.Background()
 
 	arnVal := a.Arn.Data
@@ -1363,7 +1426,7 @@ func (a *mqlAwsWafAcl) associatedLoadBalancers() ([]any, error) {
 	}
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Wafv2(wafRegionForScope(a.Scope.Data))
+	svc := conn.Wafv2(a.Region.Data)
 	arnVal := a.Arn.Data
 
 	resp, err := svc.ListResourcesForWebACL(context.Background(), &wafv2.ListResourcesForWebACLInput{

--- a/providers/aws/resources/aws_waf_test.go
+++ b/providers/aws/resources/aws_waf_test.go
@@ -39,3 +39,38 @@ func TestWafAssociatedLoadBalancersEmptyForCloudFront(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
+
+// TestWafScopesFor pins which scopes a query covers. CLOUDFRONT and REGIONAL
+// are separate estates: CloudFront web ACLs live only in us-east-1, regional
+// ones are per-region, and neither on its own describes an account's WAF
+// posture. So no scope has to mean both, not a default of one.
+func TestWafScopesFor(t *testing.T) {
+	assert.Equal(t, []string{"CLOUDFRONT"}, wafScopesFor("CLOUDFRONT"))
+	assert.Equal(t, []string{"REGIONAL"}, wafScopesFor("REGIONAL"))
+
+	both := []string{"CLOUDFRONT", "REGIONAL"}
+	assert.Equal(t, both, wafScopesFor(""), "no scope covers both")
+
+	// An unrecognized scope is not silently treated as one of the two, since
+	// picking either would report a partial estate as the whole one.
+	assert.Equal(t, both, wafScopesFor("Regional"))
+	assert.Equal(t, both, wafScopesFor("global"))
+}
+
+// TestWafRegionsFor pins where each scope is queried. CLOUDFRONT is pinned to
+// us-east-1, which is where WAF keeps those ACLs regardless of where the
+// distribution serves from; REGIONAL takes the connection's whole region list,
+// because querying only the default region reported an empty estate for every
+// account whose ACLs live anywhere else.
+func TestWafRegionsFor(t *testing.T) {
+	conn := testConn("us-east-1", "eu-west-1", "ap-southeast-2")
+
+	cloudfront, err := wafRegionsFor(conn, "CLOUDFRONT")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"us-east-1"}, cloudfront)
+
+	regional, err := wafRegionsFor(conn, "REGIONAL")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"us-east-1", "eu-west-1", "ap-southeast-2"}, regional,
+		"regional resources exist per region, so every region is queried")
+}


### PR DESCRIPTION
An account whose web ACLs are regional reported **no WAF at all**, and said
nothing about it. Two defaults combined to produce that.

**Scope.** `initAwsWaf` defaulted to `CLOUDFRONT`, so a bare `aws.waf.acls`
asked only about CloudFront.

**Region.** `wafRegionForScope` returned `""` for `REGIONAL` — the connection's
default region — so even an explicit `aws.waf(scope: "REGIONAL")` only ever saw
one region.

```go
func wafRegionForScope(scope string) string {
	if scope == "CLOUDFRONT" {
		return "us-east-1"
	}
	return ""     // <- the connection default, for a per-region service
}
```

CloudFront and regional ACLs are separate estates — CloudFront's live only in
us-east-1, regional ones exist per region — so neither default described an
account's WAF posture. And the result came back as an empty list, not an error,
which is the failure mode that looks like a clean audit.

## What changed

- **No scope now means both.** An explicit scope still lists only itself.
- **`REGIONAL` is queried across `conn.Regions()`**; `CLOUDFRONT` stays pinned to us-east-1.
- **The listers go through `forRegions`** (`aws_regional.go`), so a region without WAF contributes nothing, a region the caller cannot read is recorded as a **coverage gap** rather than being indistinguishable from an empty one, and one bad region no longer discards the rest. A scope that fails outright does not discard the other one either — the error is returned only when neither scope produced anything.

## A second bug this exposes

Every WAF resource now carries the **region it was found in**, and every detail
call about it is made there.

That was already wrong before this change: `fetchACLDetails`, the four tag
lookups, `rulegroup.rules()`, `loggingConfiguration()` and
`associatedResources()` all resolved their region from the *scope*. A regional
ACL outside the default region would have had its details fetched from the
wrong region — so the fix isn't complete without threading region through.

## Also cleaned up

The listers primed their pagination marker with a fake sentinel
(`aws.String("No-Marker-to-begin-with")`) and reassigned it in two places. They
now break on a nil marker like the rest of the provider.

## Cost

`REGIONAL` now costs one list call per region per collection, which is the same
shape every other regional lister in this provider has, and `forRegions` bounds
concurrency at 5. `aws.permissions.json` is unchanged — no new API calls, just
more regions.

## Compatibility

`aws.waf.scope` reads `""` for the default instance instead of `"CLOUDFRONT"`,
and the schema documents that empty means both. `aws.waf(scope: "CLOUDFRONT")`
and `aws.waf(scope: "REGIONAL")` are unchanged as selectors. `.lr.versions`
entries for the four new `region` fields land at `13.53.4`.

## Tests

`TestWafScopesFor` pins that no scope covers both and that an unrecognized
scope is not silently treated as one of the two. `TestWafRegionsFor` pins
CloudFront to one region and regional to the connection's full list.
