### PR TITLE
✨ claude: report how a platform uses the API on behalf of a user profile

### DIFF
--- a/providers/claude/go.mod
+++ b/providers/claude/go.mod
@@ -5,7 +5,7 @@ replace go.mondoo.com/mql => ../..
 go 1.26.6
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.63.1
+	github.com/anthropics/anthropic-sdk-go v1.66.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.0
 	go.mondoo.com/mql v0.0.0-00010101000000-000000000000

--- a/providers/claude/go.sum
+++ b/providers/claude/go.sum
@@ -35,8 +35,8 @@ github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9
 github.com/anchore/go-struct-converter v0.1.0/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/anthropics/anthropic-sdk-go v1.63.1 h1:M9dIoZzUWB453ulVpBkQp3FX0769udzrTscDrsJk1w4=
-github.com/anthropics/anthropic-sdk-go v1.63.1/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
+github.com/anthropics/anthropic-sdk-go v1.66.0 h1:/CKwgscn0Pe1q4U8aFInSOt/v06JeMc9Aq4vIlctCFw=
+github.com/anthropics/anthropic-sdk-go v1.66.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go-v2 v1.43.6 h1:RrmFcqCBxkJuf7g1axVo5krB4jM/AO8r5e5oujrgdoQ=

--- a/providers/claude/resources/access_type_test.go
+++ b/providers/claude/resources/access_type_test.go
@@ -1,0 +1,48 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// access_type is optional on the user profile payload. An absent value has to
+// report null: an empty string would read as a third access type that is
+// neither application nor passthrough, and a query filtering on either would
+// silently exclude the profile without saying why.
+func TestClaudeAccessType(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		in       anthropic.BetaUserProfileAccessType
+		wantNil  bool
+		wantData string
+	}{
+		{name: "absent", in: "", wantNil: true},
+		{
+			name:     "application",
+			in:       anthropic.BetaUserProfileAccessTypeApplication,
+			wantData: "application",
+		},
+		{
+			name:     "passthrough",
+			in:       anthropic.BetaUserProfileAccessTypePassthrough,
+			wantData: "passthrough",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := claudeAccessType(tc.in)
+			require.NotNil(t, got)
+
+			if tc.wantNil {
+				assert.Nil(t, got.Value, "an absent access type must report null, not an empty string")
+				return
+			}
+			assert.Equal(t, tc.wantData, got.Value)
+		})
+	}
+}

--- a/providers/claude/resources/claude.lr
+++ b/providers/claude/resources/claude.lr
@@ -497,6 +497,14 @@ claude.userProfile @defaults("id name relationship") {
   //
   // One of external, resold, or internal.
   relationship string
+  // How the platform uses the API on behalf of this entity
+  //
+  // `application` means the platform sells a product that calls the API
+  // behind the scenes and the profile is an individual end user of that
+  // product. `passthrough` means the platform resells raw inference and the
+  // profile identifies the company it is resold to. Null when the profile
+  // does not report an access type.
+  accessType string
   // Profile creation timestamp
   createdAt time
   // Last update timestamp

--- a/providers/claude/resources/claude.lr.go
+++ b/providers/claude/resources/claude.lr.go
@@ -631,6 +631,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"claude.userProfile.relationship": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeUserProfile).GetRelationship()).ToDataRes(types.String)
 	},
+	"claude.userProfile.accessType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlClaudeUserProfile).GetAccessType()).ToDataRes(types.String)
+	},
 	"claude.userProfile.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeUserProfile).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -1459,6 +1462,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"claude.userProfile.relationship": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlClaudeUserProfile).Relationship, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"claude.userProfile.accessType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlClaudeUserProfile).AccessType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"claude.userProfile.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3246,6 +3253,7 @@ type mqlClaudeUserProfile struct {
 	Name         plugin.TValue[string]
 	ExternalId   plugin.TValue[string]
 	Relationship plugin.TValue[string]
+	AccessType   plugin.TValue[string]
 	CreatedAt    plugin.TValue[*time.Time]
 	UpdatedAt    plugin.TValue[*time.Time]
 	Type         plugin.TValue[string]
@@ -3297,6 +3305,10 @@ func (c *mqlClaudeUserProfile) GetExternalId() *plugin.TValue[string] {
 
 func (c *mqlClaudeUserProfile) GetRelationship() *plugin.TValue[string] {
 	return &c.Relationship
+}
+
+func (c *mqlClaudeUserProfile) GetAccessType() *plugin.TValue[string] {
+	return &c.AccessType
 }
 
 func (c *mqlClaudeUserProfile) GetCreatedAt() *plugin.TValue[*time.Time] {

--- a/providers/claude/resources/claude.lr.versions
+++ b/providers/claude/resources/claude.lr.versions
@@ -208,6 +208,7 @@ claude.skill.type 13.0.0
 claude.skill.updatedAt 13.0.0
 claude.skills 13.0.0
 claude.userProfile 13.0.0
+claude.userProfile.accessType 13.1.3
 claude.userProfile.createdAt 13.0.0
 claude.userProfile.externalId 13.0.0
 claude.userProfile.id 13.0.0

--- a/providers/claude/resources/claude_beta.go
+++ b/providers/claude/resources/claude_beta.go
@@ -638,6 +638,7 @@ func (r *mqlClaude) userProfiles() ([]interface{}, error) {
 			"name":         llx.StringData(p.Name),
 			"externalId":   llx.StringData(p.ExternalID),
 			"relationship": llx.StringData(string(p.Relationship)),
+			"accessType":   claudeAccessType(p.AccessType),
 			"createdAt":    llx.TimeData(p.CreatedAt),
 			"updatedAt":    llx.TimeData(p.UpdatedAt),
 			"type":         llx.StringData(string(p.Type)),
@@ -652,4 +653,15 @@ func (r *mqlClaude) userProfiles() ([]interface{}, error) {
 	}
 
 	return res, nil
+}
+
+// claudeAccessType maps a profile's access type into MQL data, reporting null
+// when the API omits it. The field is optional on the profile payload, and an
+// empty string would read as a real access type that is neither `application`
+// nor `passthrough`.
+func claudeAccessType(t anthropic.BetaUserProfileAccessType) *llx.RawData {
+	if t == "" {
+		return llx.NilData
+	}
+	return llx.StringData(string(t))
 }


### PR DESCRIPTION
## What this adds

Item #3 from the SDK sweep on #10261. `anthropic-sdk-go` v1.66.0 added `access_type` to the user profile payload; this bumps the SDK and exposes it.

`claude.userProfile.accessType` reports how the platform uses the API on behalf of the entity a profile represents:

- **`application`** — the platform sells a product that calls the API behind the scenes, and the profile is an individual end user of that product.
- **`passthrough`** — the platform resells raw inference, and the profile identifies the company it is resold to.

```
claude.userProfiles.where(accessType == "passthrough") { name relationship }
```

It rides on the `Beta.UserProfiles.List` call the resource already makes, so it costs nothing extra.

**SDK bump: v1.63.1 → v1.66.0.** This overlaps with #10261, which bumps the same module; whichever lands second needs a trivial `go.mod` rebase.

## Breaking changes in the new SDK that do *not* reach a shipped field

v1.66.0 carries two source-breaking changes. Neither touches this provider, and `go build ./...` is clean:

- `BetaContentBlockParamUnion.OfMidConvSystem` was **removed**. The provider does not construct content blocks.
- `BetaManagedAgentsAgentToolset20260401Params.Configs` was **retyped** from `[]BetaManagedAgentsAgentToolConfigParams` to a union slice. The provider does not call the managed-agents params API.

## Design note

`accessType` is optional on the payload, so it maps through a small helper that reports **null** for an absent value rather than the empty string. An empty string would read as a third access type that is neither `application` nor `passthrough`, and a query filtering on either would silently drop the profile without saying why. A three-case table test pins this, including the absent case.

## Verification

**Unit tests — 3 subtests, passing.** `go build ./... && go test ./...` green in `providers/claude/`, `gofmt` and `typos` clean, `.lr.versions` entry at 13.1.3.

**Not verified against the live Claude Admin API.** No `ANTHROPIC_ADMIN_API_KEY` was available in this environment, so `accessType` has not been read from a real profile. Unverified specifically:

- whether real profiles populate `access_type` at all, or whether it is absent in practice and the field is always null
- whether it correlates with `relationship` the way the SDK docs imply (`passthrough` ↔ `resold`), which would make one of the two redundant

Query to run once a key is available:

```
mql shell claude --admin-token <key>
> claude.userProfiles { id name relationship accessType }
```

## Follow-up, not in this PR

v1.66.0 also **promoted `Files` and `Skills` from beta to GA** on the client. `claude_beta.go` still reaches them through `client.Beta.Files` and `client.Beta.Skills`, which require a beta header and can change shape without notice. Migrating `claude.file` and `claude.skill` to the GA accessors is a separate, mechanical change worth doing while the bump is fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
