### PR TITLE
✨ aws: expose the Organizations resource-based delegation policy

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -285,6 +285,38 @@ aws.organization @defaults("id masterAccountEmail") {
   // `policies.where(type == "RESOURCE_CONTROL_POLICY")`. A policy type that is
   // not enabled for the organization contributes nothing.
   policies() []aws.organization.policy
+  // Resource-based policy that delegates administration of the organization
+  //
+  // Grants member accounts permission to perform AWS Organizations actions -
+  // creating, attaching and updating service control, resource control, tag,
+  // backup and AI-services opt-out policies - so that policy administration
+  // does not have to happen in the management account. This is a different
+  // mechanism from `delegatedAdministrators`, which registers admins for
+  // *integrated services* such as GuardDuty or CloudTrail. Null when no
+  // delegation policy is configured, which is the ordinary state for an
+  // organization administered entirely from its management account.
+  resourcePolicy() aws.organization.resourcePolicy
+}
+
+// AWS Organizations resource-based delegation policy
+//
+// Policy attached to the organization itself, naming the member accounts that
+// may administer AWS Organizations on its behalf and the actions each may
+// take. Audit it to answer whether organization policy administration is
+// delegated away from the management account, and to whom. There is at most
+// one such policy per organization.
+private aws.organization.resourcePolicy @defaults("id") {
+  // Unique identifier of the resource policy
+  id string
+  // ARN of the resource policy
+  arn string
+  // Raw policy content document (JSON)
+  content string
+  // Parsed statements from the policy content
+  //
+  // Written in the IAM policy grammar, so the principals, actions and
+  // conditions that bound the delegation are resolved here.
+  statements() []aws.iam.policyStatement
 }
 
 // AWS Organizations service control policy

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -22,6 +22,7 @@ const (
 	ResourceAwsBilling                                                          string = "aws.billing"
 	ResourceAwsBillingBudget                                                    string = "aws.billing.budget"
 	ResourceAwsOrganization                                                     string = "aws.organization"
+	ResourceAwsOrganizationResourcePolicy                                       string = "aws.organization.resourcePolicy"
 	ResourceAwsOrganizationServiceControlPolicy                                 string = "aws.organization.serviceControlPolicy"
 	ResourceAwsOrganizationPolicy                                               string = "aws.organization.policy"
 	ResourceAwsOrganizationEffectivePolicy                                      string = "aws.organization.effectivePolicy"
@@ -1021,6 +1022,10 @@ func init() {
 		"aws.organization": {
 			Init:   initAwsOrganization,
 			Create: createAwsOrganization,
+		},
+		"aws.organization.resourcePolicy": {
+			// to override args, implement: initAwsOrganizationResourcePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsOrganizationResourcePolicy,
 		},
 		"aws.organization.serviceControlPolicy": {
 			// to override args, implement: initAwsOrganizationServiceControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -5152,6 +5157,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.organization.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
+	},
+	"aws.organization.resourcePolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganization).GetResourcePolicy()).ToDataRes(types.Resource("aws.organization.resourcePolicy"))
+	},
+	"aws.organization.resourcePolicy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationResourcePolicy).GetId()).ToDataRes(types.String)
+	},
+	"aws.organization.resourcePolicy.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationResourcePolicy).GetArn()).ToDataRes(types.String)
+	},
+	"aws.organization.resourcePolicy.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationResourcePolicy).GetContent()).ToDataRes(types.String)
+	},
+	"aws.organization.resourcePolicy.statements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationResourcePolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
 	"aws.organization.serviceControlPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetId()).ToDataRes(types.String)
@@ -36714,6 +36734,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.organization.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganization).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.resourcePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganization).ResourcePolicy, ok = plugin.RawToTValue[*mqlAwsOrganizationResourcePolicy](v.Value, v.Error)
+		return
+	},
+	"aws.organization.resourcePolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationResourcePolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.organization.resourcePolicy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationResourcePolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.resourcePolicy.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationResourcePolicy).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.resourcePolicy.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationResourcePolicy).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.resourcePolicy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationResourcePolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.organization.serviceControlPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -82960,6 +83004,7 @@ type mqlAwsOrganization struct {
 	OrganizationalUnits     plugin.TValue[[]any]
 	ServiceControlPolicies  plugin.TValue[[]any]
 	Policies                plugin.TValue[[]any]
+	ResourcePolicy          plugin.TValue[*mqlAwsOrganizationResourcePolicy]
 }
 
 // createAwsOrganization creates a new instance of this resource
@@ -83095,6 +83140,93 @@ func (c *mqlAwsOrganization) GetPolicies() *plugin.TValue[[]any] {
 		}
 
 		return c.policies()
+	})
+}
+
+func (c *mqlAwsOrganization) GetResourcePolicy() *plugin.TValue[*mqlAwsOrganizationResourcePolicy] {
+	return plugin.GetOrCompute[*mqlAwsOrganizationResourcePolicy](&c.ResourcePolicy, func() (*mqlAwsOrganizationResourcePolicy, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization", c.__id, "resourcePolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsOrganizationResourcePolicy), nil
+			}
+		}
+
+		return c.resourcePolicy()
+	})
+}
+
+// mqlAwsOrganizationResourcePolicy for the aws.organization.resourcePolicy resource
+type mqlAwsOrganizationResourcePolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsOrganizationResourcePolicyInternal it will be used here
+	Id         plugin.TValue[string]
+	Arn        plugin.TValue[string]
+	Content    plugin.TValue[string]
+	Statements plugin.TValue[[]any]
+}
+
+// createAwsOrganizationResourcePolicy creates a new instance of this resource
+func createAwsOrganizationResourcePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsOrganizationResourcePolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.organization.resourcePolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsOrganizationResourcePolicy) MqlName() string {
+	return "aws.organization.resourcePolicy"
+}
+
+func (c *mqlAwsOrganizationResourcePolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsOrganizationResourcePolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsOrganizationResourcePolicy) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsOrganizationResourcePolicy) GetContent() *plugin.TValue[string] {
+	return &c.Content
+}
+
+func (c *mqlAwsOrganizationResourcePolicy) GetStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Statements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization.resourcePolicy", c.__id, "statements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.statements()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -7776,6 +7776,11 @@ aws.organization.policy.id 13.52.2
 aws.organization.policy.name 13.52.2
 aws.organization.policy.statements 13.52.2
 aws.organization.policy.type 13.52.2
+aws.organization.resourcePolicy 13.53.4
+aws.organization.resourcePolicy.arn 13.53.4
+aws.organization.resourcePolicy.content 13.53.4
+aws.organization.resourcePolicy.id 13.53.4
+aws.organization.resourcePolicy.statements 13.53.4
 aws.organization.serviceControlPolicies 13.32.2
 aws.organization.serviceControlPolicy 13.32.2
 aws.organization.serviceControlPolicy.arn 13.32.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.53.3",
-  "generated_at": "2026-08-19T15:36:50-07:00",
+  "generated_at": "2026-08-20T18:38:52+03:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -668,6 +668,7 @@
     "organizations:DescribeEffectivePolicy",
     "organizations:DescribeOrganization",
     "organizations:DescribePolicy",
+    "organizations:DescribeResourcePolicy",
     "organizations:ListAccounts",
     "organizations:ListDelegatedAdministrators",
     "organizations:ListDelegatedServicesForAccount",
@@ -5139,6 +5140,12 @@
       "service": "organizations",
       "action": "DescribePolicy",
       "source_file": "aws_organizations_policy.go"
+    },
+    {
+      "permission": "organizations:DescribeResourcePolicy",
+      "service": "organizations",
+      "action": "DescribeResourcePolicy",
+      "source_file": "aws_organizations_resource_policy.go"
     },
     {
       "permission": "organizations:ListAccounts",

--- a/providers/aws/resources/aws_organizations_resource_policy.go
+++ b/providers/aws/resources/aws_organizations_resource_policy.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package resources

--- a/providers/aws/resources/aws_organizations_resource_policy.go
+++ b/providers/aws/resources/aws_organizations_resource_policy.go
@@ -1,0 +1,72 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/aws/connection"
+)
+
+// isResourcePolicyAbsent reports whether the error means the organization has
+// no resource-based delegation policy. That is the ordinary state for an
+// organization administered entirely from its management account, and it is
+// also the non-compliant answer an audit is looking for, so it has to reach
+// the caller as absence rather than as a failed read.
+func isResourcePolicyAbsent(err error) bool {
+	var notFound *orgtypes.ResourcePolicyNotFoundException
+	return errors.As(err, &notFound) || isPolicyTypeUnavailable(err)
+}
+
+func (a *mqlAwsOrganization) resourcePolicy() (*mqlAwsOrganizationResourcePolicy, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("")
+
+	resp, err := client.DescribeResourcePolicy(context.Background(), &organizations.DescribeResourcePolicyInput{})
+	if err != nil {
+		// A member account that is not a delegated administrator cannot read
+		// this, which is a permissions answer rather than "no policy exists".
+		// Both resolve to null so a check can be written once, but only the
+		// absent case is a statement about the organization.
+		if isResourcePolicyAbsent(err) || Is400AccessDeniedError(err) {
+			a.ResourcePolicy.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	if resp == nil || resp.ResourcePolicy == nil {
+		a.ResourcePolicy.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	policy := resp.ResourcePolicy
+	var id, arn *string
+	if policy.ResourcePolicySummary != nil {
+		id = policy.ResourcePolicySummary.Id
+		arn = policy.ResourcePolicySummary.Arn
+	}
+
+	res, err := CreateResource(a.MqlRuntime, ResourceAwsOrganizationResourcePolicy,
+		map[string]*llx.RawData{
+			"__id":    llx.StringData(a.Id.Data + "/resourcePolicy"),
+			"id":      llx.StringDataPtr(id),
+			"arn":     llx.StringDataPtr(arn),
+			"content": llx.StringDataPtr(policy.Content),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsOrganizationResourcePolicy), nil
+}
+
+// statements parses the delegation policy, which is written in the IAM policy
+// grammar, so the principals and actions it grants are readable directly.
+func (a *mqlAwsOrganizationResourcePolicy) statements() ([]any, error) {
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetContent())
+}

--- a/providers/aws/resources/aws_organizations_resource_policy_test.go
+++ b/providers/aws/resources/aws_organizations_resource_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package resources

--- a/providers/aws/resources/aws_organizations_resource_policy_test.go
+++ b/providers/aws/resources/aws_organizations_resource_policy_test.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// noResourcePolicyErr is what DescribeResourcePolicy answers for an
+// organization that has never delegated administration, which is the common
+// case rather than an edge case.
+func noResourcePolicyErr() error {
+	return &orgtypes.ResourcePolicyNotFoundException{
+		Message: strPtrOrg("We can't find a resource policy for your organization."),
+	}
+}
+
+func TestIsResourcePolicyAbsent(t *testing.T) {
+	t.Run("no delegation policy is an answer, not a failure", func(t *testing.T) {
+		assert.True(t, isResourcePolicyAbsent(noResourcePolicyErr()))
+	})
+
+	t.Run("through wrapping", func(t *testing.T) {
+		assert.True(t, isResourcePolicyAbsent(
+			fmt.Errorf("describing resource policy: %w", noResourcePolicyErr())))
+	})
+
+	// A standalone account has no organization at all, so it certainly has no
+	// delegation policy. Same answer, arrived at one step earlier.
+	t.Run("a standalone account is also absence", func(t *testing.T) {
+		assert.True(t, isResourcePolicyAbsent(notInUseErr()))
+	})
+
+	// Everything below leaves the question open. Reporting absence for any of
+	// them would say the organization delegates nothing when we simply could
+	// not find out -- and "delegates nothing" is the non-compliant finding, so
+	// the error would manufacture a result rather than lose one.
+	t.Run("a denial is not proof of absence", func(t *testing.T) {
+		assert.False(t, isResourcePolicyAbsent(orgDeniedErr()))
+	})
+
+	t.Run("a transport error is not proof of absence", func(t *testing.T) {
+		assert.False(t, isResourcePolicyAbsent(
+			errors.New("dial tcp: lookup organizations.amazonaws.com: no such host")))
+	})
+
+	t.Run("nil is not absence", func(t *testing.T) {
+		assert.False(t, isResourcePolicyAbsent(nil))
+	})
+}


### PR DESCRIPTION
Fixes #10248

## The gap

`aws.organization.delegatedAdministrators` covers `ListDelegatedAdministrators` — the accounts registered as delegated admins **for integrated services** (GuardDuty, CloudTrail, Security Hub, …).

Delegating administration of **AWS Organizations itself** is a different mechanism. Who may create, attach and update service control, resource control, tag, backup and AI-services opt-out policies is decided by a resource-based policy on the organization, managed with `PutResourcePolicy` / `DescribeResourcePolicy`. Nothing in the provider read it, so there was no way to ask whether organization policy administration is delegated away from the management account, or to whom.

The console surface is AWS Organizations → Settings → *Delegated administrator for AWS Organizations*.

## The change

```coffee
aws.organization.resourcePolicy != null                       // is administration delegated at all
aws.organization.resourcePolicy.statements                    // to whom, and for what actions
```

Two details worth review attention:

**Null is the interesting answer, not an error.** `DescribeResourcePolicy` raises `ResourcePolicyNotFoundException` when no delegation policy exists. That is simultaneously the ordinary state of an organization run entirely from its management account *and* the non-compliant finding an audit is looking for, so it has to reach the caller as absence rather than as a failed read.

**A denial is kept distinct from an absence in the code**, even though both resolve to null so a check can be written once. Reporting absence for a 403 would say "this organization delegates nothing" when we simply were not allowed to look — and since "delegates nothing" is the finding, that error would *manufacture* a result rather than lose one. The test asserts this directly: `ResourcePolicyNotFoundException` and `AWSOrganizationsNotInUseException` are absence; a 403, a transport error, and nil are not.

**`statements`** goes through the shared IAM statement parser (the policy is written in the IAM grammar), so the principals, actions and conditions are readable without hand-parsing `content` — same shape as `aws.organization.policy.statements`.

## Permissions

Adds one: `organizations:DescribeResourcePolicy`. `aws.permissions.json` goes 1025 → 1026.

## Why this came up

CIS AWS Foundations Benchmark v7.0.0 adds an Organizations section, and **2.1.5 — "Ensure delegated admin manages AWS Organizations policies"** fails outright when no delegation policy is configured. That is the automatable half of the control; steps 4 and 5 ("confirm the delegated accounts are purpose-built governance accounts", "confirm least-privilege permissions") remain a human judgement either way. Blocked in [cnspec-enterprise-policies#3326](https://github.com/mondoohq/cnspec-enterprise-policies/pull/3326) pending this.

## Testing

`go build ./...` and `go test ./resources/` pass in `providers/aws`. New table test covers the absence classification described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
