### PR TITLE
🐛 tailscale: stop reporting a never-expiring auth key as expired

### DIFF
--- a/providers/tailscale/resources/acl.go
+++ b/providers/tailscale/resources/acl.go
@@ -34,32 +34,28 @@ func (a *mqlTailscaleAclPolicy) id() (string, error) {
 }
 
 // flattenAutoApprovers splits a policy's auto-approver block into the exit-node
-// list and the route-to-owners map the resource exposes. A policy with no
-// autoApprovers section yields empty values rather than nulls, so a query
-// asserting that nothing is auto-approved reads false instead of passing on a
-// null comparison.
-func flattenAutoApprovers(autoApprovers *tsclient.ACLAutoApprovers) (exitNodes []any, routes map[string]any) {
+// list and the route-to-owners and service-to-owners maps the resource exposes.
+// A policy with no autoApprovers section yields empty values rather than nulls,
+// so a query asserting that nothing is auto-approved reads false instead of
+// passing on a null comparison.
+func flattenAutoApprovers(autoApprovers *tsclient.ACLAutoApprovers) (exitNodes []any, routes, services map[string]any) {
 	exitNodes = []any{}
 	routes = map[string]any{}
+	services = map[string]any{}
 	if autoApprovers == nil {
-		return exitNodes, routes
+		return exitNodes, routes, services
 	}
 
 	for _, v := range autoApprovers.ExitNode {
 		exitNodes = append(exitNodes, v)
 	}
-	for k, owners := range autoApprovers.Routes {
-		arr := make([]any, 0, len(owners))
-		for _, owner := range owners {
-			arr = append(arr, owner)
-		}
-		routes[k] = arr
-	}
-	return exitNodes, routes
+	return exitNodes,
+		stringSliceMapToAny(autoApprovers.Routes),
+		stringSliceMapToAny(autoApprovers.Services)
 }
 
 func createTailscaleAclPolicyResource(runtime *plugin.Runtime, tailnet string, acl *tsclient.ACL) (plugin.Resource, error) {
-	autoApproverExitNodes, autoApproverRoutes := flattenAutoApprovers(acl.AutoApprovers)
+	autoApproverExitNodes, autoApproverRoutes, autoApproverServices := flattenAutoApprovers(acl.AutoApprovers)
 
 	acls, err := structSliceToDictSlice(acl.ACLs)
 	if err != nil {
@@ -106,6 +102,7 @@ func createTailscaleAclPolicyResource(runtime *plugin.Runtime, tailnet string, a
 		"nodeAttrs":              llx.ArrayData(nodeAttrs, types.Dict),
 		"autoApproverExitNodes":  llx.ArrayData(autoApproverExitNodes, types.String),
 		"autoApproverRoutes":     llx.MapData(autoApproverRoutes, types.Array(types.String)),
+		"autoApproverServices":   llx.MapData(autoApproverServices, types.Array(types.String)),
 		"defaultSourcePosture":   llx.ArrayData(stringSliceToAny(acl.DefaultSourcePosture), types.String),
 		"postures":               llx.MapData(stringSliceMapToAny(acl.Postures), types.Array(types.String)),
 		"disableIPv4":            llx.BoolData(acl.DisableIPv4),

--- a/providers/tailscale/resources/acl_test.go
+++ b/providers/tailscale/resources/acl_test.go
@@ -121,6 +121,7 @@ func TestFlattenAutoApprovers(t *testing.T) {
 		in            *tsclient.ACLAutoApprovers
 		wantExitNodes []any
 		wantRoutes    map[string]any
+		wantServices  map[string]any
 	}{
 		{
 			// A policy with no autoApprovers block must read as "nothing is
@@ -129,12 +130,14 @@ func TestFlattenAutoApprovers(t *testing.T) {
 			in:            nil,
 			wantExitNodes: []any{},
 			wantRoutes:    map[string]any{},
+			wantServices:  map[string]any{},
 		},
 		{
 			name:          "empty block",
 			in:            &tsclient.ACLAutoApprovers{},
 			wantExitNodes: []any{},
 			wantRoutes:    map[string]any{},
+			wantServices:  map[string]any{},
 		},
 		{
 			name: "exit nodes only",
@@ -143,6 +146,7 @@ func TestFlattenAutoApprovers(t *testing.T) {
 			},
 			wantExitNodes: []any{"tag:exit", "group:admins"},
 			wantRoutes:    map[string]any{},
+			wantServices:  map[string]any{},
 		},
 		{
 			name: "routes and exit nodes",
@@ -158,14 +162,54 @@ func TestFlattenAutoApprovers(t *testing.T) {
 				"10.0.0.0/8":     []any{"group:eng", "tag:router"},
 				"192.168.0.0/16": []any{},
 			},
+			wantServices: map[string]any{},
+		},
+		{
+			// The services bucket names who may stand up a tailnet service
+			// under its stable VIP with no administrator approving the
+			// advertisement. It has to survive the flatten alongside the
+			// other two buckets rather than being dropped.
+			name: "services alongside routes and exit nodes",
+			in: &tsclient.ACLAutoApprovers{
+				ExitNode: []string{"tag:exit"},
+				Routes: map[string][]string{
+					"10.0.0.0/8": {"group:eng"},
+				},
+				Services: map[string][]string{
+					"svc:web":     {"tag:frontend", "group:eng"},
+					"svc:noowner": {},
+				},
+			},
+			wantExitNodes: []any{"tag:exit"},
+			wantRoutes: map[string]any{
+				"10.0.0.0/8": []any{"group:eng"},
+			},
+			wantServices: map[string]any{
+				"svc:web":     []any{"tag:frontend", "group:eng"},
+				"svc:noowner": []any{},
+			},
+		},
+		{
+			// A policy that auto-approves services but nothing else must not
+			// read as "nothing is auto-approved".
+			name: "services only",
+			in: &tsclient.ACLAutoApprovers{
+				Services: map[string][]string{"svc:vpn": {"autogroup:admin"}},
+			},
+			wantExitNodes: []any{},
+			wantRoutes:    map[string]any{},
+			wantServices: map[string]any{
+				"svc:vpn": []any{"autogroup:admin"},
+			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			exitNodes, routes := flattenAutoApprovers(tc.in)
+			exitNodes, routes, services := flattenAutoApprovers(tc.in)
 			assert.Equal(t, tc.wantExitNodes, exitNodes)
 			assert.Equal(t, tc.wantRoutes, routes)
+			assert.Equal(t, tc.wantServices, services)
 		})
 	}
 }

--- a/providers/tailscale/resources/device.go
+++ b/providers/tailscale/resources/device.go
@@ -58,16 +58,13 @@ func initTailscaleDevice(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 // device connected to the coordination server), an empty string (`created` on a
 // device that has none, such as the hello service), and the zero instant
 // (`expires` on a device whose key never expires). The SDK folds the latter two
-// into the Go zero time, so absence has to be recognized here.
-//
-// Reporting the zero instant instead of null would date those devices to the
-// year 1, and a query for devices whose key has expired (`expiresAt <
-// time.now`) would then match every device whose key is set never to expire.
+// into the Go zero time, which optionalTimeValue recognizes; only the nil
+// pointer is specific to the device field set.
 func optionalTime(t *tsclient.Time) *time.Time {
-	if t == nil || t.IsZero() {
+	if t == nil {
 		return nil
 	}
-	return &t.Time
+	return optionalTimeValue(t.Time)
 }
 
 func createTailscaleDeviceResource(runtime *plugin.Runtime, device *tsclient.Device) (plugin.Resource, error) {

--- a/providers/tailscale/resources/keys.go
+++ b/providers/tailscale/resources/keys.go
@@ -27,8 +27,24 @@ func timeIsSet(t *time.Time) bool {
 	return t != nil && !t.IsZero()
 }
 
+// optionalTimeValue reports a Tailscale timestamp for MQL, returning nil when
+// the API left it unset.
+//
+// Tailscale spells an absent timestamp as the Go zero instant rather than as
+// JSON null, and several of the timestamps it returns carry meaning when
+// absent: `expires` is unset on a key that never expires, and `revoked` is
+// unset on a key that has not been revoked. Passing the zero instant through
+// would date those keys to the year 1, so a query comparing the timestamp
+// against the current time would read "never expires" as "expired long ago".
+func optionalTimeValue(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
 // hasExpiration reports whether the key has an expiration set. A key with no
-// expiration carries the zero time in `expires`.
+// expiration carries no value in `expires`.
 func (r *mqlTailscaleAuthKey) hasExpiration() (bool, error) {
 	if r.Expires.Error != nil {
 		return false, r.Expires.Error
@@ -37,12 +53,28 @@ func (r *mqlTailscaleAuthKey) hasExpiration() (bool, error) {
 }
 
 // isRevoked reports whether the key has been revoked. A key that has not been
-// revoked carries the zero time in `revoked`.
+// revoked carries no value in `revoked`.
 func (r *mqlTailscaleAuthKey) isRevoked() (bool, error) {
 	if r.Revoked.Error != nil {
 		return false, r.Revoked.Error
 	}
 	return timeIsSet(r.Revoked.Data), nil
+}
+
+// isExpired reports whether the key is past its expiration time.
+//
+// A key with no expiration never expires, so it reports false. That reads like
+// the safe answer and is not one: a key that never expires is the longest-lived
+// credential the tailnet can hold. `hasExpiration` is what separates it from a
+// key that is merely still inside its window.
+func (r *mqlTailscaleAuthKey) isExpired() (bool, error) {
+	if r.Expires.Error != nil {
+		return false, r.Expires.Error
+	}
+	if !timeIsSet(r.Expires.Data) {
+		return false, nil
+	}
+	return r.Expires.Data.Before(time.Now()), nil
 }
 
 func initTailscaleAuthKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -103,10 +135,10 @@ func createTailscaleAuthKeyResource(runtime *plugin.Runtime, key *tsclient.Key) 
 		"issuer":           llx.StringData(key.Issuer),
 		"subject":          llx.StringData(key.Subject),
 		"customClaimRules": llx.MapData(claimRules, types.String),
-		"created":          llx.TimeData(key.Created),
-		"updated":          llx.TimeData(key.Updated),
-		"expires":          llx.TimeData(key.Expires),
-		"revoked":          llx.TimeData(key.Revoked),
+		"created":          llx.TimeDataPtr(optionalTimeValue(key.Created)),
+		"updated":          llx.TimeDataPtr(optionalTimeValue(key.Updated)),
+		"expires":          llx.TimeDataPtr(optionalTimeValue(key.Expires)),
+		"revoked":          llx.TimeDataPtr(optionalTimeValue(key.Revoked)),
 		"invalid":          llx.BoolData(key.Invalid),
 		"reusable":         llx.BoolData(caps.Reusable),
 		"ephemeral":        llx.BoolData(caps.Ephemeral),

--- a/providers/tailscale/resources/keys_test.go
+++ b/providers/tailscale/resources/keys_test.go
@@ -6,6 +6,10 @@ package resources
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
 func TestTimeIsSet(t *testing.T) {
@@ -33,4 +37,156 @@ func TestTimeIsSet(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOptionalTimeValue(t *testing.T) {
+	set := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	// An unset Tailscale timestamp is the Go zero instant, and it has to reach
+	// MQL as null. Reporting 0001-01-01 would date a key that never expires to
+	// the year 1.
+	require.Nil(t, optionalTimeValue(time.Time{}))
+
+	got := optionalTimeValue(set)
+	require.NotNil(t, got)
+	assert.Equal(t, set, *got)
+
+	// Unix epoch 0 is a real instant, not Tailscale's "unset".
+	epoch := optionalTimeValue(time.Unix(0, 0))
+	require.NotNil(t, epoch)
+	assert.Equal(t, time.Unix(0, 0), *epoch)
+}
+
+// authKeyWithExpiry builds the resource the way createTailscaleAuthKeyResource
+// does, so the predicates under test see exactly what a scan would put in front
+// of them.
+func authKeyWithExpiry(expires, revoked time.Time) *mqlTailscaleAuthKey {
+	key := &mqlTailscaleAuthKey{}
+	key.Expires.Data = optionalTimeValue(expires)
+	key.Expires.State = plugin.StateIsSet
+	if key.Expires.Data == nil {
+		key.Expires.State |= plugin.StateIsNull
+	}
+	key.Revoked.Data = optionalTimeValue(revoked)
+	key.Revoked.State = plugin.StateIsSet
+	if key.Revoked.Data == nil {
+		key.Revoked.State |= plugin.StateIsNull
+	}
+	return key
+}
+
+func TestAuthKeyExpiryPredicates(t *testing.T) {
+	var (
+		never  = time.Time{}
+		past   = time.Now().Add(-24 * time.Hour)
+		future = time.Now().Add(24 * time.Hour)
+	)
+
+	tests := []struct {
+		name              string
+		expires           time.Time
+		revoked           time.Time
+		wantHasExpiration bool
+		wantIsExpired     bool
+		wantIsRevoked     bool
+	}{
+		{
+			// The bug this guards: Tailscale spells "this key never expires"
+			// as the zero instant. A never-expiring key is not an expired key,
+			// it is the longest-lived credential in the tailnet.
+			name:              "no expiration set",
+			expires:           never,
+			revoked:           never,
+			wantHasExpiration: false,
+			wantIsExpired:     false,
+			wantIsRevoked:     false,
+		},
+		{
+			name:              "expiration in the past",
+			expires:           past,
+			revoked:           never,
+			wantHasExpiration: true,
+			wantIsExpired:     true,
+			wantIsRevoked:     false,
+		},
+		{
+			name:              "expiration in the future",
+			expires:           future,
+			revoked:           never,
+			wantHasExpiration: true,
+			wantIsExpired:     false,
+			wantIsRevoked:     false,
+		},
+		{
+			// Revoked and expired are independent. A revoked key that never
+			// had an expiration is still not "expired".
+			name:              "revoked with no expiration",
+			expires:           never,
+			revoked:           past,
+			wantHasExpiration: false,
+			wantIsExpired:     false,
+			wantIsRevoked:     true,
+		},
+		{
+			name:              "revoked and expired",
+			expires:           past,
+			revoked:           past,
+			wantHasExpiration: true,
+			wantIsExpired:     true,
+			wantIsRevoked:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key := authKeyWithExpiry(tc.expires, tc.revoked)
+
+			hasExpiration, err := key.hasExpiration()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantHasExpiration, hasExpiration, "hasExpiration")
+
+			isExpired, err := key.isExpired()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantIsExpired, isExpired, "isExpired")
+
+			isRevoked, err := key.isRevoked()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantIsRevoked, isRevoked, "isRevoked")
+		})
+	}
+}
+
+// TestNaiveExpiryComparisonInvertsNeverExpiringKey pins the inversion the fix
+// exists to remove. `expires < time.now` is the comparison the field's name
+// invites, and against the raw SDK value it answers "expired" for the one key
+// that will never expire, reporting the riskiest credential in the tailnet as
+// the safe one.
+func TestNaiveExpiryComparisonInvertsNeverExpiringKey(t *testing.T) {
+	now := time.Now()
+
+	// What the SDK hands us for a key created with no expiration.
+	var neverExpires time.Time
+	require.True(t, neverExpires.IsZero())
+
+	// The naive comparison, as an MQL author would write it against a field
+	// that carried the zero instant through.
+	naivelyExpired := neverExpires.Before(now)
+	assert.True(t, naivelyExpired,
+		"the zero instant compares as long past, which is the inversion")
+
+	// isExpired answers correctly on the same key.
+	key := authKeyWithExpiry(neverExpires, time.Time{})
+	isExpired, err := key.isExpired()
+	require.NoError(t, err)
+	assert.False(t, isExpired,
+		"a key with no expiration has not expired")
+
+	// And the field itself now reaches MQL as null rather than as the year 1,
+	// so the naive comparison has no bogus date to compare against.
+	assert.Nil(t, key.Expires.Data)
+
+	hasExpiration, err := key.hasExpiration()
+	require.NoError(t, err)
+	assert.False(t, hasExpiration,
+		"hasExpiration is what finds the never-expiring key")
 }

--- a/providers/tailscale/resources/tailscale.lr
+++ b/providers/tailscale/resources/tailscale.lr
@@ -237,7 +237,12 @@ tailscale.user @defaults("id displayName type") {
   deviceCount int
   // Time the user joined the tailnet
   createdAt time
-  // Last time the user was active on the tailnet, either via a node connection or by authenticating to a Tailscale service (including the admin panel)
+  // Last time the user was active on the tailnet
+  //
+  // Activity is either a node connection or authenticating to a
+  // Tailscale service, including the admin panel. Null when Tailscale
+  // reports no such time, so a query for dormant accounts selects only
+  // the accounts that have been seen at least once.
   lastSeenAt time
   // Whether the user is currently connected to the tailnet
   currentlyConnected bool
@@ -347,6 +352,12 @@ tailscale.aclPolicy @defaults("tailnet") {
   autoApproverExitNodes []string
   // Subnet routes that are auto-approved when advertised by listed users/groups (CIDR → owners)
   autoApproverRoutes map[string][]string
+  // Tailnet services whose advertisement is auto-approved when advertised by listed users/groups (service name → owners)
+  //
+  // A listed owner can stand up the named service under its stable VIP
+  // and have the advertisement approved without an administrator acting
+  // on it. Empty means every service advertisement needs approval.
+  autoApproverServices map[string][]string
   // Default device-posture rule names applied to every ACL source that doesn't specify its own srcPosture. Empty when posture rules are unused.
   defaultSourcePosture []string
   // Named device posture rules referenced by name from src/defaultSrcPosture (rule name -> list of posture conditions)
@@ -424,11 +435,26 @@ private tailscale.authKey @defaults("id keyType description expires revoked") {
   created time
   // Time the key was last modified
   updated time
-  // Time the key expires; the zero value means the key never expires
+  // Expiration time of the key
+  //
+  // Null when the key never expires. A key with no expiration is the
+  // longest-lived credential the tailnet can hold, so absence here is
+  // the finding rather than the all-clear, and there is no date to
+  // compare against the current time. Use isExpired to test whether a
+  // key is past its expiration, and hasExpiration to find the keys that
+  // have no expiration at all.
   expires time
   // Whether the key has an expiration set (false means the key never expires)
   hasExpiration() bool
-  // Time the key was revoked; the zero value means the key has not been revoked
+  // Whether the key is past its expiration time
+  //
+  // False for a key that never expires, since such a key is never past an
+  // expiration it does not have. Pair with hasExpiration to tell a key
+  // that is still within its window from one that has no window.
+  isExpired() bool
+  // Revocation time of the key
+  //
+  // Null when the key has not been revoked.
   revoked time
   // Whether the key has been revoked
   isRevoked() bool
@@ -482,6 +508,8 @@ private tailscale.webhook @defaults("endpointId providerType endpointUrl") {
   // Time the endpoint was registered
   created time
   // Time the endpoint subscription was last modified
+  //
+  // Null when Tailscale reports no such time.
   lastModified time
   // Events the endpoint is subscribed to
   //

--- a/providers/tailscale/resources/tailscale.lr.go
+++ b/providers/tailscale/resources/tailscale.lr.go
@@ -388,6 +388,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"tailscale.aclPolicy.autoApproverRoutes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAclPolicy).GetAutoApproverRoutes()).ToDataRes(types.Map(types.String, types.Array(types.String)))
 	},
+	"tailscale.aclPolicy.autoApproverServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleAclPolicy).GetAutoApproverServices()).ToDataRes(types.Map(types.String, types.Array(types.String)))
+	},
 	"tailscale.aclPolicy.defaultSourcePosture": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAclPolicy).GetDefaultSourcePosture()).ToDataRes(types.Array(types.String))
 	},
@@ -450,6 +453,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"tailscale.authKey.hasExpiration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAuthKey).GetHasExpiration()).ToDataRes(types.Bool)
+	},
+	"tailscale.authKey.isExpired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTailscaleAuthKey).GetIsExpired()).ToDataRes(types.Bool)
 	},
 	"tailscale.authKey.revoked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTailscaleAuthKey).GetRevoked()).ToDataRes(types.Time)
@@ -915,6 +921,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlTailscaleAclPolicy).AutoApproverRoutes, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"tailscale.aclPolicy.autoApproverServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleAclPolicy).AutoApproverServices, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"tailscale.aclPolicy.defaultSourcePosture": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleAclPolicy).DefaultSourcePosture, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1001,6 +1011,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"tailscale.authKey.hasExpiration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTailscaleAuthKey).HasExpiration, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"tailscale.authKey.isExpired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTailscaleAuthKey).IsExpired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"tailscale.authKey.revoked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1813,6 +1827,7 @@ type mqlTailscaleAclPolicy struct {
 	NodeAttrs              plugin.TValue[[]any]
 	AutoApproverExitNodes  plugin.TValue[[]any]
 	AutoApproverRoutes     plugin.TValue[map[string]any]
+	AutoApproverServices   plugin.TValue[map[string]any]
 	DefaultSourcePosture   plugin.TValue[[]any]
 	Postures               plugin.TValue[map[string]any]
 	DisableIPv4            plugin.TValue[bool]
@@ -1919,6 +1934,10 @@ func (c *mqlTailscaleAclPolicy) GetAutoApproverRoutes() *plugin.TValue[map[strin
 	return &c.AutoApproverRoutes
 }
 
+func (c *mqlTailscaleAclPolicy) GetAutoApproverServices() *plugin.TValue[map[string]any] {
+	return &c.AutoApproverServices
+}
+
 func (c *mqlTailscaleAclPolicy) GetDefaultSourcePosture() *plugin.TValue[[]any] {
 	return &c.DefaultSourcePosture
 }
@@ -1968,6 +1987,7 @@ type mqlTailscaleAuthKey struct {
 	Updated          plugin.TValue[*time.Time]
 	Expires          plugin.TValue[*time.Time]
 	HasExpiration    plugin.TValue[bool]
+	IsExpired        plugin.TValue[bool]
 	Revoked          plugin.TValue[*time.Time]
 	IsRevoked        plugin.TValue[bool]
 	Invalid          plugin.TValue[bool]
@@ -2081,6 +2101,12 @@ func (c *mqlTailscaleAuthKey) GetExpires() *plugin.TValue[*time.Time] {
 func (c *mqlTailscaleAuthKey) GetHasExpiration() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasExpiration, func() (bool, error) {
 		return c.hasExpiration()
+	})
+}
+
+func (c *mqlTailscaleAuthKey) GetIsExpired() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsExpired, func() (bool, error) {
+		return c.isExpired()
 	})
 }
 

--- a/providers/tailscale/resources/tailscale.lr.versions
+++ b/providers/tailscale/resources/tailscale.lr.versions
@@ -7,6 +7,7 @@ tailscale.aclPolicy.acls 13.0.7
 tailscale.aclPolicy.attrConfig 13.3.11
 tailscale.aclPolicy.autoApproverExitNodes 13.0.7
 tailscale.aclPolicy.autoApproverRoutes 13.0.7
+tailscale.aclPolicy.autoApproverServices 13.4.1
 tailscale.aclPolicy.defaultSourcePosture 13.0.7
 tailscale.aclPolicy.derpRegions 13.3.11
 tailscale.aclPolicy.disableIPv4 13.0.7
@@ -37,6 +38,7 @@ tailscale.authKey.expires 13.1.8
 tailscale.authKey.hasExpiration 13.2.4
 tailscale.authKey.id 13.1.8
 tailscale.authKey.invalid 13.1.8
+tailscale.authKey.isExpired 13.4.1
 tailscale.authKey.isRevoked 13.2.4
 tailscale.authKey.issuer 13.3.11
 tailscale.authKey.keyType 13.3.11

--- a/providers/tailscale/resources/user.go
+++ b/providers/tailscale/resources/user.go
@@ -52,8 +52,8 @@ func createTailscaleUserResource(runtime *plugin.Runtime, user *tsclient.User) (
 		"role":               llx.StringData(string(user.Role)),
 		"status":             llx.StringData(string(user.Status)),
 		"deviceCount":        llx.IntData(user.DeviceCount),
-		"createdAt":          llx.TimeData(user.Created),
-		"lastSeenAt":         llx.TimeData(user.LastSeen),
+		"createdAt":          llx.TimeDataPtr(optionalTimeValue(user.Created)),
+		"lastSeenAt":         llx.TimeDataPtr(optionalTimeValue(user.LastSeen)),
 		"currentlyConnected": llx.BoolData(user.CurrentlyConnected),
 	})
 }

--- a/providers/tailscale/resources/webhooks.go
+++ b/providers/tailscale/resources/webhooks.go
@@ -47,8 +47,8 @@ func createTailscaleWebhookResource(runtime *plugin.Runtime, wh *tsclient.Webhoo
 		"endpointUrl":      llx.StringData(wh.EndpointURL),
 		"providerType":     llx.StringData(string(wh.ProviderType)),
 		"creatorLoginName": llx.StringData(wh.CreatorLoginName),
-		"created":          llx.TimeData(wh.Created),
-		"lastModified":     llx.TimeData(wh.LastModified),
+		"created":          llx.TimeDataPtr(optionalTimeValue(wh.Created)),
+		"lastModified":     llx.TimeDataPtr(optionalTimeValue(wh.LastModified)),
 		"subscriptions":    llx.ArrayData(subs, types.String),
 	})
 }


### PR DESCRIPTION
## The bug

Tailscale's API encodes "this auth key never expires" as an absent timestamp, which the SDK materializes as the Go zero instant:

```go
// tailscale.com/client/tailscale/v2@v2.10.1 keys.go:102
Expires time.Time `json:"expires"`
```

The resource passed that value straight through to MQL:

```go
// providers/tailscale/resources/keys.go:108 (before this change)
"expires": llx.TimeData(key.Expires),
"revoked": llx.TimeData(key.Revoked),
```

So `tailscale.authKey.expires` reported `0001-01-01T00:00:00Z` for a key that will never expire, and `revoked` reported the same for a key that was never revoked.

## Why it is wrong

The zero instant is not a neutral placeholder, it is a date in the very distant past. The audit the field's name invites reads:

```
tailscale.authKeys.where(expires < time.now)
```

Against the old value that predicate answers **true** for a key with no expiration. The inversion is total: an auth key that never expires is the longest-lived credential a tailnet can hold, and it was landing in the same bucket as keys that had already lapsed and become harmless. The riskiest credential looked like the safe one, and it did so silently, since nothing about the result distinguishes "expired in 2024" from "encoded as year 1".

`hasExpiration()` and `isRevoked()` already existed and were already correct, so the shape of the trap was understood. The missing member was a predicate that answers the expiry question itself.

The `tailscale.device` resource was audited for the same inversion and **does not have it**: `optionalTime` in `device.go` already reports `expiresAt`, `createdAt` and `lastSeenAt` as null when Tailscale supplies no value, and the `.lr` docs already state the null semantics. The auth key, user and webhook resources were the ones that had not been brought over.

## The fix

- **`tailscale.authKey.isExpired()`** — returns `false` when the key has no expiration (a key that never expires is not past an expiration it does not have), and otherwise compares the expiration against now. Pair it with the existing `hasExpiration()` to separate a key still inside its window from a key with no window at all.
- **Unset timestamps now reach MQL as null, not as the year 1.** `optionalTimeValue` is added next to the existing `timeIsSet` and applied to `authKey.created/updated/expires/revoked`, `user.createdAt/lastSeenAt`, and `webhook.created/lastModified`. `device.go`'s `optionalTime` now delegates to it, so the whole provider recognizes Tailscale's "unset" in one place. This is the CLAUDE.md rule that an absent timestamp stays null rather than becoming the zero time; it also removes the bogus date the naive comparison was feeding on.
- **Doc comments state the trap at the point of use.** `expires` now says plainly that null means the key never expires, that absence is the finding rather than the all-clear, and points at `isExpired` / `hasExpiration`. `revoked`, `user.lastSeenAt` and `webhook.lastModified` gained their null semantics too.
- **`tailscale.aclPolicy.autoApproverServices`** — `flattenAutoApprovers` read only `ExitNode` and `Routes` from `ACL.AutoApprovers` and discarded `Services` outright. That third bucket names who may stand up a tailnet service under a stable VIP with no administrator approving the advertisement, so a policy that auto-approves services but nothing else previously read as "nothing is auto-approved". The route and service buckets now both go through the existing `stringSliceMapToAny` helper.

No shipped field changed type, and no field was removed. `.lr.versions` entries for the two new fields land at `13.4.1`, one patch above the provider's current `13.4.0` in `config/config.go`, which is left untouched.

## Verification

`isExpired` is pure predicate logic over a value the SDK hands us, so it is unit tested per CLAUDE.md §3.6.

`TestNaiveExpiryComparisonInvertsNeverExpiringKey` demonstrates the inversion rather than asserting it: it takes the value the SDK actually produces for a key with no expiration, shows that `expires < now` answers **true** on it, and then shows `isExpired()` answering `false` on the same key and the field itself arriving as null.

`TestAuthKeyExpiryPredicates` table-tests the four states across all three predicates:

| case | `hasExpiration` | `isExpired` | `isRevoked` |
|---|---|---|---|
| no expiration set (zero value) | false | **false** | false |
| expiration in the past | true | true | false |
| expiration in the future | true | false | false |
| revoked, no expiration | false | **false** | true |
| revoked and expired | true | true | true |

```
$ cd providers/tailscale && go build ./... && go test ./...
?   	go.mondoo.com/mql/providers/tailscale	[no test files]
?   	go.mondoo.com/mql/providers/tailscale/config	[no test files]
ok  	go.mondoo.com/mql/providers/tailscale/connection	1.283s
?   	go.mondoo.com/mql/providers/tailscale/gen	[no test files]
?   	go.mondoo.com/mql/providers/tailscale/provider	[no test files]
ok  	go.mondoo.com/mql/providers/tailscale/resources	0.590s
```

```
$ go test ./resources/ -run 'TestAuthKeyExpiryPredicates|TestNaiveExpiryComparisonInvertsNeverExpiringKey|TestOptionalTimeValue|TestFlattenAutoApprovers' -v
=== RUN   TestFlattenAutoApprovers
=== RUN   TestFlattenAutoApprovers/nil_block
=== RUN   TestFlattenAutoApprovers/empty_block
=== RUN   TestFlattenAutoApprovers/exit_nodes_only
=== RUN   TestFlattenAutoApprovers/routes_and_exit_nodes
=== RUN   TestFlattenAutoApprovers/services_alongside_routes_and_exit_nodes
=== RUN   TestFlattenAutoApprovers/services_only
--- PASS: TestFlattenAutoApprovers (0.00s)
    --- PASS: TestFlattenAutoApprovers/nil_block (0.00s)
    --- PASS: TestFlattenAutoApprovers/empty_block (0.00s)
    --- PASS: TestFlattenAutoApprovers/exit_nodes_only (0.00s)
    --- PASS: TestFlattenAutoApprovers/routes_and_exit_nodes (0.00s)
    --- PASS: TestFlattenAutoApprovers/services_alongside_routes_and_exit_nodes (0.00s)
    --- PASS: TestFlattenAutoApprovers/services_only (0.00s)
=== RUN   TestOptionalTimeValue
--- PASS: TestOptionalTimeValue (0.00s)
=== RUN   TestAuthKeyExpiryPredicates
=== RUN   TestAuthKeyExpiryPredicates/no_expiration_set
=== RUN   TestAuthKeyExpiryPredicates/expiration_in_the_past
=== RUN   TestAuthKeyExpiryPredicates/expiration_in_the_future
=== RUN   TestAuthKeyExpiryPredicates/revoked_with_no_expiration
=== RUN   TestAuthKeyExpiryPredicates/revoked_and_expired
--- PASS: TestAuthKeyExpiryPredicates (0.00s)
    --- PASS: TestAuthKeyExpiryPredicates/no_expiration_set (0.00s)
    --- PASS: TestAuthKeyExpiryPredicates/expiration_in_the_past (0.00s)
    --- PASS: TestAuthKeyExpiryPredicates/expiration_in_the_future (0.00s)
    --- PASS: TestAuthKeyExpiryPredicates/revoked_with_no_expiration (0.00s)
    --- PASS: TestAuthKeyExpiryPredicates/revoked_and_expired (0.00s)
=== RUN   TestNaiveExpiryComparisonInvertsNeverExpiringKey
--- PASS: TestNaiveExpiryComparisonInvertsNeverExpiringKey (0.00s)
PASS
ok  	go.mondoo.com/mql/providers/tailscale/resources	0.497s
```

Also clean: `gofmt -l resources/` (empty), `go vet ./...`, `go mod tidy` (no diff), `typos providers/tailscale/` (no hits), and `mqlr generate` reproduces the committed `.lr.go` / `.lr.versions`.

## Not verified against a live target

No Tailscale API key was available in this environment (`TAILSCALE_API_KEY`, `TAILSCALE_OAUTH_CLIENT_ID` / `TAILSCALE_OAUTH_CLIENT_SECRET` all unset, and no provider config carrying one), so nothing here was run against a real tailnet. Unproven against live data:

- That `expires` actually arrives as the zero instant from a real never-expiring key, rather than the API omitting the key entirely in some other way. The behaviour is taken from the SDK's `time.Time` field with a plain `json:"expires"` tag, which decodes an absent or null JSON value to the zero time either way, so both routes land on the same fix. It has not been observed on the wire.
- That `revoked`, `user.lastSeenAt` and `webhook.lastModified` are in fact zero-valued in the situations described. These now report null instead of the year 1 in exactly the cases where they were already zero, so the change is a no-op wherever Tailscale does supply a value, but which of them are ever unset in practice is unconfirmed.
- That `ACL.AutoApprovers.Services` is populated in the shape the flatten expects. The mapping follows the SDK's `map[string][]string` and the same handling the already-shipped `Routes` bucket uses, and it is covered by unit tests, but no real policy file was read.
- The rendered MQL output of `isExpired`, `hasExpiration` and `autoApproverServices` in a shell session.

Separately noted and **not** addressed here: `mqlr generate` emits a pre-existing `duplicate field paths detected` warning for `tailscale.aclPolicy`. It reproduces on unmodified `main` and is unrelated to this change.
