### PR TITLE
🐛 ollama: probe write auth, not just read auth

### DIFF
--- a/providers/ollama/connection/connection.go
+++ b/providers/ollama/connection/connection.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -139,14 +140,53 @@ func (c *OllamaConnection) Version(ctx context.Context) (string, error) {
 	return c.version, c.versionErr
 }
 
+// writeProbeBody is the body of the unauthenticated write probe. It is
+// truncated JSON: the object is opened and a key is started, then the bytes
+// stop. No JSON decoder can parse it, so no field of a create request, above
+// all no model name, can be read out of it. The key names the probe so an
+// operator reading their server log can see what sent it.
+const writeProbeBody = `{"mondoo_write_auth_probe":`
+
 // AnonymousStatus issues a read-only request with no credentials attached and
 // returns the HTTP status code the instance answers with. It deliberately uses
 // the model listing endpoint: it is a plain GET that changes nothing, so the
 // probe cannot alter the instance it is auditing.
 func (c *OllamaConnection) AnonymousStatus(ctx context.Context) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL.JoinPath("/api/tags").String(), nil)
+	return c.anonymousStatus(ctx, http.MethodGet, "/api/tags", "")
+}
+
+// AnonymousWriteStatus reports the HTTP status an unauthenticated caller gets
+// from the model-creation endpoint, which is what decides whether a stranger
+// can replace the weights this instance serves.
+//
+// The probe cannot create, pull, or delete anything. It posts a body that is
+// not valid JSON, and /api/create decodes its body before it does anything
+// else: a body that fails to decode is answered 400 by the handler's first
+// branch, with no model named and no state touched. Deleting and pulling are
+// never attempted at all, because both take a model name and there is no
+// malformed form of those requests that is safe to send.
+//
+// A server that gates writes rejects the request before its body is ever
+// looked at, so its answer (401, 403, 407) is distinguishable from the 400 a
+// server that accepts anonymous writes returns for the unparseable body.
+func (c *OllamaConnection) AnonymousWriteStatus(ctx context.Context) (int, error) {
+	return c.anonymousStatus(ctx, http.MethodPost, "/api/create", writeProbeBody)
+}
+
+// anonymousStatus issues one request with no credentials attached and returns
+// the status code the instance answers with.
+func (c *OllamaConnection) anonymousStatus(ctx context.Context, method, path, body string) (int, error) {
+	var payload io.Reader
+	if body != "" {
+		payload = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL.JoinPath(path).String(), payload)
 	if err != nil {
 		return 0, err
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	// A fresh client, so the token-bearing transport cannot be reached.

--- a/providers/ollama/connection/connection_test.go
+++ b/providers/ollama/connection/connection_test.go
@@ -4,6 +4,8 @@
 package connection
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -101,4 +103,65 @@ func TestVersionIsFetchedOnce(t *testing.T) {
 		assert.Equal(t, "0.12.6", version)
 	}
 	assert.Equal(t, 1, calls, "asset detection and the version field share a single call")
+}
+
+func TestAnonymousWriteStatusCannotMutate(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+		gotBody   []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	conn := testConnection(t, srv.URL, func(c *inventory.Config) {
+		c.Options[TokenOption] = "a-token-the-probe-must-not-send"
+	})
+
+	code, err := conn.AnonymousWriteStatus(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, code)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/create", gotPath,
+		"the probe must go to the creation endpoint, never to delete or pull")
+	assert.Empty(t, gotAuth, "the probe must be unauthenticated or it proves nothing")
+
+	// The body is what makes the probe safe: it cannot be decoded, so no model
+	// name, file, or digest can be read out of it.
+	var decoded any
+	assert.Error(t, json.Unmarshal(gotBody, &decoded),
+		"the probe body must not be valid JSON, or the server could act on it")
+	assert.NotContains(t, string(gotBody), "model",
+		"the probe body must not name a model under any key")
+}
+
+func TestAnonymousWriteStatusGatedInstance(t *testing.T) {
+	var reached bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	code, err := testConnection(t, srv.URL).AnonymousWriteStatus(t.Context())
+	require.NoError(t, err)
+	assert.True(t, reached)
+	assert.Equal(t, http.StatusUnauthorized, code)
+}
+
+func TestAnonymousWriteStatusUnreachableHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	_, err := testConnection(t, url).AnonymousWriteStatus(t.Context())
+	assert.Error(t, err, "a transport failure must surface, never read as writes being open")
 }

--- a/providers/ollama/resources/ollama.go
+++ b/providers/ollama/resources/ollama.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,23 +46,54 @@ func (r *mqlOllama) isLocal() (bool, error) {
 	return ollamaConn(r.MqlRuntime).IsLocal(), nil
 }
 
+// authRequiredStatuses are the answers that mean the request was refused for
+// lack of credentials, whoever refused it: the instance itself, or a proxy in
+// front of it.
+var authRequiredStatuses = []int{
+	http.StatusUnauthorized,
+	http.StatusForbidden,
+	http.StatusProxyAuthRequired,
+}
+
+// readOpenStatuses are the answers that mean an unauthenticated read was
+// served.
+var readOpenStatuses = []int{http.StatusOK}
+
+// writeOpenStatuses are the answers that mean an unauthenticated write reached
+// the instance's own handler and was turned away only because the probe's body
+// is unparseable. Nothing stood between the caller and the write path, so a
+// well-formed request from the same caller would have been carried out.
+var writeOpenStatuses = []int{http.StatusBadRequest, http.StatusUnprocessableEntity}
+
+// classifyAuthProbe turns the status an unauthenticated probe was answered with
+// into whether that access path demands credentials. Anything outside the two
+// known sets (a redirect to a login page, a gateway error, an endpoint the
+// instance does not serve) says nothing reliable, and guessing either way would
+// be worse than reporting that we could not tell.
+func classifyAuthProbe(code int, openStatuses []int, access string) (bool, error) {
+	if slices.Contains(authRequiredStatuses, code) {
+		return true, nil
+	}
+	if slices.Contains(openStatuses, code) {
+		return false, nil
+	}
+	return false, fmt.Errorf("cannot determine whether %s authentication is required: unauthenticated request answered with status %d", access, code)
+}
+
 func (r *mqlOllama) authenticationRequired() (bool, error) {
 	code, err := ollamaConn(r.MqlRuntime).AnonymousStatus(context.Background())
 	if err != nil {
 		return false, err
 	}
+	return classifyAuthProbe(code, readOpenStatuses, "read")
+}
 
-	switch code {
-	case http.StatusOK:
-		return false, nil
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusProxyAuthRequired:
-		return true, nil
+func (r *mqlOllama) writeAuthenticationRequired() (bool, error) {
+	code, err := ollamaConn(r.MqlRuntime).AnonymousWriteStatus(context.Background())
+	if err != nil {
+		return false, err
 	}
-
-	// Anything else (a redirect to a login page, a gateway error) says nothing
-	// reliable about the instance's own authentication, and guessing either way
-	// would be worse than reporting that we could not tell.
-	return false, fmt.Errorf("cannot determine whether authentication is required: unauthenticated request answered with status %d", code)
+	return classifyAuthProbe(code, writeOpenStatuses, "write")
 }
 
 func (r *mqlOllama) cloudEnabled() (bool, error) {
@@ -148,6 +180,13 @@ func (r *mqlOllama) models() ([]interface{}, error) {
 		mqlModel, err := CreateResource(r.MqlRuntime, "ollama.model", ollamaModelArgs(m))
 		if err != nil {
 			return nil, err
+		}
+		if len(m.Capabilities) > 0 {
+			model := mqlModel.(*mqlOllamaModel)
+			model.listCapabilities = make([]string, len(m.Capabilities))
+			for i, c := range m.Capabilities {
+				model.listCapabilities[i] = string(c)
+			}
 		}
 		res = append(res, mqlModel)
 	}
@@ -286,6 +325,13 @@ type mqlOllamaModelInternal struct {
 	fetched bool
 	show    *api.ShowResponse
 	lock    sync.Mutex
+
+	// listCapabilities holds the capabilities the model listing already
+	// reported, so reading the capabilities field costs nothing extra. Nil when
+	// the listing did not carry them, which is how a server older than the field
+	// answers and how a model reached by cross-reference rather than by listing
+	// arrives; the per-model Show call is then still made.
+	listCapabilities []string
 }
 
 func (r *mqlOllamaModel) fetchShow() (*api.ShowResponse, error) {
@@ -394,6 +440,17 @@ func (r *mqlOllamaModel) template() (string, error) {
 }
 
 func (r *mqlOllamaModel) capabilities() ([]interface{}, error) {
+	// The model listing reports capabilities, so asking every model to describe
+	// itself again would cost one extra request per installed model on a query
+	// that is often the whole point of the scan.
+	if len(r.listCapabilities) > 0 {
+		caps := make([]interface{}, len(r.listCapabilities))
+		for i, c := range r.listCapabilities {
+			caps[i] = c
+		}
+		return caps, nil
+	}
+
 	show, err := r.fetchShow()
 	if err != nil {
 		return nil, err
@@ -403,6 +460,32 @@ func (r *mqlOllamaModel) capabilities() ([]interface{}, error) {
 		caps[i] = string(c)
 	}
 	return caps, nil
+}
+
+// parameters returns the PARAMETER block of the model's Modelfile verbatim, the
+// runtime defaults the server applies to every request for this model.
+func (r *mqlOllamaModel) parameters() (string, error) {
+	show, err := r.fetchShow()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(show.Parameters), nil
+}
+
+func (r *mqlOllamaModel) renderer() (string, error) {
+	show, err := r.fetchShow()
+	if err != nil {
+		return "", err
+	}
+	return show.Renderer, nil
+}
+
+func (r *mqlOllamaModel) parser() (string, error) {
+	show, err := r.fetchShow()
+	if err != nil {
+		return "", err
+	}
+	return show.Parser, nil
 }
 
 func (r *mqlOllamaModel) info() (*mqlOllamaModelInfo, error) {

--- a/providers/ollama/resources/ollama.lr
+++ b/providers/ollama/resources/ollama.lr
@@ -13,10 +13,10 @@ option go_package = "go.mondoo.com/mql/providers/ollama/resources"
 // authentication.
 //
 // The server version, transport encryption, whether the address is
-// reachable beyond the local machine, whether unauthenticated callers are
-// accepted, and whether inference may be offloaded to Ollama Cloud are all
-// queryable, so an instance can be audited for exposure and for the
-// advisories that apply to the version it runs.
+// reachable beyond the local machine, whether unauthenticated callers may
+// read and whether they may write, and whether inference may be offloaded to
+// Ollama Cloud are all queryable, so an instance can be audited for exposure
+// and for the advisories that apply to the version it runs.
 ollama @defaults("host version") {
   // Host address of the Ollama instance
   host() string
@@ -37,13 +37,25 @@ ollama @defaults("host version") {
   // connections from other hosts, and authenticationRequired and tls decide
   // who can reach it and on what terms.
   isLocal() bool
-  // Whether the API rejects unauthenticated requests
+  // Whether the API rejects unauthenticated read requests
   //
   // Determined by re-issuing a read-only request with the authorization header
-  // removed. False means any client that can reach the host can list, pull,
-  // delete, and run models without credentials. Ollama does not require
+  // removed. False means any client that can reach the host can list models and
+  // read their metadata without credentials. It says nothing about writes, which
+  // writeAuthenticationRequired reports separately. Ollama does not require
   // authentication by default.
   authenticationRequired() bool
+  // Whether the API rejects unauthenticated write requests
+  //
+  // Determined by sending a deliberately unparseable body to the model creation
+  // endpoint with no authorization header. The body cannot be decoded, so
+  // nothing is created, pulled, or deleted whatever the answer. A refusal for
+  // lack of credentials reports true. A rejection of the body alone reports
+  // false, meaning any client that can reach the host can create, pull, and
+  // delete models without credentials, and so can replace the weights this
+  // instance serves. An instance can gate reads and still leave writes open, so
+  // this is checked apart from authenticationRequired.
+  writeAuthenticationRequired() bool
   // Whether the instance may offload inference to Ollama Cloud
   //
   // When enabled, prompts and completions for cloud-hosted models leave the
@@ -169,6 +181,25 @@ ollama.model @defaults("name family parameterSize") {
   //
   // For example completion, tools, vision, or thinking.
   capabilities() []string
+  // Runtime parameters baked into the model
+  //
+  // The PARAMETER block of the model's Modelfile verbatim, the defaults the
+  // server applies to every request for this model. Covers settings such as
+  // num_ctx, temperature, and the stop sequences that terminate generation.
+  // Empty for a model whose Modelfile sets no parameters.
+  parameters() string
+  // Built-in renderer that formats messages for the model
+  //
+  // Names the server-side renderer that turns a request into the model's
+  // prompt format, for example qwen3-coder. Empty for a model that is rendered
+  // by its chat template instead.
+  renderer() string
+  // Built-in parser that reads the model's output
+  //
+  // Names the server-side parser that interprets what the model emits,
+  // including tool calls and thinking segments, for example harmony. Empty for
+  // a model whose output needs no parsing beyond plain text.
+  parser() string
   // Structured GGUF metadata extracted from the model's configuration
   info() ollama.model.info
 }

--- a/providers/ollama/resources/ollama.lr.go
+++ b/providers/ollama/resources/ollama.lr.go
@@ -133,6 +133,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"ollama.authenticationRequired": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOllama).GetAuthenticationRequired()).ToDataRes(types.Bool)
 	},
+	"ollama.writeAuthenticationRequired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOllama).GetWriteAuthenticationRequired()).ToDataRes(types.Bool)
+	},
 	"ollama.cloudEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOllama).GetCloudEnabled()).ToDataRes(types.Bool)
 	},
@@ -225,6 +228,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"ollama.model.capabilities": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOllamaModel).GetCapabilities()).ToDataRes(types.Array(types.String))
+	},
+	"ollama.model.parameters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOllamaModel).GetParameters()).ToDataRes(types.String)
+	},
+	"ollama.model.renderer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOllamaModel).GetRenderer()).ToDataRes(types.String)
+	},
+	"ollama.model.parser": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOllamaModel).GetParser()).ToDataRes(types.String)
 	},
 	"ollama.model.info": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOllamaModel).GetInfo()).ToDataRes(types.Resource("ollama.model.info"))
@@ -344,6 +356,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ollama.authenticationRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOllama).AuthenticationRequired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"ollama.writeAuthenticationRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOllama).WriteAuthenticationRequired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"ollama.cloudEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -476,6 +492,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"ollama.model.capabilities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOllamaModel).Capabilities, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"ollama.model.parameters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOllamaModel).Parameters, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ollama.model.renderer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOllamaModel).Renderer, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"ollama.model.parser": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOllamaModel).Parser, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"ollama.model.info": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -627,15 +655,16 @@ type mqlOllama struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlOllamaInternal it will be used here
-	Host                   plugin.TValue[string]
-	Version                plugin.TValue[string]
-	Tls                    plugin.TValue[bool]
-	IsLocal                plugin.TValue[bool]
-	AuthenticationRequired plugin.TValue[bool]
-	CloudEnabled           plugin.TValue[bool]
-	CloudAccount           plugin.TValue[*mqlOllamaAccount]
-	Models                 plugin.TValue[[]any]
-	RunningModels          plugin.TValue[[]any]
+	Host                        plugin.TValue[string]
+	Version                     plugin.TValue[string]
+	Tls                         plugin.TValue[bool]
+	IsLocal                     plugin.TValue[bool]
+	AuthenticationRequired      plugin.TValue[bool]
+	WriteAuthenticationRequired plugin.TValue[bool]
+	CloudEnabled                plugin.TValue[bool]
+	CloudAccount                plugin.TValue[*mqlOllamaAccount]
+	Models                      plugin.TValue[[]any]
+	RunningModels               plugin.TValue[[]any]
 }
 
 // createOllama creates a new instance of this resource
@@ -702,6 +731,12 @@ func (c *mqlOllama) GetIsLocal() *plugin.TValue[bool] {
 func (c *mqlOllama) GetAuthenticationRequired() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.AuthenticationRequired, func() (bool, error) {
 		return c.authenticationRequired()
+	})
+}
+
+func (c *mqlOllama) GetWriteAuthenticationRequired() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.WriteAuthenticationRequired, func() (bool, error) {
+		return c.writeAuthenticationRequired()
 	})
 }
 
@@ -846,6 +881,9 @@ type mqlOllamaModel struct {
 	System            plugin.TValue[string]
 	Template          plugin.TValue[string]
 	Capabilities      plugin.TValue[[]any]
+	Parameters        plugin.TValue[string]
+	Renderer          plugin.TValue[string]
+	Parser            plugin.TValue[string]
 	Info              plugin.TValue[*mqlOllamaModelInfo]
 }
 
@@ -987,6 +1025,24 @@ func (c *mqlOllamaModel) GetTemplate() *plugin.TValue[string] {
 func (c *mqlOllamaModel) GetCapabilities() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Capabilities, func() ([]any, error) {
 		return c.capabilities()
+	})
+}
+
+func (c *mqlOllamaModel) GetParameters() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Parameters, func() (string, error) {
+		return c.parameters()
+	})
+}
+
+func (c *mqlOllamaModel) GetRenderer() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Renderer, func() (string, error) {
+		return c.renderer()
+	})
+}
+
+func (c *mqlOllamaModel) GetParser() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Parser, func() (string, error) {
+		return c.parser()
 	})
 }
 

--- a/providers/ollama/resources/ollama.lr.versions
+++ b/providers/ollama/resources/ollama.lr.versions
@@ -48,11 +48,14 @@ ollama.model.modifiedAt 13.0.0
 ollama.model.name 13.0.0
 ollama.model.namespace 13.0.13
 ollama.model.parameterSize 13.0.0
+ollama.model.parameters 13.1.4
 ollama.model.parentModel 13.0.0
+ollama.model.parser 13.1.4
 ollama.model.quantizationLevel 13.0.0
 ollama.model.registry 13.0.13
 ollama.model.remoteHost 13.0.13
 ollama.model.remoteModel 13.0.13
+ollama.model.renderer 13.1.4
 ollama.model.repository 13.0.13
 ollama.model.size 13.0.0
 ollama.model.system 13.0.0
@@ -69,3 +72,4 @@ ollama.runningModel.sizeVram 13.0.0
 ollama.runningModels 13.0.0
 ollama.tls 13.0.13
 ollama.version 13.0.13
+ollama.writeAuthenticationRequired 13.1.4

--- a/providers/ollama/resources/ollama_test.go
+++ b/providers/ollama/resources/ollama_test.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"testing"
@@ -181,3 +182,63 @@ func TestModelfileAdaptersDoesNotMaterializeLines(t *testing.T) {
 }
 
 var sink []string
+
+func TestClassifyAuthProbe(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    int
+		open    []int
+		want    bool
+		wantErr bool
+	}{
+		// A refusal for lack of credentials means that path is gated, whether
+		// the instance or a proxy in front of it did the refusing.
+		{"read 401", http.StatusUnauthorized, readOpenStatuses, true, false},
+		{"read 403", http.StatusForbidden, readOpenStatuses, true, false},
+		{"read 407", http.StatusProxyAuthRequired, readOpenStatuses, true, false},
+		{"write 401", http.StatusUnauthorized, writeOpenStatuses, true, false},
+		{"write 403", http.StatusForbidden, writeOpenStatuses, true, false},
+		{"write 407", http.StatusProxyAuthRequired, writeOpenStatuses, true, false},
+
+		// A served read, and a write turned away only for its unparseable body.
+		{"read 200", http.StatusOK, readOpenStatuses, false, false},
+		{"write 400", http.StatusBadRequest, writeOpenStatuses, false, false},
+		{"write 422", http.StatusUnprocessableEntity, writeOpenStatuses, false, false},
+
+		// A 400 says nothing about reads, and a 200 to an unparseable create
+		// body is not an Ollama create handler answering.
+		{"read 400", http.StatusBadRequest, readOpenStatuses, false, true},
+		{"write 200", http.StatusOK, writeOpenStatuses, false, true},
+
+		// An endpoint that is not served, a login redirect, and a gateway
+		// failure are all "could not tell", never a posture claim.
+		{"404", http.StatusNotFound, writeOpenStatuses, false, true},
+		{"405", http.StatusMethodNotAllowed, writeOpenStatuses, false, true},
+		{"302", http.StatusFound, readOpenStatuses, false, true},
+		{"500", http.StatusInternalServerError, writeOpenStatuses, false, true},
+		{"502", http.StatusBadGateway, readOpenStatuses, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := classifyAuthProbe(tt.code, tt.open, "write")
+			if tt.wantErr {
+				assert.Error(t, err, "an unclassifiable answer must not be reported as a posture finding")
+				assert.False(t, got)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWriteOpenStatusesDoNotOverlapAuthRequired(t *testing.T) {
+	for _, code := range writeOpenStatuses {
+		assert.NotContains(t, authRequiredStatuses, code,
+			"a status cannot mean both that writes are gated and that they are open")
+	}
+	for _, code := range readOpenStatuses {
+		assert.NotContains(t, authRequiredStatuses, code)
+	}
+}


### PR DESCRIPTION
## The bug

`providers/ollama/resources/ollama.go:47` and `providers/ollama/connection/connection.go:139`

```go
func (r *mqlOllama) authenticationRequired() (bool, error) {
	code, err := ollamaConn(r.MqlRuntime).AnonymousStatus(context.Background())
	...
}

// AnonymousStatus ...
func (c *OllamaConnection) AnonymousStatus(ctx context.Context) (int, error) {
	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL.JoinPath("/api/tags").String(), nil)
```

The only probe is `GET /api/tags`. The schema then claimed more than the probe proved:

> False means any client that can reach the host can list, **pull, delete, and run** models without credentials.

## Why it is wrong

A read probe answers a read question. An instance that gates reads but permits anonymous writes reads as authenticated, and that is the consequential direction: an unauthenticated caller who can reach `POST /api/create`, `/api/pull` or `/api/delete` can replace the weights the machine serves. That is arbitrary model substitution on a host somebody trusts, and it was reported as `authenticationRequired: true`.

This is not hypothetical. Ollama ships no authentication of its own, so gating is done by whatever sits in front of it, and a proxy config that protects the listing endpoints while leaving `/api/create` unmatched is an ordinary mistake. Reproduced live below.

## The fix

A second, separate field. `authenticationRequired` keeps its meaning (its doc-comment is corrected to say "read" and to stop claiming anything about writes); `writeAuthenticationRequired` is new.

`AnonymousWriteStatus` posts to `/api/create` with no authorization header and this body:

```
{"mondoo_write_auth_probe":
```

Classification (`classifyAuthProbe`):

| answer | reading |
|---|---|
| 401, 403, 407 | write auth is required |
| 400, 422 | the request reached the write handler and was refused only for its body, so writes are open |
| anything else | reported as an error, never as a posture claim |

### Why the probe cannot mutate anything

This is the part that has to be right, so it is stated exactly.

1. **The body is not valid JSON.** It opens an object and starts a key, then the bytes stop. No decoder can parse it, so no field of a create request can be read out of it, and above all **no model name**. There is nothing for any server to act on even if it wanted to.
2. **`/api/create` decodes before it does anything else.** In `server/create.go`, `CreateHandler`'s first statement is `c.ShouldBindJSON(&r)`; a body that fails to decode is answered `400` by the second branch and the handler returns. Nothing is read, written, downloaded, or deleted. This is upstream's own control flow, not an assumption about it.
3. **`/api/delete` and `/api/pull` are never contacted at all.** Both take a model name as their whole payload, and there is no malformed form of either that is worth sending. The probe touches one endpoint.
4. **No credentials are attached.** The probe builds its own `http.Client` from `baseTransport`, which carries the TLS settings but never the token-bearing transport. A probe that sent the token would prove nothing anyway.
5. **The body names itself.** An operator who sees `POST /api/create -> 400` in their server log can grep `mondoo_write_auth_probe` and find out what sent it.
6. **It is lazy.** `writeAuthenticationRequired` is a computed field outside `@defaults`, so nothing is sent unless a query asks for it.

Verified empirically below: across the whole live session the server logged 5 `POST /api/create` requests, all `400`, and its model list was unchanged.

## Also in this PR

Two things that were already paid for and thrown away:

- **`parameters`, `renderer`, `parser`** — `fetchShow()` already retrieves `ShowResponse.Parameters`, `.Renderer` and `.Parser` and discards them. They are now fields on `ollama.model`. `ShowResponse.Messages` is deliberately **not** exposed: those are Modelfile-baked conversation turns, and this provider does not surface prompt or completion content.
- **`capabilities` no longer costs a `Show` call per model.** `ListModelResponse.Capabilities` now ships on the list response, so `capabilities()` reads what the listing already returned. When the listing omits them (an older server, or a model reached by cross-reference rather than by listing) the `Show` call is still made, so nothing regresses to an empty answer.

New entries land at `13.1.4` in `.lr.versions` (`config.go` `Version` is `13.1.3`, not bumped here).

## Verification

Live, against `ollama/ollama:latest` (server `0.32.15`) in Docker, queried with the real provider binary via `PROVIDERS_PATH`.

### The probe body, raw

```
$ curl -s -i -X POST -H 'Content-Type: application/json' \
    --data-raw '{"mondoo_write_auth_probe":' http://127.0.0.1:21434/api/create
HTTP/1.1 400 Bad Request
{"error":"unexpected EOF"}
```

### 1. Default unauthenticated container: no read regression, writes correctly reported open

```
$ mql run ollama --host http://127.0.0.1:21434 \
    -c 'ollama { host version tls isLocal authenticationRequired writeAuthenticationRequired }'
ollama: {
  writeAuthenticationRequired: false
  tls: false
  host: "http://127.0.0.1:21434"
  version: "0.32.15"
  isLocal: true
  authenticationRequired: false
}
```

`authenticationRequired` is `false`, exactly as before this change.

### 2. The bug, reproduced: nginx gates reads, leaves `/api/create` unmatched

```
GET  /api/tags   -> 401
POST /api/create -> 400

$ mql run ollama --host http://127.0.0.1:21435 \
    -c 'ollama { authenticationRequired writeAuthenticationRequired }'
ollama: {
  writeAuthenticationRequired: false
  authenticationRequired: true
}
```

This instance looks authenticated and anyone who can reach it can overwrite its models. Before this PR that was invisible.

### 3. The probe flips: proxy requires credentials for reads and writes

```
GET  /api/tags   anonymous  -> 401
POST /api/create anonymous  -> 401
GET  /api/tags   with token -> 200

$ mql run ollama --host http://127.0.0.1:21435 --token <redacted> \
    -c 'ollama { host version authenticationRequired writeAuthenticationRequired }'
ollama: {
  writeAuthenticationRequired: true
  host: "http://127.0.0.1:21435"
  version: "0.32.15"
  authenticationRequired: true
}
```

The authenticated query still works while the probe, which strips credentials, is refused. That is the point: it measures what a stranger gets, not what we get.

### 4. Nothing was created, pulled, or deleted

Every request the server saw across the entire session:

```
   1 GET /api/status  -> 200
  13 GET /api/tags    -> 200
   8 GET /api/version -> 200
   3 HEAD /           -> 200
   5 POST /api/create -> 400
   1 POST /api/pull   -> 200
   2 POST /api/show   -> 200
```

All five `/api/create` are the probe, all `400`. The single `/api/pull` is my own `ollama pull all-minilm`, run by hand to have a model to test the model fields against. **No `DELETE` was ever issued.** Model list before the probes: empty. After: still only the model I pulled myself.

```
$ docker exec mql-ollama-probe ollama list
NAME                 ID              SIZE     MODIFIED
all-minilm:latest    1b226e2802db    45 MB    52 seconds ago
```

Container and proxy torn down afterwards; `docker ps -a --filter name=mql-ollama` returns nothing.

### 5. `capabilities` no longer calls `Show` (A/B against `main`)

Same query, same server, the only difference being which provider binary answered.

`main`:
```
GET  "/api/version" | GET "/api/tags" | POST "/api/show"
```

this branch:
```
GET  "/api/version" | GET "/api/tags"
```

Both returned `capabilities: ["embedding"]`. The `Show` call is gone, and it was one per installed model.

### 6. The new `Show`-backed fields return real data

```
$ mql run ollama --host http://127.0.0.1:21434 \
    -c 'ollama.models { name family parameterSize capabilities parameters renderer parser }'
ollama.models: [
  0: {
    parameterSize: "23M"
    capabilities: [ 0: "embedding" ]
    renderer: ""
    parameters: "num_ctx                        256"
    parser: ""
    family: "bert"
    name: "all-minilm:latest"
  }
]
```

`renderer` and `parser` are legitimately empty for this model (it is rendered by its chat template and its output needs no parsing) rather than absent.

### Unit tests

```
$ cd providers/ollama && go build ./... && go test ./...
ok  	go.mondoo.com/mql/providers/ollama/connection	0.828s
ok  	go.mondoo.com/mql/providers/ollama/provider	1.290s
ok  	go.mondoo.com/mql/providers/ollama/resources	0.480s
```

`connection`:
- `TestAnonymousWriteStatusCannotMutate` — asserts the method and path (`POST /api/create`, never delete or pull), that no `Authorization` header is sent even when a token is configured, that the captured body **fails** `json.Unmarshal`, and that it does not contain the substring `model` under any key.
- `TestAnonymousWriteStatusGatedInstance` — a `401` is returned as `401`.
- `TestAnonymousWriteStatusUnreachableHost` — a transport failure surfaces as an error, never as "writes are open".

`resources`: `TestClassifyAuthProbe` covers 16 synthetic status codes across both probes, including the ones that must **not** become findings (`404`, `405`, `302`, `500`, `502`, a `400` on the read probe, a `200` on the write probe). `TestWriteOpenStatusesDoNotOverlapAuthRequired` pins that no status can mean both.

`gofmt` clean, `go vet` clean, `go mod tidy` produces no diff, `typos` clean, codegen regenerated with `mqlr generate`.

## Not verified against a live target

- **Ollama Cloud.** `cloudEnabled` / `cloudAccount` were not touched and were not exercised; the container reported `cloudEnabled: true` and nothing beyond that was checked.
- **Real-world auth proxies.** The gated cases were reproduced with nginx configured by hand (a `401` on missing credentials). A production gateway that answers `403`, `407`, or redirects to a login page is covered only by the unit tests over synthetic status codes, not live.
- **`renderer` / `parser` with non-empty values.** Only `all-minilm` (45 MB) was pulled, which sets neither. Models that do set them (a `harmony` parser, a `qwen3-coder` renderer) were not downloaded; the field plumbing is a direct passthrough of `ShowResponse` fields, but a non-empty value was never observed.
- **A server whose listing omits `capabilities`.** The `Show` fallback path is reasoned from `omitempty` on the SDK struct and exercised through the cross-reference path in code, but no server old enough to omit the field was run.
