### PR TITLE
✨ ms365: expose Entra ID and Intune tenant diagnostic settings

### DIFF
--- a/providers/ms365/resources/diagnostic_settings.go
+++ b/providers/ms365/resources/diagnostic_settings.go
@@ -1,0 +1,183 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/providers/ms365/connection"
+	"go.mondoo.com/mql/types"
+)
+
+const (
+	// armScope is the token audience for Azure Resource Manager. Tenant
+	// diagnostic settings are ARM resources rather than Microsoft Graph ones,
+	// so a Graph token does not open them.
+	armScope = "https://management.azure.com/.default"
+
+	// Both endpoints are tenant-scoped: neither carries a subscription in its
+	// path, and each is pinned to the only api-version its resource provider
+	// publishes. Casing follows what the resource providers register.
+	entraDiagnosticSettingsUrl  = "https://management.azure.com/providers/microsoft.aadiam/diagnosticSettings?api-version=2017-04-01-preview"
+	intuneDiagnosticSettingsUrl = "https://management.azure.com/providers/Microsoft.Intune/diagnosticSettings?api-version=2017-04-01-preview"
+
+	// armHTTPTimeout bounds a single request. These requests do not run through
+	// an SDK pipeline that would impose a deadline of its own, so without it a
+	// stalled connection blocks the field forever.
+	armHTTPTimeout = 60 * time.Second
+)
+
+// armHTTPClient is shared by the ARM requests so they all get the timeout.
+// http.Client is safe for concurrent use.
+var armHTTPClient = &http.Client{Timeout: armHTTPTimeout}
+
+// armDiagnosticSettingsList is the ARM collection envelope. Both resource
+// providers return a plain value array with no continuation link: a tenant is
+// capped at five diagnostic settings per resource, so there is no page to
+// follow.
+type armDiagnosticSettingsList struct {
+	Value []armDiagnosticSetting `json:"value"`
+}
+
+type armDiagnosticSetting struct {
+	Id         string                         `json:"id"`
+	Name       string                         `json:"name"`
+	Type       string                         `json:"type"`
+	Properties armDiagnosticSettingProperties `json:"properties"`
+}
+
+type armDiagnosticSettingProperties struct {
+	Logs                        []armDiagnosticLogSetting `json:"logs"`
+	WorkspaceId                 string                    `json:"workspaceId"`
+	StorageAccountId            string                    `json:"storageAccountId"`
+	EventHubName                string                    `json:"eventHubName"`
+	EventHubAuthorizationRuleId string                    `json:"eventHubAuthorizationRuleId"`
+}
+
+type armDiagnosticLogSetting struct {
+	Category string `json:"category"`
+	// Enabled decides whether the category is exported. A setting lists every
+	// category it knows about, switched on or off, so reading the flag is the
+	// only way to tell an exported stream from a listed one.
+	Enabled         bool `json:"enabled"`
+	RetentionPolicy any  `json:"retentionPolicy,omitempty"`
+}
+
+// enabledLogCategories returns the categories the setting actually exports, in
+// the order the service reports them. A category with an empty name is dropped:
+// it names no log stream, and reporting it would put "" into a list that checks
+// test with contains.
+func (p armDiagnosticSettingProperties) enabledLogCategories() []string {
+	out := []string{}
+	for _, l := range p.Logs {
+		if !l.Enabled || l.Category == "" {
+			continue
+		}
+		out = append(out, l.Category)
+	}
+	return out
+}
+
+// armGet issues an authenticated GET against ARM and decodes the collection.
+//
+// Any non-200 response is reported as an error rather than as an empty
+// collection. The distinction matters more here than usual: a tenant that has
+// configured no diagnostic settings answers 200 with an empty array, so an
+// empty list is a real finding, and letting a 403 arrive the same way would
+// turn "we were not allowed to look" into "nothing is configured".
+func armGet(ctx context.Context, token string, url string) (*armDiagnosticSettingsList, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := armHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("azure resource manager returned %s for %s: %s", resp.Status, url, string(body))
+	}
+
+	list := &armDiagnosticSettingsList{}
+	if err := json.Unmarshal(body, list); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+// diagnosticSettings fetches one tenant-scoped diagnostic settings collection
+// and maps it to MQL resources.
+func diagnosticSettings(runtime *plugin.Runtime, url string) ([]any, error) {
+	conn, ok := runtime.Connection.(*connection.Ms365Connection)
+	if !ok {
+		return nil, fmt.Errorf("wrong connection type for microsoft.diagnosticSetting")
+	}
+	ctx := context.Background()
+
+	armToken, err := conn.Token().GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{armScope},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := armGet(ctx, armToken.Token, url)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range list.Value {
+		setting := list.Value[i]
+
+		logs, err := convert.JsonToDictSlice(setting.Properties.Logs)
+		if err != nil {
+			return nil, err
+		}
+
+		mqlSetting, err := CreateResource(runtime, "microsoft.diagnosticSetting", map[string]*llx.RawData{
+			"__id":                        llx.StringData(setting.Id),
+			"id":                          llx.StringData(setting.Id),
+			"name":                        llx.StringData(setting.Name),
+			"type":                        llx.StringData(setting.Type),
+			"enabledLogCategories":        llx.ArrayData(convert.SliceAnyToInterface(setting.Properties.enabledLogCategories()), types.String),
+			"logs":                        llx.ArrayData(logs, types.Dict),
+			"workspaceId":                 llx.StringData(setting.Properties.WorkspaceId),
+			"storageAccountId":            llx.StringData(setting.Properties.StorageAccountId),
+			"eventHubName":                llx.StringData(setting.Properties.EventHubName),
+			"eventHubAuthorizationRuleId": llx.StringData(setting.Properties.EventHubAuthorizationRuleId),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlSetting)
+	}
+	return res, nil
+}
+
+func (a *mqlMicrosoft) entraDiagnosticSettings() ([]any, error) {
+	return diagnosticSettings(a.MqlRuntime, entraDiagnosticSettingsUrl)
+}
+
+func (a *mqlMicrosoft) intuneDiagnosticSettings() ([]any, error) {
+	return diagnosticSettings(a.MqlRuntime, intuneDiagnosticSettingsUrl)
+}

--- a/providers/ms365/resources/diagnostic_settings_test.go
+++ b/providers/ms365/resources/diagnostic_settings_test.go
@@ -1,0 +1,160 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// entraPayload is shaped like a real microsoft.aadiam/diagnosticSettings
+// response: one setting exporting three of the categories it lists, with a Log
+// Analytics destination and no storage or Event Hub.
+const entraPayload = `{
+  "value": [
+    {
+      "id": "/providers/microsoft.aadiam/diagnosticSettings/entra-to-la",
+      "name": "entra-to-la",
+      "type": "microsoft.aadiam/diagnosticSettings",
+      "properties": {
+        "workspaceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/logs/providers/Microsoft.OperationalInsights/workspaces/tenant-logs",
+        "logs": [
+          {"category": "AuditLogs", "enabled": true, "retentionPolicy": {"days": 0, "enabled": false}},
+          {"category": "SignInLogs", "enabled": true, "retentionPolicy": {"days": 0, "enabled": false}},
+          {"category": "MicrosoftGraphActivityLogs", "enabled": true, "retentionPolicy": {"days": 0, "enabled": false}},
+          {"category": "ProvisioningLogs", "enabled": false, "retentionPolicy": {"days": 0, "enabled": false}}
+        ]
+      }
+    }
+  ]
+}`
+
+func TestArmDiagnosticSettingDecode(t *testing.T) {
+	list := &armDiagnosticSettingsList{}
+	require.NoError(t, json.Unmarshal([]byte(entraPayload), list))
+	require.Len(t, list.Value, 1)
+
+	got := list.Value[0]
+	assert.Equal(t, "/providers/microsoft.aadiam/diagnosticSettings/entra-to-la", got.Id)
+	assert.Equal(t, "entra-to-la", got.Name)
+	assert.Equal(t, "microsoft.aadiam/diagnosticSettings", got.Type)
+
+	// A mistyped destination tag decodes to "", which reads as "no destination
+	// configured" on a setting that has one. Pin each destination tag.
+	assert.Equal(t,
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/logs/providers/Microsoft.OperationalInsights/workspaces/tenant-logs",
+		got.Properties.WorkspaceId)
+	assert.Empty(t, got.Properties.StorageAccountId)
+	assert.Empty(t, got.Properties.EventHubName)
+	assert.Empty(t, got.Properties.EventHubAuthorizationRuleId)
+
+	require.Len(t, got.Properties.Logs, 4)
+	assert.Equal(t, "AuditLogs", got.Properties.Logs[0].Category)
+	assert.True(t, got.Properties.Logs[0].Enabled)
+	assert.False(t, got.Properties.Logs[3].Enabled)
+}
+
+func TestEnabledLogCategories(t *testing.T) {
+	t.Run("returns only the categories that are switched on", func(t *testing.T) {
+		list := &armDiagnosticSettingsList{}
+		require.NoError(t, json.Unmarshal([]byte(entraPayload), list))
+
+		// ProvisioningLogs is listed but disabled. A setting names every category
+		// it knows about, so taking the list at face value would report a stream
+		// as exported when it is switched off.
+		assert.Equal(t,
+			[]string{"AuditLogs", "SignInLogs", "MicrosoftGraphActivityLogs"},
+			list.Value[0].Properties.enabledLogCategories())
+	})
+
+	t.Run("a setting that exports nothing reports an empty list", func(t *testing.T) {
+		props := armDiagnosticSettingProperties{Logs: []armDiagnosticLogSetting{
+			{Category: "AuditLogs", Enabled: false},
+			{Category: "SignInLogs", Enabled: false},
+		}}
+		got := props.enabledLogCategories()
+		assert.NotNil(t, got, "must be an empty list, not nil, so contains is answerable")
+		assert.Empty(t, got)
+	})
+
+	t.Run("a setting with no logs at all reports an empty list", func(t *testing.T) {
+		got := armDiagnosticSettingProperties{}.enabledLogCategories()
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	// An unnamed category names no log stream. Keeping it would put "" into a
+	// list that checks test with contains.
+	t.Run("drops an entry with no category name", func(t *testing.T) {
+		props := armDiagnosticSettingProperties{Logs: []armDiagnosticLogSetting{
+			{Category: "", Enabled: true},
+			{Category: "AuditLogs", Enabled: true},
+		}}
+		assert.Equal(t, []string{"AuditLogs"}, props.enabledLogCategories())
+	})
+}
+
+func TestArmGet(t *testing.T) {
+	t.Run("decodes a successful response and sends the bearer token", func(t *testing.T) {
+		var gotAuth string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(entraPayload))
+		}))
+		defer srv.Close()
+
+		list, err := armGet(context.Background(), "a-token", srv.URL)
+		require.NoError(t, err)
+		require.Len(t, list.Value, 1)
+		assert.Equal(t, "Bearer a-token", gotAuth)
+	})
+
+	// A tenant with nothing configured answers 200 with an empty array. That is
+	// a real finding and must not be confused with a failure.
+	t.Run("an empty collection is not an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"value": []}`))
+		}))
+		defer srv.Close()
+
+		list, err := armGet(context.Background(), "a-token", srv.URL)
+		require.NoError(t, err)
+		assert.Empty(t, list.Value)
+	})
+
+	// The failure that matters: credentials without the role get a 403. Reading
+	// that as an empty collection would report "no diagnostic settings are
+	// configured" for a tenant nobody was allowed to look at, and every check
+	// over the categories would pass vacuously.
+	t.Run("a forbidden response is an error, not an empty collection", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":"AuthorizationFailed","message":"does not have authorization to perform action 'Microsoft.Intune/diagnosticSettings/read'"}}`))
+		}))
+		defer srv.Close()
+
+		list, err := armGet(context.Background(), "a-token", srv.URL)
+		require.Error(t, err)
+		assert.Nil(t, list)
+		assert.Contains(t, err.Error(), "403")
+		assert.Contains(t, err.Error(), "AuthorizationFailed")
+	})
+
+	t.Run("a body that is not the expected shape is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`not json`))
+		}))
+		defer srv.Close()
+
+		_, err := armGet(context.Background(), "a-token", srv.URL)
+		require.Error(t, err)
+	})
+}

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -47,6 +47,21 @@ microsoft {
   identityAndAccess() microsoft.identityAndAccess
   // Access review definitions
   accessReviews() microsoft.identityAndAccess.accessReviews
+  // Diagnostic settings exporting Microsoft Entra ID tenant logs
+  //
+  // The tenant-scoped diagnostic settings configured under Entra ID
+  // monitoring, which decide whether sign-in, audit, provisioning, and
+  // Microsoft Graph activity logs leave the tenant and where they land.
+  // Retention beyond the portal's own window depends on one of these existing.
+  entraDiagnosticSettings() []microsoft.diagnosticSetting
+  // Diagnostic settings exporting Microsoft Intune tenant logs
+  //
+  // The tenant-scoped diagnostic settings configured under Intune reports,
+  // covering the audit, operational, device compliance, and device inventory
+  // log streams. Reading these needs a role that grants
+  // Microsoft.Intune/diagnosticSettings/read, which is granted separately from
+  // the Entra one, so the two lists can succeed and fail independently.
+  intuneDiagnosticSettings() []microsoft.diagnosticSetting
 }
 
 // Microsoft Entra ID Access Review Definitions
@@ -5487,4 +5502,51 @@ private ms365.exchangeonline.roleAssignmentPolicyEntry @defaults("name isDefault
   description string
   // Management roles assigned by the policy
   assignedRoles []string
+}
+
+// Tenant diagnostic setting
+//
+// One Azure Monitor diagnostic setting attached to a tenant-wide service,
+// keyed by its resource id. Covers the log categories the setting exports and
+// the destination they are sent to: a Log Analytics workspace, a storage
+// account, or an Event Hub. Microsoft Entra ID and Microsoft Intune each hold
+// their own tenant-scoped settings, reached through entraDiagnosticSettings
+// and intuneDiagnosticSettings. A tenant may hold several settings at once, so
+// a log category counts as exported when any one setting enables it.
+private microsoft.diagnosticSetting @defaults("name enabledLogCategories") {
+  // Resource id of the diagnostic setting
+  id string
+  // Name of the diagnostic setting
+  name string
+  // Resource type the setting is attached to
+  //
+  // Either microsoft.aadiam/diagnosticSettings for Microsoft Entra ID or
+  // Microsoft.Intune/diagnosticSettings for Microsoft Intune.
+  type string
+  // Log categories the setting exports
+  //
+  // Only the categories switched on, so a setting that exists but exports
+  // nothing reports an empty list. The available categories are an open set
+  // that grows as services add log streams. Microsoft Entra ID publishes
+  // AuditLogs, SignInLogs, NonInteractiveUserSignInLogs,
+  // ServicePrincipalSignInLogs, ManagedIdentitySignInLogs, ProvisioningLogs,
+  // RiskyUsers, and MicrosoftGraphActivityLogs among others. Microsoft Intune
+  // publishes AuditLogs, OperationalLogs, DeviceComplianceOrg, Devices, and
+  // Windows365AuditLogs.
+  enabledLogCategories []string
+  // Per-category log settings
+  //
+  // Each entry describes one log stream with its `category`, whether it is
+  // `enabled`, and the legacy `retentionPolicy` carrying `days` and `enabled`.
+  // Retention is managed at the destination now, so the policy here is
+  // reported as the service returns it rather than as the effective setting.
+  logs []dict
+  // Resource id of the Log Analytics workspace logs are sent to, empty when no workspace destination is configured
+  workspaceId string
+  // Resource id of the storage account logs are archived to, empty when no storage destination is configured
+  storageAccountId string
+  // Name of the Event Hub logs are streamed to, empty when no Event Hub destination is configured
+  eventHubName string
+  // Resource id of the authorization rule for the Event Hub destination
+  eventHubAuthorizationRuleId string
 }

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -207,6 +207,7 @@ const (
 	ResourceMs365ExchangeonlineAtpPolicyForO365Entry                                                     string = "ms365.exchangeonline.atpPolicyForO365Entry"
 	ResourceMs365ExchangeonlineSharingPolicyEntry                                                        string = "ms365.exchangeonline.sharingPolicyEntry"
 	ResourceMs365ExchangeonlineRoleAssignmentPolicyEntry                                                 string = "ms365.exchangeonline.roleAssignmentPolicyEntry"
+	ResourceMicrosoftDiagnosticSetting                                                                   string = "microsoft.diagnosticSetting"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -977,6 +978,10 @@ func init() {
 			// to override args, implement: initMs365ExchangeonlineRoleAssignmentPolicyEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMs365ExchangeonlineRoleAssignmentPolicyEntry,
 		},
+		"microsoft.diagnosticSetting": {
+			// to override args, implement: initMicrosoftDiagnosticSetting(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMicrosoftDiagnosticSetting,
+		},
 	}
 }
 
@@ -1092,6 +1097,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"microsoft.accessReviews": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoft).GetAccessReviews()).ToDataRes(types.Resource("microsoft.identityAndAccess.accessReviews"))
+	},
+	"microsoft.entraDiagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoft).GetEntraDiagnosticSettings()).ToDataRes(types.Array(types.Resource("microsoft.diagnosticSetting")))
+	},
+	"microsoft.intuneDiagnosticSettings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoft).GetIntuneDiagnosticSettings()).ToDataRes(types.Array(types.Resource("microsoft.diagnosticSetting")))
 	},
 	"microsoft.identityAndAccess.accessReviews.filter": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftIdentityAndAccessAccessReviews).GetFilter()).ToDataRes(types.String)
@@ -5887,6 +5898,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ms365.exchangeonline.roleAssignmentPolicyEntry.assignedRoles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMs365ExchangeonlineRoleAssignmentPolicyEntry).GetAssignedRoles()).ToDataRes(types.Array(types.String))
 	},
+	"microsoft.diagnosticSetting.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetId()).ToDataRes(types.String)
+	},
+	"microsoft.diagnosticSetting.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetName()).ToDataRes(types.String)
+	},
+	"microsoft.diagnosticSetting.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetType()).ToDataRes(types.String)
+	},
+	"microsoft.diagnosticSetting.enabledLogCategories": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetEnabledLogCategories()).ToDataRes(types.Array(types.String))
+	},
+	"microsoft.diagnosticSetting.logs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetLogs()).ToDataRes(types.Array(types.Dict))
+	},
+	"microsoft.diagnosticSetting.workspaceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetWorkspaceId()).ToDataRes(types.String)
+	},
+	"microsoft.diagnosticSetting.storageAccountId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetStorageAccountId()).ToDataRes(types.String)
+	},
+	"microsoft.diagnosticSetting.eventHubName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetEventHubName()).ToDataRes(types.String)
+	},
+	"microsoft.diagnosticSetting.eventHubAuthorizationRuleId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftDiagnosticSetting).GetEventHubAuthorizationRuleId()).ToDataRes(types.String)
+	},
 }
 
 func GetData(resource plugin.Resource, field string, args map[string]*llx.RawData) *plugin.DataRes {
@@ -5961,6 +5999,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.accessReviews": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoft).AccessReviews, ok = plugin.RawToTValue[*mqlMicrosoftIdentityAndAccessAccessReviews](v.Value, v.Error)
+		return
+	},
+	"microsoft.entraDiagnosticSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoft).EntraDiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.intuneDiagnosticSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoft).IntuneDiagnosticSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"microsoft.identityAndAccess.accessReviews.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -13115,6 +13161,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMs365ExchangeonlineRoleAssignmentPolicyEntry).AssignedRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"microsoft.diagnosticSetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).__id, ok = v.Value.(string)
+		return
+	},
+	"microsoft.diagnosticSetting.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.enabledLogCategories": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).EnabledLogCategories, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.logs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).Logs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.workspaceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).WorkspaceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.storageAccountId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).StorageAccountId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.eventHubName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).EventHubName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.diagnosticSetting.eventHubAuthorizationRuleId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftDiagnosticSetting).EventHubAuthorizationRuleId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 }
 
 func SetData(resource plugin.Resource, field string, val *llx.RawData) error {
@@ -13144,21 +13230,23 @@ type mqlMicrosoft struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlMicrosoftInternal
-	Organizations          plugin.TValue[[]any]
-	Users                  plugin.TValue[*mqlMicrosoftUsers]
-	Groups                 plugin.TValue[*mqlMicrosoftGroups]
-	GroupLifecyclePolicies plugin.TValue[[]any]
-	Domains                plugin.TValue[[]any]
-	Applications           plugin.TValue[*mqlMicrosoftApplications]
-	Serviceprincipals      plugin.TValue[[]any]
-	EnterpriseApplications plugin.TValue[[]any]
-	Oauth2PermissionGrants plugin.TValue[[]any]
-	Roles                  plugin.TValue[*mqlMicrosoftRoles]
-	Settings               plugin.TValue[any]
-	GroupSettings          plugin.TValue[[]any]
-	TenantDomainName       plugin.TValue[string]
-	IdentityAndAccess      plugin.TValue[*mqlMicrosoftIdentityAndAccess]
-	AccessReviews          plugin.TValue[*mqlMicrosoftIdentityAndAccessAccessReviews]
+	Organizations            plugin.TValue[[]any]
+	Users                    plugin.TValue[*mqlMicrosoftUsers]
+	Groups                   plugin.TValue[*mqlMicrosoftGroups]
+	GroupLifecyclePolicies   plugin.TValue[[]any]
+	Domains                  plugin.TValue[[]any]
+	Applications             plugin.TValue[*mqlMicrosoftApplications]
+	Serviceprincipals        plugin.TValue[[]any]
+	EnterpriseApplications   plugin.TValue[[]any]
+	Oauth2PermissionGrants   plugin.TValue[[]any]
+	Roles                    plugin.TValue[*mqlMicrosoftRoles]
+	Settings                 plugin.TValue[any]
+	GroupSettings            plugin.TValue[[]any]
+	TenantDomainName         plugin.TValue[string]
+	IdentityAndAccess        plugin.TValue[*mqlMicrosoftIdentityAndAccess]
+	AccessReviews            plugin.TValue[*mqlMicrosoftIdentityAndAccessAccessReviews]
+	EntraDiagnosticSettings  plugin.TValue[[]any]
+	IntuneDiagnosticSettings plugin.TValue[[]any]
 }
 
 // createMicrosoft creates a new instance of this resource
@@ -13410,6 +13498,38 @@ func (c *mqlMicrosoft) GetAccessReviews() *plugin.TValue[*mqlMicrosoftIdentityAn
 		}
 
 		return c.accessReviews()
+	})
+}
+
+func (c *mqlMicrosoft) GetEntraDiagnosticSettings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EntraDiagnosticSettings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft", c.__id, "entraDiagnosticSettings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.entraDiagnosticSettings()
+	})
+}
+
+func (c *mqlMicrosoft) GetIntuneDiagnosticSettings() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IntuneDiagnosticSettings, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("microsoft", c.__id, "intuneDiagnosticSettings")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.intuneDiagnosticSettings()
 	})
 }
 
@@ -31213,4 +31333,88 @@ func (c *mqlMs365ExchangeonlineRoleAssignmentPolicyEntry) GetDescription() *plug
 
 func (c *mqlMs365ExchangeonlineRoleAssignmentPolicyEntry) GetAssignedRoles() *plugin.TValue[[]any] {
 	return &c.AssignedRoles
+}
+
+// mqlMicrosoftDiagnosticSetting for the microsoft.diagnosticSetting resource
+type mqlMicrosoftDiagnosticSetting struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMicrosoftDiagnosticSettingInternal it will be used here
+	Id                          plugin.TValue[string]
+	Name                        plugin.TValue[string]
+	Type                        plugin.TValue[string]
+	EnabledLogCategories        plugin.TValue[[]any]
+	Logs                        plugin.TValue[[]any]
+	WorkspaceId                 plugin.TValue[string]
+	StorageAccountId            plugin.TValue[string]
+	EventHubName                plugin.TValue[string]
+	EventHubAuthorizationRuleId plugin.TValue[string]
+}
+
+// createMicrosoftDiagnosticSetting creates a new instance of this resource
+func createMicrosoftDiagnosticSetting(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMicrosoftDiagnosticSetting{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("microsoft.diagnosticSetting", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) MqlName() string {
+	return "microsoft.diagnosticSetting"
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetEnabledLogCategories() *plugin.TValue[[]any] {
+	return &c.EnabledLogCategories
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetLogs() *plugin.TValue[[]any] {
+	return &c.Logs
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetWorkspaceId() *plugin.TValue[string] {
+	return &c.WorkspaceId
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetStorageAccountId() *plugin.TValue[string] {
+	return &c.StorageAccountId
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetEventHubName() *plugin.TValue[string] {
+	return &c.EventHubName
+}
+
+func (c *mqlMicrosoftDiagnosticSetting) GetEventHubAuthorizationRuleId() *plugin.TValue[string] {
+	return &c.EventHubAuthorizationRuleId
 }

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -669,6 +669,16 @@ microsoft.devices 11.1.21
 microsoft.devices.filter 11.1.21
 microsoft.devices.list 11.1.21
 microsoft.devices.search 11.1.21
+microsoft.diagnosticSetting 13.12.1
+microsoft.diagnosticSetting.enabledLogCategories 13.12.1
+microsoft.diagnosticSetting.eventHubAuthorizationRuleId 13.12.1
+microsoft.diagnosticSetting.eventHubName 13.12.1
+microsoft.diagnosticSetting.id 13.12.1
+microsoft.diagnosticSetting.logs 13.12.1
+microsoft.diagnosticSetting.name 13.12.1
+microsoft.diagnosticSetting.storageAccountId 13.12.1
+microsoft.diagnosticSetting.type 13.12.1
+microsoft.diagnosticSetting.workspaceId 13.12.1
 microsoft.domain 9.0.0
 microsoft.domain.authenticationType 9.0.0
 microsoft.domain.availabilityStatus 9.0.0
@@ -701,6 +711,7 @@ microsoft.domaindnsrecord.ttl 9.0.0
 microsoft.domaindnsrecord.weight 13.2.2
 microsoft.domains 9.0.0
 microsoft.enterpriseApplications 9.0.0
+microsoft.entraDiagnosticSettings 13.12.1
 microsoft.externalIdentitiesPolicy 11.1.99
 microsoft.externalIdentitiesPolicy.allowExternalIdentitiesToLeave 11.1.99
 microsoft.externalIdentitiesPolicy.description 11.1.99
@@ -818,6 +829,7 @@ microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleDefinition 13.3.
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.roleEligibilityScheduleId 11.1.41
 microsoft.identityAndAccess.roleEligibilityScheduleInstance.startDateTime 11.1.41
 microsoft.identityAndAccess.roleEligibilityScheduleInstances 11.1.40
+microsoft.intuneDiagnosticSettings 13.12.1
 microsoft.keyCredential 11.0.28
 microsoft.keyCredential.description 11.0.28
 microsoft.keyCredential.expired 11.0.28


### PR DESCRIPTION
## Problem

Microsoft Entra ID and Microsoft Intune each have their own **tenant-scoped** Azure Monitor diagnostic settings, and neither was reachable: the azure provider's `monitor.diagnosticSettings` is subscription-scoped, and ms365 modelled no diagnostic-settings resource at all.

## Where the data actually lives

Not in Microsoft Graph. Both are ARM resources with no subscription in the path, registered under their own resource providers. I confirmed the endpoint shapes against a live tenant before writing anything:

```
GET https://management.azure.com/providers/microsoft.aadiam/diagnosticSettings?api-version=2017-04-01-preview
→ 200 {"value": []}

GET https://management.azure.com/providers/Microsoft.Intune/diagnosticSettings?api-version=2017-04-01-preview
→ 403 AuthorizationFailed, action 'Microsoft.Intune/diagnosticSettings/read', scope '/providers/Microsoft.Intune'
```

A 403 naming the exact action is what proves the path is real; a 404 would not have. The api-version is the only one either resource provider publishes, confirmed from `GET /providers/Microsoft.Intune?api-version=2021-04-01`.

Reading them needs a token for the ARM audience. That is not a new auth surface for this provider — it already mints tokens for the Power BI, Teams, SharePoint, Outlook, and Compliance audiences from the same credential, and this follows `powerbi.go`.

## What changed

`microsoft.diagnosticSetting` carries the enabled log categories and the destination: Log Analytics workspace, storage account, or Event Hub. Field names mirror `azure.subscription.monitorService.diagnosticsetting` so a query written against one reads the same against the other.

**Two root fields, not the single `microsoft.diagnosticSettings` the issue sketched.** The two endpoints authorize separately, and the live run below shows why that matters: the same credentials read Entra successfully and get 403 on Intune. One merged list would have let that 403 blank the Entra answer too, which is the opposite of what these controls need.

```coffee
microsoft.entraDiagnosticSettings.any(enabledLogCategories.contains("MicrosoftGraphActivityLogs"))
microsoft.intuneDiagnosticSettings.any(enabledLogCategories.contains("DeviceComplianceOrg"))
```

**A non-200 is an error, never an empty collection.** A tenant with nothing configured answers `200 {"value": []}`, so an empty list is a real finding. Letting a 403 arrive the same way would turn "we were not allowed to look" into "nothing is configured", and every check over the categories would pass vacuously.

`enabledLogCategories` reports only the categories switched **on**. A setting lists every category it knows about with an `enabled` flag, so taking the list at face value would report a stream as exported while it is off. The full per-category payload stays available on `logs`.

## Live verification

Tenant `lunalectricsandbox`, cert-based app registration, provider built from this branch:

```
$ mql run ms365 --certificate-path ... -c 'microsoft.entraDiagnosticSettings { name enabledLogCategories workspaceId }'
microsoft.entraDiagnosticSettings: []

$ mql run ms365 --certificate-path ... -c 'microsoft.intuneDiagnosticSettings { name enabledLogCategories }'
azure resource manager returned 403 Forbidden for https://management.azure.com/providers/Microsoft.Intune/diagnosticSettings?api-version=2017-04-01-preview:
{"error":{"code":"AuthorizationFailed","message":"... does not have authorization to perform action 'Microsoft.Intune/diagnosticSettings/read' over scope '/providers/Microsoft.Intune' ..."}}
```

That proves the ARM token acquisition, both endpoints, the empty case, and the error path — and it validates the two-field split directly, since Entra resolved in the same run in which Intune failed.

**What it does not prove**, stated plainly: the field mapping has not been read from a tenant that actually *has* a diagnostic setting. The sandbox tenant carries no Azure subscription, so there is no Log Analytics workspace, storage account, or Event Hub to point a setting at, and one cannot be created there. The mapping is covered by unit tests against a payload shaped like a real `microsoft.aadiam` response, with every destination tag pinned individually — a mistyped tag decodes to `""`, which reads as "no destination configured" on a setting that has one. If you have a tenant with a real Entra diagnostic setting, that is the run worth doing before merge.

The 403 is also the expected result for most ms365 app registrations: reading Intune diagnostic settings needs a role granting `Microsoft.Intune/diagnosticSettings/read`, which is not implied by Global Reader on Graph.

## Tests

`providers/ms365/resources/diagnostic_settings_test.go` covers decoding a realistic aadiam payload (id, name, type, and each destination tag), `enabledLogCategories` (only enabled, empty-not-nil when nothing is exported, drops an unnamed category), and `armGet` (bearer header sent, empty collection is not an error, **403 is an error and not an empty collection**, malformed body is an error).

The categories named in the schema doc were read from the live tenant's `diagnosticSettingsCategories` endpoint (26 for Entra) rather than from documentation; the doc comment says the set is open, because it is.

Fixes #10152
