### PR TITLE
🐛 mysqldb: derive hasPassword without moving the password hash

### DIFF
--- a/providers/mysqldb/resources/mysqldb_test.go
+++ b/providers/mysqldb/resources/mysqldb_test.go
@@ -3,7 +3,11 @@
 
 package resources
 
-import "testing"
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
 
 func TestIsYes(t *testing.T) {
 	for _, s := range []string{"YES", "Y", "ON", "1"} {
@@ -40,5 +44,114 @@ func TestIdentifierBuilders(t *testing.T) {
 	c := privilegeResourceID("p", "TABLE", "appdb", "t1", "SELECT")
 	if a == b || b == c || a == c {
 		t.Errorf("privilegeResourceID collides: %q %q %q", a, b, c)
+	}
+}
+
+// The hasPassword field must be derived from a server-side emptiness test, so
+// that mysql.user.authentication_string (the credential) never crosses the
+// connection. These tests pin both halves of that: the SQL projection and the
+// mapping of its result.
+
+func TestHasPasswordExprDoesNotSelectTheCredential(t *testing.T) {
+	for _, alias := range []string{"", "u."} {
+		expr := hasPasswordExpr(alias)
+		want := "LENGTH(COALESCE(" + alias + "authentication_string, '')) > 0"
+		if expr != want {
+			t.Errorf("hasPasswordExpr(%q) = %q, want %q", alias, expr, want)
+		}
+		// the column may only appear inside LENGTH(), never as a bare
+		// projection that would transfer the hash itself
+		if !strings.Contains(expr, "LENGTH(") {
+			t.Errorf("hasPasswordExpr(%q) = %q, must project through LENGTH", alias, expr)
+		}
+	}
+}
+
+func TestUserColumnsNeverProjectsTheCredential(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		alias   string
+		mariadb bool
+	}{
+		{"mysql", "", false},
+		{"mysql aliased", "u.", false},
+		{"mariadb", "", true},
+		{"mariadb aliased", "u.", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cols := userColumns(tc.alias, tc.mariadb)
+			// every mention of the credential column must be wrapped in the
+			// length comparison; a bare COALESCE(...) would ship the hash
+			if strings.Contains(cols, "COALESCE("+tc.alias+"authentication_string, ''),") {
+				t.Errorf("userColumns projects the raw credential: %s", cols)
+			}
+			if !strings.Contains(cols, hasPasswordExpr(tc.alias)) {
+				t.Errorf("userColumns missing hasPassword projection: %s", cols)
+			}
+			if n := strings.Count(cols, "authentication_string"); n != 1 {
+				t.Errorf("authentication_string appears %d times, want 1: %s", n, cols)
+			}
+		})
+	}
+}
+
+// countSelectColumns counts comma-separated projections at parenthesis depth
+// zero, so commas inside COALESCE() and LENGTH() do not inflate the count.
+func countSelectColumns(list string) int {
+	depth, n := 0, 1
+	for _, r := range list {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func TestUserColumnsCountMatchesScan(t *testing.T) {
+	// the scan targets in scanMysqldbUser are positional, so replacing the
+	// credential projection must keep the column count intact
+	if got := countSelectColumns(userColumns("", false)); got != 11 {
+		t.Errorf("mysql userColumns has %d columns, want 11", got)
+	}
+	if got := countSelectColumns(userColumns("u.", false)); got != 11 {
+		t.Errorf("aliased mysql userColumns has %d columns, want 11", got)
+	}
+	if got := countSelectColumns(userColumns("", true)); got != 8 {
+		t.Errorf("mariadb userColumns has %d columns, want 8", got)
+	}
+	if got := countSelectColumns(userColumns("u.", true)); got != 8 {
+		t.Errorf("aliased mariadb userColumns has %d columns, want 8", got)
+	}
+}
+
+func TestHasPasswordValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   sql.NullInt64
+		want bool
+	}{
+		// a hashing plugin with a credential set: caching_sha2_password,
+		// mysql_native_password, ed25519 -> non-empty -> 1
+		{"password set", sql.NullInt64{Int64: 1, Valid: true}, true},
+		// CREATE USER with no IDENTIFIED BY, and the socket plugins
+		// (auth_socket / unix_socket), both store an empty string -> 0
+		{"no password", sql.NullInt64{Int64: 0, Valid: true}, false},
+		// COALESCE rules this out, but a NULL must read as "no password"
+		// rather than erroring or reporting a credential
+		{"null", sql.NullInt64{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasPasswordValue(tc.in); got != tc.want {
+				t.Errorf("hasPasswordValue(%+v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/providers/mysqldb/resources/users.go
+++ b/providers/mysqldb/resources/users.go
@@ -12,23 +12,45 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
+// hasPasswordExpr is the server-side projection behind the hasPassword field.
+//
+// mysql.user.authentication_string holds the account's credential (a password
+// hash for the hashing plugins, empty otherwise). hasPassword only needs to
+// know whether one is set, so the emptiness test is evaluated by the server and
+// nothing but the resulting boolean crosses the connection. COALESCE keeps a
+// NULL column reading as "no password", matching the pre-existing behavior.
+//
+// On MariaDB 10.4+ mysql.user is a view over mysql.global_priv whose
+// authentication_string is itself a COALESCE expression, so it is never NULL
+// and LENGTH over it behaves exactly as it does on MySQL.
+func hasPasswordExpr(alias string) string {
+	return fmt.Sprintf("LENGTH(COALESCE(%sauthentication_string, '')) > 0", alias)
+}
+
 // userColumns returns the mysql.user SELECT list for a flavor, with an optional
 // table alias applied to each column (for joins).
 func userColumns(alias string, mariadb bool) string {
 	if mariadb {
-		return fmt.Sprintf(`%[1]sUser, %[1]sHost, COALESCE(%[1]splugin, ''), COALESCE(%[1]sauthentication_string, ''),
+		return fmt.Sprintf(`%[1]sUser, %[1]sHost, COALESCE(%[1]splugin, ''), %[2]s,
 			COALESCE(%[1]sssl_type, ''), %[1]smax_connections, %[1]smax_user_connections,
-			COALESCE(%[1]spassword_expired, 'N')`, alias)
+			COALESCE(%[1]spassword_expired, 'N')`, alias, hasPasswordExpr(alias))
 	}
-	return fmt.Sprintf(`%[1]sUser, %[1]sHost, COALESCE(%[1]splugin, ''), COALESCE(%[1]sauthentication_string, ''),
+	return fmt.Sprintf(`%[1]sUser, %[1]sHost, COALESCE(%[1]splugin, ''), %[2]s,
 		COALESCE(%[1]sssl_type, ''), %[1]smax_connections, %[1]smax_user_connections,
 		COALESCE(%[1]spassword_expired, 'N'), COALESCE(%[1]saccount_locked, 'N'),
-		%[1]spassword_lifetime, %[1]spassword_last_changed`, alias)
+		%[1]spassword_lifetime, %[1]spassword_last_changed`, alias, hasPasswordExpr(alias))
+}
+
+// hasPasswordValue maps the scanned hasPasswordExpr result to the field value.
+// The comparison comes back as 1/0; a NULL (which COALESCE already rules out)
+// reads as "no password" rather than becoming an error.
+func hasPasswordValue(v sql.NullInt64) bool {
+	return v.Valid && v.Int64 > 0
 }
 
 // buildMysqldbUser creates a user resource. Fields unavailable on the flavor are
 // passed as nil/invalid and rendered as null.
-func buildMysqldbUser(runtime *plugin.Runtime, serverID, user, host, authPlugin, authString, sslType string,
+func buildMysqldbUser(runtime *plugin.Runtime, serverID, user, host, authPlugin, sslType string, hasPassword bool,
 	maxConn, maxUserConn int64, passwordExpired string,
 	accountLocked *string, passwordLifetime sql.NullInt64, passwordLastChanged sql.NullTime) (*mqlMysqldbUser, error) {
 	fields := map[string]*llx.RawData{
@@ -36,7 +58,7 @@ func buildMysqldbUser(runtime *plugin.Runtime, serverID, user, host, authPlugin,
 		"user":               llx.StringData(user),
 		"host":               llx.StringData(host),
 		"authPlugin":         llx.StringData(authPlugin),
-		"hasPassword":        llx.BoolData(authString != ""),
+		"hasPassword":        llx.BoolData(hasPassword),
 		"isAnonymous":        llx.BoolData(user == ""),
 		"isWildcardHost":     llx.BoolData(host == "%"),
 		"passwordExpired":    llx.BoolData(isYes(passwordExpired)),
@@ -69,23 +91,24 @@ func buildMysqldbUser(runtime *plugin.Runtime, serverID, user, host, authPlugin,
 }
 
 func scanMysqldbUser(runtime *plugin.Runtime, serverID string, rows *sql.Rows, mariadb bool) (*mqlMysqldbUser, error) {
-	var user, host, plugin, authString, sslType, passwordExpired string
+	var user, host, plugin, sslType, passwordExpired string
+	var hasPassword sql.NullInt64
 	var maxConn, maxUserConn int64
 	if mariadb {
-		if err := rows.Scan(&user, &host, &plugin, &authString, &sslType, &maxConn, &maxUserConn, &passwordExpired); err != nil {
+		if err := rows.Scan(&user, &host, &plugin, &hasPassword, &sslType, &maxConn, &maxUserConn, &passwordExpired); err != nil {
 			return nil, err
 		}
-		return buildMysqldbUser(runtime, serverID, user, host, plugin, authString, sslType,
+		return buildMysqldbUser(runtime, serverID, user, host, plugin, sslType, hasPasswordValue(hasPassword),
 			maxConn, maxUserConn, passwordExpired, nil, sql.NullInt64{}, sql.NullTime{})
 	}
 	var accountLocked string
 	var passwordLifetime sql.NullInt64
 	var passwordLastChanged sql.NullTime
-	if err := rows.Scan(&user, &host, &plugin, &authString, &sslType, &maxConn, &maxUserConn,
+	if err := rows.Scan(&user, &host, &plugin, &hasPassword, &sslType, &maxConn, &maxUserConn,
 		&passwordExpired, &accountLocked, &passwordLifetime, &passwordLastChanged); err != nil {
 		return nil, err
 	}
-	return buildMysqldbUser(runtime, serverID, user, host, plugin, authString, sslType,
+	return buildMysqldbUser(runtime, serverID, user, host, plugin, sslType, hasPasswordValue(hasPassword),
 		maxConn, maxUserConn, passwordExpired, &accountLocked, passwordLifetime, passwordLastChanged)
 }
 


### PR DESCRIPTION
## The defect

`providers/mysqldb/resources/users.go:19` and `:23` selected the account's credential in full:

```sql
SELECT User, Host, COALESCE(plugin, ''), COALESCE(authentication_string, ''),
    COALESCE(ssl_type, ''), ...
FROM mysql.user
```

`mysql.user.authentication_string` holds the account's password hash. The only thing the provider did with it was `users.go:39`:

```go
"hasPassword": llx.BoolData(authString != ""),
```

**The hash is not exposed through the schema** — `mysqldb.user` has no field carrying it, and that part was already correct. But it still left the server, crossed the network, and landed in the scanning process's memory, purely to answer a yes/no question the server can answer itself.

## Why it matters

A credential that is read but never reported is still a credential in the address space of a long-running process. From there it can reach:

- a crash dump or core file,
- a debug/trace log of the driver or the row buffer,
- a recording made by the provider recording/replay system, which persists resource traffic to disk.

None of those are hypothetical failure modes for a scanner that runs unattended across a fleet. The value being derived (`hasPassword`) is one bit, and MySQL can compute it without handing anything over.

## The fix

Project the emptiness test server-side, so only the resulting boolean crosses the connection:

```sql
LENGTH(COALESCE(authentication_string, '')) > 0
```

Why this is sufficient and exactly equivalent:

- `hasPassword` was previously `authString != ""` over `COALESCE(authentication_string, '')`. `LENGTH(x) > 0` is true on precisely the same set of values, and the `COALESCE` is retained so a NULL column still reads as "no password" rather than erroring.
- **Passwordless accounts** and **`auth_socket` / `unix_socket` accounts** both store the empty string, not NULL, so both continue to report `hasPassword: false`. Verified live on both engines (see below).
- **MariaDB.** On 10.4+ `mysql.user` is a *view* over `mysql.global_priv`, so the column shape genuinely differs. Confirmed against MariaDB 11.8.8 that the view's `authentication_string` is itself a `COALESCE(...)` expression (`information_schema.VIEWS` shows it ending `'') AS authentication_string`), so it is never NULL and `LENGTH` over it behaves exactly as on MySQL. The provider's existing MariaDB/MySQL column-list split is unchanged.

The credential column now appears exactly once in the projection, wrapped in `LENGTH()`, on every flavor and both the plain and JOIN-aliased forms.

Documentation: [MySQL 8.0 — Grant Tables](https://dev.mysql.com/doc/refman/8.0/en/grant-tables.html) ("The `user` table `plugin` and `authentication_string` columns store authentication plugin and credential information."). The empty-vs-NULL behaviour for passwordless and socket-auth accounts is not spelled out in the manual, so it was established empirically against both engines rather than assumed.

## Verification

Live, against containerised **MySQL 8.0.46** and **MariaDB 11.8.8**, with accounts covering every branch: a password account (`caching_sha2_password` / native), a passwordless account, a `mysql_native_password` account, and a socket-auth account (`auth_socket` on MySQL, `unix_socket` on MariaDB).

### Output is byte-identical before and after

This is a data-handling change whose whole claim is that nothing observable changes, so that is what is shown — not merely that it runs. Same query, provider built from `main` vs. from this branch:

```
$ PROVIDERS_PATH=... mql run mysqldb --host 127.0.0.1 --port ... --user root -p ... \
    --discover none -c "mysqldb.instance.users { user host authPlugin hasPassword }"

$ diff mysql8-before.txt mysql8-after.txt      # no output
$ diff mariadb-before.txt mariadb-after.txt    # no output

$ shasum -a 256 mysql8-*.txt mariadb-*.txt
5e80fa514924711e5bc4ff8ffa9b8cc5ed48a1a39eeea3cea65d35db43e53d1c  mysql8-after.txt
5e80fa514924711e5bc4ff8ffa9b8cc5ed48a1a39eeea3cea65d35db43e53d1c  mysql8-before.txt
4dd363d3c0920de826323ae4f3d0df41f382ea935c0f73b01cedab205baa10e0  mariadb-after.txt
4dd363d3c0920de826323ae4f3d0df41f382ea935c0f73b01cedab205baa10e0  mariadb-before.txt
```

The MySQL result set, unchanged across the fix (both socket and passwordless accounts correctly `false`):

```
native_user  %          mysql_native_password   hasPassword: true
nopw_user    %          caching_sha2_password   hasPassword: false
pw_user      %          caching_sha2_password   hasPassword: true
root         %          caching_sha2_password   hasPassword: true
sock_user    localhost  auth_socket             hasPassword: false
```

### The credential column is no longer requested

Both containers ran with the general query log enabled (`--general-log=1`).

**Before** (provider built from `main`):

```
Query   SELECT User, Host, COALESCE(plugin, ''), COALESCE(authentication_string, ''),
        COALESCE(ssl_type, ''), max_connections, max_user_connections,
        COALESCE(password_expired, 'N'), COALESCE(account_locked, 'N'),
        password_lifetime, password_last_changed FROM mysql.user ORDER BY User, Host
```

**After** (this branch) — MySQL 8.0:

```
Query   SELECT User, Host, COALESCE(plugin, ''), LENGTH(COALESCE(authentication_string, '')) > 0,
        COALESCE(ssl_type, ''), max_connections, max_user_connections,
        COALESCE(password_expired, 'N'), COALESCE(account_locked, 'N'),
        password_lifetime, password_last_changed FROM mysql.user ORDER BY User, Host
```

**After** — MariaDB 11.8:

```
Query   SELECT User, Host, COALESCE(plugin, ''), LENGTH(COALESCE(authentication_string, '')) > 0,
        COALESCE(ssl_type, ''), max_connections, max_user_connections,
        COALESCE(password_expired, 'N') FROM mysql.user ORDER BY User, Host
```

Count of bare `COALESCE(authentication_string, ''),` projections in the newest emitted query: **0** on both engines.

### Tests

New unit tests cover the projection and every branch of the derived value, including the socket-auth and passwordless cases and a NULL that `COALESCE` already rules out. They also assert the credential column can never reappear as a bare projection, and that the column count still matches the positional scan (counted at parenthesis depth zero, so commas inside `COALESCE()` do not skew it).

```
$ cd providers/mysqldb && gofmt -l resources/ && go vet ./... && go build ./... && go test ./...
?   	go.mondoo.com/mql/providers/mysqldb	[no test files]
?   	go.mondoo.com/mql/providers/mysqldb/config	[no test files]
ok  	go.mondoo.com/mql/providers/mysqldb/connection	0.874s
?   	go.mondoo.com/mql/providers/mysqldb/gen	[no test files]
?   	go.mondoo.com/mql/providers/mysqldb/provider	[no test files]
ok  	go.mondoo.com/mql/providers/mysqldb/resources	0.845s

$ go test ./resources/ -run 'TestHasPassword|TestUserColumns' -v
--- PASS: TestHasPasswordExprDoesNotSelectTheCredential (0.00s)
--- PASS: TestUserColumnsNeverProjectsTheCredential (0.00s)
    --- PASS: .../mysql   .../mysql_aliased   .../mariadb   .../mariadb_aliased
--- PASS: TestUserColumnsCountMatchesScan (0.00s)
--- PASS: TestHasPasswordValue (0.00s)
    --- PASS: .../password_set   .../no_password   .../null
ok  	go.mondoo.com/mql/providers/mysqldb/resources	0.487s
```

No real credential material appears in any test fixture, commit, or log excerpt in this branch.

## Scope

No schema change, so no `.lr` edit, no codegen, and no `.lr.versions` entries; `git status` is clean apart from the two touched Go files. `hasPassword` keeps its type and its meaning, and the provider `Version` in `config/config.go` is untouched.
