### PR TITLE
✨ os: report packages held at their current version as pinned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -464,6 +464,14 @@ test/go/plain-ci: prep/tools test/generate providers/build/mock providers/build/
 test/integration:
 	go test -cover -p 1 $(shell go list ./... | grep '/test/')
 
+# Docker-backed regression matrix for the package resource, one image per
+# package manager. Deliberately manual: it pulls several images and takes
+# minutes, so it carries the debugtest tag and stays out of `go test ./...`.
+# Run it when changing anything under providers/os/resources/packages.
+.PHONY: test/packages/matrix
+test/packages/matrix:
+	go test -tags debugtest -count=1 -timeout 30m -v ./test/providers/ -run TestPackagesMatrix
+
 test/go-cli/plain-ci: prep/tools test/generate providers/build
 	gotestsum --junitfile report.xml --format pkgname -- -cover -p 1 $(shell go list ./... | grep '/test/')
 

--- a/docs/adr/044-package-pinned-state.md
+++ b/docs/adr/044-package-pinned-state.md
@@ -1,0 +1,130 @@
+# ADR 044: Reporting Packages Held at Their Current Version
+
+## Status
+
+Accepted
+
+## Context
+
+An audit that finds an outdated package cannot currently tell two very
+different situations apart:
+
+- nobody has applied the update yet, or
+- this host is **configured** never to apply it.
+
+Only the second needs a human. An administrator who runs `apt-mark hold nginx`
+or `dnf versionlock add kernel` has made a deliberate decision, usually to keep
+a working system working. That decision is invisible to `mql` today, so a report
+lists the package as outdated with no indication that the update is blocked, and
+a remediation ticket goes to someone who will discover the hold only after
+trying to patch.
+
+The `package` resource already carries `outdated`, `available` and `status`. It
+does not carry the fact that upgrading is switched off.
+
+## Decision
+
+Add a `pinned bool` field to `package`.
+
+`pinned` is true when the package manager is configured not to upgrade the
+package: a dpkg or opkg hold, a dnf or yum versionlock, or a zypper lock.
+
+### It is read from files, not from the tools
+
+Every mechanism has a file behind it, and the commands are wrappers over those
+files:
+
+| manager | source | verified against |
+|---|---|---|
+| dpkg | `/var/lib/dpkg/status`, `Status: hold ok installed` | `debian:12` |
+| opkg | `/usr/lib/opkg/status`, `Status: install hold installed` | fixture in-repo |
+| dnf4 | `/etc/dnf/plugins/versionlock.list` | `almalinux:9` |
+| yum | `/etc/yum/pluginconf.d/versionlock.list` | `amazonlinux:2` |
+| dnf5 | `/etc/dnf/versionlock.toml` | `fedora:latest` |
+| zypper | `/etc/zypp/locks` | `opensuse/leap:15` |
+
+This is the decision with the longest reach, and it is made for coverage rather
+than for speed. `mql` scans container images, mounted filesystems and disk
+snapshots, and on those targets **no command can run at all**. A reader built on
+`apt-mark showhold` or `dnf versionlock list` reports "nothing is pinned" there,
+which is indistinguishable from a host that genuinely holds nothing — a check
+that passes precisely where it has the least information.
+
+Reading files also matches how the resource already works: `packages` parses the
+dpkg database and the rpmdb directly rather than shelling out to `dpkg-query` or
+`rpm -qa` when it can avoid it.
+
+The behaviour is verified on both connection types. The same locked host is
+scanned as a running container and as a committed image, and both report
+`pinned: true`.
+
+### Locations are probed, not derived from the platform version
+
+`RpmPkgManager` serves RHEL, AlmaLinux, Rocky, Oracle Linux, Amazon Linux,
+Photon, azurelinux, bottlerocket and wrlinux, each on its own dnf/yum/tdnf
+timeline. A version gate would encode a guess about every one of them.
+
+The three versionlock stores are therefore probed in order, newest first, and
+the first that exists wins. This mirrors how the same file already locates the
+rpm database across three eras (`rpmdb.sqlite`, `Packages`, `Packages.db`), and
+it stays correct on a distribution nobody anticipated. On RHEL 9 the yum path is
+a symlink onto the dnf one, so probing resolves both with a single read.
+
+### A manager with no mechanism reports false
+
+apk has no lock concept. Photon's tdnf has no versionlock plugin, none is
+available in its repositories, and `tdnf versionlock` is not a command
+(`No such command: versionlock`, tdnf 3.6.5).
+
+On those platforms `pinned` is always false, and that is stated in the field
+documentation. The distinction matters: false has to mean "there is no such
+thing here", not "this was not checked".
+
+### Debian's apt preferences are out of scope
+
+In Debian terminology "pinning" usually means `/etc/apt/preferences`, which
+assigns priorities that bias which candidate apt selects. That is not a hold: a
+pinned-by-priority package can still be upgraded. Treating it as `pinned: true`
+would report a host as frozen when it is not, so the field covers holds and
+version locks only, and its documentation says so to head off the obvious
+misreading.
+
+## Consequences
+
+- A policy can distinguish "not yet patched" from "patching is switched off",
+  and can flag the second for review rather than for remediation.
+- The field answers identically on a live host, an image and a mounted
+  filesystem, so a fleet report does not change shape with the connection type.
+- Two managers cost nothing to support: the hold is already in the status the
+  resource parses, so dpkg and opkg required no new I/O.
+- New lock mechanisms are additive: a new store is one more probed path.
+
+## Alternatives Considered
+
+### Running the tools
+
+`apt-mark showhold`, `dnf versionlock list`, `zypper locks`. Rejected: it
+answers nothing on an image, a mounted filesystem or a snapshot, and those are a
+large share of what gets scanned. It also spawns a process per manager per scan
+to read data already present on disk.
+
+### A `pinnedReason` string, or an enum of mechanisms
+
+Rejected. The question a check asks is yes/no, and the mechanism is already
+implied by the platform: a `deb` package is held by dpkg, an `rpm` by
+versionlock or zypper. A string invites checks that match on the wording of a
+mechanism name, which is the kind of assertion that breaks when a distribution
+changes tooling.
+
+### Reusing `status` alone
+
+`status` already exposes the dpkg triple, so a check *could* match `hold` in it.
+Rejected: it answers only for dpkg and opkg, is empty on rpm-based systems, and
+pushes string parsing into every policy that wants the answer. It also could not
+express a versionlock, which lives outside the package database entirely.
+
+### Covering pacman's `IgnorePkg`
+
+Arch records held packages in `/etc/pacman.conf`. It is a real equivalent and
+was left out only to keep this change to the managers in the original request.
+It is additive under the same design: one more source, one more `lockedNames`.

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -966,6 +966,20 @@ package @defaults("name version") {
   format string
   // Status of this package (e.g., if it is needed)
   status() string
+  // Whether the package is held at its current version
+  //
+  // True when the package manager is configured not to upgrade it: a
+  // dpkg or opkg hold, a dnf or yum versionlock, or a zypper lock. An
+  // outdated package that is pinned is a deliberate state rather than a
+  // missed patch, and it will not receive a security update until the
+  // pin is released.
+  //
+  // Read from the package manager's own files, so it answers the same
+  // way on a running host, a container image and a mounted filesystem.
+  // Debian's apt preferences are priorities rather than holds and do
+  // not set this. False on package managers with no lock mechanism,
+  // where it means there is no such thing rather than not checked.
+  pinned bool
 
   // Package URL (purl) identifier for this package
   purl string

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3702,6 +3702,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"package.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackage).GetStatus()).ToDataRes(types.String)
 	},
+	"package.pinned": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPackage).GetPinned()).ToDataRes(types.Bool)
+	},
 	"package.purl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPackage).GetPurl()).ToDataRes(types.String)
 	},
@@ -16762,6 +16765,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"package.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPackage).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"package.pinned": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPackage).Pinned, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -38776,6 +38783,7 @@ type mqlPackage struct {
 	Epoch       plugin.TValue[string]
 	Format      plugin.TValue[string]
 	Status      plugin.TValue[string]
+	Pinned      plugin.TValue[bool]
 	Purl        plugin.TValue[string]
 	Cpes        plugin.TValue[[]any]
 	Origin      plugin.TValue[string]
@@ -38853,6 +38861,10 @@ func (c *mqlPackage) GetStatus() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Status, func() (string, error) {
 		return c.status()
 	})
+}
+
+func (c *mqlPackage) GetPinned() *plugin.TValue[bool] {
+	return &c.Pinned
 }
 
 func (c *mqlPackage) GetPurl() *plugin.TValue[string] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2845,6 +2845,7 @@ package.license 13.16.10
 package.name 9.0.0
 package.origin 9.0.0
 package.outdated 9.0.0
+package.pinned 13.40.10
 package.purl 9.1.6
 package.status 9.0.0
 package.vendor 11.2.18

--- a/providers/os/resources/packages.go
+++ b/providers/os/resources/packages.go
@@ -66,6 +66,10 @@ func initPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	res.Name = plugin.TValue[string]{Data: name, State: plugin.StateIsSet}
 	res.Installed = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Outdated = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
+	// A package that is not installed is not held at a version either. Like
+	// installed and outdated above, this is a concrete false rather than null:
+	// there is nothing unknown about it.
+	res.Pinned = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet}
 	res.Version.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Epoch.State = plugin.StateIsSet | plugin.StateIsNull
 	res.Available.State = plugin.StateIsSet | plugin.StateIsNull
@@ -174,6 +178,7 @@ func fillPackageArgs(args map[string]*llx.RawData, osPkg *packages.Package, avai
 	args["available"] = llx.StringData(available)
 	args["arch"] = llx.StringData(osPkg.Arch)
 	args["status"] = llx.StringData(osPkg.Status)
+	args["pinned"] = llx.BoolData(osPkg.Pinned)
 	args["description"] = llx.StringData(osPkg.Description)
 	args["format"] = llx.StringData(osPkg.Format)
 	args["installed"] = llx.BoolData(true)

--- a/providers/os/resources/packages/dpkg_packages.go
+++ b/providers/os/resources/packages/dpkg_packages.go
@@ -75,6 +75,9 @@ func ParseDpkgPackages(pf *inventory.Platform, input io.Reader) ([]Package, erro
 	add := func(pkg Package) {
 		// do sanitization checks to ensure we have minimal information
 		if pkg.Name != "" && pkg.Version != "" {
+			// A hold lives in the status triple that was just parsed, so it
+			// costs no extra read and is answered the same way on an image.
+			pkg.Pinned = isHeldStatus(pkg.Status)
 			pkg.PUrl = purl.NewPackageURL(pf, purl.TypeDebian, pkg.Name, pkg.Version,
 				purl.WithArch(pkg.Arch),
 				purl.WithEpoch(pkg.Epoch),

--- a/providers/os/resources/packages/opkg_packages.go
+++ b/providers/os/resources/packages/opkg_packages.go
@@ -53,6 +53,9 @@ func ParseOpkgPackages(input io.Reader) ([]Package, error) {
 	add := func(pkg Package) {
 		// do sanitization checks to ensure we have minimal information
 		if pkg.Name != "" && pkg.Version != "" {
+			// opkg records a hold in the flag field of the status triple,
+			// where dpkg carried it historically.
+			pkg.Pinned = isHeldStatus(pkg.Status)
 			pkgs = append(pkgs, pkg)
 		} else {
 			log.Debug().Msg("ignored opkg packages since information is missing")

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -4,6 +4,7 @@
 package packages
 
 import (
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -25,11 +26,16 @@ const (
 )
 
 type Package struct {
-	Name        string `json:"name"`
-	Version     string `json:"version"`
-	Epoch       string `json:"epoch,omitempty"`
-	Arch        string `json:"arch"`
-	Status      string `json:"status,omitempty"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Epoch   string `json:"epoch,omitempty"`
+	Arch    string `json:"arch"`
+	Status  string `json:"status,omitempty"`
+
+	// Pinned reports that the package manager is configured to hold this
+	// package at its current version: a dpkg or opkg hold, a dnf or yum
+	// versionlock, or a zypper lock.
+	Pinned      bool   `json:"pinned,omitempty"`
 	Description string `json:"description"`
 
 	// this may be the source package or an origin
@@ -194,4 +200,28 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 	}
 
 	return pms, nil
+}
+
+// isHeldStatus reports whether a dpkg-style status triple holds the package at
+// its current version.
+//
+// The triple is "<want> <flag> <state>". dpkg records a hold in the want field,
+// which is what `apt-mark hold` writes:
+//
+//	Status: hold ok installed
+//
+// opkg records it in the flag field, where dpkg carried it historically:
+//
+//	Status: install hold installed
+//
+// Only those two positions are considered. Matching "hold" anywhere in the
+// string would also fire on a package whose name or state merely contains it.
+func isHeldStatus(status string) bool {
+	fields := strings.Fields(status)
+	for i := 0; i < len(fields) && i < 2; i++ {
+		if fields[i] == "hold" {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/os/resources/packages/pkg_locks.go
+++ b/providers/os/resources/packages/pkg_locks.go
@@ -1,0 +1,271 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"io"
+	"path"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+)
+
+// Lock files are read rather than the tools being asked, so a held package is
+// reported the same way on a running host, a container image and a mounted
+// filesystem. The commands (`dnf versionlock list`, `zypper locks`) only print
+// what these files already contain, and they cannot run on an image at all.
+
+// versionlockPaths are the stores the RPM family writes locks to, newest first.
+//
+// On RHEL 9 and its rebuilds the yum path is a symlink to the dnf one, so
+// probing rather than gating on a platform version resolves both with one read
+// and stays correct on distributions this list has never heard of.
+var versionlockPaths = []string{
+	"/etc/dnf/versionlock.toml",              // dnf5: RHEL 10, Fedora 41+
+	"/etc/dnf/plugins/versionlock.list",      // dnf4: RHEL 8/9, Fedora <= 40
+	"/etc/yum/pluginconf.d/versionlock.list", // yum: RHEL 7, Amazon Linux 2
+}
+
+// zypperLocksPath is where zypper records `zypper addlock`.
+const zypperLocksPath = "/etc/zypp/locks"
+
+// lockedNames is the set of package names a lock store holds. A nil or empty
+// set means nothing is locked, which is the normal state of most hosts.
+type lockedNames map[string]struct{}
+
+func (l lockedNames) has(name string) bool {
+	if len(l) == 0 || name == "" {
+		return false
+	}
+	if _, ok := l[name]; ok {
+		return true
+	}
+	// A lock may be written as a glob, e.g. `kernel*`.
+	for pattern := range l {
+		if !strings.ContainsAny(pattern, "*?[") {
+			continue
+		}
+		if ok, err := path.Match(pattern, name); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// readVersionlock returns the package names locked on an RPM-family host. A
+// missing store is the common case and is not an error: it means the
+// versionlock plugin is not installed, so nothing is locked.
+func readVersionlock(fs afero.Fs) lockedNames {
+	for _, p := range versionlockPaths {
+		f, err := fs.Open(p)
+		if err != nil {
+			continue
+		}
+		raw, err := io.ReadAll(f)
+		f.Close()
+		if err != nil {
+			log.Debug().Err(err).Str("path", p).Msg("could not read the versionlock store")
+			continue
+		}
+
+		if strings.HasSuffix(p, ".toml") {
+			return parseVersionlockTOML(raw)
+		}
+		return parseVersionlockList(string(raw))
+	}
+	return nil
+}
+
+// parseVersionlockList reads the flat store dnf4 and yum write, one entry per
+// line with `#` comments:
+//
+//	# Added lock on Sun Aug 23 10:39:39 2026
+//	vim-minimal-2:8.2.2637-26.el9_8.4.*
+//
+// The two write the epoch in different places. dnf4 puts it after the name, as
+// above; yum puts it in front of the whole entry:
+//
+//	2:vim-minimal-9.0.2153-1.amzn2.0.9.*
+//
+// Both are handled, because both were read off a real host: the first from
+// AlmaLinux 9, the second from Amazon Linux 2.
+func parseVersionlockList(content string) lockedNames {
+	out := lockedNames{}
+	for _, line := range strings.Split(content, "\n") {
+		entry := strings.TrimSpace(line)
+		if idx := strings.IndexByte(entry, '#'); idx >= 0 {
+			entry = strings.TrimSpace(entry[:idx])
+		}
+		if entry == "" {
+			continue
+		}
+		if name := versionlockEntryName(entry); name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// versionlockEntryName recovers the package name from a versionlock entry.
+//
+// An entry is a NEVRA with globs: `name-[epoch:]version-release.arch`. Both the
+// name and the release contain hyphens, so neither the first nor the last one
+// separates the name. The version and release are the last two hyphen-separated
+// components, so removing them leaves the name whatever it contains:
+//
+//	vim-minimal-2:8.2.2637-26.el9_8.4.*   -> vim-minimal
+//	java-1.8.0-openjdk-1:1.8.0.442-2.el9  -> java-1.8.0-openjdk
+//
+// The second is why a left-to-right scan for "hyphen followed by a digit" does
+// not work: that name begins with one. An entry with fewer than two hyphens
+// names no version and is returned whole, so a glob such as `kernel*` survives
+// for `has` to match as a pattern.
+func versionlockEntryName(entry string) string {
+	// yum writes a leading `<epoch>:`; strip it before splitting.
+	if idx := strings.IndexByte(entry, ':'); idx > 0 && isAllDigits(entry[:idx]) {
+		entry = entry[idx+1:]
+	}
+
+	// drop release.arch, then epoch:version
+	rest, _, found := cutLast(entry, '-')
+	if !found {
+		return entry
+	}
+	name, _, found := cutLast(rest, '-')
+	if !found {
+		return entry
+	}
+	return name
+}
+
+// cutLast splits s around the last instance of sep.
+func cutLast(s string, sep byte) (before, after string, found bool) {
+	i := strings.LastIndexByte(s, sep)
+	if i < 0 {
+		return s, "", false
+	}
+	return s[:i], s[i+1:], true
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// versionlockTOML is the store dnf5 writes, which is a different format rather
+// than a different path:
+//
+//	version = "1.0"
+//
+//	[[packages]]
+//	name = "vim-minimal"
+//	comment = "Added by 'versionlock add' command on 2026-08-23"
+//
+//	[[packages.conditions]]
+//	key = "evr"
+//	comparator = "="
+//	value = "2:9.2.530-1.fc44"
+//
+// Only the name is needed: a lock pinned to a specific version still means the
+// installed package is held.
+type versionlockTOML struct {
+	Packages []struct {
+		Name string `toml:"name"`
+	} `toml:"packages"`
+}
+
+func parseVersionlockTOML(raw []byte) lockedNames {
+	var doc versionlockTOML
+	if err := toml.Unmarshal(raw, &doc); err != nil {
+		// A store that does not parse is not an empty store. Report it and
+		// return nothing rather than claiming the host has no locks.
+		log.Warn().Err(err).Msg("could not parse the dnf versionlock store, locks will not be reported")
+		return nil
+	}
+
+	out := lockedNames{}
+	for _, pkg := range doc.Packages {
+		if pkg.Name != "" {
+			out[pkg.Name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// readZypperLocks returns the package names locked with `zypper addlock`. The
+// store is a paragraph per lock:
+//
+//	type: package
+//	match_type: glob
+//	case_sensitive: on
+//	solvable_name: vim
+//
+// A lock may target something other than a package (a pattern, a product), and
+// those are skipped: they do not hold an installed package at its version.
+func readZypperLocks(fs afero.Fs) lockedNames {
+	f, err := fs.Open(zypperLocksPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	raw, err := io.ReadAll(f)
+	if err != nil {
+		log.Debug().Err(err).Msg("could not read the zypper lock store")
+		return nil
+	}
+	return parseZypperLocks(string(raw))
+}
+
+func parseZypperLocks(content string) lockedNames {
+	out := lockedNames{}
+
+	// Paragraphs are separated by blank lines. A lock with no explicit type is
+	// a package lock, which is what zypper writes by default.
+	for _, block := range strings.Split(content, "\n\n") {
+		name := ""
+		isPackage := true
+		for _, line := range strings.Split(block, "\n") {
+			key, value, found := strings.Cut(line, ":")
+			if !found {
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			switch key {
+			case "solvable_name":
+				name = value
+			case "type":
+				isPackage = value == "package"
+			}
+		}
+		if name != "" && isPackage {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// markPinned flags the packages a lock store holds. Called once per listing,
+// so the store is read once rather than once per package.
+func markPinned(pkgs []Package, locks lockedNames) []Package {
+	if len(locks) == 0 {
+		return pkgs
+	}
+	for i := range pkgs {
+		if locks.has(pkgs[i].Name) {
+			pkgs[i].Pinned = true
+		}
+	}
+	return pkgs
+}

--- a/providers/os/resources/packages/pkg_locks_test.go
+++ b/providers/os/resources/packages/pkg_locks_test.go
@@ -1,0 +1,194 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsHeldStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		held   bool
+		why    string
+	}{
+		{"hold ok installed", true, "dpkg records the hold in the want field, which is what apt-mark hold writes"},
+		{"install hold installed", true, "opkg records it in the flag field, where dpkg carried it historically"},
+		{"install ok installed", false, "the ordinary installed package"},
+		{"deinstall ok config-files", false, "removed but configured"},
+		{"", false, "no status at all"},
+		{"install ok not-installed", false, ""},
+		// The reason this reads two fields rather than searching the string:
+		// a package may be called anything.
+		{"install ok installed hold-foo", false, "a token after the triple is not a hold"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.status, func(t *testing.T) {
+			assert.Equal(t, test.held, isHeldStatus(test.status), test.why)
+		})
+	}
+}
+
+// The entry formats below were read off real hosts, not written by hand: the
+// dnf4 one from AlmaLinux 9, the yum one from Amazon Linux 2. They put the
+// epoch in different places, which is the detail documentation does not warn
+// about.
+func TestVersionlockEntryName(t *testing.T) {
+	tests := []struct {
+		entry string
+		name  string
+		why   string
+	}{
+		{"vim-minimal-2:8.2.2637-26.el9_8.4.*", "vim-minimal", "dnf4: epoch sits after the name"},
+		{"2:vim-minimal-9.0.2153-1.amzn2.0.9.*", "vim-minimal", "yum: epoch prefixes the whole entry"},
+		{"kernel-0:5.14.0-284.el9.x86_64", "kernel", ""},
+		// A name containing a hyphen must not be cut at the first one.
+		{"python3-dnf-plugin-versionlock-4.3.0-1.el9.noarch", "python3-dnf-plugin-versionlock", ""},
+		// The case that rules out a left-to-right scan: this name itself
+		// begins with a hyphen followed by a digit.
+		{"java-1.8.0-openjdk-1:1.8.0.442.b06-2.el9.x86_64", "java-1.8.0-openjdk", "a name that contains a version-looking part"},
+		{"kernel*", "kernel*", "a bare glob names no version and is kept whole"},
+		{"nginx", "nginx", "a bare name"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.entry, func(t *testing.T) {
+			assert.Equal(t, test.name, versionlockEntryName(test.entry), test.why)
+		})
+	}
+}
+
+func TestParseVersionlockListFixtures(t *testing.T) {
+	for _, tc := range []struct{ fixture, why string }{
+		{"versionlock_dnf4.list", "written by dnf versionlock add on almalinux:9"},
+		{"versionlock_yum.list", "written by yum versionlock add on amazonlinux:2"},
+	} {
+		t.Run(tc.fixture, func(t *testing.T) {
+			raw, err := os.ReadFile("testdata/" + tc.fixture)
+			require.NoError(t, err)
+
+			locks := parseVersionlockList(string(raw))
+			assert.True(t, locks.has("vim-minimal"), tc.why)
+			// The comment line and the leading blank line are not entries.
+			assert.Len(t, locks, 1)
+			// A different package on the same host is not locked.
+			assert.False(t, locks.has("vim"), "a prefix of a locked name is a different package")
+			assert.False(t, locks.has("bash"))
+		})
+	}
+}
+
+func TestParseVersionlockTOMLFixture(t *testing.T) {
+	// dnf5 changed the format, not just the path.
+	raw, err := os.ReadFile("testdata/versionlock_dnf5.toml")
+	require.NoError(t, err)
+
+	locks := parseVersionlockTOML(raw)
+	assert.True(t, locks.has("vim-minimal"), "written by dnf versionlock add on fedora:latest")
+	assert.Len(t, locks, 1)
+	assert.False(t, locks.has("vim"))
+}
+
+func TestParseZypperLocksFixture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/zypp_locks")
+	require.NoError(t, err)
+
+	locks := parseZypperLocks(string(raw))
+	assert.True(t, locks.has("vim"), "written by zypper al on opensuse/leap:15")
+	assert.Len(t, locks, 1)
+}
+
+// A lock on something that is not a package does not hold an installed package
+// at its version, so it must not mark one pinned.
+func TestParseZypperLocksSkipsNonPackageLocks(t *testing.T) {
+	locks := parseZypperLocks(`type: package
+match_type: glob
+case_sensitive: on
+solvable_name: vim
+
+type: pattern
+match_type: glob
+case_sensitive: on
+solvable_name: devel_basis
+`)
+	assert.True(t, locks.has("vim"))
+	assert.False(t, locks.has("devel_basis"), "a pattern lock is not a package lock")
+	assert.Len(t, locks, 1)
+}
+
+// An absent store is the normal state of most hosts: the plugin is not
+// installed, so nothing is locked. It must not read as an error.
+func TestReadLocksWithNoStore(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	assert.Empty(t, readVersionlock(fs))
+	assert.Empty(t, readZypperLocks(fs))
+	assert.False(t, readVersionlock(fs).has("anything"))
+}
+
+func TestReadVersionlockPrefersTheNewestStore(t *testing.T) {
+	// RHEL 9 symlinks the yum path onto the dnf one; a host that carries both
+	// a dnf5 and a dnf4 store should be read as dnf5.
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/etc/dnf/versionlock.toml",
+		[]byte("version = \"1.0\"\n\n[[packages]]\nname = \"from-toml\"\n"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/etc/dnf/plugins/versionlock.list",
+		[]byte("from-list-1.0-1.el9.*\n"), 0o644))
+
+	locks := readVersionlock(fs)
+	assert.True(t, locks.has("from-toml"))
+	assert.False(t, locks.has("from-list"))
+}
+
+func TestLockedNamesGlob(t *testing.T) {
+	locks := lockedNames{"kernel*": struct{}{}, "nginx": struct{}{}}
+	assert.True(t, locks.has("kernel-core"), "a glob lock covers the packages it matches")
+	assert.True(t, locks.has("nginx"))
+	assert.False(t, locks.has("bash"))
+	assert.False(t, lockedNames{}.has("anything"), "an empty store locks nothing")
+	assert.False(t, locks.has(""), "an empty name matches nothing")
+}
+
+// The opkg status fixture in this repo has carried a held package since before
+// this field existed: `Status: install hold installed` on libc. It is the one
+// fixture that already contained the shape, so it is the one that proves the
+// status-file path end to end rather than proving the helper in isolation.
+func TestOpkgFixtureReportsTheHeldPackage(t *testing.T) {
+	raw, err := os.ReadFile("testdata/packages_opkg_statusfile.toml")
+	require.NoError(t, err)
+
+	// pull the embedded status file out of the mock fixture
+	content := string(raw)
+	start := strings.Index(content, `[files."/usr/lib/opkg/status"]`)
+	require.GreaterOrEqual(t, start, 0)
+	start = strings.Index(content[start:], `"""`) + start + 3
+	end := strings.Index(content[start:], `"""`) + start
+
+	pkgs, err := ParseOpkgPackages(strings.NewReader(content[start:end]))
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs)
+
+	pinned := map[string]bool{}
+	for _, p := range pkgs {
+		pinned[p.Name] = p.Pinned
+	}
+	// Both of the fixture's held packages, and only those two.
+	assert.True(t, pinned["libc"], "libc carries `Status: install hold installed`")
+	assert.True(t, pinned["libpthread"], "libpthread carries it too")
+
+	var held []string
+	for name, isPinned := range pinned {
+		if isPinned {
+			held = append(held, name)
+		}
+	}
+	assert.ElementsMatch(t, []string{"libc", "libpthread"}, held,
+		"exactly the held packages are pinned, out of %d in the fixture", len(pinned))
+}

--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -300,11 +300,47 @@ func (rpm *RpmPkgManager) isStaticAnalysis() bool {
 }
 
 func (rpm *RpmPkgManager) List() ([]Package, error) {
+	var pkgs []Package
+	var err error
 	if rpm.isStaticAnalysis() {
-		return rpm.staticList()
+		pkgs, err = rpm.staticList()
 	} else {
-		return rpm.runtimeList()
+		pkgs, err = rpm.runtimeList()
 	}
+	if err != nil {
+		return nil, err
+	}
+	return markPinned(pkgs, rpm.lockedPackages()), nil
+}
+
+// lockedPackages reads the versionlock store. Overridden by SusePkgManager,
+// which locks through zypper instead.
+func (rpm *RpmPkgManager) lockedPackages() lockedNames {
+	return readVersionlock(rpm.conn.FileSystem())
+}
+
+// lockedPackages reads zypper's lock store. SUSE has no versionlock plugin, so
+// reading the dnf paths there would always come back empty.
+func (spm *SusePkgManager) lockedPackages() lockedNames {
+	return readZypperLocks(spm.conn.FileSystem())
+}
+
+// List reads the rpm database and marks the packages zypper holds. The
+// embedded RpmPkgManager.List cannot be reused for this: it calls
+// lockedPackages on the embedded value, which resolves to the versionlock
+// reader rather than this override.
+func (spm *SusePkgManager) List() ([]Package, error) {
+	var pkgs []Package
+	var err error
+	if spm.isStaticAnalysis() {
+		pkgs, err = spm.staticList()
+	} else {
+		pkgs, err = spm.runtimeList()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return markPinned(pkgs, spm.lockedPackages()), nil
 }
 
 func (rpm *RpmPkgManager) Available() (map[string]PackageUpdate, error) {

--- a/providers/os/resources/packages/testdata/versionlock_dnf4.list
+++ b/providers/os/resources/packages/testdata/versionlock_dnf4.list
@@ -1,0 +1,3 @@
+
+# Added lock on Sun Aug 23 10:39:39 2026
+vim-minimal-2:8.2.2637-26.el9_8.4.*

--- a/providers/os/resources/packages/testdata/versionlock_dnf5.toml
+++ b/providers/os/resources/packages/testdata/versionlock_dnf5.toml
@@ -1,0 +1,11 @@
+version = "1.0"
+
+[[packages]]
+name = "vim-minimal"
+comment = "Added by 'versionlock add' command on 2026-08-23 10:40:07"
+
+[[packages.conditions]]
+key = "evr"
+comparator = "="
+value = "2:9.2.530-1.fc44"
+

--- a/providers/os/resources/packages/testdata/versionlock_yum.list
+++ b/providers/os/resources/packages/testdata/versionlock_yum.list
@@ -1,0 +1,3 @@
+
+# Added locks on Sun Aug 23 10:40:58 2026
+2:vim-minimal-9.0.2153-1.amzn2.0.9.*

--- a/providers/os/resources/packages/testdata/zypp_locks
+++ b/providers/os/resources/packages/testdata/zypp_locks
@@ -1,0 +1,6 @@
+
+type: package
+match_type: glob
+case_sensitive: on
+solvable_name: vim
+

--- a/test/providers/packages_matrix_test.go
+++ b/test/providers/packages_matrix_test.go
@@ -1,0 +1,258 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build debugtest
+
+// Package-resource regression matrix.
+//
+// Run it deliberately while working on `packages`, not on every build:
+//
+//	make test/packages/matrix
+//
+// It pulls one image per package manager, so it costs minutes and bandwidth,
+// which is why it carries the debugtest tag and does not compile into
+// `go test ./...`.
+//
+// It asserts *invariants*, not recorded values. A golden file over public
+// images breaks every time upstream rebuilds, and a test that fails for that
+// reason gets muted, which is worse than not having it.
+package providers
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/test"
+)
+
+type matrixPkg struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Arch    string `json:"arch"`
+	Format  string `json:"format"`
+	Purl    string `json:"purl"`
+	Pinned  bool   `json:"pinned"`
+}
+
+type matrixCase struct {
+	image  string
+	format string // the package format this platform must resolve to
+	// pkg is locked, then re-scanned. Empty means the manager has no lock
+	// mechanism, and the assertion becomes "nothing is ever pinned".
+	pkg  string
+	lock string
+}
+
+// One image per manager and era. The lock commands are the real ones; what
+// they write to disk is what the resource reads.
+var packageMatrix = []matrixCase{
+	{
+		image: "debian:12", format: "deb", pkg: "nginx",
+		lock: "apt-get update -qq && apt-get install -y -qq nginx && apt-mark hold nginx",
+	},
+	{
+		image: "almalinux:9", format: "rpm", pkg: "vim-minimal",
+		lock: "dnf install -y python3-dnf-plugin-versionlock && dnf versionlock add vim-minimal",
+	},
+	{
+		image: "amazonlinux:2", format: "rpm", pkg: "vim-minimal",
+		lock: "yum install -y yum-plugin-versionlock && yum versionlock add vim-minimal",
+	},
+	{
+		image: "fedora:latest", format: "rpm", pkg: "vim-minimal",
+		lock: "dnf install -y 'dnf5-command(versionlock)' && dnf versionlock add vim-minimal",
+	},
+	{
+		image: "opensuse/leap:15", format: "rpm", pkg: "vim",
+		lock: "zypper --non-interactive install vim && zypper --non-interactive al vim",
+	},
+	// tdnf ships no versionlock plugin, and none is available in the Photon
+	// repositories, so a Photon host can never report a pinned package.
+	{image: "photon:5.0", format: "rpm"},
+	// apk has no lock mechanism at all.
+	{image: "alpine:3.21", format: "apk"},
+}
+
+func TestPackagesMatrix(t *testing.T) {
+	once.Do(setup)
+	requireDocker(t)
+
+	// setup() installs the provider into the user's config directory, but a
+	// system-wide provider under /Library/Mondoo (or /opt/mondoo) shadows it
+	// when one is present, and a stale system provider silently answers with
+	// the previous schema. Point the search path at the build under test
+	// instead, so this matrix always exercises the working tree.
+	providerDir := stageProviderUnderTest(t)
+	t.Setenv("PROVIDERS_PATH", providerDir)
+
+	for _, tc := range packageMatrix {
+		t.Run(tc.image, func(t *testing.T) {
+			id := dockerRunDetached(t, tc.image)
+
+			before := matrixPackages(t, "docker", "container", id)
+			assertPackageInvariants(t, tc, before)
+
+			for _, p := range before {
+				assert.Falsef(t, p.Pinned, "%s is pinned before anything was locked", p.Name)
+			}
+
+			if tc.pkg == "" {
+				// Nothing to lock: this manager has no mechanism, and the
+				// assertion above is the whole test.
+				return
+			}
+
+			target := findPackage(before, tc.pkg)
+			if target == nil {
+				// Install happens as part of the lock command below, so an
+				// absent package here is expected for images that do not ship
+				// it. The post-lock scan is what matters.
+				t.Logf("%s is not preinstalled; the lock command installs it", tc.pkg)
+			}
+
+			runInContainer(t, id, tc.lock)
+
+			// Re-scan the same running container.
+			after := matrixPackages(t, "docker", "container", id)
+			assertPackageInvariants(t, tc, after)
+			assertOnlyPinned(t, after, tc.pkg)
+
+			// The same state read as an image, where no command can run. This
+			// is the assertion the file-based design rests on: a reader that
+			// shelled out would report nothing pinned here.
+			img := commitContainer(t, id)
+			viaImage := matrixPackages(t, "docker", "image", img)
+			assertPackageInvariants(t, tc, viaImage)
+			assertOnlyPinned(t, viaImage, tc.pkg)
+
+			assert.ElementsMatch(t, names(after), names(viaImage),
+				"the container and image connections disagree about which packages exist")
+		})
+	}
+}
+
+// assertPackageInvariants holds for every image, before and after locking.
+func assertPackageInvariants(t *testing.T, tc matrixCase, pkgs []matrixPkg) {
+	t.Helper()
+	require.NotEmpty(t, pkgs, "no packages were read at all")
+
+	seen := map[string]string{}
+	for _, p := range pkgs {
+		assert.NotEmptyf(t, p.Name, "a package has no name: %+v", p)
+		assert.NotEmptyf(t, p.Version, "%s has no version", p.Name)
+		assert.Equalf(t, tc.format, p.Format, "%s has the wrong format for this platform", p.Name)
+		assert.Truef(t, strings.HasPrefix(p.Purl, "pkg:"), "%s has an unparseable purl %q", p.Name, p.Purl)
+
+		// The identity a package is cached under. A collision means one entry
+		// silently reports another's data.
+		key := p.Name + "\x00" + p.Arch + "\x00" + p.Version
+		if prev, dup := seen[key]; dup {
+			t.Errorf("two packages share name+arch+version: %s and %s", prev, p.Name)
+		}
+		seen[key] = p.Name
+	}
+}
+
+// assertOnlyPinned checks that the locked package is pinned and nothing else is.
+func assertOnlyPinned(t *testing.T, pkgs []matrixPkg, locked string) {
+	t.Helper()
+
+	var pinned []string
+	for _, p := range pkgs {
+		if p.Pinned {
+			pinned = append(pinned, p.Name)
+		}
+	}
+	assert.Equalf(t, []string{locked}, pinned,
+		"expected exactly %q to be pinned", locked)
+}
+
+func findPackage(pkgs []matrixPkg, name string) *matrixPkg {
+	for i := range pkgs {
+		if pkgs[i].Name == name {
+			return &pkgs[i]
+		}
+	}
+	return nil
+}
+
+func names(pkgs []matrixPkg) []string {
+	out := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		out = append(out, p.Name)
+	}
+	return out
+}
+
+// matrixPackages runs the query the same way the rpm smoke test does, and
+// parses the result key-agnostically so it does not depend on how mql labels
+// the queried block.
+func matrixPackages(t *testing.T, target ...string) []matrixPkg {
+	t.Helper()
+
+	args := make([]string, 0, 4+len(target))
+	args = append(args, "run")
+	args = append(args, target...)
+	args = append(args, "-c", "packages.list { name version arch format purl pinned }", "-j")
+
+	r := test.NewCliTestRunner("./mql", args...)
+	require.NoError(t, r.Run())
+	require.Equalf(t, 0, r.ExitCode(), "mql exited non-zero; stderr: %s", string(r.Stderr()))
+
+	var assets []map[string][]matrixPkg
+	if err := r.Json(&assets); err != nil {
+		t.Fatalf("parsing mql json failed: %v\n--- stdout ---\n%s\n--- stderr ---\n%s",
+			err, string(r.Stdout()), string(r.Stderr()))
+	}
+	require.Lenf(t, assets, 1, "expected exactly one asset result; stdout: %s", string(r.Stdout()))
+	for _, list := range assets[0] {
+		return list
+	}
+	t.Fatalf("no package list in mql output; stdout: %s", string(r.Stdout()))
+	return nil
+}
+
+// stageProviderUnderTest copies the freshly built os provider into a directory
+// of its own and returns it for PROVIDERS_PATH, which replaces the provider
+// search path entirely.
+func stageProviderUnderTest(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	osDir := filepath.Join(dir, "os")
+	require.NoError(t, os.MkdirAll(osDir, 0o755))
+
+	matches, err := filepath.Glob(filepath.Join("..", "..", "providers", "os", "dist", "os*"))
+	require.NoError(t, err)
+	require.NotEmptyf(t, matches, "no built os provider in providers/os/dist; setup() should have built one")
+
+	for _, src := range matches {
+		raw, err := os.ReadFile(src)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(osDir, filepath.Base(src)), raw, 0o755))
+	}
+	return dir
+}
+
+func runInContainer(t *testing.T, id, script string) {
+	t.Helper()
+	cmd := exec.Command("docker", "exec", id, "sh", "-c", script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("could not apply the lock in %s: %v\n%s", id, err, string(out))
+	}
+}
+
+func commitContainer(t *testing.T, id string) string {
+	t.Helper()
+	tag := fmt.Sprintf("mql-pkgmatrix-%s:latest", id[:12])
+	out, err := exec.Command("docker", "commit", id, tag).CombinedOutput()
+	require.NoErrorf(t, err, "could not commit %s: %s", id, string(out))
+	t.Cleanup(func() { _ = exec.Command("docker", "rmi", "-f", tag).Run() })
+	return tag
+}


### PR DESCRIPTION
An audit that finds an outdated package cannot tell **"nobody has patched this yet"** from **"this host is configured never to patch it."** Only the second needs a human — somebody ran `apt-mark hold` on purpose — and today that decision is invisible, so the remediation ticket goes to someone who discovers the hold only after trying to patch.

`package.pinned` is true when the package manager is configured not to upgrade the package.

```javascript
packages.where(outdated && pinned)          // blocked, needs a decision
packages.where(outdated && !pinned)         // simply unpatched
```

## It reads files, not tools

This is the decision with the longest reach, and it is made for coverage. mql scans images, mounted filesystems and snapshots, where **no command can run at all**. A reader built on `apt-mark showhold` reports "nothing is pinned" there, which is indistinguishable from a host that holds nothing — a check that passes precisely where it knows least.

Verified on both connection types. The same locked host, scanned as a running container and as a committed image:

```
$ mql run docker container lp-debian -c 'packages.where(name=="nginx"){pinned}'   -> pinned: true
$ mql run docker image  pinned-test-debian -c 'packages.where(name=="nginx"){pinned}'  -> pinned: true
```

## What the real hosts taught me

The formats were captured off running containers rather than taken from documentation, which is where both surprises came from:

**dnf5 changes the format, not just the path.** `/etc/dnf/versionlock.toml`, and it is TOML:

```toml
[[packages]]
name = "vim-minimal"
```

**dnf4 and yum put the epoch in different places** — same plugin name, same command, different output:

```
dnf4 (almalinux:9)     vim-minimal-2:8.2.2637-26.el9_8.4.*
yum  (amazonlinux:2)   2:vim-minimal-9.0.2153-1.amzn2.0.9.*
```

**Photon's tdnf has no versionlock at all** — no plugin, no config directory, nothing in its repositories, and `tdnf versionlock` answers `No such command`. So Photon reports false, like apk, and the field documentation says so. False has to mean "there is no such thing here", not "this was not checked".

**Two managers cost nothing.** The hold is already in the status triple the resource parses, in two spellings that are both real — dpkg writes it in the *want* field, opkg in the *flag* field, where dpkg carried it historically. The opkg fixture already in this repo holds two packages, so that path was testable before this change existed.

## Probing, not version gating

The three versionlock stores are probed newest-first. One `RpmPkgManager` serves RHEL, Alma, Rocky, Oracle, Amazon Linux, Photon, azurelinux, bottlerocket and wrlinux on independent dnf/yum/tdnf timelines, so a version gate would encode a guess about each. This is the same probing the file already does to find the rpmdb across three eras. On RHEL 9 the yum path is a symlink onto the dnf one, so one read resolves both.

## Out of scope, deliberately

`/etc/apt/preferences` — those are priorities that bias candidate selection, not a freeze. Reporting them as pinned would call a host frozen when it is not. pacman's `IgnorePkg` is a real equivalent, left out only to keep this to the requested managers; it is additive under the same design.

## `make test/packages/matrix`

A docker-backed regression matrix for the package resource, tagged `debugtest` so it never runs in CI. **Full run, all seven images, 2m41s:**

```
--- PASS: TestPackagesMatrix (160.93s)
    --- PASS: debian:12          (14.96s)   dpkg
    --- PASS: almalinux:9        (24.34s)   dnf4
    --- PASS: amazonlinux:2      (29.30s)   yum
    --- PASS: fedora:latest      (18.29s)   dnf5
    --- PASS: opensuse/leap:15   (65.96s)   zypper
    --- PASS: photon:5.0          (1.95s)   tdnf, no mechanism
    --- PASS: alpine:3.21         (2.64s)   apk, no mechanism
```

Per image it locks a package, re-scans, commits to an image and re-scans that, then asserts **invariants rather than recorded values** — a golden file over public images breaks whenever upstream rebuilds, and a test that fails for that reason gets muted. It checks every package has a name, version and plausible purl; that `format` matches the platform; that no two packages share name+arch+version; that exactly the locked package is pinned; and that the container and image connections agree.

**It stages the provider under `PROVIDERS_PATH` rather than relying on `make providers/install/os`.** That is not incidental: on this machine a root-owned system provider at `/Library/Mondoo/providers/os` shadows the user install, so the matrix initially failed with `cannot find field 'pinned'` while the installed schema plainly contained it. The binaries were byte-identical; the system copy (17 fields) was simply winning over the home copy (18). Staging the build under test removes that whole class of confusion — and stops the suite clobbering a developer's installed provider.

## Regression check

Against a provider built from current `main`, `packages { name version arch epoch status installed format purl origin }` is **byte-identical across 413 packages** on almalinux, debian and opensuse. Unit tests cover both status spellings, both epoch layouts, the TOML store, zypper's non-package locks, glob locks, an absent store, and a package literally named `hold-foo`.

Closes the request in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
