### PR TITLE
fix(sbom): emit package licenses in the CycloneDX and SPDX renderers

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -126,13 +126,15 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 		emitted[ref] = true
 
 		bomPkg := cyclonedx.Component{
-			BOMRef:     ref,
-			Type:       cyclonedx.ComponentTypeLibrary,
-			Name:       pkg.Name,
-			Version:    pkg.Version,
-			PackageURL: pkg.Purl,
-			CPE:        cpe,
-			Evidence:   evidence,
+			BOMRef:      ref,
+			Type:        cyclonedx.ComponentTypeLibrary,
+			Name:        pkg.Name,
+			Version:     pkg.Version,
+			PackageURL:  pkg.Purl,
+			CPE:         cpe,
+			Evidence:    evidence,
+			Description: pkg.Description,
+			Licenses:    cycloneDXLicenses(pkg.License),
 		}
 		if pkg.Scope == PackageScopeDev {
 			bomPkg.Scope = cyclonedx.ScopeExcluded
@@ -338,4 +340,67 @@ var familyMap = map[string][]string{
 	"alpine":  {"linux", "unix", "os"},
 	"fedora":  {"linux", "unix", "os"},
 	"rhel":    {"linux", "unix", "os"},
+}
+
+// cycloneDXLicenses renders a package's declared license as a CycloneDX license
+// list, or nil when there is none.
+//
+// CycloneDX models a license three mutually exclusive ways, and choosing the
+// wrong one fails schema validation:
+//
+//   - expression, for a full SPDX expression such as "MIT OR Apache-2.0";
+//   - license.id, for a bare SPDX identifier;
+//   - license.name, for anything that is neither.
+//
+// Package license strings in the wild are all three, so the shape is decided
+// per value rather than assumed. A string containing an SPDX operator is an
+// expression; one that looks like a bare identifier is an id; everything else —
+// "BSD-like", "see LICENSE" — is a name, which is honest rather than lossy.
+func cycloneDXLicenses(license string) *cyclonedx.Licenses {
+	license = strings.TrimSpace(license)
+	if license == "" {
+		return nil
+	}
+	if isSPDXExpression(license) {
+		return &cyclonedx.Licenses{{Expression: license}}
+	}
+	if isSPDXIdentifierShaped(license) {
+		return &cyclonedx.Licenses{{License: &cyclonedx.License{ID: license}}}
+	}
+	return &cyclonedx.Licenses{{License: &cyclonedx.License{Name: license}}}
+}
+
+// isSPDXExpression reports whether a license string joins operands with SPDX
+// operators, which is what makes it an expression rather than an identifier.
+func isSPDXExpression(s string) bool {
+	for _, t := range strings.Fields(s) {
+		switch strings.ToUpper(t) {
+		case "AND", "OR", "WITH":
+			return true
+		}
+	}
+	return strings.ContainsAny(s, "()")
+}
+
+// isSPDXIdentifierShaped reports whether a license string could be a bare SPDX
+// identifier: one token of the characters identifiers actually use.
+//
+// It deliberately does not check the value against the SPDX list. This package
+// renders whatever the extractors found and must not silently drop a license it
+// does not recognize; an unlisted identifier still belongs in the document, and
+// a consumer validating against the SPDX list will say so more usefully than a
+// renderer that omitted it.
+func isSPDXIdentifierShaped(s string) bool {
+	if s == "" || strings.ContainsAny(s, " \t") {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-' || r == '.' || r == '+' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/sbom/license_render_test.go
+++ b/sbom/license_render_test.go
@@ -1,0 +1,202 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sbom
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The renderers dropped every package license for as long as they existed,
+// because nothing asserted on one: the SBOM tests all check packages, none
+// checked licenses. These tests exist so that cannot recur.
+
+func licenseBom() *Sbom {
+	return &Sbom{
+		Generator: &Generator{Vendor: "Mondoo, Inc", Name: "test", Version: "1"},
+		Asset:     &Asset{Name: "test-asset", Platform: &Platform{Name: "linux", Version: "1"}},
+		Packages: []*Package{
+			{Name: "plain-id", Version: "1.0.0", Purl: "pkg:npm/plain-id@1.0.0", License: "MIT"},
+			{Name: "expression", Version: "1.0.0", Purl: "pkg:npm/expression@1.0.0", License: "MIT OR Apache-2.0"},
+			{Name: "with-exception", Version: "1.0.0", Purl: "pkg:npm/with-exception@1.0.0",
+				License: "GPL-2.0-only WITH Classpath-exception-2.0"},
+			{Name: "free-text", Version: "1.0.0", Purl: "pkg:npm/free-text@1.0.0", License: "BSD-like, see LICENSE"},
+			{Name: "custom-ref", Version: "1.0.0", Purl: "pkg:npm/custom-ref@1.0.0", License: "LicenseRef-Acme-Internal"},
+			{Name: "undeclared", Version: "1.0.0", Purl: "pkg:npm/undeclared@1.0.0"},
+		},
+	}
+}
+
+func renderTo(t *testing.T, format string) string {
+	t.Helper()
+	var b strings.Builder
+	h := New(format)
+	if h == nil {
+		t.Fatalf("no handler for %q", format)
+	}
+	if err := h.Render(&b, licenseBom()); err != nil {
+		t.Fatalf("Render(%s): %v", format, err)
+	}
+	return b.String()
+}
+
+// TestCycloneDXEmitsLicenses covers the three mutually exclusive shapes
+// CycloneDX models a license with. Choosing the wrong one fails schema
+// validation, so the shape has to be decided per value rather than assumed.
+func TestCycloneDXEmitsLicenses(t *testing.T) {
+	var doc struct {
+		Components []struct {
+			Name     string `json:"name"`
+			Licenses []struct {
+				Expression string `json:"expression"`
+				License    *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"license"`
+			} `json:"licenses"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal([]byte(renderTo(t, FormatCycloneDxJSON)), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	byName := map[string]int{}
+	for i, c := range doc.Components {
+		byName[c.Name] = i
+	}
+	get := func(name string) []struct {
+		Expression string `json:"expression"`
+		License    *struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"license"`
+	} {
+		i, ok := byName[name]
+		if !ok {
+			t.Fatalf("component %q missing from the document", name)
+		}
+		return doc.Components[i].Licenses
+	}
+
+	// A bare SPDX identifier goes in license.id.
+	if ls := get("plain-id"); len(ls) != 1 || ls[0].License == nil || ls[0].License.ID != "MIT" {
+		t.Errorf("plain-id licenses = %+v, want license.id MIT", ls)
+	}
+	// An expression goes in expression, never in id.
+	for _, name := range []string{"expression", "with-exception"} {
+		ls := get(name)
+		if len(ls) != 1 || ls[0].Expression == "" {
+			t.Errorf("%s licenses = %+v, want an expression", name, ls)
+			continue
+		}
+		if ls[0].License != nil {
+			t.Errorf("%s set both expression and license — they are mutually exclusive", name)
+		}
+	}
+	// Anything else goes in license.name rather than being dropped.
+	if ls := get("free-text"); len(ls) != 1 || ls[0].License == nil || ls[0].License.Name == "" {
+		t.Errorf("free-text licenses = %+v, want license.name", ls)
+	}
+	// A custom identifier is still an identifier.
+	if ls := get("custom-ref"); len(ls) != 1 || ls[0].License == nil ||
+		ls[0].License.ID != "LicenseRef-Acme-Internal" {
+		t.Errorf("custom-ref licenses = %+v, want license.id", ls)
+	}
+	// An undeclared license emits no licenses key at all, which is valid
+	// CycloneDX — unlike SPDX, it has no NOASSERTION to state.
+	if ls := get("undeclared"); len(ls) != 0 {
+		t.Errorf("undeclared licenses = %+v, want none", ls)
+	}
+}
+
+// TestSPDXEmitsLicenseFields pins the three SPDX requirements the renderer used
+// to miss: a concluded value, a copyright field, and NOASSERTION rather than an
+// empty string.
+func TestSPDXEmitsLicenseFields(t *testing.T) {
+	out := renderTo(t, FormatSpdxJSON)
+
+	var doc struct {
+		Packages []struct {
+			Name            string `json:"name"`
+			LicenseDeclared string `json:"licenseDeclared"`
+			LicenseCncluded string `json:"licenseConcluded"`
+			CopyrightText   string `json:"copyrightText"`
+		} `json:"packages"`
+		HasExtractedLicensingInfos []struct {
+			LicenseID     string `json:"licenseId"`
+			ExtractedText string `json:"extractedText"`
+		} `json:"hasExtractedLicensingInfos"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	for _, p := range doc.Packages {
+		if p.LicenseDeclared == "" {
+			t.Errorf("%s: licenseDeclared is empty; SPDX requires NOASSERTION", p.Name)
+		}
+		if p.LicenseCncluded == "" {
+			t.Errorf("%s: licenseConcluded is missing", p.Name)
+		}
+		if p.CopyrightText == "" {
+			t.Errorf("%s: copyrightText is empty; SPDX requires NOASSERTION", p.Name)
+		}
+		if p.Name == "undeclared" {
+			if p.LicenseDeclared != "NOASSERTION" {
+				t.Errorf("an undeclared license rendered as %q, want NOASSERTION", p.LicenseDeclared)
+			}
+		}
+		if p.Name == "plain-id" && p.LicenseDeclared != "MIT" {
+			t.Errorf("plain-id licenseDeclared = %q, want MIT", p.LicenseDeclared)
+		}
+	}
+
+	// A LicenseRef-* identifier must be declared before it is referenced.
+	if len(doc.HasExtractedLicensingInfos) != 1 {
+		t.Fatalf("hasExtractedLicensingInfos = %+v, want the one LicenseRef", doc.HasExtractedLicensingInfos)
+	}
+	if got := doc.HasExtractedLicensingInfos[0].LicenseID; got != "LicenseRef-Acme-Internal" {
+		t.Errorf("extracted license id = %q", got)
+	}
+	if doc.HasExtractedLicensingInfos[0].ExtractedText == "" {
+		t.Error("extractedText is required and must not be empty")
+	}
+}
+
+// TestLicenseContentIsDeterministic keeps a committed SBOM diffable: rendering
+// the same input twice must not change what it says about licenses.
+//
+// It compares content rather than whole documents, because a CycloneDX BOM
+// carries a fresh serialNumber and timestamp per render by design — each
+// document is a distinct instance, and asserting otherwise would be asserting
+// against the format.
+func TestLicenseContentIsDeterministic(t *testing.T) {
+	strip := func(s string) string {
+		var kept []string
+		for _, line := range strings.Split(s, "\n") {
+			t := strings.TrimSpace(line)
+			if strings.HasPrefix(t, `"serialNumber"`) || strings.HasPrefix(t, `"timestamp"`) ||
+				strings.HasPrefix(t, `"created"`) || strings.HasPrefix(t, `"documentNamespace"`) {
+				continue
+			}
+			kept = append(kept, line)
+		}
+		return strings.Join(kept, "\n")
+	}
+
+	for _, format := range []string{FormatCycloneDxJSON, FormatSpdxJSON} {
+		first := strip(renderTo(t, format))
+		for i := 0; i < 3; i++ {
+			if strip(renderTo(t, format)) != first {
+				t.Errorf("%s content is not stable across renders", format)
+				break
+			}
+		}
+		// The licenses themselves must be in there, or the comparison is vacuous.
+		if !strings.Contains(first, "MIT") {
+			t.Errorf("%s output carries no license content to compare", format)
+		}
+	}
+}

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -44,6 +45,7 @@ func (s *Spdx) ApplyOptions(opts ...renderOption) {
 }
 
 func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
+	extractedLicenses := extractedLicenseSet{}
 	doc := &spdx.Document{
 		SPDXVersion:                spdx.Version,
 		SPDXIdentifier:             "DOCUMENT",
@@ -116,17 +118,36 @@ func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
 			})
 		}
 
+		// The SPDX specification requires NOASSERTION rather than an empty value
+		// for the license and copyright fields. An empty string is not valid
+		// SPDX, and a strict consumer may reject the whole document over it.
+		declared := spdxLicenseValue(pkg.License)
 		doc.Packages = append(doc.Packages, &spdx.Package{
-			PackageSPDXIdentifier:     id,
-			PackageName:               pkg.Name,
-			PackageVersion:            pkg.Version,
-			PackageLicenseDeclared:    pkg.License,
+			PackageSPDXIdentifier:  id,
+			PackageName:            pkg.Name,
+			PackageVersion:         pkg.Version,
+			PackageLicenseDeclared: declared,
+			// Concluded is the license this document asserts the package is
+			// under. With only a declared value to go on, the honest concluded
+			// value is the same one — asserting more than was determined is what
+			// NOASSERTION exists to avoid.
+			PackageLicenseConcluded: declared,
+			// The model carries no copyright field yet, so this states
+			// NOASSERTION rather than omitting a spec-required field. When
+			// Package gains one, this is the single line that changes.
+			PackageCopyrightText:      spdxNoAssertionValue,
 			PackageDescription:        pkg.Description,
 			PackageExternalReferences: refs,
 			PackageFileName:           pkg.Location,
 			PackageChecksums:          checksums,
 		})
+		// A LicenseRef-* identifier is not on the SPDX license list, so the
+		// specification requires the document to define it before it may be
+		// referenced.
+		extractedLicenses.add(pkg.License)
 	}
+
+	doc.OtherLicenses = extractedLicenses.render()
 
 	// Emit the package→package dependency graph as SPDX DEPENDS_ON relationships,
 	// skipping any edge whose endpoints are not in this document.
@@ -322,4 +343,62 @@ func (s *Spdx) convertToSbom(doc *spdx.Document) *Sbom {
 	}
 
 	return bom
+}
+
+// spdxNoAssertion returns the SPDX-mandated NOASSERTION for an empty value.
+func spdxNoAssertion(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return spdxNoAssertionValue
+	}
+	return v
+}
+
+// spdxLicenseValue renders a license for an SPDX license field.
+func spdxLicenseValue(license string) string { return spdxNoAssertion(license) }
+
+const spdxNoAssertionValue = "NOASSERTION"
+
+// licenseRefPrefix marks a custom identifier that is not on the SPDX license
+// list.
+const licenseRefPrefix = "LicenseRef-"
+
+// extractedLicenseSet collects the LicenseRef-* identifiers a document
+// references, so each can be declared in hasExtractedLicensingInfos as the
+// specification requires.
+type extractedLicenseSet map[string]struct{}
+
+func (s extractedLicenseSet) add(license string) {
+	for _, tok := range strings.FieldsFunc(license, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '(' || r == ')'
+	}) {
+		if strings.HasPrefix(tok, licenseRefPrefix) {
+			s[tok] = struct{}{}
+		}
+	}
+}
+
+// render returns the collected identifiers as SPDX other-license entries, sorted
+// so a document is byte-stable across runs.
+func (s extractedLicenseSet) render() []*spdx.OtherLicense {
+	if len(s) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(s))
+	for id := range s {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	out := make([]*spdx.OtherLicense, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, &spdx.OtherLicense{
+			LicenseIdentifier: id,
+			// The text is not available here — the extractors carry an
+			// identifier, not a license body — so the field states that rather
+			// than inventing one.
+			ExtractedText: spdxNoAssertionValue,
+			LicenseName:   id,
+		})
+	}
+	return out
 }


### PR DESCRIPTION
## What

The CycloneDX renderer built every component **without a `Licenses` field**, so a generated CycloneDX BOM carried no license information at all — including the license the extractors had already populated on the package. `Description` was dropped the same way. The SPDX renderer set only `PackageLicenseDeclared`, and rendered an undeclared license as an empty string, which is not valid SPDX.

Found while building license-compliance tooling that can determine a great deal about a dependency's license and had nowhere to put it.

## How

**CycloneDX** models a license three mutually exclusive ways, and choosing the wrong one fails schema validation, so the shape is decided per value rather than assumed:

| Value | Rendered as |
| --- | --- |
| `MIT OR Apache-2.0` | `expression` |
| `MIT` | `license.id` |
| `BSD-like, see LICENSE` | `license.name` |

The last row is deliberate — this package renders what the extractors found and must not silently drop a license it cannot classify. The identifier check is shape-only and does not validate against the SPDX list: an unlisted identifier still belongs in the document, and a consumer validating against the list will report it more usefully than a renderer that omitted it.

**SPDX** now emits `PackageLicenseConcluded` alongside declared, `PackageCopyrightText`, and `NOASSERTION` wherever a value is unknown, as the specification requires. Any `LicenseRef-*` identifier a document references is declared in `hasExtractedLicensingInfos`, sorted so the document is byte-stable.

## Deliberately not done here

- **Copyright is `NOASSERTION`** rather than a real value, because `Package` carries no copyright field yet. When it gains one, that is a single line.
- **Concluded equals declared.** With only a declared license to go on, asserting anything else is exactly what `NOASSERTION` exists to prevent.

Both become real once the `Package` model carries a license list with an acquisition mode, confidence and evidence. That needs a `.proto` change and a regeneration with this repo's own toolchain, so it belongs in its own change — see the TODO below.

## Tests

Adds `sbom/license_render_test.go`, whose absence is why this shipped: every existing SBOM test asserts on packages, **none asserted on a license**. It covers all three CycloneDX shapes, the SPDX required fields, `NOASSERTION` for an undeclared license, `LicenseRef` declaration, and content stability across renders.

`go test ./sbom/` passes.

## TODO before merge — needs a local run

I could not do these in this environment; each needs a maintainer with the repo's toolchain.

- [ ] **Run the full test suite.** I ran `go test ./sbom/` and `go vet ./sbom/` only.
- [ ] **Validate the emitted documents against the published schemas.** The tests assert structure, not schema conformance. A CycloneDX JSON schema check and an SPDX validator run against a license-bearing BOM would close that gap — particularly the expression-vs-id-vs-name exclusivity, which is where a wrong choice fails validation.
- [ ] **Confirm no downstream consumer breaks on the new fields.** These are additive, but `licenseConcluded` and `copyrightText` are new keys in every SPDX package object.

## Follow-up (separate change)

Extend `sbom.Package` with a license model — repeated licenses carrying `spdx_id` / `expression` / `name`, an `acquisition` mode (`declared` | `concluded`), `confidence`, and an evidence location, plus `copyright` and `supplier`. It needs `make sbom/generate` with `protoc` v6.33.6 and the vendored plugins; regenerating with a different protoc produces a large, noisy diff, which is why it is not attempted here.

That is what lets a *concluded* license distinct from the declared one, its confidence, and extracted copyright holders reach the document.

## Related

Unblocks downstream license-compliance tooling that consumes these fields.

---

