### PR TITLE
🐛 activedirectory: count primary-group membership and expose RBCD trustees

### DIFF
--- a/providers/activedirectory/resources/activedirectory.lr
+++ b/providers/activedirectory/resources/activedirectory.lr
@@ -398,6 +398,14 @@ activedirectory.computer @defaults("name operatingSystem enabled") {
   constrainedDelegationTargets []string
   // Resource-based constrained delegation configured
   rbcd bool
+  // Resource-based constrained delegation trustees
+  //
+  // Security identifiers of the principals granted rights in the
+  // msDS-AllowedToActOnBehalfOfOtherIdentity security descriptor. These are
+  // the accounts that can request Kerberos service tickets to this host on
+  // behalf of any user, which is what makes a resource-based constrained
+  // delegation entry a finding. Empty when rbcd is false.
+  rbcdPrincipals []string
   // Service Principal Names
   servicePrincipalNames []string
   // Whether LAPS is deployed on this computer

--- a/providers/activedirectory/resources/activedirectory.lr
+++ b/providers/activedirectory/resources/activedirectory.lr
@@ -255,6 +255,15 @@ activedirectory.user @defaults("sAMAccountName displayName enabled") {
   isStale bool
   // Group memberships (direct)
   memberOf []string
+  // Primary group RID
+  //
+  // Relative identifier of the account's primary group, for example 513 for
+  // Domain Users, 512 for Domain Admins, 519 for Enterprise Admins, or 518
+  // for Schema Admins. Primary group membership is a full membership but it
+  // never appears in memberOf and the account never appears in the group's
+  // member list, so a privileged value here is a group membership that a
+  // memberOf review will not show.
+  primaryGroupId int
   // Whether user is member of Domain Admins
   isDomainAdmin() bool
   // Whether user is member of Enterprise Admins

--- a/providers/activedirectory/resources/activedirectory.lr.go
+++ b/providers/activedirectory/resources/activedirectory.lr.go
@@ -580,6 +580,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"activedirectory.computer.rbcd": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlActivedirectoryComputer).GetRbcd()).ToDataRes(types.Bool)
 	},
+	"activedirectory.computer.rbcdPrincipals": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlActivedirectoryComputer).GetRbcdPrincipals()).ToDataRes(types.Array(types.String))
+	},
 	"activedirectory.computer.servicePrincipalNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlActivedirectoryComputer).GetServicePrincipalNames()).ToDataRes(types.Array(types.String))
 	},
@@ -1455,6 +1458,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"activedirectory.computer.rbcd": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlActivedirectoryComputer).Rbcd, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"activedirectory.computer.rbcdPrincipals": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlActivedirectoryComputer).RbcdPrincipals, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"activedirectory.computer.servicePrincipalNames": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3038,6 +3045,7 @@ type mqlActivedirectoryComputer struct {
 	ConstrainedDelegation        plugin.TValue[bool]
 	ConstrainedDelegationTargets plugin.TValue[[]any]
 	Rbcd                         plugin.TValue[bool]
+	RbcdPrincipals               plugin.TValue[[]any]
 	ServicePrincipalNames        plugin.TValue[[]any]
 	LapsEnabled                  plugin.TValue[bool]
 	LapsExpirationTime           plugin.TValue[*time.Time]
@@ -3158,6 +3166,10 @@ func (c *mqlActivedirectoryComputer) GetConstrainedDelegationTargets() *plugin.T
 
 func (c *mqlActivedirectoryComputer) GetRbcd() *plugin.TValue[bool] {
 	return &c.Rbcd
+}
+
+func (c *mqlActivedirectoryComputer) GetRbcdPrincipals() *plugin.TValue[[]any] {
+	return &c.RbcdPrincipals
 }
 
 func (c *mqlActivedirectoryComputer) GetServicePrincipalNames() *plugin.TValue[[]any] {

--- a/providers/activedirectory/resources/activedirectory.lr.go
+++ b/providers/activedirectory/resources/activedirectory.lr.go
@@ -439,6 +439,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"activedirectory.user.memberOf": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlActivedirectoryUser).GetMemberOf()).ToDataRes(types.Array(types.String))
 	},
+	"activedirectory.user.primaryGroupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlActivedirectoryUser).GetPrimaryGroupId()).ToDataRes(types.Int)
+	},
 	"activedirectory.user.isDomainAdmin": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlActivedirectoryUser).GetIsDomainAdmin()).ToDataRes(types.Bool)
 	},
@@ -1252,6 +1255,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"activedirectory.user.memberOf": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlActivedirectoryUser).MemberOf, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"activedirectory.user.primaryGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlActivedirectoryUser).PrimaryGroupId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"activedirectory.user.isDomainAdmin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2620,6 +2627,7 @@ type mqlActivedirectoryUser struct {
 	DaysSinceLastLogon            plugin.TValue[int64]
 	IsStale                       plugin.TValue[bool]
 	MemberOf                      plugin.TValue[[]any]
+	PrimaryGroupId                plugin.TValue[int64]
 	IsDomainAdmin                 plugin.TValue[bool]
 	IsEnterpriseAdmin             plugin.TValue[bool]
 	IsSchemaAdmin                 plugin.TValue[bool]
@@ -2765,6 +2773,10 @@ func (c *mqlActivedirectoryUser) GetIsStale() *plugin.TValue[bool] {
 
 func (c *mqlActivedirectoryUser) GetMemberOf() *plugin.TValue[[]any] {
 	return &c.MemberOf
+}
+
+func (c *mqlActivedirectoryUser) GetPrimaryGroupId() *plugin.TValue[int64] {
+	return &c.PrimaryGroupId
 }
 
 func (c *mqlActivedirectoryUser) GetIsDomainAdmin() *plugin.TValue[bool] {

--- a/providers/activedirectory/resources/activedirectory.lr.versions
+++ b/providers/activedirectory/resources/activedirectory.lr.versions
@@ -67,6 +67,7 @@ activedirectory.computer.passwordAgeDays 13.0.1
 activedirectory.computer.protocolTransition 13.0.1
 activedirectory.computer.pwdLastSet 13.0.1
 activedirectory.computer.rbcd 13.0.1
+activedirectory.computer.rbcdPrincipals 13.1.14
 activedirectory.computer.sAMAccountName 13.0.1
 activedirectory.computer.servicePrincipalNames 13.0.1
 activedirectory.computer.sid 13.0.1

--- a/providers/activedirectory/resources/activedirectory.lr.versions
+++ b/providers/activedirectory/resources/activedirectory.lr.versions
@@ -237,6 +237,7 @@ activedirectory.user.ouPath 13.0.1
 activedirectory.user.passwordAgeDays 13.0.1
 activedirectory.user.passwordNeverExpires 13.0.1
 activedirectory.user.passwordNotRequired 13.0.1
+activedirectory.user.primaryGroupId 13.1.14
 activedirectory.user.protectedUser 13.0.1
 activedirectory.user.pwdLastSet 13.0.1
 activedirectory.user.reversibleEncryption 13.0.1

--- a/providers/activedirectory/resources/computers.go
+++ b/providers/activedirectory/resources/computers.go
@@ -128,8 +128,16 @@ func (a *mqlActivedirectory) computers() ([]interface{}, error) {
 			delegateTargetsRaw[i] = v
 		}
 
-		// Resource-Based Constrained Delegation (RBCD)
-		rbcd := len(entry.GetRawAttributeValue("msDS-AllowedToActOnBehalfOfOtherIdentity")) > 0
+		// Resource-Based Constrained Delegation (RBCD). The attribute is a
+		// security descriptor; the principals named in its DACL are the
+		// accounts that can impersonate onto this host.
+		rbcdRaw := entry.GetRawAttributeValue("msDS-AllowedToActOnBehalfOfOtherIdentity")
+		rbcd := len(rbcdRaw) > 0
+		rbcdPrincipals := rbcdPrincipalSIDs(rbcdRaw)
+		rbcdPrincipalsRaw := make([]interface{}, len(rbcdPrincipals))
+		for i, v := range rbcdPrincipals {
+			rbcdPrincipalsRaw[i] = v
+		}
 
 		// Service principal names
 		spns := connection.GetStringSliceAttr(entry, "servicePrincipalName")
@@ -174,6 +182,7 @@ func (a *mqlActivedirectory) computers() ([]interface{}, error) {
 				"constrainedDelegation":        llx.BoolData(constrainedDelegation),
 				"constrainedDelegationTargets": llx.ArrayData(delegateTargetsRaw, types.String),
 				"rbcd":                         llx.BoolData(rbcd),
+				"rbcdPrincipals":               llx.ArrayData(rbcdPrincipalsRaw, types.String),
 				"servicePrincipalNames":        llx.ArrayData(spnsRaw, types.String),
 				"lapsEnabled":                  llx.BoolData(lapsEnabled),
 				"lapsExpirationTime":           llx.TimeData(lapsExpirationTime),

--- a/providers/activedirectory/resources/privileged.go
+++ b/providers/activedirectory/resources/privileged.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-ldap/ldap/v3"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers/activedirectory/connection"
 )
 
@@ -213,6 +214,226 @@ var ridToField = map[string]string{
 	"525": "ProtectedUsers",
 }
 
+// markPrivileged records a distinguished name in the union set and, when the
+// group has a dedicated set, in that set as well.
+func markPrivileged(pm *privilegedMemberships, field, dn string) {
+	pm.AllPrivileged[dn] = true
+
+	switch field {
+	case "DomainAdmins":
+		pm.DomainAdmins[dn] = true
+	case "EnterpriseAdmins":
+		pm.EnterpriseAdmins[dn] = true
+	case "SchemaAdmins":
+		pm.SchemaAdmins[dn] = true
+	case "ProtectedUsers":
+		pm.ProtectedUsers[dn] = true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primary group membership
+// ---------------------------------------------------------------------------
+//
+// An account's primary group is stored as the primaryGroupID attribute (a RID
+// relative to the account's own domain) and is a full membership: the account
+// is a member of that group even though the group never appears in memberOf
+// and the account never appears in the group's member attribute. The
+// LDAP_MATCHING_RULE_IN_CHAIN queries above therefore cannot see it, so it is
+// resolved separately here.
+
+// primaryGroupRecord is one account's primary group assignment, as read from
+// LDAP.
+type primaryGroupRecord struct {
+	dn             string
+	objectSID      string
+	primaryGroupID int64
+}
+
+// domainSIDFromObjectSID strips the trailing RID from an object SID, yielding
+// the SID of the domain that issued it. It returns "" for SIDs that no domain
+// issued, such as the well-known S-1-5-11 (Authenticated Users) or a BUILTIN
+// SID like S-1-5-32-544, neither of which can prefix a primaryGroupID.
+func domainSIDFromObjectSID(objectSID string) string {
+	// A domain account SID is S-1-5-21-<a>-<b>-<c>-<rid>: eight dash-separated
+	// parts. Anything shorter has no domain prefix to extract.
+	parts := strings.Split(objectSID, "-")
+	if len(parts) < 8 {
+		return ""
+	}
+	return strings.Join(parts[:len(parts)-1], "-")
+}
+
+// primaryGroupSIDForAccount resolves an account's primaryGroupID to the SID of
+// the group it names. The RID is relative to the domain that issued the
+// account's own SID, which keeps this correct in a multi-domain forest.
+func primaryGroupSIDForAccount(objectSID string, primaryGroupID int64) string {
+	if primaryGroupID <= 0 {
+		return ""
+	}
+	domainSID := domainSIDFromObjectSID(objectSID)
+	if domainSID == "" {
+		return ""
+	}
+	return domainSID + "-" + strconv.FormatInt(primaryGroupID, 10)
+}
+
+// primaryGroupCandidateRIDs returns the privileged RIDs that can appear as an
+// account's primaryGroupID. BUILTIN groups (S-1-5-32-*) are domain-local
+// groups on the machine and can never be a primary group, so they are skipped.
+func primaryGroupCandidateRIDs() []string {
+	rids := make([]string, 0, len(privilegedGroups))
+	seen := make(map[string]bool, len(privilegedGroups))
+	for _, pg := range privilegedGroups {
+		if pg.Base == "builtin" || seen[pg.RID] {
+			continue
+		}
+		seen[pg.RID] = true
+		rids = append(rids, pg.RID)
+	}
+	return rids
+}
+
+// primaryGroupSearchFilter builds the LDAP filter that selects every account
+// whose primaryGroupID is one of the given privileged RIDs. It returns "" when
+// there is nothing to search for.
+func primaryGroupSearchFilter(rids []string) string {
+	if len(rids) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(rids))
+	for _, rid := range rids {
+		parts = append(parts, fmt.Sprintf("(primaryGroupID=%s)", ldap.EscapeFilter(rid)))
+	}
+	return fmt.Sprintf("(&%s(|%s))", userObjectFilter, strings.Join(parts, ""))
+}
+
+// privilegedGroupSIDIndex maps the SID of every privileged group that can be a
+// primary group to the privilegedMemberships field it feeds. Groups that only
+// contribute to AllPrivileged map to "".
+func privilegedGroupSIDIndex(conn *connection.ActiveDirectoryConnection) (map[string]string, error) {
+	index := make(map[string]string, len(privilegedGroups))
+	for _, pg := range privilegedGroups {
+		if pg.Base == "builtin" {
+			continue
+		}
+		sidStr, err := privilegedGroupSID(conn, pg)
+		if err != nil {
+			return nil, err
+		}
+		// A group SID with no domain prefix means the domain SID was never
+		// discovered; skip it rather than indexing a bare "-512".
+		if strings.HasPrefix(sidStr, "-") {
+			continue
+		}
+		index[sidStr] = ridToField[pg.RID]
+	}
+	return index, nil
+}
+
+// fetchPrimaryGroupRecords reads every account whose primaryGroupID names a
+// privileged group, across all domain naming contexts the connection knows.
+func fetchPrimaryGroupRecords(conn *connection.ActiveDirectoryConnection) ([]primaryGroupRecord, error) {
+	filter := primaryGroupSearchFilter(primaryGroupCandidateRIDs())
+	if filter == "" {
+		return nil, nil
+	}
+
+	searchBases := conn.DomainNamingContexts()
+	if len(searchBases) == 0 {
+		searchBases = []string{conn.BaseDN()}
+	}
+
+	seen := make(map[string]bool)
+	var records []primaryGroupRecord
+
+	for _, searchBase := range searchBases {
+		if searchBase == "" {
+			continue
+		}
+
+		entries, err := connection.PagedSearch(conn.LDAPConn(), ldap.NewSearchRequest(
+			searchBase,
+			ldap.ScopeWholeSubtree,
+			ldap.NeverDerefAliases, 0, 0, false,
+			filter,
+			[]string{"distinguishedName", "objectSid", "primaryGroupID"},
+			nil,
+		))
+		if err != nil {
+			// Non-fatal: a naming context may not be searchable with these
+			// credentials. Keep whatever the other contexts returned.
+			log.Warn().Err(err).Str("searchBase", searchBase).Msg("primary group search failed")
+			continue
+		}
+
+		for _, entry := range entries {
+			dn := entry.DN
+			if dn == "" || seen[dn] {
+				continue
+			}
+			seen[dn] = true
+
+			sidStr, err := connection.DecodeSID(connection.GetBinaryAttr(entry, "objectSid"))
+			if err != nil {
+				log.Warn().Err(err).Str("dn", dn).Msg("failed to decode SID for primary group lookup")
+				continue
+			}
+
+			records = append(records, primaryGroupRecord{
+				dn:             dn,
+				objectSID:      sidStr,
+				primaryGroupID: parseInt64Attr(entry.GetAttributeValue("primaryGroupID")),
+			})
+		}
+	}
+
+	return records, nil
+}
+
+// applyPrimaryGroupMemberships folds primary group membership into the
+// privileged sets. sidToField maps a privileged group SID to the
+// privilegedMemberships field it feeds.
+func applyPrimaryGroupMemberships(pm *privilegedMemberships, sidToField map[string]string, records []primaryGroupRecord) {
+	for _, rec := range records {
+		if rec.dn == "" {
+			continue
+		}
+
+		groupSID := primaryGroupSIDForAccount(rec.objectSID, rec.primaryGroupID)
+		if groupSID == "" {
+			continue
+		}
+
+		field, ok := sidToField[groupSID]
+		if !ok {
+			continue
+		}
+
+		markPrivileged(pm, field, rec.dn)
+	}
+}
+
+// addPrimaryGroupMemberships resolves and folds primary group membership into
+// the already-populated privileged sets.
+func addPrimaryGroupMemberships(conn *connection.ActiveDirectoryConnection, pm *privilegedMemberships) error {
+	index, err := privilegedGroupSIDIndex(conn)
+	if err != nil {
+		return err
+	}
+	if len(index) == 0 {
+		return nil
+	}
+
+	records, err := fetchPrimaryGroupRecords(conn)
+	if err != nil {
+		return err
+	}
+
+	applyPrimaryGroupMemberships(pm, index, records)
+	return nil
+}
+
 // buildPrivilegedMembershipSets resolves all well-known privileged group
 // memberships via recursive LDAP queries and returns populated sets.
 // Results are cached on the connection for the lifetime of the scan.
@@ -269,21 +490,16 @@ func buildPrivilegedMembershipSets(conn *connection.ActiveDirectoryConnection) (
 				}
 
 				for _, entry := range entries {
-					dn := entry.DN
-					pm.AllPrivileged[dn] = true
-
-					switch field {
-					case "DomainAdmins":
-						pm.DomainAdmins[dn] = true
-					case "EnterpriseAdmins":
-						pm.EnterpriseAdmins[dn] = true
-					case "SchemaAdmins":
-						pm.SchemaAdmins[dn] = true
-					case "ProtectedUsers":
-						pm.ProtectedUsers[dn] = true
-					}
+					markPrivileged(pm, field, entry.DN)
 				}
 			}
+		}
+
+		// Primary group membership is invisible to the memberOf chain above,
+		// so fold it in separately. A failure here must not drop the
+		// memberOf-derived results, so it is logged rather than returned.
+		if err := addPrimaryGroupMemberships(conn, pm); err != nil {
+			log.Warn().Err(err).Msg("failed to resolve primary group memberships")
 		}
 
 		return pm, nil

--- a/providers/activedirectory/resources/privileged_primary_group_test.go
+++ b/providers/activedirectory/resources/privileged_primary_group_test.go
@@ -1,0 +1,220 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+)
+
+// Documentation-example domain SIDs. S-1-5-21-100-200-300 stands in for the
+// scanned domain and S-1-5-21-900-800-700 for the forest root.
+const (
+	testDomainSID     = "S-1-5-21-100-200-300"
+	testRootDomainSID = "S-1-5-21-900-800-700"
+)
+
+// testSIDIndex mirrors what privilegedGroupSIDIndex builds from a connection,
+// without needing a live directory.
+func testSIDIndex() map[string]string {
+	return map[string]string{
+		testDomainSID + "-512":     "DomainAdmins",
+		testDomainSID + "-525":     "ProtectedUsers",
+		testRootDomainSID + "-518": "SchemaAdmins",
+		testRootDomainSID + "-519": "EnterpriseAdmins",
+	}
+}
+
+func newTestMemberships() *privilegedMemberships {
+	return &privilegedMemberships{
+		DomainAdmins:     make(map[string]bool),
+		EnterpriseAdmins: make(map[string]bool),
+		SchemaAdmins:     make(map[string]bool),
+		ProtectedUsers:   make(map[string]bool),
+		AllPrivileged:    make(map[string]bool),
+	}
+}
+
+func TestDomainSIDFromObjectSID(t *testing.T) {
+	tests := []struct {
+		name string
+		sid  string
+		want string
+	}{
+		{"user SID", testDomainSID + "-1105", testDomainSID},
+		{"domain admins group SID", testDomainSID + "-512", testDomainSID},
+		{"forest root user SID", testRootDomainSID + "-1200", testRootDomainSID},
+		{"well-known Authenticated Users", "S-1-5-11", ""},
+		{"well-known Everyone", "S-1-1-0", ""},
+		{"BUILTIN Administrators", "S-1-5-32-544", ""},
+		{"empty", "", ""},
+		{"no dash", "S", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := domainSIDFromObjectSID(tt.sid); got != tt.want {
+				t.Errorf("domainSIDFromObjectSID(%q) = %q, want %q", tt.sid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrimaryGroupSIDForAccount(t *testing.T) {
+	tests := []struct {
+		name      string
+		objectSID string
+		rid       int64
+		want      string
+	}{
+		{"Domain Admins", testDomainSID + "-1105", 512, testDomainSID + "-512"},
+		{"Domain Users", testDomainSID + "-1105", 513, testDomainSID + "-513"},
+		{"Enterprise Admins in root domain", testRootDomainSID + "-1200", 519, testRootDomainSID + "-519"},
+		// A RID is relative to the account's own domain, so 519 on an account
+		// in a child domain does not name the forest-root Enterprise Admins.
+		{"519 in a child domain", testDomainSID + "-1105", 519, testDomainSID + "-519"},
+		{"unset primaryGroupID", testDomainSID + "-1105", 0, ""},
+		{"negative primaryGroupID", testDomainSID + "-1105", -1, ""},
+		{"well-known object SID", "S-1-5-11", 512, ""},
+		{"empty object SID", "", 512, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := primaryGroupSIDForAccount(tt.objectSID, tt.rid); got != tt.want {
+				t.Errorf("primaryGroupSIDForAccount(%q, %d) = %q, want %q",
+					tt.objectSID, tt.rid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrimaryGroupCandidateRIDs(t *testing.T) {
+	rids := primaryGroupCandidateRIDs()
+
+	want := map[string]bool{"512": true, "518": true, "519": true, "525": true}
+	got := make(map[string]bool, len(rids))
+	for _, rid := range rids {
+		if got[rid] {
+			t.Errorf("duplicate RID %q in candidate list", rid)
+		}
+		got[rid] = true
+	}
+
+	for rid := range want {
+		if !got[rid] {
+			t.Errorf("candidate RIDs missing %q, got %v", rid, rids)
+		}
+	}
+	// BUILTIN groups are domain-local and can never be a primary group.
+	for _, builtin := range []string{"544", "548", "549", "550", "551"} {
+		if got[builtin] {
+			t.Errorf("candidate RIDs must not contain BUILTIN RID %q, got %v", builtin, rids)
+		}
+	}
+}
+
+func TestPrimaryGroupSearchFilter(t *testing.T) {
+	if got := primaryGroupSearchFilter(nil); got != "" {
+		t.Errorf("primaryGroupSearchFilter(nil) = %q, want empty", got)
+	}
+
+	filter := primaryGroupSearchFilter([]string{"512", "519"})
+	for _, want := range []string{"(primaryGroupID=512)", "(primaryGroupID=519)", userObjectFilter} {
+		if !strings.Contains(filter, want) {
+			t.Errorf("filter %q does not contain %q", filter, want)
+		}
+	}
+	if !strings.HasPrefix(filter, "(&") || !strings.HasSuffix(filter, ")") {
+		t.Errorf("filter %q is not a well-formed AND clause", filter)
+	}
+}
+
+func TestApplyPrimaryGroupMemberships(t *testing.T) {
+	const (
+		stealthAdminDN = "CN=Stealth Admin,CN=Users,DC=example,DC=com"
+		ordinaryUserDN = "CN=Ordinary User,CN=Users,DC=example,DC=com"
+		rootAdminDN    = "CN=Root Admin,CN=Users,DC=example,DC=test"
+		schemaAdminDN  = "CN=Schema Owner,CN=Users,DC=example,DC=test"
+		protectedDN    = "CN=Protected,CN=Users,DC=example,DC=com"
+	)
+
+	pm := newTestMemberships()
+	applyPrimaryGroupMemberships(pm, testSIDIndex(), []primaryGroupRecord{
+		// The stealth case: primaryGroupID 512 with nothing in memberOf.
+		{dn: stealthAdminDN, objectSID: testDomainSID + "-1105", primaryGroupID: 512},
+		// Domain Users is the default and must not be privileged.
+		{dn: ordinaryUserDN, objectSID: testDomainSID + "-1106", primaryGroupID: 513},
+		{dn: rootAdminDN, objectSID: testRootDomainSID + "-1200", primaryGroupID: 519},
+		{dn: schemaAdminDN, objectSID: testRootDomainSID + "-1201", primaryGroupID: 518},
+		{dn: protectedDN, objectSID: testDomainSID + "-1107", primaryGroupID: 525},
+		// 519 relative to a non-root domain is not Enterprise Admins.
+		{dn: "CN=Child 519,CN=Users,DC=child,DC=example,DC=com", objectSID: testDomainSID + "-1108", primaryGroupID: 519},
+		// Malformed / unusable records must be dropped, not panic.
+		{dn: "", objectSID: testDomainSID + "-1109", primaryGroupID: 512},
+		{dn: "CN=No SID,CN=Users,DC=example,DC=com", objectSID: "", primaryGroupID: 512},
+		{dn: "CN=No RID,CN=Users,DC=example,DC=com", objectSID: testDomainSID + "-1110", primaryGroupID: 0},
+	})
+
+	if !pm.DomainAdmins[stealthAdminDN] {
+		t.Errorf("account with primaryGroupID 512 is not in DomainAdmins")
+	}
+	if !pm.AllPrivileged[stealthAdminDN] {
+		t.Errorf("account with primaryGroupID 512 is not privileged")
+	}
+	if pm.AllPrivileged[ordinaryUserDN] {
+		t.Errorf("account with primaryGroupID 513 (Domain Users) must not be privileged")
+	}
+	if !pm.EnterpriseAdmins[rootAdminDN] || !pm.AllPrivileged[rootAdminDN] {
+		t.Errorf("forest-root account with primaryGroupID 519 is not an Enterprise Admin")
+	}
+	if !pm.SchemaAdmins[schemaAdminDN] || !pm.AllPrivileged[schemaAdminDN] {
+		t.Errorf("forest-root account with primaryGroupID 518 is not a Schema Admin")
+	}
+	if !pm.ProtectedUsers[protectedDN] || !pm.AllPrivileged[protectedDN] {
+		t.Errorf("account with primaryGroupID 525 is not in Protected Users")
+	}
+	if pm.AllPrivileged["CN=Child 519,CN=Users,DC=child,DC=example,DC=com"] {
+		t.Errorf("RID 519 relative to a non-root domain must not map to Enterprise Admins")
+	}
+	if pm.AllPrivileged["CN=No SID,CN=Users,DC=example,DC=com"] ||
+		pm.AllPrivileged["CN=No RID,CN=Users,DC=example,DC=com"] ||
+		pm.AllPrivileged[""] {
+		t.Errorf("unusable records must not produce memberships: %v", pm.AllPrivileged)
+	}
+}
+
+// TestPrimaryGroupMembershipDoesNotDisturbMemberOfResults proves the memberOf
+// chain still works on its own and that folding primary groups in is additive.
+func TestPrimaryGroupMembershipDoesNotDisturbMemberOfResults(t *testing.T) {
+	const memberOfAdminDN = "CN=MemberOf Admin,CN=Users,DC=example,DC=com"
+
+	pm := newTestMemberships()
+	// Simulate what the LDAP_MATCHING_RULE_IN_CHAIN pass records.
+	markPrivileged(pm, "DomainAdmins", memberOfAdminDN)
+
+	applyPrimaryGroupMemberships(pm, testSIDIndex(), []primaryGroupRecord{
+		{dn: "CN=Stealth,CN=Users,DC=example,DC=com", objectSID: testDomainSID + "-1105", primaryGroupID: 512},
+	})
+
+	if !pm.DomainAdmins[memberOfAdminDN] || !pm.AllPrivileged[memberOfAdminDN] {
+		t.Errorf("memberOf-derived membership was lost when primary groups were folded in")
+	}
+	if len(pm.DomainAdmins) != 2 {
+		t.Errorf("DomainAdmins = %v, want both the memberOf and primary group accounts", pm.DomainAdmins)
+	}
+}
+
+func TestMarkPrivileged(t *testing.T) {
+	const dn = "CN=Someone,CN=Users,DC=example,DC=com"
+
+	// A group with no dedicated set still contributes to AllPrivileged.
+	pm := newTestMemberships()
+	markPrivileged(pm, "", dn)
+	if !pm.AllPrivileged[dn] {
+		t.Errorf("markPrivileged with no field must still record AllPrivileged")
+	}
+	if len(pm.DomainAdmins) != 0 || len(pm.EnterpriseAdmins) != 0 ||
+		len(pm.SchemaAdmins) != 0 || len(pm.ProtectedUsers) != 0 {
+		t.Errorf("markPrivileged with no field must not populate a dedicated set")
+	}
+}

--- a/providers/activedirectory/resources/rbcd_test.go
+++ b/providers/activedirectory/resources/rbcd_test.go
@@ -1,0 +1,151 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"testing"
+)
+
+// webServerSID is a synthetic computer-account SID, S-1-5-21-100-200-300-1108,
+// standing in for a host granted resource-based constrained delegation.
+var webServerSID = []byte{
+	0x01,                               // revision
+	0x05,                               // sub-authority count
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x05, // authority = 5
+	0x15, 0x00, 0x00, 0x00, // 21
+	0x64, 0x00, 0x00, 0x00, // 100
+	0xC8, 0x00, 0x00, 0x00, // 200
+	0x2C, 0x01, 0x00, 0x00, // 300
+	0x54, 0x04, 0x00, 0x00, // 1108
+}
+
+// appServerSID is a second synthetic computer-account SID,
+// S-1-5-21-100-200-300-1109.
+var appServerSID = []byte{
+	0x01,
+	0x05,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x05,
+	0x15, 0x00, 0x00, 0x00, // 21
+	0x64, 0x00, 0x00, 0x00, // 100
+	0xC8, 0x00, 0x00, 0x00, // 200
+	0x2C, 0x01, 0x00, 0x00, // 300
+	0x55, 0x04, 0x00, 0x00, // 1109
+}
+
+func TestRBCDPrincipalSIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+		want []string
+	}{
+		{
+			name: "single trustee",
+			raw:  buildSD(buildDACL(buildBasicACE(rightGenericAll, webServerSID))),
+			want: []string{"S-1-5-21-100-200-300-1108"},
+		},
+		{
+			name: "two trustees keep DACL order",
+			raw: buildSD(buildDACL(
+				buildBasicACE(rightGenericAll, webServerSID),
+				buildBasicACE(rightGenericAll, appServerSID),
+			)),
+			want: []string{"S-1-5-21-100-200-300-1108", "S-1-5-21-100-200-300-1109"},
+		},
+		{
+			name: "duplicate ACEs for one trustee collapse",
+			raw: buildSD(buildDACL(
+				buildBasicACE(rightGenericAll, webServerSID),
+				buildBasicACE(rightGenericWrite, webServerSID),
+			)),
+			want: []string{"S-1-5-21-100-200-300-1108"},
+		},
+		{
+			name: "well-known trustee",
+			raw:  buildSD(buildDACL(buildBasicACE(rightGenericAll, everyoneSID))),
+			want: []string{"S-1-1-0"},
+		},
+		{
+			name: "object ACE trustee",
+			raw: buildSD(buildDACL(buildObjectACE(
+				rightGenericAll, 0x00, nil, nil, webServerSID,
+			))),
+			want: []string{"S-1-5-21-100-200-300-1108"},
+		},
+		{
+			name: "empty attribute",
+			raw:  nil,
+			want: nil,
+		},
+		{
+			name: "zero-length attribute",
+			raw:  []byte{},
+			want: nil,
+		},
+		{
+			name: "descriptor with an empty DACL",
+			raw:  buildSD(buildDACL()),
+			want: []string{},
+		},
+		{
+			name: "descriptor too short to be a security descriptor",
+			raw:  []byte{0x01, 0x00, 0x04, 0x80},
+			want: []string{},
+		},
+		{
+			name: "truncated DACL",
+			raw:  buildSD(buildDACL(buildBasicACE(rightGenericAll, webServerSID)))[:24],
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rbcdPrincipalSIDs(tt.raw)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("rbcdPrincipalSIDs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRBCDPrincipalSIDsMatchesRBCDBoolean pins the invariant that the boolean
+// the provider has always exposed and the new principal list agree: an empty
+// attribute means rbcd is false and there are no principals, and a populated
+// attribute means rbcd is true and the trustees are readable.
+func TestRBCDPrincipalSIDsMatchesRBCDBoolean(t *testing.T) {
+	tests := []struct {
+		name           string
+		raw            []byte
+		wantRBCD       bool
+		wantPrincipals int
+	}{
+		{"attribute absent", nil, false, 0},
+		{
+			name:           "attribute present with one trustee",
+			raw:            buildSD(buildDACL(buildBasicACE(rightGenericAll, webServerSID))),
+			wantRBCD:       true,
+			wantPrincipals: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This is the expression computers() uses for the rbcd field.
+			rbcd := len(tt.raw) > 0
+			if rbcd != tt.wantRBCD {
+				t.Errorf("rbcd = %v, want %v", rbcd, tt.wantRBCD)
+			}
+
+			principals := rbcdPrincipalSIDs(tt.raw)
+			if len(principals) != tt.wantPrincipals {
+				t.Errorf("rbcdPrincipalSIDs() returned %d principals (%v), want %d",
+					len(principals), principals, tt.wantPrincipals)
+			}
+		})
+	}
+}

--- a/providers/activedirectory/resources/sd_helpers.go
+++ b/providers/activedirectory/resources/sd_helpers.go
@@ -233,6 +233,36 @@ func parseObjectACE(sd []byte, offset int) (aceEntry, bool) {
 	return aceEntry{aceType: 0x05, mask: mask, sid: sid, objectGUID: objectGUID}, true
 }
 
+// rbcdPrincipalSIDs extracts the trustee SIDs from a raw
+// msDS-AllowedToActOnBehalfOfOtherIdentity value. The attribute holds a
+// self-relative SECURITY_DESCRIPTOR whose DACL names every principal allowed
+// to impersonate onto the host, so the SIDs in that DACL are the whole content
+// of a resource-based constrained delegation finding.
+//
+// The result preserves DACL order and is deduplicated. An empty, short, or
+// unparseable descriptor yields an empty list.
+func rbcdPrincipalSIDs(raw []byte) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	parsed := parseSecurityDescriptor(raw)
+
+	seen := make(map[string]bool, len(parsed.aces))
+	sids := make([]string, 0, len(parsed.aces))
+	for _, ace := range parsed.aces {
+		// parseDACL only collects allow ACEs (types 0x00 and 0x05), but guard
+		// explicitly so a deny entry can never be reported as a trustee.
+		if ace.aceType == 0x01 || ace.sid == "" || seen[ace.sid] {
+			continue
+		}
+		seen[ace.sid] = true
+		sids = append(sids, ace.sid)
+	}
+
+	return sids
+}
+
 // decodeGUID converts a 16-byte binary GUID (mixed-endian as used by AD)
 // to its lowercase string form: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
 func decodeGUID(b []byte) string {

--- a/providers/activedirectory/resources/users.go
+++ b/providers/activedirectory/resources/users.go
@@ -15,6 +15,10 @@ import (
 	"go.mondoo.com/mql/types"
 )
 
+// userObjectFilter matches every object the activedirectory.user resource
+// represents: ordinary user accounts and Group Managed Service Accounts.
+const userObjectFilter = "(|(&(objectCategory=person)(objectClass=user))(objectClass=msDS-GroupManagedServiceAccount))"
+
 // extractOU returns the OU path from a DN by removing the object's own RDN.
 func extractOU(dn string) string {
 	idx := strings.Index(dn, ",")
@@ -32,7 +36,7 @@ func (a *mqlActivedirectory) users() ([]interface{}, error) {
 	conn := a.MqlRuntime.Connection.(*connection.ActiveDirectoryConnection)
 	baseDN := conn.BaseDN()
 
-	filter := "(|(&(objectCategory=person)(objectClass=user))(objectClass=msDS-GroupManagedServiceAccount))"
+	filter := userObjectFilter
 	attrs := []string{
 		"sAMAccountName",
 		"userPrincipalName",
@@ -48,6 +52,7 @@ func (a *mqlActivedirectory) users() ([]interface{}, error) {
 		"description",
 		"mail",
 		"memberOf",
+		"primaryGroupID",
 		"sIDHistory",
 		"msDS-AllowedToDelegateTo",
 		"objectClass",
@@ -122,6 +127,10 @@ func (a *mqlActivedirectory) users() ([]interface{}, error) {
 			memberOfIface[i] = m
 		}
 
+		// Primary group membership never appears in memberOf, so expose the
+		// RID directly for rules that assert on it.
+		primaryGroupID := parseInt64Attr(entry.GetAttributeValue("primaryGroupID"))
+
 		email := entry.GetAttributeValue("mail")
 		description := entry.GetAttributeValue("description")
 		ouPath := extractOU(dn)
@@ -181,6 +190,7 @@ func (a *mqlActivedirectory) users() ([]interface{}, error) {
 				"daysSinceLastLogon":            llx.IntData(daysSinceLastLogon),
 				"isStale":                       llx.BoolData(isStale),
 				"memberOf":                      llx.ArrayData(memberOfIface, types.String),
+				"primaryGroupId":                llx.IntData(primaryGroupID),
 				"description":                   llx.StringData(description),
 				"email":                         llx.StringData(email),
 				"ouPath":                        llx.StringData(ouPath),


### PR DESCRIPTION
Two confirmed bugs in the `activedirectory` provider, one commit each.

## 1. `isDomainAdmin` / `isPrivileged` miss primary-group membership

### The bug

`providers/activedirectory/resources/privileged.go:245-248` resolves membership of every well-known privileged group through one LDAP matching rule and nothing else:

```go
// Recursive membership via LDAP_MATCHING_RULE_IN_CHAIN.
filter := fmt.Sprintf(
    "(&(objectCategory=person)(objectClass=user)(memberOf:1.2.840.113556.1.4.1941:=%s))",
    ldap.EscapeFilter(groupDN),
)
```

The result sets built from that filter are what `activedirectory.user.isDomainAdmin`, `isEnterpriseAdmin`, `isSchemaAdmin`, `protectedUser` and `isPrivileged` are read from (`users.go:209-264`).

### Why it is wrong

`LDAP_MATCHING_RULE_IN_CHAIN` walks the `member` / `memberOf` linked-attribute pair. Primary-group membership is not stored in that pair: it lives in the account's `primaryGroupID` attribute, a RID relative to the account's own domain. It is nevertheless a full membership. An account with `primaryGroupID` 512 is a Domain Admin, but the group does not appear in its `memberOf` and the account does not appear in the group's `member` list.

So this is **a false negative in five already-shipped boolean fields**: a real Domain Admin reads back `isDomainAdmin: false, isPrivileged: false` today, and any policy built on those fields silently passes over it. Primary-group manipulation is a documented **stealth / persistence technique** used precisely because the resulting membership is invisible to a `memberOf` review, and the shipped code reproduces that blind spot exactly.

The provider did not even request `primaryGroupID` from LDAP (`users.go:36-54`), so there was no way for a user to work around it in MQL either.

### The fix

- `primaryGroupID` is now read for every account and folded into the privileged sets next to the `memberOf` chain.
- The group SID is derived from the account's **own** object SID with its trailing RID replaced by `primaryGroupID`. That keeps the mapping correct in a multi-domain forest, where RID 519 only means Enterprise Admins when the account lives in the forest root.
- BUILTIN groups (`S-1-5-32-*`) are excluded from the candidate RIDs: a domain-local group cannot be an account's primary group.
- The extra lookup is non-fatal. A failure is logged, and the `memberOf`-derived results are kept.
- `primaryGroupId` is exposed on `activedirectory.user` so a policy can assert on the RID directly.

## 2. `computer.rbcd` is a boolean over a security descriptor that is then discarded

### The bug

`providers/activedirectory/resources/computers.go:131-132`:

```go
// Resource-Based Constrained Delegation (RBCD)
rbcd := len(entry.GetRawAttributeValue("msDS-AllowedToActOnBehalfOfOtherIdentity")) > 0
```

`rawvalue` is measured and thrown away.

### Why it is wrong

`msDS-AllowedToActOnBehalfOfOtherIdentity` is a self-relative `SECURITY_DESCRIPTOR`. The principals in its DACL are the accounts that can request Kerberos service tickets to that host on behalf of any user, including a Domain Admin. **Which** principals those are is the entire content of the finding: "some delegation is configured here" is not actionable, and "this workstation account can impersonate onto a domain controller" is. That detail was already in hand and was unreachable from MQL.

The provider has parsed exactly this descriptor format since it shipped, in `parseSecurityDescriptor` (`sd_helpers.go`), used by the `dangerousPermissions` ACL scan. It simply was never called here.

### The fix

- `rbcdPrincipals` on `activedirectory.computer` returns the trustee SIDs from the descriptor's DACL, deduplicated and in DACL order.
- Parsing goes through the existing `parseSecurityDescriptor` helper. Deny entries are never reported as trustees. A short, empty, or unparseable descriptor yields an empty list, never an error.
- `rbcd` keeps its type and meaning. No shipped field changed.

The SIDs are returned unresolved. The provider has no SID-to-name resolver today, and `activedirectory.dangerousPermission` likewise exposes a bare `principalSID`, so this stays consistent with the existing schema rather than adding an LDAP round trip that could not be verified here.

`activedirectory.user` was left alone: its lister does not request `msDS-AllowedToActOnBehalfOfOtherIdentity`, so there is no descriptor being discarded there.

## Verification

Both fixes are pure Go logic over LDAP attribute values, so both are covered by table tests per CLAUDE.md 3.6.

**New tests** (`resources/privileged_primary_group_test.go`, `resources/rbcd_test.go`), all fixtures built from documentation-example SIDs:

- `TestApplyPrimaryGroupMemberships` covers the required cases directly: `primaryGroupID=512` with no `memberOf` comes back in `DomainAdmins` **and** `AllPrivileged`; `primaryGroupID=513` (Domain Users) comes back in neither; RID 519 relative to a non-root domain does **not** map to Enterprise Admins; empty DN, empty SID, and unset RID are dropped rather than panicking.
- `TestPrimaryGroupMembershipDoesNotDisturbMemberOfResults` proves a user privileged only via `memberOf` still works exactly as before and that the new pass is purely additive.
- `TestDomainSIDFromObjectSID`, `TestPrimaryGroupSIDForAccount`, `TestPrimaryGroupCandidateRIDs`, `TestPrimaryGroupSearchFilter`, `TestMarkPrivileged` cover the helpers, including well-known and BUILTIN SIDs that must not be treated as domain-issued.
- `TestRBCDPrincipalSIDs` feeds real binary security-descriptor fixtures built with the same `buildSD` / `buildDACL` / `buildBasicACE` / `buildObjectACE` helpers the existing `sd_helpers_test.go` uses: one trustee, two trustees in DACL order, duplicate ACEs collapsing to one principal, a well-known trustee, an object ACE, an empty attribute, an empty DACL, a too-short descriptor, and a truncated DACL.
- `TestRBCDPrincipalSIDsMatchesRBCDBoolean` pins the invariant between the shipped boolean and the new list: absent attribute means `rbcd == false` and zero principals.

**Before the fix** (test files present, production changes reverted to `main`):

```
$ go test ./resources/...
# go.mondoo.com/mql/providers/activedirectory/resources [.../resources.test]
resources/privileged_primary_group_test.go:56:14: undefined: domainSIDFromObjectSID
resources/privileged_primary_group_test.go:83:14: undefined: primaryGroupSIDForAccount
resources/privileged_primary_group_test.go:92:10: undefined: primaryGroupCandidateRIDs
resources/privileged_primary_group_test.go:117:12: undefined: primaryGroupSearchFilter
resources/privileged_primary_group_test.go:121:12: undefined: primaryGroupSearchFilter
resources/privileged_primary_group_test.go:122:80: undefined: userObjectFilter
resources/privileged_primary_group_test.go:142:2: undefined: applyPrimaryGroupMemberships
resources/privileged_primary_group_test.go:142:53: undefined: primaryGroupRecord
resources/privileged_primary_group_test.go:193:2: undefined: markPrivileged
resources/privileged_primary_group_test.go:195:2: undefined: applyPrimaryGroupMemberships
resources/privileged_primary_group_test.go:195:2: too many errors
FAIL	go.mondoo.com/mql/providers/activedirectory/resources [build failed]
FAIL
```

To be precise about what that run does and does not show: it is a build failure, not an assertion failure, because on `main` neither code path exists at all. There is no input that makes the shipped algorithm return `true` for an account privileged only via `primaryGroupID`, since it consults only the `memberOf` chain; and there is no shipped symbol that returns RBCD trustees, since `computers.go` discards the descriptor. The absence *is* the bug in both cases.

**After the fix:**

```
$ go build ./... && go test ./...
?   	go.mondoo.com/mql/providers/activedirectory	[no test files]
?   	go.mondoo.com/mql/providers/activedirectory/config	[no test files]
ok  	go.mondoo.com/mql/providers/activedirectory/connection	0.769s
?   	go.mondoo.com/mql/providers/activedirectory/gen	[no test files]
ok  	go.mondoo.com/mql/providers/activedirectory/provider	0.821s
ok  	go.mondoo.com/mql/providers/activedirectory/resources	1.196s
```

All 9 new test functions, 37 cases counting subtests, pass individually under `-v`. `gofmt -l` is clean, `go mod tidy` produces no diff, and codegen was re-run per commit, so `.lr.go` and `.lr.versions` are current. Both new `.lr.versions` entries land at `13.1.14`, one patch above the `13.1.13` in `config/config.go`; `config.go` itself is untouched.

One test caught a real defect during development: `domainSIDFromObjectSID` originally accepted `S-1-5-32-544` as domain-issued, which would have let a BUILTIN SID prefix a `primaryGroupID`. The helper now requires the full eight-component shape of a domain account SID.

## Not verified against a live target

**No live Active Directory was available for this work.** Everything below is proven by unit test only and has not been observed against a real directory:

- That an account with `primaryGroupID` 512 is reported as `isDomainAdmin` / `isPrivileged` end to end through the resource. The membership-folding logic and the SID arithmetic are tested; the LDAP search that feeds them (`fetchPrimaryGroupRecords`) is not, so the filter's behaviour against a real DC, the attribute's presence on gMSA objects, and the multi-naming-context search are unproven.
- That `primaryGroupId` populates on `activedirectory.user` against a real directory.
- That `rbcdPrincipals` returns the expected SIDs for a host with real RBCD configured. The descriptor parsing is tested against synthetic fixtures built in the shape `sd_helpers_test.go` already uses, but no descriptor produced by a real domain controller was parsed.
- The non-fatal error paths (a naming context that is not searchable, a DC that refuses the primary-group search) are exercised only by code inspection.

The `rbcd` boolean, and the `memberOf`-derived privilege flags, are unchanged in behaviour, so the regression surface is limited to the two new fields and the additional membership rows in the privileged sets.
