### PR TITLE
🧹 deprecate resources for cloud services the vendor has shut down

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -21504,14 +21504,24 @@ private aws.codedeploy.deployment @defaults("deploymentId status applicationName
 // user's root folder, including creator references, resource state,
 // labels, and (for documents) latest-version metadata. Folder and document
 // discovery is bounded to one level below each user's root folder; deeper
-// subtrees are not traversed.
-aws.workdocs {
-  // List of WorkDocs users across all enabled regions
-  users() []aws.workdocs.user
-  // List of WorkDocs folders reachable from each user's root folder (one level deep)
-  folders() []aws.workdocs.folder
-  // List of WorkDocs documents reachable from each user's root folder (one level deep)
-  documents() []aws.workdocs.document
+// subtrees are not traversed. AWS shut WorkDocs down on 2025-04-25 and
+// deleted all user data the following day, so every list below is empty on
+// any account and an assertion made over one passes without checking
+// anything. There is no replacement service. Will be removed in the next
+// major release.
+aws.workdocs @maturity("deprecated") {
+  // WorkDocs users across all enabled regions
+  //
+  // AWS shut WorkDocs down on 2025-04-25, so this list is always empty.
+  users() @maturity("deprecated") []aws.workdocs.user
+  // WorkDocs folders reachable from each user's root folder (one level deep)
+  //
+  // AWS shut WorkDocs down on 2025-04-25, so this list is always empty.
+  folders() @maturity("deprecated") []aws.workdocs.folder
+  // WorkDocs documents reachable from each user's root folder (one level deep)
+  //
+  // AWS shut WorkDocs down on 2025-04-25, so this list is always empty.
+  documents() @maturity("deprecated") []aws.workdocs.document
 }
 
 // Amazon WorkDocs user
@@ -21522,7 +21532,9 @@ aws.workdocs {
 // storage rule (allocated bytes, type), and current utilization. The
 // `rootFolder` and `recycleBinFolder` fields resolve to the user's folders
 // so audits can traverse into the WorkDocs hierarchy without copying ids.
-private aws.workdocs.user @defaults("username emailAddress status") {
+// AWS shut WorkDocs down on 2025-04-25, so no account returns one. Will be
+// removed in the next major release.
+private aws.workdocs.user @defaults("username emailAddress status") @maturity("deprecated") {
   // Internal user ID
   id string
   // Username
@@ -21571,8 +21583,9 @@ private aws.workdocs.user @defaults("username emailAddress status") {
 // resource state (ACTIVE, RESTORING, RECYCLING, RECYCLED), latest-version
 // size, signature, and labels. Folders are discovered by walking one level
 // below each WorkDocs user's root folder; deeper subtrees are not yet
-// traversed.
-private aws.workdocs.folder @defaults("name id resourceState") {
+// traversed. AWS shut WorkDocs down on 2025-04-25, so no account returns
+// one. Will be removed in the next major release.
+private aws.workdocs.folder @defaults("name id resourceState") @maturity("deprecated") {
   // ID of the folder
   id string
   // Name of the folder
@@ -21610,8 +21623,10 @@ private aws.workdocs.folder @defaults("name id resourceState") {
 // the metadata of the document's latest version (content type, size,
 // signature, status, source, and timestamps). Documents are discovered by
 // walking one level below each WorkDocs user's root folder; documents
-// nested deeper than one level are not yet traversed.
-private aws.workdocs.document @defaults("id resourceState") {
+// nested deeper than one level are not yet traversed. AWS shut WorkDocs
+// down on 2025-04-25, so no account returns one. Will be removed in the
+// next major release.
+private aws.workdocs.document @defaults("id resourceState") @maturity("deprecated") {
   // ID of the document
   id string
   // Parent folder

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -10934,8 +10934,12 @@ private azure.subscription.authorizationService {
   managedIdentities() []azure.subscription.managedIdentity
   // Deny assignments: read-only deny rules that block actions even for owners (e.g., managed-app deny on resources)
   denyAssignments() []azure.subscription.authorizationService.denyAssignment
-  // Classic (ASM) co-administrators: legacy admin grants that should normally be zero
-  classicAdministrators() []azure.subscription.authorizationService.classicAdministrator
+  // Classic (ASM) co-administrators
+  //
+  // Deprecated in favor of roleAssignments. Azure retired classic
+  // administrators on 2024-08-31 and converted the remaining grants to RBAC
+  // Owner assignments, so this list is always empty.
+  classicAdministrators() @maturity("deprecated") []azure.subscription.authorizationService.classicAdministrator
   // PIM role eligibility schedules: who is eligible to activate which privileged role
   roleEligibilitySchedules() []azure.subscription.authorizationService.roleEligibilitySchedule
   // PIM role assignment schedules: currently active (including time-bound) privileged role assignments
@@ -11145,10 +11149,12 @@ private azure.subscription.authorizationService.denyAssignment @defaults("name d
 //
 // Legacy co-administrator or service administrator grant from the classic
 // (Azure Service Management) deployment model. These grants predate role-based
-// access control and carry broad subscription-wide access, so on a hardened
-// subscription the count should normally be zero. Select by the administrator's
-// resource ID.
-private azure.subscription.authorizationService.classicAdministrator @defaults("emailAddress role") {
+// access control and carry broad subscription-wide access. Deprecated in favor
+// of azure.subscription.authorizationService.roleAssignment: Azure retired
+// classic administrators on 2024-08-31 and converted the remaining grants to
+// RBAC Owner assignments, so no subscription returns one. Select by the
+// administrator's resource ID. Will be removed in the next major release.
+private azure.subscription.authorizationService.classicAdministrator @defaults("emailAddress role") @maturity("deprecated") {
   // Classic administrator ID
   id string
   // Resource name (typically the email)

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1100,7 +1100,10 @@ gcp.project @defaults("name number") {
   // GCP Vertex AI Workbench resources
   workbench() gcp.project.workbenchService
   // GCP legacy Notebooks resources
-  notebooks() gcp.project.notebooksService
+  //
+  // Deprecated in favor of workbench. Google deleted the last managed and
+  // user-managed notebook instances on 2026-03-30.
+  notebooks() @maturity("deprecated") gcp.project.notebooksService
   // GCP Cloud Composer resources
   composer() gcp.project.composerService
   // GCP Cloud Healthcare resources
@@ -11755,13 +11758,20 @@ private gcp.project.workbenchService.instance @defaults("name state healthState"
 // Legacy Notebooks service for the project, hosting the user-managed
 // notebook `instances`. Each instance exposes its machine configuration,
 // network settings, and public-IP exposure, so you can audit notebook VMs
-// left over from before the move to Vertex AI Workbench. New deployments
-// should use `workbench` instead.
-private gcp.project.notebooksService {
+// left over from before the move to Vertex AI Workbench. Deprecated in favor
+// of `workbench`: Google deleted the last managed and user-managed notebook
+// instances on 2026-03-30, so this returns nothing on any project and an
+// assertion made over it passes without checking anything. Will be removed in
+// the next major release.
+private gcp.project.notebooksService @maturity("deprecated") {
   // Project ID
   projectId string
-  // List of legacy User-Managed Notebooks instances
-  instances() []gcp.project.notebooksService.instance
+  // Legacy User-Managed Notebooks instances
+  //
+  // Deprecated in favor of the instances field on gcp.project.workbenchService.
+  // Google deleted the last notebook instances on 2026-03-30, so this list is
+  // always empty.
+  instances() @maturity("deprecated") []gcp.project.notebooksService.instance
 }
 
 // Google Cloud (GCP) legacy Notebooks instance
@@ -11770,8 +11780,11 @@ private gcp.project.notebooksService {
 // JupyterLab. Audit its network exposure through `noPublicIp` (whether an
 // external IP is assigned) and `noProxyAccess` (whether the notebook proxy is
 // registered), review the VPC network and subnet it runs in, and check the
-// service account it runs as and the creator who provisioned it.
-private gcp.project.notebooksService.instance @defaults("name state noPublicIp") {
+// service account it runs as and the creator who provisioned it. Deprecated
+// in favor of the instance resource on gcp.project.workbenchService: Google
+// deleted the last notebook instances on 2026-03-30, so no project returns
+// one. Will be removed in the next major release.
+private gcp.project.notebooksService.instance @defaults("name state noPublicIp") @maturity("deprecated") {
   // Project ID
   projectId string
   // Full resource name (projects/{project}/locations/{location}/instances/{instance})


### PR DESCRIPTION
Three more services the providers model are past their turndown, so these resources can never return data on a current account:

| Resource | Service | Turned down |
|---|---|---|
| `aws.workdocs` (+ `.user`, `.folder`, `.document`) | Amazon WorkDocs | **2025-04-25** (user data deleted 2025-04-26) |
| `gcp.project.notebooksService` (+ `.instance`) | Vertex AI Workbench legacy Notebooks (`notebooks/v1`) | **2026-03-30** |
| `azure.subscription.authorizationService.classicAdministrator` | Azure classic (ASM) administrators | **2024-08-31** |

They return an empty list rather than an error, and an empty list makes `.all()` and `.none()` vacuously true. A policy written against them reports compliant forever instead of inconclusive.

## What this does

Marks each resource, its sub-resources and the accessors that reach them with `@maturity("deprecated")`, carrying the turndown date as the reason and pointing at the replacement where one exists:

- **Notebooks** → `workbench` / `gcp.project.workbenchService`, which already ships in the same file and calls `notebooks/v2`.
- **Classic administrators** → `roleAssignments`. Azure converted the remaining grants to RBAC Owner assignments in December 2025 and removed the portal tab in May 2026.
- **WorkDocs** has no replacement. It is on AWS's own [Services in Full Shutdown](https://docs.aws.amazon.com/general/latest/gr/full_shutdown_services.html) list.

Removal is deferred to the next major release.

## Notes

- `classicAdministrator` already degrades correctly at runtime — `azureClassicAdministratorsRetired` maps ARM's 404 `InvalidResourceType` to an empty list, pinned by `iam_deadapi_test.go`. Only the schema marker was missing.
- WorkDocs is the largest of the three at 4 resources / 48 fields; removing it later also drops the `service/workdocs` SDK dependency.
- A pure `@maturity` change regenerates byte-identical `.lr.go` and `.lr.versions`, so the three schema files are the whole diff. `./mqlr generate` was run for all three providers and produced no other changes.

## Scope

This came out of a sweep of all 2376 resource declarations across aws, azure, gcp, oci, hetzner and digitalocean against vendor end-of-life announcements, cross-checking AWS's full-shutdown table and Oracle's [Service Change Announcements](https://docs.oracle.com/en-us/iaas/Content/servicechanges.htm). OCI and DigitalOcean were clean; `hetzner.datacenter` is already deprecated. Deliberately **not** included, since the services still hold data: `gcp.project.sourceRepositoriesService` (end of sale, no shutdown date announced), `gcp.project.memcacheService` (shutdown 2029-01-31), Cloud Functions 1st gen.

`azure.subscription.{mySql,postgreSql}Service.database` is shared with the live flexible servers and is left alone, same as in #10255.

Follows #10255 and #10256.
