### PR TITLE
🐛 gcp: list BigQuery reservations and connections in every location

### DIFF
--- a/providers/gcp/resources/bigquery_connection.go
+++ b/providers/gcp/resources/bigquery_connection.go
@@ -10,43 +10,11 @@ import (
 
 	bqconnection "cloud.google.com/go/bigquery/connection/apiv1"
 	"cloud.google.com/go/bigquery/connection/apiv1/connectionpb"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers/gcp/connection"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
-
-// bigqueryLocations returns the unique set of locations discovered from the
-// project's datasets. BigQuery connections and reservations are location-scoped
-// and there is no project-wide list endpoint, so we use the dataset locations
-// as the set of locations to query. A project with no datasets in a region will
-// also have no connections/reservations there in practice.
-func (g *mqlGcpProjectBigqueryService) bigqueryLocations() ([]string, error) {
-	datasets := g.GetDatasets()
-	if datasets.Error != nil {
-		return nil, datasets.Error
-	}
-
-	seen := make(map[string]struct{}, len(datasets.Data))
-	locations := make([]string, 0, len(datasets.Data))
-	for _, d := range datasets.Data {
-		ds := d.(*mqlGcpProjectBigqueryServiceDataset)
-		if ds.Location.Error != nil || ds.Location.Data == "" {
-			continue
-		}
-		// BigQuery connections/reservations APIs expect uppercase for
-		// multi-regions ("US", "EU") but the REST dataset metadata returns
-		// them uppercase already. Regional locations are lowercase in both.
-		loc := ds.Location.Data
-		if _, ok := seen[loc]; ok {
-			continue
-		}
-		seen[loc] = struct{}{}
-		locations = append(locations, loc)
-	}
-	return locations, nil
-}
 
 func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
 	enabled, err := g.isEnabled()
@@ -61,14 +29,6 @@ func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
 	}
 	projectId := g.ProjectId.Data
 
-	locations, err := g.bigqueryLocations()
-	if err != nil {
-		return nil, err
-	}
-	if len(locations) == 0 {
-		return nil, nil
-	}
-
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 	creds, err := conn.Credentials(bqconnection.DefaultAuthScopes()...)
 	if err != nil {
@@ -82,8 +42,8 @@ func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
 	}
 	defer client.Close()
 
-	var res []any
-	for _, location := range locations {
+	return listBigqueryLocations(func(location string) ([]any, error) {
+		var res []any
 		it := client.ListConnections(ctx, &connectionpb.ListConnectionsRequest{
 			Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, location),
 		})
@@ -93,10 +53,6 @@ func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isSkippable(err) {
-					log.Warn().Err(err).Str("location", location).Msg("could not list BigQuery connections")
-					break
-				}
 				return nil, err
 			}
 
@@ -134,8 +90,8 @@ func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
 			}
 			res = append(res, mqlConn)
 		}
-	}
-	return res, nil
+		return res, nil
+	})
 }
 
 // connectionProperties returns the connection type and a dict of the

--- a/providers/gcp/resources/bigquery_locations.go
+++ b/providers/gcp/resources/bigquery_locations.go
@@ -1,0 +1,206 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/codes"
+)
+
+// bigqueryLocations is every location BigQuery serves, named as the API names
+// them: the two multi-regions, the single regions, and the BigQuery Omni
+// locations that sit in AWS and Azure.
+//
+// The set has to be enumerated because neither API this drives accepts a
+// wildcard parent. `projects/<p>/locations/-/reservations`,
+// `.../capacityCommitments` and `.../reservations:searchAllAssignments` are all
+// rejected with INVALID_ARGUMENT, and there is no project-wide list endpoint
+// for connections either, so a caller has to name each location it wants.
+//
+// This list previously came from the project's own dataset locations, on the
+// assumption that a region holding no dataset holds no reservation or
+// connection. That assumption is wrong in both directions that matter. Slot
+// capacity is routinely bought in a region where the project holds no dataset,
+// because queries may run against datasets in another project, and a connection
+// to Cloud SQL, Spanner, or an Omni region needs no dataset at all. A project
+// with no datasets therefore reported nothing at all while the API held both.
+//
+// Sourced from https://cloud.google.com/bigquery/docs/locations. It needs
+// updating as Google adds locations, and a location missing from here is
+// invisible rather than reported, which is why the list lives in one place with
+// this note attached to it.
+var bigqueryLocations = []string{
+	// multi-regions
+	"US",
+	"EU",
+
+	// Americas
+	"northamerica-northeast1",
+	"northamerica-northeast2",
+	"northamerica-south1",
+	"southamerica-east1",
+	"southamerica-west1",
+	"us-central1",
+	"us-central2",
+	"us-east1",
+	"us-east4",
+	"us-east5",
+	"us-south1",
+	"us-west1",
+	"us-west2",
+	"us-west3",
+	"us-west4",
+
+	// Asia Pacific
+	"asia-east1",
+	"asia-east2",
+	"asia-northeast1",
+	"asia-northeast2",
+	"asia-northeast3",
+	"asia-south1",
+	"asia-south2",
+	"asia-southeast1",
+	"asia-southeast2",
+	"asia-southeast3",
+	"australia-southeast1",
+	"australia-southeast2",
+
+	// Europe
+	"europe-central2",
+	"europe-north1",
+	"europe-north2",
+	"europe-southwest1",
+	"europe-west1",
+	"europe-west2",
+	"europe-west3",
+	"europe-west4",
+	"europe-west6",
+	"europe-west8",
+	"europe-west9",
+	"europe-west10",
+	"europe-west12",
+
+	// Middle East and Africa
+	"africa-south1",
+	"me-central1",
+	"me-central2",
+	"me-west1",
+
+	// BigQuery Omni
+	"aws-ap-northeast-2",
+	"aws-ap-southeast-2",
+	"aws-eu-central-1",
+	"aws-eu-west-1",
+	"aws-us-east-1",
+	"aws-us-west-2",
+	"azure-eastus2",
+}
+
+// bigqueryLocationConcurrency bounds how many locations are in flight at once.
+// The whole list is queried on every call, so it is the difference between one
+// slow round trip and fifty of them, but an unbounded fan-out would open a
+// connection per location and is not worth the burst.
+const bigqueryLocationConcurrency = 10
+
+// bigqueryLocationUnsupported reports whether err means the location itself
+// does not apply: BigQuery is not offered there, the project cannot reach it,
+// or the parent path names nothing.
+//
+// It deliberately does not reuse isSkippable, which folds PermissionDenied in
+// with "nothing here". Permission for these APIs is granted per project rather
+// than per location, so a denial answers every location identically, and
+// classifying it as "nothing here" is exactly how a fan-out ends up reporting
+// an empty list for a project nobody was allowed to read.
+func bigqueryLocationUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	if s, ok := grpcStatusOf(err); ok {
+		switch s.Code() {
+		case codes.NotFound, codes.Unimplemented, codes.InvalidArgument, codes.FailedPrecondition:
+			return true
+		}
+	}
+	return false
+}
+
+// listBigqueryLocations calls list once per BigQuery location and concatenates
+// what comes back.
+//
+// How a failure is handled is the point of this helper, because the bug it
+// replaces was a silent empty list:
+//
+//   - The API not being enabled on the project means there is genuinely nothing
+//     to find in any location, so it degrades to an empty result.
+//   - A location that does not apply is skipped. Most of the list is expected
+//     to answer this way for any given project.
+//   - Anything else, a permission denial above all, is a failure. If no
+//     location succeeded, the failure is returned rather than an empty list:
+//     "we were not allowed to look" must not arrive looking like "there is
+//     nothing here", or every assertion over the result passes vacuously.
+//   - If some locations succeeded and others failed, the partial result is
+//     returned and the failures are logged, because failing the whole field
+//     over one unreachable location would hide the reservations that were read.
+func listBigqueryLocations(list func(location string) ([]any, error)) ([]any, error) {
+	type failure struct {
+		location string
+		err      error
+	}
+
+	var (
+		mu        sync.Mutex
+		out       []any
+		succeeded int
+		failures  []failure
+	)
+
+	sem := make(chan struct{}, bigqueryLocationConcurrency)
+	wg := sync.WaitGroup{}
+	for _, location := range bigqueryLocations {
+		wg.Add(1)
+		go func(location string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			res, err := list(location)
+
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				succeeded++
+				out = append(out, res...)
+			case isServiceDisabled(err):
+				// The API is off for the whole project. Every location says so,
+				// and none of them is a failure to report.
+			case bigqueryLocationUnsupported(err):
+				log.Debug().Err(err).Str("location", location).Msg("skipping BigQuery location")
+			default:
+				failures = append(failures, failure{location: location, err: err})
+			}
+		}(location)
+	}
+	wg.Wait()
+
+	if len(failures) == 0 {
+		return out, nil
+	}
+
+	locations := make([]string, 0, len(failures))
+	for _, f := range failures {
+		locations = append(locations, f.location)
+	}
+	if succeeded == 0 {
+		return nil, fmt.Errorf("could not read any BigQuery location (%s): %w",
+			strings.Join(locations, ", "), failures[0].err)
+	}
+	log.Warn().Err(failures[0].err).Str("locations", strings.Join(locations, ", ")).
+		Msg("could not read every BigQuery location, results are partial")
+	return out, nil
+}

--- a/providers/gcp/resources/bigquery_locations_test.go
+++ b/providers/gcp/resources/bigquery_locations_test.go
@@ -1,0 +1,196 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestBigqueryLocations(t *testing.T) {
+	if len(bigqueryLocations) == 0 {
+		t.Fatal("bigqueryLocations is empty, every BigQuery listing would report nothing")
+	}
+
+	// A duplicate would list one location twice and report its reservations
+	// twice, since each pass creates the same resources again.
+	seen := map[string]struct{}{}
+	for _, l := range bigqueryLocations {
+		if _, ok := seen[l]; ok {
+			t.Fatalf("location %q appears twice", l)
+		}
+		seen[l] = struct{}{}
+	}
+
+	// The multi-regions are where most reservations are actually bought, and
+	// they are the two entries an alphabetical sort of the list would be most
+	// likely to lose.
+	for _, want := range []string{"US", "EU", "us-central1", "europe-west1", "aws-us-east-1"} {
+		if _, ok := seen[want]; !ok {
+			t.Fatalf("location %q missing from bigqueryLocations", want)
+		}
+	}
+}
+
+func TestBigqueryLocationUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "not found", err: status.Error(codes.NotFound, "no such parent"), want: true},
+		{name: "unimplemented", err: status.Error(codes.Unimplemented, "not offered here"), want: true},
+		{name: "invalid argument", err: status.Error(codes.InvalidArgument, "failed to parse the URI"), want: true},
+		{name: "failed precondition", err: status.Error(codes.FailedPrecondition, "location unavailable"), want: true},
+
+		// The one that decides whether the fix works. isSkippable folds a
+		// permission denial in with "nothing here"; if this classifier did the
+		// same, a project the caller cannot read would report an empty list from
+		// every location and every assertion over it would pass vacuously.
+		{name: "permission denied is not a location problem", err: status.Error(codes.PermissionDenied, "caller lacks bigquery.reservations.list"), want: false},
+		{name: "unavailable is not a location problem", err: status.Error(codes.Unavailable, "backend unavailable"), want: false},
+		{name: "plain error", err: fmt.Errorf("connection reset"), want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bigqueryLocationUnsupported(tc.err); got != tc.want {
+				t.Fatalf("bigqueryLocationUnsupported(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+
+	// A classification has to survive a caller wrapping the error for context,
+	// or the skip path stops firing the moment somebody adds a %w.
+	t.Run("survives wrapping", func(t *testing.T) {
+		wrapped := fmt.Errorf("listing reservations: %w", status.Error(codes.InvalidArgument, "bad parent"))
+		if !bigqueryLocationUnsupported(wrapped) {
+			t.Fatal("wrapped InvalidArgument was not recognized")
+		}
+	})
+}
+
+func TestListBigqueryLocations(t *testing.T) {
+	t.Run("visits every location exactly once", func(t *testing.T) {
+		var mu sync.Mutex
+		visited := []string{}
+		_, err := listBigqueryLocations(func(location string) ([]any, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			visited = append(visited, location)
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(visited) != len(bigqueryLocations) {
+			t.Fatalf("visited %d locations, want %d", len(visited), len(bigqueryLocations))
+		}
+		sort.Strings(visited)
+		want := append([]string{}, bigqueryLocations...)
+		sort.Strings(want)
+		for i := range want {
+			if visited[i] != want[i] {
+				t.Fatalf("visited[%d] = %q, want %q", i, visited[i], want[i])
+			}
+		}
+	})
+
+	t.Run("concatenates the results of every location", func(t *testing.T) {
+		got, err := listBigqueryLocations(func(location string) ([]any, error) {
+			if location == "US" || location == "europe-west1" {
+				return []any{location}, nil
+			}
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %v, want two entries", got)
+		}
+	})
+
+	// The bug this whole change exists to fix: a project with nothing
+	// configured is a real, reportable answer, and it has to stay one.
+	t.Run("no results anywhere is an empty list, not an error", func(t *testing.T) {
+		got, err := listBigqueryLocations(func(location string) ([]any, error) {
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %v, want empty", got)
+		}
+	})
+
+	t.Run("an unsupported location is skipped", func(t *testing.T) {
+		got, err := listBigqueryLocations(func(location string) ([]any, error) {
+			if location == "US" {
+				return []any{"reservation"}, nil
+			}
+			return nil, status.Error(codes.InvalidArgument, "not a BigQuery location for this project")
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %v, want the one readable location's result", got)
+		}
+	})
+
+	t.Run("an API that is not enabled reports empty rather than failing", func(t *testing.T) {
+		got, err := listBigqueryLocations(func(location string) ([]any, error) {
+			return nil, status.Error(codes.PermissionDenied,
+				"BigQuery Reservation API has not been used in project 1234 before or it is disabled")
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("got %v, want empty", got)
+		}
+	})
+
+	// Denied everywhere must not look like "there is nothing here". This is the
+	// distinction the issue asked for: the empty case has to be
+	// distinguishable from the not-checked case.
+	t.Run("denied in every location is an error, not an empty list", func(t *testing.T) {
+		got, err := listBigqueryLocations(func(location string) ([]any, error) {
+			return nil, status.Error(codes.PermissionDenied, "caller lacks bigquery.reservations.list")
+		})
+		if err == nil {
+			t.Fatalf("got %v and no error, want an error", got)
+		}
+		if got != nil {
+			t.Fatalf("got %v alongside the error, want nil", got)
+		}
+	})
+
+	// One unreachable location must not throw away what the others returned.
+	t.Run("a partial failure returns what was read", func(t *testing.T) {
+		got, err := listBigqueryLocations(func(location string) ([]any, error) {
+			if location == "US" {
+				return nil, status.Error(codes.PermissionDenied, "denied in this location only")
+			}
+			if location == "EU" {
+				return []any{"reservation"}, nil
+			}
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("got %v, want the readable location's result", got)
+		}
+	})
+}

--- a/providers/gcp/resources/bigquery_reservation.go
+++ b/providers/gcp/resources/bigquery_reservation.go
@@ -9,7 +9,6 @@ import (
 
 	bqreservation "cloud.google.com/go/bigquery/reservation/apiv1"
 	"cloud.google.com/go/bigquery/reservation/apiv1/reservationpb"
-	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/providers/gcp/connection"
@@ -31,14 +30,6 @@ func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
 	}
 	projectId := g.ProjectId.Data
 
-	locations, err := g.bigqueryLocations()
-	if err != nil {
-		return nil, err
-	}
-	if len(locations) == 0 {
-		return nil, nil
-	}
-
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 	creds, err := conn.Credentials(bqreservation.DefaultAuthScopes()...)
 	if err != nil {
@@ -52,8 +43,8 @@ func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
 	}
 	defer client.Close()
 
-	var res []any
-	for _, location := range locations {
+	return listBigqueryLocations(func(location string) ([]any, error) {
+		var res []any
 		it := client.ListReservations(ctx, &reservationpb.ListReservationsRequest{
 			Parent: fmt.Sprintf("projects/%s/locations/%s", projectId, location),
 		})
@@ -63,10 +54,6 @@ func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
 				break
 			}
 			if err != nil {
-				if isSkippable(err) {
-					log.Warn().Err(err).Str("location", location).Msg("could not list BigQuery reservations")
-					break
-				}
 				return nil, err
 			}
 
@@ -108,8 +95,8 @@ func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
 			}
 			res = append(res, mqlRes)
 		}
-	}
-	return res, nil
+		return res, nil
+	})
 }
 
 func (g *mqlGcpProjectBigqueryServiceReservation) id() (string, error) {


### PR DESCRIPTION
## Problem

`gcp.project.bigqueryService.reservations` and `.connections` returned an empty list whenever the project had no BigQuery **dataset** in the same region. `bigqueryLocations()` derived its location set from the project's datasets, and both callers took the `len(locations) == 0 → return nil, nil` early return.

The assumption in that helper's comment — "a project with no datasets in a region will also have no connections/reservations there in practice" — is wrong in both directions that matter. Slot capacity is routinely bought in a region where the project holds no dataset, because queries may run against datasets in another project, and a connection to Cloud SQL, Spanner, or a BigQuery Omni region needs no dataset at all.

The failure was silent: no error, no log line, and an empty list is indistinguishable from "this project has no reservations". Cost-control policies over slot commitments and data-egress policies over external connections passed vacuously.

## What changed

Neither API accepts a wildcard parent and neither has a project-wide list endpoint, so the locations are now enumerated. `bigqueryLocations` is the list of every location BigQuery serves — two multi-regions, 43 single regions, seven Omni locations — queried concurrently with a bounded worker pool (10 in flight).

The other half of the fix is how a per-location failure is classified, because the bug being replaced *was* a silent empty list:

| condition | behaviour |
|---|---|
| API not enabled on the project | empty result, no error — there is genuinely nothing to find anywhere |
| location does not apply (`NotFound`, `Unimplemented`, `InvalidArgument`, `FailedPrecondition`) | skipped; most of the list answers this way for any given project |
| anything else, **no** location succeeded | **error** — "we were not allowed to look" must not arrive looking like "there is nothing here" |
| anything else, some locations succeeded | partial result returned, failures logged — one unreachable location must not discard what was read |

This deliberately does not reuse `isSkippable`, which folds `PermissionDenied` in with "nothing here". Permission for these APIs is granted per project rather than per location, so a denial answers every location identically and reusing it would reproduce the original bug at a larger scale. `TestBigqueryLocationUnsupported` pins that distinction.

## Live verification

Against `tim-learning-project`, which has **zero BigQuery datasets**. A `CLOUD_RESOURCE` connection was created in `europe-west1` (no dataset anywhere in the project), both provider builds were run against it, and the connection was deleted and its removal confirmed afterwards.

| | `origin/main` | this branch |
|---|---|---|
| `datasets.length` | 0 | 0 |
| `connections` | `[]` | `mqlv-conn` / `europe-west1` / `CLOUD_RESOURCE` |
| `reservations.length` | 0 | 0 |

```
$ PROVIDERS_PATH=/tmp/pd-gcpbq mql run gcp project <p> --discover none \
    -c 'gcp.project.bigqueryService { datasets.length connections { name location type } reservations.length }'
gcp.project.bigqueryService: {
  reservations.length: 0
  connections: [
    0: {
      location: "europe-west1"
      name: "projects/.../locations/europe-west1/connections/mqlv-conn"
      type: "CLOUD_RESOURCE"
    }
  ]
  datasets.length: 0
}
```

That is the exact shape the issue reports: a resource the API returns and mql could not see.

**Cost.** The full fan-out for both fields — 106 API calls — took **5.3 s** wall clock on a single project; `connections` alone took 3.3 s. The calls are lazy, so a query that touches neither field pays nothing.

## Tests

`providers/gcp/resources/bigquery_locations_test.go` covers the location list (non-empty, no duplicates, multi-regions present), the classifier (including that `PermissionDenied` is *not* a location problem, and that classification survives `%w` wrapping), and the fan-out policy: every location visited exactly once, results concatenated, empty-is-not-an-error, disabled-API degrades, denied-everywhere errors, partial failure returns what was read. `go test -race` is clean.

`gcp.permissions.json` is unchanged (287 permissions) — no new API calls, and the extractor still sees the existing ones through the closure.

## Note on the alternatives

The issue laid out three routes. This is option 1. Cloud Asset Inventory (option 2) would be one call instead of 53, but it adds a `cloudasset.googleapis.com` dependency and a `cloudasset.assets.searchAllResources` permission the provider does not require today — customers without it would get an error where they used to get a quiet wrong answer. Option 3 keeps the silent-empty bug for any region outside the curated set.

The list needs updating as Google adds locations. It lives in one place with that caveat attached to it, and a location missing from it is invisible rather than reported — which is why the note is in the code and not only here.

Fixes #9889
