### PR TITLE
🐛 aws: list athena named queries from every workgroup, not just primary

### DIFF
--- a/providers/aws/resources/aws_athena.go
+++ b/providers/aws/resources/aws_athena.go
@@ -628,10 +628,40 @@ func athenaLambdaArnFromParams(params map[string]any) string {
 	return ""
 }
 
+// namedQueries lists every saved query in the account.
+//
+// A named query belongs to exactly one workgroup, and ListNamedQueries returns
+// the saved queries of a single workgroup: the one named in the request, or
+// primary when the request names none. Listing without a workgroup therefore
+// reports only the primary workgroup's queries, and an account that keeps its
+// analytics in a named workgroup - which is what workgroup separation is for -
+// reported none at all.
+//
+// The workgroups come from the workgroups field rather than a fresh
+// ListWorkGroups call, so a scan that reads both collections lists them once.
 func (a *mqlAwsAthena) namedQueries() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+
+	workgroups := a.GetWorkgroups()
+	if workgroups.Error != nil {
+		return nil, workgroups.Error
+	}
+
+	workgroupsByRegion := map[string][]string{}
+	for _, raw := range workgroups.Data {
+		wg, ok := raw.(*mqlAwsAthenaWorkgroup)
+		if !ok {
+			continue
+		}
+		// A disabled workgroup still holds its saved queries, and they are still
+		// worth auditing, so state is deliberately not filtered on here.
+		if name := wg.Name.Data; name != "" {
+			workgroupsByRegion[wg.Region.Data] = append(workgroupsByRegion[wg.Region.Data], name)
+		}
+	}
+
 	res := []any{}
-	poolOfJobs := jobpool.CreatePool(a.getNamedQueries(conn), 5)
+	poolOfJobs := jobpool.CreatePool(a.getNamedQueries(conn, workgroupsByRegion), 5)
 	poolOfJobs.Run()
 
 	if poolOfJobs.HasErrors() {
@@ -645,50 +675,77 @@ func (a *mqlAwsAthena) namedQueries() ([]any, error) {
 	return res, nil
 }
 
-func (a *mqlAwsAthena) getNamedQueries(conn *connection.AwsConnection) []*jobpool.Job {
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.Regions()
-	if err != nil {
-		return []*jobpool.Job{{Err: err}}
+// listNamedQueryIDs lists the saved query ids in one workgroup.
+//
+// A workgroup that cannot be read contributes nothing rather than failing the
+// region. ListNamedQueries requires access to the specific workgroup, so a role
+// scoped to some workgroups can legitimately see a workgroup in ListWorkGroups
+// and be denied its queries; and a workgroup deleted between the two calls
+// comes back as an invalid request rather than an empty list.
+func listNamedQueryIDs(ctx context.Context, svc *athena.Client, region, workgroup string) ([]string, error) {
+	var queryIds []string
+	paginator := athena.NewListNamedQueriesPaginator(svc, &athena.ListNamedQueriesInput{
+		WorkGroup: &workgroup,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				log.Warn().Str("region", region).Str("workgroup", workgroup).
+					Msg("not permitted to list the named queries of this workgroup")
+				return nil, nil
+			}
+			var invalid *athena_types.InvalidRequestException
+			if errors.As(err, &invalid) {
+				log.Debug().Str("region", region).Str("workgroup", workgroup).
+					Msg("workgroup no longer available while listing named queries")
+				return nil, nil
+			}
+			return nil, err
+		}
+		queryIds = append(queryIds, page.NamedQueryIds...)
 	}
+	return queryIds, nil
+}
 
-	for _, region := range regions {
+func (a *mqlAwsAthena) getNamedQueries(conn *connection.AwsConnection, workgroupsByRegion map[string][]string) []*jobpool.Job {
+	tasks := make([]*jobpool.Job, 0, len(workgroupsByRegion))
+
+	for region, workgroupNames := range workgroupsByRegion {
 		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("athena>getNamedQueries>calling aws with region %s", region)
+			log.Debug().Str("region", region).Int("workgroups", len(workgroupNames)).
+				Msg("athena>getNamedQueries>calling aws")
 
 			svc := conn.Athena(region)
 			ctx := context.Background()
 			res := []any{}
 
-			// First, collect all named query IDs
-			var queryIds []string
-			paginator := athena.NewListNamedQueriesPaginator(svc, &athena.ListNamedQueriesInput{})
-			for paginator.HasMorePages() {
-				page, err := paginator.NextPage(ctx)
+			for _, workgroup := range workgroupNames {
+				queryIds, err := listNamedQueryIDs(ctx, svc, region, workgroup)
 				if err != nil {
-					if Is400AccessDeniedError(err) {
-						log.Warn().Str("region", region).Msg("error accessing region for AWS API")
-						return res, nil
-					}
 					return nil, err
 				}
-				queryIds = append(queryIds, page.NamedQueryIds...)
-			}
 
-			// Batch get named queries (max 50 per call)
-			for chunk := range slices.Chunk(queryIds, 50) {
-				batch, err := svc.BatchGetNamedQuery(ctx, &athena.BatchGetNamedQueryInput{
-					NamedQueryIds: chunk,
-				})
-				if err != nil {
-					return nil, err
-				}
-				for _, nq := range batch.NamedQueries {
-					mqlNQ, err := newMqlAwsAthenaNamedQuery(a.MqlRuntime, region, nq)
+				// Batch get named queries (max 50 per call)
+				for chunk := range slices.Chunk(queryIds, 50) {
+					batch, err := svc.BatchGetNamedQuery(ctx, &athena.BatchGetNamedQueryInput{
+						NamedQueryIds: chunk,
+					})
 					if err != nil {
+						if Is400AccessDeniedError(err) {
+							log.Warn().Str("region", region).Str("workgroup", workgroup).
+								Msg("not permitted to read the named queries of this workgroup")
+							break
+						}
 						return nil, err
 					}
-					res = append(res, mqlNQ)
+					for _, nq := range batch.NamedQueries {
+						mqlNQ, err := newMqlAwsAthenaNamedQuery(a.MqlRuntime, region, workgroup, nq)
+						if err != nil {
+							return nil, err
+						}
+						res = append(res, mqlNQ)
+					}
 				}
 			}
 			return jobpool.JobResult(res), nil
@@ -698,7 +755,7 @@ func (a *mqlAwsAthena) getNamedQueries(conn *connection.AwsConnection) []*jobpoo
 	return tasks
 }
 
-func newMqlAwsAthenaNamedQuery(runtime *plugin.Runtime, region string, nq athena_types.NamedQuery) (*mqlAwsAthenaNamedQuery, error) {
+func newMqlAwsAthenaNamedQuery(runtime *plugin.Runtime, region, workgroup string, nq athena_types.NamedQuery) (*mqlAwsAthenaNamedQuery, error) {
 	id := fmt.Sprintf("aws.athena.namedQuery/%s/%s", region, convert.ToValue(nq.NamedQueryId))
 
 	resource, err := CreateResource(runtime, "aws.athena.namedQuery",
@@ -714,7 +771,13 @@ func newMqlAwsAthenaNamedQuery(runtime *plugin.Runtime, region string, nq athena
 	if err != nil {
 		return nil, err
 	}
-	resource.(*mqlAwsAthenaNamedQuery).cacheWorkGroup = convert.ToValue(nq.WorkGroup)
+	// BatchGetNamedQuery reports the workgroup, but the query was listed under a
+	// known one, so fall back to that rather than leaving the reference unset.
+	queryWorkgroup := convert.ToValue(nq.WorkGroup)
+	if queryWorkgroup == "" {
+		queryWorkgroup = workgroup
+	}
+	resource.(*mqlAwsAthenaNamedQuery).cacheWorkGroup = queryWorkgroup
 	return resource.(*mqlAwsAthenaNamedQuery), nil
 }
 


### PR DESCRIPTION
`ListNamedQueries` is a **single-workgroup** operation, not an account-wide one.
The SDK says so twice:

```go
// The name of the workgroup from which the named queries are being returned. If a
// workgroup is not specified, the saved queries for the primary workgroup are
// returned.
WorkGroup *string
```

> Provides a list of available query IDs **only for queries saved in the
> specified workgroup**. Requires that you have access to the specified
> workgroup. If a workgroup is not specified, lists the saved queries for the
> primary workgroup.

The lister passed `&athena.ListNamedQueriesInput{}`, so it silently meant
"primary". Workgroup separation is exactly what an analytics account uses to
isolate teams and cost — so the accounts most likely to have saved queries
worth auditing are the ones that reported `[]`.

## The fix

**Enumerate workgroups, then list per workgroup.** Unavoidable; there is no
account-wide variant of the call.

**Source the workgroups from the resource field, not a fresh API call.**
`a.GetWorkgroups()` is already a modeled collection with `name` and `region`
set at creation, so a scan that reads both collections calls `ListWorkGroups`
once, and the read goes through `GetOrCompute` like every other field access —
resource cache and recording replay both keep working.

**A workgroup that cannot be read must not fail the region.** This is the part
that makes it a fix rather than just a fan-out:

- "Requires that you have access to the specified workgroup" — a role scoped to *some* workgroups can legitimately see one in `ListWorkGroups` and be denied its queries.
- A workgroup deleted between the two calls returns `InvalidRequestException`, not an empty list.

Both now contribute nothing rather than erroring. Without this, adding the
fan-out would have made the lister **more** fragile than the bug it fixes: one
inaccessible workgroup would take out every query in the region.

**Disabled workgroups are deliberately included** — they still hold their saved
queries, and a query with an embedded credential does not stop mattering
because the workgroup was disabled. There is a comment saying so, to stop it
being "optimized" away later.

**The workgroup is seeded from the loop** as a fallback, since the query was
listed under a known one.

## What does not change

- **`__id`** — `aws.athena.namedQuery/<region>/<id>` is already unique, and a named query belongs to exactly one workgroup, so nothing double-counts and no dedup is needed.
- **Permissions** — `athena:ListWorkGroups`, `athena:ListNamedQueries` and `athena:BatchGetNamedQuery` were all already in the manifest. `make providers/build/aws` reports `1025 permissions (unchanged)`.
- **Schema** — `namedQuery.queryWorkgroup()` already existed as a typed reference.

## Cost

Per region: 1 call → 1 + N, where N is the workgroup count and the `+1` is
shared with the `workgroups` field. `BatchGetNamedQuery` still chunks at 50.

## Scope

I swept the rest of the file. `ListQueryExecutions` and `ListPreparedStatements`
have the same workgroup semantics but are **not modeled**, so there is nothing
else to fix; `ListDatabases` / `ListTableMetadata` key on catalog, not
workgroup. The bug is confined to `namedQueries`.

## Tests

None added, and worth being explicit about why: the new code is one SDK call
plus mapping, except the region grouping and the error classification — and the
classifier cannot be exercised without a stubbed Athena client, which needs a
`connection.NewTestConnection` helper that does not exist yet. A test here
would pin the grouping map and little else. Verification is an account with a
named workgroup holding a saved query.
