### PR TITLE
🐛 cloudflare: report R2 buckets public via a custom domain

### DIFF
--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -542,8 +542,8 @@ private cloudflare.streams.video @defaults("name uid") {
 //
 // Object-storage resources for a Cloudflare account. The buckets field
 // enumerates every R2 bucket, which is the starting point for auditing
-// where account data is stored and which buckets serve objects publicly
-// through the managed r2.dev subdomain.
+// where account data is stored and which buckets serve objects publicly,
+// whether over the managed r2.dev subdomain or a custom domain.
 private cloudflare.r2 @defaults("buckets") {
 	// R2 buckets in the account
 	buckets() []cloudflare.r2.bucket
@@ -551,12 +551,13 @@ private cloudflare.r2 @defaults("buckets") {
 
 // Cloudflare R2 bucket
 //
-// Single R2 storage bucket, identified by its name. The publicAccessEnabled
-// and publicAccessDomain fields report whether the bucket serves its objects
-// publicly over the managed r2.dev subdomain, the primary exposure to audit
-// for an R2 bucket, alongside its storage location and creation time.
+// Single R2 storage bucket, identified by its name. A bucket reaches the
+// internet over two independent paths: the managed r2.dev subdomain, reported
+// by publicAccessEnabled and publicAccessDomain, and custom domains, listed by
+// customDomains. The isPublic field reports whether either path currently
+// serves the bucket, alongside its storage location and creation time.
 private cloudflare.r2.bucket {
- 	// Bucket name
+  // Bucket name
   name string
   // Bucket location
   //
@@ -565,10 +566,61 @@ private cloudflare.r2.bucket {
   location string
   // Time the bucket was created
   createdOn time
-  // Whether public access via the managed r2.dev subdomain is enabled
+  // Whether public access over the managed r2.dev subdomain is enabled
+  //
+  // Covers the managed r2.dev subdomain only. A bucket published through a
+  // custom domain is served publicly no matter what this reports, so use
+  // isPublic to decide whether the bucket is reachable from the internet.
   publicAccessEnabled() bool
   // Managed r2.dev domain assigned to the bucket (empty when public access is disabled)
   publicAccessDomain() string
+  // Custom domains registered for the bucket
+  //
+  // Domains in the account's own zones that serve the bucket's objects, each
+  // with its enabled flag, ownership and certificate status, and minimum TLS
+  // version. Empty when the bucket has no custom domain, and also when the
+  // token cannot read the list, so check isPublic for the exposure question.
+  customDomains() []cloudflare.r2.bucket.customDomain
+  // Whether the bucket is reachable from the internet
+  //
+  // True when the managed r2.dev subdomain is enabled, or when at least one
+  // custom domain is registered and enabled. Null when nothing proved the
+  // bucket public but one of the two paths could not be read, so a bucket
+  // whose exposure is unknown is never reported as private.
+  isPublic() bool
+}
+
+// Custom domain serving a Cloudflare R2 bucket
+//
+// Domain in one of the account's zones that publishes an R2 bucket's objects
+// on the internet, separately from the managed r2.dev subdomain. The enabled
+// field reports whether the domain currently serves the bucket, ownershipStatus
+// and sslStatus report how far the domain got through validation and
+// certificate issuance, and minTlsVersion reports the lowest TLS version the
+// domain accepts.
+private cloudflare.r2.bucket.customDomain @defaults("domain enabled") {
+  // Domain name serving the bucket
+  domain string
+  // Whether the bucket is publicly accessible at this domain
+  enabled bool
+  // Ownership status of the domain
+  //
+  // One of pending, active, deactivated, blocked, error, or unknown.
+  ownershipStatus string
+  // SSL certificate status for the domain
+  //
+  // One of initializing, pending, active, deactivated, error, or unknown.
+  sslStatus string
+  // Whether an SSL certificate is issued and active for the domain
+  //
+  // True only when sslStatus is active. A domain whose certificate is still
+  // initializing or pending cannot yet terminate TLS for the bucket.
+  certificateActive bool
+  // Minimum TLS version the domain accepts for incoming connections
+  //
+  // One of 1.0, 1.1, 1.2, or 1.3. Empty when the API reports no value, in
+  // which case the domain accepts TLS 1.0.
+  minTlsVersion string
 }
 
 // Cloudflare Workers namespace

--- a/providers/cloudflare/resources/cloudflare.lr.go
+++ b/providers/cloudflare/resources/cloudflare.lr.go
@@ -33,6 +33,7 @@ const (
 	ResourceCloudflareStreamsVideo                                    string = "cloudflare.streams.video"
 	ResourceCloudflareR2                                              string = "cloudflare.r2"
 	ResourceCloudflareR2Bucket                                        string = "cloudflare.r2.bucket"
+	ResourceCloudflareR2BucketCustomDomain                            string = "cloudflare.r2.bucket.customDomain"
 	ResourceCloudflareWorkers                                         string = "cloudflare.workers"
 	ResourceCloudflareWorkersWorker                                   string = "cloudflare.workers.worker"
 	ResourceCloudflareWorkersPage                                     string = "cloudflare.workers.page"
@@ -165,6 +166,10 @@ func init() {
 		"cloudflare.r2.bucket": {
 			// to override args, implement: initCloudflareR2Bucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createCloudflareR2Bucket,
+		},
+		"cloudflare.r2.bucket.customDomain": {
+			// to override args, implement: initCloudflareR2BucketCustomDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createCloudflareR2BucketCustomDomain,
 		},
 		"cloudflare.workers": {
 			Init:   initCloudflareWorkers,
@@ -928,6 +933,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"cloudflare.r2.bucket.publicAccessDomain": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareR2Bucket).GetPublicAccessDomain()).ToDataRes(types.String)
+	},
+	"cloudflare.r2.bucket.customDomains": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2Bucket).GetCustomDomains()).ToDataRes(types.Array(types.Resource("cloudflare.r2.bucket.customDomain")))
+	},
+	"cloudflare.r2.bucket.isPublic": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2Bucket).GetIsPublic()).ToDataRes(types.Bool)
+	},
+	"cloudflare.r2.bucket.customDomain.domain": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2BucketCustomDomain).GetDomain()).ToDataRes(types.String)
+	},
+	"cloudflare.r2.bucket.customDomain.enabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2BucketCustomDomain).GetEnabled()).ToDataRes(types.Bool)
+	},
+	"cloudflare.r2.bucket.customDomain.ownershipStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2BucketCustomDomain).GetOwnershipStatus()).ToDataRes(types.String)
+	},
+	"cloudflare.r2.bucket.customDomain.sslStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2BucketCustomDomain).GetSslStatus()).ToDataRes(types.String)
+	},
+	"cloudflare.r2.bucket.customDomain.certificateActive": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2BucketCustomDomain).GetCertificateActive()).ToDataRes(types.Bool)
+	},
+	"cloudflare.r2.bucket.customDomain.minTlsVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareR2BucketCustomDomain).GetMinTlsVersion()).ToDataRes(types.String)
 	},
 	"cloudflare.workers.workers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareWorkers).GetWorkers()).ToDataRes(types.Array(types.Resource("cloudflare.workers.worker")))
@@ -3061,6 +3090,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cloudflare.r2.bucket.publicAccessDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareR2Bucket).PublicAccessDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.customDomains": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2Bucket).CustomDomains, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.isPublic": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2Bucket).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.customDomain.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2BucketCustomDomain).__id, ok = v.Value.(string)
+		return
+	},
+	"cloudflare.r2.bucket.customDomain.domain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2BucketCustomDomain).Domain, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.customDomain.enabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2BucketCustomDomain).Enabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.customDomain.ownershipStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2BucketCustomDomain).OwnershipStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.customDomain.sslStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2BucketCustomDomain).SslStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.customDomain.certificateActive": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2BucketCustomDomain).CertificateActive, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"cloudflare.r2.bucket.customDomain.minTlsVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareR2BucketCustomDomain).MinTlsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"cloudflare.workers.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7196,6 +7261,8 @@ type mqlCloudflareR2Bucket struct {
 	CreatedOn           plugin.TValue[*time.Time]
 	PublicAccessEnabled plugin.TValue[bool]
 	PublicAccessDomain  plugin.TValue[string]
+	CustomDomains       plugin.TValue[[]any]
+	IsPublic            plugin.TValue[bool]
 }
 
 // createCloudflareR2Bucket creates a new instance of this resource
@@ -7257,6 +7324,97 @@ func (c *mqlCloudflareR2Bucket) GetPublicAccessDomain() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.PublicAccessDomain, func() (string, error) {
 		return c.publicAccessDomain()
 	})
+}
+
+func (c *mqlCloudflareR2Bucket) GetCustomDomains() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.CustomDomains, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.r2.bucket", c.__id, "customDomains")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.customDomains()
+	})
+}
+
+func (c *mqlCloudflareR2Bucket) GetIsPublic() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
+		return c.isPublic()
+	})
+}
+
+// mqlCloudflareR2BucketCustomDomain for the cloudflare.r2.bucket.customDomain resource
+type mqlCloudflareR2BucketCustomDomain struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlCloudflareR2BucketCustomDomainInternal it will be used here
+	Domain            plugin.TValue[string]
+	Enabled           plugin.TValue[bool]
+	OwnershipStatus   plugin.TValue[string]
+	SslStatus         plugin.TValue[string]
+	CertificateActive plugin.TValue[bool]
+	MinTlsVersion     plugin.TValue[string]
+}
+
+// createCloudflareR2BucketCustomDomain creates a new instance of this resource
+func createCloudflareR2BucketCustomDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlCloudflareR2BucketCustomDomain{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("cloudflare.r2.bucket.customDomain", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) MqlName() string {
+	return "cloudflare.r2.bucket.customDomain"
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) GetDomain() *plugin.TValue[string] {
+	return &c.Domain
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) GetEnabled() *plugin.TValue[bool] {
+	return &c.Enabled
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) GetOwnershipStatus() *plugin.TValue[string] {
+	return &c.OwnershipStatus
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) GetSslStatus() *plugin.TValue[string] {
+	return &c.SslStatus
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) GetCertificateActive() *plugin.TValue[bool] {
+	return &c.CertificateActive
+}
+
+func (c *mqlCloudflareR2BucketCustomDomain) GetMinTlsVersion() *plugin.TValue[string] {
+	return &c.MinTlsVersion
 }
 
 // mqlCloudflareWorkers for the cloudflare.workers resource

--- a/providers/cloudflare/resources/cloudflare.lr.versions
+++ b/providers/cloudflare/resources/cloudflare.lr.versions
@@ -296,6 +296,15 @@ cloudflare.pages.envVar.type 13.1.1
 cloudflare.r2 11.0.0
 cloudflare.r2.bucket 11.0.0
 cloudflare.r2.bucket.createdOn 11.0.0
+cloudflare.r2.bucket.customDomain 13.8.1
+cloudflare.r2.bucket.customDomain.certificateActive 13.8.1
+cloudflare.r2.bucket.customDomain.domain 13.8.1
+cloudflare.r2.bucket.customDomain.enabled 13.8.1
+cloudflare.r2.bucket.customDomain.minTlsVersion 13.8.1
+cloudflare.r2.bucket.customDomain.ownershipStatus 13.8.1
+cloudflare.r2.bucket.customDomain.sslStatus 13.8.1
+cloudflare.r2.bucket.customDomains 13.8.1
+cloudflare.r2.bucket.isPublic 13.8.1
 cloudflare.r2.bucket.location 11.0.0
 cloudflare.r2.bucket.name 11.0.0
 cloudflare.r2.bucket.publicAccessDomain 13.1.1

--- a/providers/cloudflare/resources/r2.go
+++ b/providers/cloudflare/resources/r2.go
@@ -69,6 +69,11 @@ type mqlCloudflareR2BucketInternal struct {
 	publicAccessAvailable   bool
 	cachePublicAccessOn     bool
 	cachePublicAccessDomain string
+
+	customDomainsLock      sync.Mutex
+	customDomainsFetched   bool
+	customDomainsAvailable bool
+	cacheCustomDomains     []r2.BucketDomainCustomListResponseDomain
 }
 
 func (c *mqlCloudflareR2Bucket) id() (string, error) {
@@ -211,4 +216,115 @@ func (c *mqlCloudflareR2Bucket) publicAccessDomain() (string, error) {
 		return "", nil
 	}
 	return domain, nil
+}
+
+// fetchCustomDomains lists the bucket's custom domains. A custom domain serves
+// the bucket's objects on the internet independently of the managed r2.dev
+// subdomain, so this is the second half of the bucket's public-exposure answer.
+//
+// The endpoint returns the whole set in one `result.domains` array with no
+// cursor or page counter in the envelope, so there is nothing to page through.
+//
+// The `available` return is false when the caller cannot read the domain list;
+// callers must not read that as "no custom domains".
+func (c *mqlCloudflareR2Bucket) fetchCustomDomains() (available bool, domains []r2.BucketDomainCustomListResponseDomain, err error) {
+	if c.customDomainsFetched {
+		return c.customDomainsAvailable, c.cacheCustomDomains, nil
+	}
+	c.customDomainsLock.Lock()
+	defer c.customDomainsLock.Unlock()
+	if c.customDomainsFetched {
+		return c.customDomainsAvailable, c.cacheCustomDomains, nil
+	}
+
+	if c.accountID == "" {
+		c.customDomainsFetched = true
+		return false, nil, nil
+	}
+
+	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
+	resp, rerr := conn.Cf.R2.Buckets.Domains.Custom.List(context.TODO(), c.GetName().Data, r2.BucketDomainCustomListParams{
+		AccountID: cloudflare.F(c.accountID),
+	})
+	if rerr != nil {
+		if isUnavailable(rerr) {
+			c.customDomainsFetched = true
+			return false, nil, nil
+		}
+		return false, nil, rerr
+	}
+
+	c.customDomainsAvailable = true
+	c.cacheCustomDomains = resp.Domains
+	c.customDomainsFetched = true
+	return c.customDomainsAvailable, c.cacheCustomDomains, nil
+}
+
+func (c *mqlCloudflareR2Bucket) customDomains() ([]any, error) {
+	available, domains, err := c.fetchCustomDomains()
+	if err != nil {
+		return nil, err
+	}
+	if !available {
+		return []any{}, nil
+	}
+
+	result := make([]any, 0, len(domains))
+	for i := range domains {
+		d := domains[i]
+		res, err := CreateResource(c.MqlRuntime, "cloudflare.r2.bucket.customDomain", map[string]*llx.RawData{
+			"__id":            llx.StringData(c.accountID + "/" + c.GetName().Data + "/domains/custom/" + d.Domain),
+			"domain":          llx.StringData(d.Domain),
+			"enabled":         llx.BoolData(d.Enabled),
+			"ownershipStatus": llx.StringData(string(d.Status.Ownership)),
+			"sslStatus":       llx.StringData(string(d.Status.SSL)),
+			// A domain only terminates TLS once its certificate is issued;
+			// initializing/pending/error all mean there is no usable cert yet.
+			"certificateActive": llx.BoolData(d.Status.SSL == r2.BucketDomainCustomListResponseDomainsStatusSSLActive),
+			"minTlsVersion":     llx.StringData(string(d.MinTLS)),
+		})
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, res)
+	}
+
+	return result, nil
+}
+
+// isPublic reports whether the bucket is reachable from the internet over
+// either of the two independent paths Cloudflare offers: the managed r2.dev
+// subdomain, and any custom domain registered against the bucket.
+//
+// publicAccessEnabled covers only the first, so a bucket published through a
+// custom domain reads false there while being world-readable. Use this for the
+// exposure question.
+//
+// When neither path proves the bucket public, the answer is only `false` if
+// both were actually read. If either could not be read the field is null, so an
+// unreadable bucket is never reported as private.
+func (c *mqlCloudflareR2Bucket) isPublic() (bool, error) {
+	managedAvailable, managedEnabled, _, err := c.fetchPublicAccess()
+	if err != nil {
+		return false, err
+	}
+	if managedAvailable && managedEnabled {
+		return true, nil
+	}
+
+	customAvailable, domains, err := c.fetchCustomDomains()
+	if err != nil {
+		return false, err
+	}
+	for i := range domains {
+		if domains[i].Enabled {
+			return true, nil
+		}
+	}
+
+	if !managedAvailable || !customAvailable {
+		c.IsPublic.State = plugin.StateIsNull | plugin.StateIsSet
+		return false, nil
+	}
+	return false, nil
 }

--- a/providers/cloudflare/resources/r2_test.go
+++ b/providers/cloudflare/resources/r2_test.go
@@ -152,3 +152,208 @@ func TestR2BucketsUnboundAccountIssuesNoRequest(t *testing.T) {
 	require.ErrorIs(t, err, errNoAccountBound)
 	assert.Nil(t, res, "must not degrade to an empty list, which would pass vacuously")
 }
+
+// bucketFor lists the account's buckets and returns the one named `name`,
+// already wired to the test account so its per-bucket endpoints resolve.
+func bucketFor(t *testing.T, r2 *mqlCloudflareR2, name string) *mqlCloudflareR2Bucket {
+	t.Helper()
+	buckets, err := r2.buckets()
+	require.NoError(t, err)
+	for _, b := range buckets {
+		bucket := b.(*mqlCloudflareR2Bucket)
+		if bucket.Name.Data == name {
+			return bucket
+		}
+	}
+	t.Fatalf("bucket %q not found", name)
+	return nil
+}
+
+func handleBuckets(env *testEnv) {
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, loadFixture("r2_buckets"))
+	})
+}
+
+func TestR2BucketCustomDomains(t *testing.T) {
+	env := setupTestEnv(t)
+	r2 := createTestR2(t, env)
+	handleBuckets(env)
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/public-assets/domains/custom", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		jsonResponse(w, loadFixture("r2_custom_domains"))
+	})
+
+	bucket := bucketFor(t, r2, "public-assets")
+	domains, err := bucket.customDomains()
+	require.NoError(t, err)
+	require.Len(t, domains, 2)
+
+	d1 := domains[0].(*mqlCloudflareR2BucketCustomDomain)
+	assert.Equal(t, "assets.example.com", d1.Domain.Data)
+	assert.True(t, d1.Enabled.Data)
+	assert.Equal(t, "active", d1.OwnershipStatus.Data)
+	assert.Equal(t, "active", d1.SslStatus.Data)
+	assert.True(t, d1.CertificateActive.Data)
+	assert.Equal(t, "1.2", d1.MinTlsVersion.Data)
+
+	// A domain still validating is registered but not yet serving TLS, and the
+	// API omits minTLS entirely for it.
+	d2 := domains[1].(*mqlCloudflareR2BucketCustomDomain)
+	assert.Equal(t, "staging-assets.example.com", d2.Domain.Data)
+	assert.False(t, d2.Enabled.Data)
+	assert.Equal(t, "pending", d2.OwnershipStatus.Data)
+	assert.Equal(t, "initializing", d2.SslStatus.Data)
+	assert.False(t, d2.CertificateActive.Data, "a certificate that is still initializing is not active")
+	assert.Equal(t, "", d2.MinTlsVersion.Data)
+
+	// Each domain must get its own cache key, or the second overwrites the first.
+	assert.NotEqual(t, d1.MqlID(), d2.MqlID())
+}
+
+// TestR2BucketIsPublicViaCustomDomainOnly is the regression guard for the false
+// negative this file's fix addresses: a bucket published through a custom domain
+// with the managed r2.dev subdomain switched off is world-readable, but
+// publicAccessEnabled reports only the r2.dev path and so reads false.
+func TestR2BucketIsPublicViaCustomDomainOnly(t *testing.T) {
+	env := setupTestEnv(t)
+	r2 := createTestR2(t, env)
+	handleBuckets(env)
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/logs-archive/domains/managed", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, loadFixture("r2_managed_domain_disabled"))
+	})
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/logs-archive/domains/custom", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, loadFixture("r2_custom_domains"))
+	})
+
+	bucket := bucketFor(t, r2, "logs-archive")
+
+	enabled, err := bucket.publicAccessEnabled()
+	require.NoError(t, err)
+	assert.False(t, enabled, "the r2.dev subdomain really is off; that field keeps its narrow meaning")
+
+	public, err := bucket.isPublic()
+	require.NoError(t, err)
+	assert.True(t, public, "an enabled custom domain serves the bucket on the internet")
+	assert.Zero(t, bucket.IsPublic.State&plugin.StateIsNull)
+}
+
+func TestR2BucketIsPublicViaManagedDomain(t *testing.T) {
+	env := setupTestEnv(t)
+	r2 := createTestR2(t, env)
+	handleBuckets(env)
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/public-assets/domains/managed", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, loadFixture("r2_managed_domain_enabled"))
+	})
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/public-assets/domains/custom", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("the managed subdomain already answered the question; no custom-domain call is needed")
+	})
+
+	bucket := bucketFor(t, r2, "public-assets")
+	public, err := bucket.isPublic()
+	require.NoError(t, err)
+	assert.True(t, public)
+}
+
+func TestR2BucketIsPublicNeitherPath(t *testing.T) {
+	env := setupTestEnv(t)
+	r2 := createTestR2(t, env)
+	handleBuckets(env)
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/backups/domains/managed", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, loadFixture("r2_managed_domain_disabled"))
+	})
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/backups/domains/custom", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, loadFixture("r2_custom_domains_empty"))
+	})
+
+	bucket := bucketFor(t, r2, "backups")
+
+	domains, err := bucket.customDomains()
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+
+	public, err := bucket.isPublic()
+	require.NoError(t, err)
+	assert.False(t, public)
+	assert.Zero(t, bucket.IsPublic.State&plugin.StateIsNull, "both paths were read, so false is a real answer")
+}
+
+// TestR2BucketIsPublicUnreadablePathIsNull covers the half-read case. Reporting
+// `false` when one of the two exposure paths could not be read would reproduce
+// the same false negative in a new field, so the answer is null instead.
+func TestR2BucketIsPublicUnreadablePathIsNull(t *testing.T) {
+	for _, tc := range []struct{ name, unreadable, readable string }{
+		{"custom domains forbidden", "custom", "managed"},
+		{"managed subdomain forbidden", "managed", "custom"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTestEnv(t)
+			r2 := createTestR2(t, env)
+			handleBuckets(env)
+
+			base := fmt.Sprintf("/accounts/%s/r2/buckets/backups/domains/", testAccountID)
+			env.Mux.HandleFunc(base+tc.unreadable, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				jsonResponse(w, `{"success":false,"errors":[{"code":10000,"message":"Forbidden"}]}`)
+			})
+			switch tc.readable {
+			case "managed":
+				env.Mux.HandleFunc(base+"managed", func(w http.ResponseWriter, r *http.Request) {
+					jsonResponse(w, loadFixture("r2_managed_domain_disabled"))
+				})
+			case "custom":
+				env.Mux.HandleFunc(base+"custom", func(w http.ResponseWriter, r *http.Request) {
+					jsonResponse(w, loadFixture("r2_custom_domains_empty"))
+				})
+			}
+
+			bucket := bucketFor(t, r2, "backups")
+			public, err := bucket.isPublic()
+			require.NoError(t, err)
+			assert.False(t, public)
+			assert.Equal(t, plugin.StateIsNull|plugin.StateIsSet, bucket.IsPublic.State,
+				"exposure is unknown, so the bucket must not be reported as private")
+		})
+	}
+}
+
+func TestR2BucketCustomDomainsForbidden(t *testing.T) {
+	env := setupTestEnv(t)
+	r2 := createTestR2(t, env)
+	handleBuckets(env)
+
+	env.Mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/backups/domains/custom", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		jsonResponse(w, `{"success":false,"errors":[{"code":10000,"message":"Forbidden"}]}`)
+	})
+
+	bucket := bucketFor(t, r2, "backups")
+	domains, err := bucket.customDomains()
+	require.NoError(t, err, "a gated or unreadable add-on must not fail the whole query")
+	assert.Empty(t, domains)
+}
+
+// TestR2BucketCustomDomainsUnboundAccountIssuesNoRequest mirrors the buckets()
+// guard: with no account bound the request would go to /accounts//r2/... , which
+// the API answers 404 and isUnavailable degrades to empty. Skip the request.
+func TestR2BucketCustomDomainsUnboundAccountIssuesNoRequest(t *testing.T) {
+	env := setupTestEnv(t)
+	env.Mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no request may be issued without an account: %s", r.URL.Path)
+	})
+
+	res, err := CreateResource(env.Runtime, "cloudflare.r2.bucket", map[string]*llx.RawData{
+		"__id": llx.StringData("unbound"),
+		"name": llx.StringData("backups"),
+	})
+	require.NoError(t, err)
+	bucket := res.(*mqlCloudflareR2Bucket) // no accountID bound
+
+	domains, err := bucket.customDomains()
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+}

--- a/providers/cloudflare/resources/testdata/r2_custom_domains.json
+++ b/providers/cloudflare/resources/testdata/r2_custom_domains.json
@@ -1,0 +1,30 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "domains": [
+      {
+        "domain": "assets.example.com",
+        "enabled": true,
+        "status": {
+          "ownership": "active",
+          "ssl": "active"
+        },
+        "minTLS": "1.2",
+        "zoneId": "d56084adb405e0b7e32c52321bf07be6",
+        "zoneName": "example.com"
+      },
+      {
+        "domain": "staging-assets.example.com",
+        "enabled": false,
+        "status": {
+          "ownership": "pending",
+          "ssl": "initializing"
+        },
+        "zoneId": "d56084adb405e0b7e32c52321bf07be6",
+        "zoneName": "example.com"
+      }
+    ]
+  }
+}

--- a/providers/cloudflare/resources/testdata/r2_custom_domains_empty.json
+++ b/providers/cloudflare/resources/testdata/r2_custom_domains_empty.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "domains": []
+  }
+}


### PR DESCRIPTION
## The bug

`cloudflare.r2.bucket.publicAccessEnabled` reads **only** the managed `r2.dev`
subdomain. `providers/cloudflare/resources/r2.go:192` (on `main`):

```go
func (c *mqlCloudflareR2Bucket) publicAccessEnabled() (bool, error) {
	available, enabled, _, err := c.fetchPublicAccess()
	...
}
```

`fetchPublicAccess` calls exactly one endpoint,
`GET accounts/{account_id}/r2/buckets/{name}/domains/managed`.

The schema then presented that single answer as the whole exposure story.
`providers/cloudflare/resources/cloudflare.lr:556` (on `main`):

```
// publicly over the managed r2.dev subdomain, the primary exposure to audit
// for an R2 bucket, alongside its storage location and creation time.
```

## Why it is wrong

An R2 bucket has **two independent** paths to the internet. The Cloudflare docs
are explicit: "These options can be used independently. Enabling custom domains
does not require enabling `r2.dev` access."

So a bucket published on a custom domain, with the `r2.dev` subdomain switched
off, is world-readable and currently reads `publicAccessEnabled: false`. That is
a false negative on a public-data-exposure control, not a coverage gap: a policy
asserting `cloudflare.r2.buckets.none(publicAccessEnabled)` **passes** on an
account whose buckets are served to the world. Custom domains are also the
production path (the docs note `r2.dev` is rate-limited and "intended for
non-production traffic"), so the missed case is the likely one.

## The fix

- **`customDomains()` on `cloudflare.r2.bucket`**, backed by the SDK's typed
  `R2.Buckets.Domains.Custom.List` (`GET
  accounts/{account_id}/r2/buckets/{bucket_name}/domains/custom`), rather than
  the generic `cfGetPaged` walker. The endpoint returns the whole set in one
  `result.domains` array with no cursor or page counter in the envelope, so
  there is nothing to page through; that is noted at the call site.
- **New sub-resource `cloudflare.r2.bucket.customDomain`** with `domain`,
  `enabled`, `ownershipStatus`, `sslStatus`, `certificateActive`, and
  `minTlsVersion`. `certificateActive` is derived (`sslStatus == "active"`), so a
  domain whose certificate is still `initializing` or `pending` does not read as
  having one. Each domain gets its own `__id`
  (`<account>/<bucket>/domains/custom/<domain>`).
- **`isPublic()` on `cloudflare.r2.bucket`** — true when the managed `r2.dev`
  subdomain is enabled **or** any custom domain is enabled. This is the
  established meaning of `isPublic` across the codebase ("reachable from the
  internet"), which is exactly what it means here.
- **`publicAccessEnabled` is unchanged in type and meaning.** Its doc-comment now
  says precisely what it covers and points at `isPublic` for the real question.
  The resource-level comment no longer calls the `r2.dev` path "the primary
  exposure to audit".

Null handling on `isPublic` is deliberately strict: when neither path proves the
bucket public, the answer is `false` only if **both** were actually read. If
either the managed subdomain or the custom-domain list could not be read, the
field is null. Reporting `false` there would reproduce the same false negative in
a brand-new field.

`customDomains()` keeps this provider's `degradedList`/`isUnavailable`
convention and degrades an unreadable list to empty; the schema comment says so,
and `isPublic` is the field that carries the null.

`corsRules()` and `objectLockEnabled()` were considered and left out, to keep
this change to the exposure fix.

## Verification

The endpoint path and response shape were confirmed against the Cloudflare API
reference and the vendored SDK
(`cloudflare-go/v7@v7.9.0/r2/bucketdomaincustom.go` plus its `api.md`), including the
nested `status.{ownership,ssl}` enums and the optional `minTLS`.

Ran in `providers/cloudflare/`:

```
$ go build ./...
$ go test ./...
?   	go.mondoo.com/mql/providers/cloudflare	[no test files]
?   	go.mondoo.com/mql/providers/cloudflare/config	[no test files]
ok  	go.mondoo.com/mql/providers/cloudflare/connection	1.151s
?   	go.mondoo.com/mql/providers/cloudflare/gen	[no test files]
?   	go.mondoo.com/mql/providers/cloudflare/provider	[no test files]
ok  	go.mondoo.com/mql/providers/cloudflare/resources	1.642s
```

Also run: `go vet ./...` (clean), `gofmt -l` on both changed `.go` files (clean),
`go mod tidy` inside `providers/cloudflare/` (no diff), and `typos` over
`providers/cloudflare/` (clean).

New tests against `httptest` fixtures shaped like the documented response:

- `TestR2BucketCustomDomains` — pins every struct tag, including the derived
  `certificateActive` and the absent-`minTLS` case, and asserts the two domains
  do not collide on one cache key.
- `TestR2BucketIsPublicViaCustomDomainOnly` — the regression guard. Managed
  subdomain **off**, custom domain **on**: `publicAccessEnabled` stays `false`
  (its narrow meaning is preserved) while `isPublic` is `true`.
- `TestR2BucketIsPublicViaManagedDomain` — `true` from the managed path, and the
  custom-domain endpoint is registered with a handler that fails the test if
  called, proving the early return costs no extra API call.
- `TestR2BucketIsPublicNeitherPath` — both paths read, both negative, `false`
  with the null bit clear.
- `TestR2BucketIsPublicUnreadablePathIsNull` — table over both halves: whichever
  path answers 403, `isPublic` is null rather than `false`.
- `TestR2BucketCustomDomainsForbidden` — a 403 degrades to an empty list instead
  of failing the query.
- `TestR2BucketCustomDomainsUnboundAccountIssuesNoRequest` — mirrors the existing
  `buckets()` guard: with no account bound, no request is issued.

Codegen re-run with `mqlr generate`; the nine new `.lr.versions` entries landed
at `13.8.1`, one patch above the provider's current `13.8.0` in
`config/config.go`, which is left untouched.

## Not verified against a live target

No Cloudflare API token is configured on this machine (`CLOUDFLARE_API_TOKEN` /
`CF_API_TOKEN` are unset, and there is no stored provider credential), so nothing
here was exercised against a real account. Unproven as a result:

- The live wire shape of `GET .../domains/custom` — the decode is pinned only
  against a fixture built from the documented schema and the SDK struct tags.
- Whether a real account's `status.ownership` / `status.ssl` ever return values
  outside the documented enum sets listed in the `.lr` comments.
- The actual behaviour of the endpoint on an account without R2, and on a token
  without R2 read scope. Both are assumed to answer 401/403/404 and degrade
  through `isUnavailable`. Worth flagging for whoever verifies live: because
  `degradedList`/`isUnavailable` maps 401/403/404 to an empty list, an
  under-permissioned token reports "no custom domains" rather than an error.
  `isPublic` is null in that case, which is the signal to look at, but confirm
  the token genuinely has R2 read scope before believing an empty
  `customDomains`.
- End-to-end `mql shell cloudflare -c "cloudflare.r2.buckets { name isPublic customDomains { domain enabled certificateActive } }"`
  has not been run.
