### PR TITLE
🧹 link-check: skip docs.ansible.com

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -20,6 +20,9 @@
     },
     {
       "pattern": "^https:\\/\\/nmap\\.org\\/"
+    },
+    {
+      "pattern": "^https:\\/\\/docs\\.ansible\\.com\\/"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds `docs.ansible.com` to the `ignorePatterns` list in `.github/actions/link-check/config.json`, so the markdown link checker stops flagging it.

## Why

`providers/ansible/README.md` links to the `ansible.builtin.dnf` module docs. That host sits behind Cloudflare bot protection, which answers the checker's requests with a `403` even though the page loads fine in a browser:

```
$ curl -o /dev/null -w '%{http_code}\n' \
    https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/dnf_module.html
403

$ curl -I https://docs.ansible.com/ | grep -iE '^(HTTP|server|cf-)'
HTTP/2 200
cf-ray: ...
server: cloudflare
```

So the failure is a scraper problem, not a broken link, and the job goes red on a doc reference that is actually correct.

## Approach

Ignoring the host was preferred over adding `403` to `aliveStatusCodes`: that setting is global, so it would suppress genuine `403`s on every other link in the repo. The pattern is anchored to the scheme and host (`^https:\/\/docs\.ansible\.com\/`) so it only covers this one origin, and does not silence, for example, a broken `github.com/ansible/...` link.

This follows the existing entries for `platform.openai.com`, `console.mistral.ai`, and `nmap.org`, which are ignored for the same reason.

## Test plan

- [x] `config.json` still parses as valid JSON
- [x] The pattern matches the README's URL, compiled the way `markdown-link-check` compiles it (`new RegExp(pattern)`), and does not match unrelated links
- [ ] The Link Checking job passes on this PR
