### PR TITLE
🐛 providers: complete a schema-only install when the provider must run (v13)

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -314,6 +314,11 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	// fork/exec error, so catch schema-only installations here. With
 	// auto-update enabled, TryProviderUpdate above already completed such an
 	// installation, so this only triggers when auto-update is off.
+	// The disk is probed instead of trusting provider.HasBinary: that field
+	// is only populated by readProviderDir, so a Provider handed to the
+	// coordinator any other way (e.g. SetProviders) reads false even when
+	// the binary exists, and probing also reflects installs that happened
+	// after the provider list was cached.
 	if !config.ProbeFile(provider.binPath()) {
 		return nil, errors.New("provider '" + provider.Name + "' is installed schema-only and has no binary to run; install it fully or enable auto-update")
 	}

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/cli/config"
 	"go.mondoo.com/mql/v13/logger"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	pp "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -307,6 +308,14 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 		} else {
 			provider = updated
 		}
+	}
+
+	// Without a binary the exec below can only fail with an obscure
+	// fork/exec error, so catch schema-only installations here. With
+	// auto-update enabled, TryProviderUpdate above already completed such an
+	// installation, so this only triggers when auto-update is off.
+	if !config.ProbeFile(provider.binPath()) {
+		return nil, errors.New("provider '" + provider.Name + "' is installed schema-only and has no binary to run; install it fully or enable auto-update")
 	}
 
 	// LoadResources is idempotent and safe under concurrent calls; it

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1032,6 +1032,28 @@ func TryProviderUpdate(provider *Provider, update UpdateProvidersConfig) (*Provi
 		return nil, errors.New("cannot determine installation path for provider")
 	}
 
+	// A schema-only installation has no binary to run. Whatever its version,
+	// complete it by installing the full package for that version. This check
+	// comes before any freshness check: a provider whose schema is current is
+	// still unusable without its binary.
+	if !config.ProbeFile(provider.binPath()) {
+		log.Info().
+			Str("version", provider.Version).
+			Msg("provider '" + provider.Name + "' is installed schema-only, downloading its binary")
+		completed, err := installVersion(ctx, provider.Name, provider.Version)
+		if err != nil {
+			return nil, err
+		}
+		PrintInstallResults([]*Provider{completed})
+
+		if providers, err := ListActive(); err == nil {
+			if err := installDependencies(completed, providers); err != nil {
+				return nil, err
+			}
+		}
+		return completed, nil
+	}
+
 	statPath := provider.confJSONPath()
 	stat, err := os.Stat(statPath)
 	if err != nil {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1035,7 +1035,9 @@ func TryProviderUpdate(provider *Provider, update UpdateProvidersConfig) (*Provi
 	// A schema-only installation has no binary to run. Whatever its version,
 	// complete it by installing the full package for that version. This check
 	// comes before any freshness check: a provider whose schema is current is
-	// still unusable without its binary.
+	// still unusable without its binary. The disk is probed instead of
+	// trusting provider.HasBinary, which is only populated by readProviderDir
+	// and reads false on Provider values built any other way.
 	if !config.ProbeFile(provider.binPath()) {
 		log.Info().
 			Str("version", provider.Version).


### PR DESCRIPTION
## Problem

A provider installed with `--schema-only` (#9062, on this branch as #10142) has its config and resource schema on disk but no binary. When anything actually starts it:

- `TryProviderUpdate` sees the version is current and does nothing, and
- the coordinator then execs a binary that does not exist, failing with an obscure `fork/exec ... no such file or directory`.

## Fix

- `TryProviderUpdate` checks for the binary **before** any freshness check and completes a schema-only installation by installing the full package at the installed version (dependencies included). A current schema is no use without its binary.
- With auto-update disabled, `unsafeStartProvider` now reports `provider 'x' is installed schema-only and has no binary to run; install it fully or enable auto-update` instead of the fork/exec error.

## Why v13

This backs mondoohq/cnspec#3536, which makes scans pull only provider **schemas** for bundle requirements (fixing scans dying on providers that don't ship binaries for the scanning platform, e.g. db2 on darwin/arm64) and installs binaries per asset. With this fix, any runtime path that starts a schema-only provider self-heals; cnspec pins the v13 line. A forward-port to main follows separately.

## Verified

- `go build ./providers/` passes; `go test ./providers/` on this branch fails to build **before and after** this change (pre-existing missing `NewMockProviderPlugin` mock on v13), so the identical change was validated on main's checkout where the full providers suite passes.
- End-to-end with a cnspec build: deleting a provider's binary (leaving json + resources.json) and scanning prints `provider 'os' is installed schema-only, downloading its binary`, installs it at the pinned version, and the scan completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)