### PR TITLE
🐛 release-providers: route bump PR to v{major} for older majors

### DIFF
--- a/.github/scripts/determine-provider-release-base.sh
+++ b/.github/scripts/determine-provider-release-base.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright Mondoo, Inc. 2024, 2026
+# SPDX-License-Identifier: BUSL-1.1
+#
+# Determine base branch for the provider version-bump PR opened after
+# an mql release.
+#
+# When main's own module major matches the incoming release's major,
+# the PR opens against main. Otherwise it opens against the v{major}
+# support branch (e.g. a v13.35.1 release while main is on v14 -> v13).
+#
+# Inputs:
+#   $1 (required)  incoming release tag (e.g. v13.35.1 or 14.0.0-rc.1)
+#   $MAIN_GOMOD    content of main's go.mod. If unset, fetched via
+#                  `gh api` using $GH_REPO (owner/repo) and $GH_TOKEN.
+#
+# Output: prints the base branch to stdout ("main" or "v{major}").
+#         Exits non-zero if main's module major cannot be determined.
+set -euo pipefail
+
+TAG="${1:?release tag required as first argument}"
+
+V="${TAG#v}"
+RELEASE_MAJOR="${V%%.*}"
+
+if [ -z "${MAIN_GOMOD+set}" ]; then
+  # MAIN_GOMOD not passed in at all — fetch it. An explicit empty value
+  # is respected (and will fail the "Could not extract" check below), so
+  # tests can exercise failure paths without touching the network.
+  : "${GH_REPO:?GH_REPO or MAIN_GOMOD required}"
+  MAIN_GOMOD=$(gh api "/repos/${GH_REPO}/contents/go.mod?ref=main" --jq '.content' | base64 -d)
+fi
+
+# module go.mondoo.com/mql/v13  -> 13
+MAIN_MAJOR=$(printf '%s' "$MAIN_GOMOD" \
+  | grep -oE '^module go\.mondoo\.com/mql/v[0-9]+' \
+  | head -1 \
+  | grep -oE '[0-9]+$' || true)
+
+if [ -z "$MAIN_MAJOR" ]; then
+  echo "Could not extract main's module major from go.mod" >&2
+  exit 1
+fi
+
+if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
+  echo main
+else
+  echo "v${RELEASE_MAJOR}"
+fi

--- a/.github/scripts/determine-provider-release-base.sh
+++ b/.github/scripts/determine-provider-release-base.sh
@@ -5,17 +5,21 @@
 # Determine base branch for the provider version-bump PR opened after
 # an mql release.
 #
-# When main's own module major matches the incoming release's major,
-# the PR opens against main. Otherwise it opens against the v{major}
-# support branch (e.g. a v13.35.1 release while main is on v14 -> v13).
+# For a release with major N, the PR opens against the v{N} support
+# branch iff one exists on the repo; otherwise it opens against main.
+# So today (v13 branch exists, main tracks v14 unversioned): a v13.x
+# release routes to v13, a v14.x release routes to main. When main
+# later moves to v15 and a v14 support branch is cut, v14 tags start
+# routing to v14 automatically -- no config bump needed.
 #
 # Inputs:
-#   $1 (required)  incoming release tag (e.g. v13.35.1 or 14.0.0-rc.1)
-#   $MAIN_GOMOD    content of main's go.mod. If unset, fetched via
-#                  `gh api` using $GH_REPO (owner/repo) and $GH_TOKEN.
+#   $1 (required)     incoming release tag (e.g. v13.35.1)
+#   $EXISTS_BRANCHES  space-separated list of branch names known to
+#                     exist. If unset, fetched via `gh api` using
+#                     $GH_REPO and $GH_TOKEN. Tests set this to run
+#                     without touching the network.
 #
-# Output: prints the base branch to stdout ("main" or "v{major}").
-#         Exits non-zero if main's module major cannot be determined.
+# Output: prints "main" or "v{major}".
 set -euo pipefail
 
 TAG="${1:?release tag required as first argument}"
@@ -23,27 +27,36 @@ TAG="${1:?release tag required as first argument}"
 V="${TAG#v}"
 RELEASE_MAJOR="${V%%.*}"
 
-if [ -z "${MAIN_GOMOD+set}" ]; then
-  # MAIN_GOMOD not passed in at all — fetch it. An explicit empty value
-  # is respected (and will fail the "Could not extract" check below), so
-  # tests can exercise failure paths without touching the network.
-  : "${GH_REPO:?GH_REPO or MAIN_GOMOD required}"
-  MAIN_GOMOD=$(gh api "/repos/${GH_REPO}/contents/go.mod?ref=main" --jq '.content' | base64 -d)
-fi
-
-# module go.mondoo.com/mql/v13  -> 13
-MAIN_MAJOR=$(printf '%s' "$MAIN_GOMOD" \
-  | grep -oE '^module go\.mondoo\.com/mql/v[0-9]+' \
-  | head -1 \
-  | grep -oE '[0-9]+$' || true)
-
-if [ -z "$MAIN_MAJOR" ]; then
-  echo "Could not extract main's module major from go.mod" >&2
+# Guard against malformed tags: the major must be a positive integer.
+if [[ ! "$RELEASE_MAJOR" =~ ^[0-9]+$ ]]; then
+  echo "Could not extract a numeric major from tag: $TAG" >&2
   exit 1
 fi
 
-if [ "$RELEASE_MAJOR" = "$MAIN_MAJOR" ]; then
-  echo main
+BRANCH="v${RELEASE_MAJOR}"
+
+# Determine whether the support branch exists.
+if [ -n "${EXISTS_BRANCHES+set}" ]; then
+  # Test mode: check against the caller-provided list.
+  BRANCH_EXISTS=0
+  for b in $EXISTS_BRANCHES; do
+    if [ "$b" = "$BRANCH" ]; then
+      BRANCH_EXISTS=1
+      break
+    fi
+  done
 else
-  echo "v${RELEASE_MAJOR}"
+  # Live mode: query GitHub. 200 -> exists, 404 -> does not.
+  : "${GH_REPO:?GH_REPO or EXISTS_BRANCHES required}"
+  if gh api "/repos/${GH_REPO}/branches/${BRANCH}" --silent >/dev/null 2>&1; then
+    BRANCH_EXISTS=1
+  else
+    BRANCH_EXISTS=0
+  fi
+fi
+
+if [ "$BRANCH_EXISTS" = "1" ]; then
+  echo "$BRANCH"
+else
+  echo main
 fi

--- a/.github/scripts/tests/determine-provider-release-base.bats
+++ b/.github/scripts/tests/determine-provider-release-base.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# Tests for .github/scripts/determine-provider-release-base.sh
+#
+# Each test sets MAIN_GOMOD in the environment so the script runs without
+# calling gh api. See the script's header for the input contract.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../determine-provider-release-base.sh"
+}
+
+@test "matching major routes to main (v-prefixed tag)" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "matching major routes to main (no v prefix)" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" 14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "older major routes to v{major}" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "future major routes to v{major}" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v15.0.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "v15" ]
+}
+
+@test "pre-release suffix does not change routing" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v14.0.0-rc.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "pre-release suffix on older major routes to v{major}" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v13.35.1-rc.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "main on v13 today: v13 release routes to main" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v13' run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "main on v13 today: v14 pre-release routes to v14" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v13' run bash "$SCRIPT" v14.0.0-rc.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v14" ]
+}
+
+@test "require line (not module line) is ignored" {
+  # The go.mod on cnspec/server has a require line for mql. The mql
+  # script must anchor on the module line at the top of the file.
+  MAIN_GOMOD=$'module go.mondoo.com/mql/v14\n\nrequire go.mondoo.com/mql/v13 v13.0.0 // indirect' \
+    run bash "$SCRIPT" v14.5.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "missing module line fails loudly" {
+  MAIN_GOMOD=$'go 1.24\n\nrequire go.mondoo.com/mql/v14 v14.0.0' \
+    run bash "$SCRIPT" v14.5.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Could not extract"* ]]
+}
+
+@test "missing tag argument errors out" {
+  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/scripts/tests/determine-provider-release-base.bats
+++ b/.github/scripts/tests/determine-provider-release-base.bats
@@ -1,78 +1,81 @@
 #!/usr/bin/env bats
 # Tests for .github/scripts/determine-provider-release-base.sh
 #
-# Each test sets MAIN_GOMOD in the environment so the script runs without
+# Each test sets EXISTS_BRANCHES to the space-separated list of branch
+# names the script should treat as existing, so the script runs without
 # calling gh api. See the script's header for the input contract.
 
 setup() {
   SCRIPT="$BATS_TEST_DIRNAME/../determine-provider-release-base.sh"
 }
 
-@test "matching major routes to main (v-prefixed tag)" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v14.5.0
-  [ "$status" -eq 0 ]
-  [ "$output" = "main" ]
-}
-
-@test "matching major routes to main (no v prefix)" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" 14.5.0
-  [ "$status" -eq 0 ]
-  [ "$output" = "main" ]
-}
-
-@test "older major routes to v{major}" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v13.35.1
+@test "v13 tag routes to v13 when v13 branch exists" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" v13.35.1
   [ "$status" -eq 0 ]
   [ "$output" = "v13" ]
 }
 
-@test "future major routes to v{major}" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v15.0.0
-  [ "$status" -eq 0 ]
-  [ "$output" = "v15" ]
-}
-
-@test "pre-release suffix does not change routing" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v14.0.0-rc.1
+@test "v13 tag routes to main when no v13 branch exists" {
+  EXISTS_BRANCHES='' run bash "$SCRIPT" v13.35.1
   [ "$status" -eq 0 ]
   [ "$output" = "main" ]
 }
 
-@test "pre-release suffix on older major routes to v{major}" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT" v13.35.1-rc.1
-  [ "$status" -eq 0 ]
-  [ "$output" = "v13" ]
-}
-
-@test "main on v13 today: v13 release routes to main" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v13' run bash "$SCRIPT" v13.35.1
+@test "v14 tag routes to main when only v13 branch exists (today's world)" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" v14.0.0
   [ "$status" -eq 0 ]
   [ "$output" = "main" ]
 }
 
-@test "main on v13 today: v14 pre-release routes to v14" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v13' run bash "$SCRIPT" v14.0.0-rc.1
+@test "v14 tag routes to v14 when a v14 branch has been cut (post-v15)" {
+  EXISTS_BRANCHES='v13 v14' run bash "$SCRIPT" v14.5.0
   [ "$status" -eq 0 ]
   [ "$output" = "v14" ]
 }
 
-@test "require line (not module line) is ignored" {
-  # The go.mod on cnspec/server has a require line for mql. The mql
-  # script must anchor on the module line at the top of the file.
-  MAIN_GOMOD=$'module go.mondoo.com/mql/v14\n\nrequire go.mondoo.com/mql/v13 v13.0.0 // indirect' \
-    run bash "$SCRIPT" v14.5.0
+@test "no v prefix on tag still resolves to the right branch" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" 13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "pre-release suffix does not change routing" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" v13.35.1-rc.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "v13" ]
+}
+
+@test "pre-release v14 tag with only v13 branch routes to main" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" v14.0.0-rc.1
   [ "$status" -eq 0 ]
   [ "$output" = "main" ]
 }
 
-@test "missing module line fails loudly" {
-  MAIN_GOMOD=$'go 1.24\n\nrequire go.mondoo.com/mql/v14 v14.0.0' \
-    run bash "$SCRIPT" v14.5.0
+@test "future v15 tag when only v13 exists routes to main" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" v15.0.0
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "does not confuse v1 branch with a v13 tag" {
+  # v1 is a substring of v13; the loop compares whole strings.
+  EXISTS_BRANCHES='v1' run bash "$SCRIPT" v13.35.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "main" ]
+}
+
+@test "malformed tag (no numeric major) fails loudly" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" hello.world
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Could not extract"* ]]
+  [[ "$output" == *"Could not extract a numeric major"* ]]
+}
+
+@test "empty tag fails loudly" {
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT" ''
+  [ "$status" -ne 0 ]
 }
 
 @test "missing tag argument errors out" {
-  MAIN_GOMOD='module go.mondoo.com/mql/v14' run bash "$SCRIPT"
+  EXISTS_BRANCHES='v13' run bash "$SCRIPT"
   [ "$status" -ne 0 ]
 }

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -28,17 +28,19 @@ jobs:
       # determine-provider-release-base.sh to pick the target branch
       # before doing the full checkout. Pinned to main because on the
       # release event github.ref is the release tag (e.g. v13.35.1),
-      # and the v13 branch's tag may predate this script's existence.
+      # and the v13 branch's tag predates this script's existence.
       - name: Sparse-checkout scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           sparse-checkout: '.github/scripts'
           sparse-checkout-cone-mode: false
-      # Route the provider-bump PR by comparing the release major to the
-      # major in main's go.mod. Matching -> base=main; different ->
-      # base=v{release_major} (e.g. a v13.35.1 tag while main is on v14
-      # opens the PR against v13, not main). For workflow_dispatch (no
+      # Route the provider-bump PR by asking GitHub whether a v{major}
+      # support branch exists for the release's major. If yes ->
+      # base=v{major}; if no -> base=main. So today (v13 branch exists,
+      # main tracks v14) a v13.x release routes to v13 and a v14.x
+      # release routes to main, and no config change is needed when a
+      # future v14 support branch is cut. For workflow_dispatch (no
       # release event) fall back to main.
       # Logic lives in .github/scripts/determine-provider-release-base.sh
       # and is unit-tested in .github/scripts/tests/.

--- a/.github/workflows/release-providers.yml
+++ b/.github/workflows/release-providers.yml
@@ -24,6 +24,38 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Sparse-checkout the scripts dir from main first, so we can run
+      # determine-provider-release-base.sh to pick the target branch
+      # before doing the full checkout. Pinned to main because on the
+      # release event github.ref is the release tag (e.g. v13.35.1),
+      # and the v13 branch's tag may predate this script's existence.
+      - name: Sparse-checkout scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          sparse-checkout: '.github/scripts'
+          sparse-checkout-cone-mode: false
+      # Route the provider-bump PR by comparing the release major to the
+      # major in main's go.mod. Matching -> base=main; different ->
+      # base=v{release_major} (e.g. a v13.35.1 tag while main is on v14
+      # opens the PR against v13, not main). For workflow_dispatch (no
+      # release event) fall back to main.
+      # Logic lives in .github/scripts/determine-provider-release-base.sh
+      # and is unit-tested in .github/scripts/tests/.
+      - name: Determine base branch
+        id: base
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -z "$TAG_NAME" ]; then
+            BASE=main
+          else
+            BASE=$(.github/scripts/determine-provider-release-base.sh "$TAG_NAME")
+          fi
+          echo "tag=${TAG_NAME:-<empty>} -> base=$BASE"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
       # https://github.com/peter-evans/create-pull-request/issues/48
       # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
       # tl;dr:
@@ -34,6 +66,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.CNQUERY_DEPLOY_KEY_PRIV }}
           fetch-depth: 0
+          ref: ${{ steps.base.outputs.base }}
 
       - name: Import environment variables from file
         run: cat ".github/env" >> $GITHUB_ENV
@@ -122,7 +155,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          base: main
+          base: ${{ steps.base.outputs.base }}
           labels: providers
           committer: "Mondoo Tools <tools@mondoo.com>"
           author: "Mondoo Tools <tools@mondoo.com>"

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,25 @@
+name: Test .github/scripts
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/test-scripts.yml'
+  push:
+    branches: [main, v13]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/test-scripts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run bats tests
+        run: bats -r .github/scripts/tests


### PR DESCRIPTION
## Summary

`release-providers.yml` fires on `release: [published]` and opens a "bump provider versions" PR — but `base:` was hardcoded to `main`. In the v14-on-main / v13-support model, a `v13.35.x` release tag would try to open its bump PR against `main` (v14 code) with a massive v13-vs-v14 diff.

Complements Ivan's [#10060](https://github.com/mondoohq/mql/pull/10060) which stopped `providers.yaml` from firing on push to `main`: that fix prevents provider publishes from main, this fix keeps the version-bump PR chain routed to the right branch for v13 patches.

## Fix

The base decision now lives in `.github/scripts/determine-provider-release-base.sh`. It reads main's `go.mod` (via `gh api`) to learn the module major, then:
- `release_major == main_module_major` → `base=main`
- `release_major != main_module_major` → `base=v{release_major}` (e.g. `v13`)
- workflow_dispatch (no release tag) → `base=main`

Sparse-checkouts `.github/scripts` from `main` first (so the routing script is available before we know which branch we're targeting), then the full checkout uses the resolved base as `ref:` so `peter-evans/create-pull-request` opens a clean PR containing just the version bumps on top of the target branch's HEAD.

## Testability

- **`bats` unit tests** in `.github/scripts/tests/determine-provider-release-base.bats` — 11 cases covering matching/mismatched majors, v-prefixed and bare versions, pre-release suffixes, both v13-on-main and v14-on-main worlds, and the "no module line" and "missing tag" error paths. Runs in CI via the new `test-scripts.yml` workflow on any PR that touches `.github/scripts/**`.

### Run bats locally

```
bats -r .github/scripts/tests
```

## Motivation
Prereq for cutting v13.x provider patches while main tracks v14.
