### PR TITLE
🐛 aws: identify an autoscaling target by its dimension, and use the real arn

### DIFF
--- a/providers/aws/resources/aws_applicationautoscaling.go
+++ b/providers/aws/resources/aws_applicationautoscaling.go
@@ -22,6 +22,24 @@ func (a *mqlAwsApplicationAutoscaling) id() (string, error) {
 	return "aws.applicationAutoscaling." + a.Namespace.Data, nil
 }
 
+// scalableTargetArn returns the ARN that identifies a scalable target.
+//
+// Application Auto Scaling reports one, and it is what should be used. The
+// fallback matters for the identity as much as for the value: a scalable target
+// is keyed by its resource AND its dimension, so a DynamoDB table with both
+// read and write autoscaling has two targets sharing one resourceId. The
+// previous ARN was assembled without the dimension, so the two collapsed onto
+// one cache row - the read target was reported twice and the write target's
+// policies were never reachable.
+func scalableTargetArn(target aatypes.ScalableTarget, region, accountID string) string {
+	if arn := convert.ToValue(target.ScalableTargetARN); arn != "" {
+		return arn
+	}
+	return fmt.Sprintf("arn:aws:application-autoscaling:%s:%s:%s/%s/%s",
+		region, accountID, string(target.ServiceNamespace),
+		convert.ToValue(target.ResourceId), string(target.ScalableDimension))
+}
+
 func (a *mqlAwsApplicationAutoscalingTarget) id() (string, error) {
 	return a.Arn.Data, nil
 }
@@ -91,7 +109,7 @@ func (a *mqlAwsApplicationAutoscaling) getTargets(conn *connection.AwsConnection
 					}
 					mqlSTarget, err := CreateResource(a.MqlRuntime, "aws.applicationAutoscaling.target",
 						map[string]*llx.RawData{
-							"arn":               llx.StringData(fmt.Sprintf("arn:aws:application-autoscaling:%s:%s:%s/%s", region, conn.AccountId(), namespace, convert.ToValue(target.ResourceId))),
+							"arn":               llx.StringData(scalableTargetArn(target, region, conn.AccountId())),
 							"namespace":         llx.StringData(string(target.ServiceNamespace)),
 							"resourceId":        llx.StringData(convert.ToValue(target.ResourceId)),
 							"region":            llx.StringData(region),

--- a/providers/aws/resources/aws_applicationautoscaling_test.go
+++ b/providers/aws/resources/aws_applicationautoscaling_test.go
@@ -1,0 +1,72 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	aatypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestScalableTargetArn pins the identity of a scalable target. A target is
+// keyed by its resource AND its dimension: a DynamoDB table with both read and
+// write autoscaling has two targets sharing one resourceId, and an ARN built
+// without the dimension collapsed them onto one cache row.
+func TestScalableTargetArn(t *testing.T) {
+	const (
+		region  = "us-east-1"
+		account = "000000000000"
+	)
+
+	target := func(resourceID string, dimension aatypes.ScalableDimension) aatypes.ScalableTarget {
+		return aatypes.ScalableTarget{
+			ServiceNamespace:  aatypes.ServiceNamespaceDynamodb,
+			ResourceId:        aws.String(resourceID),
+			ScalableDimension: dimension,
+		}
+	}
+
+	t.Run("the reported arn is preferred", func(t *testing.T) {
+		reported := "arn:aws:application-autoscaling:us-east-1:000000000000:scalable-target/0123456789abcdef"
+		tgt := target("table/my-table", aatypes.ScalableDimensionDynamoDBTableReadCapacityUnits)
+		tgt.ScalableTargetARN = aws.String(reported)
+
+		assert.Equal(t, reported, scalableTargetArn(tgt, region, account))
+	})
+
+	t.Run("read and write targets on one table do not collide", func(t *testing.T) {
+		read := scalableTargetArn(
+			target("table/my-table", aatypes.ScalableDimensionDynamoDBTableReadCapacityUnits), region, account)
+		write := scalableTargetArn(
+			target("table/my-table", aatypes.ScalableDimensionDynamoDBTableWriteCapacityUnits), region, account)
+
+		assert.NotEqual(t, read, write,
+			"one table's read and write autoscaling are two targets, not one")
+	})
+
+	t.Run("different resources do not collide", func(t *testing.T) {
+		first := scalableTargetArn(
+			target("table/my-table", aatypes.ScalableDimensionDynamoDBTableReadCapacityUnits), region, account)
+		second := scalableTargetArn(
+			target("table/other-table", aatypes.ScalableDimensionDynamoDBTableReadCapacityUnits), region, account)
+
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("regions do not collide", func(t *testing.T) {
+		tgt := target("table/my-table", aatypes.ScalableDimensionDynamoDBTableReadCapacityUnits)
+		assert.NotEqual(t,
+			scalableTargetArn(tgt, "us-east-1", account),
+			scalableTargetArn(tgt, "us-west-2", account))
+	})
+
+	t.Run("an empty reported arn falls back rather than emptying the key", func(t *testing.T) {
+		tgt := target("table/my-table", aatypes.ScalableDimensionDynamoDBTableReadCapacityUnits)
+		tgt.ScalableTargetARN = aws.String("")
+
+		assert.NotEmpty(t, scalableTargetArn(tgt, region, account))
+	})
+}


### PR DESCRIPTION
A scalable target is identified by its resource **and** its dimension together.
A DynamoDB table with read *and* write autoscaling has two targets sharing one
`resourceId`, differing only in `ScalableDimension`:

- `table/my-table` + `dynamodb:table:ReadCapacityUnits`
- `table/my-table` + `dynamodb:table:WriteCapacityUnits`

The ARN was assembled by hand, without the dimension:

```go
"arn": llx.StringData(fmt.Sprintf("arn:aws:application-autoscaling:%s:%s:%s/%s",
    region, conn.AccountId(), namespace, convert.ToValue(target.ResourceId))),
```

and `id()` returns `a.Arn.Data`. So the two targets computed the same key, the
second was never created, and the table reported its **read** target twice —
with the write target's policies and scheduled actions unreachable.

## The fix

Application Auto Scaling **reports the ARN**. The SDK has carried it all along:

```go
// The ARN of the scalable target.
ScalableTargetARN *string
```

So the hand-assembled ARN was never needed. Use the reported one, and keep a
fallback that now includes the dimension for the case where the service returns
none.

## On changing a public field

This changes the value of `arn` — from a fabricated ARN that no AWS API would
recognize, to the one the service reports. The field keeps its type and its
meaning; what changes is that it now identifies what it claims to. I'd rather
flag that explicitly than bury it: if you'd prefer to keep the fabricated value
and fix identity through an explicit `__id` instead, say so and I'll switch it.

## Tests

`TestScalableTargetArn` — the reported ARN is preferred; read and write targets
on one table don't collide; different resources and different regions don't
collide; an empty reported ARN falls back rather than emptying the key.
