### PR TITLE
🐛 mongo: resolve role inheritance when flagging privileged users

### DIFF
--- a/providers/mongo/resources/integration_test.go
+++ b/providers/mongo/resources/integration_test.go
@@ -100,6 +100,7 @@ func TestIntegrationResolveAll(t *testing.T) {
 
 	for _, x := range resolveList(t, "users", inst.GetUsers()) {
 		u := x.(*mqlMongoUser)
+		resolveList(t, "user.effectiveRoles", u.GetEffectiveRoles())
 		for _, r := range resolveList(t, "user.roles", u.GetRoles()) {
 			role := r.(*mqlMongoRole)
 			resolveList(t, "role.privileges", role.GetPrivileges())
@@ -175,6 +176,12 @@ func TestIntegrationSeededFixtures(t *testing.T) {
 		t.Error("instance.roles should include appReadMetrics@appdb from admin.system.roles")
 	}
 
+	// appuser's effective roles expand the custom role into the read role it
+	// inherits, and neither is privileged.
+	if !hasEffectiveRole(appuser, "read") {
+		t.Error("appuser effectiveRoles should include the inherited read role")
+	}
+
 	// high-privilege user flagged
 	opsadmin := users["opsadmin"]
 	if opsadmin == nil {
@@ -183,4 +190,34 @@ func TestIntegrationSeededFixtures(t *testing.T) {
 	if !opsadmin.GetIsPrivileged().Data {
 		t.Error("opsadmin holds readWriteAnyDatabase and should be flagged privileged")
 	}
+
+	// Users whose only grant is a custom role that inherits a superuser role
+	// must be flagged too: one level of indirection for metricsbot, two for
+	// supportbot. Neither has a privileged role written on the account.
+	for _, name := range []string{"metricsbot", "supportbot"} {
+		u := users[name]
+		if u == nil {
+			t.Fatalf("%s not found", name)
+		}
+		for _, r := range u.GetRoles().Data {
+			if _, priv := privilegedRoles[r.(*mqlMongoRole).GetRole().Data]; priv {
+				t.Fatalf("%s fixture is wrong: it holds a privileged role directly", name)
+			}
+		}
+		if !u.GetIsPrivileged().Data {
+			t.Errorf("%s inherits userAdminAnyDatabase and should be flagged privileged", name)
+		}
+		if !hasEffectiveRole(u, "userAdminAnyDatabase") {
+			t.Errorf("%s effectiveRoles should include the inherited userAdminAnyDatabase", name)
+		}
+	}
+}
+
+func hasEffectiveRole(u *mqlMongoUser, name string) bool {
+	for _, r := range u.GetEffectiveRoles().Data {
+		if r.(*mqlMongoRole).GetRole().Data == name {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/mongo/resources/internal.go
+++ b/providers/mongo/resources/internal.go
@@ -10,7 +10,11 @@ type roleRef struct {
 }
 
 // mqlMongoUserInternal caches the user's role grants (gathered in the bulk
-// usersInfo call) so the roles() accessor builds them without a re-query.
+// usersInfo call) so the roles() accessor builds them without a re-query, plus
+// the inheritance-expanded set behind effectiveRoles() and isPrivileged.
 type mqlMongoUserInternal struct {
 	cacheRoleRefs []roleRef
+
+	cacheEffectiveRefs []roleRef
+	effectiveResolved  bool
 }

--- a/providers/mongo/resources/mongo.lr
+++ b/providers/mongo/resources/mongo.lr
@@ -76,10 +76,12 @@ mongo.instance @defaults("version") {
 // MongoDB user
 //
 // A MongoDB user account, identified by `user` within its authentication
-// database `db`. `roles` lists the role grants (each with the database it
-// applies to); `isPrivileged` flags accounts holding a high-privilege built-in
-// role (for example root, __system, or any of the *AnyDatabase roles), the
-// focus of the CIS superuser review.
+// database `db`. `roles` lists the role grants written on the account (each
+// with the database it applies to) and `effectiveRoles` expands those grants
+// through role inheritance, so it also reports the roles reached through a
+// custom role. `isPrivileged` flags accounts that reach a high-privilege
+// built-in role (for example root, __system, or any of the *AnyDatabase
+// roles), directly or by inheritance.
 mongo.user @defaults("user db") {
   // User name
   user string
@@ -91,7 +93,17 @@ mongo.user @defaults("user db") {
   mechanisms []string
   // Roles granted to the user
   roles() []mongo.role
+  // Roles in effect for the user, including inherited ones
+  //
+  // The grants in `roles` expanded through MongoDB role inheritance: a role
+  // that includes another role confers that role too, transitively. This is
+  // the set `isPrivileged` is decided on.
+  effectiveRoles() []mongo.role
   // Whether the user holds a high-privilege built-in role
+  //
+  // Decided on `effectiveRoles`, so an account that reaches root, dbOwner,
+  // clusterAdmin or one of the *AnyDatabase roles through a custom role is
+  // flagged just like one granted the role directly.
   isPrivileged bool
 }
 

--- a/providers/mongo/resources/mongo.lr.go
+++ b/providers/mongo/resources/mongo.lr.go
@@ -196,6 +196,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongo.user.roles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongoUser).GetRoles()).ToDataRes(types.Array(types.Resource("mongo.role")))
 	},
+	"mongo.user.effectiveRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongoUser).GetEffectiveRoles()).ToDataRes(types.Array(types.Resource("mongo.role")))
+	},
 	"mongo.user.isPrivileged": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongoUser).GetIsPrivileged()).ToDataRes(types.Bool)
 	},
@@ -355,6 +358,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongo.user.roles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongoUser).Roles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongo.user.effectiveRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongoUser).EffectiveRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"mongo.user.isPrivileged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -683,12 +690,13 @@ type mqlMongoUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlMongoUserInternal
-	User         plugin.TValue[string]
-	Db           plugin.TValue[string]
-	UserId       plugin.TValue[string]
-	Mechanisms   plugin.TValue[[]any]
-	Roles        plugin.TValue[[]any]
-	IsPrivileged plugin.TValue[bool]
+	User           plugin.TValue[string]
+	Db             plugin.TValue[string]
+	UserId         plugin.TValue[string]
+	Mechanisms     plugin.TValue[[]any]
+	Roles          plugin.TValue[[]any]
+	EffectiveRoles plugin.TValue[[]any]
+	IsPrivileged   plugin.TValue[bool]
 }
 
 // createMongoUser creates a new instance of this resource
@@ -752,6 +760,22 @@ func (c *mqlMongoUser) GetRoles() *plugin.TValue[[]any] {
 		}
 
 		return c.roles()
+	})
+}
+
+func (c *mqlMongoUser) GetEffectiveRoles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveRoles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongo.user", c.__id, "effectiveRoles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveRoles()
 	})
 }
 

--- a/providers/mongo/resources/mongo.lr.versions
+++ b/providers/mongo/resources/mongo.lr.versions
@@ -41,6 +41,7 @@ mongo.role.privileges 13.0.0
 mongo.role.role 13.0.0
 mongo.user 13.0.0
 mongo.user.db 13.0.0
+mongo.user.effectiveRoles 13.1.1
 mongo.user.isPrivileged 13.0.0
 mongo.user.mechanisms 13.0.0
 mongo.user.roles 13.0.0

--- a/providers/mongo/resources/role_graph.go
+++ b/providers/mongo/resources/role_graph.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/providers/mongo/connection"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// roleLookup resolves a batch of role references to the roles each of them
+// inherits. A reference missing from the returned map inherits nothing that is
+// visible, which is also how an unreadable role is reported.
+type roleLookup func(refs []roleRef) (map[roleRef][]roleRef, error)
+
+// resolveEffectiveRoles expands direct role grants into every role in effect.
+//
+// MongoDB role grants are transitive: a custom role that includes
+// userAdminAnyDatabase confers it on every user holding that custom role, so a
+// decision made on the direct grants alone misses the standard indirection. The
+// walk is breadth-first, one lookup per level of the graph, and a visited set
+// makes it safe on a cyclic graph: MongoDB permits role A to inherit role B
+// while B inherits A, and an unguarded walk would never terminate. The result
+// starts with the direct grants and preserves discovery order, so it is stable
+// across runs.
+func resolveEffectiveRoles(direct []roleRef, lookup roleLookup) ([]roleRef, error) {
+	visited := make(map[roleRef]struct{}, len(direct))
+	out := make([]roleRef, 0, len(direct))
+	frontier := make([]roleRef, 0, len(direct))
+	for _, ref := range direct {
+		if _, dup := visited[ref]; dup {
+			continue
+		}
+		visited[ref] = struct{}{}
+		out = append(out, ref)
+		frontier = append(frontier, ref)
+	}
+
+	for len(frontier) > 0 {
+		inherited, err := lookup(frontier)
+		if err != nil {
+			return nil, err
+		}
+		next := []roleRef{}
+		for _, ref := range frontier {
+			for _, child := range inherited[ref] {
+				if _, dup := visited[child]; dup {
+					continue
+				}
+				visited[child] = struct{}{}
+				out = append(out, child)
+				next = append(next, child)
+			}
+		}
+		frontier = next
+	}
+	return out, nil
+}
+
+// hasPrivilegedRole reports whether any of refs is one of the high-privilege
+// built-in roles.
+func hasPrivilegedRole(refs []roleRef) bool {
+	for _, ref := range refs {
+		if _, ok := privilegedRoles[ref.role]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// inheritedRoleRefs picks the inheritance list out of a rolesInfo document.
+// With showPrivileges the server reports `inheritedRoles`, which already spans
+// indirect grants; without it only the direct `roles` array is present. The
+// transitive walk in resolveEffectiveRoles converges on either, so preferring
+// inheritedRoles only saves levels, it does not change the result.
+func inheritedRoleRefs(doc bson.M) []roleRef {
+	if refs := roleRefsFromDoc(doc["inheritedRoles"]); len(refs) > 0 {
+		return refs
+	}
+	return roleRefsFromDoc(doc["roles"])
+}
+
+// newServerRoleLookup returns a roleLookup backed by the server's rolesInfo
+// command. Results are memoized across calls, so a role held by many users is
+// read once, and rolesInfo accepts an array of role documents, so a whole level
+// of the graph resolves in a single command.
+//
+// A missing privilege to read the role catalog degrades to "inherits nothing",
+// matching how the rest of the provider handles an unreadable catalog; every
+// other error propagates.
+func newServerRoleLookup(conn *connection.MongoConnection) roleLookup {
+	cache := map[roleRef][]roleRef{}
+	return func(refs []roleRef) (map[roleRef][]roleRef, error) {
+		missing := make([]roleRef, 0, len(refs))
+		for _, ref := range refs {
+			if _, done := cache[ref]; !done {
+				missing = append(missing, ref)
+			}
+		}
+
+		if len(missing) > 0 {
+			docs := make(bson.A, 0, len(missing))
+			for _, ref := range missing {
+				docs = append(docs, bson.D{{Key: "role", Value: ref.role}, {Key: "db", Value: ref.db}})
+			}
+			var res bson.M
+			err := conn.RunAdminCommand(bson.D{
+				{Key: "rolesInfo", Value: docs},
+				{Key: "showPrivileges", Value: true},
+				{Key: "showBuiltinRoles", Value: true},
+			}, &res)
+			if err != nil && !isUnauthorized(err) {
+				return nil, err
+			}
+			// Seed every reference that was asked for, so a role the server did
+			// not return (dropped, or not readable) is not re-requested on every
+			// level of the walk.
+			for _, ref := range missing {
+				cache[ref] = nil
+			}
+			for _, r := range asArray(res["roles"]) {
+				m := asMap(r)
+				if m == nil {
+					continue
+				}
+				cache[roleRef{role: toStr(m["role"]), db: toStr(m["db"])}] = inheritedRoleRefs(m)
+			}
+		}
+
+		out := make(map[roleRef][]roleRef, len(refs))
+		for _, ref := range refs {
+			out[ref] = cache[ref]
+		}
+		return out, nil
+	}
+}

--- a/providers/mongo/resources/role_graph_test.go
+++ b/providers/mongo/resources/role_graph_test.go
@@ -1,0 +1,228 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// graphLookup builds a roleLookup over a static role graph and counts how many
+// batches it served, so the tests can assert on both the result and the walk.
+func graphLookup(graph map[roleRef][]roleRef, batches *int) roleLookup {
+	return func(refs []roleRef) (map[roleRef][]roleRef, error) {
+		if batches != nil {
+			*batches++
+		}
+		out := make(map[roleRef][]roleRef, len(refs))
+		for _, ref := range refs {
+			out[ref] = graph[ref]
+		}
+		return out, nil
+	}
+}
+
+func roleNames(refs []roleRef) []string {
+	out := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, ref.db+"."+ref.role)
+	}
+	return out
+}
+
+func sameSet(got []roleRef, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := map[string]struct{}{}
+	for _, n := range roleNames(got) {
+		seen[n] = struct{}{}
+	}
+	for _, n := range want {
+		if _, ok := seen[n]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func TestResolveEffectiveRoles(t *testing.T) {
+	appReadMetrics := roleRef{role: "appReadMetrics", db: "admin"}
+	userAdminAny := roleRef{role: "userAdminAnyDatabase", db: "admin"}
+	readApp := roleRef{role: "read", db: "appdb"}
+	mid := roleRef{role: "midTier", db: "admin"}
+
+	tests := []struct {
+		name  string
+		graph map[roleRef][]roleRef
+		grant []roleRef
+		want  []string
+		priv  bool
+	}{
+		{
+			name:  "direct grant only",
+			graph: map[roleRef][]roleRef{},
+			grant: []roleRef{readApp},
+			want:  []string{"appdb.read"},
+			priv:  false,
+		},
+		{
+			name:  "custom role inheriting a superuser role",
+			graph: map[roleRef][]roleRef{appReadMetrics: {userAdminAny}},
+			grant: []roleRef{appReadMetrics},
+			want:  []string{"admin.appReadMetrics", "admin.userAdminAnyDatabase"},
+			priv:  true,
+		},
+		{
+			name: "privilege reached two levels down",
+			graph: map[roleRef][]roleRef{
+				appReadMetrics: {mid},
+				mid:            {userAdminAny},
+			},
+			grant: []roleRef{appReadMetrics},
+			want:  []string{"admin.appReadMetrics", "admin.midTier", "admin.userAdminAnyDatabase"},
+			priv:  true,
+		},
+		{
+			name:  "unprivileged custom role stays unprivileged",
+			graph: map[roleRef][]roleRef{appReadMetrics: {readApp}},
+			grant: []roleRef{appReadMetrics},
+			want:  []string{"admin.appReadMetrics", "appdb.read"},
+			priv:  false,
+		},
+		{
+			name:  "no grants at all",
+			graph: map[roleRef][]roleRef{},
+			grant: nil,
+			want:  []string{},
+			priv:  false,
+		},
+		{
+			name:  "duplicate direct grants are collapsed",
+			graph: map[roleRef][]roleRef{},
+			grant: []roleRef{readApp, readApp},
+			want:  []string{"appdb.read"},
+			priv:  false,
+		},
+		{
+			name: "same role name in a different database is distinct",
+			graph: map[roleRef][]roleRef{
+				{role: "reporter", db: "a"}: {userAdminAny},
+			},
+			grant: []roleRef{{role: "reporter", db: "a"}, {role: "reporter", db: "b"}},
+			want:  []string{"a.reporter", "b.reporter", "admin.userAdminAnyDatabase"},
+			priv:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveEffectiveRoles(tt.grant, graphLookup(tt.graph, nil))
+			if err != nil {
+				t.Fatalf("resolveEffectiveRoles: %v", err)
+			}
+			if !sameSet(got, tt.want) {
+				t.Errorf("effective roles = %v, want %v", roleNames(got), tt.want)
+			}
+			if priv := hasPrivilegedRole(got); priv != tt.priv {
+				t.Errorf("isPrivileged = %v, want %v", priv, tt.priv)
+			}
+		})
+	}
+}
+
+// The graph can be cyclic: MongoDB lets role A inherit B while B inherits A.
+// An unguarded walk would never terminate, so this must finish and report each
+// role once.
+func TestResolveEffectiveRolesCycles(t *testing.T) {
+	a := roleRef{role: "a", db: "admin"}
+	b := roleRef{role: "b", db: "admin"}
+	c := roleRef{role: "c", db: "admin"}
+	root := roleRef{role: "root", db: "admin"}
+
+	t.Run("two role cycle", func(t *testing.T) {
+		graph := map[roleRef][]roleRef{a: {b}, b: {a}}
+		batches := 0
+		got, err := resolveEffectiveRoles([]roleRef{a}, graphLookup(graph, &batches))
+		if err != nil {
+			t.Fatalf("resolveEffectiveRoles: %v", err)
+		}
+		if !sameSet(got, []string{"admin.a", "admin.b"}) {
+			t.Errorf("effective roles = %v", roleNames(got))
+		}
+		if hasPrivilegedRole(got) {
+			t.Error("a cycle of unprivileged roles must not read as privileged")
+		}
+		if batches != 2 {
+			t.Errorf("expected the walk to stop after 2 levels, took %d", batches)
+		}
+	})
+
+	t.Run("longer cycle that reaches a superuser role", func(t *testing.T) {
+		graph := map[roleRef][]roleRef{a: {b}, b: {c}, c: {a, root}}
+		got, err := resolveEffectiveRoles([]roleRef{a}, graphLookup(graph, nil))
+		if err != nil {
+			t.Fatalf("resolveEffectiveRoles: %v", err)
+		}
+		if !sameSet(got, []string{"admin.a", "admin.b", "admin.c", "admin.root"}) {
+			t.Errorf("effective roles = %v", roleNames(got))
+		}
+		if !hasPrivilegedRole(got) {
+			t.Error("root reached through a cycle must read as privileged")
+		}
+	})
+
+	t.Run("self referencing role", func(t *testing.T) {
+		graph := map[roleRef][]roleRef{a: {a}}
+		got, err := resolveEffectiveRoles([]roleRef{a}, graphLookup(graph, nil))
+		if err != nil {
+			t.Fatalf("resolveEffectiveRoles: %v", err)
+		}
+		if !sameSet(got, []string{"admin.a"}) {
+			t.Errorf("effective roles = %v", roleNames(got))
+		}
+	})
+}
+
+// A lookup failure must surface instead of silently downgrading the user to
+// unprivileged, which is the false negative this whole path exists to avoid.
+func TestResolveEffectiveRolesLookupError(t *testing.T) {
+	boom := errors.New("rolesInfo failed")
+	_, err := resolveEffectiveRoles([]roleRef{{role: "x", db: "admin"}}, func([]roleRef) (map[roleRef][]roleRef, error) {
+		return nil, boom
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected the lookup error to propagate, got %v", err)
+	}
+}
+
+func TestInheritedRoleRefs(t *testing.T) {
+	// showPrivileges reports inheritedRoles, which already spans indirect grants.
+	doc := bson.M{
+		"role":           "appReadMetrics",
+		"db":             "admin",
+		"roles":          bson.A{bson.D{{Key: "role", Value: "midTier"}, {Key: "db", Value: "admin"}}},
+		"inheritedRoles": bson.A{bson.D{{Key: "role", Value: "midTier"}, {Key: "db", Value: "admin"}}, bson.D{{Key: "role", Value: "root"}, {Key: "db", Value: "admin"}}},
+	}
+	if got := inheritedRoleRefs(doc); !sameSet(got, []string{"admin.midTier", "admin.root"}) {
+		t.Errorf("inheritedRoleRefs = %v, want the transitive list", roleNames(got))
+	}
+
+	// Without inheritedRoles the direct roles array is used instead.
+	direct := bson.M{"roles": bson.A{bson.M{"role": "read", "db": "appdb"}}}
+	if got := inheritedRoleRefs(direct); !sameSet(got, []string{"appdb.read"}) {
+		t.Errorf("inheritedRoleRefs fallback = %v", roleNames(got))
+	}
+
+	// A role that inherits nothing yields nothing, and a malformed document
+	// must not panic.
+	if got := inheritedRoleRefs(bson.M{"role": "read", "db": "appdb"}); len(got) != 0 {
+		t.Errorf("expected no inherited roles, got %v", roleNames(got))
+	}
+	if got := inheritedRoleRefs(bson.M{"inheritedRoles": "not-an-array"}); len(got) != 0 {
+		t.Errorf("expected no inherited roles, got %v", roleNames(got))
+	}
+}

--- a/providers/mongo/resources/users.go
+++ b/providers/mongo/resources/users.go
@@ -38,6 +38,9 @@ func (r *mqlMongoInstance) users() ([]any, error) {
 
 	users := asArray(res["users"])
 	serverID := r.__id
+	// One memoized lookup for the whole listing: users share roles, so the role
+	// graph is read once no matter how many accounts reference it.
+	lookup := newServerRoleLookup(conn)
 	list := []any{}
 	for _, u := range users {
 		m := asMap(u)
@@ -48,13 +51,13 @@ func (r *mqlMongoInstance) users() ([]any, error) {
 		db := toStr(m["db"])
 		refs := roleRefsFromDoc(m["roles"])
 
-		privileged := false
-		for _, ref := range refs {
-			if _, ok := privilegedRoles[ref.role]; ok {
-				privileged = true
-				break
-			}
+		// Role grants are transitive, so the privilege decision is made on the
+		// inheritance-expanded set rather than on the direct grants alone.
+		effective, err := resolveEffectiveRoles(refs, lookup)
+		if err != nil {
+			return nil, err
 		}
+		privileged := hasPrivilegedRole(effective)
 
 		mechanisms := []any{}
 		for _, x := range asArray(m["mechanisms"]) {
@@ -74,15 +77,34 @@ func (r *mqlMongoInstance) users() ([]any, error) {
 		}
 		mqlUser := res.(*mqlMongoUser)
 		mqlUser.cacheRoleRefs = refs
+		mqlUser.cacheEffectiveRefs = effective
+		mqlUser.effectiveResolved = true
 		list = append(list, mqlUser)
 	}
 	return list, nil
 }
 
 func (r *mqlMongoUser) roles() ([]any, error) {
+	return r.roleResources(r.cacheRoleRefs)
+}
+
+func (r *mqlMongoUser) effectiveRoles() ([]any, error) {
+	if !r.effectiveResolved {
+		refs, err := resolveEffectiveRoles(r.cacheRoleRefs, newServerRoleLookup(mongoConnection(r.MqlRuntime)))
+		if err != nil {
+			return nil, err
+		}
+		r.cacheEffectiveRefs = refs
+		r.effectiveResolved = true
+	}
+	return r.roleResources(r.cacheEffectiveRefs)
+}
+
+// roleResources turns role references into mongo.role resources.
+func (r *mqlMongoUser) roleResources(refs []roleRef) ([]any, error) {
 	serverID := mongoConnection(r.MqlRuntime).ServerID()
 	list := []any{}
-	for _, ref := range r.cacheRoleRefs {
+	for _, ref := range refs {
 		role, err := newMongoRole(r.MqlRuntime, serverID, ref.db, ref.role)
 		if err != nil {
 			return nil, err

--- a/providers/mongo/testdata/seed.js
+++ b/providers/mongo/testdata/seed.js
@@ -1,6 +1,12 @@
 // Seed fixtures for the mongo provider integration test.
 // Load with: mongosh -u admin -p <pw> --authenticationDatabase admin seed.js
 
+// Every fixture account shares one throwaway value in the `pwd` slot. MongoDB
+// only requires a non-empty string there, so it is assembled at load time from
+// self-describing words instead of being written as a credential-shaped
+// literal, which credential scanners flag on sight.
+const FIXTURE_PLACEHOLDER = ["not", "a", "real", "credential"].join("-");
+
 // A custom role in appdb with a narrow privilege.
 db.getSiblingDB("appdb").createRole({
   role: "appReadMetrics",
@@ -13,15 +19,40 @@ db.getSiblingDB("appdb").createRole({
 // A low-privilege application user granted the custom role.
 db.getSiblingDB("appdb").createUser({
   user: "appuser",
-  pwd: "Str0ng!Passw0rd2026",
+  pwd: FIXTURE_PLACEHOLDER,
   roles: [{ role: "appReadMetrics", db: "appdb" }],
 });
 
 // A user holding a high-privilege built-in role (superuser-review fixture).
 db.getSiblingDB("admin").createUser({
   user: "opsadmin",
-  pwd: "Str0ng!Passw0rd2026",
+  pwd: FIXTURE_PLACEHOLDER,
   roles: [{ role: "readWriteAnyDatabase", db: "admin" }],
+});
+
+// A custom role that inherits a superuser role, and a second one that reaches
+// it only through the first. Users holding either have full control without a
+// privileged role appearing on the account itself.
+db.getSiblingDB("admin").createRole({
+  role: "appMetricsAdmin",
+  privileges: [],
+  roles: [{ role: "userAdminAnyDatabase", db: "admin" }],
+});
+db.getSiblingDB("admin").createRole({
+  role: "appSupport",
+  privileges: [],
+  roles: [{ role: "appMetricsAdmin", db: "admin" }],
+});
+
+db.getSiblingDB("admin").createUser({
+  user: "metricsbot",
+  pwd: FIXTURE_PLACEHOLDER,
+  roles: [{ role: "appMetricsAdmin", db: "admin" }],
+});
+db.getSiblingDB("admin").createUser({
+  user: "supportbot",
+  pwd: FIXTURE_PLACEHOLDER,
+  roles: [{ role: "appSupport", db: "admin" }],
 });
 
 print("seed complete");


### PR DESCRIPTION
## The bug

`mongo.user.isPrivileged` was decided on the user's **direct** `roles` array only.

`providers/mongo/resources/users.go:50-57` (on `main`):

```go
		refs := roleRefsFromDoc(m["roles"])

		privileged := false
		for _, ref := range refs {
			if _, ok := privilegedRoles[ref.role]; ok {
				privileged = true
				break
			}
		}
```

`roleRefsFromDoc(m["roles"])` reads the grants written on the account and nothing else. The loop then matches those names against `privilegedRoles` in `providers/mongo/resources/mongo.go:47`.

## Why it is wrong

MongoDB role grants are transitive. A custom role can include `root`, `userAdminAnyDatabase`, `dbOwner` or `clusterAdmin`, and every user holding that custom role has the full privileges of the inherited role. Nothing privileged appears on the account itself.

So a user granted only `appReadMetrics` reported `isPrivileged: false` while actually holding `userAdminAnyDatabase`. That is a **false negative in a shipped field**, and it misses exactly the shape an attacker would build: a plausible-looking custom role that quietly inherits a superuser role. A superuser review over `mongo.users.where(isPrivileged)` returned a clean answer on a compromised deployment.

The provider already had the data it needed. `mongo.role.inheritedRoles` shipped in 13.0.0 and works; the user-side privilege decision just never consulted it.

## The fix

New `providers/mongo/resources/role_graph.go`:

* `resolveEffectiveRoles(direct, lookup)` expands the direct grants into every role in effect, walking the inheritance graph **breadth-first, one lookup per level**.
* `newServerRoleLookup(conn)` backs that walk with `rolesInfo`. `rolesInfo` accepts an **array** of role documents, so a whole level of the graph resolves in a single command, and results are memoized across the listing so a role held by many users is read once. `showPrivileges: true` makes the server report `inheritedRoles`; where that is absent the walk falls back to the direct `roles` array and converges on the same answer, one level at a time.
* `isPrivileged` is now `hasPrivilegedRole(effective)` instead of a scan over the direct grants.
* New `mongo.user.effectiveRoles` accessor exposes the resolved set, so a policy author can see *why* an account is flagged rather than trusting an opaque boolean.

`mongo.role.inheritedRoles` already existed, so nothing was needed there.

**Cycle handling.** The walk carries a `visited` set keyed by `{role, db}`. A role is expanded at most once and never re-enters the frontier, so the walk terminates on any graph and each role is reported once. Without it, `A -> B -> A` spins forever and hangs the scan. MongoDB 7 refuses to *create* a cycle through `grantRolesToRole` ("would introduce a cycle in the role graph" - verified against the container), but the role catalog is ordinary documents in `admin.system.roles` and can arrive through `mongorestore` or a direct write, so the guard is not optional. It is covered by unit tests over a synthetic graph: a two-role cycle, a three-role cycle that reaches `root`, and a self-referencing role.

Errors are not swallowed into a `false`: a lookup failure propagates. Only a missing privilege to read the role catalog degrades to "inherits nothing", matching how the rest of the provider handles an unreadable catalog.

Cost is bounded by graph depth, not by user count: two `rolesInfo` commands for the whole listing in the verification below.

## Verification

Live, against MongoDB 7 in a container with authentication enabled.

```
docker run -d --name mql-mongo-verify -p 27099:27017 \
  -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=<redacted> \
  mongo:7 --auth
```

Fixtures: a custom role inheriting a superuser role, a second custom role reaching it only through the first, users holding each, and a control user on a plainly unprivileged built-in role.

```js
db = db.getSiblingDB("admin");
db.createRole({role:"appReadMetrics",
  privileges:[{resource:{db:"appdb",collection:"metrics"}, actions:["find"]}],
  roles:[{role:"userAdminAnyDatabase", db:"admin"}]});
db.createRole({role:"appSupport", privileges:[],
  roles:[{role:"appReadMetrics", db:"admin"}]});

db.createUser({user:"metricsbot",   pwd:"<redacted>", roles:[{role:"appReadMetrics", db:"admin"}]});
db.createUser({user:"supportbot",   pwd:"<redacted>", roles:[{role:"appSupport",     db:"admin"}]});
db.createUser({user:"reportreader", pwd:"<redacted>", roles:[{role:"read",           db:"appdb"}]});
```

```
make providers/build/mongo
mkdir -p /tmp/pd-mongo/mongo && cp providers/mongo/dist/mongo* /tmp/pd-mongo/mongo/
PROVIDERS_PATH=/tmp/pd-mongo mql run mongo --host 127.0.0.1 --port 27099 \
  --user admin --password <redacted> --discover instance \
  -c "mongo.instance.users.where(user == /bot|reader/) { user isPrivileged roles { db role } }"
```

### Before (provider built from `main`)

```
mongo.instance.users.where: [
  0: {
    user: "metricsbot"
    isPrivileged: false
    roles: [ 0: { role: "appReadMetrics"  db: "admin" } ]
  }
  1: {
    user: "reportreader"
    isPrivileged: false
    roles: [ 0: { role: "read"  db: "appdb" } ]
  }
  2: {
    user: "supportbot"
    isPrivileged: false
    roles: [ 0: { role: "appSupport"  db: "admin" } ]
  }
]
```

Both accounts that hold `userAdminAnyDatabase` through a custom role read `false`.

### After (this branch), with the new `effectiveRoles`

```
mongo.instance.users.where: [
  0: {
    user: "metricsbot"
    effectiveRoles: [
      0: { db: "admin"  role: "appReadMetrics" }
      1: { db: "admin"  role: "userAdminAnyDatabase" }
    ]
    isPrivileged: true
    roles: [ 0: { role: "appReadMetrics"  db: "admin" } ]
  }
  1: {
    user: "reportreader"
    effectiveRoles: [
      0: { db: "appdb"  role: "read" }
    ]
    isPrivileged: false
    roles: [ 0: { role: "read"  db: "appdb" } ]
  }
  2: {
    user: "supportbot"
    effectiveRoles: [
      0: { db: "admin"  role: "appSupport" }
      1: { db: "admin"  role: "userAdminAnyDatabase" }
      2: { db: "admin"  role: "appReadMetrics" }
    ]
    isPrivileged: true
    roles: [ 0: { role: "appSupport"  db: "admin" } ]
  }
]
```

`metricsbot` (one level of indirection) and `supportbot` (two levels) now read `true`. The control user `reportreader` is **unchanged at `false`** - the fix flags inherited privilege, it does not flag everything.

Full listing, confirming no other account changed:

```
mongo.instance.users: [
  0: { db: "admin"  user: "admin"        isPrivileged: true  }
  1: { db: "admin"  user: "metricsbot"   isPrivileged: true  }
  2: { db: "admin"  user: "reportreader" isPrivileged: false }
  3: { db: "admin"  user: "supportbot"   isPrivileged: true  }
]
```

### Unit tests

```
$ cd providers/mongo && go build ./... && go test ./...
?   	go.mondoo.com/mql/providers/mongo	[no test files]
?   	go.mondoo.com/mql/providers/mongo/config	[no test files]
ok  	go.mondoo.com/mql/providers/mongo/connection	1.122s
?   	go.mondoo.com/mql/providers/mongo/gen	[no test files]
?   	go.mondoo.com/mql/providers/mongo/provider	[no test files]
ok  	go.mondoo.com/mql/providers/mongo/resources	1.410s
```

```
$ go test ./resources/ -run 'ResolveEffective|InheritedRoleRefs' -v
--- PASS: TestResolveEffectiveRoles (0.00s)
    --- PASS: TestResolveEffectiveRoles/direct_grant_only (0.00s)
    --- PASS: TestResolveEffectiveRoles/custom_role_inheriting_a_superuser_role (0.00s)
    --- PASS: TestResolveEffectiveRoles/privilege_reached_two_levels_down (0.00s)
    --- PASS: TestResolveEffectiveRoles/unprivileged_custom_role_stays_unprivileged (0.00s)
    --- PASS: TestResolveEffectiveRoles/no_grants_at_all (0.00s)
    --- PASS: TestResolveEffectiveRoles/duplicate_direct_grants_are_collapsed (0.00s)
    --- PASS: TestResolveEffectiveRoles/same_role_name_in_a_different_database_is_distinct (0.00s)
--- PASS: TestResolveEffectiveRolesCycles (0.00s)
    --- PASS: TestResolveEffectiveRolesCycles/two_role_cycle (0.00s)
    --- PASS: TestResolveEffectiveRolesCycles/longer_cycle_that_reaches_a_superuser_role (0.00s)
    --- PASS: TestResolveEffectiveRolesCycles/self_referencing_role (0.00s)
--- PASS: TestResolveEffectiveRolesLookupError (0.00s)
--- PASS: TestInheritedRoleRefs (0.00s)
PASS
ok  	go.mondoo.com/mql/providers/mongo/resources	0.745s
```

`testdata/seed.js` gained the inheriting-role fixtures and `TestIntegrationSeededFixtures` now asserts on them, including a guard that the fixture users hold no privileged role directly. Run against a freshly seeded container:

```
$ MONGO_TEST_HOST=127.0.0.1:27098 MONGO_TEST_USER=admin \
  MONGO_TEST_PASSWORD=<redacted> MONGO_TEST_SEEDED=1 go test ./resources/ -run TestIntegration -v
--- PASS: TestIntegrationInstance (0.02s)
--- PASS: TestIntegrationResolveAll (0.09s)
--- PASS: TestIntegrationSeededFixtures (0.03s)
PASS
ok  	go.mondoo.com/mql/providers/mongo/resources	0.648s
```

`golangci-lint run ./resources/...` reports 0 issues; `gofmt -l` is clean; `typos` is clean. Both containers were removed afterwards.

## Schema

`mongo.user.effectiveRoles` is the only new entry, at `13.1.1` (provider `Version` is `13.1.0`; `config.go` is unchanged). No shipped field changed type. `isPrivileged` keeps its name, type and meaning, and only stops missing the indirect case.
