### PR TITLE
🐛 github: don't discover the repo owner as a user when scanning one repository (v13 backport)

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -88,11 +88,7 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 		assetList = append(assetList, repoAssets...)
 	}
 
-	userId := conf.Options["user"]
-	if userId == "" {
-		userId = conf.Options["owner"]
-	}
-	if userId != "" {
+	if userId := userDiscoveryTarget(conf); userId != "" {
 		userAssets, err := user(runtime, userId, conn, targets)
 		if err != nil {
 			return nil, err
@@ -101,6 +97,22 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 	}
 
 	return assetList, nil
+}
+
+// userDiscoveryTarget returns the account to discover as a user scope, or "" for
+// none. An explicit "user" option is always a user scope. "owner" is only a user
+// shortcut when it stands alone (`--owner someuser`): once a "repository" is set,
+// "owner" is merely that repo's namespace, not a user to scan — returning it
+// there would emit a phantom user asset for the repo's owner (empty-named when
+// the owner is an organization rather than a user).
+func userDiscoveryTarget(conf *inventory.Config) string {
+	if user := conf.Options["user"]; user != "" {
+		return user
+	}
+	if conf.Options["repository"] == "" {
+		return conf.Options["owner"]
+	}
+	return ""
 }
 
 func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnection, targets []string) ([]*inventory.Asset, error) {

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -116,12 +116,39 @@ func TestDiscoverUserRepos(t *testing.T) {
 	})
 
 	t.Run("an explicit repository never fans out", func(t *testing.T) {
-		// discover() reaches the user path via the owner fallback of
-		// single-repo scans — those must scan exactly the one repo
+		// a single-repo scan must scan exactly the one repo
 		assert.False(t, discoverUserRepos(
 			conf(map[string]string{"owner": "some-user", "repository": "one-repo"}),
 			[]string{connection.DiscoveryAuto},
 		))
+	})
+}
+
+// A single-repo scan carries owner+repository; "owner" is that repo's namespace,
+// not a user to discover. Treating it as a user emitted a phantom user asset for
+// the owner (empty-named when the owner is an organization).
+func TestUserDiscoveryTarget(t *testing.T) {
+	conf := func(opts map[string]string) *inventory.Config {
+		return &inventory.Config{Options: opts}
+	}
+
+	t.Run("explicit user scope discovers that user", func(t *testing.T) {
+		assert.Equal(t, "some-user",
+			userDiscoveryTarget(conf(map[string]string{"user": "some-user"})))
+	})
+
+	t.Run("bare owner (no repository) is a user shortcut", func(t *testing.T) {
+		assert.Equal(t, "some-user",
+			userDiscoveryTarget(conf(map[string]string{"owner": "some-user"})))
+	})
+
+	t.Run("owner with a repository is NOT a user scope", func(t *testing.T) {
+		assert.Empty(t, userDiscoveryTarget(
+			conf(map[string]string{"owner": "some-org", "repository": "one-repo"})))
+	})
+
+	t.Run("nothing to discover", func(t *testing.T) {
+		assert.Empty(t, userDiscoveryTarget(conf(map[string]string{})))
 	})
 
 	t.Run("no repo-ish discovery target means no fan-out", func(t *testing.T) {


### PR DESCRIPTION
Backport of #10241 to `v13`.

## Problem

Scanning a single repository (`--owner <o> --repository <r>`) emits a spurious **`GitHub User`** asset for the repository's owner — empty-named ("-") when the owner is an *organization*.

## Cause

`Discover()` resolved the user-scope target as `user`, falling back to `owner`; but `owner` is also a single-repo scan's namespace, so a repo scan was treated as a user scan and discovered the owner account.

## Fix

Only treat `owner` as a user scope when it stands alone (no `repository`). Extracted into `userDiscoveryTarget()` with unit coverage.

Cherry-picked cleanly from `main` (#10241); build + `go test ./providers/github/resources` green on `v13`.