### PR TITLE
🐛 cloudflare: migrate to cloudflare-go v7.9.0

### DIFF
--- a/providers/cloudflare/go.mod
+++ b/providers/cloudflare/go.mod
@@ -5,7 +5,7 @@ replace go.mondoo.com/mql => ../..
 go 1.26.6
 
 require (
-	github.com/cloudflare/cloudflare-go/v7 v7.8.0
+	github.com/cloudflare/cloudflare-go/v7 v7.9.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.0
 	go.mondoo.com/mql v0.0.0-00010101000000-000000000000

--- a/providers/cloudflare/go.sum
+++ b/providers/cloudflare/go.sum
@@ -97,8 +97,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.5 h1:O64F26HEqNhznd/hrC5KZXVKYuKM2rx4deZDTc4ihQA=
 github.com/cloudflare/circl v1.6.5/go.mod h1:h5LNyxAc5nTue9DS5jT+48en2PSDYt3zdGnz5OstK6c=
-github.com/cloudflare/cloudflare-go/v7 v7.8.0 h1:nCv6FOjWlD0Ran+B5dJDxIoc29Kl4Tn5E+4cW254hok=
-github.com/cloudflare/cloudflare-go/v7 v7.8.0/go.mod h1:9zcoIAtu6cmcoPszCNISvqYMXs8wObtVGXE1qGFMrNU=
+github.com/cloudflare/cloudflare-go/v7 v7.9.0 h1:Byn3v5kflN6xQ5trrBXP4tRs2T5FMkjDXIEyocLc0vk=
+github.com/cloudflare/cloudflare-go/v7 v7.9.0/go.mod h1:9zcoIAtu6cmcoPszCNISvqYMXs8wObtVGXE1qGFMrNU=
 github.com/cockroachdb/errors v1.14.0 h1:EfdVEJpN3z8rPMo43Yit59LxoiIa470fSXpZXuEs+ZI=
 github.com/cockroachdb/errors v1.14.0/go.mod h1:xRa70jZ9sNBQmISt5KmJmAD++E4dQHm89oCRiZGEdq0=
 github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 h1:ASDL+UJcILMqgNeV5jiqR4j+sTuvQNHdf2chuKj1M5k=

--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -1106,7 +1106,11 @@ private cloudflare.tunnel.connection @defaults("id coloName") {
 	// Origin IP address
 	originIp string
 	// Whether the connection is pending reconnect
-	isPendingReconnect bool
+	//
+	// Always null. Cloudflare removed this value from the tunnel connections
+	// API, so it can no longer be read. Retained for backwards compatibility
+	// and will be removed in the next major release.
+	isPendingReconnect @maturity("deprecated") bool
 }
 
 // Cloudflare tunnel route

--- a/providers/cloudflare/resources/testdata/tunnel_connections.json
+++ b/providers/cloudflare/resources/testdata/tunnel_connections.json
@@ -12,7 +12,6 @@
         {
           "id": "conn-1234",
           "colo_name": "DFW",
-          "is_pending_reconnect": false,
           "client_id": "dc6472cc-f1ae-44a0-b795-6b8a0ce29f90",
           "client_version": "2024.1.0",
           "opened_at": "2024-01-15T10:05:00Z",

--- a/providers/cloudflare/resources/tunnels.go
+++ b/providers/cloudflare/resources/tunnels.go
@@ -95,14 +95,18 @@ func tunnelConnections(runtime *plugin.Runtime, conn *connection.CloudflareConne
 			tc := client.Conns[j]
 
 			connRes, err := NewResource(runtime, "cloudflare.tunnel.connection", map[string]*llx.RawData{
-				"__id":               llx.StringData(fmt.Sprintf("tunnelConn@%s@%s", tunnelID, tc.ID)),
-				"id":                 llx.StringData(tc.ID),
-				"coloName":           llx.StringData(tc.ColoName),
-				"clientId":           llx.StringData(tc.ClientID),
-				"clientVersion":      llx.StringData(tc.ClientVersion),
-				"openedAt":           timeOrNil(tc.OpenedAt),
-				"originIp":           llx.StringData(tc.OriginIP),
-				"isPendingReconnect": llx.BoolData(tc.IsPendingReconnect),
+				"__id":          llx.StringData(fmt.Sprintf("tunnelConn@%s@%s", tunnelID, tc.ID)),
+				"id":            llx.StringData(tc.ID),
+				"coloName":      llx.StringData(tc.ColoName),
+				"clientId":      llx.StringData(tc.ClientID),
+				"clientVersion": llx.StringData(tc.ClientVersion),
+				"openedAt":      timeOrNil(tc.OpenedAt),
+				"originIp":      llx.StringData(tc.OriginIP),
+				// Cloudflare dropped is_pending_reconnect from the tunnel
+				// connections API, so there is nothing to read. Report null
+				// rather than false, which would claim the connection is
+				// actively serving traffic.
+				"isPendingReconnect": llx.NilData,
 			})
 			if err != nil {
 				return nil, err

--- a/providers/cloudflare/resources/tunnels_test.go
+++ b/providers/cloudflare/resources/tunnels_test.go
@@ -52,6 +52,10 @@ func TestTunnels(t *testing.T) {
 	assert.Equal(t, "conn-1234", conn.Id.Data)
 	assert.Equal(t, "DFW", conn.ColoName.Data)
 	assert.Equal(t, "198.51.100.1", conn.OriginIp.Data)
+	// Cloudflare removed is_pending_reconnect from the API. The field must
+	// read null, never false, which would assert the connection is actively
+	// serving traffic.
+	assert.True(t, conn.IsPendingReconnect.IsNull(), "isPendingReconnect is null, not false")
 	assert.False(t, conn.IsPendingReconnect.Data)
 	assert.False(t, conn.OpenedAt.Data.IsZero())
 

--- a/providers/cloudflare/resources/tunnels_test.go
+++ b/providers/cloudflare/resources/tunnels_test.go
@@ -55,8 +55,8 @@ func TestTunnels(t *testing.T) {
 	// Cloudflare removed is_pending_reconnect from the API. The field must
 	// read null, never false, which would assert the connection is actively
 	// serving traffic.
-	assert.True(t, conn.IsPendingReconnect.IsNull(), "isPendingReconnect is null, not false")
-	assert.False(t, conn.IsPendingReconnect.Data)
+	assert.True(t, conn.IsPendingReconnect.IsNull(), "isPendingReconnect must be null")
+	assert.True(t, conn.IsPendingReconnect.IsSet(), "isPendingReconnect must be resolved, not left unset")
 	assert.False(t, conn.OpenedAt.Data.IsZero())
 
 	// Second tunnel has no connections


### PR DESCRIPTION
Unblocks the cloudflare build in #10261, which bumps `cloudflare-go/v7` from v7.8.0 to v7.9.0.

## The break

```
resources/tunnels.go:105:43: tc.IsPendingReconnect undefined
  (type zero_trust.ClientConn has no field or method IsPendingReconnect)
```

Cloudflare removed `is_pending_reconnect` from the tunnel connections API in v7.9.0. It is gone from every struct that carried it (`shared.Connection`, `zero_trust.Connection`, `zero_trust.ClientConn`, and the warp-connector responses); there are zero occurrences left in the SDK. It is **not** mentioned in the v7.9.0 release notes or the migration guide, so the compiler was the only thing that surfaced it.

## Why null and not `false`

`cloudflare.tunnel.connection.isPendingReconnect` shipped in 13.1.0 and the provider is at 13.8.0, so it is released surface and deleting it would break existing policies. It is now marked `@maturity("deprecated")` and reports **null**.

Defaulting to `false` would have been worse than deleting it. Per the API's own definition, `false` means *"the connection is actively serving traffic"* — so a zero value would assert a connection health state we no longer read, and any policy asserting on the field would keep passing on data that was never fetched. Null makes the loss visible.

The `.lr.versions` entry stays at 13.1.0; deprecation does not bump a version.

## Audit of the rest of the v7.9.0 delta

Every documented breaking change was checked against this provider's call sites. **None are used** (0 hits each):

| Area | Change | Used here |
|---|---|---|
| billing | `Usage.Paygo`/`PaygoInfo` endpoints moved to `/billable-usage` | no |
| hostnames | `Settings.TLS.Get` now needs a hostname; `SettingTLSGetResponse` removed | no |
| intel | `AttackSurfaceReport.Issues.Dismiss` removed | no |
| rulesets | mutating methods now return `*EnvelopeResult` types | no |
| zero_trust | `ResourceLibrary` `id` param `string` to `int64` | no |
| zero_trust | CASB list methods now return `pagination.SinglePage[T]` | no |
| zones | `CT.Alerting` Get/Edit now return `CTAlertingSubscription` | no |

Checks for the breaks a compiler cannot catch:

- **JSON tag drift** (a Go field name that stays put while its tag changes, which decodes to a zero value silently): scanned every struct in both versions, **0 changes**.
- **Struct field removals/retypes** beyond the one above: the remaining removals (`OrganizationID`, `Flags`, `DeletedAt`, `Source`, `MetricID`, `IntelID`) are all on types this provider never reads.
- **Enum comment drift** against v7.9.0 constants: 2 candidates, both false positives on inspection. The `auditLog` actor-type prose already hedges with "and others", and the `all` value the tool wanted added to `clientCertificate.status` comes from `ClientCertificateListParamsStatus`, a *filter* enum, not a status the resource can carry. No changes made.

## What this does not cover

Verified against the compiler, the unit suite, and the SDK source. **Not** verified against a live Cloudflare account: I have no credentials for one, so the claim that the API stopped returning `is_pending_reconnect` rests on the SDK's own schema, not on an observed response.

## Follow-ups this unlocks (not in this PR)

- `zero_trust.Organization.WARPAuthNonBrowser401` is new and maps onto the already-modelled `cloudflare.one.organization`. It records whether failed WARP auth returns 401 instead of redirecting to a login page.
- `logs.LogExplorerDataset` gained `DeletionProtection` and `Filter`. Log Explorer datasets are not modelled at all today, so this would be a new resource rather than a field.

## Test plan

- [x] `go build ./...` in `providers/cloudflare` (clean)
- [x] `go vet ./...` (clean)
- [x] `go test ./...` (all packages pass)
- [x] `gofmt -l .` (clean)
- [x] `mqlr generate` produces no `.lr.go` or `.lr.versions` diff
- [x] `make providers/build/cloudflare` succeeds
- [x] `TestTunnels` asserts the field is null; confirmed it **fails** if `llx.NilData` is reverted to `llx.BoolData(false)`, so the guard has teeth
- [x] the connections fixture no longer carries `is_pending_reconnect`, matching the current API response
