### PR TITLE
🐛 aws: key a nat gateway address on the eni that was never in the key

### DIFF
--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -226,6 +226,10 @@ func natgatewayAddressCacheKey(networkInterfaceId, privateIp string) string {
 	return networkInterfaceId + "/" + privateIp
 }
 
+// id is a fallback only. The key that matters is passed as __id by the creator,
+// because cacheNetworkInterfaceId is assigned after CreateResource returns and
+// so is always empty by the time this runs - which left every address keyed on
+// its private IP alone, and two VPCs built from the same CIDR plan alias.
 func (a *mqlAwsVpcNatgatewayAddress) id() (string, error) {
 	return natgatewayAddressCacheKey(a.cacheNetworkInterfaceId, a.PrivateIp.Data), nil
 }
@@ -344,6 +348,8 @@ func newMqlAwsVpcNatgateway(runtime *plugin.Runtime, region string, gw vpctypes.
 	for _, address := range gw.NatGatewayAddresses {
 		mqlAddr, err := CreateResource(runtime, ResourceAwsVpcNatgatewayAddress,
 			map[string]*llx.RawData{
+				"__id": llx.StringData(natgatewayAddressCacheKey(
+					convert.ToValue(address.NetworkInterfaceId), convert.ToValue(address.PrivateIp))),
 				"allocationId": llx.StringDataPtr(address.AllocationId),
 				"privateIp":    llx.StringDataPtr(address.PrivateIp),
 				"isPrimary":    llx.BoolDataPtr(address.IsPrimary),

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -688,3 +688,48 @@ func TestVgwTelemetryKeyIsScopedToItsConnection(t *testing.T) {
 		assert.NotEqual(t, got[0], got[1])
 	})
 }
+
+// TestNatgatewayAddressKeyIsSetAtCreation pins that a NAT gateway address is
+// keyed by its ENI, not just its private IP.
+//
+// The key helper was always correct; what was broken is that id() reads it from
+// cacheNetworkInterfaceId, which the creator assigns *after* CreateResource has
+// already computed the key. So the ENI was always empty at the moment it
+// mattered, every address keyed on its private IP alone, and two VPCs built
+// from the same CIDR plan aliased onto one row — with the post-construction
+// writes then racing on the shared object.
+func TestNatgatewayAddressKeyIsSetAtCreation(t *testing.T) {
+	// A fresh runtime per gateway: these all describe different gateways, and a
+	// shared runtime would legitimately return the first one from cache.
+	newAddress := func(natGatewayId, eni, privateIp string) *mqlAwsVpcNatgatewayAddress {
+		runtime := testRuntime()
+		gw := ec2types.NatGateway{
+			NatGatewayId: aws.String(natGatewayId),
+			NatGatewayAddresses: []ec2types.NatGatewayAddress{{
+				NetworkInterfaceId: aws.String(eni),
+				PrivateIp:          aws.String(privateIp),
+			}},
+		}
+		nat, err := newMqlAwsVpcNatgateway(runtime, "us-east-1", gw)
+		require.NoError(t, err)
+		require.Len(t, nat.Addresses.Data, 1)
+		return nat.Addresses.Data[0].(*mqlAwsVpcNatgatewayAddress)
+	}
+
+	t.Run("the eni reaches the cache key", func(t *testing.T) {
+		addr := newAddress("nat-0aaaaaaaaaaaaaaaa", "eni-0aaaaaaaaaaaaaaaa", "10.0.1.10")
+		assert.Equal(t, "eni-0aaaaaaaaaaaaaaaa/10.0.1.10", addr.MqlID(),
+			"the key must carry the ENI, which id() could never see")
+	})
+
+	t.Run("two vpcs with the same private ip do not alias", func(t *testing.T) {
+		first := newAddress("nat-0aaaaaaaaaaaaaaaa", "eni-0aaaaaaaaaaaaaaaa", "10.0.1.10")
+		second := newAddress("nat-0bbbbbbbbbbbbbbbb", "eni-0bbbbbbbbbbbbbbbb", "10.0.1.10")
+		assert.NotEqual(t, first.MqlID(), second.MqlID())
+	})
+
+	t.Run("an address with no eni still keys on its private ip", func(t *testing.T) {
+		addr := newAddress("nat-0ccccccccccccccccc", "", "10.0.1.10")
+		assert.Equal(t, "/10.0.1.10", addr.MqlID())
+	})
+}


### PR DESCRIPTION
`natgatewayAddressCacheKey` is **correct**, and its comment explains exactly why
the ENI has to be in the key:

```go
// Private NAT gateways have no AllocationId, so the allocation ID alone
// collapses every private address onto the same key; the ENI plus private IP
// are always present and uniquely identify the address.
func natgatewayAddressCacheKey(networkInterfaceId, privateIp string) string {
	return networkInterfaceId + "/" + privateIp
}
```

The problem is **when it runs**. `id()` reads the ENI from
`cacheNetworkInterfaceId`, and the creator assigns that *after*
`CreateResource` has already computed the key:

```go
mqlAddr, err := CreateResource(runtime, ResourceAwsVpcNatgatewayAddress, …)  // key computed here
…
mqlAddr.(*mqlAwsVpcNatgatewayAddress).cacheNetworkInterfaceId = …            // ENI arrives here
```

So the ENI was always empty at the only moment it mattered, and every address
was keyed on its **private IP alone**. Two VPCs built from the same CIDR plan —
the normal case for an environment template — aliased onto one row, and the
three post-construction writes then raced on that shared object.

## The fix

Pass the key as `__id` from the creator, where both values are in hand.

`id()` stays as a fallback, with a comment saying why it cannot be the
authority — so the next reader doesn't conclude the helper is broken and
rewrite a key that was right all along.

## Tests

`TestNatgatewayAddressKeyIsSetAtCreation` asserts the ENI reaches `MqlID()`,
that two gateways with the same private IP don't alias, and that an address
with no ENI still keys on its IP.

Worth noting how the test found its own bug: my first version reused one
runtime and one `NatGatewayId` across the subtests, and the later ones got the
**cached** gateway back — the resource cache behaving exactly as designed. Each
gateway now gets its own runtime.
