### PR TITLE
🐛 grafana: surface isRevoked so a dead token stops reading as live

### DIFF
--- a/providers/grafana/resources/grafana.lr
+++ b/providers/grafana/resources/grafana.lr
@@ -9,11 +9,11 @@ option go_package = "go.mondoo.com/mql/providers/grafana/resources"
 // Grafana instance queried through its HTTP API: organization details,
 // human users with their roles and MFA / external-auth status, service
 // accounts and their tokens, configured datasources, alerting contact
-// points, the notification-policy routing tree, legacy API keys, RBAC
-// roles, and SSO settings (with a focused view of SAML configuration).
-// This is the surface auditors use to find weak datasource credentials,
-// missing MFA, expired or broad-scope tokens, deprecated API keys, and
-// permissive SSO configuration.
+// points, the notification-policy routing tree, RBAC roles, and SSO
+// settings (with a focused view of SAML configuration). This is the
+// surface auditors use to find weak datasource credentials, missing
+// MFA, expired, revoked, or broad-scope tokens, and permissive SSO
+// configuration.
 grafana {
   // Organization details
   organization() grafana.organization
@@ -128,7 +128,12 @@ grafana.serviceAccount @defaults("id name role") {
 // is configured), while the derived `hasExpiration` and `isExpired`
 // predicates and the `secondsUntilExpiration` countdown let audits flag
 // non-expiring or already-expired credentials that should be rotated or
-// revoked.
+// revoked. The `isRevoked` predicate separates credentials that no
+// longer authenticate from live ones, so a revocation can be confirmed
+// rather than assumed, and `lastUsedAt` records the most recent time the
+// token authenticated (null when it has never been used), which
+// identifies dormant credentials worth removing. The `serviceAccount`
+// field resolves to the account a token authenticates as.
 grafana.serviceAccountToken @defaults("id name") {
   // Token ID
   id int
@@ -146,6 +151,12 @@ grafana.serviceAccountToken @defaults("id name") {
   secondsUntilExpiration float
   // Whether the token is expired
   isExpired bool
+  // Whether the token has been revoked and no longer authenticates
+  isRevoked bool
+  // Timestamp when the token was last used to authenticate (null if never used)
+  lastUsedAt time
+  // Service account this token authenticates as
+  serviceAccount() grafana.serviceAccount
 }
 
 // Grafana datasource

--- a/providers/grafana/resources/grafana.lr.go
+++ b/providers/grafana/resources/grafana.lr.go
@@ -274,6 +274,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"grafana.serviceAccountToken.isExpired": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGrafanaServiceAccountToken).GetIsExpired()).ToDataRes(types.Bool)
 	},
+	"grafana.serviceAccountToken.isRevoked": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGrafanaServiceAccountToken).GetIsRevoked()).ToDataRes(types.Bool)
+	},
+	"grafana.serviceAccountToken.lastUsedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGrafanaServiceAccountToken).GetLastUsedAt()).ToDataRes(types.Time)
+	},
+	"grafana.serviceAccountToken.serviceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGrafanaServiceAccountToken).GetServiceAccount()).ToDataRes(types.Resource("grafana.serviceAccount"))
+	},
 	"grafana.datasource.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGrafanaDatasource).GetId()).ToDataRes(types.Int)
 	},
@@ -655,6 +664,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"grafana.serviceAccountToken.isExpired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGrafanaServiceAccountToken).IsExpired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"grafana.serviceAccountToken.isRevoked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGrafanaServiceAccountToken).IsRevoked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"grafana.serviceAccountToken.lastUsedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGrafanaServiceAccountToken).LastUsedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"grafana.serviceAccountToken.serviceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGrafanaServiceAccountToken).ServiceAccount, ok = plugin.RawToTValue[*mqlGrafanaServiceAccount](v.Value, v.Error)
 		return
 	},
 	"grafana.datasource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1442,6 +1463,9 @@ type mqlGrafanaServiceAccountToken struct {
 	HasExpiration          plugin.TValue[bool]
 	SecondsUntilExpiration plugin.TValue[float64]
 	IsExpired              plugin.TValue[bool]
+	IsRevoked              plugin.TValue[bool]
+	LastUsedAt             plugin.TValue[*time.Time]
+	ServiceAccount         plugin.TValue[*mqlGrafanaServiceAccount]
 }
 
 // createGrafanaServiceAccountToken creates a new instance of this resource
@@ -1511,6 +1535,30 @@ func (c *mqlGrafanaServiceAccountToken) GetSecondsUntilExpiration() *plugin.TVal
 
 func (c *mqlGrafanaServiceAccountToken) GetIsExpired() *plugin.TValue[bool] {
 	return &c.IsExpired
+}
+
+func (c *mqlGrafanaServiceAccountToken) GetIsRevoked() *plugin.TValue[bool] {
+	return &c.IsRevoked
+}
+
+func (c *mqlGrafanaServiceAccountToken) GetLastUsedAt() *plugin.TValue[*time.Time] {
+	return &c.LastUsedAt
+}
+
+func (c *mqlGrafanaServiceAccountToken) GetServiceAccount() *plugin.TValue[*mqlGrafanaServiceAccount] {
+	return plugin.GetOrCompute[*mqlGrafanaServiceAccount](&c.ServiceAccount, func() (*mqlGrafanaServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("grafana.serviceAccountToken", c.__id, "serviceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGrafanaServiceAccount), nil
+			}
+		}
+
+		return c.serviceAccount()
+	})
 }
 
 // mqlGrafanaDatasource for the grafana.datasource resource

--- a/providers/grafana/resources/grafana.lr.versions
+++ b/providers/grafana/resources/grafana.lr.versions
@@ -83,8 +83,11 @@ grafana.serviceAccountToken.expiration 13.0.1
 grafana.serviceAccountToken.hasExpiration 13.0.1
 grafana.serviceAccountToken.id 13.0.1
 grafana.serviceAccountToken.isExpired 13.0.1
+grafana.serviceAccountToken.isRevoked 13.1.22
+grafana.serviceAccountToken.lastUsedAt 13.1.22
 grafana.serviceAccountToken.name 13.0.1
 grafana.serviceAccountToken.secondsUntilExpiration 13.0.1
+grafana.serviceAccountToken.serviceAccount 13.1.22
 grafana.serviceAccountToken.serviceAccountId 13.0.1
 grafana.serviceAccounts 13.0.1
 grafana.ssoSettings 13.0.5

--- a/providers/grafana/resources/service_accounts.go
+++ b/providers/grafana/resources/service_accounts.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/grafana/connection"
 )
 
@@ -36,11 +38,16 @@ type grafanaServiceAccountsResponse struct {
 }
 
 // grafanaTokenJSON mirrors one element of the /api/serviceaccounts/{id}/tokens response.
+//
+// LastUsedAt is a pointer because Grafana sends null for a token that has
+// never authenticated; that has to stay distinct from a real timestamp, so
+// the field is reported as null rather than as the zero time.
 type grafanaTokenJSON struct {
 	ID                    int     `json:"id"`
 	Name                  string  `json:"name"`
 	Created               string  `json:"created"`
 	Expiration            string  `json:"expiration"`
+	LastUsedAt            *string `json:"lastUsedAt"`
 	HasExpired            bool    `json:"hasExpired"`
 	SecondsTillExpiration float64 `json:"secondsUntilExpiration"`
 	IsRevoked             bool    `json:"isRevoked"`
@@ -208,6 +215,13 @@ func (g *mqlGrafanaServiceAccount) tokens() ([]interface{}, error) {
 			secondsUntilExp = 0
 		}
 
+		// A token that has never authenticated comes back either as a null
+		// lastUsedAt or as the same "0001-01-01T00:00:00Z" sentinel Grafana
+		// uses elsewhere. Both must read as null: reporting the zero time
+		// would date a never-used credential to year 1 rather than saying
+		// nothing is known about its use.
+		lastUsedAt := parseGrafanaTimePtr(tok.LastUsedAt)
+
 		res, err := CreateResource(g.MqlRuntime, "grafana.serviceAccountToken", map[string]*llx.RawData{
 			"id":                     llx.IntData(int64(tok.ID)),
 			"serviceAccountId":       llx.IntData(saID),
@@ -217,6 +231,8 @@ func (g *mqlGrafanaServiceAccount) tokens() ([]interface{}, error) {
 			"hasExpiration":          llx.BoolData(hasExpiration),
 			"secondsUntilExpiration": llx.FloatData(secondsUntilExp),
 			"isExpired":              llx.BoolData(tok.HasExpired),
+			"isRevoked":              llx.BoolData(tok.IsRevoked),
+			"lastUsedAt":             llx.TimeDataPtr(lastUsedAt),
 		})
 		if err != nil {
 			return nil, err
@@ -224,6 +240,58 @@ func (g *mqlGrafanaServiceAccount) tokens() ([]interface{}, error) {
 		list = append(list, res)
 	}
 	return list, nil
+}
+
+// parseGrafanaTimePtr converts an optional Grafana timestamp into a time
+// pointer, mapping both a missing value and Grafana's zero-time sentinel to
+// nil so the field is reported as null.
+func parseGrafanaTimePtr(s *string) *time.Time {
+	if s == nil {
+		return nil
+	}
+	t := parseGrafanaTime(*s)
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+// serviceAccount resolves the token's serviceAccountId to the service account
+// it authenticates as.
+//
+// The lookup scans the service-account list already resolved on the grafana
+// resource instead of calling NewResource per token. NewResource runs the
+// target resource's init before the runtime cache is consulted, which would
+// turn one list request into one request per token; grafana.serviceAccounts is
+// memoized on the singleton, so scanning it costs nothing beyond the list
+// every token walk has already paid for.
+func (t *mqlGrafanaServiceAccountToken) serviceAccount() (*mqlGrafanaServiceAccount, error) {
+	res, err := CreateResource(t.MqlRuntime, "grafana", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+
+	accounts := res.(*mqlGrafana).GetServiceAccounts()
+	if accounts.Error != nil {
+		return nil, accounts.Error
+	}
+
+	saID := t.ServiceAccountId.Data
+	for _, raw := range accounts.Data {
+		sa, ok := raw.(*mqlGrafanaServiceAccount)
+		if !ok {
+			continue
+		}
+		if sa.Id.Data == saID {
+			return sa, nil
+		}
+	}
+
+	// The account the token belongs to is no longer listed (deleted between
+	// calls, or hidden by permissions). Mark the field resolved-and-null so the
+	// runtime does not treat it as unset.
+	t.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
 func (t *mqlGrafanaServiceAccountToken) id() (string, error) {

--- a/providers/grafana/resources/service_accounts_test.go
+++ b/providers/grafana/resources/service_accounts_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,3 +260,55 @@ func TestServiceAccountTokens_HasExpirationLogic(t *testing.T) {
 		})
 	}
 }
+
+// TestTokenDecode_RevokedAndLastUsed pins the struct tags for the two fields a
+// token audit turns on: a mistyped tag would decode isRevoked as false and
+// report a dead credential as live.
+func TestTokenDecode_RevokedAndLastUsed(t *testing.T) {
+	// Shaped like GET /api/serviceaccounts/{id}/tokens: one revoked token and
+	// one live token that has never authenticated.
+	const payload = `[
+	  {"id":1,"name":"revoked-token","created":"2026-08-01T10:00:00Z","expiration":"0001-01-01T00:00:00Z","lastUsedAt":"2026-08-02T11:30:00Z","hasExpired":false,"secondsUntilExpiration":0,"isRevoked":true},
+	  {"id":2,"name":"live-token","created":"2026-08-01T10:05:00Z","expiration":"0001-01-01T00:00:00Z","lastUsedAt":null,"hasExpired":false,"secondsUntilExpiration":0,"isRevoked":false}
+	]`
+
+	var toks []grafanaTokenJSON
+	require.NoError(t, json.Unmarshal([]byte(payload), &toks))
+	require.Len(t, toks, 2)
+
+	assert.True(t, toks[0].IsRevoked, "revoked token must decode isRevoked=true")
+	require.NotNil(t, toks[0].LastUsedAt)
+	lastUsed := parseGrafanaTimePtr(toks[0].LastUsedAt)
+	require.NotNil(t, lastUsed)
+	assert.Equal(t, "2026-08-02T11:30:00Z", lastUsed.UTC().Format(time.RFC3339))
+
+	assert.False(t, toks[1].IsRevoked, "live token must decode isRevoked=false")
+	assert.Nil(t, toks[1].LastUsedAt)
+	assert.Nil(t, parseGrafanaTimePtr(toks[1].LastUsedAt), "a never-used token must report null, not the zero time")
+}
+
+func TestParseGrafanaTimePtr(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  *string
+		want string // empty means nil
+	}{
+		{"absent", nil, ""},
+		{"empty string", strPtr(""), ""},
+		{"grafana zero sentinel", strPtr("0001-01-01T00:00:00Z"), ""},
+		{"valid timestamp", strPtr("2026-08-02T11:30:00Z"), "2026-08-02T11:30:00Z"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGrafanaTimePtr(tt.raw)
+			if tt.want == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.UTC().Format(time.RFC3339))
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## The bug

`providers/grafana/resources/service_accounts.go:46` decoded `isRevoked` off
`GET /api/serviceaccounts/{id}/tokens` and then never passed it to
`CreateResource`:

```go
type grafanaTokenJSON struct {
	...
	IsRevoked bool `json:"isRevoked"`   // decoded at line 46, never passed to CreateResource (lines 211-220)
}
```

`grafana.serviceAccountToken` exposed `created`, `expiration`,
`hasExpiration`, `secondsUntilExpiration` and `isExpired`, but nothing about
revocation. `lastUsedAt` was in the same response and was not decoded at all.

## Why it is wrong

A revoked token is dead: it no longer authenticates. Without the field, mql
presented it identically to a live credential, so:

- a credential inventory counted dead tokens as live and inflated the
  apparent attack surface;
- a "revoke this token" remediation could not be verified through mql. There
  was no field whose value changed when the token was revoked, so the only
  confirmable outcome was deletion.

`lastUsedAt` is the other half of the same audit. A non-expiring token that
has never authenticated is the finding a token review is looking for, and the
response already carried it.

## The fix

- `isRevoked` is surfaced on `grafana.serviceAccountToken`.
- `lastUsedAt` is surfaced, decoded through a `*string` so a token that has
  never authenticated reports **null** rather than the zero time. Grafana sends
  either `null` or its `0001-01-01T00:00:00Z` sentinel; `parseGrafanaTimePtr`
  maps both to null, because dating a never-used credential to year 1 is a
  wrong answer rather than a missing one.
- `serviceAccount()` resolves `serviceAccountId` to the account the token
  authenticates as. It scans the service-account list already memoized on the
  `grafana` resource rather than calling `NewResource` per token: `NewResource`
  runs the target's `init` **before** the runtime cache is consulted, which
  would turn one list request into one request per token.
- The `grafana` root doc-comment advertised "legacy API keys" and "deprecated
  API keys". No such resource exists in the schema, so the claim is removed.

`.lr.versions` entries land at `13.1.22` (provider `Version` is `13.1.21`);
`config.go` is untouched.

## Verification

Live, against `grafana/grafana:latest` (13.2.0) in a container: one service
account, two tokens, one of them revoked. Ground truth from the API:

```json
[
  {"id": 2, "name": "token-live",      "lastUsedAt": "2026-08-23T20:42:06Z", "isRevoked": false},
  {"id": 1, "name": "token-to-revoke", "lastUsedAt": null,                   "isRevoked": true}
]
```

**Before** (provider built from `main`) the two tokens are indistinguishable:

```
grafana.serviceAccounts: [
  0: {
    name: "mql-verify-sa"
    tokens: [
      0: { name: "token-live",      isExpired: false, hasExpiration: false }
      1: { name: "token-to-revoke", isExpired: false, hasExpiration: false }
    ]
  }
]
```

and the field does not exist:

```
$ mql run grafana ... -c "grafana.serviceAccounts { tokens { name isRevoked lastUsedAt } }"
failed to compile: cannot find field or resource 'isRevoked' in block for type 'grafana.serviceAccountToken'
```

**After** (this branch), with `token-live` as the untouched control:

```
grafana.serviceAccounts: [
  0: {
    name: "mql-verify-sa"
    tokens: [
      0: {
        name: "token-live"
        isExpired: false
        isRevoked: false
        serviceAccount: { name: "mql-verify-sa", role: "Admin", id: 2 }
        hasExpiration: false
        lastUsedAt: 2026-08-23 13:42:06 -0700 PDT
      }
      1: {
        name: "token-to-revoke"
        isExpired: false
        isRevoked: true
        serviceAccount: { name: "mql-verify-sa", role: "Admin", id: 2 }
        hasExpiration: false
        lastUsedAt: null
      }
    ]
  }
]
```

The revoked token reads `isRevoked: true` and `lastUsedAt: null` (it was never
used); the control token is unchanged apart from the two new fields, and its
`lastUsedAt` matches the timestamp of the one API call made with it. The
revocation is now expressible as a filter:

```
$ mql run grafana ... -c "grafana.serviceAccounts { tokens.where(isRevoked == false) { name lastUsedAt } }"
grafana.serviceAccounts: [
  0: { tokens.where: [ 0: { name: "token-live", lastUsedAt: 2026-08-23 13:42:06 -0700 PDT } ] }
]
```

The container was removed after the run.

Unit tests pin the struct tags and the optional-timestamp handling, so a
mistyped tag cannot silently report a dead credential as live:

```
$ go test ./resources/ -run 'Token|ParseGrafanaTimePtr' -v
--- PASS: TestTokenDecode_RevokedAndLastUsed (0.00s)
--- PASS: TestParseGrafanaTimePtr (0.00s)
    --- PASS: TestParseGrafanaTimePtr/absent (0.00s)
    --- PASS: TestParseGrafanaTimePtr/empty_string (0.00s)
    --- PASS: TestParseGrafanaTimePtr/grafana_zero_sentinel (0.00s)
    --- PASS: TestParseGrafanaTimePtr/valid_timestamp (0.00s)
PASS
```

Full provider suite:

```
$ cd providers/grafana && go build ./... && go test ./...
ok  	go.mondoo.com/mql/providers/grafana/connection	1.426s
ok  	go.mondoo.com/mql/providers/grafana/provider	1.348s
ok  	go.mondoo.com/mql/providers/grafana/resources	15.705s
```

## Not verified against a live target

- **Grafana Cloud and Enterprise.** Verification used OSS Grafana 13.2.0.
- **A token revoked by Grafana's own leaked-credential detection.** OSS Grafana
  exposes no API endpoint that sets `is_revoked`, so the revoked state was
  produced by setting `api_key.is_revoked = 1` directly in the instance
  database. The provider was then read through the normal HTTP API, and the API
  response above (`"isRevoked": true`) is the contract the fix decodes, so what
  is unverified is only how the flag comes to be set, not how it is read.
- **A token whose service account was deleted between the list call and the
  token walk.** The null-resolution branch of `serviceAccount()` is not
  reachable on a live instance without racing the API.
