### PR TITLE
🟢 ci: install the Go version the repo builds with, not the newest one

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,2 @@
-golang-version=1.26.1
+golang-version=1.26.6
 protoc-version=33.x

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Generate test files

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -87,7 +87,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -128,7 +128,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -160,7 +160,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -218,7 +218,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -251,7 +251,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-test-windows.yml
+++ b/.github/workflows/pr-test-windows.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/reusable-lint-providers.yml
+++ b/.github/workflows/reusable-lint-providers.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/update-oui-table.yaml
+++ b/.github/workflows/update-oui-table.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 


### PR DESCRIPTION
## What happened

Every `setup-go` step asks for `go-version: ">=${{ env.golang-version }}"`. `>=` is open-ended, so `setup-go` installs the **newest** release available on the runner, not the version this repo pins. Go 1.27.0 reached the runner images and CI moved onto it on its own — no commit in this repo did it:

```
Setup go version spec >=1.26.1
Successfully set up Go version >=1.26.1
go version go1.27.0 linux/amd64
```

Two jobs went red on `main` as a result:

| job | failure |
|---|---|
| `go-test` | `llx TestRawDataJson_Umlauts` — Go 1.27's `encoding/json` escapes U+FFFD as `�` instead of emitting it raw, so the expected string no longer matches |
| `golangci-lint` | golangci-lint 2.10.1 cannot read Go 1.27 export data (`export data version 4 is greater than maximum supported version 2`) and invents typecheck errors in `utils/syncx/map.go` |

Both are toolchain alone. On unmodified `main`:

```
$ GOTOOLCHAIN=go1.26.6 go test ./llx/ -run TestRawDataJson_Umlauts
ok      go.mondoo.com/mql/v13/llx

$ GOTOOLCHAIN=go1.27.0 go test ./llx/ -run TestRawDataJson_Umlauts
--- FAIL: TestRawDataJson_Umlauts
    expected: "\"Systemintegrit��t\""
    actual  : "\"Systemintegrit\\ufffdt\""
FAIL
```

## What this changes

- Drops `>=` from all **16** steps across **11** workflows, so the value in `.github/env` is the version that gets installed.
- Moves `.github/env` `golang-version` from `1.26.1` to `1.26.6`, matching the `go` directive — all **79** `go.mod` files in the tree say `1.26.6`, so that is what the code is actually built and tested against.

A Go upgrade now arrives as a reviewed one-line change to `.github/env`, which is where a change with this blast radius should be visible, instead of as unrelated PRs turning red.

## Deliberately not in scope

Making those two failures pass under Go 1.27. That is real work — the test expectation and a golangci-lint bump — and it should land on its own. This pin is what buys the time to do it.

If you'd rather remove the knob entirely, `go-version-file: go.mod` makes `go.mod` the single source of truth and cannot drift; happy to switch to that instead.
