### PR TITLE
🐛 aws: scope vpn tunnel telemetry to its connection

### DIFF
--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3578,6 +3578,9 @@ func (a *mqlAwsEc2Vpnconnection) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+// id is a fallback only. A telemetry entry carries nothing but its outside IP,
+// which is empty while the tunnel is provisioning and is not scoped to a
+// connection, so the creator passes a connection-scoped, indexed __id instead.
 func (a *mqlAwsEc2Vgwtelemetry) id() (string, error) {
 	return a.OutsideIpAddress.Data, nil
 }
@@ -3617,10 +3620,19 @@ type mqlAwsEc2VpnconnectionInternal struct {
 }
 
 func newMqlVpnConnection(runtime *plugin.Runtime, region string, accountID string, vpnConn ec2types.VpnConnection) (*mqlAwsEc2Vpnconnection, error) {
+	connID := convert.ToValue(vpnConn.VpnConnectionId)
+
 	mqlVgwT := []any{}
-	for _, vgwT := range vpnConn.VgwTelemetry {
+	for i, vgwT := range vpnConn.VgwTelemetry {
 		mqlVgwTelemetry, err := CreateResource(runtime, ResourceAwsEc2Vgwtelemetry,
 			map[string]*llx.RawData{
+				// Scoped to the connection and indexed, for the same reason the
+				// tunnel options below are: the outside IP is the only thing
+				// distinguishing one telemetry entry from another, and it is
+				// empty while a tunnel is still provisioning - so both tunnels
+				// of a new connection keyed identically, and every connection
+				// in that state shared one row across the whole account.
+				"__id":             llx.StringData(fmt.Sprintf("%s/vgwTelemetry/%d/%s", connID, i, convert.ToValue(vgwT.OutsideIpAddress))),
 				"outsideIpAddress": llx.StringData(convert.ToValue(vgwT.OutsideIpAddress)),
 				"status":           llx.StringData(string(vgwT.Status)),
 				"statusMessage":    llx.StringData(convert.ToValue(vgwT.StatusMessage)),
@@ -3644,13 +3656,12 @@ func newMqlVpnConnection(runtime *plugin.Runtime, region string, accountID strin
 		outsideIpType = convert.ToValue(opts.OutsideIpAddressType)
 		tunnelIpVersion = string(opts.TunnelInsideIpVersion)
 
-		vpnConnID := convert.ToValue(vpnConn.VpnConnectionId)
 		for i, tun := range opts.TunnelOptions {
 			outsideIP := convert.ToValue(tun.OutsideIpAddress)
 			mqlTunnelOpt, err := CreateResource(runtime, ResourceAwsEc2VpnconnectionTunnelOption,
 				map[string]*llx.RawData{
 					// index disambiguates tunnels whose outside IP is still empty during provisioning
-					"__id":                       llx.StringData(fmt.Sprintf("%s/tunnelOption/%d/%s", vpnConnID, i, outsideIP)),
+					"__id":                       llx.StringData(fmt.Sprintf("%s/tunnelOption/%d/%s", connID, i, outsideIP)),
 					"outsideIpAddress":           llx.StringData(outsideIP),
 					"tunnelInsideCidr":           llx.StringData(convert.ToValue(tun.TunnelInsideCidr)),
 					"ikeVersions":                llx.ArrayData(listValuesToStrings(tun.IkeVersions, func(v ec2types.IKEVersionsListValue) *string { return v.Value }), types.String),

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -631,3 +631,60 @@ func TestNatgatewayAddressCacheKey(t *testing.T) {
 	assert.Equal(t, "eni-4e5f6a7b/10.0.0.6", b)
 	assert.NotEqual(t, a, b)
 }
+
+// TestVgwTelemetryKeyIsScopedToItsConnection pins that a VPN connection's
+// telemetry entries are told apart from each other and from other connections'.
+//
+// A telemetry entry carries nothing but its outside IP, and that IP is empty
+// while a tunnel is still provisioning. Keying on it alone meant both tunnels
+// of a new connection shared one row, and so did every connection in that state
+// across the whole account — so a query for tunnel status during a rollout, the
+// moment it matters most, read one entry repeated.
+func TestVgwTelemetryKeyIsScopedToItsConnection(t *testing.T) {
+	newConn := func(id string, outsideIPs ...string) *mqlAwsEc2Vpnconnection {
+		telemetry := make([]ec2types.VgwTelemetry, 0, len(outsideIPs))
+		for _, ip := range outsideIPs {
+			telemetry = append(telemetry, ec2types.VgwTelemetry{
+				OutsideIpAddress: aws.String(ip),
+				Status:           ec2types.TelemetryStatusDown,
+			})
+		}
+		conn, err := newMqlVpnConnection(testRuntime(), "us-east-1", "000000000000",
+			ec2types.VpnConnection{
+				VpnConnectionId: aws.String(id),
+				VgwTelemetry:    telemetry,
+			})
+		require.NoError(t, err)
+		return conn
+	}
+
+	keys := func(conn *mqlAwsEc2Vpnconnection) []string {
+		out := []string{}
+		for _, raw := range conn.VgwTelemetry.Data {
+			out = append(out, raw.(*mqlAwsEc2Vgwtelemetry).MqlID())
+		}
+		return out
+	}
+
+	t.Run("both tunnels of a provisioning connection are distinct", func(t *testing.T) {
+		// Neither tunnel has an outside IP yet, which is the case that collapsed
+		// them onto one row.
+		got := keys(newConn("vpn-0aaaaaaaaaaaaaaaa", "", ""))
+		require.Len(t, got, 2)
+		assert.NotEqual(t, got[0], got[1])
+	})
+
+	t.Run("two provisioning connections do not share entries", func(t *testing.T) {
+		first := keys(newConn("vpn-0aaaaaaaaaaaaaaaa", "", ""))
+		second := keys(newConn("vpn-0bbbbbbbbbbbbbbbb", "", ""))
+		for _, a := range first {
+			assert.NotContains(t, second, a)
+		}
+	})
+
+	t.Run("established tunnels stay distinct too", func(t *testing.T) {
+		got := keys(newConn("vpn-0aaaaaaaaaaaaaaaa", "203.0.113.1", "203.0.113.2"))
+		require.Len(t, got, 2)
+		assert.NotEqual(t, got[0], got[1])
+	})
+}


### PR DESCRIPTION
`aws.ec2.vgwtelemetry` keyed on the outside IP address alone:

```go
func (a *mqlAwsEc2Vgwtelemetry) id() (string, error) {
	return a.OutsideIpAddress.Data, nil
}
```

That address is **empty while a tunnel is still provisioning**. So both tunnels
of a new connection keyed identically — and so did every *other* connection in
that state, across the whole account. A query for tunnel status during a
rollout, which is exactly when it matters, read one entry repeated.

Even once established, the key isn't scoped to a connection, so it relies on
outside IPs being globally distinct rather than on identity.

## The fix

Key on the connection and the index — which is what the **tunnel options built
in the same function** already do:

```go
// index disambiguates tunnels whose outside IP is still empty during provisioning
"__id": llx.StringData(fmt.Sprintf("%s/tunnelOption/%d/%s", vpnConnID, i, outsideIP)),
```

That comment was already there, on the sibling collection, describing this
exact problem. The telemetry loop just never got the same treatment.

The connection id is now computed once at the top of `newMqlVpnConnection` and
shared by both loops, rather than declared inside the options block.

## Compatibility

The key is internal — `aws.ec2.vgwtelemetry` exposes no `id` field.
`outsideIpAddress` is unchanged.

## Tests

`TestVgwTelemetryKeyIsScopedToItsConnection` — two tunnels of a connection with
**no** outside IPs yet are distinct (the case that collapsed them); two
provisioning connections share no entries; established tunnels stay distinct.
