### PR TITLE
🐛 google-workspace: sync the OAuth scope list with the code

### DIFF
--- a/providers/google-workspace/connection/workspace.go
+++ b/providers/google-workspace/connection/workspace.go
@@ -15,13 +15,21 @@ import (
 	googleoauth "golang.org/x/oauth2/google"
 	directory "google.golang.org/api/admin/directory/v1"
 	reports "google.golang.org/api/admin/reports/v1"
+	"google.golang.org/api/calendar/v3"
 	cloudidentity "google.golang.org/api/cloudidentity/v1"
+	"google.golang.org/api/groupssettings/v1"
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
 )
 
+// DefaultWorkspaceClientScopes is the OAuth scope set the provider needs. It
+// doubles as the list administrators paste into the domain-wide delegation
+// grant in the Google Workspace admin console, so it has to stay in exact sync
+// with the scopes the resource code asserts: a scope that is asserted but not
+// granted makes the whole token request fail with unauthorized_client, and a
+// scope that is granted but never asserted is an unnecessary privilege on a
+// directory-wide delegation.
 var DefaultWorkspaceClientScopes = []string{
-	directory.AdminChromePrintersReadonlyScope,
 	directory.AdminDirectoryCustomerReadonlyScope,
 	directory.AdminDirectoryDeviceChromeosReadonlyScope,
 	directory.AdminDirectoryDeviceMobileReadonlyScope,
@@ -29,14 +37,15 @@ var DefaultWorkspaceClientScopes = []string{
 	directory.AdminDirectoryGroupMemberReadonlyScope,
 	directory.AdminDirectoryGroupReadonlyScope,
 	directory.AdminDirectoryOrgunitReadonlyScope,
-	directory.AdminDirectoryResourceCalendarReadonlyScope,
 	directory.AdminDirectoryRolemanagementReadonlyScope,
-	directory.AdminDirectoryUserAliasReadonlyScope,
 	directory.AdminDirectoryUserReadonlyScope,
-	directory.AdminDirectoryUserschemaReadonlyScope,
 	directory.AdminDirectoryUserSecurityScope,
 	reports.AdminReportsAuditReadonlyScope,
 	reports.AdminReportsUsageReadonlyScope,
+	calendar.CalendarReadonlyScope,
+	calendar.CalendarSettingsReadonlyScope,
+	calendar.CalendarAclsReadonlyScope,
+	groupssettings.AppsGroupsSettingsScope,
 	cloudidentity.CloudIdentityGroupsReadonlyScope,
 	cloudidentity.CloudIdentityDevicesReadonlyScope,
 	cloudidentity.CloudIdentityPoliciesReadonlyScope,

--- a/providers/google-workspace/connection/workspace_test.go
+++ b/providers/google-workspace/connection/workspace_test.go
@@ -1,0 +1,71 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultWorkspaceClientScopes pins the exact scope set the provider asks
+// for. The list is what administrators paste into the domain-wide delegation
+// grant, so drift between it and the scopes the resource code asserts breaks
+// resources at runtime (unauthorized_client) or over-grants the delegation.
+func TestDefaultWorkspaceClientScopes(t *testing.T) {
+	want := []string{
+		// directory
+		"https://www.googleapis.com/auth/admin.directory.customer.readonly",
+		"https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly",
+		"https://www.googleapis.com/auth/admin.directory.device.mobile.readonly",
+		"https://www.googleapis.com/auth/admin.directory.domain.readonly",
+		"https://www.googleapis.com/auth/admin.directory.group.member.readonly",
+		"https://www.googleapis.com/auth/admin.directory.group.readonly",
+		"https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
+		"https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly",
+		"https://www.googleapis.com/auth/admin.directory.user.readonly",
+		"https://www.googleapis.com/auth/admin.directory.user.security",
+		// reports
+		"https://www.googleapis.com/auth/admin.reports.audit.readonly",
+		"https://www.googleapis.com/auth/admin.reports.usage.readonly",
+		// calendar
+		"https://www.googleapis.com/auth/calendar.readonly",
+		"https://www.googleapis.com/auth/calendar.settings.readonly",
+		"https://www.googleapis.com/auth/calendar.acls.readonly",
+		// groups settings
+		"https://www.googleapis.com/auth/apps.groups.settings",
+		// cloud identity
+		"https://www.googleapis.com/auth/cloud-identity.groups.readonly",
+		"https://www.googleapis.com/auth/cloud-identity.devices.readonly",
+		"https://www.googleapis.com/auth/cloud-identity.policies.readonly",
+	}
+	assert.ElementsMatch(t, want, DefaultWorkspaceClientScopes)
+}
+
+// TestDefaultWorkspaceClientScopesAreReadOnly guards against a write-capable
+// scope sneaking onto a directory-wide delegation. admin.directory.user.security
+// and apps.groups.settings have no read-only variant, so they are the only
+// exceptions.
+func TestDefaultWorkspaceClientScopesAreReadOnly(t *testing.T) {
+	writeCapable := map[string]bool{
+		"https://www.googleapis.com/auth/admin.directory.user.security": true,
+		"https://www.googleapis.com/auth/apps.groups.settings":          true,
+	}
+	for _, scope := range DefaultWorkspaceClientScopes {
+		if writeCapable[scope] {
+			continue
+		}
+		assert.True(t, len(scope) > len(".readonly") && scope[len(scope)-len(".readonly"):] == ".readonly",
+			"scope %q is not read-only and is not on the documented exception list", scope)
+	}
+}
+
+func TestDefaultWorkspaceClientScopesHaveNoDuplicates(t *testing.T) {
+	seen := map[string]bool{}
+	for _, scope := range DefaultWorkspaceClientScopes {
+		require.False(t, seen[scope], "duplicate scope %q", scope)
+		seen[scope] = true
+	}
+}

--- a/providers/google-workspace/resources/calendars.go
+++ b/providers/google-workspace/resources/calendars.go
@@ -56,7 +56,10 @@ func (g *mqlGoogleworkspace) calendars() ([]any, error) {
 
 func (g *mqlGoogleworkspaceCalendar) acl() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GoogleWorkspaceConnection)
-	calendarService, err := calendarService(conn, calendar.CalendarScope)
+	// acl.list accepts calendar, calendar.acls or calendar.acls.readonly. Ask
+	// for the read-only one so the domain-wide delegation grant never needs
+	// read/write access to every calendar in the domain.
+	calendarService, err := calendarService(conn, calendar.CalendarAclsReadonlyScope)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## The bug

`DefaultWorkspaceClientScopes` in `providers/google-workspace/connection/workspace.go:23` had drifted from the scopes the resource code actually asserts, in both directions.

**Requested but never asserted by any caller (4):**

| scope | declared at | gates only |
|---|---|---|
| `admin.chrome.printers.readonly` | `connection/workspace.go:24` | `customers.chrome.printers.*` |
| `admin.directory.resource.calendar.readonly` | `connection/workspace.go:32` | `resources.calendars/buildings/features.*` |
| `admin.directory.userschema.readonly` | `connection/workspace.go:36` | `schemas.list` / `schemas.get` |
| `admin.directory.user.alias.readonly` | `connection/workspace.go:34` | `users.aliases.*` |

None of those endpoints is called anywhere in the provider.

**Asserted by the code but never requested (4):**

| scope | asserted at | API call it authorizes |
|---|---|---|
| `calendar.readonly` | `resources/calendars.go:14` | `CalendarList.List` (`resources/calendars.go:20`, `:49`) |
| `calendar.settings.readonly` | `resources/calendars.go:14` | (none — see "Unexpected findings") |
| `apps.groups.settings` | `resources/group.go:215` | `groupssettings.Groups.Get` (`resources/group.go:228`) |
| `calendar` (full read/write) | `resources/calendars.go:59` | `Acl.List` (`resources/calendars.go:65`, `:100`) |

## Why it is wrong

That list is the source of truth administrators copy into the domain-wide delegation grant in the Google Workspace admin console. With DWD, the service account's JWT asserts a scope set and Google rejects the whole token request with `unauthorized_client` if *any* asserted scope is missing from the grant. So both directions of the drift are real defects:

- Anyone who builds their grant from this list gets `googleworkspace.calendars`, `googleworkspace.calendar.acl` and `googleworkspace.group.settings` failing at runtime with an authorization error — not a partial result, the entire fetch fails.
- At the same time the tenant grants four scopes mql never exercises. On a directory-wide delegation that is an unnecessary standing privilege over Chrome printers, calendar resources, user schema definitions and user aliases.

## The fix

Bring the list and the code back into agreement, and narrow the one over-broad scope the code was asking for.

Every scope in the new list, and every service the provider constructs:

| scope | asserted at | API call | required-scope check |
|---|---|---|---|
| `admin.directory.customer.readonly` | `connection/workspace.go:55` | `Customers.Get` (`connection/workspace.go:64`) | `customers.get` accepts it |
| `admin.directory.device.chromeos.readonly` | `resources/devices.go:30` | `Chromeosdevices.List` (`resources/devices.go:40`) | `chromeosdevices.list` accepts it |
| `admin.directory.device.mobile.readonly` | `resources/devices.go:98` | `Mobiledevices.List` (`resources/devices.go:108`) | `mobiledevices.list` accepts it |
| `admin.directory.domain.readonly` | `resources/domain.go:17`, `:38` | `Domains.List` (`resources/domain.go:22`, `:43`) | `domains.list` accepts it |
| `admin.directory.group.member.readonly` | `resources/group.go:74` | `Members.List` (`resources/group.go:86`, `:104`) | `members.list` accepts it |
| `admin.directory.group.readonly` | `resources/group.go:22` | `Groups.List` (`resources/group.go:28`, `:46`) | `groups.list` accepts it |
| `admin.directory.orgunit.readonly` | `resources/orgunit.go:15` | `Orgunits.List` (`resources/orgunit.go:26`) | `orgunits.list` accepts it |
| `admin.directory.rolemanagement.readonly` | `resources/role.go:19`, `resources/role_assignments.go:20` | `Roles.List` (`resources/role.go:25`, `:42`), `RoleAssignments.List` (`resources/role_assignments.go:28`) | both accept it |
| `admin.directory.user.readonly` | `resources/users.go:26` | `Users.List` (`resources/users.go:39`, `:57`) | `users.list` accepts it |
| `admin.directory.user.security` | `resources/users.go:505` | `Tokens.List` (`resources/users.go:515`) | `tokens.list` accepts *only* this scope |
| `admin.reports.audit.readonly` | `resources/google-workspace.go:169` | `Activities.List` (`resources/reports.go:59`, `:77`, `:96`, `:114`) | `activities.list` accepts only this scope |
| `admin.reports.usage.readonly` | `resources/google-workspace.go:169` | `UserUsageReport.Get` (`resources/reports.go:275`, `:284`) | `userUsageReport.get` accepts only this scope |
| **`calendar.readonly`** (added) | `resources/calendars.go:14` | `CalendarList.List` (`resources/calendars.go:20`, `:49`) | `calendarList.list` accepts it |
| **`calendar.settings.readonly`** (added) | `resources/calendars.go:14` | (asserted only; no `settings.*` caller) | see below |
| **`calendar.acls.readonly`** (added) | `resources/calendars.go:62` | `Acl.List` (`resources/calendars.go:65`, `:100`) | `acl.list` accepts it |
| **`apps.groups.settings`** (added) | `resources/group.go:215` | `groupssettings.Groups.Get` (`resources/group.go:228`) | `groups.get` accepts only this scope |
| `cloud-identity.groups.readonly` | `resources/group.go:263` | `Groups.GetSecuritySettings` (`resources/group.go:273`) | `groups.getSecuritySettings` accepts it |
| `cloud-identity.devices.readonly` | `resources/endpoints.go:22`, `:188` | `Devices.List` (`resources/endpoints.go:37`), `Devices.DeviceUsers.List` (`resources/endpoints.go:205`) | both accept it |
| `cloud-identity.policies.readonly` | `resources/policies.go:18` | `Policies.List` (`resources/policies.go:26`) | `policies.list` accepts it |

The required-scope column is not from memory — it is read out of the discovery documents shipped with `google.golang.org/api v0.293.0` (`admin/directory/v1/admin-api.json`, `admin/reports/v1/admin-api.json`, `calendar/v3/calendar-api.json`, `cloudidentity/v1/cloudidentity-api.json`, `groupssettings/v1/groupssettings-api.json`), extraction command below.

Five services are constructed and all five are covered: `directory`, `reports`, `calendar`, `cloudidentity`, `groupssettings`.

### Unexpected findings

**1. `googleworkspace.calendar.acl` was asking for full read/write calendar access.** `resources/calendars.go:59` passed `calendar.CalendarScope` (`https://www.googleapis.com/auth/calendar`) — read *and write* on every calendar in the domain. Adding that to the DWD list would have defeated the point of the PR. The discovery doc says `acl.list` accepts `calendar`, `calendar.acls` **or** `calendar.acls.readonly`, so the call is narrowed to `calendar.acls.readonly` instead. Note `calendar.readonly` is *not* accepted for `acl.list` (it is for `acl.get`), which is why the third calendar scope is needed rather than folding it into `calendar.readonly`.

**2. `calendar.settings.readonly` has no data-fetching caller.** It is asserted at `resources/calendars.go:14`, but nothing in the provider calls `settings.list`/`settings.get`, and the discovery doc confirms `calendarList.list` does not accept it. It is kept because as long as the code asserts it, a grant lacking it fails the entire `googleworkspace.calendars` token request with `unauthorized_client`. Dropping it from both places is safe follow-up cleanup but is a behavior change to the calendars resource, so it is left out of this fix. Flagging it rather than silently changing it.

**3. `admin.directory.userschema.readonly` is not needed for `user.customSchemas`.** `resources/users.go:115` does surface `entry.CustomSchemas`, which is the plausible objection to removing this scope. Those values arrive on the `User` resource from `Users.List(...).Projection("full")` under `admin.directory.user.readonly`; the `userschema` scope gates the separate `schemas.*` collection (schema *definitions*), which the provider never calls. Same shape for aliases: `googleworkspace.user.aliases` comes inline on the `User` record, not from `users.aliases.list`.

### Drift guard

`connection/workspace_test.go` pins the exact scope set, asserts every scope is a `.readonly` variant except the two that have none (`admin.directory.user.security`, `apps.groups.settings`), and rejects duplicates. A future scope added to the code without being added to the list still needs a human, but a scope changed in the list without intent now fails a test.

No `.lr` change, so no codegen. No `Version` bump in `config.go`.

## Verification

### Every service the provider constructs

```
$ grep -rn "NewService(" --include="*.go" providers/google-workspace/ | grep -v plugin.NewService
connection/workspace.go:60:	service, err := directory.NewService(context.Background(), option.WithHTTPClient(client))
resources/google-workspace.go:174:	service, err := reports.NewService(context.Background(), option.WithHTTPClient(client))
resources/google-workspace.go:184:	directoryService, err := directory.NewService(context.Background(), option.WithHTTPClient(client))
resources/google-workspace.go:194:	calendarsService, err := calendar.NewService(context.Background(), option.WithHTTPClient(client))
resources/google-workspace.go:204:	cloudIdentityService, err := cloudidentity.NewService(context.Background(), option.WithHTTPClient(client))
resources/google-workspace.go:214:	groupssettingsService, err := groupssettings.NewService(context.Background(), option.WithHTTPClient(client))
```

### Every scope the code asserts (post-fix)

```
$ grep -rn "Scope" --include="*.go" providers/google-workspace/resources providers/google-workspace/connection \
    | grep -v _test.go | grep -v '\.lr\.go'
resources/orgunit.go:15:	directoryService, err := directoryService(conn, directory.AdminDirectoryOrgunitReadonlyScope)
resources/group.go:22:	directoryService, err := directoryService(conn, directory.AdminDirectoryGroupReadonlyScope)
resources/group.go:74:	directoryService, err := directoryService(conn, directory.AdminDirectoryGroupMemberReadonlyScope)
resources/group.go:215:	service, err := groupSettingsService(conn, groupssettings.AppsGroupsSettingsScope)
resources/group.go:263:	service, err := cloudIdentityService(conn, cloudidentity.CloudIdentityGroupsReadonlyScope)
resources/google-workspace.go:169:	client, err := conn.Client(reports.AdminReportsAuditReadonlyScope, reports.AdminReportsUsageReadonlyScope)
resources/calendars.go:14:	calendarService, err := calendarService(conn, calendar.CalendarReadonlyScope, calendar.CalendarSettingsReadonlyScope)
resources/calendars.go:62:	calendarService, err := calendarService(conn, calendar.CalendarAclsReadonlyScope)
resources/endpoints.go:22:	service, err := cloudIdentityService(conn, cloudidentity.CloudIdentityDevicesReadonlyScope)
resources/endpoints.go:188:	service, err := cloudIdentityService(conn, cloudidentity.CloudIdentityDevicesReadonlyScope)
resources/domain.go:17:	directoryService, err := directoryService(conn, directory.AdminDirectoryDomainReadonlyScope)
resources/domain.go:38:	directoryService, err := directoryService(conn, directory.AdminDirectoryDomainReadonlyScope)
resources/role.go:19:	directoryService, err := directoryService(conn, directory.AdminDirectoryRolemanagementReadonlyScope)
resources/users.go:26:	directoryService, err := directoryService(conn, directory.AdminDirectoryUserReadonlyScope)
resources/users.go:505:	directoryService, err := directoryService(conn, directory.AdminDirectoryUserSecurityScope)
resources/role_assignments.go:20:	directoryService, err := directoryService(conn, directory.AdminDirectoryRolemanagementReadonlyScope)
resources/devices.go:30:	directoryService, err := directoryService(conn, directory.AdminDirectoryDeviceChromeosReadonlyScope)
resources/devices.go:98:	directoryService, err := directoryService(conn, directory.AdminDirectoryDeviceMobileReadonlyScope)
resources/policies.go:18:	service, err := cloudIdentityService(conn, cloudidentity.CloudIdentityPoliciesReadonlyScope)
connection/workspace.go:55:	client, err := c.Client(directory.AdminDirectoryCustomerReadonlyScope)
```

(remaining `Scope` hits are the list itself, the `Scopes:` field in `serviceAccountAuth`, and unrelated MQL fields: `googleworkspace.token.scopes`, `googleworkspace.connectedApp.scopes`, `googleworkspace.roleAssignment.scopeType`, `googleworkspace.calendar.aclRule.scope`.)

Set equality: the 19 distinct scopes in the second listing are exactly the 19 entries of `DefaultWorkspaceClientScopes`.

### The four removals have no caller

```
$ cd providers/google-workspace
$ for s in Printers ResourceCalendar Userschema UserAlias; do echo "--- $s ---"; grep -rn "$s" --include='*.go' . || echo "(no matches)"; done
--- Printers ---
(no matches)
--- ResourceCalendar ---
(no matches)
--- Userschema ---
(no matches)
--- UserAlias ---
(no matches)

$ grep -rn 'Chrome\.Printers\|\.Printers\.\|Resources\.Calendars\|Resources\.Buildings\|Resources\.Features\|Schemas\.\|Users\.Aliases\|\.Aliases\.' --include='*.go' .
(no matches)
```

Both greps run after the edit, so the only former references (the list entries themselves) are gone and nothing else in the provider touches those endpoints.

### Required scopes, read from the shipped discovery documents

```
$ python3 -c "
import json
d=json.load(open('\$(go env GOMODCACHE)/google.golang.org/api@v0.293.0/calendar/v3/calendar-api.json'))
for name,r in d['resources'].items():
    for m,mm in r.get('methods',{}).items():
        print(name, m, mm.get('scopes'))"
acl list ['https://www.googleapis.com/auth/calendar', 'https://www.googleapis.com/auth/calendar.acls', 'https://www.googleapis.com/auth/calendar.acls.readonly']
calendarList list ['https://www.googleapis.com/auth/calendar', 'https://www.googleapis.com/auth/calendar.calendarlist', 'https://www.googleapis.com/auth/calendar.calendarlist.readonly', 'https://www.googleapis.com/auth/calendar.readonly']
settings list ['https://www.googleapis.com/auth/calendar', 'https://www.googleapis.com/auth/calendar.readonly', 'https://www.googleapis.com/auth/calendar.settings.readonly']
...
```

The directory / reports / cloudidentity / groupssettings extractions used the same script against their `*-api.json` and produced the "required-scope check" column above, including:

```
schemas list        ['.../admin.directory.userschema', '.../admin.directory.userschema.readonly']
users list          ['.../admin.directory.user', '.../admin.directory.user.readonly', '.../cloud-platform']
users.aliases list  ['.../admin.directory.user', '.../admin.directory.user.alias', '.../admin.directory.user.alias.readonly', '.../admin.directory.user.readonly']
tokens list         ['.../admin.directory.user.security']
groups get          ['https://www.googleapis.com/auth/apps.groups.settings']       (groupssettings)
groups.getSecuritySettings ['.../cloud-identity.groups', '.../cloud-identity.groups.readonly', '.../cloud-platform']
activities list     ['https://www.googleapis.com/auth/admin.reports.audit.readonly']
userUsageReport get ['https://www.googleapis.com/auth/admin.reports.usage.readonly']
```

### Build and test

```
$ cd providers/google-workspace && gofmt -l .
(no output)

$ go build ./...
(no output)

$ go test ./...
?   	go.mondoo.com/mql/providers/google-workspace	[no test files]
?   	go.mondoo.com/mql/providers/google-workspace/config	[no test files]
ok  	go.mondoo.com/mql/providers/google-workspace/connection	2.758s
?   	go.mondoo.com/mql/providers/google-workspace/gen	[no test files]
ok  	go.mondoo.com/mql/providers/google-workspace/provider	3.389s
ok  	go.mondoo.com/mql/providers/google-workspace/resources	3.609s

$ go test ./connection/... -run TestDefaultWorkspaceClientScopes -v
=== RUN   TestDefaultWorkspaceClientScopes
--- PASS: TestDefaultWorkspaceClientScopes (0.00s)
=== RUN   TestDefaultWorkspaceClientScopesAreReadOnly
--- PASS: TestDefaultWorkspaceClientScopesAreReadOnly (0.00s)
=== RUN   TestDefaultWorkspaceClientScopesHaveNoDuplicates
--- PASS: TestDefaultWorkspaceClientScopesHaveNoDuplicates (0.00s)
PASS
ok  	go.mondoo.com/mql/providers/google-workspace/connection	0.709s

$ go mod tidy && git diff --stat -- go.mod go.sum
(no output — go.mod/go.sum unchanged; calendar/v3 and groupssettings/v1 were already direct deps via resources/)
```

### Documentation

The provider has no `README.md`, and the scope list is not restated anywhere else in the repo. On `main` the raw scope URLs do not appear in the tree at all (the list is built from SDK constants), and the Go var is the only reference:

```
$ git grep -l 'admin.directory.user.readonly\|admin.chrome.printers\|apps.groups.settings\|auth/calendar' origin/main -- .
(no matches)

$ grep -rn 'DefaultWorkspaceClientScopes' --exclude-dir=.git . | grep -v _test.go
providers/google-workspace/connection/workspace.go:25:// DefaultWorkspaceClientScopes is the OAuth scope set the provider needs. It
providers/google-workspace/connection/workspace.go:32:var DefaultWorkspaceClientScopes = []string{
```

Nothing to update; the exported Go var is the single source. Downstream consumers that render the domain-wide delegation instructions read this var, so they pick up the corrected list automatically. (`connection/workspace_test.go` added here is the only place the URLs are now written out as literals, deliberately, so the test fails on unintended drift rather than following it.)

## Not verified against a live target

No Google Workspace service-account credential was available in this environment — no `GOOGLE_APPLICATION_CREDENTIALS`, and no `demo.agent.credentials.json` anywhere under the home directory or the repo. `googleworkspace.calendars`, `googleworkspace.calendar.acl` and `googleworkspace.group.settings` have therefore **not** been run against a real domain, and the corrected list has not been exercised as an actual domain-wide delegation grant.

What that means for confidence:

- **The three additions** are backed by the discovery documents (`calendarList.list` accepts `calendar.readonly`; `acl.list` accepts `calendar.acls.readonly`; `groupssettings.groups.get` accepts only `apps.groups.settings`) plus the call sites that assert them. This is strong evidence, but the end-to-end proof — a DWD grant built from the new list returning calendar and group-settings data — is owed.
- **The four removals** cannot be proven safe by a unit test, since the failure mode of an over-granted scope is silence. The evidence is the static audit above: no reference to those four scope constants and no call to any endpoint they gate, anywhere in the provider. If one of those endpoints is added later, its scope has to come back with it.
- **The `acl.list` narrowing** is the item most worth a live check. It swaps a scope the code asked for (`calendar`) for a narrower one (`calendar.acls.readonly`); the discovery doc lists both as valid for that method, but only a live call proves it against the DWD path.

Live verification against a test domain is owed before this is relied on for the published grant instructions.
