### PR TITLE
🐛 aws: read an automl job with the V2 describe, and fetch dynamodb's sse key

### DIFF
--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.53.3",
-  "generated_at": "2026-08-19T11:52:57-07:00",
+  "generated_at": "2026-08-19T15:36:50-07:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -797,7 +797,7 @@
     "sagemaker:DescribeApp",
     "sagemaker:DescribeAppImageConfig",
     "sagemaker:DescribeArtifact",
-    "sagemaker:DescribeAutoMLJob",
+    "sagemaker:DescribeAutoMLJobV2",
     "sagemaker:DescribeCluster",
     "sagemaker:DescribeClusterNode",
     "sagemaker:DescribeCodeRepository",
@@ -6005,9 +6005,9 @@
       "source_file": "aws_sagemaker_lineage.go"
     },
     {
-      "permission": "sagemaker:DescribeAutoMLJob",
+      "permission": "sagemaker:DescribeAutoMLJobV2",
       "service": "sagemaker",
-      "action": "DescribeAutoMLJob",
+      "action": "DescribeAutoMLJobV2",
       "source_file": "aws_sagemaker_mlops.go"
     },
     {

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -441,6 +441,14 @@ type mqlAwsDynamodbTableInternal struct {
 }
 
 func (a *mqlAwsDynamodbTable) sseKmsKey() (*mqlAwsKmsKey, error) {
+	// cacheSseKmsKeyArn is assigned by fetchDetail, so reading it without
+	// fetching first reports null for every table - including one encrypted
+	// with a customer-managed key, which is the case this field exists to
+	// answer. sourceTable, the sibling built on the same cache, already
+	// fetches first.
+	if err := a.fetchDetail(); err != nil {
+		return nil, err
+	}
 	if a.cacheSseKmsKeyArn == nil || *a.cacheSseKmsKeyArn == "" {
 		a.SseKmsKey.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil

--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	sagemakertypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -1823,7 +1824,13 @@ func (a *mqlAwsSagemakerAutoMLJob) fetchDetails() error {
 	svc := conn.Sagemaker(a.Region.Data)
 	ctx := context.Background()
 	name := a.Name.Data
-	resp, err := svc.DescribeAutoMLJob(ctx, &sagemaker.DescribeAutoMLJobInput{AutoMLJobName: &name})
+	// DescribeAutoMLJobV2, not DescribeAutoMLJob. A job created through
+	// CreateAutoMLJobV2 cannot be described by the V1 operation at all - it
+	// answers ValidationException - and V2 is the API AWS points callers at, so
+	// every job created by the current API failed every field on this resource.
+	// V2 describes jobs created by either operation, so the V1 path has nothing
+	// left to cover.
+	resp, err := svc.DescribeAutoMLJobV2(ctx, &sagemaker.DescribeAutoMLJobV2Input{AutoMLJobName: &name})
 	if err != nil {
 		return err
 	}
@@ -1831,9 +1838,11 @@ func (a *mqlAwsSagemakerAutoMLJob) fetchDetails() error {
 	a.cacheRoleArn = resp.RoleArn
 	a.cacheFailureReason = convert.ToValue(resp.FailureReason)
 
+	targetAttributeName := autoMLTargetAttributeName(resp.AutoMLProblemTypeConfig)
+
 	// Input channels
-	channels := make([]any, 0, len(resp.InputDataConfig))
-	for i, ch := range resp.InputDataConfig {
+	channels := make([]any, 0, len(resp.AutoMLJobInputDataConfig))
+	for i, ch := range resp.AutoMLJobInputDataConfig {
 		var s3Uri, s3DataType string
 		if ch.DataSource != nil && ch.DataSource.S3DataSource != nil {
 			s3Uri = convert.ToValue(ch.DataSource.S3DataSource.S3Uri)
@@ -1846,7 +1855,7 @@ func (a *mqlAwsSagemakerAutoMLJob) fetchDetails() error {
 				// of a job, so keying on it merged the training and validation
 				// channels into one and hid the validation dataset's S3 URI.
 				"__id":                llx.StringData(autoMLInputChannelCacheKey(a.Arn.Data, i)),
-				"targetAttributeName": llx.StringDataPtr(ch.TargetAttributeName),
+				"targetAttributeName": llx.StringDataPtr(targetAttributeName),
 				"contentType":         llx.StringDataPtr(ch.ContentType),
 				"compressionType":     llx.StringData(string(ch.CompressionType)),
 				"s3Uri":               llx.StringData(s3Uri),
@@ -1963,6 +1972,21 @@ func (a *mqlAwsSagemakerAutoMLJob) failureReason() (string, error) {
 type mqlAwsSagemakerAutoMLJobInputChannelInternal struct {
 	cacheParentArn string
 	cacheIndex     int
+}
+
+// autoMLTargetAttributeName reads the column an AutoML job predicts.
+//
+// V1 reported it on every input channel. V2 moved it onto the problem-type
+// config, which is the truer place for it: it is a property of the job, not of
+// a dataset. Only a tabular job has one - image, text and time-series jobs have
+// no target column - so anything else reads null rather than empty, which would
+// claim the job named no target.
+func autoMLTargetAttributeName(cfg sagemakertypes.AutoMLProblemTypeConfig) *string {
+	tabular, ok := cfg.(*sagemakertypes.AutoMLProblemTypeConfigMemberTabularJobConfig)
+	if !ok {
+		return nil
+	}
+	return tabular.Value.TargetAttributeName
 }
 
 // autoMLInputChannelCacheKey identifies one input channel of an AutoML job by

--- a/providers/aws/resources/aws_sagemaker_mlops_test.go
+++ b/providers/aws/resources/aws_sagemaker_mlops_test.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"testing"
 
+	sagemakertypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,5 +41,46 @@ func TestAutoMLInputChannelCacheKey(t *testing.T) {
 
 	t.Run("the key is scoped to its job", func(t *testing.T) {
 		assert.Equal(t, jobArn+"/inputChannel/0", autoMLInputChannelCacheKey(jobArn, 0))
+	})
+}
+
+// TestAutoMLTargetAttributeName pins where the target column is read from on a
+// V2 AutoML job.
+//
+// V1 reported it on every input channel; V2 reports it once, on the
+// problem-type config. Only a tabular job has a target column, so every other
+// problem type has to read null rather than empty - an empty string would claim
+// the job named no target, which is a different statement from having none.
+func TestAutoMLTargetAttributeName(t *testing.T) {
+	t.Run("tabular job reports its target column", func(t *testing.T) {
+		target := "churn"
+		got := autoMLTargetAttributeName(&sagemakertypes.AutoMLProblemTypeConfigMemberTabularJobConfig{
+			Value: sagemakertypes.TabularJobConfig{TargetAttributeName: &target},
+		})
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "churn", *got)
+		}
+	})
+
+	t.Run("a tabular job that names no target reads null", func(t *testing.T) {
+		assert.Nil(t, autoMLTargetAttributeName(
+			&sagemakertypes.AutoMLProblemTypeConfigMemberTabularJobConfig{
+				Value: sagemakertypes.TabularJobConfig{},
+			}))
+	})
+
+	t.Run("a problem type with no target column reads null", func(t *testing.T) {
+		assert.Nil(t, autoMLTargetAttributeName(
+			&sagemakertypes.AutoMLProblemTypeConfigMemberTextClassificationJobConfig{
+				Value: sagemakertypes.TextClassificationJobConfig{},
+			}))
+		assert.Nil(t, autoMLTargetAttributeName(
+			&sagemakertypes.AutoMLProblemTypeConfigMemberTimeSeriesForecastingJobConfig{
+				Value: sagemakertypes.TimeSeriesForecastingJobConfig{},
+			}))
+	})
+
+	t.Run("an absent config reads null", func(t *testing.T) {
+		assert.Nil(t, autoMLTargetAttributeName(nil))
 	})
 }


### PR DESCRIPTION
Two fields that reported nothing against a real AWS account, found while verifying the last 48 hours of `aws` changes on live infrastructure.

## `aws.sagemaker.autoMLJob` could not be read at all

`fetchDetails` called `DescribeAutoMLJob`. AWS refuses that call for any job created through `CreateAutoMLJobV2`:

```
ValidationException: Please use DescribeAutoMLJobV2 API for describing AutoML jobs
created via CreateAutoMLJobV2 API. DescribeAutoMLJob cannot be used to describe
AutoML jobs that are created via CreateAutoMLJobV2 API.
```

V2 is the API AWS points callers at, so a job created by the current API failed **every** computed field on the resource at once — `inputDataConfig`, `outputDataConfig`, `bestCandidate`, `iamRole`, `failureReason`. `ListAutoMLJobs` still returned the job, so it showed up in the listing with its detail unreadable.

The SDK documents V2 as describing jobs created by either operation ("_We recommend using the new versions `CreateAutoMLJobV2` and `DescribeAutoMLJobV2`, which offer backward compatibility_"), so the V1 path has nothing left to cover.

The target attribute moves with it. V1 repeated it on every input channel; V2 reports it once on the problem-type config, which is the truer place for it — it names the column the job predicts, a property of the job rather than of a dataset. Only a tabular job has one, so `autoMLTargetAttributeName` returns null for the image, text and time-series problem types rather than an empty string, which would claim the job named no target.

## `aws.dynamodb.table.sseKmsKey` was always null

The accessor read `cacheSseKmsKeyArn` without calling `fetchDetail`, the function that assigns it. The field therefore reported null on every table — including one encrypted with a customer-managed key, which is the case the field exists to answer. A check for "encrypted with a CMK" found nothing to object to on a table that has one.

`sourceTable`, the sibling built on the same cache, already fetches first. This makes `sseKmsKey` do the same.

## Verification

Against a live account, on infrastructure provisioned for the purpose:

| | before | after |
|---|---|---|
| AutoML job with a training + validation channel | `inputDataConfig` errored | both channels resolve to their own S3 URIs |
| DynamoDB table with a CMK | `sseKmsKey: null` | resolves to the key, `keyManager: "CUSTOMER"` |

Adds `TestAutoMLTargetAttributeName` covering the tabular, no-target, non-tabular and absent-config cases. `go test ./...` passes in `providers/aws/`.

`aws.permissions.json` swaps `sagemaker:DescribeAutoMLJob` for `sagemaker:DescribeAutoMLJobV2` to match.
