### PR TITLE
🐛 snowflake: report an unreadable network rule as null, not an error

### DIFF
--- a/providers/snowflake/resources/errors.go
+++ b/providers/snowflake/resources/errors.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+
+	"github.com/snowflakedb/gosnowflake"
+)
+
+// sqlStateInsufficientPrivilege is the SQL standard SQLSTATE for a statement
+// the current role is not allowed to run. Snowflake reports it as error 003001,
+// "SQL access control error".
+const sqlStateInsufficientPrivilege = "42501"
+
+// isAccessDenied reports whether err is Snowflake refusing a statement for lack
+// of privilege, as opposed to the object being absent or the connection having
+// failed.
+//
+// The distinction decides what a field may claim. A denied read means the value
+// is unknown and the field has to say so; treating it as an empty result would
+// report the absence of a setting as fact. A transport failure is not a denial
+// and must keep propagating, or a network blip degrades into a silently
+// unpopulated field.
+//
+// Matched on the typed error rather than the message text, so a reworded
+// server message cannot turn every denial into a hard failure.
+func isAccessDenied(err error) bool {
+	var sfErr *gosnowflake.SnowflakeError
+	if !errors.As(err, &sfErr) {
+		return false
+	}
+	return sfErr.SQLState == sqlStateInsufficientPrivilege
+}

--- a/providers/snowflake/resources/errors_test.go
+++ b/providers/snowflake/resources/errors_test.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/snowflakedb/gosnowflake"
+)
+
+func TestIsAccessDenied(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			// Verbatim shape of the error DESCRIBE NETWORK RULE returns for a
+			// rule the role does not own, observed live 2026-08-20.
+			"insufficient privilege",
+			&gosnowflake.SnowflakeError{
+				Number:   3001,
+				SQLState: "42501",
+				Message:  "SQL access control error:\nInsufficient privileges to operate on network_rule 'PYPI_RULE'.",
+			},
+			true,
+		},
+		{
+			"insufficient privilege, wrapped",
+			fmt.Errorf("describe network rule: %w", &gosnowflake.SnowflakeError{
+				Number: 3001, SQLState: "42501",
+			}),
+			true,
+		},
+		{
+			// Object-does-not-exist is a different condition and must not be
+			// swallowed as a denial.
+			"object does not exist",
+			&gosnowflake.SnowflakeError{Number: 2003, SQLState: "42S02"},
+			false,
+		},
+		{
+			// The one that matters most: a transport failure degrading to a
+			// null field would let an audit pass on data never read.
+			"network error",
+			&net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			false,
+		},
+		{"plain error", errors.New("something went wrong"), false},
+		{
+			// The classifier must key on the typed error, not the text, so a
+			// lookalike message cannot trip it.
+			"lookalike message, untyped",
+			errors.New("003001 (42501): SQL access control error: Insufficient privileges"),
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAccessDenied(tc.err); got != tc.want {
+				t.Errorf("isAccessDenied(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestErrSchemaNotFoundIsMatchable guards the sentinel that lets a reference
+// resolver degrade a missing schema while still propagating a real failure.
+func TestErrSchemaNotFoundIsMatchable(t *testing.T) {
+	notFound := fmt.Errorf("snowflake.schema %q not found in database %q: %w",
+		"EXTERNAL_ACCESS", "SNOWFLAKE", errSchemaNotFound)
+
+	if !errors.Is(notFound, errSchemaNotFound) {
+		t.Error("wrapped not-found error must match errSchemaNotFound")
+	}
+	if errors.Is(errors.New("connection reset by peer"), errSchemaNotFound) {
+		t.Error("an unrelated error must not match errSchemaNotFound")
+	}
+	// The message a user sees still has to name what was missing.
+	if got := notFound.Error(); got == "" ||
+		!errors.Is(notFound, errSchemaNotFound) {
+		t.Errorf("unexpected message %q", got)
+	}
+}

--- a/providers/snowflake/resources/network_rules.go
+++ b/providers/snowflake/resources/network_rules.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
@@ -18,6 +19,7 @@ type mqlSnowflakeNetworkRuleInternal struct {
 	valuesLock    sync.Mutex
 	valuesLoaded  bool
 	valuesLoadErr error
+	valuesDenied  bool
 	values        []any
 }
 
@@ -71,13 +73,28 @@ func (r *mqlSnowflakeNetworkRule) schema() (*mqlSnowflakeSchema, error) {
 	return resolveSchemaRef(r.MqlRuntime, r.DatabaseName.Data, r.SchemaName.Data, &r.Schema)
 }
 
+// markValuesNull records that the value list was not readable. A list accessor
+// returning (nil, nil) alone renders as an empty array, so the null state has to
+// be set explicitly for the field to read as unknown.
+func (r *mqlSnowflakeNetworkRule) markValuesNull() {
+	r.ValueList.State = plugin.StateIsSet | plugin.StateIsNull
+}
+
 func (r *mqlSnowflakeNetworkRule) valueList() ([]any, error) {
 	if r.valuesLoaded {
+		if r.valuesDenied {
+			r.markValuesNull()
+			return nil, nil
+		}
 		return r.values, r.valuesLoadErr
 	}
 	r.valuesLock.Lock()
 	defer r.valuesLock.Unlock()
 	if r.valuesLoaded {
+		if r.valuesDenied {
+			r.markValuesNull()
+			return nil, nil
+		}
 		return r.values, r.valuesLoadErr
 	}
 
@@ -90,6 +107,22 @@ func (r *mqlSnowflakeNetworkRule) valueList() ([]any, error) {
 	)
 	if err != nil {
 		r.valuesLoaded = true
+		if isAccessDenied(err) {
+			// DESCRIBE NETWORK RULE requires OWNERSHIP, which no role holds on
+			// the rules Snowflake ships in SNOWFLAKE.EXTERNAL_ACCESS. Report
+			// the values as unknown rather than failing the field, and never as
+			// an empty list: empty would read as "this rule permits nothing",
+			// the opposite of what an unreadable rule means, and would let a
+			// check asserting no open value pass on a rule nobody has read.
+			r.valuesDenied = true
+			r.markValuesNull()
+			log.Debug().
+				Str("rule", r.Name.Data).
+				Str("schema", r.SchemaName.Data).
+				Str("database", r.DatabaseName.Data).
+				Msg("snowflake: insufficient privileges to describe network rule, value list unavailable")
+			return nil, nil
+		}
 		r.valuesLoadErr = err
 		return nil, err
 	}

--- a/providers/snowflake/resources/schemas.go
+++ b/providers/snowflake/resources/schemas.go
@@ -5,13 +5,21 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/snowflake/connection"
 )
+
+// errSchemaNotFound marks a schema that SHOW SCHEMAS does not report. It is a
+// sentinel rather than a bare error so a caller resolving a reference can tell
+// "this schema is not listed" apart from "the lookup itself failed", and
+// degrade only the former.
+var errSchemaNotFound = errors.New("snowflake schema not found")
 
 // initSnowflakeSchema resolves a schema by its database and name when the
 // resource is requested through a typed reference (e.g.
@@ -54,7 +62,7 @@ func initSnowflakeSchema(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 			return nil, res, nil
 		}
 	}
-	return nil, nil, fmt.Errorf("snowflake.schema %q not found in database %q", name, databaseName)
+	return nil, nil, fmt.Errorf("snowflake.schema %q not found in database %q: %w", name, databaseName, errSchemaNotFound)
 }
 
 // resolveSchemaRef returns the typed schema a database/name pair refers to, or a
@@ -77,6 +85,19 @@ func resolveSchemaRef(runtime *plugin.Runtime, databaseName, schemaName string, 
 		"name":         llx.StringData(schemaName),
 	})
 	if err != nil {
+		if errors.Is(err, errSchemaNotFound) {
+			// SHOW SCHEMAS omits schemas owned by an application, so an object
+			// can name a schema that is real and yet unlistable. Every network
+			// rule Snowflake ships sits in SNOWFLAKE.EXTERNAL_ACCESS, which is
+			// one of these. Report the reference as unknown rather than failing
+			// the field on the owning resource.
+			log.Debug().
+				Str("database", databaseName).
+				Str("schema", schemaName).
+				Msg("snowflake: schema is not listed, reporting the reference as null")
+			field.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	return res.(*mqlSnowflakeSchema), nil


### PR DESCRIPTION
Found while sweeping the whole provider against a live account. **Every one of the 317 network rules on it failed two fields.**

## The two bugs

**1. `valueList` errored on any rule the role does not own.** `DESCRIBE NETWORK RULE` requires `OWNERSHIP`, and no role — not even `ACCOUNTADMIN` — owns the rules Snowflake ships in `SNOWFLAKE.EXTERNAL_ACCESS`:

```
003001 (42501): SQL access control error:
Insufficient privileges to operate on network_rule 'PYPI_RULE'. Your primary role
ACCOUNTADMIN must have OWNERSHIP granted on NETWORK RULE SNOWFLAKE.EXTERNAL_ACCESS.PYPI_RULE.
```

**2. The `schema` reference failed to resolve for those same rules.** `SHOW SCHEMAS` does not report application-owned schemas, so `SNOWFLAKE.EXTERNAL_ACCESS` is a real schema that cannot be listed, and `initSnowflakeSchema` correctly returned not-found — which `resolveSchemaRef` then propagated as a field error.

Both conditions hold on any account carrying the built-in rules, which is every modern one. `schema()` is declared on **fourteen** resources, so the second is not confined to network rules.

## Null, not empty

An empty `valueList` reads as *"this rule permits nothing"* — the opposite of what an unreadable rule means, and it would let a check asserting no open value **pass** on a rule nobody has read. So both degrade to null, and because a list accessor returning `(nil, nil)` still renders as `[]`, the null state is set explicitly.

## Only these two conditions degrade

Deliberately narrow, so a real failure can't hide as an unpopulated field:

- access denial is matched on **gosnowflake's typed error** and SQLSTATE `42501`, not on message text
- a missing schema is matched on a **sentinel error**, so `errors.Is` distinguishes "not listed" from "the lookup itself failed"

A transport error still propagates.

## Verified live

Same rule, before and after:

```coffee
snowflake.account.networkRules.where(databaseName == "SNOWFLAKE").first {
  name owner entriesInValueList valueList schema { name } }
```

**Before** — two errors, the row unusable:
```
2 errors occurred:
  * snowflake.schema "EXTERNAL_ACCESS" not found in database "SNOWFLAKE"
  * 003001 (42501): SQL access control error: Insufficient privileges ...
valueList: 003001 (42501): SQL access control error: ...
schema:    snowflake.schema "EXTERNAL_ACCESS" not found in database "SNOWFLAKE"
```

**After** — no errors, and the fields that *were* readable survive:
```
{ valueList: null, entriesInValueList: 4, name: "PYPI_RULE", owner: "SNOWFLAKE", schema: null }
```

Note `entriesInValueList: 4` still reports — `SHOW` provides it, so we know the rule has four entries even though we may not read them. That is the honest state.

At list scale, and the regression check that matters — I created one rule the role *does* own, so both outcomes are represented:

| query | result |
|---|---|
| `networkRules.length` | 318 |
| `networkRules.where(valueList == null).length` | 317 (the built-ins) |
| `networkRules.where(valueList != null).length` | 1 (the owned fixture) |

and the owned rule is unaffected:

```
{ name: "NR_FIXTURE", valueList: ["192.0.2.0/24", "198.51.100.7"], schema: { name: "FIXTURES" } }
```

That two-state result is what shows this is a permission-degradation fix and not a field quietly switched off: the same code path still returns real values wherever the role can read them.

## Tests

`TestIsAccessDenied` — the classifier, including the two cases that make it worth having: a **transport error must not** be read as a denial (otherwise a network blip degrades to a null field and an audit passes on data never read), and a **lookalike message in an untyped error must not** match either, which is what keeps the check from regressing into string matching.

`TestErrSchemaNotFoundIsMatchable` — the sentinel survives wrapping and does not swallow unrelated errors.

Full `go test ./...` in `providers/snowflake/` is green; no `go.mod` drift.
