### PR TITLE
🐛 os: drop macOS system_profiler entries that are not application bundles

### DIFF
--- a/providers/os/resources/packages/macos_packages.go
+++ b/providers/os/resources/packages/macos_packages.go
@@ -64,35 +64,60 @@ func ParseMacOSPackages(conn shared.Connection, platform *inventory.Platform, in
 		return nil, errors.New("format not supported")
 	}
 
-	pkgs := make([]Package, len(data[0].Items))
-	for i, entry := range data[0].Items {
-		// We need a special handling for Firefox to determine ESR installations
-		purlQualifiers := getPurlQualifiers(conn, entry)
-
+	pkgs := make([]Package, 0, len(data[0].Items))
+	for _, entry := range data[0].Items {
 		// system_profiler only surfaces CFBundleShortVersionString as the
 		// version. Some bundles (e.g. PWAs) ship a version only in
 		// CFBundleVersion, so fall back to the bundle's Info.plist when
 		// system_profiler reports no version.
 		version := entry.Version
 		if version == "" {
-			version = bundleVersionFromInfoPlist(conn, entry.Path)
+			// system_profiler lists every path carrying a bundle-like
+			// extension, not only application bundles: Firefox origin storage
+			// (https+++example.app), app-group script containers
+			// (group.is.workflow.my.app) and daemon directories all show up. It
+			// names them after the basename minus its final dot component, so a
+			// reverse-DNS directory collapses into a fragment like "com" or
+			// "org.eclipse". An application bundle always carries a
+			// Contents/Info.plist, so its absence means this is not an installed
+			// application: drop the entry instead of reporting it with a
+			// versionless purl that can never match advisory data.
+			//
+			// Entries that do report a version are never checked, because some
+			// real applications have no Contents/Info.plist. Wrapped iOS apps
+			// keep theirs under Wrapper/ and would otherwise be lost.
+			bundleVersion, isBundle := bundleVersionFromInfoPlist(conn, entry.Path)
+			if !isBundle {
+				log.Debug().
+					Str("name", entry.Name).
+					Str("path", entry.Path).
+					Msg("skipping entry that is not an application bundle")
+				continue
+			}
+			version = bundleVersion
 		}
 
-		pkgs[i].Name = entry.Name
-		pkgs[i].Version = version
-		pkgs[i].Format = MacosPkgFormat
-		pkgs[i].FilesAvailable = PkgFilesIncluded
-		pkgs[i].Arch = platform.Arch
-		pkgs[i].PUrl = purl.NewPackageURL(
-			platform, purl.TypeMacos, entry.Name, version, purl.WithQualifiers(purlQualifiers),
-		).String()
+		// We need a special handling for Firefox to determine ESR installations
+		purlQualifiers := getPurlQualifiers(conn, entry)
+
+		pkg := Package{
+			Name:           entry.Name,
+			Version:        version,
+			Format:         MacosPkgFormat,
+			FilesAvailable: PkgFilesIncluded,
+			Arch:           platform.Arch,
+			PUrl: purl.NewPackageURL(
+				platform, purl.TypeMacos, entry.Name, version, purl.WithQualifiers(purlQualifiers),
+			).String(),
+		}
 		if entry.Path != "" {
-			pkgs[i].Files = []FileRecord{
+			pkg.Files = []FileRecord{
 				{
 					Path: entry.Path,
 				},
 			}
 		}
+		pkgs = append(pkgs, pkg)
 	}
 
 	return pkgs, nil
@@ -133,37 +158,44 @@ func (mpm *MacOSPkgManager) Files(name string, version string, arch string) ([]F
 // bundleVersionFromInfoPlist recovers an app's version from its
 // Contents/Info.plist when system_profiler did not report one. It prefers
 // CFBundleShortVersionString (the user-facing version) and falls back to
-// CFBundleVersion (the build version). Returns an empty string when no bundle
-// Info.plist exists (e.g. bare ".app" daemons) or it carries no version.
-func bundleVersionFromInfoPlist(conn shared.Connection, path string) string {
+// CFBundleVersion (the build version).
+//
+// The second return value reports whether the path is an application bundle at
+// all, which is true whenever a Contents/Info.plist could be read. Callers use
+// it to tell a real application that simply carries no version (some Apple
+// CoreServices apps ship neither version key) from a directory that merely has
+// a bundle-like extension.
+func bundleVersionFromInfoPlist(conn shared.Connection, path string) (string, bool) {
 	if path == "" {
-		return ""
+		return "", false
 	}
 
 	infoPath := filepath.Join(path, "Contents", "Info.plist")
 	f, err := conn.FileSystem().Open(infoPath)
 	if err != nil {
 		log.Debug().Err(err).Str("path", infoPath).Msg("could not open Info.plist")
-		return ""
+		return "", false
 	}
 	defer f.Close()
 
 	content, err := io.ReadAll(f)
 	if err != nil {
 		log.Debug().Err(err).Str("path", infoPath).Msg("could not read Info.plist")
-		return ""
+		return "", false
 	}
 
+	// The Info.plist is there, so this is a bundle even if we cannot read a
+	// version out of it.
 	var info infoPlist
 	if _, err := plist.Unmarshal(content, &info); err != nil {
 		log.Debug().Err(err).Str("path", infoPath).Msg("could not parse Info.plist")
-		return ""
+		return "", true
 	}
 
 	if info.ShortVersion != "" {
-		return info.ShortVersion
+		return info.ShortVersion, true
 	}
-	return info.BundleVersion
+	return info.BundleVersion, true
 }
 
 func getPurlQualifiers(conn shared.Connection, entry sysProfilerItem) map[string]string {

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -31,7 +31,7 @@ func TestMacOsXPackageParser(t *testing.T) {
 	}
 	m, err := packages.ParseMacOSPackages(mock, pf, c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 5, len(m), "detected the right amount of packages")
+	assert.Equal(t, 6, len(m), "detected the right amount of packages")
 
 	assert.Equal(t, "Preview", m[0].Name, "pkg name detected")
 	assert.Equal(t, "10.0", m[0].Version, "pkg version detected")
@@ -61,8 +61,37 @@ func TestMacOsXPackageParser(t *testing.T) {
 	assert.Equal(t, "7778.181", m[3].Version, "pkg version recovered from Info.plist")
 	assert.Equal(t, "pkg:macos/macos/Microsoft%20Teams%20%28PWA%29@7778.181?arch=x86_64", m[3].PUrl)
 
-	// A bare ".app" directory with no Info.plist (a system daemon) genuinely
-	// has no version anywhere, so the version stays empty.
-	assert.Equal(t, "liquiddetectiond", m[4].Name, "pkg name detected")
-	assert.Equal(t, "", m[4].Version, "no version available for a bare .app daemon")
+	// An application bundle whose Info.plist carries no version keys at all is
+	// still a real installed application, so it is reported with an empty
+	// version rather than dropped.
+	assert.Equal(t, "qFlipper", m[4].Name, "versionless app bundle kept")
+	assert.Equal(t, "", m[4].Version, "no version available in the Info.plist")
+	assert.Equal(t, "pkg:macos/macos/qFlipper?arch=x86_64", m[4].PUrl)
+
+	// Wrapped iOS apps keep their Info.plist inside Wrapper/, so there is no
+	// Contents/Info.plist to find. They report a version, so they must never
+	// be dropped by the bundle check.
+	assert.Equal(t, "Victory", m[5].Name, "wrapped iOS app kept")
+	assert.Equal(t, "3.2.1", m[5].Version, "version reported by system_profiler")
+	assert.Equal(t, "pkg:macos/macos/Victory@3.2.1?arch=x86_64", m[5].PUrl)
+
+	// system_profiler enumerates every path carrying a bundle-like extension,
+	// not just application bundles. Entries with no version and no
+	// Contents/Info.plist are not installed applications and are dropped
+	// instead of being reported with an unusable, versionless purl.
+	for _, dropped := range []string{
+		"liquiddetectiond",     // bare .app directory holding a daemon
+		"https+++bsky",         // Firefox origin storage directory
+		"group.is.workflow.my", // app-group script container
+	} {
+		assert.NotContains(t, names(m), dropped, "non-application entry dropped")
+	}
+}
+
+func names(pkgs []packages.Package) []string {
+	list := make([]string, len(pkgs))
+	for i := range pkgs {
+		list[i] = pkgs[i].Name
+	}
+	return list
 }

--- a/providers/os/resources/packages/testdata/packages_macos.toml
+++ b/providers/os/resources/packages/testdata/packages_macos.toml
@@ -115,6 +115,56 @@ stdout = """<?xml version="1.0" encoding="UTF-8"?>
 				<key>path</key>
 				<string>/System/Library/CoreServices/liquiddetectiond.app</string>
 			</dict>
+			<dict>
+				<key>_name</key>
+				<string>https+++bsky</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>unknown</string>
+				<key>path</key>
+				<string>/Users/user/Library/Application Support/Firefox/Profiles/abcd1234.default-release/storage/default/https+++bsky.app</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>group.is.workflow.my</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>unknown</string>
+				<key>path</key>
+				<string>/Users/user/Library/Application Scripts/group.is.workflow.my.app</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>qFlipper</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/qFlipper.app</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Victory</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>mac_app_store</string>
+				<key>path</key>
+				<string>/Applications/Victory.app</string>
+				<key>version</key>
+				<string>3.2.1</string>
+			</dict>
 		</array>
 		<key>_parentDataType</key>
 		<string>SPSoftwareDataType</string>
@@ -166,4 +216,19 @@ ServerURL=https://crash-reports.mozilla.com/submit?id={ec8030f7-c20a-464f-9b0e-1
 
 [AppUpdate]
 URL=https://aus5.mozilla.org/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml
+"""
+
+[files."/Applications/qFlipper.app/Contents/Info.plist"]
+content = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>qFlipper</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.yourcompany.qFlipper</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+</dict>
+</plist>
 """


### PR DESCRIPTION
Fixes #10282

## What was happening

`system_profiler SPApplicationsDataType` is not a list of installed applications. It enumerates **every path carrying a bundle-like extension**, and it names each item after the basename minus its final dot component. That is why reverse-DNS directories collapse into fragments — `group.is.workflow.my.app` is reported as `group.is.workflow.my`, and by the same mechanism a `com.*` or `org.eclipse.*` directory is reported as `com` or `org.eclipse`.

`ParseMacOSPackages` emitted every item verbatim, so those directories became inventory entries with an empty version and an unusable purl like `pkg:macos/macos/com?arch=arm64`.

The issue framed this as a binary triage: either `system_profiler` reports these names (→ filter on a `.app` suffix), or our plist decode mis-associates `_name` (→ our bug). Running the repro on an arm64 host gives a third answer: `system_profiler` **does** report them, but a `.app` suffix filter would not help — **110 of the 111 junk paths already end in `.app`**. They are Firefox origin-storage directories, app-group script containers, and `Library/HTTPStorages` entries.

Verbatim, from this host:

```
https+++bsky            /Users/…/Firefox/Profiles/…/storage/default/https+++bsky.app
group.is.workflow.my    /Users/…/Library/Application Scripts/group.is.workflow.my.app
com.apple.ctcategories  /Users/…/Library/HTTPStorages/com.apple.ctcategories.service
liquiddetectiond        /System/Library/CoreServices/liquiddetectiond.app
```

## The fix

The discriminator is `Contents/Info.plist`, not the path suffix — an application bundle always has one. When `system_profiler` reports no version **and** no `Info.plist` can be read, the entry is skipped and logged at debug level with its path, as the issue suggested.

`bundleVersionFromInfoPlist` already opened that file for the version fallback, so this adds no extra I/O — it now returns whether the bundle was found alongside the version.

**The check is gated on an already-empty version, deliberately.** `/Applications/Victory.app` is a wrapped iOS app: a `WrappedBundle` symlink into `Wrapper/`, with no top-level `Contents/Info.plist`. It reports a version, and dropping it would be a regression. Versioned entries are never checked.

## Measured on a real arm64 host

| | before | after |
|---|---|---|
| items from `system_profiler` | 497 | 497 |
| packages reported | 497 | **386** |
| versionless packages | 116 | **4** |

All 111 dropped entries lack a `Contents/Info.plist`. The 4 survivors are genuine bundles (`CFBundlePackageType => APPL`) that simply ship no version keys — `PassViewer`, `ShortcutsActions`, `Proton Mail Uninstaller`, `qFlipper`. That is the second group the issue asked to separate out during triage; they are real installed applications, so they are kept rather than dropped.

## Test plan

`macos_packages_test.go` now covers all four quadrants of version × `Info.plist`:

- versioned + `Info.plist` → kept (`Preview`, `Contacts`, `Firefox`)
- versionless + `Info.plist` **with** a version key → version recovered (`Microsoft Teams (PWA)`, from `CFBundleVersion`)
- versionless + `Info.plist` **without** version keys → kept, empty version (`qFlipper`)
- versioned + **no** `Info.plist` → kept (`Victory`, the wrapped-iOS-app regression guard)
- versionless + **no** `Info.plist` → dropped (`liquiddetectiond`, `https+++bsky`, `group.is.workflow.my`)

The testdata paths are the real shapes observed on the host, not invented ones.

```
go test ./resources/packages/...   # ok
go vet ./resources/packages/       # clean
```

Also driven end-to-end through a real local connection against this host's live `system_profiler` output to produce the table above.
