### PR TITLE
🧹 azure: deprecate the retired Single Server and Log Profile resources

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -7943,15 +7943,20 @@ private azure.subscription.sqlService.database.geoBackupPolicy @defaults("state"
 // Azure Database for PostgreSQL
 //
 // Managed PostgreSQL databases in a subscription, covering both the current
-// Flexible Server deployment model (flexibleServers) and the earlier Single
-// Server model (servers) that Azure is retiring. Use it to enumerate every
+// Flexible Server deployment model (flexibleServers) and the retired Single
+// Server model (servers). Use it to enumerate every
 // managed PostgreSQL instance and audit their network exposure,
 // authentication mode, encryption, and backup posture.
 private azure.subscription.postgreSqlService {
   // Subscription identifier
   subscriptionId string
-  // List of PostgreSQL servers
-  servers() []azure.subscription.postgreSqlService.server
+  // PostgreSQL Single Servers
+  //
+  // Deprecated in favor of flexibleServers. Azure retired PostgreSQL Single
+  // Server on 2025-03-28, so this list is empty on any current subscription
+  // and an assertion made over it passes without checking anything. Will be
+  // removed in the next major release.
+  servers() @maturity("deprecated") []azure.subscription.postgreSqlService.server
   // List of PostgreSQL flexible servers
   flexibleServers() []azure.subscription.postgreSqlService.flexibleServer
 }
@@ -8124,12 +8129,14 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
 
 // Azure Database for PostgreSQL server
 //
-// PostgreSQL Single Server instance, the earlier managed-PostgreSQL
-// deployment model that Azure is retiring in favor of Flexible Server.
-// Reports SSL enforcement, minimum TLS version, infrastructure (double)
-// encryption, public network access, firewall rules, and backup
-// configuration for auditing legacy servers still in production.
-private azure.subscription.postgreSqlService.server @defaults("id name location") {
+// Deprecated in favor of azure.subscription.postgreSqlService.flexibleServer.
+// PostgreSQL Single Server instance, the earlier managed-PostgreSQL deployment
+// model. Azure retired it on 2025-03-28, so no current subscription returns
+// one and every field below is unreachable in practice. Reports SSL
+// enforcement, minimum TLS version, infrastructure (double) encryption, public
+// network access, firewall rules, and backup configuration. Will be removed in
+// the next major release.
+private azure.subscription.postgreSqlService.server @defaults("id name location") @maturity("deprecated") {
   // PostgreSQL server ID
   id string
   // PostgreSQL server name
@@ -8354,17 +8361,34 @@ private azure.subscription.sqlService.managedInstance.database @defaults("name s
 }
 
 // Azure Database for MySQL
+//
+// Managed MySQL databases in a subscription, covering both the current
+// Flexible Server deployment model (flexibleServers) and the retired Single
+// Server model (servers). Use it to enumerate every managed MySQL instance and
+// audit their network exposure, encryption, and backup posture.
 private azure.subscription.mySqlService {
   // Subscription identifier
   subscriptionId string
-  // List of MySQL servers
-  servers() []azure.subscription.mySqlService.server
+  // MySQL Single Servers
+  //
+  // Deprecated in favor of flexibleServers. Azure retired MySQL Single Server
+  // on 2024-09-16, so this list is empty on any current subscription and an
+  // assertion made over it passes without checking anything. Will be removed
+  // in the next major release.
+  servers() @maturity("deprecated") []azure.subscription.mySqlService.server
   // List of Flexible MySQL servers
   flexibleServers() []azure.subscription.mySqlService.flexibleServer
 }
 
 // Azure Database for MySQL server
-private azure.subscription.mySqlService.server @defaults("id name location") {
+//
+// Deprecated in favor of azure.subscription.mySqlService.flexibleServer. MySQL
+// Single Server instance, the earlier managed-MySQL deployment model. Azure
+// retired it on 2024-09-16, so no current subscription returns one and every
+// field below is unreachable in practice. Reports SSL enforcement, minimum TLS
+// version, infrastructure (double) encryption, public network access, firewall
+// rules, and backup configuration. Will be removed in the next major release.
+private azure.subscription.mySqlService.server @defaults("id name location") @maturity("deprecated") {
   // MySQL server ID
   id string
   // MySQL server name
@@ -9555,8 +9579,13 @@ private azure.subscription.keyVaultService.secret @defaults("id secretName") {
 private azure.subscription.monitorService {
   // Subscription identifier
   subscriptionId string
-  // List of log profiles
-  logProfiles() []azure.subscription.monitorService.logprofile
+  // Log profiles
+  //
+  // Deprecated in favor of diagnosticSettings. Azure retired log profiles on
+  // 2023-09-01, so this list is empty on any current subscription and an
+  // assertion made over it passes without checking anything. Will be removed
+  // in the next major release.
+  logProfiles() @maturity("deprecated") []azure.subscription.monitorService.logprofile
   // List of diagnostic settings for the subscription
   diagnosticSettings() []azure.subscription.monitorService.diagnosticsetting
   // Application insights for the subscription
@@ -9861,7 +9890,13 @@ private azure.subscription.monitorService.activityLog.entry @defaults("operation
 }
 
 // Azure Monitor log profile
-private azure.subscription.monitorService.logprofile @defaults("id name location") {
+//
+// Deprecated in favor of azure.subscription.monitorService.diagnosticsetting.
+// Log profiles were the earlier way to export subscription activity logs to a
+// storage account, an event hub, or Log Analytics. Azure retired them on
+// 2023-09-01, so no current subscription returns one and every field below is
+// unreachable in practice. Will be removed in the next major release.
+private azure.subscription.monitorService.logprofile @defaults("id name location") @maturity("deprecated") {
   // Log profile ID
   id string
   // Log profile name


### PR DESCRIPTION
Closes #9984 (the deprecation half — see the companion PR for discovery).

Three Azure services the provider models are past retirement, so these resources can never return data on a current subscription:

| Resource | Azure service | Retired |
|---|---|---|
| `azure.subscription.mySqlService.server` | MySQL **Single** Server | 2024-09-16 |
| `azure.subscription.postgreSqlService.server` | PostgreSQL **Single** Server | 2025-03-28 |
| `azure.subscription.monitorService.logprofile` | Log Profiles | 2023-09-01 |

The issue asked for removal. Per @tas50 we are **deprecating instead and removing in v15**, so customers on extended support keep the resources while new policy stops being written against them.

## Why this matters

These resources return an empty list rather than an error, and an empty list makes `.all()` and `.none()` vacuously true. A policy written against them reports **compliant** forever rather than inconclusive — a green tick against a control nobody is enforcing.

## What changed

`@maturity("deprecated")` on the three resources and on the three accessors that reach them, each description leading with `Deprecated in favor of ...` and naming the replacement:

- `postgreSql.servers` / `postgreSqlService.server` → `postgreSql.flexibleServer`
- `mySql.servers` / `mySqlService.server` → `mySql.flexibleServer`
- `monitor.logProfiles` / `monitorService.logprofile` → `monitor.diagnosticSettings`

Two thin service descriptions (`mySqlService`, and `postgreSqlService`'s "that Azure is retiring") were filled in / corrected to past tense while there.

**Not deprecated:** `azure.subscription.{mySql,postgreSql}Service.database` is shared with the flexible servers and stays as-is.

## Notes for the reviewer

- **The `.lr` file is the whole diff, and that is expected.** A pure `@maturity` change regenerates byte-identical `.lr.go` and `.lr.versions`; maturity surfaces only in `*.resources.json`, which is gitignored. `./mqlr generate providers/azure/resources/azure.lr` was run and left `git status` showing only the schema edit.
- `.lr.versions` entries stay at their original versions — deprecating does not bump a field.
- No Go changes, so no live-subscription verification is possible or meaningful here: the whole point is that these code paths can no longer return anything. `go build ./...` and `go test ./...` are clean in `providers/azure/`.

## Left open deliberately

The issue's related question about `azure.subscription.cloudDefender.monitoringAgentAutoProvision` is untouched. The `Microsoft.Security/autoProvisioningSettings` API still answers even though the Log Analytics agent it provisioned is gone, so that field is a different judgement call and wants its own decision.
