### PR TITLE
🐛 aws: tell an automl job's input channels apart by position

### DIFF
--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -1840,7 +1841,11 @@ func (a *mqlAwsSagemakerAutoMLJob) fetchDetails() error {
 		}
 		mqlCh, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerAutoMLJobInputChannel,
 			map[string]*llx.RawData{
-				"__id":                llx.StringData(a.Arn.Data + "/inputChannel/" + convert.ToValue(ch.TargetAttributeName)),
+				// Keyed by position, not by target attribute: the target attribute
+				// is the column the job predicts and is the same on every channel
+				// of a job, so keying on it merged the training and validation
+				// channels into one and hid the validation dataset's S3 URI.
+				"__id":                llx.StringData(autoMLInputChannelCacheKey(a.Arn.Data, i)),
 				"targetAttributeName": llx.StringDataPtr(ch.TargetAttributeName),
 				"contentType":         llx.StringDataPtr(ch.ContentType),
 				"compressionType":     llx.StringData(string(ch.CompressionType)),
@@ -1960,8 +1965,20 @@ type mqlAwsSagemakerAutoMLJobInputChannelInternal struct {
 	cacheIndex     int
 }
 
+// autoMLInputChannelCacheKey identifies one input channel of an AutoML job by
+// its position in the job's channel list. A channel has nothing else that
+// distinguishes it: the target attribute names the column being predicted and
+// is identical across a job's channels, and the S3 URI is what a caller is
+// trying to read rather than something to key on.
+func autoMLInputChannelCacheKey(jobArn string, index int) string {
+	return jobArn + "/inputChannel/" + strconv.Itoa(index)
+}
+
+// id is a fallback only. cacheIndex is assigned after CreateResource has
+// computed the key, so this cannot see the position; the creator passes the
+// real key as __id.
 func (a *mqlAwsSagemakerAutoMLJobInputChannel) id() (string, error) {
-	return a.cacheParentArn + "/inputChannel/" + a.TargetAttributeName.Data, nil
+	return autoMLInputChannelCacheKey(a.cacheParentArn, a.cacheIndex), nil
 }
 
 type mqlAwsSagemakerAutoMLJobOutputConfigInternal struct {

--- a/providers/aws/resources/aws_sagemaker_mlops_test.go
+++ b/providers/aws/resources/aws_sagemaker_mlops_test.go
@@ -1,0 +1,44 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAutoMLInputChannelCacheKey pins that an AutoML job's input channels are
+// told apart by position.
+//
+// A channel has nothing else that distinguishes it. The target attribute names
+// the column the job predicts and is identical across every channel of a job,
+// so keying on it merged the training and validation channels into one row and
+// made the validation dataset's S3 URI unreachable.
+func TestAutoMLInputChannelCacheKey(t *testing.T) {
+	const jobArn = "arn:aws:sagemaker:us-east-1:000000000000:automl-job/my-job"
+
+	t.Run("channels of one job do not collide", func(t *testing.T) {
+		train := autoMLInputChannelCacheKey(jobArn, 0)
+		validation := autoMLInputChannelCacheKey(jobArn, 1)
+		assert.NotEqual(t, train, validation)
+	})
+
+	t.Run("the same channel keys the same", func(t *testing.T) {
+		assert.Equal(t,
+			autoMLInputChannelCacheKey(jobArn, 1),
+			autoMLInputChannelCacheKey(jobArn, 1))
+	})
+
+	t.Run("channels of different jobs do not collide", func(t *testing.T) {
+		other := "arn:aws:sagemaker:us-east-1:000000000000:automl-job/other-job"
+		assert.NotEqual(t,
+			autoMLInputChannelCacheKey(jobArn, 0),
+			autoMLInputChannelCacheKey(other, 0))
+	})
+
+	t.Run("the key is scoped to its job", func(t *testing.T) {
+		assert.Equal(t, jobArn+"/inputChannel/0", autoMLInputChannelCacheKey(jobArn, 0))
+	})
+}


### PR DESCRIPTION
The cache key for `aws.sagemaker.autoMLJob.inputChannel` was the job ARN plus
the channel's **target attribute name**:

```go
"__id": llx.StringData(a.Arn.Data + "/inputChannel/" + convert.ToValue(ch.TargetAttributeName)),
```

The target attribute is the column the job predicts. It is the **same on every
channel of a job** — that's what makes it the target. So a job with a training
channel and a validation channel produced **one** row instead of two: the
training channel was reported twice, and the validation dataset's S3 URI could
not be read at all.

## The fix

A channel has nothing else that identifies it — the S3 URI is what a caller is
trying to *read*, not something to key on — so position is the identity.

`cacheIndex` was already being assigned two lines below for exactly this, and
had no reader:

```go
ic.cacheParentArn = a.Arn.Data
ic.cacheIndex = i          // set, never used
```

`id()` cannot use it either, since `cacheIndex` is assigned *after*
`CreateResource` has computed the key. It stays as a fallback with a comment,
and the creator passes the real key.

## Compatibility

The key is internal — `aws.sagemaker.autoMLJob.inputChannel` exposes no `id`
field. Nothing user-visible changes except that a job's channels stop merging.

## Tests

`TestAutoMLInputChannelCacheKey` — channels of one job don't collide, the same
channel keys the same, channels of different jobs don't collide, and the key
stays scoped to its job ARN.
