### PR TITLE
🐛 opcua: connect to secured servers, not just insecure ones

### DIFF
--- a/providers/opcua/config/config.go
+++ b/providers/opcua/config/config.go
@@ -21,9 +21,16 @@ var Config = plugin.Provider{
 			Short: "an OPC UA device",
 			Long: `Use the opcua provider to query resources on an Open Platform Communications Unified Architecture (OPC UA) server or device. OPC UA is a protocol for machine-to-machine communication in industrial automation.
 
+By default the provider connects with the strongest security the server offers and
+falls back to weaker endpoints when a session cannot be established. Use the security
+flags to pin a policy and mode, and to supply the client certificate a hardened server
+expects.
+
 Examples:
   cnspec shell opcua --endpoint opc.tcp://<host>:<port>
   cnspec scan opcua --endpoint opc.tcp://<host>:<port>
+  cnspec scan opcua --endpoint opc.tcp://<host>:<port> --security-policy Basic256Sha256 --security-mode SignAndEncrypt --cert-file client.der --key-file client.key
+  cnspec scan opcua --endpoint opc.tcp://<host>:<port> --username <user> --password <password>
 `,
 			Discovery: []string{},
 			Flags: []plugin.Flag{
@@ -33,6 +40,44 @@ Examples:
 					Default: "",
 					Desc:    "OPC UA endpoint URL of the OPC UA server in the format opc.tcp://<host>:<port>",
 					Option:  plugin.FlagOption_Required,
+				},
+				{
+					Long:    "security-policy",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Security policy to use: None, Basic128Rsa15, Basic256, Basic256Sha256, Aes128Sha256RsaOaep, or Aes256Sha256RsaPss (default: the strongest policy the server offers)",
+				},
+				{
+					Long:    "security-mode",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Message security mode to use: None, Sign, or SignAndEncrypt (default: the strongest mode the server offers)",
+				},
+				{
+					Long:    "cert-file",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Path to the PEM or DER encoded client certificate to present on the secure channel",
+				},
+				{
+					Long:    "key-file",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Path to the PEM or DER encoded private key that belongs to the client certificate",
+				},
+				{
+					Long:    "username",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Username for OPC UA username and password authentication",
+				},
+				{
+					Long:        "password",
+					Type:        plugin.FlagType_String,
+					Default:     "",
+					Desc:        "Password for OPC UA username and password authentication",
+					Option:      plugin.FlagOption_Password,
+					ConfigEntry: "-",
 				},
 			},
 		},

--- a/providers/opcua/config/config_test.go
+++ b/providers/opcua/config/config_test.go
@@ -1,0 +1,36 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/opcua/connection"
+)
+
+// A connection option the CLI never declares can never be set by a user, so
+// every option key the connection reads needs a flag behind it.
+func TestConnectorDeclaresEveryConnectionFlag(t *testing.T) {
+	require.Len(t, Config.Connectors, 1)
+
+	declared := map[string]bool{}
+	for _, flag := range Config.Connectors[0].Flags {
+		declared[flag.Long] = true
+	}
+
+	wanted := []string{
+		connection.OptionEndpoint,
+		connection.OptionSecurityPolicy,
+		connection.OptionSecurityMode,
+		connection.OptionCertFile,
+		connection.OptionKeyFile,
+		"username",
+		"password",
+	}
+	for _, flag := range wanted {
+		assert.True(t, declared[flag], "flag %q is not declared by the opcua connector", flag)
+	}
+}

--- a/providers/opcua/connection/cert.go
+++ b/providers/opcua/connection/cert.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"time"
+)
+
+// applicationURI identifies this client to an OPC UA server. It has to match
+// the URI subject alternative name of the certificate presented on the secure
+// channel, otherwise the server rejects the channel.
+const applicationURI = "urn:mondoo:mql:opcua"
+
+// applicationName is the human readable client name sent in the session
+// description.
+const applicationName = "Mondoo MQL OPC UA client"
+
+// ephemeralCertificate builds a short lived self-signed client certificate.
+//
+// Every security policy other than None requires the client to present an
+// application instance certificate on the secure channel. Without one a
+// hardened server cannot be reached at all, so we generate a throwaway
+// certificate when the user did not supply one with `--cert-file`. A server
+// that only trusts known client certificates still needs the explicit flags,
+// but a server that accepts unknown clients becomes scannable with no setup.
+//
+// The key never leaves the process: it is created per connection, kept in
+// memory, and discarded when the connection closes.
+func ephemeralCertificate() (certDER []byte, key *rsa.PrivateKey, err error) {
+	key, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	uri, err := url.Parse(applicationURI)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	now := time.Now()
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   applicationName,
+			Organization: []string{"Mondoo"},
+		},
+		// tolerate a small clock skew between client and server
+		NotBefore:             now.Add(-1 * time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		URIs:                  []*url.URL{uri},
+	}
+
+	certDER, err = x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return certDER, key, nil
+}

--- a/providers/opcua/connection/cert.go
+++ b/providers/opcua/connection/cert.go
@@ -58,10 +58,13 @@ func ephemeralCertificate() (certDER []byte, key *rsa.PrivateKey, err error) {
 			Organization: []string{"Mondoo"},
 		},
 		// tolerate a small clock skew between client and server
-		NotBefore:             now.Add(-1 * time.Hour),
-		NotAfter:              now.Add(24 * time.Hour),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		NotBefore: now.Add(-1 * time.Hour),
+		NotAfter:  now.Add(24 * time.Hour),
+		// A client certificate signs nothing but its own handshake, so it gets
+		// neither KeyUsageCertSign nor the server EKU. Some servers reject an
+		// over-privileged client certificate outright.
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		URIs:                  []*url.URL{uri},
 	}

--- a/providers/opcua/connection/connection.go
+++ b/providers/opcua/connection/connection.go
@@ -6,11 +6,25 @@ package connection
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+// Connection option keys. They are the single source of truth shared by the
+// provider's ParseCLI and this package: a key spelled differently on either
+// side is dropped without an error and the flag becomes a no-op.
+const (
+	OptionEndpoint       = "endpoint"
+	OptionSecurityPolicy = "security-policy"
+	OptionSecurityMode   = "security-mode"
+	OptionCertFile       = "cert-file"
+	OptionKeyFile        = "key-file"
 )
 
 type OpcuaConnection struct {
@@ -19,6 +33,64 @@ type OpcuaConnection struct {
 	asset    *inventory.Asset
 	client   *opcua.Client
 	endpoint string
+}
+
+// clientOptions holds everything needed to open a session, gathered from the
+// asset configuration.
+type clientOptions struct {
+	endpoint       string
+	securityPolicy string
+	securityMode   string
+	certFile       string
+	keyFile        string
+	username       string
+	password       string
+}
+
+// tokenType returns the user identity token the configured credentials imply.
+func (o *clientOptions) tokenType() ua.UserTokenType {
+	if o.username != "" {
+		return ua.UserTokenTypeUserName
+	}
+	return ua.UserTokenTypeAnonymous
+}
+
+func newClientOptions(conf *inventory.Config) (*clientOptions, error) {
+	if conf.Options == nil || conf.Options[OptionEndpoint] == "" {
+		return nil, errors.New("opcua provider requires an endpoint. please set option `endpoint`")
+	}
+
+	opts := &clientOptions{
+		endpoint:       conf.Options[OptionEndpoint],
+		securityPolicy: conf.Options[OptionSecurityPolicy],
+		securityMode:   conf.Options[OptionSecurityMode],
+		certFile:       conf.Options[OptionCertFile],
+		keyFile:        conf.Options[OptionKeyFile],
+	}
+
+	if (opts.certFile == "") != (opts.keyFile == "") {
+		return nil, errors.New("opcua provider requires both `cert-file` and `key-file` when using a client certificate")
+	}
+
+	for _, cred := range conf.Credentials {
+		if cred == nil || cred.Type != vault.CredentialType_password {
+			continue
+		}
+		opts.username = cred.User
+		opts.password = string(cred.Secret)
+		break
+	}
+
+	// validate the security settings before we reach out to the server so a
+	// typo surfaces as a clear message instead of an endpoint mismatch
+	if _, err := parseSecurityPolicy(opts.securityPolicy); err != nil {
+		return nil, err
+	}
+	if _, err := parseSecurityMode(opts.securityMode); err != nil {
+		return nil, err
+	}
+
+	return opts, nil
 }
 
 func NewOpcuaConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*OpcuaConnection, error) {
@@ -33,52 +105,108 @@ func NewOpcuaConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 		return nil, plugin.ErrProviderTypeDoesNotMatch
 	}
 
-	if conf.Options == nil || conf.Options["endpoint"] == "" {
-		return nil, errors.New("opcua provider requires an endpoint. please set option `endpoint`")
+	opts, err := newClientOptions(conf)
+	if err != nil {
+		return nil, err
 	}
-
-	endpoint := conf.Options["endpoint"]
-
-	policy := "None" // None, Basic128Rsa15, Basic256, Basic256Sha256. Default: auto"
-	mode := "None"   //  None, Sign, SignAndEncrypt. Default: auto
-	// certFile := "created/server_cert.der"
-	// keyFile := "created/server_key.der"
 
 	ctx := context.Background()
-
-	endpoints, err := opcua.GetEndpoints(ctx, endpoint)
+	client, err := connectClient(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
-	ep, err := opcua.SelectEndpoint(endpoints, policy, ua.MessageSecurityModeFromString(mode))
-	if err != nil {
-		return nil, err
-	}
-	if ep == nil {
-		return nil, errors.New("failed to find suitable endpoint")
-	}
 
-	opts := []opcua.Option{
-		opcua.SecurityPolicy(policy),
-		opcua.SecurityModeString(mode),
-		// opcua.CertificateFile(certFile),
-		// opcua.PrivateKeyFile(keyFile),
-		opcua.AuthAnonymous(),
-		opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeAnonymous),
-	}
-
-	c, err := opcua.NewClient(endpoint, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := c.Connect(ctx); err != nil {
-		return nil, err
-	}
-
-	conn.client = c
-	conn.endpoint = endpoint
+	conn.client = client
+	conn.endpoint = opts.endpoint
 
 	return conn, nil
+}
+
+// connectClient walks the endpoints the server advertises, strongest security
+// first, and returns the first session it can establish.
+//
+// Preferring the strongest endpoint is what makes a properly secured server
+// scannable: it typically offers no None/None endpoint at all, and asking for
+// one leaves the asset unreachable. Walking down the list keeps a server that
+// only speaks None/None working exactly as before.
+func connectClient(ctx context.Context, opts *clientOptions) (*opcua.Client, error) {
+	endpoints, err := opcua.GetEndpoints(ctx, opts.endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenType := opts.tokenType()
+	candidates, err := selectEndpoints(endpoints, opts.securityPolicy, opts.securityMode, tokenType)
+	if err != nil {
+		return nil, err
+	}
+
+	attemptErrors := []error{}
+	for _, ep := range candidates {
+		client, err := dialEndpoint(ctx, opts, ep, tokenType)
+		if err == nil {
+			log.Debug().
+				Str("endpoint", opts.endpoint).
+				Str("security", describeEndpoint(ep)).
+				Msg("opcua> connected")
+			return client, nil
+		}
+
+		log.Debug().
+			Err(err).
+			Str("endpoint", opts.endpoint).
+			Str("security", describeEndpoint(ep)).
+			Msg("opcua> could not establish session, trying next endpoint")
+		attemptErrors = append(attemptErrors, fmt.Errorf("%s: %w", describeEndpoint(ep), err))
+	}
+
+	return nil, fmt.Errorf("could not connect to OPC UA server %s: %w", opts.endpoint, errors.Join(attemptErrors...))
+}
+
+// dialEndpoint opens a session against a single advertised endpoint.
+func dialEndpoint(ctx context.Context, opts *clientOptions, ep *ua.EndpointDescription, tokenType ua.UserTokenType) (*opcua.Client, error) {
+	clientOpts := []opcua.Option{
+		opcua.ApplicationName(applicationName),
+		opcua.ApplicationURI(applicationURI),
+	}
+
+	if tokenType == ua.UserTokenTypeUserName {
+		clientOpts = append(clientOpts, opcua.AuthUsername(opts.username, opts.password))
+	} else {
+		clientOpts = append(clientOpts, opcua.AuthAnonymous())
+	}
+
+	switch {
+	case opts.certFile != "":
+		clientOpts = append(clientOpts,
+			opcua.CertificateFile(opts.certFile),
+			opcua.PrivateKeyFile(opts.keyFile),
+		)
+	case ep.SecurityMode != ua.MessageSecurityModeNone || ep.SecurityPolicyURI != ua.SecurityPolicyURINone:
+		// a secured channel is only possible with a client certificate
+		certDER, key, err := ephemeralCertificate()
+		if err != nil {
+			return nil, err
+		}
+		clientOpts = append(clientOpts, opcua.Certificate(certDER), opcua.PrivateKey(key))
+	}
+
+	clientOpts = append(clientOpts, opcua.SecurityFromEndpoint(ep, tokenType))
+
+	// connect to the endpoint URL the user supplied rather than the one the
+	// server advertises: servers behind NAT or inside a container routinely
+	// advertise a hostname that is not resolvable by the client
+	client, err := opcua.NewClient(opts.endpoint, clientOpts...)
+	if err != nil {
+		return nil, err
+	}
+	if err := client.Connect(ctx); err != nil {
+		// the client holds an open socket even when the session handshake
+		// failed, so release it before moving on to the next endpoint
+		_ = client.Close(ctx)
+		return nil, err
+	}
+	return client, nil
 }
 
 func (c *OpcuaConnection) Name() string {

--- a/providers/opcua/connection/connection_test.go
+++ b/providers/opcua/connection/connection_test.go
@@ -1,0 +1,161 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+func TestNewClientOptions(t *testing.T) {
+	conf := &inventory.Config{
+		Type: "opcua",
+		Options: map[string]string{
+			OptionEndpoint:       "opc.tcp://server:4840",
+			OptionSecurityPolicy: "Basic256Sha256",
+			OptionSecurityMode:   "SignAndEncrypt",
+			OptionCertFile:       "/tmp/client.der",
+			OptionKeyFile:        "/tmp/client.key",
+		},
+		Credentials: []*vault.Credential{
+			vault.NewPasswordCredential("operator", "secret"),
+		},
+	}
+
+	opts, err := newClientOptions(conf)
+	require.NoError(t, err)
+	assert.Equal(t, "opc.tcp://server:4840", opts.endpoint)
+	assert.Equal(t, "Basic256Sha256", opts.securityPolicy)
+	assert.Equal(t, "SignAndEncrypt", opts.securityMode)
+	assert.Equal(t, "/tmp/client.der", opts.certFile)
+	assert.Equal(t, "/tmp/client.key", opts.keyFile)
+	assert.Equal(t, "operator", opts.username)
+	assert.Equal(t, "secret", opts.password)
+	assert.Equal(t, ua.UserTokenTypeUserName, opts.tokenType())
+}
+
+func TestNewClientOptions_DefaultsToAnonymousAndAutomaticSecurity(t *testing.T) {
+	opts, err := newClientOptions(&inventory.Config{
+		Type:    "opcua",
+		Options: map[string]string{OptionEndpoint: "opc.tcp://server:4840"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, opts.securityPolicy)
+	assert.Empty(t, opts.securityMode)
+	assert.Equal(t, ua.UserTokenTypeAnonymous, opts.tokenType())
+}
+
+func TestNewClientOptions_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    *inventory.Config
+		wantErr string
+	}{
+		{
+			name:    "no options at all",
+			conf:    &inventory.Config{Type: "opcua"},
+			wantErr: "requires an endpoint",
+		},
+		{
+			name:    "empty endpoint",
+			conf:    &inventory.Config{Type: "opcua", Options: map[string]string{OptionEndpoint: ""}},
+			wantErr: "requires an endpoint",
+		},
+		{
+			name: "certificate without key",
+			conf: &inventory.Config{Type: "opcua", Options: map[string]string{
+				OptionEndpoint: "opc.tcp://server:4840",
+				OptionCertFile: "/tmp/client.der",
+			}},
+			wantErr: "cert-file",
+		},
+		{
+			name: "key without certificate",
+			conf: &inventory.Config{Type: "opcua", Options: map[string]string{
+				OptionEndpoint: "opc.tcp://server:4840",
+				OptionKeyFile:  "/tmp/client.key",
+			}},
+			wantErr: "key-file",
+		},
+		{
+			name: "unknown security policy",
+			conf: &inventory.Config{Type: "opcua", Options: map[string]string{
+				OptionEndpoint:       "opc.tcp://server:4840",
+				OptionSecurityPolicy: "Basic999",
+			}},
+			wantErr: "unsupported security policy",
+		},
+		{
+			name: "unknown security mode",
+			conf: &inventory.Config{Type: "opcua", Options: map[string]string{
+				OptionEndpoint:     "opc.tcp://server:4840",
+				OptionSecurityMode: "encrypt",
+			}},
+			wantErr: "unsupported security mode",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newClientOptions(test.conf)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}
+
+// A username with no password is a valid configuration for servers that
+// authenticate against an empty secret, and must not fall back to anonymous.
+func TestNewClientOptions_UsernameWithoutPassword(t *testing.T) {
+	opts, err := newClientOptions(&inventory.Config{
+		Type:        "opcua",
+		Options:     map[string]string{OptionEndpoint: "opc.tcp://server:4840"},
+		Credentials: []*vault.Credential{vault.NewPasswordCredential("operator", "")},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ua.UserTokenTypeUserName, opts.tokenType())
+	assert.Empty(t, opts.password)
+}
+
+func TestNewClientOptions_SkipsNilAndNonPasswordCredentials(t *testing.T) {
+	opts, err := newClientOptions(&inventory.Config{
+		Type:    "opcua",
+		Options: map[string]string{OptionEndpoint: "opc.tcp://server:4840"},
+		Credentials: []*vault.Credential{
+			nil,
+			{Type: vault.CredentialType_ssh_agent, User: "ignored"},
+			vault.NewPasswordCredential("operator", "secret"),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "operator", opts.username)
+}
+
+// The certificate is what makes a secured channel possible at all, so it has to
+// carry the application URI the session announces.
+func TestEphemeralCertificate(t *testing.T) {
+	certDER, key, err := ephemeralCertificate()
+	require.NoError(t, err)
+	require.NotNil(t, key)
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+	require.Len(t, cert.URIs, 1)
+	assert.Equal(t, applicationURI, cert.URIs[0].String())
+	assert.NotZero(t, cert.KeyUsage&x509.KeyUsageDigitalSignature)
+	assert.NotZero(t, cert.KeyUsage&x509.KeyUsageKeyEncipherment)
+	assert.Contains(t, cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+	assert.True(t, cert.NotBefore.Before(cert.NotAfter))
+
+	// each connection gets its own key
+	otherDER, _, err := ephemeralCertificate()
+	require.NoError(t, err)
+	assert.NotEqual(t, certDER, otherDER)
+}

--- a/providers/opcua/connection/endpoint.go
+++ b/providers/opcua/connection/endpoint.go
@@ -1,0 +1,227 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uapolicy"
+)
+
+// securityModes maps the message security mode names accepted on the command
+// line to their protocol values.
+var securityModes = map[string]ua.MessageSecurityMode{
+	"None":           ua.MessageSecurityModeNone,
+	"Sign":           ua.MessageSecurityModeSign,
+	"SignAndEncrypt": ua.MessageSecurityModeSignAndEncrypt,
+}
+
+// endpointStrength ranks how much protection an endpoint provides. It defers to
+// the ranking the OPC UA stack keeps for every policy and mode combination, so
+// a deprecated policy that encrypts does not outrank a modern policy that only
+// signs. A policy the stack cannot negotiate ranks at zero and is therefore
+// only reached as a last-resort fallback.
+func endpointStrength(ep *ua.EndpointDescription) int {
+	return int(uapolicy.SecurityLevel(ep.SecurityPolicyURI, ep.SecurityMode))
+}
+
+// parseSecurityPolicy turns a security policy name into its canonical URI. An
+// empty name means "whatever the server offers" and yields an empty URI.
+func parseSecurityPolicy(policy string) (string, error) {
+	if policy == "" {
+		return "", nil
+	}
+	uri := ua.FormatSecurityPolicyURI(policy)
+	for _, known := range ua.SecurityPolicyURIs {
+		if known == uri {
+			return uri, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported security policy %q, expected one of %s", policy, strings.Join(securityPolicyNames(), ", "))
+}
+
+// parseSecurityMode turns a message security mode name into its protocol
+// value. An empty name means "whatever the server offers" and yields
+// MessageSecurityModeInvalid.
+func parseSecurityMode(mode string) (ua.MessageSecurityMode, error) {
+	if mode == "" {
+		return ua.MessageSecurityModeInvalid, nil
+	}
+	value, ok := securityModes[mode]
+	if !ok {
+		return ua.MessageSecurityModeInvalid, fmt.Errorf("unsupported security mode %q, expected one of None, Sign, SignAndEncrypt", mode)
+	}
+	return value, nil
+}
+
+func securityPolicyNames() []string {
+	names := make([]string, 0, len(ua.SecurityPolicyURIs))
+	for name := range ua.SecurityPolicyURIs {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return uapolicy.SecurityLevel(ua.SecurityPolicyURIs[names[i]], ua.MessageSecurityModeSignAndEncrypt) <
+			uapolicy.SecurityLevel(ua.SecurityPolicyURIs[names[j]], ua.MessageSecurityModeSignAndEncrypt)
+	})
+	return names
+}
+
+// supportsTokenType reports whether an endpoint accepts the given user token
+// type. Servers that advertise no user identity tokens at all are treated as
+// compatible: rejecting them would drop endpoints that are in fact usable.
+func supportsTokenType(ep *ua.EndpointDescription, tokenType ua.UserTokenType) bool {
+	if len(ep.UserIdentityTokens) == 0 {
+		return true
+	}
+	for _, token := range ep.UserIdentityTokens {
+		if token != nil && token.TokenType == tokenType {
+			return true
+		}
+	}
+	return false
+}
+
+// selectEndpoints returns the endpoints worth attempting, strongest security
+// first. Callers walk the result in order and fall back to the next entry when
+// a connection cannot be established, so a server that advertises an endpoint
+// it cannot actually serve still connects on a weaker one.
+//
+// policy and mode narrow the candidates to an exact match when set. They are
+// the escape hatch for a server whose advertised endpoints do not reflect what
+// it accepts; left empty, selection is automatic.
+func selectEndpoints(endpoints []*ua.EndpointDescription, policy string, mode string, tokenType ua.UserTokenType) ([]*ua.EndpointDescription, error) {
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("the OPC UA server did not advertise any endpoints")
+	}
+
+	wantPolicy, err := parseSecurityPolicy(policy)
+	if err != nil {
+		return nil, err
+	}
+	wantMode, err := parseSecurityMode(mode)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := make([]*ua.EndpointDescription, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if ep == nil {
+			continue
+		}
+		if wantPolicy != "" && ep.SecurityPolicyURI != wantPolicy {
+			continue
+		}
+		if wantMode != ua.MessageSecurityModeInvalid && ep.SecurityMode != wantMode {
+			continue
+		}
+		if !supportsTokenType(ep, tokenType) {
+			continue
+		}
+		candidates = append(candidates, ep)
+	}
+
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf(
+			"no endpoint supports %s authentication with the requested security settings, the server offers security %s and authentication %s",
+			tokenTypeName(tokenType), describeEndpoints(endpoints), describeTokenTypes(endpoints),
+		)
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		if endpointStrength(a) != endpointStrength(b) {
+			return endpointStrength(a) > endpointStrength(b)
+		}
+		// equally strong on paper, so fall back to the ranking the server
+		// itself publishes
+		return a.SecurityLevel > b.SecurityLevel
+	})
+
+	return candidates, nil
+}
+
+// modeName renders a message security mode with the short name used on the
+// command line. The generated String() prefixes every value with the type name,
+// which reads badly in a message that already says "security".
+func modeName(mode ua.MessageSecurityMode) string {
+	for name, value := range securityModes {
+		if value == mode {
+			return name
+		}
+	}
+	return "Invalid"
+}
+
+// describeEndpoint renders an endpoint's security settings for log and error
+// messages.
+func describeEndpoint(ep *ua.EndpointDescription) string {
+	policy := strings.TrimPrefix(ep.SecurityPolicyURI, ua.SecurityPolicyURIPrefix)
+	if policy == "" {
+		policy = "unknown"
+	}
+	return policy + "/" + modeName(ep.SecurityMode)
+}
+
+// tokenTypeName renders a user token type the way a user would name it.
+func tokenTypeName(tokenType ua.UserTokenType) string {
+	switch tokenType {
+	case ua.UserTokenTypeUserName:
+		return "username and password"
+	case ua.UserTokenTypeCertificate:
+		return "certificate"
+	case ua.UserTokenTypeIssuedToken:
+		return "issued token"
+	default:
+		return "anonymous"
+	}
+}
+
+// describeTokenTypes lists the authentication methods the server advertises.
+func describeTokenTypes(endpoints []*ua.EndpointDescription) string {
+	seen := map[string]struct{}{}
+	names := []string{}
+	for _, ep := range endpoints {
+		if ep == nil {
+			continue
+		}
+		for _, token := range ep.UserIdentityTokens {
+			if token == nil {
+				continue
+			}
+			name := tokenTypeName(token.TokenType)
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return "none"
+	}
+	return strings.Join(names, ", ")
+}
+
+func describeEndpoints(endpoints []*ua.EndpointDescription) string {
+	seen := map[string]struct{}{}
+	descriptions := []string{}
+	for _, ep := range endpoints {
+		if ep == nil {
+			continue
+		}
+		description := describeEndpoint(ep)
+		if _, ok := seen[description]; ok {
+			continue
+		}
+		seen[description] = struct{}{}
+		descriptions = append(descriptions, description)
+	}
+	if len(descriptions) == 0 {
+		return "none"
+	}
+	return strings.Join(descriptions, ", ")
+}

--- a/providers/opcua/connection/endpoint_test.go
+++ b/providers/opcua/connection/endpoint_test.go
@@ -1,0 +1,274 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func endpoint(policy string, mode ua.MessageSecurityMode, level uint8, tokens ...ua.UserTokenType) *ua.EndpointDescription {
+	ep := &ua.EndpointDescription{
+		EndpointURL:       "opc.tcp://server:4840",
+		SecurityPolicyURI: policy,
+		SecurityMode:      mode,
+		SecurityLevel:     level,
+	}
+	for _, t := range tokens {
+		ep.UserIdentityTokens = append(ep.UserIdentityTokens, &ua.UserTokenPolicy{TokenType: t})
+	}
+	return ep
+}
+
+// hardenedServer models a correctly configured server: it offers no None
+// endpoint at all, only Basic256Sha256 with Sign and SignAndEncrypt.
+func hardenedServer() []*ua.EndpointDescription {
+	return []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSign, 0, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeAnonymous),
+	}
+}
+
+func TestSelectEndpoints_PrefersStrongestSecurity(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURINone, ua.MessageSecurityModeNone, 0, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIBasic256, ua.MessageSecurityModeSign, 0, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIBasic128Rsa15, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeAnonymous),
+	}
+
+	candidates, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	require.Len(t, candidates, 4)
+
+	// strongest policy and mode combination first. Basic128Rsa15 is deprecated,
+	// so encrypting with it does not outrank signing with Basic256.
+	assert.Equal(t, []string{
+		"Basic256Sha256/SignAndEncrypt",
+		"Basic256/Sign",
+		"Basic128Rsa15/SignAndEncrypt",
+		"None/None",
+	}, describeAll(candidates))
+}
+
+// A server that advertises an endpoint it cannot serve must not take the whole
+// asset down: the weaker endpoints stay in the list as fallbacks.
+func TestSelectEndpoints_FallbackOrderIncludesWeakerEndpoints(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURINone, ua.MessageSecurityModeNone, 0, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIAes256Sha256RsaPss, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeAnonymous),
+	}
+
+	candidates, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"Aes256_Sha256_RsaPss/SignAndEncrypt",
+		"None/None",
+	}, describeAll(candidates))
+}
+
+// The regression guard for insecure servers: a None-only server still connects.
+func TestSelectEndpoints_NoneOnlyServerStillConnects(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURINone, ua.MessageSecurityModeNone, 0, ua.UserTokenTypeAnonymous),
+	}
+
+	candidates, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "None/None", describeEndpoint(candidates[0]))
+}
+
+// This is the shape that used to make the provider fail outright: asking for
+// None/None on a server that offers neither.
+func TestSelectEndpoints_HardenedServerIsReachable(t *testing.T) {
+	candidates, err := selectEndpoints(hardenedServer(), "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"Basic256Sha256/SignAndEncrypt",
+		"Basic256Sha256/Sign",
+	}, describeAll(candidates))
+}
+
+func TestSelectEndpoints_ExplicitPolicyAndMode(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURINone, ua.MessageSecurityModeNone, 0, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSign, 0, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeAnonymous),
+	}
+
+	candidates, err := selectEndpoints(endpoints, "Basic256Sha256", "Sign", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "Basic256Sha256/Sign", describeEndpoint(candidates[0]))
+
+	// pinning only the mode leaves every policy in that mode as a candidate
+	candidates, err = selectEndpoints(endpoints, "", "None", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "None/None", describeEndpoint(candidates[0]))
+}
+
+func TestSelectEndpoints_NoMatchForPinnedSettings(t *testing.T) {
+	_, err := selectEndpoints(hardenedServer(), "None", "None", ua.UserTokenTypeAnonymous)
+	require.Error(t, err)
+	// the error names what the server actually offers
+	assert.Contains(t, err.Error(), "Basic256Sha256/SignAndEncrypt")
+	assert.Contains(t, err.Error(), "anonymous")
+}
+
+// A server that only accepts username authentication has to say so, rather than
+// blaming the security settings.
+func TestSelectEndpoints_NoMatchForTokenTypeNamesTheAuthentication(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeUserName),
+	}
+
+	_, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeAnonymous)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no endpoint supports anonymous authentication")
+	assert.Contains(t, err.Error(), "authentication username and password")
+}
+
+func TestSelectEndpoints_FiltersByUserTokenType(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeUserName),
+		endpoint(ua.SecurityPolicyURIBasic256, ua.MessageSecurityModeSign, 0, ua.UserTokenTypeAnonymous),
+	}
+
+	anonymous, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	require.Len(t, anonymous, 1)
+	assert.Equal(t, "Basic256/Sign", describeEndpoint(anonymous[0]))
+
+	username, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeUserName)
+	require.NoError(t, err)
+	require.Len(t, username, 1)
+	assert.Equal(t, "Basic256Sha256/SignAndEncrypt", describeEndpoint(username[0]))
+}
+
+// Servers that advertise no user identity tokens at all must not be dropped.
+func TestSelectEndpoints_EndpointWithoutTokenPoliciesIsKept(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 0),
+	}
+
+	candidates, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeUserName)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+}
+
+// The level the server publishes breaks ties, but only after policy and mode.
+func TestSelectEndpoints_SecurityLevelBreaksTies(t *testing.T) {
+	low := endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 1, ua.UserTokenTypeAnonymous)
+	low.EndpointURL = "opc.tcp://low:4840"
+	high := endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 9, ua.UserTokenTypeAnonymous)
+	high.EndpointURL = "opc.tcp://high:4840"
+
+	candidates, err := selectEndpoints([]*ua.EndpointDescription{low, high}, "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	require.Len(t, candidates, 2)
+	assert.Equal(t, "opc.tcp://high:4840", candidates[0].EndpointURL)
+}
+
+// An unknown policy cannot be negotiated by this client, so it must never be
+// preferred over a policy we can actually speak.
+func TestSelectEndpoints_UnknownPolicyRanksLast(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		endpoint(ua.SecurityPolicyURIPrefix+"Future_Policy", ua.MessageSecurityModeSignAndEncrypt, 9, ua.UserTokenTypeAnonymous),
+		endpoint(ua.SecurityPolicyURIBasic256Sha256, ua.MessageSecurityModeSignAndEncrypt, 0, ua.UserTokenTypeAnonymous),
+	}
+
+	candidates, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"Basic256Sha256/SignAndEncrypt",
+		"Future_Policy/SignAndEncrypt",
+	}, describeAll(candidates))
+}
+
+func TestSelectEndpoints_NoEndpointsAdvertised(t *testing.T) {
+	_, err := selectEndpoints(nil, "", "", ua.UserTokenTypeAnonymous)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not advertise any endpoints")
+}
+
+func TestSelectEndpoints_NilEndpointsAreSkipped(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		nil,
+		endpoint(ua.SecurityPolicyURINone, ua.MessageSecurityModeNone, 0, ua.UserTokenTypeAnonymous),
+	}
+
+	candidates, err := selectEndpoints(endpoints, "", "", ua.UserTokenTypeAnonymous)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+}
+
+func TestParseSecurityPolicy(t *testing.T) {
+	tests := []struct {
+		policy  string
+		want    string
+		wantErr bool
+	}{
+		{policy: "", want: ""},
+		{policy: "None", want: ua.SecurityPolicyURINone},
+		{policy: "Basic256Sha256", want: ua.SecurityPolicyURIBasic256Sha256},
+		{policy: "Aes256Sha256RsaPss", want: ua.SecurityPolicyURIAes256Sha256RsaPss},
+		{policy: ua.SecurityPolicyURIBasic256, want: ua.SecurityPolicyURIBasic256},
+		// the policy name is case sensitive, a near miss has to be reported
+		{policy: "Basic256sha256", wantErr: true},
+		{policy: "nonsense", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.policy, func(t *testing.T) {
+			got, err := parseSecurityPolicy(test.policy)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestParseSecurityMode(t *testing.T) {
+	tests := []struct {
+		mode    string
+		want    ua.MessageSecurityMode
+		wantErr bool
+	}{
+		{mode: "", want: ua.MessageSecurityModeInvalid},
+		{mode: "None", want: ua.MessageSecurityModeNone},
+		{mode: "Sign", want: ua.MessageSecurityModeSign},
+		{mode: "SignAndEncrypt", want: ua.MessageSecurityModeSignAndEncrypt},
+		// a typo must be reported, not silently downgraded to "any mode"
+		{mode: "signandencrypt", wantErr: true},
+		{mode: "Invalid", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.mode, func(t *testing.T) {
+			got, err := parseSecurityMode(test.mode)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func describeAll(endpoints []*ua.EndpointDescription) []string {
+	res := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		res = append(res, describeEndpoint(ep))
+	}
+	return res
+}

--- a/providers/opcua/go.mod
+++ b/providers/opcua/go.mod
@@ -7,6 +7,7 @@ go 1.26.6
 require (
 	github.com/gopcua/opcua v0.9.1
 	github.com/mozillazg/go-slugify v0.2.0
+	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.1
 	go.mondoo.com/mql v0.0.0-20260821110738-57a15f4f1453
 )
@@ -74,7 +75,6 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.16.0 // indirect
-	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect

--- a/providers/opcua/provider/provider.go
+++ b/providers/opcua/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/upstream"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
 	"go.mondoo.com/mql/providers/opcua/connection"
 	"go.mondoo.com/mql/providers/opcua/resources"
 )
@@ -39,14 +40,31 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		Options: make(map[string]string),
 	}
 
-	// Do custom flag parsing
-	endpoint := ""
-	if x, ok := flags["endpoint"]; ok && len(x.Value) != 0 {
-		endpoint = string(x.Value)
+	// Do custom flag parsing. Every option key the connection reads has to be
+	// copied here: a key that is never written is silently absent from
+	// conf.Options and the flag behind it becomes a no-op.
+	for flag, option := range map[string]string{
+		"endpoint":        connection.OptionEndpoint,
+		"security-policy": connection.OptionSecurityPolicy,
+		"security-mode":   connection.OptionSecurityMode,
+		"cert-file":       connection.OptionCertFile,
+		"key-file":        connection.OptionKeyFile,
+	} {
+		if x, ok := flags[flag]; ok && len(x.Value) != 0 {
+			conf.Options[option] = string(x.Value)
+		}
 	}
 
-	if endpoint != "" {
-		conf.Options["endpoint"] = endpoint
+	username := ""
+	if x, ok := flags["username"]; ok && len(x.Value) != 0 {
+		username = string(x.Value)
+	}
+	password := ""
+	if x, ok := flags["password"]; ok && len(x.Value) != 0 {
+		password = string(x.Value)
+	}
+	if username != "" || password != "" {
+		conf.Credentials = append(conf.Credentials, vault.NewPasswordCredential(username, password))
 	}
 
 	asset := inventory.Asset{

--- a/providers/opcua/provider/provider_test.go
+++ b/providers/opcua/provider/provider_test.go
@@ -1,0 +1,75 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+func parseCLI(t *testing.T, flags map[string]*llx.Primitive) *plugin.ParseCLIRes {
+	t.Helper()
+	res, err := Init().ParseCLI(&plugin.ParseCLIReq{Connector: "opcua", Flags: flags})
+	require.NoError(t, err)
+	require.NotNil(t, res.Asset)
+	require.Len(t, res.Asset.Connections, 1)
+	return res
+}
+
+// Every connection flag has to survive the trip from the CLI into the
+// connection config. A flag that ParseCLI never copies is accepted on the
+// command line and then silently does nothing.
+func TestParseCLI_SecurityFlagsReachTheConnection(t *testing.T) {
+	res := parseCLI(t, map[string]*llx.Primitive{
+		"endpoint":        llx.StringPrimitive("opc.tcp://server:4840"),
+		"security-policy": llx.StringPrimitive("Basic256Sha256"),
+		"security-mode":   llx.StringPrimitive("SignAndEncrypt"),
+		"cert-file":       llx.StringPrimitive("/tmp/client.der"),
+		"key-file":        llx.StringPrimitive("/tmp/client.key"),
+	})
+
+	conf := res.Asset.Connections[0]
+	assert.Equal(t, map[string]string{
+		"endpoint":        "opc.tcp://server:4840",
+		"security-policy": "Basic256Sha256",
+		"security-mode":   "SignAndEncrypt",
+		"cert-file":       "/tmp/client.der",
+		"key-file":        "/tmp/client.key",
+	}, conf.Options)
+}
+
+func TestParseCLI_UsernameAndPasswordBecomeACredential(t *testing.T) {
+	res := parseCLI(t, map[string]*llx.Primitive{
+		"endpoint": llx.StringPrimitive("opc.tcp://server:4840"),
+		"username": llx.StringPrimitive("operator"),
+		"password": llx.StringPrimitive("secret"),
+	})
+
+	conf := res.Asset.Connections[0]
+	require.Len(t, conf.Credentials, 1)
+	assert.Equal(t, vault.CredentialType_password, conf.Credentials[0].Type)
+	assert.Equal(t, "operator", conf.Credentials[0].User)
+	assert.Equal(t, "secret", string(conf.Credentials[0].Secret))
+}
+
+// The unauthenticated, unencrypted case has to keep working untouched.
+func TestParseCLI_EndpointOnly(t *testing.T) {
+	res := parseCLI(t, map[string]*llx.Primitive{
+		"endpoint": llx.StringPrimitive("opc.tcp://server:4840"),
+	})
+
+	conf := res.Asset.Connections[0]
+	assert.Equal(t, map[string]string{"endpoint": "opc.tcp://server:4840"}, conf.Options)
+	assert.Empty(t, conf.Credentials)
+}
+
+func TestParseCLI_NoFlags(t *testing.T) {
+	res := parseCLI(t, nil)
+	assert.Empty(t, res.Asset.Connections[0].Options)
+}


### PR DESCRIPTION
## The bug

`providers/opcua/connection/connection.go:44-47` (before this change):

```go
policy := "None" // None, Basic128Rsa15, Basic256, Basic256Sha256. Default: auto"
mode := "None"   //  None, Sign, SignAndEncrypt. Default: auto
// certFile := "created/server_cert.der"
// keyFile := "created/server_key.der"
```

and `providers/opcua/connection/connection.go:52`:

```go
ep, err := opcua.SelectEndpoint(endpoints, policy, ua.MessageSecurityModeFromString(mode))
```

with the certificate and key options commented out at `connection.go:64-65`:

```go
	opts := []opcua.Option{
		opcua.SecurityPolicy(policy),
		opcua.SecurityModeString(mode),
		// opcua.CertificateFile(certFile),
		// opcua.PrivateKeyFile(keyFile),
		opcua.AuthAnonymous(),
		opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeAnonymous),
	}
```

## Why it is wrong

`opcua.SelectEndpoint(endpoints, "None", ua.MessageSecurityModeNone)` matches
nothing on a server that advertises only `Basic256Sha256` / `SignAndEncrypt`
with certificate or username authentication, which is what a correctly
configured OPC UA server looks like. `Connect` returns an error, the runtime
never comes up, and the asset produces no findings at all.

**A correctly secured OPC UA server currently cannot be scanned.** That is
worse than a missing field: the insecure servers scan fine and the hardened
ones vanish, so every fleet-level result the provider produces is biased
toward exactly the population that needs auditing least. Reproduced against a
live server, see below.

## The fix

**Endpoint selection (`providers/opcua/connection/endpoint.go`, new).**
`selectEndpoints` filters the advertised endpoints to those matching the
requested policy, mode and user token type, then orders them by the security
they provide, strongest first. Ranking defers to `uapolicy.SecurityLevel`, the
stack's own table, so a deprecated policy that encrypts does not outrank a
modern policy that only signs. A policy the stack cannot negotiate ranks last
instead of being preferred and always failing. Endpoints that advertise no
user identity tokens are kept rather than dropped.

**Fallback (`providers/opcua/connection/connection.go`).** `connectClient`
walks the ordered candidates and returns the first session it can establish,
logging each failed attempt at debug level. A server that advertises an
endpoint it cannot actually serve no longer takes the whole asset down, and a
None-only server still connects on its single endpoint. `dialEndpoint` closes
the client's socket before moving to the next candidate.

**Client certificate (`providers/opcua/connection/cert.go`, new).** Every
policy other than `None` requires the client to present an application
instance certificate. When the user did not pass `--cert-file`,
`ephemeralCertificate` generates a short-lived self-signed one carrying the
application URI the session announces. The key is created per connection, kept
in memory and never written anywhere.

**New connection options.** `--security-policy`, `--security-mode`,
`--cert-file`, `--key-file`, `--username`, `--password`. Only the path to a key
is accepted; key material is never a field or an option value.

Wiring a new connection option takes an edit in every one of these files, and a
key missing from any of them is a silent no-op rather than an error:

| file | what it does |
|---|---|
| `providers/opcua/config/config.go` | declares the flags on the connector, so the CLI accepts them |
| `providers/opcua/provider/provider.go` | `ParseCLI` copies each flag into `conf.Options`, and username/password into `conf.Credentials` as a `vault` password credential |
| `providers/opcua/connection/connection.go` | `OptionEndpoint` … `OptionKeyFile` constants are the shared key names; `newClientOptions` reads them back out of `conf.Options` and validates them |
| `providers/opcua/dist/opcua.json` | regenerated by `make providers/build/opcua` (gitignored, not committed) |

Two tests guard that wiring end to end:
`TestParseCLI_SecurityFlagsReachTheConnection` asserts the exact
`conf.Options` map produced by `ParseCLI` (it fails if a key is dropped), and
`TestConnectorDeclaresEveryConnectionFlag` asserts the connector declares a
flag for every option key the connection reads.

There are no schema changes in this PR, so `.lr`, `.lr.go` and `.lr.versions`
are untouched and `config.go` `Version` is unchanged.

Invalid input is now rejected up front with a message that names the valid
values, rather than being silently downgraded to "any":

```
$ mql run opcua --endpoint opc.tcp://<host>:<port> --security-policy Basic999 -c "opcua.server.state"
x unable to create runtime for asset error="... unsupported security policy \"Basic999\", expected one of None, Basic128Rsa15, Basic256, Basic256Sha256, Aes128Sha256RsaOaep, Aes256Sha256RsaPss"
```

## Investigated and found to be a non-issue: `opcua.server` on the root block

An earlier revision of this PR added a `server() opcua.server` accessor to the
`opcua` root block, on the theory that `opcua.server` was reachable only by its
dotted path because the root block does not list a `server` field. **That was
wrong, and the accessor has been removed.** Recording it here so nobody
re-derives it:

`providers-sdk/v1/mqlr/lrcore/schema.go:107-130` walks every dotted resource
name and synthesizes an implicit bridging field on each parent
(`IsImplicitResource: true`) when the parent does not declare one itself. So
the `opcua` resource already has a `server` field of type `opcua.server`
without anything in the `.lr` file.

The "but does the init still run?" concern does not hold either.
`mqlc/mqlc.go:1043` short-circuits on that flag: when a field is
`IsImplicitResource` the compiler does **not** call the field, it emits a bare
resource chunk by name and lets the runtime create the resource, which runs its
init. `initOpcuaServer` is reached through the implicit path already.

Confirmed against a provider built from unmodified `origin/main`:

```
$ mql run opcua --endpoint opc.tcp://<host>:<port> -c "opcua { server { buildInfo } }" --info
Resources and Fields used:
- opcua
  - server  type=opcua.server
- opcua.server
  - buildInfo  type=dict
```

Adding the explicit accessor was in fact actively harmful: it replaced the
implicit field with a real one, which made `mqlr generate` emit
`duplicate field paths detected` for `opcua.server` and pushed the compiler off
the bare-resource path onto a redundant field call. With it removed, that
warning is gone.

## Verification

Verified against four live OPC UA servers on this machine.

1. **hardened**, port 50000: `mcr.microsoft.com/iotedge/opc-plc:latest --pn=50000 --aa --to`, which advertises `Basic256Sha256`, `Aes128_Sha256_RsaOaep` and `Aes256_Sha256_RsaPss` in `Sign` and `SignAndEncrypt` and **no None endpoint**
2. **None-only**, port 4840: a gopcua `server` with `EnableSecurity("None", MessageSecurityModeNone)` only
3. **mixed**, port 50001: the same opc-plc image with `--ut`, which adds `None`/`None` alongside the secure policies
4. **username-only**, port 50002: opc-plc with `--daa --du=operator --dc=<password>`

### The bug, reproduced

Provider built from `origin/main`, pointed at the hardened server:

```
$ PROVIDERS_PATH=/tmp/pd-opcua-main mql run opcua --endpoint opc.tcp://localhost:50000 -c "opcua.server.state"
x unable to create runtime for asset error="rpc error: code = Unknown desc = opcua: no matching endpoint found for policy http://opcfoundation.org/UA/SecurityPolicy#None and mode MessageSecurityModeNone"
```

### The fix, against the same server

```
$ PROVIDERS_PATH=/tmp/pd-opcua mql run opcua --endpoint opc.tcp://localhost:50000 -c "opcua { server { buildInfo state } }"
opcua.server: {
  state: "ServerStateRunning"
  buildInfo: {
    BuildDate: "2025-11-20T08:31:36Z"
    BuildNumber: "88e0995a2f (OPC UA SDK 91c1a02abd399b760eb1f3616ed2b9c757bceed5 from 2025-07-30T13:04:46Z)"
    ManufacturerName: "Microsoft"
    ProductName: "IoT Edge OPC UA PLC"
    ProductURI: "https://github.com/Azure-Samples/iot-edge-opc-plc"
    SoftwareVersion: "2.12.48 (OPC UA SDK 1.5.376.244)"
  }
}
```

`buildInfo.SoftwareVersion` is what identifies the server product and version
for an OT endpoint, and this is the first time it can be read off a server that
is actually configured for security. That query was run with the schema
untouched, so it also demonstrates the implicit-bridge behaviour described
above.

### Fallback, observed live

The hardened server advertises `Aes256_Sha256_RsaPss` first by rank, and the
session cannot be established against it. Without the fallback this would be a
dead asset:

```
$ PROVIDERS_PATH=/tmp/pd-opcua mql run opcua --endpoint opc.tcp://localhost:50000 --log-level debug -c "opcua.server.state"
DBG opcua> could not establish session, trying next endpoint error=EOF endpoint=opc.tcp://localhost:50000 security=Aes256_Sha256_RsaPss/SignAndEncrypt
DBG opcua> could not establish session, trying next endpoint error=EOF endpoint=opc.tcp://localhost:50000 security=Aes256_Sha256_RsaPss/Sign
DBG opcua> connected endpoint=opc.tcp://localhost:50000 security=Aes128_Sha256_RsaOaep/SignAndEncrypt
opcua.server.state: "ServerStateRunning"
```

### No regression on insecure servers

None-only server, new provider:

```
$ PROVIDERS_PATH=/tmp/pd-opcua mql run opcua --endpoint opc.tcp://localhost:4840 --log-level debug -c "opcua.server.state"
DBG opcua> connected endpoint=opc.tcp://localhost:4840 security=None/None
opcua.server.state: "ServerStateRunning"
```

The same server on `origin/main` also returns `"ServerStateRunning"`, so this
path is unchanged. Existing resources are unaffected:
`opcua.namespaces.length: 8` and `opcua.root` resolve on the hardened server,
`opcua.nodes.length: 7415` on the None-only one.

On the mixed server the provider now picks the secure endpoint rather than the
`None` one that is also on offer, and `--security-policy None --security-mode
None` still pins it back down to `None`/`None`.

### The new options, against live servers

```
$ mql run opcua --endpoint opc.tcp://localhost:50000 --security-policy Basic256Sha256 --security-mode Sign -c "opcua.server.state"
opcua.server.state: "ServerStateRunning"

$ mql run opcua --endpoint opc.tcp://localhost:50000 --cert-file client.pem --key-file client.key \
      --security-policy Basic256Sha256 --security-mode SignAndEncrypt --log-level debug -c "opcua.server.state"
DBG opcua> connected endpoint=opc.tcp://localhost:50000 security=Basic256Sha256/SignAndEncrypt
opcua.server.state: "ServerStateRunning"

$ mql run opcua --endpoint opc.tcp://localhost:50002 --username operator --password <password> -c "opcua.server.state"
opcua.server.state: "ServerStateRunning"
```

Pinning a combination the server does not offer, and connecting anonymously to
a server that requires a username, both now fail with a message that names
what the server actually accepts instead of an opaque endpoint mismatch:

```
x ... no endpoint supports anonymous authentication with the requested security settings, the server offers security
  Basic256Sha256/SignAndEncrypt, Aes128_Sha256_RsaOaep/SignAndEncrypt, Aes256_Sha256_RsaPss/SignAndEncrypt,
  Basic256Sha256/Sign, Aes128_Sha256_RsaOaep/Sign, Aes256_Sha256_RsaPss/Sign
  and authentication username and password, certificate
```

### Unit tests

21 tests over a synthetic `[]*ua.EndpointDescription` list and the option
plumbing, including: strongest endpoint chosen; fallback order keeps the weaker
endpoints; a None-only server still connects; a hardened server (no None
endpoint at all) is reachable; explicit policy and mode; the endpoint's own
`SecurityLevel` used only as a tiebreaker; an unknown policy ranked last; nil
endpoints skipped; user token type filtering; the certificate's URI SAN and key
usage; and the two flag-wiring guards described above.

```
$ cd providers/opcua && go build ./... && go test ./...
?   	go.mondoo.com/mql/providers/opcua	[no test files]
ok  	go.mondoo.com/mql/providers/opcua/config	1.429s
ok  	go.mondoo.com/mql/providers/opcua/connection	0.619s
?   	go.mondoo.com/mql/providers/opcua/gen	[no test files]
ok  	go.mondoo.com/mql/providers/opcua/provider	1.887s
?   	go.mondoo.com/mql/providers/opcua/resources	[no test files]
```

`golangci-lint run ./...` reports `0 issues`, `gofmt -l providers/opcua/` is
empty, `typos providers/opcua/` is clean, and `go mod tidy` in
`providers/opcua/` promotes `github.com/rs/zerolog` to a direct dependency and
changes nothing else.

## Not verified against a live target

- **`Basic128Rsa15` and `Basic256`.** No test server offered them, so their
  position in the ranking is covered only by unit tests.
- **A server that rejects untrusted client certificates.** Both container
  servers were run with auto-accept, so the ephemeral certificate was always
  trusted. The `--cert-file` / `--key-file` path was proven against an
  auto-accepting server; a server with a real trust list was not available.
- **`Aes256_Sha256_RsaPss`.** Every attempt against it failed with `EOF`, which
  is what exercised the fallback. Whether that is a gopcua limitation or an
  opc-plc one was not investigated; either way the endpoint is reachable in the
  candidate list and the fallback covers it.
- **Certificate user authentication (`UserTokenTypeCertificate`).** Recognised
  by the selection logic and named in error messages, but no flag drives it and
  it was not exercised.
- **Real OT hardware.** Everything above ran against software simulators
  (Microsoft opc-plc and a gopcua server), not a PLC.
