### PR TITLE
🐛 nextdns: paginate the profile listing

### DIFF
--- a/providers/nextdns/resources/nextdns.go
+++ b/providers/nextdns/resources/nextdns.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -24,15 +26,39 @@ type profileData struct {
 
 type profilesResponse struct {
 	Data []profileData `json:"data"`
+	Meta profilesMeta  `json:"meta"`
 }
+
+// profilesMeta carries the cursor that continues a profile listing. NextDNS
+// returns an empty (or absent) cursor on the last page.
+type profilesMeta struct {
+	Pagination struct {
+		Cursor string `json:"cursor"`
+	} `json:"pagination"`
+}
+
+// maxProfilePages bounds the pagination walk. It is a backstop against a
+// server that keeps handing out fresh cursors forever, not an expected limit:
+// a NextDNS account holding this many pages of profiles is far outside any
+// real deployment.
+const maxProfilePages = 1000
 
 // fetchProfiles returns the profiles visible to the connection. When the
 // connection is scoped to a single profile, that profile is fetched directly
 // so we never list (or expose) profiles the connection shouldn't see.
+//
+// The account-level listing is paginated. It is walked to exhaustion, because
+// stopping at the first page silently drops every profile beyond it and
+// reports the short enumeration as a successful scan: findings on the missing
+// profiles simply would not exist. Both termination guards return an error
+// rather than the profiles gathered so far, since a knowingly incomplete list
+// is the very failure being fixed and must not pass for a complete one.
 func fetchProfiles(conn *connection.NextdnsConnection) ([]profileData, error) {
+	ctx := context.Background()
+
 	if scoped := conn.ProfileID(); scoped != "" {
 		var resp profileDetailResponse
-		if err := conn.Get(context.Background(), "/profiles/"+scoped, &resp); err != nil {
+		if err := conn.Get(ctx, "/profiles/"+scoped, &resp); err != nil {
 			return nil, err
 		}
 		return []profileData{{
@@ -42,11 +68,37 @@ func fetchProfiles(conn *connection.NextdnsConnection) ([]profileData, error) {
 		}}, nil
 	}
 
-	var resp profilesResponse
-	if err := conn.Get(context.Background(), "/profiles", &resp); err != nil {
-		return nil, err
+	var (
+		profiles []profileData
+		cursor   string
+		seen     = map[string]struct{}{}
+	)
+	for page := 0; page < maxProfilePages; page++ {
+		path := "/profiles"
+		if cursor != "" {
+			path += "?cursor=" + url.QueryEscape(cursor)
+		}
+
+		var resp profilesResponse
+		if err := conn.Get(ctx, path, &resp); err != nil {
+			return nil, err
+		}
+		profiles = append(profiles, resp.Data...)
+
+		next := resp.Meta.Pagination.Cursor
+		if next == "" {
+			return profiles, nil
+		}
+		// A server that repeats a cursor would otherwise spin the scan
+		// forever, re-reading the same page.
+		if _, repeated := seen[next]; repeated {
+			return nil, fmt.Errorf("nextdns profile listing returned a repeated pagination cursor after %d pages; the profile list is incomplete", page+1)
+		}
+		seen[next] = struct{}{}
+		cursor = next
 	}
-	return resp.Data, nil
+
+	return nil, fmt.Errorf("nextdns profile listing did not finish within %d pages; the profile list is incomplete", maxProfilePages)
 }
 
 // profilesToResources fetches profiles for the connection and maps them to

--- a/providers/nextdns/resources/pagination_test.go
+++ b/providers/nextdns/resources/pagination_test.go
@@ -1,0 +1,191 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/nextdns/connection"
+)
+
+// testConn points a NextDNS connection at a test server. The profile option is
+// left unset so the account-level listing (the paginated path) is exercised.
+func testConn(t *testing.T, baseURL string, opts map[string]string) *connection.NextdnsConnection {
+	t.Helper()
+	t.Setenv("NEXTDNS_API_KEY", "test-key")
+
+	options := map[string]string{"base-url": baseURL}
+	for k, v := range opts {
+		options[k] = v
+	}
+
+	conn, err := connection.NewNextdnsConnection(1, &inventory.Asset{}, &inventory.Config{Options: options})
+	if err != nil {
+		t.Fatalf("connection: %v", err)
+	}
+	return conn
+}
+
+// A listing longer than one page must yield every profile. Stopping at the
+// first page reports a short enumeration as a successful scan, so every
+// finding on an unlisted profile silently does not exist.
+func TestFetchProfilesFollowsTheCursorToExhaustion(t *testing.T) {
+	var requests []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			_, _ = w.Write([]byte(`{
+				"data": [
+					{"id":"aaa111","name":"home","fingerprint":"fp-aaa111"},
+					{"id":"bbb222","name":"office","fingerprint":"fp-bbb222"}
+				],
+				"meta": {"pagination": {"cursor": "page-2"}}
+			}`))
+		case "page-2":
+			_, _ = w.Write([]byte(`{
+				"data": [
+					{"id":"ccc333","name":"lab","fingerprint":"fp-ccc333"}
+				],
+				"meta": {"pagination": {"cursor": ""}}
+			}`))
+		default:
+			t.Errorf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	profiles, err := fetchProfiles(testConn(t, srv.URL, nil))
+	if err != nil {
+		t.Fatalf("fetchProfiles: %v", err)
+	}
+
+	want := []string{"aaa111", "bbb222", "ccc333"}
+	if len(profiles) != len(want) {
+		t.Fatalf("expected %d profiles, got %d: %+v", len(want), len(profiles), profiles)
+	}
+	for i, id := range want {
+		if profiles[i].ID != id {
+			t.Errorf("profile %d: expected id %q, got %q", i, id, profiles[i].ID)
+		}
+	}
+	if profiles[2].Name != "lab" || profiles[2].Fingerprint != "fp-ccc333" {
+		t.Errorf("second page did not decode: %+v", profiles[2])
+	}
+
+	if len(requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d: %v", len(requests), requests)
+	}
+	if requests[0] != "/profiles" {
+		t.Errorf("first request should carry no cursor, got %q", requests[0])
+	}
+	if requests[1] != "/profiles?cursor=page-2" {
+		t.Errorf("second request should carry the cursor, got %q", requests[1])
+	}
+}
+
+// A single page must still work, and must not cost a second request.
+func TestFetchProfilesSinglePage(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"data":[{"id":"aaa111","name":"home","fingerprint":"fp-aaa111"}]}`))
+	}))
+	defer srv.Close()
+
+	profiles, err := fetchProfiles(testConn(t, srv.URL, nil))
+	if err != nil {
+		t.Fatalf("fetchProfiles: %v", err)
+	}
+	if len(profiles) != 1 || profiles[0].ID != "aaa111" {
+		t.Fatalf("unexpected profiles: %+v", profiles)
+	}
+	if calls != 1 {
+		t.Errorf("an absent cursor must end the walk, got %d requests", calls)
+	}
+}
+
+// A server that hands back the same cursor forever must terminate the walk
+// rather than spin the scan, and must not report the truncated list as a
+// complete one.
+func TestFetchProfilesStuckCursorTerminates(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 50 {
+			t.Fatalf("pagination walk did not terminate: %d requests", calls)
+		}
+		_, _ = w.Write([]byte(`{
+			"data": [{"id":"aaa111","name":"home","fingerprint":"fp-aaa111"}],
+			"meta": {"pagination": {"cursor": "stuck"}}
+		}`))
+	}))
+	defer srv.Close()
+
+	profiles, err := fetchProfiles(testConn(t, srv.URL, nil))
+	if err == nil {
+		t.Fatalf("expected an error for a repeated cursor, got %d profiles", len(profiles))
+	}
+	if profiles != nil {
+		t.Errorf("an incomplete listing must not be returned, got %+v", profiles)
+	}
+	if calls != 2 {
+		t.Errorf("expected the repeat to be caught on the second request, got %d", calls)
+	}
+}
+
+// A profile-scoped connection reads the single profile directly and never
+// touches the paginated listing.
+func TestFetchProfilesScopedConnectionSkipsTheListing(t *testing.T) {
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":{"id":"aaa111","name":"home","fingerprint":"fp-aaa111"}}`))
+	}))
+	defer srv.Close()
+
+	conn := testConn(t, srv.URL, map[string]string{connection.OptionProfile: "aaa111"})
+	profiles, err := fetchProfiles(conn)
+	if err != nil {
+		t.Fatalf("fetchProfiles: %v", err)
+	}
+	if len(profiles) != 1 || profiles[0].Name != "home" {
+		t.Fatalf("unexpected profiles: %+v", profiles)
+	}
+	if len(paths) != 1 || paths[0] != "/profiles/aaa111" {
+		t.Errorf("expected a single direct profile read, got %v", paths)
+	}
+}
+
+// An error on a later page must fail the fetch rather than silently return the
+// pages already gathered.
+func TestFetchProfilesPropagatesLaterPageErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("cursor") == "" {
+			_, _ = w.Write([]byte(`{
+				"data": [{"id":"aaa111","name":"home","fingerprint":"fp-aaa111"}],
+				"meta": {"pagination": {"cursor": "page-2"}}
+			}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"errors":[{"code":"internal"}]}`))
+	}))
+	defer srv.Close()
+
+	profiles, err := fetchProfiles(testConn(t, srv.URL, nil))
+	if err == nil {
+		t.Fatalf("expected an error, got %d profiles", len(profiles))
+	}
+	if profiles != nil {
+		t.Errorf("a failed walk must not return partial results, got %+v", profiles)
+	}
+}


### PR DESCRIPTION
## The bug

`fetchProfiles` fetched the first page of `GET /profiles` and returned it,
never looking at `meta.pagination.cursor`.

`providers/nextdns/resources/nextdns.go:44-48` (before this change)

```go
	var resp profilesResponse
	if err := conn.Get(context.Background(), "/profiles", &resp); err != nil {
		return nil, err
	}
	return resp.Data, nil
```

`profilesResponse` (`providers/nextdns/resources/nextdns.go:25-27`) modelled
only `data`, so the cursor was not even decoded.

## Why it is wrong

An account with more profiles than fit on one page enumerates short, and
nothing reports it. Every finding on every unlisted profile simply does not
exist, the query returns a clean truncated list, and the scan exits
successfully. A short enumeration that reports success is worse than a failure:
a failure gets investigated, a green scan does not.

The blast radius is wider than `nextdns.profiles` and `nextdns.account.profiles`.
Discovery calls the same lister
(`providers/nextdns/resources/discovery.go:37`, `case connection.DiscoveryProfiles`),
so profiles beyond the first page were never turned into assets and were never
scanned at all.

## The fix

Decode `meta.pagination.cursor` and walk it to exhaustion, passing it back as
`?cursor=` on each subsequent request.

Two guards keep a misbehaving server from spinning the scan forever:

- **Repeated cursor.** Every cursor issued is remembered; a server that hands
  back one already seen stops the walk immediately.
- **Page ceiling.** `maxProfilePages = 1000` as a backstop against a server
  that keeps minting fresh cursors. This is not an expected limit, just a
  bound.

Both return an **error** rather than the profiles gathered so far. Returning a
partial list would reproduce exactly the bug being fixed: a knowingly
incomplete enumeration passing for a complete one.

The profile-scoped path (`conn.ProfileID() != ""`) is untouched, since it reads
one profile directly and never lists.

### Other listers in this provider

Checked, and `/profiles` is the only paginated collection endpoint the provider
touches. There are three `conn.Get` call sites in total:

| call site | endpoint | paginated |
|---|---|---|
| `resources/nextdns.go` (this fix) | `/profiles` | yes |
| `resources/nextdns.go` scoped branch | `/profiles/{id}` | no, single object |
| `resources/profile.go:204` `fetchDetail` | `/profiles/{id}` | no, single object |

Every other list in the schema (`denylist`, `allowlist`, `rewrites`,
`privacy.blocklists`, `parentalControl.services` / `.categories`,
`security.tlds`, `privacy.natives`, `setup.ipv4` / `.ipv6`) is carried inline
in that single `/profiles/{id}` detail payload, which is not a paginated
collection. **No other lister had the same omission.**

No schema change, so no `.lr` / `.lr.versions` edit and no codegen.

## Verification

`httptest`-backed unit tests, the pattern CLAUDE.md section 3.6 prescribes, all
using `example.com`-style placeholder ids:

- **two-page walk** yields all three records in order, and asserts the request
  sequence is exactly `/profiles` then `/profiles?cursor=page-2`
- **single page** with an absent cursor terminates after one request
- **stuck cursor** (same cursor returned forever) terminates on the second
  request with an error, and returns no partial list; the handler fails the
  test outright if it is called more than 50 times
- **profile-scoped connection** reads `/profiles/{id}` directly and never hits
  the listing
- **error on a later page** fails the fetch instead of silently returning page 1

```
$ cd providers/nextdns && go test ./...
?   	go.mondoo.com/mql/providers/nextdns	[no test files]
?   	go.mondoo.com/mql/providers/nextdns/config	[no test files]
ok  	go.mondoo.com/mql/providers/nextdns/connection	1.166s
?   	go.mondoo.com/mql/providers/nextdns/gen	[no test files]
?   	go.mondoo.com/mql/providers/nextdns/provider	[no test files]
ok  	go.mondoo.com/mql/providers/nextdns/resources	1.682s
```

```
$ go test ./resources/ -run TestFetchProfiles -v
=== RUN   TestFetchProfilesFollowsTheCursorToExhaustion
--- PASS: TestFetchProfilesFollowsTheCursorToExhaustion (0.00s)
=== RUN   TestFetchProfilesSinglePage
--- PASS: TestFetchProfilesSinglePage (0.00s)
=== RUN   TestFetchProfilesStuckCursorTerminates
--- PASS: TestFetchProfilesStuckCursorTerminates (0.00s)
=== RUN   TestFetchProfilesScopedConnectionSkipsTheListing
--- PASS: TestFetchProfilesScopedConnectionSkipsTheListing (0.00s)
=== RUN   TestFetchProfilesPropagatesLaterPageErrors
--- PASS: TestFetchProfilesPropagatesLaterPageErrors (0.00s)
PASS
ok  	go.mondoo.com/mql/providers/nextdns/resources	0.920s
```

`go build ./...` clean, `go mod tidy` produces no drift, `gofmt -w` run on both
changed Go files.

## Not verified against a live target

No NextDNS account was available. Unproven:

- **The wire contract itself.** That the cursor is at
  `meta.pagination.cursor`, that it is continued with the `cursor` query
  parameter, and that the last page signals the end with an empty or absent
  cursor rather than a repeat of the final one. All of this is modelled from
  the documented shape, not from an observed response. If the last page instead
  repeats its own cursor, the repeated-cursor guard would turn a correct
  listing into an error, which would be loud rather than silent, but would
  still be wrong.
- **The page size.** Whether a real account ever exceeds one page, and how many
  profiles a page holds, is unknown, so `maxProfilePages = 1000` is a guess at
  a safe bound rather than a measured one.
- **Cursor opaqueness.** The cursor is URL-escaped before being appended; that
  a real cursor survives that round trip is untested.
- No live MQL query was run: `nextdns.profiles { id name }` and a discovery run
  over a multi-page account have not been executed.
