### PR TITLE
✨ aws: expose centralized root access and trusted access on an organization

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -285,6 +285,24 @@ aws.organization @defaults("id masterAccountEmail") {
   // `policies.where(type == "RESOURCE_CONTROL_POLICY")`. A policy type that is
   // not enabled for the organization contributes nothing.
   policies() []aws.organization.policy
+  // Centralized root access features enabled for the organization
+  //
+  // One of RootCredentialsManagement, which lets the management account
+  // delete root credentials in member accounts so no long-lived root
+  // password or access key has to exist in each one, and RootSessions,
+  // which lets it take short-lived, scoped root actions in a member
+  // account without those credentials. Empty when centralized root access
+  // has not been turned on. Requires IAM trusted access, so read it
+  // together with `trustedAccessServicePrincipals`.
+  enabledRootFeatures() []string
+  // Service principals with trusted access enabled in the organization
+  //
+  // Services allowed to perform actions across the organization's accounts,
+  // for example `iam.amazonaws.com`, `cloudtrail.amazonaws.com` or
+  // `guardduty.amazonaws.com`. Trusted access is the prerequisite for a
+  // service to be administered organization-wide, so this is what to test
+  // before asking whether a given service is centrally managed.
+  trustedAccessServicePrincipals() []string
   // Resource-based policy that delegates administration of the organization
   //
   // Grants member accounts permission to perform AWS Organizations actions -

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5158,6 +5158,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.organization.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
 	},
+	"aws.organization.enabledRootFeatures": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganization).GetEnabledRootFeatures()).ToDataRes(types.Array(types.String))
+	},
+	"aws.organization.trustedAccessServicePrincipals": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganization).GetTrustedAccessServicePrincipals()).ToDataRes(types.Array(types.String))
+	},
 	"aws.organization.resourcePolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetResourcePolicy()).ToDataRes(types.Resource("aws.organization.resourcePolicy"))
 	},
@@ -36737,6 +36743,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.organization.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganization).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.enabledRootFeatures": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganization).EnabledRootFeatures, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.trustedAccessServicePrincipals": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganization).TrustedAccessServicePrincipals, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.organization.resourcePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -83000,18 +83014,20 @@ type mqlAwsOrganization struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsOrganizationInternal it will be used here
-	Arn                     plugin.TValue[string]
-	FeatureSet              plugin.TValue[string]
-	MasterAccountId         plugin.TValue[string]
-	MasterAccountArn        plugin.TValue[string]
-	MasterAccountEmail      plugin.TValue[string]
-	Accounts                plugin.TValue[[]any]
-	Id                      plugin.TValue[string]
-	DelegatedAdministrators plugin.TValue[[]any]
-	OrganizationalUnits     plugin.TValue[[]any]
-	ServiceControlPolicies  plugin.TValue[[]any]
-	Policies                plugin.TValue[[]any]
-	ResourcePolicy          plugin.TValue[*mqlAwsOrganizationResourcePolicy]
+	Arn                            plugin.TValue[string]
+	FeatureSet                     plugin.TValue[string]
+	MasterAccountId                plugin.TValue[string]
+	MasterAccountArn               plugin.TValue[string]
+	MasterAccountEmail             plugin.TValue[string]
+	Accounts                       plugin.TValue[[]any]
+	Id                             plugin.TValue[string]
+	DelegatedAdministrators        plugin.TValue[[]any]
+	OrganizationalUnits            plugin.TValue[[]any]
+	ServiceControlPolicies         plugin.TValue[[]any]
+	Policies                       plugin.TValue[[]any]
+	EnabledRootFeatures            plugin.TValue[[]any]
+	TrustedAccessServicePrincipals plugin.TValue[[]any]
+	ResourcePolicy                 plugin.TValue[*mqlAwsOrganizationResourcePolicy]
 }
 
 // createAwsOrganization creates a new instance of this resource
@@ -83147,6 +83163,18 @@ func (c *mqlAwsOrganization) GetPolicies() *plugin.TValue[[]any] {
 		}
 
 		return c.policies()
+	})
+}
+
+func (c *mqlAwsOrganization) GetEnabledRootFeatures() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EnabledRootFeatures, func() ([]any, error) {
+		return c.enabledRootFeatures()
+	})
+}
+
+func (c *mqlAwsOrganization) GetTrustedAccessServicePrincipals() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TrustedAccessServicePrincipals, func() ([]any, error) {
+		return c.trustedAccessServicePrincipals()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -7754,6 +7754,7 @@ aws.organization.effectivePolicy 13.52.2
 aws.organization.effectivePolicy.content 13.52.2
 aws.organization.effectivePolicy.lastUpdatedAt 13.52.2
 aws.organization.effectivePolicy.type 13.52.2
+aws.organization.enabledRootFeatures 13.53.4
 aws.organization.featureSet 11.15.2
 aws.organization.id 11.15.2
 aws.organization.masterAccountArn 13.38.2
@@ -7791,6 +7792,7 @@ aws.organization.serviceControlPolicy.description 13.32.2
 aws.organization.serviceControlPolicy.id 13.32.2
 aws.organization.serviceControlPolicy.name 13.32.2
 aws.organization.serviceControlPolicy.statements 13.32.2
+aws.organization.trustedAccessServicePrincipals 13.53.4
 aws.personalize 13.48.2
 aws.personalize.campaign 13.48.2
 aws.personalize.campaign.arn 13.48.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.53.3",
-  "generated_at": "2026-08-20T18:38:52+03:00",
+  "generated_at": "2026-08-20T09:20:11-07:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -542,6 +542,7 @@
     "iam:ListInstanceProfiles",
     "iam:ListMFADevices",
     "iam:ListOpenIDConnectProviders",
+    "iam:ListOrganizationsFeatures",
     "iam:ListPolicies",
     "iam:ListPolicyVersions",
     "iam:ListRolePolicies",
@@ -669,6 +670,7 @@
     "organizations:DescribeOrganization",
     "organizations:DescribePolicy",
     "organizations:DescribeResourcePolicy",
+    "organizations:ListAWSServiceAccessForOrganization",
     "organizations:ListAccounts",
     "organizations:ListDelegatedAdministrators",
     "organizations:ListDelegatedServicesForAccount",
@@ -4380,6 +4382,12 @@
       "source_file": "aws_iam.go"
     },
     {
+      "permission": "iam:ListOrganizationsFeatures",
+      "service": "iam",
+      "action": "ListOrganizationsFeatures",
+      "source_file": "aws_organizations_root_access.go"
+    },
+    {
       "permission": "iam:ListPolicies",
       "service": "iam",
       "action": "ListPolicies",
@@ -5146,6 +5154,12 @@
       "service": "organizations",
       "action": "DescribeResourcePolicy",
       "source_file": "aws_organizations_resource_policy.go"
+    },
+    {
+      "permission": "organizations:ListAWSServiceAccessForOrganization",
+      "service": "organizations",
+      "action": "ListAWSServiceAccessForOrganization",
+      "source_file": "aws_organizations_root_access.go"
     },
     {
       "permission": "organizations:ListAccounts",

--- a/providers/aws/resources/aws_organizations_root_access.go
+++ b/providers/aws/resources/aws_organizations_root_access.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package resources

--- a/providers/aws/resources/aws_organizations_root_access.go
+++ b/providers/aws/resources/aws_organizations_root_access.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	"go.mondoo.com/mql/providers/aws/connection"
+)
+
+// isRootAccessNotConfigured reports whether the error means centralized root
+// access has simply never been turned on, rather than that the read failed.
+// IAM answers OrganizationNotFoundException when the calling account is not in
+// an organization at all, and OrganizationNotInAllFeaturesModeException when
+// the organization exists but runs in consolidated-billing mode, where the
+// feature cannot be enabled. Both are "no root features are enabled", which is
+// an answer about the organization, so they resolve to an empty list.
+func isRootAccessNotConfigured(err error) bool {
+	var noOrg *iamtypes.OrganizationNotFoundException
+	var notAllFeatures *iamtypes.OrganizationNotInAllFeaturesModeException
+	var svcAccessNotEnabled *iamtypes.ServiceAccessNotEnabledException
+	return errors.As(err, &noOrg) ||
+		errors.As(err, &notAllFeatures) ||
+		errors.As(err, &svcAccessNotEnabled)
+}
+
+// enabledRootFeatures reports which centralized root access features the
+// organization has turned on. Empty means none, which is the state CIS AWS
+// Foundations 2.1.1 flags.
+func (a *mqlAwsOrganization) enabledRootFeatures() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Iam("") // IAM is global, like every other aws.iam.* call
+
+	resp, err := client.ListOrganizationsFeatures(context.Background(), &iam.ListOrganizationsFeaturesInput{})
+	if err != nil {
+		if isRootAccessNotConfigured(err) {
+			return []any{}, nil
+		}
+		// A member account cannot read this. That leaves the answer unknown
+		// rather than empty, so it stays an error: an empty list here would
+		// read as "centralized root access is off", which is the finding.
+		return nil, err
+	}
+	if resp == nil {
+		return []any{}, nil
+	}
+
+	res := make([]any, 0, len(resp.EnabledFeatures))
+	for _, feature := range resp.EnabledFeatures {
+		res = append(res, string(feature))
+	}
+	return res, nil
+}
+
+// trustedAccessServicePrincipals lists the services allowed to act across the
+// organization's accounts. This is the prerequisite for any service to be
+// administered organization-wide, including IAM for centralized root access.
+func (a *mqlAwsOrganization) trustedAccessServicePrincipals() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("")
+	ctx := context.Background()
+
+	res := []any{}
+	paginator := organizations.NewListAWSServiceAccessForOrganizationPaginator(client,
+		&organizations.ListAWSServiceAccessForOrganizationInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			// Consolidated-billing organizations cannot enable trusted access
+			// for anything, so "no principals" is the correct answer there.
+			if isPolicyTypeUnavailable(err) {
+				return res, nil
+			}
+			return nil, err
+		}
+		for _, principal := range page.EnabledServicePrincipals {
+			if principal.ServicePrincipal == nil {
+				continue
+			}
+			res = append(res, *principal.ServicePrincipal)
+		}
+	}
+	return res, nil
+}

--- a/providers/aws/resources/aws_organizations_root_access.go
+++ b/providers/aws/resources/aws_organizations_root_access.go
@@ -15,11 +15,21 @@ import (
 
 // isRootAccessNotConfigured reports whether the error means centralized root
 // access has simply never been turned on, rather than that the read failed.
-// IAM answers OrganizationNotFoundException when the calling account is not in
-// an organization at all, and OrganizationNotInAllFeaturesModeException when
-// the organization exists but runs in consolidated-billing mode, where the
-// feature cannot be enabled. Both are "no root features are enabled", which is
-// an answer about the organization, so they resolve to an empty list.
+//
+// ListOrganizationsFeatures models exactly four errors, and this covers the
+// three that establish an answer:
+//
+//   - OrganizationNotFoundException - the calling account is in no
+//     organization, so there is nothing to enable the feature on.
+//   - OrganizationNotInAllFeaturesModeException - the organization runs in
+//     consolidated-billing mode, where the feature cannot be enabled.
+//   - ServiceAccessNotEnabledException - IAM has no trusted access in the
+//     organization, which is the prerequisite, so nothing is enabled.
+//
+// The fourth, AccountNotManagementOrDelegatedAdministratorException, is
+// deliberately absent: it fires on a plain member account, which leaves the
+// organization's setting unknown rather than off. It stays an error for the
+// reason given at the call site.
 func isRootAccessNotConfigured(err error) bool {
 	var noOrg *iamtypes.OrganizationNotFoundException
 	var notAllFeatures *iamtypes.OrganizationNotInAllFeaturesModeException
@@ -41,9 +51,11 @@ func (a *mqlAwsOrganization) enabledRootFeatures() ([]any, error) {
 		if isRootAccessNotConfigured(err) {
 			return []any{}, nil
 		}
-		// A member account cannot read this. That leaves the answer unknown
-		// rather than empty, so it stays an error: an empty list here would
-		// read as "centralized root access is off", which is the finding.
+		// Anything else - a plain member account
+		// (AccountNotManagementOrDelegatedAdministratorException), a denial, a
+		// transport failure - leaves the answer unknown rather than empty, so
+		// it stays an error. An empty list here would read as "centralized root
+		// access is off", which is the finding an audit acts on.
 		return nil, err
 	}
 	if resp == nil {
@@ -71,9 +83,17 @@ func (a *mqlAwsOrganization) trustedAccessServicePrincipals() ([]any, error) {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			// Consolidated-billing organizations cannot enable trusted access
-			// for anything, so "no principals" is the correct answer there.
-			if isPolicyTypeUnavailable(err) {
+			// A standalone account has no organization, so it has no trusted
+			// access to report. That is the only error this operation models
+			// that establishes an answer rather than hiding one: the rest are
+			// AccessDenied, ConstraintViolation, InvalidInput, Service,
+			// TooManyRequests and UnsupportedAPIEndpoint, none of which say
+			// anything about which services are trusted.
+			//
+			// Note that a consolidated-billing organization is *not* an error
+			// here - it is a real organization and answers normally, with a
+			// list that is simply short.
+			if isOrganizationsNotInUseError(err) {
 				return res, nil
 			}
 			return nil, err

--- a/providers/aws/resources/aws_organizations_root_access_test.go
+++ b/providers/aws/resources/aws_organizations_root_access_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package resources

--- a/providers/aws/resources/aws_organizations_root_access_test.go
+++ b/providers/aws/resources/aws_organizations_root_access_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,5 +49,35 @@ func TestIsRootAccessNotConfigured(t *testing.T) {
 
 	t.Run("nil is not a not-configured answer", func(t *testing.T) {
 		assert.False(t, isRootAccessNotConfigured(nil))
+	})
+
+	// A plain member account cannot read this. That leaves the organization's
+	// setting unknown, not off, so it must stay an error -- the empty list is
+	// the finding.
+	t.Run("a member account is not proof that the feature is off", func(t *testing.T) {
+		assert.False(t, isRootAccessNotConfigured(
+			&iamtypes.AccountNotManagementOrDelegatedAdministratorException{}))
+	})
+}
+
+// TestTrustedAccessErrorClassification pins which errors
+// trustedAccessServicePrincipals treats as an answer. ListAWSServiceAccess-
+// ForOrganization models seven errors, and only AWSOrganizationsNotInUse-
+// Exception establishes one; the policy-type exceptions belong to the policy
+// operations and can never reach this path.
+func TestTrustedAccessErrorClassification(t *testing.T) {
+	t.Run("a standalone account has no trusted access to report", func(t *testing.T) {
+		assert.True(t, isOrganizationsNotInUseError(notInUseErr()))
+	})
+
+	t.Run("a policy-type error cannot come from this API and is not an answer", func(t *testing.T) {
+		// Guards the reason this predicate is not isPolicyTypeUnavailable:
+		// matching these here would be dead code that reads as intent.
+		assert.False(t, isOrganizationsNotInUseError(&orgtypes.PolicyTypeNotEnabledException{}))
+		assert.False(t, isOrganizationsNotInUseError(&orgtypes.PolicyTypeNotAvailableForOrganizationException{}))
+	})
+
+	t.Run("a denial is not proof of no trusted access", func(t *testing.T) {
+		assert.False(t, isOrganizationsNotInUseError(orgDeniedErr()))
 	})
 }

--- a/providers/aws/resources/aws_organizations_root_access_test.go
+++ b/providers/aws/resources/aws_organizations_root_access_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRootAccessNotConfigured(t *testing.T) {
+	// Each of these establishes that no centralized root access feature is
+	// enabled, so an empty list is the honest answer rather than a lost read.
+	t.Run("the account is in no organization", func(t *testing.T) {
+		assert.True(t, isRootAccessNotConfigured(&iamtypes.OrganizationNotFoundException{}))
+	})
+
+	t.Run("the organization runs in consolidated-billing mode", func(t *testing.T) {
+		// The feature cannot be enabled at all in that mode.
+		assert.True(t, isRootAccessNotConfigured(&iamtypes.OrganizationNotInAllFeaturesModeException{}))
+	})
+
+	t.Run("IAM has no trusted access in the organization", func(t *testing.T) {
+		// Trusted access is the prerequisite, so without it nothing is enabled.
+		assert.True(t, isRootAccessNotConfigured(&iamtypes.ServiceAccessNotEnabledException{}))
+	})
+
+	t.Run("through wrapping", func(t *testing.T) {
+		assert.True(t, isRootAccessNotConfigured(
+			fmt.Errorf("listing organizations features: %w", &iamtypes.OrganizationNotFoundException{})))
+	})
+
+	// These leave the answer unknown. Returning an empty list for them would
+	// report centralized root access as switched off -- which is the finding --
+	// on an organization we merely failed to read.
+	t.Run("a denial is not proof that the feature is off", func(t *testing.T) {
+		assert.False(t, isRootAccessNotConfigured(orgDeniedErr()))
+	})
+
+	t.Run("a transport error is not proof that the feature is off", func(t *testing.T) {
+		assert.False(t, isRootAccessNotConfigured(
+			errors.New("dial tcp: lookup iam.amazonaws.com: no such host")))
+	})
+
+	t.Run("nil is not a not-configured answer", func(t *testing.T) {
+		assert.False(t, isRootAccessNotConfigured(nil))
+	})
+}


### PR DESCRIPTION
Fixes #10247

## The gap

Centralized root access is AWS's own answer to long-lived root credentials sitting in every member account: with it enabled, the management account can delete those credentials and take short-lived, scoped root actions when one is genuinely needed. Whether an organization has it on was not readable.

`aws.organization` covered accounts, OUs, policies, delegated administrators and delegated services — but nothing answered *"is root credentials management turned on for member accounts?"*

## The change

Two fields on `aws.organization`:

```coffee
aws.organization.enabledRootFeatures.contains("RootCredentialsManagement")
aws.organization.trustedAccessServicePrincipals.contains("iam.amazonaws.com")
```

**`enabledRootFeatures`** — IAM's `ListOrganizationsFeatures`, returning `RootCredentialsManagement`, `RootSessions`, or neither. Empty is the meaningful answer: it is exactly the "Root access management is disabled" banner the IAM console shows.

**`trustedAccessServicePrincipals`** — the services allowed to act across the organization's accounts. Trusted access is the prerequisite for any service to be administered organization-wide, IAM included, so the two fields answer the same question from both ends.

Worth flagging for review: this is **not** `delegatedServices`. That is `ListDelegatedServicesForAccount`, scoped to a single account, and it does not say whether a service has trusted access at the organization level. The names are close enough that conflating them is easy, which is part of why this gap went unnoticed.

## The error handling draws one line deliberately

An organization that is absent, in consolidated-billing mode, or has no IAM trusted access **cannot** have the feature enabled, so those resolve to an empty list — a statement about the organization.

A denial or a transport error leaves the answer unknown and stays an error. An empty list there would read as "centralized root access is off", which is the finding an audit acts on, so returning it for a failed read would *manufacture* that finding rather than lose it. The test asserts both directions.

## Permissions

Adds two: `iam:ListOrganizationsFeatures` and `organizations:ListAWSServiceAccessForOrganization`. `aws.permissions.json` goes 1025 → 1027.

Both calls are management-account-scoped, and both are in SDK clients the provider already vendors and constructs.

## Why this came up

CIS AWS Foundations Benchmark v7.0.0 adds an Organizations section, and **2.1.1 — "Ensure centralized root access in AWS Organizations"** needs exactly these two facts: its audit procedure sends you to the IAM console's Root access management page, and to the Organizations services list to confirm IAM has trusted access. Blocked in [cnspec-enterprise-policies#3326](https://github.com/mondoohq/cnspec-enterprise-policies/pull/3326) pending this.

## Testing

`go build ./...` and `go test ./resources/` pass in `providers/aws`. New table test covers the not-configured vs. unknown classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
