### PR TITLE
🟢 ci: install the Go version the repo builds with, not the newest one (v13 backport)

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,2 @@
-golang-version=1.26.1
+golang-version=1.26.6
 protoc-version=33.x

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-extended-linting.yml
+++ b/.github/workflows/pr-extended-linting.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
       - name: Generate test files

--- a/.github/workflows/pr-test-generated-files.yaml
+++ b/.github/workflows/pr-test-generated-files.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-test-lint.yml
+++ b/.github/workflows/pr-test-lint.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -87,7 +87,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -128,7 +128,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -160,7 +160,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -218,7 +218,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 
@@ -251,7 +251,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/pr-test-windows.yml
+++ b/.github/workflows/pr-test-windows.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/reusable-lint-providers.yml
+++ b/.github/workflows/reusable-lint-providers.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 

--- a/.github/workflows/update-oui-table.yaml
+++ b/.github/workflows/update-oui-table.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ">=${{ env.golang-version }}"
+          go-version: "${{ env.golang-version }}"
           check-latest: true
           cache: false
 


### PR DESCRIPTION
Backport of #10217 to `v13`.

Every `setup-go` step on `v13` asks for `>=${{ env.golang-version }}` with `check-latest: true`, an open-ended constraint — so setup-go installs the newest Go it can find. Go 1.27.0 reached the runner images and CI moved onto it on its own, turning two checks red on every v13 PR (e.g. #10242):

- **golangci-lint** — golangci-lint 2.10.1 cannot read Go 1.27 export data (`export data version 4 is greater than maximum supported version 2`) and reports invented typecheck errors in `utils/syncx/map.go`.
- **go-test** — `llx TestRawDataJson_Umlauts`: Go 1.27's `encoding/json` escapes U+FFFD differently, so the test's expected string no longer matches.

Cherry-picks #10217 unchanged: drops the `>=` from every `setup-go` step (16 steps across 11 workflows) so the pinned version in `.github/env` is the version installed, and sets that value to a `1.26.x` release. A Go upgrade now arrives as a reviewed change to `.github/env` instead of unrelated PRs going red.

Note: `.github/env` carries `1.26.6` from the source commit; v13's `go.mod` directive is `1.26.5`. With `check-latest: true` both resolve to the latest `1.26.x` patch, so the installed toolchain is identical either way — the fix is purely dropping the open-ended `>=`.

CI-only change; no code touched.