### PR TITLE
✨ aws: reach the containing VPC from a subnet

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -713,6 +713,14 @@ private aws.vpc.subnet @defaults("id cidrs region availabilityZone defaultForAva
   networkInterfaces() []aws.ec2.networkinterface
   // EC2 instances running in this subnet, resolved through their network interfaces
   instances() []aws.ec2.instance
+  // VPC that contains this subnet
+  //
+  // The containing VPC, for reaching VPC-level context from a subnet handed
+  // out by another resource. Without it a check starting from, say,
+  // `aws.workspaces.directory.subnets` has to scan every VPC in the account to
+  // find the one its subnets belong to. Null when the subnet was created
+  // without a known VPC id.
+  vpc() aws.vpc
 }
 
 // Amazon Virtual Private Cloud (VPC) endpoint

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5540,6 +5540,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.subnet.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcSubnet).GetInstances()).ToDataRes(types.Array(types.Resource("aws.ec2.instance")))
 	},
+	"aws.vpc.subnet.vpc": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcSubnet).GetVpc()).ToDataRes(types.Resource("aws.vpc"))
+	},
 	"aws.vpc.endpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetId()).ToDataRes(types.String)
 	},
@@ -37275,6 +37278,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.vpc.subnet.instances": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcSubnet).Instances, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.subnet.vpc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcSubnet).Vpc, ok = plugin.RawToTValue[*mqlAwsVpc](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.endpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -84536,6 +84543,7 @@ type mqlAwsVpcSubnet struct {
 	Ipv6CidrBlock               plugin.TValue[string]
 	NetworkInterfaces           plugin.TValue[[]any]
 	Instances                   plugin.TValue[[]any]
+	Vpc                         plugin.TValue[*mqlAwsVpc]
 }
 
 // createAwsVpcSubnet creates a new instance of this resource
@@ -84734,6 +84742,22 @@ func (c *mqlAwsVpcSubnet) GetInstances() *plugin.TValue[[]any] {
 		}
 
 		return c.instances()
+	})
+}
+
+func (c *mqlAwsVpcSubnet) GetVpc() *plugin.TValue[*mqlAwsVpc] {
+	return plugin.GetOrCompute[*mqlAwsVpc](&c.Vpc, func() (*mqlAwsVpc, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.subnet", c.__id, "vpc")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsVpc), nil
+			}
+		}
+
+		return c.vpc()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -10850,6 +10850,7 @@ aws.vpc.subnet.region 11.15.2
 aws.vpc.subnet.routeTable 11.15.2
 aws.vpc.subnet.state 11.15.2
 aws.vpc.subnet.tags 11.15.2
+aws.vpc.subnet.vpc 13.53.4
 aws.vpc.subnets 11.15.2
 aws.vpc.tags 11.15.2
 aws.vpc.vpnGateway 11.15.2

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1240,6 +1240,25 @@ type mqlAwsVpcSubnetInternal struct {
 	cacheVpcId string
 }
 
+// vpc resolves the VPC that contains this subnet. DescribeSubnets returns
+// VpcId on every subnet, so both paths that build a subnet already seed
+// cacheVpcId and this costs no extra call once the VPC has been listed.
+func (a *mqlAwsVpcSubnet) vpc() (*mqlAwsVpc, error) {
+	if a.cacheVpcId == "" {
+		a.Vpc.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	mqlVpc, err := NewResource(a.MqlRuntime, ResourceAwsVpc,
+		map[string]*llx.RawData{
+			"arn": llx.StringData(fmt.Sprintf(vpcArnPattern, a.Region.Data, conn.AccountId(), a.cacheVpcId)),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return mqlVpc.(*mqlAwsVpc), nil
+}
+
 func (a *mqlAwsVpcSubnet) routeTable() (*mqlAwsVpcRoutetable, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	region := a.Region.Data

--- a/providers/aws/resources/aws_vpc_init_test.go
+++ b/providers/aws/resources/aws_vpc_init_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,5 +154,59 @@ func TestInitAwsVpc(t *testing.T) {
 		_, _, err := initAwsVpc(runtime, args)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "arn or id required")
+	})
+}
+
+func TestAwsVpcSubnetVpc(t *testing.T) {
+	const (
+		vpcId    = "vpc-0abc123def456"
+		subnetId = "subnet-0abc123def456"
+		region   = "us-east-1"
+	)
+
+	t.Run("reports null when the subnet carries no VPC id", func(t *testing.T) {
+		runtime := testAwsRuntime("irrelevant", nil, nil)
+		subnet := &mqlAwsVpcSubnet{
+			MqlRuntime: runtime,
+			Id:         plugin.TValue[string]{Data: subnetId, State: plugin.StateIsSet},
+			Region:     plugin.TValue[string]{Data: region, State: plugin.StateIsSet},
+		}
+
+		vpc, err := subnet.vpc()
+		require.NoError(t, err)
+		assert.Nil(t, vpc)
+		// Without the explicit null state the runtime never learns the field
+		// was resolved, and re-fetches it forever.
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, subnet.Vpc.State)
+	})
+
+	t.Run("resolves the containing VPC without an API call", func(t *testing.T) {
+		runtime := testAwsRuntime("irrelevant", nil, nil)
+		conn := runtime.Connection.(*connection.AwsConnection)
+
+		// The ARN a listed VPC is cached under. Resolving through the cache is
+		// the whole point: an ARN composed any other way misses and falls
+		// through to DescribeVpcs, which this runtime has no client for.
+		vpcArn := fmt.Sprintf(vpcArnPattern, region, conn.AccountId(), vpcId)
+		cachedVpc := &mqlAwsVpc{
+			MqlRuntime: runtime,
+			Id:         plugin.TValue[string]{Data: vpcId, State: plugin.StateIsSet},
+			Arn:        plugin.TValue[string]{Data: vpcArn, State: plugin.StateIsSet},
+			Region:     plugin.TValue[string]{Data: region, State: plugin.StateIsSet},
+		}
+		runtime.Resources.Set(ResourceAwsVpc+"\x00"+vpcArn, cachedVpc)
+
+		subnet := &mqlAwsVpcSubnet{
+			MqlRuntime: runtime,
+			Id:         plugin.TValue[string]{Data: subnetId, State: plugin.StateIsSet},
+			Region:     plugin.TValue[string]{Data: region, State: plugin.StateIsSet},
+		}
+		subnet.cacheVpcId = vpcId
+
+		vpc, err := subnet.vpc()
+		require.NoError(t, err)
+		require.NotNil(t, vpc)
+		assert.Equal(t, vpcId, vpc.Id.Data)
+		assert.Same(t, cachedVpc, vpc)
 	})
 }


### PR DESCRIPTION
Closes #9881.

`aws.vpc.subnet` had no way back to the VPC that contains it. The traversal only ran the other way (`aws.vpc.subnets`), so anything handed a subnet directly — `aws.rds.dbinstance.subnets`, `aws.workspaces.directory.subnets`, `aws.appstream.fleet.subnets`, `aws.vpc.natgateway.subnet` — had to scan every VPC in the account to find its parent, from inside an `.all()` where the outer subnet can't be referenced at all.

## What changed

One computed field:

```
private aws.vpc.subnet {
  ...
  // VPC that contains this subnet
  vpc() aws.vpc
}
```

`DescribeSubnets` returns `VpcId` on every subnet, and **both** paths that build a subnet resource (the VPC lister, and `initAwsVpcSubnet`) already seed `cacheVpcId` — it was added for `routeTable()`. So the value was being carried and thrown away; this only exposes it.

The ARN is composed exactly as `aws.vpcs` composes it, so a VPC already listed resolves straight out of the resource cache with **no API call**; otherwise it costs one targeted `DescribeVpcs`. `aws.permissions.json` is unchanged at 1025 permissions.

No raw `vpcId string` alongside it: `aws.lr` carries `vpc() aws.vpc` on ~20 resources and a raw `vpcId` on none.

## Verified live (us-east-1)

Both directions, so a field that never moves can't pass for a working one.

**Subnets reached from their VPC** — each resolves to its own parent, and the two VPCs disagree:

```coffee
aws.vpcs.map({ vpc: id, isDefault: isDefault, subnetVpcDefault: subnets.map(vpc.isDefault) })
```
```
0: { vpc: "vpc-6be2c011",          isDefault: true,  subnetVpcDefault: [true,  true,  true,  true,  true,  true]  }
1: { vpc: "vpc-0a68d4de58bf24ad8", isDefault: false, subnetVpcDefault: [false, false, false, false, false, false] }
```

**Subnets reached from another resource** — the `initAwsVpcSubnet` path the issue is actually about:

```coffee
aws.rds.instances.map({ name: id, subnets: subnets.map({ s: id, v: vpc.id, def: vpc.isDefault, cidr: vpc.cidrBlock }) })
```
```
0: { name: "luna-sensitive", subnets: [
     { s: "subnet-7555704b", v: "vpc-6be2c011", def: true, cidr: "172.31.0.0/16" }, ... x6 ] }
```

**The check that could not be written before**, in both directions:

```coffee
aws.vpcs.where(isDefault == false).all(subnets.all(vpc.isDefault == false))   # [ok] true
aws.vpcs.where(isDefault == true ).all(subnets.all(vpc.isDefault == false))   # [failed], as it should
aws.rds.instances.all(subnets.all(vpc.isDefault == false))                    # [failed] — this DB really is in the default VPC
```

## Tests

`TestAwsVpcSubnetVpc` covers the two branches that can't be seen from a live run:

- a subnet with no cached VPC id returns nil **and** sets `StateIsSet|StateIsNull` — without that the runtime never learns the field resolved and re-fetches forever;
- a subnet with one resolves out of the cache, asserting `assert.Same` on the cached instance, which fails if the composed ARN diverges by even a character from the one `aws.vpcs` caches under.

## Diff shape

Strictly additive — `git diff --numstat` reports **0 deletions** across all five files.
