### PR TITLE
🐛 aws: give WAF rate-based statements a real __id

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1185,7 +1185,12 @@ private aws.waf.rule.statement.orstatement {
 }
 
 // Rule statement that matches at a certain rate of requests (rate limiting)
-private aws.waf.rule.statement.ratebasedstatement {}
+private aws.waf.rule.statement.ratebasedstatement {
+  // Name of the rule this statement belongs to
+  ruleName string
+  // ID of the statement
+  statementID string
+}
 
 // Rule statement that checks for a regex pattern defined in a regex pattern set
 private aws.waf.rule.statement.regexpatternsetreferencestatement {

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5985,6 +5985,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.waf.rule.statement.orstatement.statements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRuleStatementOrstatement).GetStatements()).ToDataRes(types.Array(types.Resource("aws.waf.rule.statement")))
 	},
+	"aws.waf.rule.statement.ratebasedstatement.ruleName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafRuleStatementRatebasedstatement).GetRuleName()).ToDataRes(types.String)
+	},
+	"aws.waf.rule.statement.ratebasedstatement.statementID": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafRuleStatementRatebasedstatement).GetStatementID()).ToDataRes(types.String)
+	},
 	"aws.waf.rule.statement.regexpatternsetreferencestatement.ruleName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRuleStatementRegexpatternsetreferencestatement).GetRuleName()).ToDataRes(types.String)
 	},
@@ -38028,6 +38034,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.waf.rule.statement.ratebasedstatement.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRuleStatementRatebasedstatement).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.waf.rule.statement.ratebasedstatement.ruleName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafRuleStatementRatebasedstatement).RuleName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.waf.rule.statement.ratebasedstatement.statementID": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafRuleStatementRatebasedstatement).StatementID, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.waf.rule.statement.regexpatternsetreferencestatement.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -86728,6 +86742,8 @@ type mqlAwsWafRuleStatementRatebasedstatement struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlAwsWafRuleStatementRatebasedstatementInternal it will be used here
+	RuleName    plugin.TValue[string]
+	StatementID plugin.TValue[string]
 }
 
 // createAwsWafRuleStatementRatebasedstatement creates a new instance of this resource
@@ -86765,6 +86781,14 @@ func (c *mqlAwsWafRuleStatementRatebasedstatement) MqlName() string {
 
 func (c *mqlAwsWafRuleStatementRatebasedstatement) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlAwsWafRuleStatementRatebasedstatement) GetRuleName() *plugin.TValue[string] {
+	return &c.RuleName
+}
+
+func (c *mqlAwsWafRuleStatementRatebasedstatement) GetStatementID() *plugin.TValue[string] {
+	return &c.StatementID
 }
 
 // mqlAwsWafRuleStatementRegexpatternsetreferencestatement for the aws.waf.rule.statement.regexpatternsetreferencestatement resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -11139,6 +11139,8 @@ aws.waf.rule.statement.orstatement.statementID 11.15.2
 aws.waf.rule.statement.orstatement.statements 11.15.2
 aws.waf.rule.statement.rateBasedStatement 11.15.2
 aws.waf.rule.statement.ratebasedstatement 11.15.2
+aws.waf.rule.statement.ratebasedstatement.ruleName 13.53.4
+aws.waf.rule.statement.ratebasedstatement.statementID 13.53.4
 aws.waf.rule.statement.regexMatchStatement 11.15.2
 aws.waf.rule.statement.regexPatternSetReferenceStatement 11.15.2
 aws.waf.rule.statement.regexmatchstatement 11.15.2

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -499,7 +499,7 @@ func (a *mqlAwsWafRuleStatementAndstatement) id() (string, error) {
 }
 
 func (a *mqlAwsWafRuleStatementRatebasedstatement) id() (string, error) {
-	return "not implemented", nil
+	return a.StatementID.Data, nil
 }
 
 func (a *mqlAwsWafRuleStatementRegexpatternsetreferencestatement) id() (string, error) {
@@ -981,7 +981,10 @@ func createStatementResource(runtime *plugin.Runtime, statement *waftypes.Statem
 		}
 		if statement.RateBasedStatement != nil {
 			kind = "RateBasedStatement"
-			ratebasedstatement, err = CreateResource(runtime, "aws.waf.rule.statement.ratebasedstatement", map[string]*llx.RawData{})
+			ratebasedstatement, err = CreateResource(runtime, "aws.waf.rule.statement.ratebasedstatement", map[string]*llx.RawData{
+				"statementID": llx.StringData(mqlStatementID),
+				"ruleName":    llx.StringDataPtr(ruleName),
+			})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## The bug

`createStatementResource` built the rate-based statement from an **empty argument map**, and its `id()` returned a constant:

```go
// providers/aws/resources/aws_waf.go
ratebasedstatement, err = CreateResource(runtime, "aws.waf.rule.statement.ratebasedstatement",
    map[string]*llx.RawData{})   // no __id, no fields

func (a *mqlAwsWafRuleStatementRatebasedstatement) id() (string, error) {
    return "not implemented", nil
}
```

The runtime cache key is `resourceName + "\x00" + __id`, so **every rate-based rule in an account collapsed onto one entry** — `aws.waf.rule.statement.ratebasedstatement\x00not implemented`. The second and later statements resolved to the first one's cached resource.

The collision is unobservable today *only* because the schema block was empty:

```
private aws.waf.rule.statement.ratebasedstatement {}
```

That is exactly why it needed fixing before any field is added. The first field added to this block would have reported the first rule's value for every rate-based rule in the account, with nothing to indicate it — a silent wrong answer on the primary credential-stuffing control.

## The fix

Give the resource the two fields every one of its 12 sibling statement types already carries, and derive `id()` from `statementID`, which is already unique per statement (`ruleID + "/" + uuid`).

## Verification

Built from this branch and run against a live WAFv2 web ACL carrying **two** rate-based rules (created for the test and destroyed afterwards — teardown confirmed by re-listing).

**Before (`origin/main`)** — the query cannot compile, because the block has no fields:

```
failed to compile: cannot find field or resource 'ruleName'
in block for type 'aws.waf.rule.statement.ratebasedstatement'
```

**After (this branch)** — two distinct statements, each `ruleName` matching its own parent rule:

```
aws.waf.acls.where: [
  0: {
    name: "mql-ratebased-verify"
    rules: [
      0: { name: "RateLimitLogin"
           statement: { kind: "RateBasedStatement"
             rateBasedStatement: {
               ruleName: "RateLimitLogin"
               statementID: ".../webacl/mql-ratebased-verify/<acl-id>/RateLimitLogin/a74ea4a8-..." } } }
      1: { name: "RateLimitApi"
           statement: { kind: "RateBasedStatement"
             rateBasedStatement: {
               ruleName: "RateLimitApi"
               statementID: ".../webacl/mql-ratebased-verify/<acl-id>/RateLimitApi/322bd308-..." } } }
    ]
  }
]
```

Distinct `statementID` values, and each `ruleName` resolving to its own rule, is the evidence the two statements are now separate cache entries rather than one shared instance.

Also run: `gofmt` clean, `go build ./...`, `go test ./resources/...` (3 packages ok), `mqlr generate` reproduces the committed `.lr.go`.

## Notes

- `.lr.versions` entries land at `13.53.4`, one patch above the provider's shipped `13.53.3`. No `config.go` version bump.
- Scope is the identity fix only. Populating the block with the actual rate-limit posture — `limit`, `evaluationWindowSec`, `aggregateKeyType`, `scopeDownStatement` — is worth doing next, and is now safe to do; without this change those fields would have been wrong for every rule but the first.
