### PR TITLE
✨ aws: expose access-log settings on a REST API Gateway stage

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -16360,6 +16360,14 @@ private aws.apigateway.stage @defaults("arn") {
   cacheClusterStatus string
   // Whether the stage response cache is encrypted, from the default method settings
   cacheDataEncrypted bool
+  // Access-log configuration for the stage
+  //
+  // Keys: destinationArn (CloudWatch Logs log group or Kinesis Data
+  // Firehose delivery stream) and format (the $context log format
+  // string). Null when access logging is off. Mirrors
+  // `aws.apigatewayv2.stage.accessLogSettings`, so one check can cover
+  // REST and HTTP APIs the same way.
+  accessLogSettings dict
   // Client certificate ID for mutual TLS with backend
   clientCertificateId string
   // WAF web ACL associated with the stage

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -21527,6 +21527,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.apigateway.stage.cacheDataEncrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayStage).GetCacheDataEncrypted()).ToDataRes(types.Bool)
 	},
+	"aws.apigateway.stage.accessLogSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApigatewayStage).GetAccessLogSettings()).ToDataRes(types.Dict)
+	},
 	"aws.apigateway.stage.clientCertificateId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApigatewayStage).GetClientCertificateId()).ToDataRes(types.String)
 	},
@@ -60634,6 +60637,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.apigateway.stage.cacheDataEncrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApigatewayStage).CacheDataEncrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.apigateway.stage.accessLogSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApigatewayStage).AccessLogSettings, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"aws.apigateway.stage.clientCertificateId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -146103,6 +146110,7 @@ type mqlAwsApigatewayStage struct {
 	CacheClusterSize     plugin.TValue[string]
 	CacheClusterStatus   plugin.TValue[string]
 	CacheDataEncrypted   plugin.TValue[bool]
+	AccessLogSettings    plugin.TValue[any]
 	ClientCertificateId  plugin.TValue[string]
 	WebAcl               plugin.TValue[*mqlAwsWafAcl]
 	CreatedAt            plugin.TValue[*time.Time]
@@ -146187,6 +146195,10 @@ func (c *mqlAwsApigatewayStage) GetCacheClusterStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsApigatewayStage) GetCacheDataEncrypted() *plugin.TValue[bool] {
 	return &c.CacheDataEncrypted
+}
+
+func (c *mqlAwsApigatewayStage) GetAccessLogSettings() *plugin.TValue[any] {
+	return &c.AccessLogSettings
 }
 
 func (c *mqlAwsApigatewayStage) GetClientCertificateId() *plugin.TValue[string] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -133,6 +133,7 @@ aws.apigateway.restapi.stages 11.15.2
 aws.apigateway.restapi.tags 11.15.2
 aws.apigateway.restapi.version 11.15.2
 aws.apigateway.stage 11.15.2
+aws.apigateway.stage.accessLogSettings 13.53.4
 aws.apigateway.stage.arn 11.15.2
 aws.apigateway.stage.cacheClusterEnabled 11.15.2
 aws.apigateway.stage.cacheClusterSize 11.15.2

--- a/providers/aws/resources/aws_apigateway.go
+++ b/providers/aws/resources/aws_apigateway.go
@@ -189,6 +189,13 @@ func (a *mqlAwsApigatewayRestapi) stages() ([]any, error) {
 		if ms, ok := stage.MethodSettings["*/*"]; ok {
 			cacheDataEncrypted = ms.CacheDataEncrypted
 		}
+		// Nil when access logging is off, which JsonToDict maps to a null dict
+		// rather than an empty one, so `accessLogSettings == null` is the test
+		// for "logging is not configured".
+		accessLogSettings, err := convert.JsonToDict(stage.AccessLogSettings)
+		if err != nil {
+			return nil, err
+		}
 		mqlStage, err := CreateResource(a.MqlRuntime, ResourceAwsApigatewayStage,
 			map[string]*llx.RawData{
 				"arn":                  llx.StringData(fmt.Sprintf(apiStageArnPattern, region, conn.AccountId(), restApiId, convert.ToValue(stage.StageName))),
@@ -201,6 +208,7 @@ func (a *mqlAwsApigatewayRestapi) stages() ([]any, error) {
 				"cacheClusterSize":     llx.StringData(string(stage.CacheClusterSize)),
 				"cacheClusterStatus":   llx.StringData(string(stage.CacheClusterStatus)),
 				"cacheDataEncrypted":   llx.BoolData(cacheDataEncrypted),
+				"accessLogSettings":    llx.DictData(accessLogSettings),
 				"clientCertificateId":  llx.StringData(convert.ToValue(stage.ClientCertificateId)),
 				"createdAt":            llx.TimeDataPtr(stage.CreatedDate),
 				"lastUpdatedAt":        llx.TimeDataPtr(stage.LastUpdatedDate),


### PR DESCRIPTION
Fixes #10249

## The gap

`aws.apigatewayv2.stage` exposes `accessLogSettings`. `aws.apigateway.stage` — the REST/v1 flavour — had no equivalent, so a check for "is access logging enabled on this API" could cover HTTP APIs and not REST ones.

That is the failure mode worth avoiding: a check written today would score CloudFront, ALB/NLB and HTTP APIs correctly and say nothing at all about a REST API, so a REST API with logging switched off **passes**. Partial coverage that reads as full coverage.

## The change

`GetStages` already returns `AccessLogSettings` on every stage, and `stages()` already reads that same `types.Stage` for every other field it maps. The value was being carried and discarded; this exposes it.

- No extra API call.
- No new IAM permission — `aws.permissions.json` unchanged at 1025.
- Shaped and documented to match the v2 field exactly: a `dict` with `destinationArn` and `format`, null when access logging is off. `convert.JsonToDict` maps the nil pointer to a null dict rather than an empty one, so `accessLogSettings == null` is the test for "not configured".

Matching v2 is deliberate — it lets one check treat both API Gateway flavours the same way:

```coffee
aws.apigateway.restapis.all(
  stages.all(accessLogSettings != null)
)
```

## Why this came up

Implementing **CIS AWS Foundations Benchmark v7.0.0 control 4.10** — "Ensure all AWS-managed web front-end services have access logging enabled" — in [cnspec-enterprise-policies#3326](https://github.com/mondoohq/cnspec-enterprise-policies/pull/3326). Three of the four front-end types the control names were already reachable:

| service | field | status before this PR |
|---|---|---|
| CloudFront | `aws.cloudfront.distribution.logging` | ✅ |
| ALB / NLB | `aws.elb.loadbalancer.attributes.accessLogsEnabled` | ✅ |
| API Gateway HTTP (v2) | `aws.apigatewayv2.stage.accessLogSettings` | ✅ |
| API Gateway REST (v1) | — | ❌ |

## Testing

`go build ./...` and `go test ./resources/` pass in `providers/aws`.

No unit test added: `stages()` calls the SDK directly with no mock harness in this file (the v2 `accessLogSettings` field has none either), and the change carries no logic beyond the same `JsonToDict` conversion used for `methodSettings` two lines above. A test here would assert that `JsonToDict` works, not that this mapping is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
