### PR TITLE
🐛 github: don't discover the repo owner as a user when scanning one repository

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -88,11 +88,7 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 		assetList = append(assetList, repoAssets...)
 	}
 
-	userId := conf.Options["user"]
-	if userId == "" {
-		userId = conf.Options["owner"]
-	}
-	if userId != "" {
+	if userId := userDiscoveryTarget(conf); userId != "" {
 		userAssets, err := user(runtime, userId, conn, targets)
 		if err != nil {
 			return nil, err
@@ -101,6 +97,22 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 	}
 
 	return assetList, nil
+}
+
+// userDiscoveryTarget returns the account to discover as a user scope, or "" for
+// none. An explicit "user" option is always a user scope. "owner" is only a user
+// shortcut when it stands alone (`--owner someuser`): once a "repository" is set,
+// "owner" is merely that repo's namespace, not a user to scan — returning it
+// there would emit a phantom user asset for the repo's owner (empty-named when
+// the owner is an organization rather than a user).
+func userDiscoveryTarget(conf *inventory.Config) string {
+	if user := conf.Options["user"]; user != "" {
+		return user
+	}
+	if conf.Options["repository"] == "" {
+		return conf.Options["owner"]
+	}
+	return ""
 }
 
 func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnection, targets []string) ([]*inventory.Asset, error) {

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -116,12 +116,39 @@ func TestDiscoverUserRepos(t *testing.T) {
 	})
 
 	t.Run("an explicit repository never fans out", func(t *testing.T) {
-		// discover() reaches the user path via the owner fallback of
-		// single-repo scans — those must scan exactly the one repo
+		// a single-repo scan must scan exactly the one repo
 		assert.False(t, discoverUserRepos(
 			conf(map[string]string{"owner": "some-user", "repository": "one-repo"}),
 			[]string{connection.DiscoveryAuto},
 		))
+	})
+}
+
+// A single-repo scan carries owner+repository; "owner" is that repo's namespace,
+// not a user to discover. Treating it as a user emitted a phantom user asset for
+// the owner (empty-named when the owner is an organization).
+func TestUserDiscoveryTarget(t *testing.T) {
+	conf := func(opts map[string]string) *inventory.Config {
+		return &inventory.Config{Options: opts}
+	}
+
+	t.Run("explicit user scope discovers that user", func(t *testing.T) {
+		assert.Equal(t, "some-user",
+			userDiscoveryTarget(conf(map[string]string{"user": "some-user"})))
+	})
+
+	t.Run("bare owner (no repository) is a user shortcut", func(t *testing.T) {
+		assert.Equal(t, "some-user",
+			userDiscoveryTarget(conf(map[string]string{"owner": "some-user"})))
+	})
+
+	t.Run("owner with a repository is NOT a user scope", func(t *testing.T) {
+		assert.Empty(t, userDiscoveryTarget(
+			conf(map[string]string{"owner": "some-org", "repository": "one-repo"})))
+	})
+
+	t.Run("nothing to discover", func(t *testing.T) {
+		assert.Empty(t, userDiscoveryTarget(conf(map[string]string{})))
 	})
 
 	t.Run("no repo-ish discovery target means no fan-out", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Scanning a **single repository** (`--owner <o> --repository <r>`, or a connection carrying `owner`+`repository`) emits a spurious **`GitHub User`** asset for the repository's owner — and it's empty-named ("-") when the owner is an *organization* rather than a user.

## Cause

`Discover()` resolved the user-scope target as the `user` option, falling back to `owner` when `user` was unset:

```go
userId := conf.Options["user"]
if userId == "" {
    userId = conf.Options["owner"]  // ← also the namespace of a single-repo scan
}
if userId != "" { user(runtime, userId, ...) }  // emits a GitHub User asset
```

But `owner` is also how a single-repo scan names the repository's namespace, so a repo scan was treated as a user scan and discovered the owner account.

## Fix

Only treat `owner` as a user scope when it stands **alone** (no `repository` set). Extracted the decision into `userDiscoveryTarget()`:

- `user` set → that user scope (unchanged).
- `owner` alone (no `repository`) → user shortcut (unchanged, e.g. `--owner someuser`).
- `owner` **with** `repository` → repo namespace only; **no** user discovery.

Added `TestUserDiscoveryTarget` covering all four cases. Existing discovery tests unchanged and green.

## Verify

```
cnquery shell github --owner some-org --repository some-repo --discover auto
```
→ discovers the repository asset only; no phantom `GitHub User` for the owner.