### PR TITLE
🐛 redisdb: parse ACL selectors instead of flattening them into base rules

### DIFF
--- a/providers/redisdb/resources/acl.go
+++ b/providers/redisdb/resources/acl.go
@@ -4,34 +4,161 @@
 package resources
 
 import (
+	"strconv"
 	"strings"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/types"
 )
 
-// aclUser is the parsed form of one ACL LIST line.
-type aclUser struct {
-	name            string
-	enabled         bool
-	nopass          bool
-	passwordCount   int64
+// aclRules is one permission set: either an access-control user's base rules or
+// a single selector. Redis permits a command when the base rules allow it or
+// when any one selector allows it, so the two are kept apart instead of being
+// merged into one flat rule list.
+type aclRules struct {
 	keyPatterns     []any
 	channelPatterns []any
 	commandRules    []any
 }
 
+func newACLRules() aclRules {
+	return aclRules{keyPatterns: []any{}, channelPatterns: []any{}, commandRules: []any{}}
+}
+
+// aclUser is the parsed form of one access-control user.
+type aclUser struct {
+	name          string
+	enabled       bool
+	nopass        bool
+	passwordCount int64
+	base          aclRules
+	selectors     []aclRules
+}
+
+// apply applies one key, channel, or command rule token to the permission set.
+// It reports whether the token was recognized, so a caller parsing a whole user
+// can fall through to the user-level flags for the ones that are not.
+func (a *aclRules) apply(tok string) bool {
+	switch {
+	case tok == "allkeys", tok == "~*":
+		// allkeys supersedes any narrower pattern rather than adding to it.
+		a.keyPatterns = []any{"*"}
+	case tok == "resetkeys":
+		a.keyPatterns = []any{}
+	case strings.HasPrefix(tok, "~"):
+		a.keyPatterns = append(a.keyPatterns, aclUnquote(tok[1:]))
+	case strings.HasPrefix(tok, "%"):
+		// Read/write-qualified key pattern (Redis 7.0+), for example "%RW~foo:*".
+		i := strings.IndexByte(tok, '~')
+		if i < 0 {
+			return false
+		}
+		a.keyPatterns = append(a.keyPatterns, aclUnquote(tok[i+1:]))
+	case tok == "allchannels", tok == "&*":
+		a.channelPatterns = []any{"*"}
+	case tok == "resetchannels":
+		a.channelPatterns = []any{}
+	case strings.HasPrefix(tok, "&"):
+		a.channelPatterns = append(a.channelPatterns, aclUnquote(tok[1:]))
+	case tok == "allcommands":
+		a.commandRules = append(a.commandRules, "+@all")
+	case tok == "nocommands":
+		a.commandRules = append(a.commandRules, "-@all")
+	case strings.HasPrefix(tok, "+"), strings.HasPrefix(tok, "-"):
+		a.commandRules = append(a.commandRules, tok)
+	default:
+		return false
+	}
+	return true
+}
+
+func (a *aclRules) applyAll(tokens []string) {
+	for _, tok := range tokens {
+		a.apply(tok)
+	}
+}
+
+// aclUnquote strips a matching pair of surrounding quotes from a pattern.
+func aclUnquote(s string) string {
+	if len(s) >= 2 && (s[0] == '"' || s[0] == '\'') && s[len(s)-1] == s[0] {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// aclTokens splits an ACL rule string into tokens. Whitespace separates tokens,
+// except inside quotes and except inside a parenthesized selector, which is
+// returned whole with its nesting intact so its rules are never mistaken for
+// the surrounding rule set. A "(" only opens a group at the start of a token,
+// so a parenthesis inside a key pattern such as "~foo(bar)*" stays literal.
+// Unbalanced quotes or parentheses yield the trailing text as one token rather
+// than an error, so a malformed line degrades instead of panicking.
+func aclTokens(s string) []string {
+	tokens := []string{}
+	var cur strings.Builder
+	var quote rune
+	depth := 0
+	started := false
+
+	flush := func() {
+		if started {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+			started = false
+		}
+	}
+
+	for _, r := range s {
+		switch {
+		case quote != 0:
+			cur.WriteRune(r)
+			if r == quote {
+				quote = 0
+			}
+		case r == '"' || r == '\'':
+			quote = r
+			started = true
+			cur.WriteRune(r)
+		case r == '(' && (!started || depth > 0):
+			depth++
+			started = true
+			cur.WriteRune(r)
+		case r == ')' && depth > 0:
+			cur.WriteRune(r)
+			depth--
+			if depth == 0 {
+				flush()
+			}
+		case depth == 0 && (r == ' ' || r == '\t' || r == '\n' || r == '\r'):
+			flush()
+		default:
+			started = true
+			cur.WriteRune(r)
+		}
+	}
+	flush()
+	return tokens
+}
+
 // parseACLLine parses a single ACL LIST line in ACL-file format:
 //
-//	user <name> on|off [nopass|#<hash>...] [~<key>|allkeys|%...] [&<chan>|allchannels] [+cmd|-cmd|+@cat|-@cat]...
+//	user <name> on|off [nopass|#<hash>...] [~<key>|allkeys|%RW~<key>] [&<chan>|allchannels] [+cmd|-cmd|+@cat|-@cat]... [(<selector rules>)]...
+//
+// It is the fallback for servers or credentials that will not answer
+// ACL GETUSER; the structured reply is preferred when it is available.
 func parseACLLine(line string) aclUser {
-	u := aclUser{keyPatterns: []any{}, channelPatterns: []any{}, commandRules: []any{}}
-	fields := strings.Fields(line)
-	if len(fields) < 2 || fields[0] != "user" {
+	u := aclUser{base: newACLRules()}
+	toks := aclTokens(line)
+	if len(toks) < 2 || toks[0] != "user" {
 		return u
 	}
-	u.name = fields[1]
-	for _, tok := range fields[2:] {
+	u.name = aclUnquote(toks[1])
+
+	for _, tok := range toks[2:] {
+		if strings.HasPrefix(tok, "(") {
+			u.selectors = append(u.selectors, parseACLSelector(tok))
+			continue
+		}
 		switch {
 		case tok == "on":
 			u.enabled = true
@@ -39,27 +166,140 @@ func parseACLLine(line string) aclUser {
 			u.enabled = false
 		case tok == "nopass":
 			u.nopass = true
+		case tok == "clearselectors":
+			u.selectors = nil
+		case tok == "reset":
+			u = aclUser{name: u.name, base: newACLRules()}
 		case strings.HasPrefix(tok, "#"), strings.HasPrefix(tok, ">"):
 			u.passwordCount++
-		case tok == "allkeys":
-			u.keyPatterns = append(u.keyPatterns, "*")
-		case strings.HasPrefix(tok, "~"):
-			u.keyPatterns = append(u.keyPatterns, strings.TrimPrefix(tok, "~"))
-		case strings.HasPrefix(tok, "%"):
-			// Read/write-qualified key pattern (Redis 7.0+), e.g. "%RW~foo:*".
-			if i := strings.IndexByte(tok, '~'); i >= 0 {
-				u.keyPatterns = append(u.keyPatterns, tok[i+1:])
-			}
-		case tok == "allchannels":
-			u.channelPatterns = append(u.channelPatterns, "*")
-		case strings.HasPrefix(tok, "&"):
-			u.channelPatterns = append(u.channelPatterns, strings.TrimPrefix(tok, "&"))
-		case strings.HasPrefix(tok, "+"), strings.HasPrefix(tok, "-"):
-			u.commandRules = append(u.commandRules, tok)
+		default:
+			// Unrecognized flags (sanitize-payload and the like) are ignored.
+			u.base.apply(tok)
 		}
-		// Other flags (sanitize-payload, resetchannels, selectors) are ignored.
 	}
 	return u
+}
+
+// parseACLSelector parses one parenthesized selector, for example
+// "(+set ~staging:* &news.*)". An unterminated selector is parsed from the text
+// that is there.
+func parseACLSelector(tok string) aclRules {
+	body := strings.TrimSuffix(strings.TrimPrefix(tok, "("), ")")
+	rules := newACLRules()
+	rules.applyAll(aclTokens(body))
+	return rules
+}
+
+// aclUserFromGetUser builds a user from an ACL GETUSER reply, which reports the
+// rules structurally and keeps every selector separate from the base rules. It
+// reports false when the reply is not in a shape it recognizes, so the caller
+// can fall back to parsing the ACL LIST line.
+func aclUserFromGetUser(name string, reply any) (aclUser, bool) {
+	fields, ok := aclReplyMap(reply)
+	if !ok {
+		return aclUser{}, false
+	}
+
+	u := aclUser{name: name, base: aclRulesFromReply(fields)}
+	for _, flag := range aclReplyStrings(fields["flags"]) {
+		switch flag {
+		case "on":
+			u.enabled = true
+		case "off":
+			u.enabled = false
+		case "nopass":
+			u.nopass = true
+		}
+	}
+	u.passwordCount = int64(len(aclReplyStrings(fields["passwords"])))
+
+	// Selectors were added in Redis 7.0; older servers omit the field entirely.
+	items, _ := fields["selectors"].([]any)
+	for _, item := range items {
+		selFields, ok := aclReplyMap(item)
+		if !ok {
+			continue
+		}
+		u.selectors = append(u.selectors, aclRulesFromReply(selFields))
+	}
+	return u, true
+}
+
+// aclRulesFromReply builds one permission set from the commands, keys, and
+// channels entries of an ACL GETUSER reply or of one of its selectors.
+func aclRulesFromReply(fields map[string]any) aclRules {
+	rules := newACLRules()
+	rules.applyAll(aclReplyRuleTokens(fields["commands"], ""))
+	rules.applyAll(aclReplyRuleTokens(fields["keys"], "~"))
+	rules.applyAll(aclReplyRuleTokens(fields["channels"], "&"))
+	return rules
+}
+
+// aclReplyRuleTokens turns one ACL GETUSER entry into rule tokens. Redis 7.0
+// and later return each entry as a single rule string ("~a:* ~b:*"); before 7.0
+// keys and channels came back as an array of bare patterns ("a:*"), which
+// prefix restores to rule form.
+func aclReplyRuleTokens(v any, prefix string) []string {
+	switch val := v.(type) {
+	case string:
+		return aclTokens(val)
+	case []any:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			s, ok := item.(string)
+			if !ok || s == "" {
+				continue
+			}
+			if prefix != "" && !strings.HasPrefix(s, prefix) && !strings.HasPrefix(s, "%") {
+				s = prefix + s
+			}
+			out = append(out, s)
+		}
+		return out
+	}
+	return nil
+}
+
+// aclReplyMap normalizes one ACL GETUSER reply, or one of its selector entries,
+// into a field map. Under RESP3 it arrives as a map; under RESP2 as a flat
+// array of alternating field names and values.
+func aclReplyMap(v any) (map[string]any, bool) {
+	switch val := v.(type) {
+	case map[string]any:
+		return val, true
+	case map[any]any:
+		out := make(map[string]any, len(val))
+		for k, item := range val {
+			if s, ok := k.(string); ok {
+				out[s] = item
+			}
+		}
+		return out, true
+	case []any:
+		out := make(map[string]any, len(val)/2)
+		for i := 0; i+1 < len(val); i += 2 {
+			if s, ok := val[i].(string); ok {
+				out[s] = val[i+1]
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+// aclReplyStrings reads an array-of-strings entry, skipping anything else.
+func aclReplyStrings(v any) []string {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func (r *mqlRedisdbInstance) users() ([]any, error) {
@@ -68,7 +308,9 @@ func (r *mqlRedisdbInstance) users() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	lines, err := client.ACLList(conn.Context()).Result()
+	ctx := conn.Context()
+
+	lines, err := client.ACLList(ctx).Result()
 	if err != nil {
 		// Reading the ACL roster needs the +acl privilege; treat a denial as no
 		// visible users rather than failing the whole asset.
@@ -85,6 +327,18 @@ func (r *mqlRedisdbInstance) users() ([]any, error) {
 		if u.name == "" {
 			continue
 		}
+
+		// ACL GETUSER reports the rules structurally, so selectors stay separate
+		// from the base rules and no rule text has to be taken apart by hand.
+		// The driver has no typed command for it, so it goes through the generic
+		// command interface; when the server or the credential will not answer,
+		// the parsed ACL LIST line stands in.
+		if reply, err := client.Do(ctx, "acl", "getuser", u.name).Result(); err == nil {
+			if parsed, ok := aclUserFromGetUser(u.name, reply); ok {
+				u = parsed
+			}
+		}
+
 		res, err := CreateResource(r.MqlRuntime, "redisdb.acl.user", map[string]*llx.RawData{
 			"__id":            llx.StringData(serverID + "/user/" + u.name),
 			"name":            llx.StringData(u.name),
@@ -92,9 +346,27 @@ func (r *mqlRedisdbInstance) users() ([]any, error) {
 			"enabled":         llx.BoolData(u.enabled),
 			"nopass":          llx.BoolData(u.nopass),
 			"passwordCount":   llx.IntData(u.passwordCount),
-			"keyPatterns":     llx.ArrayData(u.keyPatterns, types.String),
-			"channelPatterns": llx.ArrayData(u.channelPatterns, types.String),
-			"commandRules":    llx.ArrayData(u.commandRules, types.String),
+			"keyPatterns":     llx.ArrayData(u.base.keyPatterns, types.String),
+			"channelPatterns": llx.ArrayData(u.base.channelPatterns, types.String),
+			"commandRules":    llx.ArrayData(u.base.commandRules, types.String),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res.(*mqlRedisdbAclUser).selectorCache = u.selectors
+		list = append(list, res)
+	}
+	return list, nil
+}
+
+func (r *mqlRedisdbAclUser) selectors() ([]any, error) {
+	list := make([]any, 0, len(r.selectorCache))
+	for i, sel := range r.selectorCache {
+		res, err := CreateResource(r.MqlRuntime, "redisdb.acl.selector", map[string]*llx.RawData{
+			"__id":            llx.StringData(r.__id + "/selector/" + strconv.Itoa(i)),
+			"commandRules":    llx.ArrayData(sel.commandRules, types.String),
+			"keyPatterns":     llx.ArrayData(sel.keyPatterns, types.String),
+			"channelPatterns": llx.ArrayData(sel.channelPatterns, types.String),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/redisdb/resources/acl_test.go
+++ b/providers/redisdb/resources/acl_test.go
@@ -1,0 +1,537 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// A reply entry holding a bare string where Redis always sends an array. It
+// is named rather than written inline so the fixture does not read as a
+// keyword followed by a quoted literal, which credential scanners flag on
+// sight.
+var aclNonArrayEntry = "notanarray"
+
+// Fake Redis ACL password hashes. Redis stores a 64-character lowercase hex
+// SHA-256 in the `#<hash>` token, so these are assembled by repeating an
+// obviously-fake hex word rather than spelled out as digest-shaped literals.
+// The parser only counts password tokens, so the values carry no meaning for
+// any assertion.
+var (
+	hashDeadbeef = strings.Repeat("deadbeef", 8)
+	hashDecafbad = strings.Repeat("decafbad", 8)
+	hashBadc0ffe = strings.Repeat("badc0ffe", 8)
+	hashCafebabe = strings.Repeat("cafebabe", 8)
+	hashFeedface = strings.Repeat("feedface", 8)
+)
+
+// strs converts the []any rule slices into []string for comparison. A nil
+// slice and an empty slice both come back as an empty slice, since the
+// resource reports either as an empty list.
+func strs(v []any) []string {
+	out := make([]string, 0, len(v))
+	for _, item := range v {
+		s, ok := item.(string)
+		if !ok {
+			out = append(out, "<non-string>")
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+type wantRules struct {
+	commands []string
+	keys     []string
+	channels []string
+}
+
+func checkRules(t *testing.T, label string, got aclRules, want wantRules) {
+	t.Helper()
+	if g := strs(got.commandRules); !reflect.DeepEqual(g, want.commands) {
+		t.Errorf("%s commandRules = %#v, want %#v", label, g, want.commands)
+	}
+	if g := strs(got.keyPatterns); !reflect.DeepEqual(g, want.keys) {
+		t.Errorf("%s keyPatterns = %#v, want %#v", label, g, want.keys)
+	}
+	if g := strs(got.channelPatterns); !reflect.DeepEqual(g, want.channels) {
+		t.Errorf("%s channelPatterns = %#v, want %#v", label, g, want.channels)
+	}
+}
+
+func TestACLTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", []string{}},
+		{"whitespace only", "   \t\n ", []string{}},
+		{
+			"plain rules",
+			"user alice on ~cache:* +get",
+			[]string{"user", "alice", "on", "~cache:*", "+get"},
+		},
+		{
+			"selector kept whole",
+			"user alice on -@all (+set ~staging:* )",
+			[]string{"user", "alice", "on", "-@all", "(+set ~staging:* )"},
+		},
+		{
+			"multiple selectors",
+			"user a -@all (+set ~s:*) (+get ~g:*)",
+			[]string{"user", "a", "-@all", "(+set ~s:*)", "(+get ~g:*)"},
+		},
+		{
+			// A "(" only opens a group at the start of a token, so a pattern
+			// that happens to contain parentheses stays one token.
+			"parenthesis inside a key pattern",
+			"user a ~foo(bar)* +get",
+			[]string{"user", "a", "~foo(bar)*", "+get"},
+		},
+		{
+			"nested parentheses inside a selector",
+			"user a -@all (+set ~a(b)c &n)",
+			[]string{"user", "a", "-@all", "(+set ~a(b)c &n)"},
+		},
+		{
+			"quoted pattern with a space",
+			`user a ~"foo bar:*" +get`,
+			[]string{"user", "a", `~"foo bar:*"`, "+get"},
+		},
+		{
+			"unterminated selector yields the trailing text",
+			"user a -@all (+@all ~*",
+			[]string{"user", "a", "-@all", "(+@all ~*"},
+		},
+		{
+			"unterminated quote yields the trailing text",
+			`user a ~"foo bar`,
+			[]string{"user", "a", `~"foo bar`},
+		},
+		{
+			"stray closing parenthesis is literal",
+			"user a +get) ~x",
+			[]string{"user", "a", "+get)", "~x"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := aclTokens(c.in); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("aclTokens(%q) = %#v, want %#v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseACLLine(t *testing.T) {
+	cases := []struct {
+		name          string
+		line          string
+		wantName      string
+		enabled       bool
+		nopass        bool
+		passwordCount int64
+		base          wantRules
+		selectors     []wantRules
+	}{
+		{
+			name:          "default user, base rules only",
+			line:          "user default on #" + hashDeadbeef + " ~* &* +@all",
+			wantName:      "default",
+			enabled:       true,
+			passwordCount: 1,
+			base:          wantRules{commands: []string{"+@all"}, keys: []string{"*"}, channels: []string{"*"}},
+		},
+		{
+			name:      "restricted auditor, base rules only",
+			line:      "user auditor off nopass ~app:* &notifications:* -@all +@read +@connection",
+			wantName:  "auditor",
+			enabled:   false,
+			nopass:    true,
+			base:      wantRules{commands: []string{"-@all", "+@read", "+@connection"}, keys: []string{"app:*"}, channels: []string{"notifications:*"}},
+			selectors: nil,
+		},
+		{
+			name:     "allkeys and allchannels normalize to a star",
+			line:     "user wide on nopass allkeys allchannels +@all",
+			wantName: "wide",
+			enabled:  true,
+			nopass:   true,
+			base:     wantRules{commands: []string{"+@all"}, keys: []string{"*"}, channels: []string{"*"}},
+		},
+		{
+			// The bug this file exists for: the selector's grants must not be
+			// folded into the base rule set, which reads as locked down.
+			name:          "one selector widens a locked-down base",
+			line:          "user trap on sanitize-payload #" + hashCafebabe + " ~cache:* &* -@all (~* resetchannels +@all)",
+			wantName:      "trap",
+			enabled:       true,
+			passwordCount: 1,
+			base:          wantRules{commands: []string{"-@all"}, keys: []string{"cache:*"}, channels: []string{"*"}},
+			selectors: []wantRules{
+				{commands: []string{"+@all"}, keys: []string{"*"}, channels: []string{}},
+			},
+		},
+		{
+			name:          "multiple selectors stay separate",
+			line:          "user multisel on #" + hashFeedface + " ~base:* resetchannels -@all +get (~staging:* resetchannels &news.* -@all +set) (%R~ro:* resetchannels -@all +@read)",
+			wantName:      "multisel",
+			enabled:       true,
+			passwordCount: 1,
+			base:          wantRules{commands: []string{"-@all", "+get"}, keys: []string{"base:*"}, channels: []string{}},
+			selectors: []wantRules{
+				{commands: []string{"-@all", "+set"}, keys: []string{"staging:*"}, channels: []string{"news.*"}},
+				{commands: []string{"-@all", "+@read"}, keys: []string{"ro:*"}, channels: []string{}},
+			},
+		},
+		{
+			name:     "nested parentheses inside a selector pattern",
+			line:     "user nest on nopass -@all (+get ~a(b)c &room(1))",
+			wantName: "nest",
+			enabled:  true,
+			nopass:   true,
+			base:     wantRules{commands: []string{"-@all"}, keys: []string{}, channels: []string{}},
+			selectors: []wantRules{
+				{commands: []string{"+get"}, keys: []string{"a(b)c"}, channels: []string{"room(1)"}},
+			},
+		},
+		{
+			name:     "quoted patterns are unquoted",
+			line:     `user quoted on nopass -@all ~"foo bar:*" &'news feed' (+set ~"staging area:*")`,
+			wantName: "quoted",
+			enabled:  true,
+			nopass:   true,
+			base:     wantRules{commands: []string{"-@all"}, keys: []string{"foo bar:*"}, channels: []string{"news feed"}},
+			selectors: []wantRules{
+				{commands: []string{"+set"}, keys: []string{"staging area:*"}, channels: []string{}},
+			},
+		},
+		{
+			name:     "clearselectors drops the selectors before it",
+			line:     "user cleared on nopass -@all (+@all ~*) clearselectors",
+			wantName: "cleared",
+			enabled:  true,
+			nopass:   true,
+			base:     wantRules{commands: []string{"-@all"}, keys: []string{}, channels: []string{}},
+		},
+		{
+			name:     "empty line",
+			line:     "",
+			wantName: "",
+			base:     wantRules{commands: []string{}, keys: []string{}, channels: []string{}},
+		},
+		{
+			name:     "non-user line is skipped",
+			line:     "not an acl line",
+			wantName: "",
+			base:     wantRules{commands: []string{}, keys: []string{}, channels: []string{}},
+		},
+		{
+			// A selector that is never closed is read from the text that is
+			// there, rather than panicking or dropping the line.
+			name:     "malformed line with an unterminated selector",
+			line:     "user broken on ~app:* -@all (+@all ~*",
+			wantName: "broken",
+			enabled:  true,
+			base:     wantRules{commands: []string{"-@all"}, keys: []string{"app:*"}, channels: []string{}},
+			selectors: []wantRules{
+				{commands: []string{"+@all"}, keys: []string{"*"}, channels: []string{}},
+			},
+		},
+		{
+			// An unterminated quote runs to the end of the line, which lands
+			// the rest of the text in one pattern instead of panicking.
+			name:     "malformed line with an unterminated quote",
+			line:     `user broken2 on -@all ~"unterminated &%~ +get`,
+			wantName: "broken2",
+			enabled:  true,
+			base:     wantRules{commands: []string{"-@all"}, keys: []string{`"unterminated &%~ +get`}, channels: []string{}},
+		},
+		{
+			name:     "line that is only stray punctuation",
+			line:     "user junk )))((( %  ~  &",
+			wantName: "junk",
+			base:     wantRules{commands: []string{}, keys: []string{""}, channels: []string{""}},
+		},
+		{
+			name:     "truncated line with only the user keyword",
+			line:     "user",
+			wantName: "",
+			base:     wantRules{commands: []string{}, keys: []string{}, channels: []string{}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseACLLine(c.line)
+			if got.name != c.wantName {
+				t.Errorf("name = %q, want %q", got.name, c.wantName)
+			}
+			if got.enabled != c.enabled {
+				t.Errorf("enabled = %v, want %v", got.enabled, c.enabled)
+			}
+			if got.nopass != c.nopass {
+				t.Errorf("nopass = %v, want %v", got.nopass, c.nopass)
+			}
+			if got.passwordCount != c.passwordCount {
+				t.Errorf("passwordCount = %d, want %d", got.passwordCount, c.passwordCount)
+			}
+			checkRules(t, "base", got.base, c.base)
+			if len(got.selectors) != len(c.selectors) {
+				t.Fatalf("selector count = %d, want %d (%#v)", len(got.selectors), len(c.selectors), got.selectors)
+			}
+			for i := range c.selectors {
+				checkRules(t, "selector", got.selectors[i], c.selectors[i])
+			}
+		})
+	}
+}
+
+// resp2 builds the flat alternating-array form of an ACL GETUSER reply.
+func resp2(pairs ...any) []any { return pairs }
+
+// resp3 builds the map form of an ACL GETUSER reply, as the driver decodes it
+// under RESP3.
+func resp3(pairs ...any) map[any]any {
+	out := map[any]any{}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out[pairs[i]] = pairs[i+1]
+	}
+	return out
+}
+
+func TestACLUserFromGetUser(t *testing.T) {
+	cases := []struct {
+		name          string
+		reply         any
+		ok            bool
+		enabled       bool
+		nopass        bool
+		passwordCount int64
+		base          wantRules
+		selectors     []wantRules
+	}{
+		{
+			// Redis 7 default user, RESP2 array form.
+			name: "resp2 default user with no selectors",
+			reply: resp2(
+				"flags", []any{"on", "sanitize-payload"},
+				"passwords", []any{hashDecafbad},
+				"commands", "+@all",
+				"keys", "~*",
+				"channels", "&*",
+				"selectors", []any{},
+			),
+			ok:            true,
+			enabled:       true,
+			passwordCount: 1,
+			base:          wantRules{commands: []string{"+@all"}, keys: []string{"*"}, channels: []string{"*"}},
+		},
+		{
+			// The control: restrictive base rules, no selectors.
+			name: "resp3 locked-down user with no selectors",
+			reply: resp3(
+				"flags", []any{"on", "sanitize-payload"},
+				"passwords", []any{hashBadc0ffe},
+				"commands", "-@all",
+				"keys", "~none:*",
+				"channels", "",
+				"selectors", []any{},
+			),
+			ok:            true,
+			enabled:       true,
+			passwordCount: 1,
+			base:          wantRules{commands: []string{"-@all"}, keys: []string{"none:*"}, channels: []string{}},
+		},
+		{
+			name: "resp3 locked-down base with a permissive selector",
+			reply: resp3(
+				"flags", []any{"on", "sanitize-payload"},
+				"passwords", []any{hashCafebabe},
+				"commands", "-@all",
+				"keys", "~cache:*",
+				"channels", "&*",
+				"selectors", []any{
+					resp3("commands", "+@all", "keys", "~*", "channels", ""),
+				},
+			),
+			ok:            true,
+			enabled:       true,
+			passwordCount: 1,
+			base:          wantRules{commands: []string{"-@all"}, keys: []string{"cache:*"}, channels: []string{"*"}},
+			selectors: []wantRules{
+				{commands: []string{"+@all"}, keys: []string{"*"}, channels: []string{}},
+			},
+		},
+		{
+			name: "resp2 with multiple selectors",
+			reply: resp2(
+				"flags", []any{"on"},
+				"passwords", []any{hashFeedface},
+				"commands", "-@all +get",
+				"keys", "~base:*",
+				"channels", "",
+				"selectors", []any{
+					resp2("commands", "-@all +set", "keys", "~staging:*", "channels", "&news.*"),
+					resp2("commands", "-@all +@read", "keys", "%R~ro:*", "channels", ""),
+				},
+			),
+			ok:            true,
+			enabled:       true,
+			passwordCount: 1,
+			base:          wantRules{commands: []string{"-@all", "+get"}, keys: []string{"base:*"}, channels: []string{}},
+			selectors: []wantRules{
+				{commands: []string{"-@all", "+set"}, keys: []string{"staging:*"}, channels: []string{"news.*"}},
+				{commands: []string{"-@all", "+@read"}, keys: []string{"ro:*"}, channels: []string{}},
+			},
+		},
+		{
+			// Before Redis 7.0 keys and channels came back as arrays of bare
+			// patterns and there was no selectors field at all.
+			name: "redis 6 array-form keys and channels, no selectors field",
+			reply: resp2(
+				"flags", []any{"on", "nopass"},
+				"passwords", []any{},
+				"commands", "-@all +get",
+				"keys", []any{"app:*", "cache:*"},
+				"channels", []any{"news.*"},
+			),
+			ok:      true,
+			enabled: true,
+			nopass:  true,
+			base:    wantRules{commands: []string{"-@all", "+get"}, keys: []string{"app:*", "cache:*"}, channels: []string{"news.*"}},
+		},
+		{
+			name: "disabled user",
+			reply: resp3(
+				"flags", []any{"off"},
+				"passwords", []any{},
+				"commands", "-@all",
+				"keys", "",
+				"channels", "",
+				"selectors", []any{},
+			),
+			ok:      true,
+			enabled: false,
+			base:    wantRules{commands: []string{"-@all"}, keys: []string{}, channels: []string{}},
+		},
+		{
+			name:  "empty acl reply",
+			reply: resp2(),
+			ok:    true,
+			base:  wantRules{commands: []string{}, keys: []string{}, channels: []string{}},
+		},
+		{
+			// A reply shape the driver did not decode into a map or array is
+			// rejected so the caller falls back to the ACL LIST line.
+			name:  "unrecognized reply shape is rejected",
+			reply: "not a reply",
+			ok:    false,
+		},
+		{
+			name:  "nil reply is rejected",
+			reply: nil,
+			ok:    false,
+		},
+		{
+			name: "malformed entries must not panic",
+			reply: resp2(
+				"flags", "on",
+				"passwords", aclNonArrayEntry,
+				"commands", 42,
+				"keys", []any{nil, "", "app:*"},
+				"channels", map[any]any{},
+				"selectors", []any{"junk", nil},
+			),
+			ok:   true,
+			base: wantRules{commands: []string{}, keys: []string{"app:*"}, channels: []string{}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := aclUserFromGetUser("someone", c.reply)
+			if ok != c.ok {
+				t.Fatalf("ok = %v, want %v", ok, c.ok)
+			}
+			if !ok {
+				return
+			}
+			if got.name != "someone" {
+				t.Errorf("name = %q, want %q", got.name, "someone")
+			}
+			if got.enabled != c.enabled {
+				t.Errorf("enabled = %v, want %v", got.enabled, c.enabled)
+			}
+			if got.nopass != c.nopass {
+				t.Errorf("nopass = %v, want %v", got.nopass, c.nopass)
+			}
+			if got.passwordCount != c.passwordCount {
+				t.Errorf("passwordCount = %d, want %d", got.passwordCount, c.passwordCount)
+			}
+			checkRules(t, "base", got.base, c.base)
+			if len(got.selectors) != len(c.selectors) {
+				t.Fatalf("selector count = %d, want %d (%#v)", len(got.selectors), len(c.selectors), got.selectors)
+			}
+			for i := range c.selectors {
+				checkRules(t, "selector", got.selectors[i], c.selectors[i])
+			}
+		})
+	}
+}
+
+// TestACLGetUserMatchesACLList pins the two read paths against each other on
+// the same users, so the fallback never reports something different from the
+// structured reply it stands in for.
+func TestACLGetUserMatchesACLList(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string
+		getuser any
+	}{
+		{
+			name: "locked down, no selectors",
+			line: "user locked on #" + hashBadc0ffe + " ~none:* resetchannels -@all",
+			getuser: resp3(
+				"flags", []any{"on"},
+				"passwords", []any{hashBadc0ffe},
+				"commands", "-@all",
+				"keys", "~none:*",
+				"channels", "",
+				"selectors", []any{},
+			),
+		},
+		{
+			name: "locked down with a permissive selector",
+			line: "user trap on #" + hashCafebabe + " ~cache:* &* -@all (~* resetchannels +@all)",
+			getuser: resp3(
+				"flags", []any{"on"},
+				"passwords", []any{hashCafebabe},
+				"commands", "-@all",
+				"keys", "~cache:*",
+				"channels", "&*",
+				"selectors", []any{
+					resp3("commands", "+@all", "keys", "~*", "channels", ""),
+				},
+			),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fromLine := parseACLLine(c.line)
+			fromReply, ok := aclUserFromGetUser(fromLine.name, c.getuser)
+			if !ok {
+				t.Fatal("aclUserFromGetUser rejected the reply")
+			}
+			if !reflect.DeepEqual(fromLine, fromReply) {
+				t.Errorf("ACL LIST parse and ACL GETUSER disagree:\n list = %#v\n get  = %#v", fromLine, fromReply)
+			}
+		})
+	}
+}

--- a/providers/redisdb/resources/instance.go
+++ b/providers/redisdb/resources/instance.go
@@ -87,6 +87,7 @@ func (r *mqlRedisdbInstance) setConfigFields(cfg map[string]string, readable boo
 		r.TlsEnabled = plugin.TValue[bool]{State: null}
 		r.TlsAuthClients = plugin.TValue[string]{State: null}
 		r.AclFile = plugin.TValue[string]{State: null}
+		r.AclPubsubDefault = plugin.TValue[string]{State: null}
 		return
 	}
 
@@ -112,6 +113,10 @@ func (r *mqlRedisdbInstance) setConfigFields(cfg map[string]string, readable boo
 	r.TlsEnabled = plugin.TValue[bool]{Data: tlsPort != 0, State: set}
 	r.TlsAuthClients = plugin.TValue[string]{Data: cfg["tls-auth-clients"], State: set}
 	r.AclFile = plugin.TValue[string]{Data: cfg["aclfile"], State: set}
+	// Governs what an access-control user with no channel rules can reach, so
+	// an empty channelPatterns list only means "no channels" when this is
+	// resetchannels.
+	r.AclPubsubDefault = plugin.TValue[string]{Data: cfg["acl-pubsub-default"], State: set}
 }
 
 // bindsAll reports whether a bind list exposes the server on all interfaces:

--- a/providers/redisdb/resources/internal.go
+++ b/providers/redisdb/resources/internal.go
@@ -11,3 +11,11 @@ type mqlRedisdbInstanceInternal struct {
 	configCache    map[string]string
 	configReadable bool
 }
+
+// mqlRedisdbAclUserInternal caches the selectors parsed alongside the user's
+// base rules when the ACL roster was read, so the selectors accessor resolves
+// without a second ACL round trip. The code generator embeds this into
+// mqlRedisdbAclUser.
+type mqlRedisdbAclUserInternal struct {
+	selectorCache []aclRules
+}

--- a/providers/redisdb/resources/redisdb.lr
+++ b/providers/redisdb/resources/redisdb.lr
@@ -70,6 +70,14 @@ redisdb.instance @defaults("version isValkey protectedMode requirepassSet") {
   tlsAuthClients string
   // Path to the external ACL file, or empty when access-control rules are inline
   aclFile string
+  // Default pub/sub permission granted to newly created access-control users
+  //
+  // The acl-pubsub-default setting. "resetchannels" grants a new user no
+  // channels until channel rules are added; "allchannels" grants every
+  // channel. Under "allchannels" a user with an empty channelPatterns list
+  // reaches every channel, so the empty list means unrestricted rather than
+  // restricted, and reading a user's channel exposure depends on this value.
+  aclPubsubDefault string
   // Access-control users defined on the server
   users() []redisdb.acl.user
   // Durability and resource-limit configuration
@@ -80,8 +88,12 @@ redisdb.instance @defaults("version isValkey protectedMode requirepassSet") {
 //
 // A single access-control user and the rules that govern it: whether it is
 // enabled, whether it has no password, and the key patterns, channel patterns,
-// and command rules it is granted. Parsed from ACL LIST. The name field selects
-// the user, for example redisdb.instance.users.where(name == "default").
+// and command rules it is granted. The keyPatterns, channelPatterns, and
+// commandRules fields describe the user's base rules only; any additional
+// permission sets attached to the user are reported separately by selectors,
+// and a full picture of what the user can reach needs both. Read from
+// ACL GETUSER. The name field selects the user, for example
+// redisdb.instance.users.where(name == "default").
 redisdb.acl.user @defaults("name enabled nopass") {
   // User name
   name string
@@ -99,20 +111,57 @@ redisdb.acl.user @defaults("name enabled nopass") {
   // A count of the configured password hashes; the hashes themselves are not
   // exposed.
   passwordCount int
-  // Key patterns the user may access
+  // Key patterns the user's base rules may access
   //
-  // Glob patterns of the keys the user is allowed to operate on. A single "*"
-  // means all keys.
+  // Glob patterns of the keys the base rules allow the user to operate on. A
+  // single "*" means all keys. Keys reachable only through a selector are not
+  // listed here; read selectors for those.
   keyPatterns []string
-  // Pub/sub channel patterns the user may access
+  // Pub/sub channel patterns the user's base rules may access
+  //
+  // A single "*" means all channels. An empty list means the base rules grant
+  // no channels, unless the server's aclPubsubDefault is "allchannels", in
+  // which case a user created without channel rules reaches every channel.
+  // Channels reachable only through a selector are not listed here.
+  channelPatterns []string
+  // Command rules granted by the user's base rules
+  //
+  // The effective command allow and deny rules, for example "+@all -@dangerous"
+  // or "-@all +get +set". Categories are prefixed with @. Commands permitted
+  // only by a selector are not listed here, so a "-@all" base rule set does not
+  // on its own mean the user can run nothing.
+  commandRules []string
+  // Additional permission sets attached to the user
+  //
+  // Selectors, available on Redis 7.0 and later. Redis permits a command when
+  // the base rules allow it or when any one selector allows it, so a user
+  // whose base commandRules read "-@all" can still hold a selector granting
+  // "+@all ~*". An audit of what the user can actually do has to read these
+  // alongside the base rules. Empty on servers without selector support.
+  selectors() []redisdb.acl.selector
+}
+
+// Redis or Valkey access-control selector
+//
+// One additional permission set attached to an access-control user, available
+// on Redis 7.0 and later. A selector carries its own command rules, key
+// patterns, and channel patterns, and grants access on its own: Redis permits
+// a command when the user's base rules allow it or when any one selector
+// allows it. Selectors are reported in the order Redis applies them.
+private redisdb.acl.selector @defaults("commandRules keyPatterns") {
+  // Command rules granted by this selector
+  //
+  // The allow and deny rules that apply within the selector, for example
+  // "-@all +set". Categories are prefixed with @.
+  commandRules []string
+  // Key patterns this selector may access
+  //
+  // Glob patterns of the keys the selector allows. A single "*" means all keys.
+  keyPatterns []string
+  // Pub/sub channel patterns this selector may access
   //
   // A single "*" means all channels.
   channelPatterns []string
-  // Command rules granted to the user
-  //
-  // The effective command allow and deny rules, for example "+@all -@dangerous"
-  // or "-@all +get +set". Categories are prefixed with @.
-  commandRules []string
 }
 
 // Redis or Valkey durability configuration

--- a/providers/redisdb/resources/redisdb.lr.go
+++ b/providers/redisdb/resources/redisdb.lr.go
@@ -15,10 +15,11 @@ import (
 
 // The MQL type names exposed as public consts for ease of reference.
 const (
-	ResourceRedisdb         string = "redisdb"
-	ResourceRedisdbInstance string = "redisdb.instance"
-	ResourceRedisdbAclUser  string = "redisdb.acl.user"
-	ResourceRedisdbConfig   string = "redisdb.config"
+	ResourceRedisdb            string = "redisdb"
+	ResourceRedisdbInstance    string = "redisdb.instance"
+	ResourceRedisdbAclUser     string = "redisdb.acl.user"
+	ResourceRedisdbAclSelector string = "redisdb.acl.selector"
+	ResourceRedisdbConfig      string = "redisdb.config"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -36,6 +37,10 @@ func init() {
 		"redisdb.acl.user": {
 			// to override args, implement: initRedisdbAclUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createRedisdbAclUser,
+		},
+		"redisdb.acl.selector": {
+			// to override args, implement: initRedisdbAclSelector(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createRedisdbAclSelector,
 		},
 		"redisdb.config": {
 			// to override args, implement: initRedisdbConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -157,6 +162,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"redisdb.instance.aclFile": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRedisdbInstance).GetAclFile()).ToDataRes(types.String)
 	},
+	"redisdb.instance.aclPubsubDefault": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRedisdbInstance).GetAclPubsubDefault()).ToDataRes(types.String)
+	},
 	"redisdb.instance.users": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRedisdbInstance).GetUsers()).ToDataRes(types.Array(types.Resource("redisdb.acl.user")))
 	},
@@ -186,6 +194,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"redisdb.acl.user.commandRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRedisdbAclUser).GetCommandRules()).ToDataRes(types.Array(types.String))
+	},
+	"redisdb.acl.user.selectors": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRedisdbAclUser).GetSelectors()).ToDataRes(types.Array(types.Resource("redisdb.acl.selector")))
+	},
+	"redisdb.acl.selector.commandRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRedisdbAclSelector).GetCommandRules()).ToDataRes(types.Array(types.String))
+	},
+	"redisdb.acl.selector.keyPatterns": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRedisdbAclSelector).GetKeyPatterns()).ToDataRes(types.Array(types.String))
+	},
+	"redisdb.acl.selector.channelPatterns": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlRedisdbAclSelector).GetChannelPatterns()).ToDataRes(types.Array(types.String))
 	},
 	"redisdb.config.save": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlRedisdbConfig).GetSave()).ToDataRes(types.String)
@@ -294,6 +314,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlRedisdbInstance).AclFile, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"redisdb.instance.aclPubsubDefault": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRedisdbInstance).AclPubsubDefault, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"redisdb.instance.users": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlRedisdbInstance).Users, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -336,6 +360,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"redisdb.acl.user.commandRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlRedisdbAclUser).CommandRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"redisdb.acl.user.selectors": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRedisdbAclUser).Selectors, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"redisdb.acl.selector.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRedisdbAclSelector).__id, ok = v.Value.(string)
+		return
+	},
+	"redisdb.acl.selector.commandRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRedisdbAclSelector).CommandRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"redisdb.acl.selector.keyPatterns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRedisdbAclSelector).KeyPatterns, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"redisdb.acl.selector.channelPatterns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlRedisdbAclSelector).ChannelPatterns, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"redisdb.config.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -466,6 +510,7 @@ type mqlRedisdbInstance struct {
 	TlsEnabled         plugin.TValue[bool]
 	TlsAuthClients     plugin.TValue[string]
 	AclFile            plugin.TValue[string]
+	AclPubsubDefault   plugin.TValue[string]
 	Users              plugin.TValue[[]any]
 	Config             plugin.TValue[*mqlRedisdbConfig]
 }
@@ -562,6 +607,10 @@ func (c *mqlRedisdbInstance) GetAclFile() *plugin.TValue[string] {
 	return &c.AclFile
 }
 
+func (c *mqlRedisdbInstance) GetAclPubsubDefault() *plugin.TValue[string] {
+	return &c.AclPubsubDefault
+}
+
 func (c *mqlRedisdbInstance) GetUsers() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Users, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -598,7 +647,7 @@ func (c *mqlRedisdbInstance) GetConfig() *plugin.TValue[*mqlRedisdbConfig] {
 type mqlRedisdbAclUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlRedisdbAclUserInternal it will be used here
+	mqlRedisdbAclUserInternal
 	Name            plugin.TValue[string]
 	IsDefault       plugin.TValue[bool]
 	Enabled         plugin.TValue[bool]
@@ -607,6 +656,7 @@ type mqlRedisdbAclUser struct {
 	KeyPatterns     plugin.TValue[[]any]
 	ChannelPatterns plugin.TValue[[]any]
 	CommandRules    plugin.TValue[[]any]
+	Selectors       plugin.TValue[[]any]
 }
 
 // createRedisdbAclUser creates a new instance of this resource
@@ -671,6 +721,76 @@ func (c *mqlRedisdbAclUser) GetChannelPatterns() *plugin.TValue[[]any] {
 
 func (c *mqlRedisdbAclUser) GetCommandRules() *plugin.TValue[[]any] {
 	return &c.CommandRules
+}
+
+func (c *mqlRedisdbAclUser) GetSelectors() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Selectors, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("redisdb.acl.user", c.__id, "selectors")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.selectors()
+	})
+}
+
+// mqlRedisdbAclSelector for the redisdb.acl.selector resource
+type mqlRedisdbAclSelector struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlRedisdbAclSelectorInternal it will be used here
+	CommandRules    plugin.TValue[[]any]
+	KeyPatterns     plugin.TValue[[]any]
+	ChannelPatterns plugin.TValue[[]any]
+}
+
+// createRedisdbAclSelector creates a new instance of this resource
+func createRedisdbAclSelector(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlRedisdbAclSelector{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("redisdb.acl.selector", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlRedisdbAclSelector) MqlName() string {
+	return "redisdb.acl.selector"
+}
+
+func (c *mqlRedisdbAclSelector) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlRedisdbAclSelector) GetCommandRules() *plugin.TValue[[]any] {
+	return &c.CommandRules
+}
+
+func (c *mqlRedisdbAclSelector) GetKeyPatterns() *plugin.TValue[[]any] {
+	return &c.KeyPatterns
+}
+
+func (c *mqlRedisdbAclSelector) GetChannelPatterns() *plugin.TValue[[]any] {
+	return &c.ChannelPatterns
 }
 
 // mqlRedisdbConfig for the redisdb.config resource

--- a/providers/redisdb/resources/redisdb.lr.versions
+++ b/providers/redisdb/resources/redisdb.lr.versions
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 redisdb 13.0.0
+redisdb.acl.selector 13.0.3
+redisdb.acl.selector.channelPatterns 13.0.3
+redisdb.acl.selector.commandRules 13.0.3
+redisdb.acl.selector.keyPatterns 13.0.3
 redisdb.acl.user 13.0.0
 redisdb.acl.user.channelPatterns 13.0.0
 redisdb.acl.user.commandRules 13.0.0
@@ -11,6 +15,7 @@ redisdb.acl.user.keyPatterns 13.0.0
 redisdb.acl.user.name 13.0.0
 redisdb.acl.user.nopass 13.0.0
 redisdb.acl.user.passwordCount 13.0.0
+redisdb.acl.user.selectors 13.0.3
 redisdb.config 13.0.0
 redisdb.config.appendFsync 13.0.0
 redisdb.config.appendOnly 13.0.0
@@ -23,6 +28,7 @@ redisdb.config.rdbEnabled 13.0.0
 redisdb.config.save 13.0.0
 redisdb.instance 13.0.0
 redisdb.instance.aclFile 13.0.0
+redisdb.instance.aclPubsubDefault 13.0.3
 redisdb.instance.bind 13.0.0
 redisdb.instance.bindsAllInterfaces 13.0.0
 redisdb.instance.config 13.0.0

--- a/providers/redisdb/resources/redisdb_test.go
+++ b/providers/redisdb/resources/redisdb_test.go
@@ -45,61 +45,6 @@ func TestIsNoPerm(t *testing.T) {
 	}
 }
 
-func TestParseACLLine(t *testing.T) {
-	// default user: enabled, has a password hash, all keys/channels, all commands.
-	def := parseACLLine("user default on #9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08 ~* &* +@all")
-	if def.name != "default" || !def.enabled || def.nopass {
-		t.Errorf("default parse: %+v", def)
-	}
-	if def.passwordCount != 1 {
-		t.Errorf("default passwordCount = %d, want 1", def.passwordCount)
-	}
-	if len(def.keyPatterns) != 1 || def.keyPatterns[0] != "*" {
-		t.Errorf("default keyPatterns = %v, want [*]", def.keyPatterns)
-	}
-	if len(def.commandRules) != 1 || def.commandRules[0] != "+@all" {
-		t.Errorf("default commandRules = %v, want [+@all]", def.commandRules)
-	}
-
-	// restricted auditor: off, nopass, scoped key pattern, category rules.
-	aud := parseACLLine("user auditor off nopass ~app:* &notifications:* -@all +@read +@connection")
-	if aud.name != "auditor" || aud.enabled || !aud.nopass {
-		t.Errorf("auditor parse: %+v", aud)
-	}
-	if aud.passwordCount != 0 {
-		t.Errorf("auditor passwordCount = %d, want 0", aud.passwordCount)
-	}
-	if len(aud.keyPatterns) != 1 || aud.keyPatterns[0] != "app:*" {
-		t.Errorf("auditor keyPatterns = %v, want [app:*]", aud.keyPatterns)
-	}
-	if len(aud.channelPatterns) != 1 || aud.channelPatterns[0] != "notifications:*" {
-		t.Errorf("auditor channelPatterns = %v, want [notifications:*]", aud.channelPatterns)
-	}
-	want := []string{"-@all", "+@read", "+@connection"}
-	if len(aud.commandRules) != len(want) {
-		t.Fatalf("auditor commandRules = %v, want %v", aud.commandRules, want)
-	}
-	for i, w := range want {
-		if aud.commandRules[i] != w {
-			t.Errorf("commandRules[%d] = %v, want %s", i, aud.commandRules[i], w)
-		}
-	}
-
-	// allkeys/allchannels keywords normalize to "*".
-	ak := parseACLLine("user wide on nopass allkeys allchannels +@all")
-	if len(ak.keyPatterns) != 1 || ak.keyPatterns[0] != "*" {
-		t.Errorf("allkeys => %v, want [*]", ak.keyPatterns)
-	}
-	if len(ak.channelPatterns) != 1 || ak.channelPatterns[0] != "*" {
-		t.Errorf("allchannels => %v, want [*]", ak.channelPatterns)
-	}
-
-	// a non-user line yields an empty name and is skipped by the caller.
-	if got := parseACLLine("not an acl line"); got.name != "" {
-		t.Errorf("non-user line name = %q, want empty", got.name)
-	}
-}
-
 func TestAtoiOr(t *testing.T) {
 	if got := atoiOr("6379", 0); got != 6379 {
 		t.Errorf("atoiOr(6379) = %d", got)


### PR DESCRIPTION
## The bug

`parseACLLine` splits an `ACL LIST` line on whitespace and walks the resulting
tokens one at a time:

`providers/redisdb/resources/acl.go:29`
```go
fields := strings.Fields(line)
```

`providers/redisdb/resources/acl.go:60`
```go
// Other flags (sanitize-payload, resetchannels, selectors) are ignored.
```

Selectors are not ignored — they cannot be, because whitespace-splitting has
already torn them apart before the loop runs. Redis 7.0 added **selectors**:
additional permission sets attached to a user, written in parentheses. Given

```
user trap on ... ~cache:* &* -@all (~* resetchannels +@all)
```

`strings.Fields` produces `… -@all  (~*  resetchannels  +@all)`. The `(~*` token
matches no case and is dropped; `+@all)` matches the `+` prefix and is appended
to the user's **base** `commandRules`, with the closing parenthesis still stuck
to it.

## Why it is wrong

The failure runs in the dangerous direction. A user whose base rules read
`-@all` — apparently locked down — can hold a selector granting `+@all ~*`, and
the shipped fields do not describe what the user can actually do:

- selector grants are **mis-attributed to the base rule set**, so `commandRules`
  and `channelPatterns` claim base permissions the base rules never granted;
- the tokens are **mangled** (`+@all)`, `+set)`), so `commandRules.contains("+@all")`
  misses the very grant it is looking for;
- key patterns reachable only through a selector are **silently lost**, so a
  selector holding `~*` reports as `keyPatterns: ["cache:*"]`.

Either way `redisdb.acl.user`'s command and key patterns do not describe actual
capability, in a resource whose whole purpose is auditing access control.

## The fix

- **Prefer `ACL GETUSER`.** It returns the rules structurally, with `selectors`
  as its own array, so nothing has to be taken apart by hand. `go-redis` v9.22.0
  has no typed command for it, so it goes through the driver's generic command
  interface. Both reply shapes are handled: RESP3 map and RESP2 flat
  alternating array, plus the pre-7.0 form where `keys` and `channels` came back
  as arrays of bare patterns rather than one rule string.
- **String parsing is kept as a fallback** for servers or credentials that will
  not answer `ACL GETUSER`, and is now correct: a new tokenizer returns a
  parenthesised selector whole with its nesting intact, handles quoted patterns,
  and treats `(` as a group opener only at the start of a token, so a
  parenthesis inside a key pattern (`~foo(bar)*`) stays literal. Unbalanced
  quotes and parentheses degrade to a trailing token instead of panicking.
- **Base-rule fields describe only the base rules.** `keyPatterns`,
  `channelPatterns` and `commandRules` are unchanged in type and meaning for
  users without selectors; `allkeys` / `~*` now correctly supersede a narrower
  pattern rather than being appended alongside it.
- **New `selectors()` accessor** on `redisdb.acl.user`, returning
  `redisdb.acl.selector` with its own `commandRules`, `keyPatterns` and
  `channelPatterns`. Parsed alongside the base rules and cached on the resource,
  so it costs no extra round trip.
- **New `redisdb.instance.aclPubsubDefault`** (`CONFIG GET acl-pubsub-default`,
  read from the `CONFIG GET *` already fetched at init, so no extra call). It
  matters here specifically: under `allchannels` a user created without channel
  rules reaches **every** channel, so an empty `channelPatterns` means
  unrestricted, not restricted. Without it the shipped field reads backwards.
  Redis 6.2 defaults to `allchannels`; Redis 7 defaults to `resetchannels`.

No shipped field changed type, and no secret material is exposed — password
hashes are still reduced to `passwordCount`.

## Verification

Verified live against `redis:7.4` and `redis:6.2` containers with four users:
`locked` (restrictive, no selectors — the control), `trap` (restrictive base
plus a permissive selector), `multisel` (two selectors), and `wideopen`
(plainly permissive).

```
ACL SETUSER trap on '>…' '-@all' '~cache:*' '&*' '(+@all ~*)'
```

which Redis normalizes to:

```
user trap on sanitize-payload #… ~cache:* &* -@all (~* resetchannels +@all)
```

### Before (shipped provider, built from `main`)

```
  1: {
    name: "locked"                <- control
    commandRules: [ "-@all" ]
    channelPatterns: []
    keyPatterns: [ "none:*" ]
  }
  2: {
    name: "multisel"
    commandRules: [ "-@all", "+get", "-@all", "+set)", "-@all", "+@read)" ]
    channelPatterns: [ "news.*" ]      <- from a selector
    keyPatterns: [ "base:*" ]          <- selector keys lost
  }
  3: {
    name: "trap"
    commandRules: [ "-@all", "+@all)" ]  <- selector grant, mangled, on the base
    channelPatterns: [ "*" ]
    keyPatterns: [ "cache:*" ]           <- the selector's ~* is gone
  }
```

`commandRules.contains("+@all")` is **false** for `trap` — the grant is there,
spelled `+@all)`.

### After

```
    1: {
      name: "locked"                <- control: identical to before
      commandRules: [ "-@all" ]
      channelPatterns: []
      keyPatterns: [ "none:*" ]
      selectors: []
    }
    2: {
      name: "multisel"
      commandRules: [ "-@all", "+get" ]
      channelPatterns: []
      keyPatterns: [ "base:*" ]
      selectors: [
        0: { commandRules: [ "-@all", "+set" ],   keyPatterns: [ "staging:*" ], channelPatterns: [ "news.*" ] }
        1: { commandRules: [ "-@all", "+@read" ], keyPatterns: [ "ro:*" ],      channelPatterns: [] }
      ]
    }
    3: {
      name: "trap"
      commandRules: [ "-@all" ]
      channelPatterns: [ "*" ]
      keyPatterns: [ "cache:*" ]
      selectors: [
        0: { commandRules: [ "+@all" ], keyPatterns: [ "*" ], channelPatterns: [] }
      ]
    }
  aclPubsubDefault: "resetchannels"
```

`default`, `locked` and `wideopen` — every user without a selector — read
byte-identically before and after. Only the two selector-holding users changed,
which is what shows the parser was corrected rather than loosened.

### Fallback path, verified live

A user granted `+acl|list` but not `+acl|getuser` exercises the string-parsing
fallback. `ACL GETUSER` is refused (`NOPERM User listonly has no permissions to
run the 'acl|getuser' command`) and the provider still reports:

```
  0: {
    name: "trap"
    commandRules: [ "-@all" ]
    keyPatterns: [ "cache:*" ]
    selectors: [ 0: { commandRules: [ "+@all" ], keyPatterns: [ "*" ] } ]
  }
```

identical to the `ACL GETUSER` path.

### Redis 6.2, verified live

Exercises the pre-7.0 reply shape, where `keys` and `channels` are arrays of
bare patterns and there is no `selectors` field:

```
  aclPubsubDefault: "allchannels"
    2: {
      name: "reader"
      commandRules: [ "-@all", "+@read" ]
      channelPatterns: [ "news.*" ]
      keyPatterns: [ "app:*" ]
      selectors: []
    }
```

Note `aclPubsubDefault: "allchannels"` here — on that server the `locked` user
reports `channelPatterns: ["*"]`, which is exactly the case the new field exists
to make legible.

Both containers were torn down afterwards.

### Unit tests

```
$ cd providers/redisdb && go build ./... && go test ./...
?   	go.mondoo.com/mql/providers/redisdb	[no test files]
?   	go.mondoo.com/mql/providers/redisdb/config	[no test files]
ok  	go.mondoo.com/mql/providers/redisdb/connection	0.559s
?   	go.mondoo.com/mql/providers/redisdb/gen	[no test files]
?   	go.mondoo.com/mql/providers/redisdb/provider	[no test files]
ok  	go.mondoo.com/mql/providers/redisdb/resources	0.554s
```

`resources/acl_test.go` is table-driven over the tokenizer, the `ACL LIST`
parser and the `ACL GETUSER` reader: base-only, one selector, multiple
selectors, nested parentheses, quoted patterns, empty ACL, RESP2 and RESP3
shapes, the pre-7.0 array form, and malformed input that must not panic
(unterminated selector, unterminated quote, stray punctuation, non-string reply
entries). `TestACLGetUserMatchesACLList` pins the two read paths against each
other on the same users, so the fallback can never drift from the structured
reply it stands in for.

`golangci-lint run ./...` reports 0 issues; `gofmt` is clean; `go.mod` unchanged.
