### PR TITLE
✨ let providers declare a default scan parallelism

### DIFF
--- a/providers-sdk/v1/plugin/start.go
+++ b/providers-sdk/v1/plugin/start.go
@@ -39,6 +39,17 @@ type Provider struct {
 	// hardcoding name/family/kind/runtime inline.
 	Platforms []*PlatformInfo `json:",omitempty"`
 	Maturity  string          `json:",omitempty"`
+	// DefaultParallelism is how many of this provider's assets may be scanned
+	// concurrently when the user did not ask for a specific number. Zero (the
+	// default) means the provider has not opted in and its assets are scanned
+	// one at a time.
+	//
+	// Declare the number the provider's backend can sustain -- its API rate
+	// limits, its throttling behavior, the blast radius of hitting one account
+	// or cluster from several assets at once. The scanner caps whatever is
+	// declared here by the CPUs available on the machine, so this is a
+	// statement about the target, not about the host running the scan.
+	DefaultParallelism int `json:",omitempty"`
 }
 
 // PlatformInfo is the static, pre-declarable description of one platform a

--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -17,6 +17,10 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
 	Version:         "13.53.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
+	// Throttling is per service and per region, and an organization scan spreads
+	// its calls over separate accounts, so the limits are rarely the binding
+	// constraint before the CPU cap is.
+	DefaultParallelism: 8,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "aws",

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -20,6 +20,10 @@ var Config = plugin.Provider{
 		provider.ConnectionType,
 		string(azureinstancesnapshot.SnapshotConnectionType),
 	},
+	// Lower than the other clouds: ARM read throttling is scoped to the
+	// subscription, so it bites hardest in the common case where several assets
+	// share one.
+	DefaultParallelism: 6,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "azure",

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -20,6 +20,9 @@ var Config = plugin.Provider{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),
 	},
+	// Quotas are per project, and an organization scan spreads its calls over
+	// separate projects.
+	DefaultParallelism: 8,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "gcp",

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -15,6 +15,10 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
 	Version:         "13.9.0",
 	ConnectionTypes: []string{provider.ConnectionType},
+	// GitHub's 5,000 requests/hour is already the binding constraint on a large
+	// organization, and there is a secondary limit on concurrent requests, so
+	// this stays deliberately low.
+	DefaultParallelism: 4,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "github",

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -18,7 +18,11 @@ var Config = plugin.Provider{
 		provider.GitlabGroupConnection,
 		provider.GitlabProjectConnection,
 	},
-	Platforms: provider.Platforms,
+	// Held low by gitlab.com's request rate limit. The IaC targets clone each
+	// repository during connect, which the scanner still does one at a time, so
+	// a higher number would not buy much there either.
+	DefaultParallelism: 4,
+	Platforms:          provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "gitlab",

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -16,6 +16,10 @@ var Config = plugin.Provider{
 	Version:         "13.10.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
+	// The client-go rate limiter is already raised well above its defaults, so
+	// concurrent asset scans reach the API server rather than queueing locally.
+	// Kept at 8 so a small control plane's API Priority and Fairness has room.
+	DefaultParallelism: 8,
 	Connectors: []plugin.Connector{
 		{
 			Name:    "k8s",

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -16,6 +16,10 @@ var Config = plugin.Provider{
 	Version:         "13.3.0",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	Platforms:       provider.Platforms,
+	// Host scans are almost entirely spent waiting on DNS, TLS and HTTP against
+	// unrelated targets, with no shared rate limit to trip, so this is the
+	// highest default we hand out.
+	DefaultParallelism: 10,
 	CrossProviderTypes: []string{
 		"go.mondoo.com/mql/providers/os",
 		"go.mondoo.com/mql/providers/k8s",

--- a/providers/parallelism.go
+++ b/providers/parallelism.go
@@ -1,0 +1,110 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	goruntime "runtime"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// SequentialParallelism scans one asset at a time. It is the fallback whenever
+// we cannot establish that every asset in the scan belongs to a provider that
+// opted into concurrent scanning.
+const SequentialParallelism = 1
+
+// ResolveParallelism decides how many assets may be scanned concurrently.
+//
+// A requested value greater than zero wins outright and is returned unchanged.
+// The CPU cap below exists to keep the *default* safe on small machines, not to
+// overrule an operator who named a number.
+//
+// Without an explicit request we take the smallest DefaultParallelism declared
+// by the providers behind the root assets, capped by cpuCap(). If any root
+// resolves to a provider that has not opted in -- or to no provider at all --
+// the whole scan stays sequential: one shared worker pool serves every asset in
+// the tree, so we can only go concurrent when all of the roots agree it is safe.
+func ResolveParallelism(requested int, roots []*inventory.Asset) int {
+	if requested > 0 {
+		return requested
+	}
+
+	provs, err := ListActive()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to list providers, scanning assets sequentially")
+		return SequentialParallelism
+	}
+
+	return resolveParallelism(roots, provs, cpuCap())
+}
+
+// resolveParallelism is the pure core of ResolveParallelism, with the installed
+// providers and the CPU cap passed in so it can be tested without touching the
+// provider directory or the host's core count.
+func resolveParallelism(roots []*inventory.Asset, provs Providers, cpuLimit int) int {
+	declared := 0
+	for _, asset := range roots {
+		if asset == nil {
+			continue
+		}
+
+		for _, conf := range asset.Connections {
+			if conf == nil || conf.Type == "" {
+				continue
+			}
+
+			n := declaredParallelism(provs, conf.Type)
+			if n <= 0 {
+				// Either the provider has not opted in, or we could not resolve
+				// the connection type to a provider at all. Either way we do not
+				// know that these assets are safe to scan concurrently.
+				log.Debug().
+					Str("connection-type", conf.Type).
+					Msg("provider does not declare a default parallelism, scanning assets sequentially")
+				return SequentialParallelism
+			}
+
+			if declared == 0 || n < declared {
+				declared = n
+			}
+		}
+	}
+
+	if declared <= 0 {
+		return SequentialParallelism
+	}
+	return min(declared, cpuLimit)
+}
+
+// declaredParallelism returns the parallelism the provider behind connType
+// declares, or 0 when the provider is unknown or has not opted in.
+func declaredParallelism(provs Providers, connType string) int {
+	provider := provs.Lookup(ProviderLookup{ConnType: connType})
+	if provider == nil || provider.Provider == nil {
+		return 0
+	}
+	return provider.DefaultParallelism
+}
+
+// cpuCap is the ceiling we apply to any provider-declared default on this
+// machine.
+func cpuCap() int {
+	// GOMAXPROCS, not NumCPU: since Go 1.25 it accounts for the cgroup CPU
+	// limit, so a scanner running under a Kubernetes `cpu:` quota sees the
+	// share it was actually given. NumCPU reports the node's cores and would
+	// have us over-subscribe exactly where it hurts most.
+	return cpuCapFor(goruntime.GOMAXPROCS(0))
+}
+
+// cpuCapFor keeps half the machine free for the mql runtime, the provider
+// subprocesses and everything else sharing the box. Scanning is largely spent
+// waiting on remote APIs, so this is deliberately below what the workload alone
+// could use.
+func cpuCapFor(cpus int) int {
+	if cpus <= 2 {
+		return SequentialParallelism
+	}
+	return max(2, cpus/2)
+}

--- a/providers/parallelism_test.go
+++ b/providers/parallelism_test.go
@@ -1,0 +1,229 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// testProviders builds a provider index for the resolver tests. Each entry maps
+// a provider name to the connection types it serves and the parallelism it
+// declares.
+func testProviders() Providers {
+	mk := func(name string, parallelism int, connTypes ...string) *Provider {
+		return &Provider{
+			Provider: &plugin.Provider{
+				Name:               name,
+				ID:                 "go.mondoo.com/cnquery/v9/providers/" + name,
+				ConnectionTypes:    connTypes,
+				DefaultParallelism: parallelism,
+			},
+		}
+	}
+
+	all := []*Provider{
+		mk("aws", 8, "aws", "ebs"),
+		mk("azure", 6, "azure", "azure-snapshot"),
+		mk("github", 4, "github"),
+		mk("network", 10, "host"),
+		// os has not opted in
+		mk("os", 0, "ssh", "local"),
+	}
+
+	res := make(Providers, len(all))
+	for _, p := range all {
+		res[p.ID] = p
+	}
+	return res
+}
+
+func asset(connTypes ...string) *inventory.Asset {
+	a := &inventory.Asset{}
+	for _, t := range connTypes {
+		a.Connections = append(a.Connections, &inventory.Config{Type: t})
+	}
+	return a
+}
+
+func TestResolveParallelismExplicitRequestWins(t *testing.T) {
+	// An operator who names a number gets it, even above what the machine or
+	// the provider would have chosen on its own.
+	assert.Equal(t, 20, ResolveParallelism(20, []*inventory.Asset{asset("github")}))
+	assert.Equal(t, 1, ResolveParallelism(1, []*inventory.Asset{asset("aws")}))
+}
+
+func TestResolveParallelismUsesProviderDefault(t *testing.T) {
+	provs := testProviders()
+
+	tests := []struct {
+		name     string
+		roots    []*inventory.Asset
+		cpuLimit int
+		expected int
+	}{
+		{
+			name:     "single provider under the cap",
+			roots:    []*inventory.Asset{asset("aws")},
+			cpuLimit: 16,
+			expected: 8,
+		},
+		{
+			name:     "alternate connection type of the same provider",
+			roots:    []*inventory.Asset{asset("azure-snapshot")},
+			cpuLimit: 16,
+			expected: 6,
+		},
+		{
+			name:     "capped by available cpu",
+			roots:    []*inventory.Asset{asset("host")},
+			cpuLimit: 6,
+			expected: 6,
+		},
+		{
+			name:     "several assets of one provider",
+			roots:    []*inventory.Asset{asset("aws"), asset("aws"), asset("ebs")},
+			cpuLimit: 16,
+			expected: 8,
+		},
+		{
+			name:     "mixed roots take the smallest declared value",
+			roots:    []*inventory.Asset{asset("host"), asset("github"), asset("aws")},
+			cpuLimit: 16,
+			expected: 4,
+		},
+		{
+			name:     "one asset carrying several connections",
+			roots:    []*inventory.Asset{asset("aws", "github")},
+			cpuLimit: 16,
+			expected: 4,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, resolveParallelism(tc.roots, provs, tc.cpuLimit))
+		})
+	}
+}
+
+func TestResolveParallelismFallsBackToSequential(t *testing.T) {
+	provs := testProviders()
+
+	tests := []struct {
+		name  string
+		roots []*inventory.Asset
+	}{
+		{
+			name:  "no roots",
+			roots: nil,
+		},
+		{
+			name:  "provider has not opted in",
+			roots: []*inventory.Asset{asset("ssh")},
+		},
+		{
+			// The one that matters: a single un-vetted root has to hold the
+			// whole scan back, because one worker pool serves every asset.
+			name:  "one opted-in root next to one that is not",
+			roots: []*inventory.Asset{asset("aws"), asset("ssh")},
+		},
+		{
+			name:  "unknown connection type",
+			roots: []*inventory.Asset{asset("not-a-real-provider")},
+		},
+		{
+			name:  "asset without connections",
+			roots: []*inventory.Asset{{}},
+		},
+		{
+			name:  "connection without a type",
+			roots: []*inventory.Asset{{Connections: []*inventory.Config{{}}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, SequentialParallelism, resolveParallelism(tc.roots, provs, 16))
+		})
+	}
+}
+
+func TestResolveParallelismToleratesNilEntries(t *testing.T) {
+	provs := testProviders()
+	roots := []*inventory.Asset{nil, asset("aws"), {Connections: []*inventory.Config{nil}}}
+	assert.Equal(t, 8, resolveParallelism(roots, provs, 16))
+}
+
+// TestDefaultParallelismSurvivesTheDescriptor covers the path the value really
+// travels: a provider declares it in config.go, gen marshals it into
+// dist/<name>.json, and Provider.LoadJSON reads it back on the client.
+func TestDefaultParallelismSurvivesTheDescriptor(t *testing.T) {
+	data, err := json.Marshal(&plugin.Provider{
+		Name:               "gitlab",
+		ID:                 "go.mondoo.com/cnquery/v9/providers/gitlab",
+		ConnectionTypes:    []string{"gitlab"},
+		DefaultParallelism: 4,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"DefaultParallelism":4`)
+
+	var decoded plugin.Provider
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, 4, decoded.DefaultParallelism)
+}
+
+// TestDefaultParallelismAbsentFromOlderDescriptor pins the version-skew
+// behavior: a provider built before this field existed decodes to zero, which
+// resolves to sequential scanning rather than to a surprise default.
+func TestDefaultParallelismAbsentFromOlderDescriptor(t *testing.T) {
+	var decoded plugin.Provider
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"Name": "gitlab",
+		"ID": "go.mondoo.com/cnquery/v9/providers/gitlab",
+		"ConnectionTypes": ["gitlab"]
+	}`), &decoded))
+	assert.Equal(t, 0, decoded.DefaultParallelism)
+
+	provs := Providers{decoded.ID: {Provider: &decoded}}
+	assert.Equal(t, SequentialParallelism, resolveParallelism([]*inventory.Asset{asset("gitlab")}, provs, 16))
+}
+
+func TestCpuCapFor(t *testing.T) {
+	tests := []struct {
+		cpus     int
+		expected int
+	}{
+		{cpus: 0, expected: 1},
+		{cpus: 1, expected: 1},
+		{cpus: 2, expected: 1},
+		{cpus: 3, expected: 2},
+		{cpus: 4, expected: 2},
+		{cpus: 8, expected: 4},
+		{cpus: 12, expected: 6},
+		{cpus: 16, expected: 8},
+		{cpus: 64, expected: 32},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.expected, cpuCapFor(tc.cpus), "cpus=%d", tc.cpus)
+	}
+}
+
+// TestCpuCapForLeavesHeadroom pins the property the cap exists for: we never
+// hand the scanner every core on the machine.
+func TestCpuCapForLeavesHeadroom(t *testing.T) {
+	for cpus := 1; cpus <= 128; cpus++ {
+		cap := cpuCapFor(cpus)
+		assert.GreaterOrEqual(t, cap, 1, "cpus=%d", cpus)
+		if cpus > 2 {
+			assert.Less(t, cap, cpus, "cpus=%d must keep cores free", cpus)
+		}
+	}
+}


### PR DESCRIPTION
Lets a provider state how many of its assets may be scanned concurrently, so a scan can pick a sensible default instead of running everything sequentially or making the user guess a `--parallelism` number.

Nothing changes today: this only adds the declaration and the resolver. The behavior lands when cnspec's scanner calls `ResolveParallelism` (follow-up PR).

## What's in here

**`plugin.Provider.DefaultParallelism`** (`providers-sdk/v1/plugin/start.go`) — an optional int on the provider descriptor. It rides the existing path: declared in `config/config.go`, marshalled by `gen` into `dist/<name>.json`, read back client-side by `Provider.LoadJSON` before anything connects.

**`providers.ResolveParallelism(requested, roots)`** (`providers/parallelism.go`):

- an explicit request (`--parallelism N`) wins outright and is **not** capped — the cap exists to make the *default* safe, not to overrule an operator;
- otherwise: the smallest value declared across the root assets' providers, capped by available CPU;
- if any root resolves to a provider that hasn't opted in — or to no provider at all — the **whole scan stays sequential**. One worker pool serves every asset in the tree, so we can only go concurrent when all of the roots agree it's safe. This is the deliberate conservative choice: an inventory mixing an `aws` root with an `ssh` root runs sequentially rather than scanning un-vetted assets 8-wide.

**The CPU cap** is `max(2, GOMAXPROCS/2)`, and `1` at two cores or fewer. `GOMAXPROCS` rather than `NumCPU` because since Go 1.25 it accounts for the cgroup CPU limit, so a scanner running under a Kubernetes `cpu:` quota sees the share it was actually given; `NumCPU` reports the node's cores and would over-subscribe exactly where it hurts most.

## Providers opted in

| Provider | Declared | What constrains it |
|---|---|---|
| network (`host`) | 10 | Almost entirely DNS/TLS/HTTP wait against unrelated targets, no shared rate limit |
| aws | 8 | Throttling is per service and per region; org scans spread calls over accounts |
| gcp | 8 | Quotas are per project |
| k8s | 8 | client-go's rate limiter is already raised well above defaults, so concurrent scans reach the API server rather than queueing locally; kept at 8 to leave a small control plane's APF room |
| azure | 6 | ARM read throttling is scoped to the subscription, so it bites when assets share one |
| gitlab | 4 | gitlab.com request rate limit |
| github | 4 | 5,000 req/hour is already binding on a large org, plus a secondary concurrent-request limit |

The numbers describe what each **backend** sustains; the CPU cap keeps them honest on the host. On a 12-core machine everything tops out at 6; at 8 cores, at 4.

## Testing

`providers/parallelism_test.go` — explicit-request passthrough, per-provider defaults, the min-across-mixed-roots rule, every sequential fallback (no roots, not opted in, opted-in next to not, unknown connection type, missing connections), nil tolerance, and the cap table. Passes under `-race`.

Three of them were mutation-tested to confirm they're load-bearing: removing the CPU cap, letting un-vetted roots slide, and removing the CPU headroom each produce a failure.

Two tests pin the descriptor path specifically — that the field survives marshal→unmarshal, and that a descriptor written *without* it (a provider built before this field existed) decodes to `0` and therefore resolves to sequential rather than to a surprise default.

Also verified by hand: `dist/gitlab.json` really carries `"DefaultParallelism":4` after regeneration, and every opted-in provider's `ParseCLI` sets `Config.Type` to a value its `ConnectionTypes` contains, so `Providers.Lookup` resolves each one (k8s's `kubernetes` alias goes through `Lookup`'s alias fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)