### PR TITLE
✨ databricks: report personal access token last use, scope, and who may mint one

### DIFF
--- a/providers/databricks/resources/databricks.lr
+++ b/providers/databricks/resources/databricks.lr
@@ -96,6 +96,14 @@ databricks {
   appIntegrations() []databricks.appIntegration
   // Serverless egress network policies in the account
   networkPolicies() []databricks.networkPolicy
+  // Who may create and use personal access tokens in the workspace
+  //
+  // The workspace access control list of the token authorization object, which
+  // governs personal access tokens as a whole rather than any single token. A
+  // principal holding CAN_USE may create tokens. Read it together with the
+  // tokensEnabled field on workspaceSettings, which says whether tokens are
+  // permitted at all: this list says who may create one once they are.
+  tokenPermissions() []databricks.permission
 }
 
 // Databricks workspace
@@ -414,6 +422,18 @@ databricks.token @defaults("comment createdByUsername expiryTime") {
   creationTime time
   // Time the token expires, null when the token never expires
   expiryTime time
+  // Day the token was last used, null when it has never been used
+  //
+  // The API reports the last use to a day's resolution rather than to a
+  // timestamp, so this answers whether a standing credential is still in use,
+  // not the moment it was last used. A token that has never been used reports
+  // null, which is distinct from a token last used today.
+  lastUsedDay time
+  // API scopes the token is restricted to, empty when the token is unscoped
+  //
+  // An unscoped token carries the full authority of the user that owns it. A
+  // scoped token may only call the APIs covered by the scopes listed here.
+  scopes []string
 }
 
 // Databricks secret scope

--- a/providers/databricks/resources/databricks.lr.go
+++ b/providers/databricks/resources/databricks.lr.go
@@ -470,6 +470,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"databricks.networkPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricks).GetNetworkPolicies()).ToDataRes(types.Array(types.Resource("databricks.networkPolicy")))
 	},
+	"databricks.tokenPermissions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricks).GetTokenPermissions()).ToDataRes(types.Array(types.Resource("databricks.permission")))
+	},
 	"databricks.workspace.workspaceId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksWorkspace).GetWorkspaceId()).ToDataRes(types.Int)
 	},
@@ -751,6 +754,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"databricks.token.expiryTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksToken).GetExpiryTime()).ToDataRes(types.Time)
+	},
+	"databricks.token.lastUsedDay": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricksToken).GetLastUsedDay()).ToDataRes(types.Time)
+	},
+	"databricks.token.scopes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricksToken).GetScopes()).ToDataRes(types.Array(types.String))
 	},
 	"databricks.secretScope.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksSecretScope).GetName()).ToDataRes(types.String)
@@ -2391,6 +2400,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDatabricks).NetworkPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"databricks.tokenPermissions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricks).TokenPermissions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"databricks.workspace.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDatabricksWorkspace).__id, ok = v.Value.(string)
 		return
@@ -2809,6 +2822,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"databricks.token.expiryTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDatabricksToken).ExpiryTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"databricks.token.lastUsedDay": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricksToken).LastUsedDay, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"databricks.token.scopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricksToken).Scopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"databricks.secretScope.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4995,6 +5016,7 @@ type mqlDatabricks struct {
 	FederationPolicies        plugin.TValue[[]any]
 	AppIntegrations           plugin.TValue[[]any]
 	NetworkPolicies           plugin.TValue[[]any]
+	TokenPermissions          plugin.TValue[[]any]
 }
 
 // createDatabricks creates a new instance of this resource
@@ -5655,6 +5677,22 @@ func (c *mqlDatabricks) GetNetworkPolicies() *plugin.TValue[[]any] {
 		}
 
 		return c.networkPolicies()
+	})
+}
+
+func (c *mqlDatabricks) GetTokenPermissions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TokenPermissions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks", c.__id, "tokenPermissions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.tokenPermissions()
 	})
 }
 
@@ -6619,6 +6657,8 @@ type mqlDatabricksToken struct {
 	CreatedByUsername plugin.TValue[string]
 	CreationTime      plugin.TValue[*time.Time]
 	ExpiryTime        plugin.TValue[*time.Time]
+	LastUsedDay       plugin.TValue[*time.Time]
+	Scopes            plugin.TValue[[]any]
 }
 
 // createDatabricksToken creates a new instance of this resource
@@ -6675,6 +6715,14 @@ func (c *mqlDatabricksToken) GetCreationTime() *plugin.TValue[*time.Time] {
 
 func (c *mqlDatabricksToken) GetExpiryTime() *plugin.TValue[*time.Time] {
 	return &c.ExpiryTime
+}
+
+func (c *mqlDatabricksToken) GetLastUsedDay() *plugin.TValue[*time.Time] {
+	return &c.LastUsedDay
+}
+
+func (c *mqlDatabricksToken) GetScopes() *plugin.TValue[[]any] {
+	return &c.Scopes
 }
 
 // mqlDatabricksSecretScope for the databricks.secretScope resource

--- a/providers/databricks/resources/databricks.lr.versions
+++ b/providers/databricks/resources/databricks.lr.versions
@@ -590,7 +590,10 @@ databricks.token.createdByUsername 13.0.0
 databricks.token.creationTime 13.0.0
 databricks.token.expiryTime 13.0.0
 databricks.token.id 13.0.0
+databricks.token.lastUsedDay 13.3.1
 databricks.token.ownerId 13.0.0
+databricks.token.scopes 13.3.1
+databricks.tokenPermissions 13.3.1
 databricks.tokens 13.0.0
 databricks.user 13.0.0
 databricks.user.active 13.0.0

--- a/providers/databricks/resources/permissions.go
+++ b/providers/databricks/resources/permissions.go
@@ -26,6 +26,12 @@ const (
 	permissionObjectServingEndpoint = "serving-endpoints"
 	permissionObjectRepo            = "repos"
 	permissionObjectInstancePool    = "instance-pools"
+	// The authorization object type has no per-instance id: the workspace-wide
+	// switches it guards are addressed by a fixed name in the id position.
+	permissionObjectAuthorization = "authorization"
+	// authorizationObjectTokens is the id of the authorization object that
+	// governs personal access tokens for the whole workspace.
+	authorizationObjectTokens = "tokens"
 )
 
 // principalKinds classifies an access control entry. Exactly one of the three
@@ -155,6 +161,18 @@ func mqlDatabricksPermissions(runtime *plugin.Runtime, objectType string, object
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// tokenPermissions reads the access control list of the workspace-wide token
+// authorization object, which is what decides who may mint a personal access
+// token. It is not the ACL of any one token: personal access tokens carry no
+// per-token ACL.
+//
+// It answers who may create a token, not whether tokens are permitted at all.
+// The workspace's tokensEnabled setting answers that, and a workspace with
+// tokens switched off can still carry an access control list here.
+func (r *mqlDatabricks) tokenPermissions() ([]any, error) {
+	return mqlDatabricksPermissions(r.MqlRuntime, permissionObjectAuthorization, authorizationObjectTokens)
 }
 
 func (r *mqlDatabricksCluster) permissions() ([]any, error) {

--- a/providers/databricks/resources/tokens_test.go
+++ b/providers/databricks/resources/tokens_test.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/service/settings"
+)
+
+// timeOf reads a time field back out of the mapped fields, reporting whether it
+// carries a value at all. A nil value is what MQL renders as null, and telling
+// that apart from a zero time is the point of most of these cases.
+func timeOf(t *testing.T, fields map[string]any, key string) (time.Time, bool) {
+	t.Helper()
+	raw, ok := fields[key]
+	if !ok {
+		t.Fatalf("field %q missing from the mapping", key)
+	}
+	if raw == nil {
+		return time.Time{}, false
+	}
+	got, ok := raw.(*time.Time)
+	if !ok {
+		t.Fatalf("field %q = %T, want *time.Time", key, raw)
+	}
+	if got == nil {
+		return time.Time{}, false
+	}
+	return *got, true
+}
+
+// rawValues drops the llx wrapper so the assertions read against plain Go
+// values rather than against RawData internals.
+func rawValues(t *testing.T, info settings.TokenInfo) map[string]any {
+	t.Helper()
+	out := map[string]any{}
+	for k, v := range tokenFields(info) {
+		if v == nil {
+			out[k] = nil
+			continue
+		}
+		out[k] = v.Value
+	}
+	return out
+}
+
+func TestTokenFields(t *testing.T) {
+	// 2026-08-01T00:00:00Z and 2027-08-01T00:00:00Z in epoch milliseconds.
+	const (
+		createdMs  int64 = 1785110400000
+		expiresMs  int64 = 1816646400000
+		lastUsedMs int64 = 1787788800000
+	)
+
+	t.Run("a fully populated token maps every field", func(t *testing.T) {
+		got := rawValues(t, settings.TokenInfo{
+			TokenId:           "1234abcd",
+			Comment:           "ci runner",
+			OwnerId:           42,
+			CreatedByUsername: "ci@example.com",
+			CreationTime:      createdMs,
+			ExpiryTime:        expiresMs,
+			LastUsedDay:       lastUsedMs,
+			Scopes:            []string{"sql", "dashboards.genie"},
+		})
+
+		if got["__id"] != "databricks.token/1234abcd" {
+			t.Fatalf("__id = %v, want databricks.token/1234abcd", got["__id"])
+		}
+		if got["id"] != "1234abcd" {
+			t.Fatalf("id = %v, want 1234abcd", got["id"])
+		}
+		if got["comment"] != "ci runner" {
+			t.Fatalf("comment = %v, want ci runner", got["comment"])
+		}
+		if got["ownerId"] != int64(42) {
+			t.Fatalf("ownerId = %v, want 42", got["ownerId"])
+		}
+		if got["createdByUsername"] != "ci@example.com" {
+			t.Fatalf("createdByUsername = %v, want ci@example.com", got["createdByUsername"])
+		}
+
+		lastUsed, ok := timeOf(t, got, "lastUsedDay")
+		if !ok {
+			t.Fatal("lastUsedDay is null, want a time")
+		}
+		if want := time.UnixMilli(lastUsedMs); !lastUsed.Equal(want) {
+			t.Fatalf("lastUsedDay = %v, want %v", lastUsed, want)
+		}
+
+		scopes, ok := got["scopes"].([]any)
+		if !ok {
+			t.Fatalf("scopes = %T, want []any", got["scopes"])
+		}
+		if len(scopes) != 2 || scopes[0] != "sql" || scopes[1] != "dashboards.genie" {
+			t.Fatalf("scopes = %v, want [sql dashboards.genie]", scopes)
+		}
+	})
+
+	// A token that has never been used carries no last_used_day at all. Mapping
+	// the missing value to the zero time would report 1 January 1970 as a real
+	// last use, and "used before any date you care about" is exactly the answer
+	// a stale-credential check would accept.
+	t.Run("a token that has never been used reports null", func(t *testing.T) {
+		got := rawValues(t, settings.TokenInfo{TokenId: "unused", CreationTime: createdMs})
+		if _, ok := timeOf(t, got, "lastUsedDay"); ok {
+			t.Fatalf("lastUsedDay = %v, want null", got["lastUsedDay"])
+		}
+	})
+
+	// A token with no expiry is a standing credential. It has to stay null so a
+	// check for an over-long lifetime can tell "never expires" apart from
+	// "expired at the epoch".
+	t.Run("a token with no expiry reports null", func(t *testing.T) {
+		got := rawValues(t, settings.TokenInfo{TokenId: "forever", CreationTime: createdMs})
+		if _, ok := timeOf(t, got, "expiryTime"); ok {
+			t.Fatalf("expiryTime = %v, want null", got["expiryTime"])
+		}
+		created, ok := timeOf(t, got, "creationTime")
+		if !ok {
+			t.Fatal("creationTime is null, want a time")
+		}
+		if want := time.UnixMilli(createdMs); !created.Equal(want) {
+			t.Fatalf("creationTime = %v, want %v", created, want)
+		}
+	})
+
+	// An unscoped token carries the owner's full authority. It must arrive as an
+	// empty list rather than nil, so `scopes.length == 0` is answerable without
+	// tripping over a null.
+	t.Run("an unscoped token reports an empty list", func(t *testing.T) {
+		got := rawValues(t, settings.TokenInfo{TokenId: "unscoped"})
+		scopes, ok := got["scopes"].([]any)
+		if !ok {
+			t.Fatalf("scopes = %T, want []any", got["scopes"])
+		}
+		if len(scopes) != 0 {
+			t.Fatalf("scopes = %v, want empty", scopes)
+		}
+	})
+}

--- a/providers/databricks/resources/workspace.go
+++ b/providers/databricks/resources/workspace.go
@@ -46,6 +46,25 @@ func (r *mqlDatabricks) ipAccessLists() ([]any, error) {
 	return out, nil
 }
 
+// tokenFields maps one token record to its MQL fields. The mapping is kept
+// apart from the API call so the absent cases can be asserted directly: a
+// token that has never been used and a token that never expires both have to
+// arrive as null rather than as the zero time, which would read as a real date
+// in the year 1.
+func tokenFields(t settings.TokenInfo) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":              llx.StringData("databricks.token/" + t.TokenId),
+		"id":                llx.StringData(t.TokenId),
+		"comment":           llx.StringData(t.Comment),
+		"ownerId":           llx.IntData(t.OwnerId),
+		"createdByUsername": llx.StringData(t.CreatedByUsername),
+		"creationTime":      llx.TimeDataPtr(epochMsTime(t.CreationTime)),
+		"expiryTime":        llx.TimeDataPtr(epochMsTime(t.ExpiryTime)),
+		"lastUsedDay":       llx.TimeDataPtr(epochMsTime(t.LastUsedDay)),
+		"scopes":            llx.ArrayData(strSlice(t.Scopes), types.String),
+	}
+}
+
 func (r *mqlDatabricks) tokens() ([]any, error) {
 	ws, err := workspaceClient(r.MqlRuntime)
 	if err != nil {
@@ -59,16 +78,7 @@ func (r *mqlDatabricks) tokens() ([]any, error) {
 
 	out := []any{}
 	for i := range tokens {
-		t := tokens[i]
-		res, err := CreateResource(r.MqlRuntime, "databricks.token", map[string]*llx.RawData{
-			"__id":              llx.StringData("databricks.token/" + t.TokenId),
-			"id":                llx.StringData(t.TokenId),
-			"comment":           llx.StringData(t.Comment),
-			"ownerId":           llx.IntData(t.OwnerId),
-			"createdByUsername": llx.StringData(t.CreatedByUsername),
-			"creationTime":      llx.TimeDataPtr(epochMsTime(t.CreationTime)),
-			"expiryTime":        llx.TimeDataPtr(epochMsTime(t.ExpiryTime)),
-		})
+		res, err := CreateResource(r.MqlRuntime, "databricks.token", tokenFields(tokens[i]))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What the issue asked for, and what was already here

The issue asked for cluster Spark configuration and a personal access token inventory with expiry and last use, and proposed that reaching them needs a Databricks provider or a workspace-scoped extension of the azure one.

The provider already exists and already talks to the workspace API directly — the same surface an Azure Databricks workspace exposes at `https://adb-<id>.<n>.azuredatabricks.net`. Two of the three asks were already covered:

- **Cluster Spark configuration** — `databricks.cluster.sparkConf` is a `map[string]string` of the cluster's Spark settings, so `spark.authenticate`, `spark.network.crypto.enabled` and `spark.io.encryption.enabled` are readable today. `databricks.clusterSpec.sparkConf` carries the same for job clusters.
- **Token inventory and expiry** — `databricks.tokens` already lists the **whole workspace** through `TokenManagement.ListAll` rather than only the caller's own tokens, with `creationTime` and `expiryTime`. `workspaceSettings.maxTokenLifetimeDays` and `workspaceSettings.tokensEnabled` cover the lifetime cap.

Two things were genuinely missing, and this closes both.

## What changed

**`token.lastUsedDay`** — the SDK's `TokenInfo` carries `last_used_day` and the mapper dropped it. Without it a token inventory answers when a standing credential was issued but not whether anyone is still using it, which is the question a stale-credential review actually asks.

It is reported to a day's resolution rather than a timestamp, and a token that has never been used carries no value at all, so it maps to **null** rather than to the zero time. Mapping the absent value to zero would report 1 January 1970 as a real last use — a date before anything a check would compare against, so a "used in the last 90 days" assertion would fail loudly and a "never used" assertion would quietly never match.

**`databricks.tokenPermissions`** — who may create a token was not modelled at all. That lives on the workspace-wide *token authorization object* rather than on any single token: personal access tokens have no per-token ACL. It maps onto the existing `databricks.permission` machinery because the permissions API keys objects by path segment, so `authorization` + `tokens` slots straight into `GetByRequestObjectTypeAndRequestObjectId` with no new resource type.

It answers who may create a token, not whether tokens are permitted at all — `workspaceSettings.tokensEnabled` answers that, and the doc comment says to read them together.

**`token.scopes`** — a scoped token may only call the APIs its scopes cover; an unscoped one carries the full authority of the user that owns it. Empty rather than null when unscoped, so `scopes.length == 0` is answerable without tripping over a null.

## Verification

⚠️ **Not yet run against a live workspace.** The stored databricks CLI profile is account-plane and its refresh token has expired, so `TokenManagement.ListAll`'s `last_used_day` and the `authorization/tokens` ACL have not been read from a real workspace. Treat that as a blocker on merging, not a footnote — I will add the observed values to this PR once a workspace is reachable, and the two queries are:

```coffee
databricks.tokens { id comment createdByUsername creationTime expiryTime lastUsedDay scopes }
databricks.tokenPermissions { principal principalType permissionLevel inherited }
```

The workspace plane of this provider was live-verified previously, including `tokens` itself, so the surrounding call path is proven; what is unverified is specifically the two new sources.

## Tests

`providers/databricks/resources/tokens_test.go` covers the field mapping, extracted from the lister so the absent cases can be asserted directly: a fully populated token maps every field, a token that has never been used reports **null**, a token with no expiry reports **null** while its creation time still resolves, and an unscoped token reports an empty list rather than nil.

`go test ./...` is green in `providers/databricks/`, `go.mod` is clean, and `.lr.versions` entries are at 13.3.1 against the provider's shipped 13.3.0.

Fixes #10153
