### PR TITLE
🐛 netlify: report visitor password protection per site

### DIFF
--- a/providers/netlify/resources/decode_test.go
+++ b/providers/netlify/resources/decode_test.go
@@ -486,3 +486,86 @@ func TestStrSliceToAny(t *testing.T) {
 		t.Fatalf("expected an empty slice for nil input, got %v", empty)
 	}
 }
+
+// The site password is a secret and is never modelled. Its presence is the
+// finding, so the derivation has to survive every form the API may report the
+// value in, and an unreported key must stay null rather than becoming a
+// confident "not protected".
+func TestSitePasswordProtected(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    *bool
+	}{
+		{
+			name:    "key absent stays null",
+			payload: `{"id":"site_1","name":"www"}`,
+			want:    nil,
+		},
+		{
+			name:    "explicit json null is a reported absence",
+			payload: `{"id":"site_1","password":null}`,
+			want:    ptr(false),
+		},
+		{
+			name:    "empty string is no password",
+			payload: `{"id":"site_1","password":""}`,
+			want:    ptr(false),
+		},
+		{
+			name:    "literal password is protected",
+			payload: `{"id":"site_1","password":"correct-horse"}`,
+			want:    ptr(true),
+		},
+		{
+			name:    "redacted placeholder is still protected",
+			payload: `{"id":"site_1","password":"****"}`,
+			want:    ptr(true),
+		},
+		{
+			name:    "boolean marker true is protected",
+			payload: `{"id":"site_1","password":true}`,
+			want:    ptr(true),
+		},
+		{
+			name:    "boolean marker false is not protected",
+			payload: `{"id":"site_1","password":false}`,
+			want:    ptr(false),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec siteRecord
+			if err := json.Unmarshal([]byte(tc.payload), &rec); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+
+			got := sitePasswordProtected(rec.Password)
+			switch {
+			case tc.want == nil && got != nil:
+				t.Fatalf("expected null, got %v", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("expected %v, got null", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Fatalf("expected %v, got %v", *tc.want, *got)
+			}
+		})
+	}
+}
+
+// The raw password must never be readable from the record as a string field:
+// only the derived presence is exposed. This pins the type so a later change
+// that widens it to a plain string fails here.
+func TestSitePasswordIsNotExposedAsAValue(t *testing.T) {
+	var rec siteRecord
+	if err := json.Unmarshal([]byte(`{"id":"site_1","password":"correct-horse"}`), &rec); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(rec.Password) == 0 {
+		t.Fatal("expected the raw password to decode so presence can be derived")
+	}
+	if got := sitePasswordProtected(rec.Password); got == nil || !*got {
+		t.Fatalf("expected the site to read as password protected, got %v", got)
+	}
+}

--- a/providers/netlify/resources/netlify.lr
+++ b/providers/netlify/resources/netlify.lr
@@ -249,7 +249,8 @@ private netlify.envVar @defaults("key isSecret") {
 // enforcement, `untrustedFlow` for what a fork's pull request may run,
 // `customDomain` and `domainAliases` for the names it answers on, the `repo`
 // fields for the source a build runs from, `publicRepo` and `privateLogs` for
-// build-output exposure, `stopBuilds` for whether automatic deploys are
+// build-output exposure, `passwordProtected` for whether visitors must supply
+// a password to reach it, `stopBuilds` for whether automatic deploys are
 // suspended, and `preventNonGitProdDeploys` for whether production can be
 // published outside of git. The `environmentVariables`, `buildHooks`,
 // `notificationHooks`, and `snippets` fields cover what a deploy injects and
@@ -354,6 +355,18 @@ private netlify.site @defaults("name url") {
   privateLogs bool
   // Whether automatic builds are suspended for the site
   stopBuilds bool
+  // Whether the site is gated behind a visitor password
+  //
+  // Reported per site, unlike the account-wide hasSitePassword rollup, so a
+  // single unprotected site inside an otherwise protected account is visible.
+  // Derived from whether the API reports a password for the site; the
+  // password itself is a secret and is never exposed. Netlify may report the
+  // value as a literal password, as a redacted placeholder, or as a
+  // boolean-ish marker, and in every form the presence of a value is the
+  // signal that a visitor password is set. Null when the API does not report
+  // the field at all, which is indistinguishable from a site that never set
+  // one, so test with `== true` to find the sites known to be protected.
+  passwordProtected bool
   // Deploy key granting the build access to the repository
   deployKey() netlify.deployKey
   // Environment variables that apply to the site

--- a/providers/netlify/resources/netlify.lr.go
+++ b/providers/netlify/resources/netlify.lr.go
@@ -444,6 +444,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"netlify.site.stopBuilds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNetlifySite).GetStopBuilds()).ToDataRes(types.Bool)
 	},
+	"netlify.site.passwordProtected": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNetlifySite).GetPasswordProtected()).ToDataRes(types.Bool)
+	},
 	"netlify.site.deployKey": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNetlifySite).GetDeployKey()).ToDataRes(types.Resource("netlify.deployKey"))
 	},
@@ -998,6 +1001,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"netlify.site.stopBuilds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNetlifySite).StopBuilds, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"netlify.site.passwordProtected": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNetlifySite).PasswordProtected, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"netlify.site.deployKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1901,6 +1908,7 @@ type mqlNetlifySite struct {
 	PublicRepo                plugin.TValue[bool]
 	PrivateLogs               plugin.TValue[bool]
 	StopBuilds                plugin.TValue[bool]
+	PasswordProtected         plugin.TValue[bool]
 	DeployKey                 plugin.TValue[*mqlNetlifyDeployKey]
 	EnvironmentVariables      plugin.TValue[[]any]
 	BuildHooks                plugin.TValue[[]any]
@@ -2104,6 +2112,10 @@ func (c *mqlNetlifySite) GetPrivateLogs() *plugin.TValue[bool] {
 
 func (c *mqlNetlifySite) GetStopBuilds() *plugin.TValue[bool] {
 	return &c.StopBuilds
+}
+
+func (c *mqlNetlifySite) GetPasswordProtected() *plugin.TValue[bool] {
+	return &c.PasswordProtected
 }
 
 func (c *mqlNetlifySite) GetDeployKey() *plugin.TValue[*mqlNetlifyDeployKey] {

--- a/providers/netlify/resources/netlify.lr.versions
+++ b/providers/netlify/resources/netlify.lr.versions
@@ -114,6 +114,7 @@ netlify.site.notificationHook.id 13.0.0
 netlify.site.notificationHook.type 13.0.0
 netlify.site.notificationHook.updatedAt 13.0.0
 netlify.site.notificationHooks 13.0.0
+netlify.site.passwordProtected 13.1.1
 netlify.site.plan 13.0.0
 netlify.site.prerender 13.0.0
 netlify.site.preventNonGitProdDeploys 13.0.0

--- a/providers/netlify/resources/sites.go
+++ b/providers/netlify/resources/sites.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
 	"strconv"
@@ -50,7 +51,55 @@ type siteRecord struct {
 	CreatedAt                 netlifyTime        `json:"created_at"`
 	UpdatedAt                 netlifyTime        `json:"updated_at"`
 	BuildSettings             *buildSettingsData `json:"build_settings"`
+
+	// Password is the site's visitor password as the API reports it. It is
+	// held as raw JSON so the value never lands in a field, and so an absent
+	// key stays distinguishable from a reported one. A non-pointer
+	// json.RawMessage is deliberate: a pointer would collapse an explicit
+	// JSON null back into the absent case. Only its presence is surfaced,
+	// through passwordProtected.
+	Password json.RawMessage `json:"password"`
 }
+
+// sitePasswordProtected reports whether a site is gated behind a visitor
+// password, from the raw password value the API returned.
+//
+// The password itself is a secret and is never modelled. Only its presence is
+// the finding, and presence survives every form the API may report the value
+// in: a literal password, a redacted placeholder such as "****", or a
+// boolean-ish marker. A key the API did not return at all yields nil, which
+// reaches MQL as null rather than as a confident "not protected", because an
+// unreported field is indistinguishable from a site that never set one.
+func sitePasswordProtected(raw json.RawMessage) *bool {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		// The key was returned in a shape we cannot read. A value is present,
+		// which is the signal we report.
+		return ptr(true)
+	}
+
+	switch t := v.(type) {
+	case nil:
+		// Explicitly reported as having no password.
+		return ptr(false)
+	case string:
+		// A literal password or a redacted placeholder. Either way a password
+		// is set; an empty string is the API saying none is.
+		return ptr(t != "")
+	case bool:
+		return ptr(t)
+	case float64:
+		return ptr(t != 0)
+	default:
+		return ptr(true)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
 
 // buildSettingsData is the repository configuration a build runs from. Netlify
 // returns it inline with the site.
@@ -148,6 +197,7 @@ func newNetlifySite(runtime *plugin.Runtime, rec *siteRecord) (*mqlNetlifySite, 
 		"skipAutomaticBuilds":       optionalBool(build.SkipAutomaticBuilds),
 		"idDomain":                  llx.StringData(rec.IDDomain),
 		"stopBuilds":                llx.BoolData(build.StopBuilds),
+		"passwordProtected":         optionalBool(sitePasswordProtected(rec.Password)),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## The bug

`netlify.account.hasSitePassword` is an **account-wide rollup**, and the schema
had no per-site equivalent. `siteRecord` decoded no password field at all:

`providers/netlify/resources/sites.go:27-52` (before this change)

```go
type siteRecord struct {
	ID                        string             `json:"id"`
	Name                      string             `json:"name"`
	...
	CreatedAt                 netlifyTime        `json:"created_at"`
	UpdatedAt                 netlifyTime        `json:"updated_at"`
	BuildSettings             *buildSettingsData `json:"build_settings"`
}
```

`GET /sites/{site_id}` returns `site.password`, and both the account listing
(`/{account_slug}/sites`) and the single-site read decode into this same
struct, so the signal was on the wire and thrown away.

The account rollup lives at `providers/netlify/resources/netlify.lr:118-123`.

> A prior tracking note recorded this field as already shipped. It was not.
> Confirmed absent against `providers/netlify/resources/netlify.lr` before
> writing the fix: `netlify.site` had no `passwordProtected`, and
> `netlify.lr.versions` had no entry for it.

## Why it is wrong

An account rollup answers "is *any* site gated behind a visitor password". It
cannot answer "is *this* site gated". One unprotected staging site inside an
otherwise protected account reads exactly like a fully protected account, and
staging is precisely where unreleased content and pre-production credentials
sit. There was no way to write the check at all.

## The fix

`netlify.site.passwordProtected`, derived from whether the API reports a
password for the site.

**The password itself is a secret and is never modelled.** It is held as raw
JSON inside the record purely so its presence can be derived, and only the
derived boolean reaches the schema.

The API may report the value in more than one shape, so presence is computed
across all of them:

| API value | `passwordProtected` |
|---|---|
| key absent | `null` |
| `null` | `false` |
| `""` | `false` |
| `"correct-horse"` (literal) | `true` |
| `"****"` (redacted placeholder) | `true` |
| `true` / `false` (boolean marker) | `true` / `false` |

If Netlify redacts the value to a fixed placeholder, presence is still the
right signal and the field is still correct; that case is called out in the
doc-comment.

**Null versus false.** A key the API did not return at all yields `null`, not
`false`. An unreported field is indistinguishable from a site that never set a
password, and reporting an unknown as "not protected" would be a confident
wrong answer in the unsafe direction. An explicitly reported `null` or `""` is
a real answer and does read as `false`. The doc-comment tells users to test
with `== true` to find the sites known to be protected.

`.lr.versions` entry lands at `netlify.site.passwordProtected 13.1.1`
(`config/config.go` Version is `13.1.0`; the Version itself is unchanged).

## Verification

Table-driven unit tests over fixtures shaped like the documented
`GET /sites/{site_id}` response, covering absent, explicit null, empty string,
literal, redacted placeholder, and both boolean markers, plus a test pinning
that the raw password is not exposed as a value field. All values are
`example.com`-style.

```
$ cd providers/netlify && go test ./...
?   	go.mondoo.com/mql/providers/netlify	[no test files]
?   	go.mondoo.com/mql/providers/netlify/config	[no test files]
ok  	go.mondoo.com/mql/providers/netlify/connection	1.337s
?   	go.mondoo.com/mql/providers/netlify/gen	[no test files]
?   	go.mondoo.com/mql/providers/netlify/provider	[no test files]
ok  	go.mondoo.com/mql/providers/netlify/resources	1.162s
```

```
$ go test ./... -run 'TestSitePassword|TestSiteRecord|TestBuildSettings' -v
=== RUN   TestSiteRecordDecodesPostureFields
--- PASS: TestSiteRecordDecodesPostureFields (0.00s)
=== RUN   TestSiteRecordWithoutBuildSettings
--- PASS: TestSiteRecordWithoutBuildSettings (0.00s)
=== RUN   TestBuildSettingsOmittedControlsStayAbsent
--- PASS: TestBuildSettingsOmittedControlsStayAbsent (0.00s)
=== RUN   TestSitePasswordProtected
=== RUN   TestSitePasswordProtected/key_absent_stays_null
=== RUN   TestSitePasswordProtected/explicit_json_null_is_a_reported_absence
=== RUN   TestSitePasswordProtected/empty_string_is_no_password
=== RUN   TestSitePasswordProtected/literal_password_is_protected
=== RUN   TestSitePasswordProtected/redacted_placeholder_is_still_protected
=== RUN   TestSitePasswordProtected/boolean_marker_true_is_protected
=== RUN   TestSitePasswordProtected/boolean_marker_false_is_not_protected
--- PASS: TestSitePasswordProtected (0.00s)
=== RUN   TestSitePasswordIsNotExposedAsAValue
--- PASS: TestSitePasswordIsNotExposedAsAValue (0.00s)
PASS
ok  	go.mondoo.com/mql/providers/netlify/resources	1.181s
```

`go build ./...` clean, `go mod tidy` produces no drift, `gofmt -w` run on both
changed Go files, codegen regenerated with
`./mqlr generate providers/netlify/resources/netlify.lr --dist providers/netlify/resources`.

The tri-state pointer path is the one `privateLogs`, `skipPrs` and
`skipAutomaticBuilds` already use (`optionalBool`), so `null` rendering follows
shipped behaviour.

## Not verified against a live target

No Netlify account was available. Unproven:

- **Which shape Netlify actually returns.** The derivation handles literal,
  redacted placeholder, boolean marker, empty string and explicit null, but
  which one a real API response carries is untested. All three shapes give the
  correct answer, so the field is right either way; only the exercised branch
  is unknown.
- **Whether the account listing `/{account_slug}/sites` includes `password` at
  all.** If Netlify omits the key there and only returns it from
  `GET /sites/{site_id}`, sites reached through `netlify.account.sites` will
  read `null` rather than `true`/`false`, while `netlify.site(id: ...)` reads a
  real value. The null-on-absent choice is what keeps that case honest instead
  of reporting every listed site as unprotected, but the split has not been
  observed.
- **Whether an unprotected site omits the key or returns `""`/`null`.** This
  decides whether the common unprotected site reads `null` or `false`.
- No live MQL query was run: `netlify.sites { name passwordProtected }` has not
  been executed against a real account.
