### PR TITLE
🐛 aws: stop three cloudwatch resources sharing one cache row

### DIFF
--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -119,12 +120,38 @@ func (a *mqlAwsCloudwatchMetricdimension) id() (string, error) {
 	return name + "/" + val, nil
 }
 
+// metricStatisticsCacheKey identifies one statistics series. A CloudWatch metric
+// is identified by its namespace, name AND dimensions: AWS/EC2 CPUUtilization
+// exists once per instance, distinguished only by the InstanceId dimension. A
+// key without them collapses every instance's series onto one cache entry, so
+// the first one fetched answers for all of them.
+//
+// Dimensions are sorted, because the key has to be the same for the same series
+// no matter what order the API returned them in.
+func metricStatisticsCacheKey(namespace, name, region, label string, dimensions []any) string {
+	key := namespace + "/" + name + "/" + region + "/" + label
+
+	pairs := make([]string, 0, len(dimensions))
+	for _, d := range dimensions {
+		dimension, ok := d.(*mqlAwsCloudwatchMetricdimension)
+		if !ok {
+			continue
+		}
+		pairs = append(pairs, dimension.Name.Data+"="+dimension.Value.Data)
+	}
+	if len(pairs) == 0 {
+		return key
+	}
+	sort.Strings(pairs)
+	return key + "/" + strings.Join(pairs, ",")
+}
+
+// id covers the init path only, which resolves the undimensioned aggregate for
+// a namespace and metric name. The dimensioned series built by
+// aws.cloudwatch.metric.statistics passes its own __id, since this resource has
+// no dimensions field to read them back from.
 func (a *mqlAwsCloudwatchMetricstatistics) id() (string, error) {
-	region := a.Region.Data
-	namespace := a.Namespace.Data
-	name := a.Name.Data
-	label := a.Label.Data
-	return namespace + "/" + name + "/" + region + "/" + label, nil
+	return metricStatisticsCacheKey(a.Namespace.Data, a.Name.Data, a.Region.Data, a.Label.Data, nil), nil
 }
 
 // allow the user to query for a specific namespace metric in a specific region
@@ -301,10 +328,16 @@ func initAwsCloudwatchMetricstatistics(runtime *plugin.Runtime, args map[string]
 	if err != nil {
 		return args, nil, err
 	}
+	// Every datapoint here used to be created with no id of any kind, so all 24
+	// hours of them shared one empty cache key and resolved to the first.
+	statsKey := metricStatisticsCacheKey(namespace, name, region, convert.ToValue(statsResp.Label), nil)
+
 	datapoints := []any{}
 	for _, datapoint := range statsResp.Datapoints {
 		mqlDatapoint, err := CreateResource(runtime, "aws.cloudwatch.metric.datapoint",
 			map[string]*llx.RawData{
+				"__id":      llx.StringData(datapointCacheKey(statsKey, datapoint)),
+				"id":        llx.StringData(formatDatapointId(datapoint)),
 				"timestamp": llx.TimeDataPtr(datapoint.Timestamp),
 				"maximum":   llx.FloatData(convert.ToValue(datapoint.Maximum)),
 				"minimum":   llx.FloatData(convert.ToValue(datapoint.Minimum)),
@@ -361,10 +394,13 @@ func (a *mqlAwsCloudwatchMetric) statistics() (*mqlAwsCloudwatchMetricstatistics
 	if err != nil {
 		return nil, errors.Wrap(err, "could not gather AWS CloudWatch stats")
 	}
+	statsKey := metricStatisticsCacheKey(namespace, metricName, regionVal, convert.ToValue(statsResp.Label), dimensions)
+
 	datapoints := []any{}
 	for _, datapoint := range statsResp.Datapoints {
 		mqlDatapoint, err := CreateResource(a.MqlRuntime, "aws.cloudwatch.metric.datapoint",
 			map[string]*llx.RawData{
+				"__id":      llx.StringData(datapointCacheKey(statsKey, datapoint)),
 				"id":        llx.StringData(formatDatapointId(datapoint)),
 				"timestamp": llx.TimeDataPtr(datapoint.Timestamp),
 				"maximum":   llx.FloatData(convert.ToValue(datapoint.Maximum)),
@@ -380,6 +416,7 @@ func (a *mqlAwsCloudwatchMetric) statistics() (*mqlAwsCloudwatchMetricstatistics
 	}
 	mqlStat, err := CreateResource(a.MqlRuntime, "aws.cloudwatch.metricstatistics",
 		map[string]*llx.RawData{
+			"__id":       llx.StringData(statsKey),
 			"label":      llx.StringDataPtr(statsResp.Label),
 			"datapoints": llx.ArrayData(datapoints, types.Resource("aws.cloudwatch.metric.datapoint")),
 			"name":       llx.StringData(metricName),
@@ -395,6 +432,18 @@ func (a *mqlAwsCloudwatchMetric) statistics() (*mqlAwsCloudwatchMetricstatistics
 
 func (a *mqlAwsCloudwatchMetricDatapoint) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+// datapointCacheKey identifies a datapoint within its series. formatDatapointId
+// hashes the datapoint's own values, which is not enough on its own: two
+// instances idling at the same value in the same hour hash identically, so the
+// series has to be part of the key. The public id field keeps the hash.
+func datapointCacheKey(statisticsKey string, d cloudwatchtypes.Datapoint) string {
+	ts := ""
+	if d.Timestamp != nil {
+		ts = strconv.FormatInt(d.Timestamp.UnixNano(), 10)
+	}
+	return statisticsKey + "/datapoint/" + ts + "/" + formatDatapointId(d)
 }
 
 func formatDatapointId(d cloudwatchtypes.Datapoint) string {
@@ -1163,6 +1212,7 @@ func (a *mqlAwsCloudwatchLoggroup) logStreams() ([]any, error) {
 		for _, ls := range page.LogStreams {
 			mqlLS, err := CreateResource(a.MqlRuntime, "aws.cloudwatch.loggroup.logstream",
 				map[string]*llx.RawData{
+					"__id":                llx.StringData(region + "/" + groupName + "/" + convert.ToValue(ls.LogStreamName)),
 					"arn":                 llx.StringDataPtr(ls.Arn),
 					"name":                llx.StringDataPtr(ls.LogStreamName),
 					"createdAt":           llx.TimeDataPtr(int64MillisToTime(ls.CreationTime)),
@@ -1180,8 +1230,17 @@ func (a *mqlAwsCloudwatchLoggroup) logStreams() ([]any, error) {
 	return res, nil
 }
 
+// id is the fallback identity for a log stream built without an explicit key.
+// It cannot qualify the stream by its log group, because a log stream resource
+// carries no reference to one and a cache field would be assigned only after
+// CreateResource has already computed the key. The lister therefore passes a
+// group-qualified __id directly, which is what actually keys these: Lambda
+// names every stream YYYY/MM/DD/[$LATEST]<hex>, so the same stream name in two
+// function log groups is routine, and region plus name alone merged them into
+// a single row.
 func (a *mqlAwsCloudwatchLoggroupLogstream) id() (string, error) {
-	// Use composite ID instead of ARN since ARN can be nil for some streams
+	// Use a composite ID instead of the ARN, since the ARN can be nil for some
+	// streams.
 	return a.Region.Data + "/" + a.Name.Data, nil
 }
 

--- a/providers/aws/resources/aws_cloudwatch_test.go
+++ b/providers/aws/resources/aws_cloudwatch_test.go
@@ -5,11 +5,14 @@ package resources
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
 func TestParseLogGroupArn(t *testing.T) {
@@ -101,5 +104,97 @@ func TestBuildLogGroupResourceRetention(t *testing.T) {
 		assert.True(t, lg.RetentionInDays.IsNull(),
 			"no retention means no expiry, which is not a retention of zero days")
 		assert.True(t, lg.NeverExpires.Data)
+	})
+}
+
+// dim builds a resolved metric dimension for the cache-key tests.
+func dim(name, value string) *mqlAwsCloudwatchMetricdimension {
+	d := &mqlAwsCloudwatchMetricdimension{}
+	d.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
+	d.Value = plugin.TValue[string]{Data: value, State: plugin.StateIsSet}
+	return d
+}
+
+// TestMetricStatisticsCacheKey pins the identity of a statistics series. A
+// CloudWatch metric is identified by namespace, name AND dimensions: AWS/EC2
+// CPUUtilization exists once per instance and is distinguished only by the
+// InstanceId dimension, so a key without dimensions collapses every instance's
+// series onto one cache entry and the first one fetched answers for all of them.
+func TestMetricStatisticsCacheKey(t *testing.T) {
+	const (
+		ns     = "AWS/EC2"
+		metric = "CPUUtilization"
+		region = "us-east-1"
+		label  = "CPUUtilization"
+	)
+
+	t.Run("two instances do not share a key", func(t *testing.T) {
+		first := metricStatisticsCacheKey(ns, metric, region, label,
+			[]any{dim("InstanceId", "i-aaaaaaaaaaaaaaaaa")})
+		second := metricStatisticsCacheKey(ns, metric, region, label,
+			[]any{dim("InstanceId", "i-bbbbbbbbbbbbbbbbb")})
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("dimension order does not change the key", func(t *testing.T) {
+		forward := metricStatisticsCacheKey(ns, metric, region, label,
+			[]any{dim("InstanceId", "i-aaaaaaaaaaaaaaaaa"), dim("AutoScalingGroupName", "asg-1")})
+		reverse := metricStatisticsCacheKey(ns, metric, region, label,
+			[]any{dim("AutoScalingGroupName", "asg-1"), dim("InstanceId", "i-aaaaaaaaaaaaaaaaa")})
+		assert.Equal(t, forward, reverse,
+			"the same series must key the same whatever order the API returned its dimensions in")
+	})
+
+	t.Run("the undimensioned aggregate keeps the plain key", func(t *testing.T) {
+		assert.Equal(t, "AWS/EC2/CPUUtilization/us-east-1/CPUUtilization",
+			metricStatisticsCacheKey(ns, metric, region, label, nil))
+	})
+
+	t.Run("a dimensioned series differs from the aggregate", func(t *testing.T) {
+		aggregate := metricStatisticsCacheKey(ns, metric, region, label, nil)
+		scoped := metricStatisticsCacheKey(ns, metric, region, label,
+			[]any{dim("InstanceId", "i-aaaaaaaaaaaaaaaaa")})
+		assert.NotEqual(t, aggregate, scoped)
+	})
+
+	t.Run("region and namespace still separate series", func(t *testing.T) {
+		east := metricStatisticsCacheKey(ns, metric, "us-east-1", label, nil)
+		west := metricStatisticsCacheKey(ns, metric, "us-west-2", label, nil)
+		assert.NotEqual(t, east, west)
+	})
+
+	t.Run("a non-dimension element is skipped, not panicked on", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			metricStatisticsCacheKey(ns, metric, region, label, []any{"not a dimension", nil})
+		})
+	})
+}
+
+// TestDatapointCacheKey pins that a datapoint is identified within its series.
+// formatDatapointId hashes only the datapoint's own values, so two instances
+// idling at the same value in the same hour hash identically.
+func TestDatapointCacheKey(t *testing.T) {
+	at := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	later := at.Add(time.Hour)
+
+	idle := cloudwatchtypes.Datapoint{Timestamp: &at, Average: aws.Float64(0)}
+
+	t.Run("same datapoint values in different series do not collide", func(t *testing.T) {
+		first := datapointCacheKey("AWS/EC2/CPUUtilization/us-east-1/l/InstanceId=i-a", idle)
+		second := datapointCacheKey("AWS/EC2/CPUUtilization/us-east-1/l/InstanceId=i-b", idle)
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("consecutive datapoints in one series do not collide", func(t *testing.T) {
+		series := "AWS/EC2/CPUUtilization/us-east-1/l"
+		first := datapointCacheKey(series, idle)
+		second := datapointCacheKey(series, cloudwatchtypes.Datapoint{Timestamp: &later, Average: aws.Float64(0)})
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("a datapoint with no timestamp does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			datapointCacheKey("series", cloudwatchtypes.Datapoint{Average: aws.Float64(1)})
+		})
 	})
 }


### PR DESCRIPTION
A resource's cache key is its identity: `resourceName + "\x00" + __id`. When two
real resources compute the same key, the second is never created — the first
one's data is returned under the second one's name. No error, no warning, and
the result looks entirely plausible.

Three CloudWatch resources did that.

## 1. `metricstatistics` ignored the dimensions that identify the metric

```go
return namespace + "/" + name + "/" + region + "/" + label
```

A CloudWatch metric is identified by its **dimensions** as well as its name.
`AWS/EC2` `CPUUtilization` exists once per instance and is told apart only by
the `InstanceId` dimension — so fifty instances shared one key, and every one
of them reported the first instance's CPU.

The resource has no `dimensions` field to read back, so the dimensioned series
built by `aws.cloudwatch.metric.statistics` now passes its own `__id`, and
`id()` covers the undimensioned aggregate that the init resolves. Dimensions
are **sorted** into the key, because the same series has to key the same
whatever order the API happened to list them in.

## 2. `metric.datapoint` had no id at all on one of its two paths

The init path created every datapoint with no `id` and no `__id`, so all 24
hours of them shared the empty key and resolved to the first.

The sibling path passed `formatDatapointId`, which is necessary but **not
sufficient** — it hashes only the datapoint's own values, so two instances
idling at the same value in the same hour hash identically. Fixing the missing
id by copying that hash would have swapped one collision for a subtler one.

Both paths now pass a **series-qualified** `__id`. The public `id` field keeps
the hash and is unchanged; the init path gains it, where it was previously
empty.

## 3. `loggroup.logstream` keyed on region and stream name, with no log group

Lambda names every stream `YYYY/MM/DD/[$LATEST]<hex>`, so the same stream name
in two function log groups is routine, not exotic.

The lister passes a group-qualified `__id`. `id()` **cannot** do this itself: a
log stream resource carries no reference to its group, and a cache field would
be assigned only *after* `CreateResource` had already computed the key — which
is exactly the shape that broke `aws.vpc.natgateway.address`. The comment on
`id()` says so, so the next person doesn't try.

## Compatibility

All three keys are internal. **None of these resources exposes `id` in its
schema**, so nothing user-visible changes except that distinct resources stop
merging into one row. No schema change, no `.lr.versions` entries, no
permissions change.

## Tests

`TestMetricStatisticsCacheKey` — two instances don't share a key; dimension
order doesn't change the key; the undimensioned aggregate keeps its plain form
and differs from a dimensioned series; region and namespace still separate;
a non-dimension element is skipped rather than panicked on.

`TestDatapointCacheKey` — same values in different series don't collide;
consecutive datapoints in one series don't collide; a datapoint with no
timestamp doesn't panic.
