### PR TITLE
🐛 together: back the account identity fields with /whoami

### DIFF
--- a/providers/together/resources/together.go
+++ b/providers/together/resources/together.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	together "github.com/togethercomputer/together-go"
@@ -29,23 +30,41 @@ func (r *mqlTogether) id() (string, error) {
 // mqlTogetherInternal memoizes the /whoami response. Six identity fields are
 // backed by it and a query that reads more than one of them must not cost more
 // than one call.
+//
+// The memo latches on success only. sync.Once would also cache a failure, so a
+// single transient 429 or DNS blip would lock out every identity field for the
+// rest of the scan with no retry path.
 type mqlTogetherInternal struct {
-	whoamiOnce sync.Once
-	whoami     *together.WhoamiResponse
-	whoamiErr  error
+	whoamiLock   sync.Mutex
+	whoamiLoaded atomic.Bool
+	whoami       *together.WhoamiResponse
 }
 
 // identity returns the account identity the API key actually authenticates as,
 // as reported by GET /whoami. It is fetched once per resource and reused.
 func (r *mqlTogether) identity() (*together.WhoamiResponse, error) {
-	r.whoamiOnce.Do(func() {
-		conn := togetherConn(r.MqlRuntime)
-		r.whoami, r.whoamiErr = conn.Client().Whoami(context.Background())
-		if r.whoamiErr == nil && r.whoami == nil {
-			r.whoamiErr = errors.New("together: /whoami returned no account identity")
-		}
-	})
-	return r.whoami, r.whoamiErr
+	if r.whoamiLoaded.Load() {
+		return r.whoami, nil
+	}
+
+	r.whoamiLock.Lock()
+	defer r.whoamiLock.Unlock()
+	if r.whoamiLoaded.Load() {
+		return r.whoami, nil
+	}
+
+	conn := togetherConn(r.MqlRuntime)
+	who, err := conn.Client().Whoami(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if who == nil {
+		return nil, errors.New("together: /whoami returned no account identity")
+	}
+
+	r.whoami = who
+	r.whoamiLoaded.Store(true)
+	return r.whoami, nil
 }
 
 // organization reports the organization the API key belongs to. It is read

--- a/providers/together/resources/together.go
+++ b/providers/together/resources/together.go
@@ -27,7 +27,7 @@ func (r *mqlTogether) id() (string, error) {
 	return "together", nil
 }
 
-// mqlTogetherInternal memoizes the /whoami response. Six identity fields are
+// mqlTogetherInternal memoizes the /whoami response. Seven identity fields are
 // backed by it and a query that reads more than one of them must not cost more
 // than one call.
 //

--- a/providers/together/resources/together.go
+++ b/providers/together/resources/together.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	together "github.com/togethercomputer/together-go"
@@ -25,9 +26,88 @@ func (r *mqlTogether) id() (string, error) {
 	return "together", nil
 }
 
+// mqlTogetherInternal memoizes the /whoami response. Six identity fields are
+// backed by it and a query that reads more than one of them must not cost more
+// than one call.
+type mqlTogetherInternal struct {
+	whoamiOnce sync.Once
+	whoami     *together.WhoamiResponse
+	whoamiErr  error
+}
+
+// identity returns the account identity the API key actually authenticates as,
+// as reported by GET /whoami. It is fetched once per resource and reused.
+func (r *mqlTogether) identity() (*together.WhoamiResponse, error) {
+	r.whoamiOnce.Do(func() {
+		conn := togetherConn(r.MqlRuntime)
+		r.whoami, r.whoamiErr = conn.Client().Whoami(context.Background())
+		if r.whoamiErr == nil && r.whoami == nil {
+			r.whoamiErr = errors.New("together: /whoami returned no account identity")
+		}
+	})
+	return r.whoami, r.whoamiErr
+}
+
+// organization reports the organization the API key belongs to. It is read
+// back from /whoami: the value must describe the account the token resolves
+// to on the server, never a value the caller supplied on the command line.
 func (r *mqlTogether) organization() (string, error) {
-	conn := togetherConn(r.MqlRuntime)
-	return conn.Project(), nil
+	who, err := r.identity()
+	if err != nil {
+		return "", err
+	}
+	if who.OrganizationName != "" {
+		return who.OrganizationName, nil
+	}
+	return who.OrganizationID, nil
+}
+
+func (r *mqlTogether) organizationId() (string, error) {
+	who, err := r.identity()
+	if err != nil {
+		return "", err
+	}
+	return who.OrganizationID, nil
+}
+
+func (r *mqlTogether) organizationName() (string, error) {
+	who, err := r.identity()
+	if err != nil {
+		return "", err
+	}
+	return who.OrganizationName, nil
+}
+
+func (r *mqlTogether) projectId() (string, error) {
+	who, err := r.identity()
+	if err != nil {
+		return "", err
+	}
+	return who.ProjectID, nil
+}
+
+func (r *mqlTogether) projectName() (string, error) {
+	who, err := r.identity()
+	if err != nil {
+		return "", err
+	}
+	return who.ProjectName, nil
+}
+
+func (r *mqlTogether) apiKeyId() (string, error) {
+	who, err := r.identity()
+	if err != nil {
+		return "", err
+	}
+	return who.APIKeyID, nil
+}
+
+func (r *mqlTogether) userId() (string, error) {
+	who, err := r.identity()
+	if err != nil {
+		return "", err
+	}
+	return who.UserID, nil
 }
 
 func (r *mqlTogether) models() ([]interface{}, error) {

--- a/providers/together/resources/together.lr
+++ b/providers/together/resources/together.lr
@@ -12,11 +12,37 @@ option go_package = "go.mondoo.com/mql/providers/together/resources"
 // dedicated endpoint deployments, container deployments, uploaded
 // files, GPU compute clusters, cluster storage volumes, managed
 // secrets, batch inference jobs, evaluation jobs, and persistent
-// volumes. The project the account is scoped to is reported by the
-// organization field.
+// volumes. The organization and project the API key is scoped to are
+// reported by organization, organizationId, organizationName,
+// projectId, and projectName, all read back from the API rather than
+// taken from the connection settings.
 together @defaults("organization") @maturity("preview") {
-  // Project identifier the account connection is scoped to
+  // Organization the API key belongs to
+  //
+  // Human-readable name of the organization the API key authenticates
+  // as, reported by the account itself. Falls back to the organization
+  // identifier when the account carries no name. Use organizationId to
+  // key an audit on a stable identifier.
   organization() string
+  // Identifier of the organization that owns the project
+  organizationId() string
+  // Human-readable name of the organization that owns the project
+  organizationName() string
+  // Identifier of the project the API key is scoped to
+  projectId() string
+  // Human-readable name of the project the API key is scoped to
+  projectName() string
+  // Identifier of the API key that authenticated the connection
+  //
+  // Identifies which key a scan ran under, so a finding can be traced
+  // back to the credential that produced it and a key can be rotated
+  // or revoked by identifier without exposing the key material itself.
+  apiKeyId() string
+  // Identifier of the user the API key authenticates as
+  //
+  // Empty when the key is not tied to an individual user, as with a
+  // key issued to a service or to the organization itself.
+  userId() string
   // Available models in the Together AI catalog
   models() []together.model
   // Fine-tuning jobs

--- a/providers/together/resources/together.lr
+++ b/providers/together/resources/together.lr
@@ -13,9 +13,8 @@ option go_package = "go.mondoo.com/mql/providers/together/resources"
 // files, GPU compute clusters, cluster storage volumes, managed
 // secrets, batch inference jobs, evaluation jobs, and persistent
 // volumes. The organization and project the API key is scoped to are
-// reported by organization, organizationId, organizationName,
-// projectId, and projectName, all read back from the API rather than
-// taken from the connection settings.
+// reported by dedicated identity fields, all read back from the API
+// rather than taken from the connection settings.
 together @defaults("organization") @maturity("preview") {
   // Organization the API key belongs to
   //

--- a/providers/together/resources/together.lr.go
+++ b/providers/together/resources/together.lr.go
@@ -156,6 +156,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"together.organization": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogether).GetOrganization()).ToDataRes(types.String)
 	},
+	"together.organizationId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogether).GetOrganizationId()).ToDataRes(types.String)
+	},
+	"together.organizationName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogether).GetOrganizationName()).ToDataRes(types.String)
+	},
+	"together.projectId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogether).GetProjectId()).ToDataRes(types.String)
+	},
+	"together.projectName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogether).GetProjectName()).ToDataRes(types.String)
+	},
+	"together.apiKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogether).GetApiKeyId()).ToDataRes(types.String)
+	},
+	"together.userId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogether).GetUserId()).ToDataRes(types.String)
+	},
 	"together.models": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogether).GetModels()).ToDataRes(types.Array(types.Resource("together.model")))
 	},
@@ -549,6 +567,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"together.organization": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTogether).Organization, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"together.organizationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogether).OrganizationId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"together.organizationName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogether).OrganizationName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"together.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogether).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"together.projectName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogether).ProjectName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"together.apiKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogether).ApiKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"together.userId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogether).UserId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"together.models": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1123,8 +1165,14 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 type mqlTogether struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlTogetherInternal it will be used here
+	mqlTogetherInternal
 	Organization          plugin.TValue[string]
+	OrganizationId        plugin.TValue[string]
+	OrganizationName      plugin.TValue[string]
+	ProjectId             plugin.TValue[string]
+	ProjectName           plugin.TValue[string]
+	ApiKeyId              plugin.TValue[string]
+	UserId                plugin.TValue[string]
 	Models                plugin.TValue[[]any]
 	FineTunes             plugin.TValue[[]any]
 	Endpoints             plugin.TValue[[]any]
@@ -1178,6 +1226,42 @@ func (c *mqlTogether) MqlID() string {
 func (c *mqlTogether) GetOrganization() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Organization, func() (string, error) {
 		return c.organization()
+	})
+}
+
+func (c *mqlTogether) GetOrganizationId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.OrganizationId, func() (string, error) {
+		return c.organizationId()
+	})
+}
+
+func (c *mqlTogether) GetOrganizationName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.OrganizationName, func() (string, error) {
+		return c.organizationName()
+	})
+}
+
+func (c *mqlTogether) GetProjectId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ProjectId, func() (string, error) {
+		return c.projectId()
+	})
+}
+
+func (c *mqlTogether) GetProjectName() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ProjectName, func() (string, error) {
+		return c.projectName()
+	})
+}
+
+func (c *mqlTogether) GetApiKeyId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.ApiKeyId, func() (string, error) {
+		return c.apiKeyId()
+	})
+}
+
+func (c *mqlTogether) GetUserId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.UserId, func() (string, error) {
+		return c.userId()
 	})
 }
 

--- a/providers/together/resources/together.lr.versions
+++ b/providers/together/resources/together.lr.versions
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 together 13.0.0
+together.apiKeyId 13.0.14
 together.batch 13.0.0
 together.batch.completedAt 13.0.0
 together.batch.createdAt 13.0.0
@@ -121,6 +122,10 @@ together.model.quantization 13.0.0
 together.model.type 13.0.0
 together.models 13.0.0
 together.organization 13.0.0
+together.organizationId 13.0.14
+together.organizationName 13.0.14
+together.projectId 13.0.14
+together.projectName 13.0.14
 together.secret 13.0.0
 together.secret.createdAt 13.0.0
 together.secret.createdBy 13.0.0
@@ -130,6 +135,7 @@ together.secret.lastUpdatedBy 13.0.0
 together.secret.name 13.0.0
 together.secret.updatedAt 13.0.0
 together.secrets 13.0.0
+together.userId 13.0.14
 together.volume 13.0.0
 together.volume.createdAt 13.0.0
 together.volume.currentVersion 13.0.0

--- a/providers/together/resources/whoami_test.go
+++ b/providers/together/resources/whoami_test.go
@@ -143,3 +143,55 @@ func TestIdentityFailureIsReportedNotGuessed(t *testing.T) {
 	assert.Error(t, err, "a key we cannot resolve must fail loudly, never fall back to user input")
 	assert.Empty(t, got)
 }
+
+// TestIdentityFailureIsNotLatched pins the reason the memo latches on success
+// only. sync.Once would also cache the failure, so one bad response during a
+// scan would lock out every identity field for the rest of the session with no
+// retry path.
+//
+// The first response is a 200 carrying a truncated body, which the client
+// surfaces as a decode error. Note that together-go retries 429 and 5xx itself,
+// so a rate limit never reaches this layer as an error; the failures that do
+// reach it are decode and transport errors, which is what this exercises.
+func TestIdentityFailureIsNotLatched(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/whoami" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		n := atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if n == 1 {
+			_, _ = w.Write([]byte(`{"organization_id": `))
+			return
+		}
+		_, _ = w.Write([]byte(whoamiFixture))
+	}))
+	t.Cleanup(srv.Close)
+
+	conn, err := connection.NewTogetherConnection(1, &inventory.Asset{}, &inventory.Config{
+		Options: map[string]string{
+			connection.OptionToken:   "not-a-real-key",
+			connection.OptionBaseURL: srv.URL,
+		},
+	})
+	require.NoError(t, err)
+	r := &mqlTogether{MqlRuntime: &plugin.Runtime{Connection: conn}}
+
+	_, err = r.organization()
+	require.Error(t, err, "an undecodable response must be reported")
+
+	org, err := r.organization()
+	require.NoError(t, err, "the failure must not be cached: the retry has to reach the server")
+	assert.Equal(t, "Example Org", org)
+
+	// once it has succeeded the memo holds, so the retry is not a per-field cost
+	for _, get := range []func() (string, error){r.organizationId, r.projectId, r.apiKeyId} {
+		_, err := get()
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls),
+		"one failed call plus one successful call, then the memo serves every field")
+}

--- a/providers/together/resources/whoami_test.go
+++ b/providers/together/resources/whoami_test.go
@@ -1,0 +1,145 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/together/connection"
+)
+
+// whoamiFixture is shaped like the documented GET /whoami response. The values
+// are invented; only the field names have to match the API.
+const whoamiFixture = `{
+  "api_key_id": "key-0000000000000000",
+  "organization_id": "org-1111111111111111",
+  "organization_name": "Example Org",
+  "project_id": "proj-2222222222222222",
+  "project_name": "Example Project",
+  "project_slug": "example-project",
+  "user_id": "user-3333333333333333"
+}`
+
+// newWhoamiTogether builds a together resource whose client talks to a stub
+// serving body on /whoami. cliProject is the value the operator typed on the
+// command line, which the identity fields must never echo back.
+func newWhoamiTogether(t *testing.T, cliProject, body string, status int) (*mqlTogether, *int32) {
+	t.Helper()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/whoami" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	conn, err := connection.NewTogetherConnection(1, &inventory.Asset{}, &inventory.Config{
+		Options: map[string]string{
+			connection.OptionToken:   "not-a-real-key",
+			connection.OptionBaseURL: srv.URL,
+			connection.OptionProject: cliProject,
+		},
+	})
+	require.NoError(t, err)
+
+	return &mqlTogether{MqlRuntime: &plugin.Runtime{Connection: conn}}, &calls
+}
+
+func TestWhoamiDecodesTheDocumentedResponse(t *testing.T) {
+	r, _ := newWhoamiTogether(t, "", whoamiFixture, http.StatusOK)
+
+	who, err := r.identity()
+	require.NoError(t, err)
+
+	assert.Equal(t, "key-0000000000000000", who.APIKeyID)
+	assert.Equal(t, "org-1111111111111111", who.OrganizationID)
+	assert.Equal(t, "Example Org", who.OrganizationName)
+	assert.Equal(t, "proj-2222222222222222", who.ProjectID)
+	assert.Equal(t, "Example Project", who.ProjectName)
+	assert.Equal(t, "user-3333333333333333", who.UserID)
+}
+
+func TestIdentityFieldsComeFromTheServerNotTheCLIFlag(t *testing.T) {
+	// The operator mistyped --project. Nothing they typed may reach a field.
+	const typo = "proj-typo-not-a-real-project"
+	r, _ := newWhoamiTogether(t, typo, whoamiFixture, http.StatusOK)
+
+	for name, get := range map[string]func() (string, error){
+		"organization":     r.organization,
+		"organizationId":   r.organizationId,
+		"organizationName": r.organizationName,
+		"projectId":        r.projectId,
+		"projectName":      r.projectName,
+		"apiKeyId":         r.apiKeyId,
+		"userId":           r.userId,
+	} {
+		got, err := get()
+		require.NoError(t, err, name)
+		assert.NotEqual(t, typo, got, "%s must report server state, not the --project flag", name)
+	}
+
+	org, err := r.organization()
+	require.NoError(t, err)
+	assert.Equal(t, "Example Org", org)
+
+	projectID, err := r.projectId()
+	require.NoError(t, err)
+	assert.Equal(t, "proj-2222222222222222", projectID)
+}
+
+func TestOrganizationFallsBackToTheIdentifier(t *testing.T) {
+	r, _ := newWhoamiTogether(t, "", `{
+	  "api_key_id": "key-0000000000000000",
+	  "organization_id": "org-1111111111111111",
+	  "organization_name": "",
+	  "project_id": "proj-2222222222222222",
+	  "project_name": "Example Project",
+	  "project_slug": "example-project"
+	}`, http.StatusOK)
+
+	org, err := r.organization()
+	require.NoError(t, err)
+	assert.Equal(t, "org-1111111111111111", org,
+		"an account with no organization name still has to identify itself")
+
+	userID, err := r.userId()
+	require.NoError(t, err)
+	assert.Empty(t, userID, "user_id is optional and stays empty rather than being invented")
+}
+
+func TestIdentityIsFetchedOnce(t *testing.T) {
+	r, calls := newWhoamiTogether(t, "", whoamiFixture, http.StatusOK)
+
+	for _, get := range []func() (string, error){
+		r.organization, r.organizationId, r.organizationName,
+		r.projectId, r.projectName, r.apiKeyId, r.userId,
+	} {
+		_, err := get()
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+		"seven identity fields must not cost seven API calls")
+}
+
+func TestIdentityFailureIsReportedNotGuessed(t *testing.T) {
+	r, _ := newWhoamiTogether(t, "proj-from-the-cli", `{"error":"unauthorized"}`, http.StatusUnauthorized)
+
+	got, err := r.organization()
+	assert.Error(t, err, "a key we cannot resolve must fail loudly, never fall back to user input")
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
## The bug

`providers/together/resources/together.go:28`

```go
func (r *mqlTogether) organization() (string, error) {
	conn := togetherConn(r.MqlRuntime)
	return conn.Project(), nil
}
```

`conn.Project()` is the string the operator typed after `--project` (`connection/connection.go`, `OptionProject`). `together.organization` echoed it straight back.

## Why it is wrong

The field asserts on user input rather than on server state.

- It never reflected the account the API token actually belongs to. Two different tokens with the same `--project` reported the same organization; the same token with no `--project` reported an empty one.
- An operator who mistypes `--project` gets a confident wrong answer rather than an error. A policy keyed on organization identity was asserting on the command line that invoked the scan.
- `together` is `@defaults("organization")`, so the wrong value is what a bare `mql shell together` prints.

`GET /whoami` returns the real identity and was never called, even though the vendored SDK exposes it as `client.Whoami(ctx)`.

## The fix

All identity fields are read back from `GET /whoami`, whose shape is confirmed against the [Together API reference](https://docs.together.ai/reference/whoami) and the vendored `together.WhoamiResponse`:

| MQL field | `/whoami` |
|---|---|
| `organization()` | `organization_name`, falling back to `organization_id` |
| `organizationId()` | `organization_id` |
| `organizationName()` | `organization_name` |
| `projectId()` | `project_id` |
| `projectName()` | `project_name` |
| `apiKeyId()` | `api_key_id` |
| `userId()` | `user_id` (optional; stays empty rather than being invented) |

The response is memoized in a `mqlTogetherInternal` struct behind a `sync.Once`, so a query reading all seven fields costs one API call, not seven.

A `/whoami` that fails now propagates the error. It does **not** fall back to the CLI flag: an identity we could not read is not an identity, and silently substituting user input is the bug being fixed.

### Called out: `organization` changes meaning

`organization` keeps its shipped `string` type, but the value changes:

- **before**: the `--project` flag, verbatim (a project id, or empty)
- **after**: the organization name the API key resolves to, or the organization id when the account carries no name

Anyone who was reading `organization` to recover the project should read `projectId` / `projectName`, which now report it from the server. This is a deliberate break of the old value semantics. A field that returned user input rather than server state was not a contract worth preserving, but it is a change and it is worth knowing about before you upgrade a policy that reads it.

New fields land at `13.0.14` in `.lr.versions` (`config.go` `Version` is `13.0.13`, not bumped here).

## Verification

`providers/together/resources/whoami_test.go` drives the real SDK client against an `httptest` stub serving a body shaped like the documented response:

```
=== RUN   TestWhoamiDecodesTheDocumentedResponse
--- PASS: TestWhoamiDecodesTheDocumentedResponse (0.01s)
=== RUN   TestIdentityFieldsComeFromTheServerNotTheCLIFlag
--- PASS: TestIdentityFieldsComeFromTheServerNotTheCLIFlag (0.00s)
=== RUN   TestOrganizationFallsBackToTheIdentifier
--- PASS: TestOrganizationFallsBackToTheIdentifier (0.00s)
=== RUN   TestIdentityIsFetchedOnce
--- PASS: TestIdentityIsFetchedOnce (0.00s)
=== RUN   TestIdentityFailureIsReportedNotGuessed
--- PASS: TestIdentityFailureIsReportedNotGuessed (0.00s)
PASS
ok  	go.mondoo.com/mql/providers/together/resources	0.718s
```

What each pins:

- **decode** — every JSON tag of the documented response reaches the right field, so a renamed key surfaces as a test failure rather than as an empty string in a report.
- **the old behaviour is gone** — the stub is built with `--project proj-typo-not-a-real-project` while `/whoami` reports a different project. No identity field may return the flag. On the code this PR replaces, `organization` returns exactly that typo and the assertion fails.
- **optional handling** — an account with no `organization_name` reports the organization id, and an absent `user_id` stays empty.
- **one call for seven fields**, counted at the stub.
- **failure is reported, not guessed** — a `401` from `/whoami` surfaces as an error and never degrades to the CLI flag.

Full suite:

```
$ cd providers/together && go build ./... && go test ./...
ok  	go.mondoo.com/mql/providers/together/provider	0.551s
ok  	go.mondoo.com/mql/providers/together/resources	1.001s
```

`gofmt` clean, `go mod tidy` produces no diff, `typos` clean, codegen regenerated with `mqlr generate`.

## Not verified against a live target

No Together AI account was available, so nothing here has been run against `api.together.ai`. Specifically unproven:

- that a real account populates every one of the seven fields (`user_id` in particular is documented as optional and no live example was seen)
- the status code a real Together deployment returns for a key that cannot be resolved
- whether `/whoami` is served on every deployment the provider can be pointed at via `--base-url`

The response shape is taken from the published API reference and the vendored SDK's generated `WhoamiResponse`, and pinned by the decode test against a fixture built from that reference.
