### PR TITLE
🐛 aws: give inspector coverage rows and their children real identities

### DIFF
--- a/providers/aws/resources/aws_inspector.go
+++ b/providers/aws/resources/aws_inspector.go
@@ -24,8 +24,13 @@ func (a *mqlAwsInspector) id() (string, error) {
 	return "aws.inspector", nil
 }
 
+// id identifies one coverage row. Inspector reports a resource once per scan
+// type, so an instance covered by both PACKAGE and NETWORK produces two rows
+// that differ only in scanType - without it they collapsed into one and the
+// second scan type became invisible. The region is part of it too, since
+// resource ids like an ECR repository name are only unique within one.
 func (a *mqlAwsInspectorCoverage) id() (string, error) {
-	return a.AccountId.Data + "/" + a.ResourceId.Data, nil
+	return a.AccountId.Data + "/" + a.Region.Data + "/" + a.ResourceId.Data + "/" + a.ScanType.Data, nil
 }
 
 func (a *mqlAwsInspector) coverages() ([]any, error) {
@@ -121,17 +126,20 @@ type mqlAwsInspectorCoverageInstanceInternal struct {
 	cacheAmiId string
 }
 
+// id is a fallback only. The coverage that owns this instance passes an
+// explicit __id, because an instance is a one-to-one detail of a coverage row
+// and has nothing of its own that identifies it: the previous key concatenated
+// the tag map, which is neither unique (two instances tagged alike collide) nor
+// stable (Go randomizes map iteration, so the same instance could key
+// differently between two runs of the same scan).
 func (a *mqlAwsInspectorCoverageInstance) id() (string, error) {
-	strTags := ""
-	for k, v := range a.Tags.Data {
-		strTags = strTags + k + "/" + v.(string) + "/"
-	}
-	return a.Region.Data + "/" + strTags, nil
+	return a.Region.Data, nil
 }
 
 func (a *mqlAwsInspectorCoverage) ec2Instance() (*mqlAwsInspectorCoverageInstance, error) {
 	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.Ec2 != nil {
 		args := map[string]*llx.RawData{
+			"__id":     llx.StringData(a.MqlID() + "/ec2Instance"),
 			"platform": llx.StringData(string(a.cacheCoverage.ResourceMetadata.Ec2.Platform)),
 			"tags":     llx.MapData(toInterfaceMap(a.cacheCoverage.ResourceMetadata.Ec2.Tags), llxtypes.String),
 			"region":   llx.StringData(a.Region.Data),
@@ -163,17 +171,17 @@ func listMapConversion(m []string) map[string]any {
 	return newMap
 }
 
+// id is a fallback only, for the same reason as the instance above: the owning
+// coverage passes an explicit __id, and an image tag list is neither a unique
+// nor a stably ordered identity.
 func (a *mqlAwsInspectorCoverageImage) id() (string, error) {
-	tagString := ""
-	for k, v := range a.Tags.Data {
-		tagString = tagString + k + "/" + v.(string) + "/"
-	}
-	return a.Region.Data + "/" + tagString, nil
+	return a.Region.Data, nil
 }
 
 func (a *mqlAwsInspectorCoverage) ecrImage() (*mqlAwsInspectorCoverageImage, error) {
 	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.EcrImage != nil {
 		mqlEcr, err := CreateResource(a.MqlRuntime, "aws.inspector.coverage.image", map[string]*llx.RawData{
+			"__id":          llx.StringData(a.MqlID() + "/ecrImage"),
 			"tags":          llx.MapData(listMapConversion(a.cacheCoverage.ResourceMetadata.EcrImage.Tags), llxtypes.String),
 			"imagePulledAt": llx.TimeDataPtr(a.cacheCoverage.ResourceMetadata.EcrImage.ImagePulledAt),
 			"region":        llx.StringData(a.Region.Data),
@@ -193,6 +201,7 @@ func (a *mqlAwsInspectorCoverageRepository) id() (string, error) {
 func (a *mqlAwsInspectorCoverage) ecrRepo() (*mqlAwsInspectorCoverageRepository, error) {
 	if a.cacheCoverage != nil && a.cacheCoverage.ResourceMetadata != nil && a.cacheCoverage.ResourceMetadata.EcrRepository != nil {
 		mqlEcr, err := CreateResource(a.MqlRuntime, "aws.inspector.coverage.repository", map[string]*llx.RawData{
+			"__id":          llx.StringData(a.MqlID() + "/ecrRepo"),
 			"name":          llx.StringDataPtr(a.cacheCoverage.ResourceMetadata.EcrRepository.Name),
 			"scanFrequency": llx.StringData(string(a.cacheCoverage.ResourceMetadata.EcrRepository.ScanFrequency)),
 			"region":        llx.StringData(a.Region.Data),

--- a/providers/aws/resources/aws_inspector_test.go
+++ b/providers/aws/resources/aws_inspector_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func coverageRow(accountID, region, resourceID, scanType string) *mqlAwsInspectorCoverage {
+	c := &mqlAwsInspectorCoverage{}
+	c.AccountId = plugin.TValue[string]{Data: accountID, State: plugin.StateIsSet}
+	c.Region = plugin.TValue[string]{Data: region, State: plugin.StateIsSet}
+	c.ResourceId = plugin.TValue[string]{Data: resourceID, State: plugin.StateIsSet}
+	c.ScanType = plugin.TValue[string]{Data: scanType, State: plugin.StateIsSet}
+	return c
+}
+
+// TestInspectorCoverageID pins that a coverage row is identified by its scan
+// type and region as well as the resource. Inspector reports a resource once
+// per scan type, so an instance covered by both PACKAGE and NETWORK produces
+// two rows that differ only in scanType; without it the second row resolved to
+// the first and became invisible.
+func TestInspectorCoverageID(t *testing.T) {
+	const (
+		account  = "000000000000"
+		region   = "us-east-1"
+		instance = "i-0123456789abcdef0"
+	)
+
+	t.Run("scan types do not collide", func(t *testing.T) {
+		pkg, err := coverageRow(account, region, instance, "PACKAGE").id()
+		require.NoError(t, err)
+		network, err := coverageRow(account, region, instance, "NETWORK").id()
+		require.NoError(t, err)
+		assert.NotEqual(t, pkg, network)
+	})
+
+	t.Run("regions do not collide", func(t *testing.T) {
+		// An ECR repository name is only unique within a region, so two regions
+		// can legitimately report the same resource id.
+		east, err := coverageRow(account, "us-east-1", "my-repo", "PACKAGE").id()
+		require.NoError(t, err)
+		west, err := coverageRow(account, "us-west-2", "my-repo", "PACKAGE").id()
+		require.NoError(t, err)
+		assert.NotEqual(t, east, west)
+	})
+
+	t.Run("accounts do not collide", func(t *testing.T) {
+		first, err := coverageRow("000000000000", region, instance, "PACKAGE").id()
+		require.NoError(t, err)
+		second, err := coverageRow("111111111111", region, instance, "PACKAGE").id()
+		require.NoError(t, err)
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("the same row keys the same", func(t *testing.T) {
+		first, err := coverageRow(account, region, instance, "PACKAGE").id()
+		require.NoError(t, err)
+		second, err := coverageRow(account, region, instance, "PACKAGE").id()
+		require.NoError(t, err)
+		assert.Equal(t, first, second)
+	})
+}
+
+// TestInspectorCoverageChildIDsAreNotTagDerived pins that the one-to-one child
+// resources are no longer identified by their tag map. That key was neither
+// unique — two instances tagged alike produced the same string — nor stable,
+// since Go randomizes map iteration, so the same instance could key differently
+// between two runs of the same scan.
+func TestInspectorCoverageChildIDsAreNotTagDerived(t *testing.T) {
+	tags := map[string]any{"Name": "web", "env": "prod", "team": "platform", "app": "api"}
+
+	t.Run("instance id is stable across iterations", func(t *testing.T) {
+		inst := &mqlAwsInspectorCoverageInstance{}
+		inst.Region = plugin.TValue[string]{Data: "us-east-1", State: plugin.StateIsSet}
+		inst.Tags = plugin.TValue[map[string]any]{Data: tags, State: plugin.StateIsSet}
+
+		first, err := inst.id()
+		require.NoError(t, err)
+		for range 50 {
+			again, err := inst.id()
+			require.NoError(t, err)
+			assert.Equal(t, first, again, "the id must not depend on map iteration order")
+		}
+	})
+
+	t.Run("image id is stable across iterations", func(t *testing.T) {
+		img := &mqlAwsInspectorCoverageImage{}
+		img.Region = plugin.TValue[string]{Data: "us-east-1", State: plugin.StateIsSet}
+		img.Tags = plugin.TValue[map[string]any]{Data: tags, State: plugin.StateIsSet}
+
+		first, err := img.id()
+		require.NoError(t, err)
+		for range 50 {
+			again, err := img.id()
+			require.NoError(t, err)
+			assert.Equal(t, first, again)
+		}
+	})
+}


### PR DESCRIPTION
## 1. A coverage row ignored its scan type

```go
return a.AccountId.Data + "/" + a.ResourceId.Data
```

Inspector reports a resource **once per scan type**, so an instance covered by
both `PACKAGE` and `NETWORK` produces two rows that differ only in `scanType`.
They collapsed onto one key, the second was never created, and the query "is
this instance covered by network scanning" got the package row's answer.

The **region** belongs in the key too: a resource id like an ECR repository
name is only unique within a region.

## 2. The children keyed on map iteration order

Both one-to-one children — `coverage.instance` and `coverage.image` — built
their identity by concatenating their tag map:

```go
for k, v := range a.Tags.Data {
    strTags = strTags + k + "/" + v.(string) + "/"
}
return a.Region.Data + "/" + strTags
```

Two failures in one:

- **Not unique.** Two instances tagged alike produce the same string, so one overwrites the other.
- **Not stable.** Go deliberately randomizes map iteration order. The same instance could key differently between two runs of the same scan, and a single scan could merge or split rows at random — the kind of bug that reproduces once in ten runs.

An instance or an image here is a one-to-one detail of a coverage row with no
identity of its own, so the **coverage passes an explicit parent-qualified
`__id`**, which is the documented pattern for a synthetic key. The ECR
repository child gets one too, for consistency.

The `id()` methods stay as fallbacks, each with a comment explaining why they
cannot do the job themselves — so the next person doesn't try to rebuild the
tag key.

## Compatibility

All four keys are internal. **None of these resources exposes `id` in its
schema.** No schema change, no `.lr.versions` entries, no permissions change.

## Tests

`TestInspectorCoverageID` — scan types, regions and accounts each separate a
row; the same row keys the same twice.

`TestInspectorCoverageChildIDsAreNotTagDerived` — calls `id()` fifty times on a
four-tag resource and asserts the answer never changes. Against the old code
that fails as soon as Go picks a different iteration order, which on a four-key
map is quick.
