### PR TITLE
🐛 bitwarden: follow the continuation token when reading list endpoints

### DIFF
--- a/providers/bitwarden/connection/client.go
+++ b/providers/bitwarden/connection/client.go
@@ -76,13 +76,12 @@ func (f *flexEnum) UnmarshalJSON(b []byte) error {
 // listResponse is the envelope Bitwarden's Public API wraps list endpoints
 // in: {"object": "list", "data": [...], "continuationToken": null}.
 //
-// Known limitation: the list readers below (ListPolicies, ListMembers,
-// ListGroups, ListCollections) return only the first page (out.Data) and do
-// not follow ContinuationToken. The Bitwarden Public API returns the full set
-// in a single response for these organization-scoped endpoints (the token is
-// null in practice), so results are complete today. If a future API version
-// starts paginating any of these, add a loop that re-requests with the
-// continuation token until it is nil, or results will be silently truncated.
+// ContinuationToken is the API's pagination cursor: when it is non-null the
+// response is a partial page and the next one is fetched by repeating the
+// request with ?continuationToken=<value>. It is documented on the list
+// envelope of every list endpoint this provider reads (collections, groups,
+// members, policies), so the readers below walk it via listAll rather than
+// stopping at the first page.
 type listResponse[T any] struct {
 	Object            string  `json:"object"`
 	Data              []T     `json:"data"`
@@ -162,22 +161,70 @@ func (c *Client) get(ctx context.Context, path string, out any) error {
 	return nil
 }
 
+// maxListPages bounds a single pagination walk. The organization-scoped list
+// endpoints this provider reads return at most a few hundred records, so the
+// cap is far above any real response set and only serves as a backstop against
+// a server that hands out fresh cursors forever.
+const maxListPages = 1000
+
+// listAll reads every page of a Public API list endpoint, following the
+// continuation cursor until the server stops handing one out, and returns the
+// concatenated records.
+//
+// Termination is guarded twice, because a pagination loop that trusts the
+// server is a loop that can spin for the length of a scan:
+//   - a repeated cursor (the server echoing the token it was just given, which
+//     would re-serve the same page forever) is reported as an error rather than
+//     silently truncating the result;
+//   - maxListPages caps the total number of requests for a server that keeps
+//     minting new cursors.
+//
+// It is a free function rather than a method because Go does not allow type
+// parameters on methods.
+func listAll[T any](ctx context.Context, c *Client, path string) ([]T, error) {
+	var all []T
+	seen := map[string]struct{}{}
+	next := ""
+
+	for range maxListPages {
+		page := path
+		if next != "" {
+			sep := "?"
+			if strings.Contains(path, "?") {
+				sep = "&"
+			}
+			page = path + sep + "continuationToken=" + url.QueryEscape(next)
+		}
+
+		var out listResponse[T]
+		if err := c.get(ctx, page, &out); err != nil {
+			return nil, err
+		}
+		all = append(all, out.Data...)
+
+		// A null or empty cursor is the API saying this was the last page.
+		if out.ContinuationToken == nil || *out.ContinuationToken == "" {
+			return all, nil
+		}
+
+		next = *out.ContinuationToken
+		if _, repeated := seen[next]; repeated {
+			return nil, errors.Newf("bitwarden: %s returned the same continuation token twice, refusing to page forever", path)
+		}
+		seen[next] = struct{}{}
+	}
+
+	return nil, errors.Newf("bitwarden: %s did not stop paginating after %d pages", path, maxListPages)
+}
+
 // ListPolicies lists every security policy configured for the organization.
 func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
-	var out listResponse[Policy]
-	if err := c.get(ctx, "/policies", &out); err != nil {
-		return nil, err
-	}
-	return out.Data, nil
+	return listAll[Policy](ctx, c, "/policies")
 }
 
 // ListMembers lists every member of the organization.
 func (c *Client) ListMembers(ctx context.Context) ([]Member, error) {
-	var out listResponse[Member]
-	if err := c.get(ctx, "/members", &out); err != nil {
-		return nil, err
-	}
-	return out.Data, nil
+	return listAll[Member](ctx, c, "/members")
 }
 
 // GetMember reads a single member by its member (organization user) ID.
@@ -200,11 +247,7 @@ func (c *Client) GetMemberGroupIds(ctx context.Context, id string) ([]string, er
 
 // ListGroups lists every group defined in the organization.
 func (c *Client) ListGroups(ctx context.Context) ([]Group, error) {
-	var out listResponse[Group]
-	if err := c.get(ctx, "/groups", &out); err != nil {
-		return nil, err
-	}
-	return out.Data, nil
+	return listAll[Group](ctx, c, "/groups")
 }
 
 // GetGroup reads a single group by its ID.
@@ -227,11 +270,7 @@ func (c *Client) GetGroupMemberIds(ctx context.Context, id string) ([]string, er
 
 // ListCollections lists every collection defined in the organization.
 func (c *Client) ListCollections(ctx context.Context) ([]Collection, error) {
-	var out listResponse[Collection]
-	if err := c.get(ctx, "/collections", &out); err != nil {
-		return nil, err
-	}
-	return out.Data, nil
+	return listAll[Collection](ctx, c, "/collections")
 }
 
 // GetCollection reads a single collection by its ID.

--- a/providers/bitwarden/connection/client_test.go
+++ b/providers/bitwarden/connection/client_test.go
@@ -4,8 +4,12 @@
 package connection
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -282,5 +286,151 @@ func TestListResponseDecode(t *testing.T) {
 	}
 	if out.ContinuationToken != nil {
 		t.Fatalf("ContinuationToken = %v, want nil", out.ContinuationToken)
+	}
+}
+
+// pagedHandler serves a list endpoint in pages of the given size, using the
+// index of the next record as the continuation cursor, the way the Public API
+// documents the field: a cursor on a partial page, null on the last one.
+func pagedHandler(t *testing.T, ids []string, pageSize int, requests *[]string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		*requests = append(*requests, r.URL.RequestURI())
+
+		start := 0
+		if tok := r.URL.Query().Get("continuationToken"); tok != "" {
+			var err error
+			start, err = strconv.Atoi(tok)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
+		end := start + pageSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		body := map[string]any{"object": "list"}
+		data := make([]map[string]any, 0, end-start)
+		for _, id := range ids[start:end] {
+			data = append(data, map[string]any{"id": id, "name": id, "externalId": nil, "groups": nil})
+		}
+		body["data"] = data
+		if end < len(ids) {
+			body["continuationToken"] = strconv.Itoa(end)
+		} else {
+			body["continuationToken"] = nil
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+func TestListAllFollowsContinuationToken(t *testing.T) {
+	ids := []string{"c1", "c2", "c3", "c4", "c5"}
+	var requests []string
+	srv := httptest.NewServer(pagedHandler(t, ids, 3, &requests))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, srv.Client())
+	got, err := c.ListCollections(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(ids) {
+		t.Fatalf("got %d collections, want %d (short enumeration)", len(got), len(ids))
+	}
+	for i, want := range ids {
+		if got[i].Id != want {
+			t.Fatalf("collection %d = %q, want %q", i, got[i].Id, want)
+		}
+	}
+
+	wantRequests := []string{"/collections", "/collections?continuationToken=3"}
+	if len(requests) != len(wantRequests) {
+		t.Fatalf("requests = %v, want %v", requests, wantRequests)
+	}
+	for i, want := range wantRequests {
+		if requests[i] != want {
+			t.Fatalf("request %d = %q, want %q", i, requests[i], want)
+		}
+	}
+}
+
+func TestListAllSinglePageIssuesOneRequest(t *testing.T) {
+	ids := []string{"m1", "m2"}
+	var requests []string
+	srv := httptest.NewServer(pagedHandler(t, ids, 10, &requests))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, srv.Client())
+	got, err := c.ListMembers(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d members, want 2", len(got))
+	}
+	if len(requests) != 1 {
+		t.Fatalf("requests = %v, want a single request when the cursor is null", requests)
+	}
+}
+
+// TestListAllStuckTokenTerminates covers a server that keeps echoing the same
+// cursor. Without the repeat guard the walk would re-fetch the same page for
+// the length of the scan.
+func TestListAllStuckTokenTerminates(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object":            "list",
+			"data":              []map[string]any{{"id": "g1", "name": "g1"}},
+			"continuationToken": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, srv.Client())
+	_, err := c.ListGroups(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for a server that never advances its cursor")
+	}
+	if !strings.Contains(err.Error(), "same continuation token twice") {
+		t.Fatalf("error = %v, want the repeated-cursor error", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2 (the guard must fire on the first repeat)", requests)
+	}
+}
+
+// TestListAllPageCapTerminates covers a server that mints a fresh cursor on
+// every response, which the repeat guard cannot catch.
+func TestListAllPageCapTerminates(t *testing.T) {
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object":            "list",
+			"data":              []map[string]any{{"id": strconv.Itoa(requests), "type": 1, "enabled": false}},
+			"continuationToken": strconv.Itoa(requests),
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, srv.Client())
+	_, err := c.ListPolicies(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for a server that paginates forever")
+	}
+	if !strings.Contains(err.Error(), "did not stop paginating") {
+		t.Fatalf("error = %v, want the page-cap error", err)
+	}
+	if requests != maxListPages {
+		t.Fatalf("requests = %d, want the walk to stop at maxListPages (%d)", requests, maxListPages)
 	}
 }


### PR DESCRIPTION
## The bug

`providers/bitwarden/connection/client.go:79` documented the defect rather
than fixing it:

```go
// Known limitation: the list readers below (ListPolicies, ListMembers,
// ListGroups, ListCollections) return only the first page (out.Data) and do
// not follow ContinuationToken.
type listResponse[T any] struct {
	Object            string  `json:"object"`
	Data              []T     `json:"data"`
	ContinuationToken *string `json:"continuationToken"`
}
```

All four readers had the same shape (`client.go:166`, `:175`, `:202`, `:229`):

```go
func (c *Client) ListMembers(ctx context.Context) ([]Member, error) {
	var out listResponse[Member]
	if err := c.get(ctx, "/members", &out); err != nil {
		return nil, err
	}
	return out.Data, nil   // page 1 only; ContinuationToken discarded
}
```

Confirmed against the official Public API spec
(`bitwarden/docs`, `api/specs/public/swagger.json`): the field is
`continuationToken`, "A cursor for use in pagination", `nullable`, present on
the list envelope of `/public/collections`, `/public/groups`,
`/public/members`, `/public/policies` and `/public/events`, and the cursor is
passed back as the `continuationToken` **query parameter**.

## Why it is wrong

This is a short enumeration that reports success. There is no error, no
partial-result signal, and no way for a caller to tell a complete list from a
truncated one: `bitwarden.members` simply returns fewer members than the
organization has, and every audit built on it (a two-factor sweep, a
collection-permission review) passes on records it never saw.

It has not bitten yet only because these organization-scoped endpoints fit a
whole org in one response today. That is a property of the current server, not
of the contract the client codes against, and it stops holding the moment any
genuinely paginating endpoint is read.

## The fix

A shared `listAll[T]` walk in the client, which all four readers delegate to:

```go
func (c *Client) ListMembers(ctx context.Context) ([]Member, error) {
	return listAll[Member](ctx, c, "/members")
}
```

It repeats the request with `?continuationToken=<value>` until the server
returns a null or empty cursor, and concatenates the pages. Two termination
guards, because a pagination loop that trusts the server is a loop that can
spin for the length of a scan:

- **repeated cursor** (the server echoing back the token it was just given,
  which would re-serve the same page forever) fails with an explicit error
  rather than silently truncating;
- **`maxListPages`** backstops a server that keeps minting fresh cursors.

`listAll` is a free function because Go does not allow type parameters on
methods. The readers keep their exported signatures, so no caller changes.

## Verification

`httptest`, four cases (`connection/client_test.go`):

```
$ cd providers/bitwarden && go test ./connection/ -run 'ListAll' -v
=== RUN   TestListAllFollowsContinuationToken
--- PASS: TestListAllFollowsContinuationToken (0.00s)
=== RUN   TestListAllSinglePageIssuesOneRequest
--- PASS: TestListAllSinglePageIssuesOneRequest (0.00s)
=== RUN   TestListAllStuckTokenTerminates
--- PASS: TestListAllStuckTokenTerminates (0.00s)
=== RUN   TestListAllPageCapTerminates
--- PASS: TestListAllPageCapTerminates (0.07s)
PASS
ok  	go.mondoo.com/mql/providers/bitwarden/connection	0.556s
```

The two-page case also asserts the exact request sequence
(`/collections`, then `/collections?continuationToken=3`), and the single-page
case asserts exactly one request is issued when the cursor is null, so the fix
adds no round trip to today's responses.

The same tests run against the pre-fix reader show the bug they cover:

```
--- FAIL: TestListAllFollowsContinuationToken (0.00s)
    client_test.go:343: got 3 collections, want 5 (short enumeration)
--- FAIL: TestListAllStuckTokenTerminates (0.00s)
    client_test.go:400: expected an error for a server that never advances its cursor
```

Full provider suite:

```
$ cd providers/bitwarden && go build ./... && go test ./...
ok  	go.mondoo.com/mql/providers/bitwarden/connection	0.926s
```

No schema change, so no codegen and no `.lr.versions` entries.

## Not verified against a live target

No Bitwarden tenant is available, so nothing here ran against the real Public
API. What that leaves unproven:

- that a live server's cursor round-trips as the `continuationToken` query
  parameter on the four org-scoped list endpoints. The swagger declares the
  query parameter explicitly only for `/public/events`; for the other four it
  declares the cursor on the response envelope and documents the same
  `?continuationToken=` form in the Public API help. A server that ignored an
  unknown query parameter would re-serve page 1, which the repeated-cursor
  guard turns into a loud error rather than a duplicated list;
- the real page size, and therefore whether any current organization actually
  paginates;
- ordering stability across pages (the walk concatenates in server order and
  does not sort or de-duplicate).
