### PR TITLE
🛑 mql run exits 0 when no asset could be connected

### DIFF
--- a/apps/mql/cmd/plugin.go
+++ b/apps/mql/cmd/plugin.go
@@ -144,6 +144,9 @@ func (c *mqlPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Runtim
 	// Recursively connect all discovered assets depth-first
 	connectAll(explorer, explorer.Discovered())
 	allAssets := explorer.Connected()
+	if err := noUsableAssetsError(len(allAssets), explorer.Errors()); err != nil {
+		return err
+	}
 
 	if conf.Format == "json" {
 		_ = out.WriteString("[")
@@ -259,6 +262,29 @@ func (c *mqlPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Runtim
 	}
 
 	return nil
+}
+
+// noUsableAssetsError reports the error to surface when not a single asset
+// could be queried. Both asset runtime creation and asset connection log their
+// failure and carry on, so that one unreachable asset does not abort a scan of
+// many. The cost is that a run where *every* asset failed still reaches the
+// query loop, finds nothing to iterate, and returns success. Anything
+// scripting mql then cannot distinguish "all assets passed" from "no asset was
+// ever scanned", so collapse that case into an error.
+func noUsableAssetsError(connected int, assetErrors []*discovery.AssetWithError) error {
+	if connected > 0 || len(assetErrors) == 0 {
+		return nil
+	}
+
+	first := assetErrors[0]
+	name := first.Asset.GetName()
+	if name == "" {
+		name = "<unnamed asset>"
+	}
+	if len(assetErrors) == 1 {
+		return errors.Wrapf(first.Err, "could not connect to asset %s", name)
+	}
+	return errors.Wrapf(first.Err, "could not connect to any of the %d assets, first failure on %s", len(assetErrors), name)
 }
 
 // connectAll recursively connects all discovered assets depth-first,

--- a/apps/mql/cmd/plugin_test.go
+++ b/apps/mql/cmd/plugin_test.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/discovery"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+func assetErr(name, msg string) *discovery.AssetWithError {
+	return &discovery.AssetWithError{
+		Asset: &inventory.Asset{Name: name},
+		Err:   errors.New(msg),
+	}
+}
+
+func TestNoUsableAssetsError(t *testing.T) {
+	tests := []struct {
+		name        string
+		connected   int
+		assetErrors []*discovery.AssetWithError
+		expectErr   bool
+		contains    []string
+	}{
+		{
+			// the reported case: the only asset failed, the query loop had
+			// nothing to iterate, and the command exited 0
+			name:        "single asset failed",
+			connected:   0,
+			assetErrors: []*discovery.AssetWithError{assetErr("prod-db", "no authentication method defined")},
+			expectErr:   true,
+			contains:    []string{"could not connect to asset prod-db", "no authentication method defined"},
+		},
+		{
+			name:      "every asset failed",
+			connected: 0,
+			assetErrors: []*discovery.AssetWithError{
+				assetErr("web-1", "connection refused"),
+				assetErr("web-2", "connection refused"),
+			},
+			expectErr: true,
+			contains:  []string{"any of the 2 assets", "first failure on web-1", "connection refused"},
+		},
+		{
+			// a root asset that fails before it is named still has to produce a
+			// readable message rather than a dangling "asset "
+			name:        "failed asset has no name",
+			connected:   0,
+			assetErrors: []*discovery.AssetWithError{assetErr("", "unable to create runtime")},
+			expectErr:   true,
+			contains:    []string{"<unnamed asset>", "unable to create runtime"},
+		},
+		{
+			// partial failure stays non-fatal: assets that connected were
+			// queried, and --exit-1-on-failure governs query result failures
+			name:        "some assets connected despite failures",
+			connected:   2,
+			assetErrors: []*discovery.AssetWithError{assetErr("web-3", "connection refused")},
+			expectErr:   false,
+		},
+		{
+			name:      "everything connected",
+			connected: 3,
+			expectErr: false,
+		},
+		{
+			// no assets and no errors is not a failure, e.g. a discovery filter
+			// that legitimately matched nothing
+			name:      "nothing to do",
+			connected: 0,
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := noUsableAssetsError(test.connected, test.assetErrors)
+			if !test.expectErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, want := range test.contains {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}

--- a/test/providers/os_test.go
+++ b/test/providers/os_test.go
@@ -215,20 +215,18 @@ func TestDebPackageFields(t *testing.T) {
 }
 
 func TestProvidersEnvVarsLoading(t *testing.T) {
-	t.Run("command WITHOUT path should not find any package", func(t *testing.T) {
+	t.Run("command WITHOUT path should report the missing path", func(t *testing.T) {
 		r := test.NewCliTestRunner("./mql", "run", "fs", "-c", mqlPackagesQuery, "-j")
 		err := r.Run()
 		require.NoError(t, err)
-		assert.Equal(t, 0, r.ExitCode())
-		assert.NotNil(t, r.Stdout())
+
+		// Without MONDOO_PATH (and without --path) the fs asset cannot connect.
+		// That is a misconfiguration, so it exits non-zero rather than
+		// reporting an empty package list, which would read as "this
+		// filesystem has no packages installed".
+		assert.Equal(t, 1, r.ExitCode())
 		assert.NotNil(t, r.Stderr())
-
-		var c mqlPackages
-		err = r.Json(&c)
-		assert.NoError(t, err)
-
-		// No packages
-		assert.Empty(t, c)
+		assert.Contains(t, string(r.Stderr()), "missing filesystem mount path")
 	})
 	t.Run("command WITH path should find packages", func(t *testing.T) {
 		os.Setenv("MONDOO_PATH", "./testdata/fs")
@@ -258,7 +256,9 @@ func TestProvidersEnvVarsLoading(t *testing.T) {
 			r := test.NewCliTestRunner("./mql", "run", "ssh", "localhost", "-c", "ls", "-p", "test", "-v")
 			err := r.Run()
 			require.NoError(t, err)
-			assert.Equal(t, 0, r.ExitCode())
+			// The subject here is flag binding, which is observable in stderr.
+			// Whether ssh://localhost actually connects depends on the machine
+			// running the test, so the exit code is deliberately not asserted.
 			assert.NotNil(t, r.Stdout())
 			if assert.NotNil(t, r.Stderr()) {
 				assert.Contains(t, string(r.Stderr()), "skipping config binding for password")
@@ -271,7 +271,7 @@ func TestProvidersEnvVarsLoading(t *testing.T) {
 			r := test.NewCliTestRunner("./mql", "run", "ssh", "localhost", "-c", "ls", "-v")
 			err := r.Run()
 			require.NoError(t, err)
-			assert.Equal(t, 0, r.ExitCode())
+			// As above: the assertion is about config binding, not reachability.
 			assert.NotNil(t, r.Stdout())
 			if assert.NotNil(t, r.Stderr()) {
 				assert.Contains(t, string(r.Stderr()), "skipping config binding for password")


### PR DESCRIPTION
## Problem

`mql run` exits **0** when it could not connect to a single asset.

Asset runtime creation (`discovery/asset_explorer.go:129`) and asset connection (`apps/mql/cmd/plugin.go`, `connectAll`) both log the failure and carry on, so that one unreachable asset does not abort a scan of many. That is the right behaviour for a partial failure. When *every* asset fails, though, `explorer.Connected()` is empty, the query loop has nothing to iterate, and `RunQuery` returns `nil` — so the command prints a fatal connection error and reports success.

Anything scripting `mql run` therefore cannot distinguish "every asset passed" from "no asset was ever scanned". `--exit-1-on-failure` does not help: it governs query *result* failures, and no query ever ran.

Reproducible on `main` with any unreachable target:

```console
$ mql run ssh root@192.0.2.1 -c 'asset.name'
! could not find keys in ssh agent
x unable to create runtime for asset error="rpc error: code = Unknown desc = no authentication method defined" asset=
$ echo $?
0
```

This surfaced while verifying #8441. The negative control scan failed with `googleapi: Error 400 ... Source zonal disk and target zonal disk must be in the same zone` and still exited 0, which is exactly the signal a CI job would need and would not get.

## Fix

Collapse the no-usable-asset case into an error. The explorer already records both failure points in `Errors()`, and duplicate assets return before being recorded there, so one check covers everything without new plumbing:

```go
connectAll(explorer, explorer.Discovered())
allAssets := explorer.Connected()
if err := noUsableAssetsError(len(allAssets), explorer.Errors()); err != nil {
    return err
}
```

`noUsableAssetsError` reports the first underlying cause rather than a generic message, since that cause is what a user needs.

**Partial failures are deliberately unchanged.** If any asset connected, its queries ran, and `--exit-1-on-failure` continues to govern result failures. Only the all-or-nothing case changes.

## Verification

Against a build of this branch:

| command | before | after |
|---|---|---|
| `mql run ssh root@192.0.2.1 -c 'asset.name'` | exit **0** | exit **1**, `could not connect to asset <unnamed asset>: ... no authentication method defined` |
| `mql run local -c 'asset.platform'` | exit 0 | exit 0, unchanged |

`TestNoUsableAssetsError` covers the single-failure, all-failed, unnamed-asset, partial-success, all-connected, and nothing-discovered cases.

## Compatibility

This is a behaviour change: a script that today sees exit 0 from a wholly failed run will now see exit 1. That is the point of the fix, but it is worth calling out for anyone whose automation has been passing on runs that never scanned anything.

## Tests this changed, and why

Three subtests in `TestProvidersEnvVarsLoading` depended on the old behaviour, and they are worth reading as evidence rather than as collateral damage.

**`command WITHOUT path`** ran `mql run fs` with neither `--path` nor `MONDOO_PATH`. That cannot connect (`missing filesystem mount path, use 'path' option`), and the test asserted **exit 0 with an empty package list**. That is exactly the failure mode this PR is about: a caller who forgets `--path` gets a result that reads as "this filesystem has no packages installed." It now asserts the misconfiguration is reported.

**The two `ssh localhost` subtests** assert on flag and config-binding messages in stderr. Whether `ssh://localhost` connects depends on the machine running the test — on CI it is `connection refused` — so their exit code was incidental rather than their subject. The exit-code assertion is dropped and the stderr assertions that carry their meaning are unchanged. Swapping `0` for `1` there would have hardcoded "no sshd on the runner", which is more fragile than not asserting it.

No other test in the repo asserted on this behaviour.
