### PR TITLE
🐛 postgresdb: derive passwordType without moving the credential

### DIFF
--- a/providers/postgresdb/resources/postgresdb.go
+++ b/providers/postgresdb/resources/postgresdb.go
@@ -61,7 +61,32 @@ func privilegeResourceID(parentID, grantee, privilegeType string) string {
 
 // --- password classification ------------------------------------------------
 
-// classifyPassword maps a pg_authid.rolpassword value to how the password is
+// passwordFormExpr is the server-side projection behind the passwordType field.
+//
+// pg_authid.rolpassword holds the role's stored credential. passwordType only
+// reports which form that credential is stored in, so the discriminator is
+// derived by the server and nothing but a fixed token crosses the connection.
+//
+// A fixed-width prefix would not be enough. Per the PostgreSQL documentation
+// the SCRAM form is "SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:
+// <ServerKey>", whose discriminator is exactly 14 characters, but the md5 form
+// is "md5" followed by a 32-character hex digest. Any prefix wide enough to
+// name SCRAM therefore also carries 11 hex digits of an md5 role's digest, and
+// a legacy plaintext value (possible on a catalog upgraded in place from
+// before PostgreSQL 10) would be transferred outright. Emitting the token
+// itself is the only projection that leaks nothing for every form.
+//
+// The tokens are the prefixes classifyPassword already recognizes, so the
+// values reported by passwordType are unchanged.
+const passwordFormExpr = `CASE
+		WHEN rolpassword IS NULL THEN NULL
+		WHEN rolpassword = '' THEN ''
+		WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256$'
+		WHEN rolpassword LIKE 'md5%' THEN 'md5'
+		ELSE 'other'
+	END`
+
+// classifyPassword maps a passwordFormExpr token to how the password is
 // stored. A nil pointer (unreadable or no password) yields "none".
 func classifyPassword(rolpassword *string) string {
 	if rolpassword == nil || *rolpassword == "" {

--- a/providers/postgresdb/resources/postgresdb_test.go
+++ b/providers/postgresdb/resources/postgresdb_test.go
@@ -5,23 +5,38 @@ package resources
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestClassifyPassword(t *testing.T) {
-	scram := "SCRAM-SHA-256$4096:abc$def:ghi"
-	md5 := "md5deadbeef"
-	other := "plaintext"
+	// The values below are the tokens passwordFormExpr emits, plus the raw
+	// shapes the classifier still tolerates. No real credential material is
+	// used: the SCRAM and md5 bodies are placeholders.
+	scramToken := "SCRAM-SHA-256$"
+	scramRaw := "SCRAM-SHA-256$4096:AAAA$BBBB:CCCC"
+	md5Token := "md5"
+	md5Raw := "md5" + strings.Repeat("0", 32) // synthetic, not a real digest
+	other := "other"
+	plaintext := "plaintext"
 	cases := []struct {
 		name string
 		in   *string
 		want string
 	}{
+		// rolpassword IS NULL: the role has no password at all
 		{"nil", nil, "none"},
+		// the '' branch of passwordFormExpr
 		{"empty", strPtr(""), "none"},
-		{"scram", &scram, "scram-sha-256"},
-		{"md5", &md5, "md5"},
-		{"other", &other, "other"},
+		// tokens as emitted by passwordFormExpr
+		{"scram token", &scramToken, "scram-sha-256"},
+		{"md5 token", &md5Token, "md5"},
+		{"other token", &other, "other"},
+		// raw catalog shapes must classify the same way, so the mapping is
+		// unchanged for any caller holding a full rolpassword value
+		{"scram raw", &scramRaw, "scram-sha-256"},
+		{"md5 raw", &md5Raw, "md5"},
+		{"plaintext", &plaintext, "other"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -29,6 +44,45 @@ func TestClassifyPassword(t *testing.T) {
 				t.Errorf("classifyPassword = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestPasswordFormExprEmitsOnlyDiscriminators pins the invariant this
+// projection exists for: every branch yields NULL or a fixed token, so
+// rolpassword itself never crosses the connection.
+func TestPasswordFormExprEmitsOnlyDiscriminators(t *testing.T) {
+	if strings.Contains(passwordFormExpr, "substring") || strings.Contains(passwordFormExpr, "left(") {
+		t.Errorf("passwordFormExpr must not transfer a slice of the credential:\n%s", passwordFormExpr)
+	}
+	// rolpassword may only appear on the left of a comparison, never as a
+	// THEN/ELSE result that would be sent to the client
+	for _, result := range []string{"THEN NULL", "THEN ''", "THEN 'SCRAM-SHA-256$'", "THEN 'md5'", "ELSE 'other'"} {
+		if !strings.Contains(passwordFormExpr, result) {
+			t.Errorf("passwordFormExpr missing branch %q:\n%s", result, passwordFormExpr)
+		}
+	}
+	if n := strings.Count(passwordFormExpr, "THEN rolpassword"); n != 0 {
+		t.Errorf("passwordFormExpr returns the credential in %d branch(es)", n)
+	}
+}
+
+// TestPasswordFormExprTokensRoundTrip proves the SQL tokens and the Go
+// classifier agree, so the values reported by passwordType do not change.
+func TestPasswordFormExprTokensRoundTrip(t *testing.T) {
+	want := map[string]string{
+		"SCRAM-SHA-256$": "scram-sha-256",
+		"md5":            "md5",
+		"other":          "other",
+		"":               "none",
+	}
+	for token, expect := range want {
+		if !strings.Contains(passwordFormExpr, "'"+token+"'") && token != "" {
+			t.Errorf("passwordFormExpr does not emit token %q", token)
+		}
+		tok := token
+		if got := classifyPassword(&tok); got != expect {
+			t.Errorf("classifyPassword(%q) = %q, want %q", token, got, expect)
+		}
 	}
 }
 

--- a/providers/postgresdb/resources/roles.go
+++ b/providers/postgresdb/resources/roles.go
@@ -19,24 +19,25 @@ const roleColumns = `r.rolname, r.oid::bigint, r.rolsuper, r.rolcanlogin, r.rolc
 	r.rolvaliduntil, r.rolconfig`
 
 // passwordTypesByOid best-effort reads pg_authid (superuser-only) and maps each
-// role oid to how its password is stored. An empty map means the catalog was
-// not readable, so passwordType is left null.
+// role oid to how its password is stored. The credential itself stays in the
+// server: only the passwordFormExpr discriminator is selected. An empty map
+// means the catalog was not readable, so passwordType is left null.
 func passwordTypesByOid(pool *pgxpool.Pool) map[int64]string {
 	out := map[int64]string{}
-	rows, err := pool.Query(pgContext(), "SELECT oid::bigint, rolpassword FROM pg_authid")
+	rows, err := pool.Query(pgContext(), "SELECT oid::bigint, "+passwordFormExpr+" FROM pg_authid")
 	if err != nil {
 		return out
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var oid int64
-		var rolpassword *string
-		if err := rows.Scan(&oid, &rolpassword); err != nil {
+		var passwordForm *string
+		if err := rows.Scan(&oid, &passwordForm); err != nil {
 			// Return an empty map on a partial read so every role reports a
 			// uniform null passwordType rather than a confusing mix.
 			return map[int64]string{}
 		}
-		out[oid] = classifyPassword(rolpassword)
+		out[oid] = classifyPassword(passwordForm)
 	}
 	if err := rows.Err(); err != nil {
 		return map[int64]string{}


### PR DESCRIPTION
## The defect

`providers/postgresdb/resources/roles.go:26` selected the role's stored credential in full:

```go
rows, err := pool.Query(pgContext(), "SELECT oid::bigint, rolpassword FROM pg_authid")
```

`pg_authid.rolpassword` holds the role's credential. The only thing the provider did with it was classify it (`roles.go:39`) into the `passwordType` field — `scram-sha-256`, `md5`, or `none`.

**The credential is not exposed through the schema** — `postgresdb.role` has no field carrying it, and that part was already correct. But it still left the server, crossed the network, and landed in the scanning process's memory, purely to derive a three-valued label the server can derive itself.

## Why it matters

A credential that is read but never reported is still a credential in the address space of a long-running process. From there it can reach:

- a crash dump or core file,
- a debug/trace log of the driver or the row buffer,
- a recording made by the provider recording/replay system, which persists resource traffic to disk.

`pg_authid` is superuser-only, so this runs precisely on the connections that already carry the most privilege — and it pulls *every* role's credential, not just one.

## The fix

Classify server-side, so only a fixed discriminator token crosses the connection:

```sql
SELECT oid::bigint, CASE
        WHEN rolpassword IS NULL THEN NULL
        WHEN rolpassword = '' THEN ''
        WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256$'
        WHEN rolpassword LIKE 'md5%' THEN 'md5'
        ELSE 'other'
    END
FROM pg_authid
```

### Why not a fixed-width prefix

A `substring(rolpassword, 1, 14)` was the obvious candidate, and 14 is genuinely the right width for SCRAM — but it is the wrong *shape*, and checking the documented formats is what shows why. Per [PostgreSQL 16 — `pg_authid`](https://www.postgresql.org/docs/16/catalog-pg-authid.html):

> "Encrypted password; null if none. The format depends on the form of encryption used."
>
> "If the password is encrypted with SCRAM-SHA-256, it has the format: `SCRAM-SHA-256$<iteration count>:<salt>$<StoredKey>:<ServerKey>` ... This format is the same as that specified by RFC 5803."
>
> "For an MD5 encrypted password, `rolpassword` column will begin with the string `md5` followed by a 32-character hexadecimal MD5 hash."

So:

- `SCRAM-SHA-256$` is **exactly 14 characters** — 14 is sufficient to name SCRAM, and no wider is needed. Confirmed live: a SCRAM `rolpassword` is 133 characters, of which the first 14 are the discriminator.
- But the **md5 discriminator is only 3 characters**, followed immediately by the digest. Confirmed live: an md5 `rolpassword` is 35 characters (`md5` + 32 hex). A 14-character prefix therefore ships `md5` plus **11 of the 32 hex digits** of that role's digest — roughly a third of the credential, for every md5 role on the server.
- And the `ELSE` branch exists for a reason: a catalog upgraded in place from before PostgreSQL 10 can still hold a plaintext value, which a 14-character prefix would transfer outright.

There is no prefix width that is simultaneously wide enough for SCRAM and narrow enough to leak nothing for md5, because the two discriminators are different lengths. Emitting the token itself is the only projection that leaks nothing for **every** form, so the fix widens past the substring idea entirely rather than tuning its length.

The emitted tokens are exactly the prefixes `classifyPassword` already matches on, so the Go classifier is unchanged and the mapping round-trips: `NULL`/`''` → `none`, `SCRAM-SHA-256$` → `scram-sha-256`, `md5` → `md5`, `other` → `other`. `LIKE` is case-sensitive in PostgreSQL and both discriminators have fixed casing, and neither pattern contains a `%` or `_` outside the intended wildcard.

## Verification

Live, against a containerised **PostgreSQL 16.15** with roles covering every branch: a SCRAM login role, an md5 login role (created after `SET password_encryption = 'md5'`), a passwordless login role, and a passwordless NOLOGIN group role.

### Output is byte-identical before and after

This is a data-handling change whose whole claim is that nothing observable changes, so that is what is shown — not merely that it runs. Same query, provider built from `main` vs. from this branch:

```
$ PROVIDERS_PATH=... mql run postgresdb --host 127.0.0.1 --port ... --user postgres -p ... \
    --discover none -c "postgresdb.instance.roles.where(name != /^pg_/) { name canLogin passwordType }"

$ diff pg-before.txt pg-after.txt    # no output

$ shasum -a 256 pg-before.txt pg-after.txt
2edfba2c19fa75ef66ec9f131bca2fc42d9095bd3ceb90ad3bc9c6c895cf5b67  pg-before.txt
2edfba2c19fa75ef66ec9f131bca2fc42d9095bd3ceb90ad3bc9c6c895cf5b67  pg-after.txt
```

The result set, unchanged across the fix, with all four branches represented:

```
grp_role     canLogin: false   passwordType: "none"
md5_user     canLogin: true    passwordType: "md5"
nopw_user    canLogin: true    passwordType: "none"
postgres     canLogin: true    passwordType: "scram-sha-256"
scram_user   canLogin: true    passwordType: "scram-sha-256"
```

### The credential column is no longer requested

The container ran with `log_statement = 'all'`.

**Before** (provider built from `main`):

```
LOG:  execute stmtcache_058a7bd4...: SELECT oid::bigint, rolpassword FROM pg_authid
```

**After** (this branch):

```
LOG:  execute stmtcache_d0492178...: SELECT oid::bigint, CASE
            WHEN rolpassword IS NULL THEN NULL
            WHEN rolpassword = '' THEN ''
            WHEN rolpassword LIKE 'SCRAM-SHA-256$%' THEN 'SCRAM-SHA-256$'
            WHEN rolpassword LIKE 'md5%' THEN 'md5'
            ELSE 'other'
        END FROM pg_authid
```

`rolpassword` now appears only on the left of a comparison; no branch returns it.

### Tests

`TestClassifyPassword` is extended to cover every form in both shapes — the tokens the new projection emits *and* the raw catalog shapes — so the mapping is pinned as unchanged for any caller holding a full value. Two new tests assert the projection never returns the credential (no `substring`/`left(`, no `THEN rolpassword`) and that the SQL tokens and the Go classifier agree.

```
$ cd providers/postgresdb && gofmt -l resources/ && go vet ./... && go build ./... && go test ./...
?   	go.mondoo.com/mql/providers/postgresdb	[no test files]
?   	go.mondoo.com/mql/providers/postgresdb/config	[no test files]
?   	go.mondoo.com/mql/providers/postgresdb/connection	[no test files]
?   	go.mondoo.com/mql/providers/postgresdb/gen	[no test files]
?   	go.mondoo.com/mql/providers/postgresdb/provider	[no test files]
ok  	go.mondoo.com/mql/providers/postgresdb/resources	0.876s

$ go test ./resources/ -run 'TestClassifyPassword|TestPasswordFormExpr' -v
--- PASS: TestClassifyPassword (0.00s)
    --- PASS: .../nil  .../empty  .../scram_token  .../md5_token
    --- PASS: .../other_token  .../scram_raw  .../md5_raw  .../plaintext
--- PASS: TestPasswordFormExprEmitsOnlyDiscriminators (0.00s)
--- PASS: TestPasswordFormExprTokensRoundTrip (0.00s)
ok  	go.mondoo.com/mql/providers/postgresdb/resources	0.491s
```

Test fixtures use obviously-synthetic values (`"md5" + strings.Repeat("0", 32)`, a placeholder SCRAM body). No real credential material appears in any fixture, commit, or log excerpt in this branch.

## Scope

No schema change, so no `.lr` edit, no codegen, and no `.lr.versions` entries; `git status` is clean apart from the three touched Go files. `passwordType` keeps its type and its meaning, and the provider `Version` in `config/config.go` is untouched.
