### PR TITLE
✨ k8s: model workload isolation from the host (hostUsers, RuntimeClass, typed volumes, node runtime handlers)

### DIFF
--- a/providers/k8s/connection/shared/resources/manifest_file.go
+++ b/providers/k8s/connection/shared/resources/manifest_file.go
@@ -23,6 +23,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
+	nodev1 "k8s.io/api/node/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -76,6 +77,7 @@ func ClientSchema() *runtime.Scheme {
 	networkingv1.AddToScheme(scheme)
 	rbacv1.AddToScheme(scheme)
 	schedulingv1.AddToScheme(scheme)
+	nodev1.AddToScheme(scheme)
 	storagev1.AddToScheme(scheme)
 	admissionregistrationv1.AddToScheme(scheme)
 	certificatesv1.AddToScheme(scheme)

--- a/providers/k8s/connection/shared/resources/testdata/pod-securitycontext.yaml
+++ b/providers/k8s/connection/shared/resources/testdata/pod-securitycontext.yaml
@@ -4,6 +4,9 @@ metadata:
   name: secctx
   namespace: default
 spec:
+  # hostUsers: false is required by the API server before it accepts
+  # procMount: Unmasked, so the fixture stays a manifest a cluster would take.
+  hostUsers: false
   containers:
   - name: app
     image: nginx:1.25
@@ -19,5 +22,12 @@ spec:
         drop: ["ALL"]
       seccompProfile:
         type: RuntimeDefault
+      appArmorProfile:
+        type: Localhost
+        localhostProfile: mql-verify-profile
+      procMount: Unmasked
+      seLinuxOptions:
+        type: spc_t
+        level: s0:c1,c2
   - name: bare
     image: busybox:1.36

--- a/providers/k8s/connection/shared/resources/testdata/pod-volumes.yaml
+++ b/providers/k8s/connection/shared/resources/testdata/pod-volumes.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: first
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: busybox:1.36
+  volumes:
+  # The same volume name appears on both pods, so the cache key has to carry
+  # the owning object as well as the name.
+  - name: shared-name
+    hostPath:
+      path: /var/log
+      type: Directory
+  - name: tokens
+    projected:
+      sources:
+      - serviceAccountToken:
+          audience: first-audience
+          expirationSeconds: 600
+          path: token
+      - serviceAccountToken:
+          path: legacy-token
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: second
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: busybox:1.36
+  volumes:
+  - name: shared-name
+    emptyDir:
+      medium: Memory
+      sizeLimit: 32Mi

--- a/providers/k8s/resources/common.go
+++ b/providers/k8s/resources/common.go
@@ -441,3 +441,65 @@ func k8sManagedFields(runtime *plugin.Runtime, obj any) ([]any, error) {
 	}
 	return out, nil
 }
+
+// namespacedByName indexes an already-fetched k8s root collection by
+// namespace and name so callers can resolve a reference without a per-item
+// NewResource lookup. NewResource runs the target's init before the runtime
+// cache is consulted, so resolving one parent per child would turn a single
+// list into one lookup per reference.
+func namespacedByName[T K8sNamespacedObject](
+	runtime *plugin.Runtime, all func(k *mqlK8s) *plugin.TValue[[]any],
+) (map[string]T, error) {
+	o, err := CreateResource(runtime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	items := all(o.(*mqlK8s))
+	if items.Error != nil {
+		return nil, items.Error
+	}
+	out := make(map[string]T, len(items.Data))
+	for i := range items.Data {
+		item, ok := items.Data[i].(T)
+		if !ok {
+			continue
+		}
+		out[item.GetNamespace().Data+"/"+item.GetName().Data] = item
+	}
+	return out, nil
+}
+
+// resolveNamespaced returns the modeled resources named by refs in the given
+// namespace, in the order the references appear. A reference whose object is
+// gone (or that the scan had no permission to read) is skipped rather than
+// failing the accessor, and duplicate references resolve once.
+func resolveNamespaced[T K8sNamespacedObject](
+	runtime *plugin.Runtime, namespace string, refs []string, all func(k *mqlK8s) *plugin.TValue[[]any],
+) ([]any, error) {
+	out := []any{}
+	if len(refs) == 0 {
+		return out, nil
+	}
+	index, err := namespacedByName[T](runtime, all)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(refs))
+	for _, name := range refs {
+		if name == "" {
+			continue
+		}
+		key := namespace + "/" + name
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		item, ok := index[key]
+		if !ok {
+			log.Debug().Str("namespace", namespace).Str("name", name).Msg("referenced Kubernetes object not found")
+			continue
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}

--- a/providers/k8s/resources/container.go
+++ b/providers/k8s/resources/container.go
@@ -27,10 +27,19 @@ var (
 // containerSecurityContextArgs flattens the security-relevant fields of a
 // container's SecurityContext into typed resource args. Pointer fields stay
 // null when unset so policies can distinguish "not configured" from false.
+//
+// The string-valued confinement fields (seccomp, AppArmor, procMount, SELinux)
+// stay empty when the container sets nothing, which is what lets a policy tell
+// "this container asked for no confinement of its own, so the pod-level
+// setting decides" apart from an explicit Unconfined.
 func containerSecurityContextArgs(sc *corev1.SecurityContext) map[string]*llx.RawData {
 	added := []any{}
 	dropped := []any{}
 	seccompType := ""
+	appArmorType := ""
+	procMount := ""
+	seLinuxType := ""
+	seLinuxLevel := ""
 
 	var (
 		privileged, allowPrivEsc, runAsNonRoot, readOnlyRoot *bool
@@ -55,6 +64,16 @@ func containerSecurityContextArgs(sc *corev1.SecurityContext) map[string]*llx.Ra
 		if sc.SeccompProfile != nil {
 			seccompType = string(sc.SeccompProfile.Type)
 		}
+		if sc.AppArmorProfile != nil {
+			appArmorType = string(sc.AppArmorProfile.Type)
+		}
+		if sc.ProcMount != nil {
+			procMount = string(*sc.ProcMount)
+		}
+		if sc.SELinuxOptions != nil {
+			seLinuxType = sc.SELinuxOptions.Type
+			seLinuxLevel = sc.SELinuxOptions.Level
+		}
 	}
 
 	return map[string]*llx.RawData{
@@ -67,6 +86,10 @@ func containerSecurityContextArgs(sc *corev1.SecurityContext) map[string]*llx.Ra
 		"addedCapabilities":        llx.ArrayData(added, types.String),
 		"droppedCapabilities":      llx.ArrayData(dropped, types.String),
 		"seccompProfileType":       llx.StringData(seccompType),
+		"appArmorProfileType":      llx.StringData(appArmorType),
+		"procMount":                llx.StringData(procMount),
+		"seLinuxType":              llx.StringData(seLinuxType),
+		"seLinuxLevel":             llx.StringData(seLinuxLevel),
 	}
 }
 

--- a/providers/k8s/resources/container_securitycontext_test.go
+++ b/providers/k8s/resources/container_securitycontext_test.go
@@ -51,6 +51,10 @@ func TestContainerSecurityContextFields(t *testing.T) {
 		assert.Equal(t, []any{"NET_BIND_SERVICE"}, c.GetAddedCapabilities().Data)
 		assert.Equal(t, []any{"ALL"}, c.GetDroppedCapabilities().Data)
 		assert.Equal(t, "RuntimeDefault", c.GetSeccompProfileType().Data)
+		assert.Equal(t, "Localhost", c.GetAppArmorProfileType().Data)
+		assert.Equal(t, "Unmasked", c.GetProcMount().Data)
+		assert.Equal(t, "spc_t", c.GetSeLinuxType().Data)
+		assert.Equal(t, "s0:c1,c2", c.GetSeLinuxLevel().Data)
 	})
 
 	t.Run("absent security context leaves pointer fields null", func(t *testing.T) {
@@ -61,5 +65,16 @@ func TestContainerSecurityContextFields(t *testing.T) {
 		assert.Empty(t, c.GetAddedCapabilities().Data)
 		assert.Empty(t, c.GetDroppedCapabilities().Data)
 		assert.Equal(t, "", c.GetSeccompProfileType().Data)
+		// An unset confinement field must stay empty rather than reporting a
+		// default: empty means "the container asked for nothing, so the pod
+		// level decides", which is not the same as an explicit Unconfined.
+		assert.Equal(t, "", c.GetAppArmorProfileType().Data)
+		assert.Equal(t, "", c.GetProcMount().Data)
+		assert.Equal(t, "", c.GetSeLinuxType().Data)
+		assert.Equal(t, "", c.GetSeLinuxLevel().Data)
+	})
+
+	t.Run("pod requesting its own user namespace", func(t *testing.T) {
+		assert.Equal(t, false, pod.GetHostUsers().Data)
 	})
 }

--- a/providers/k8s/resources/context.go
+++ b/providers/k8s/resources/context.go
@@ -268,6 +268,11 @@ func (x *mqlK8sResourcequota) context() (*mqlK8sContext, error) {
 	return nil, nil
 }
 
+func (x *mqlK8sRuntimeclass) context() (*mqlK8sContext, error) {
+	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}
+
 func (x *mqlK8sSecret) context() (*mqlK8sContext, error) {
 	x.Context.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil

--- a/providers/k8s/resources/gateway.go
+++ b/providers/k8s/resources/gateway.go
@@ -22,7 +22,10 @@ type mqlK8sGatewayInternal struct {
 }
 
 func (k *mqlK8s) gateways() ([]any, error) {
-	return k8sResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("gateways")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
+	// Gateway API ships as CRDs, so a cluster that never installed them has no
+	// such kind. That is a cluster with no Gateways, not a failed scan, so the
+	// list degrades to empty rather than erroring.
+	return k8sOptionalResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("gateways")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
 		ts := obj.GetCreationTimestamp()
 
 		gw, ok := resource.(*gatewayv1.Gateway)

--- a/providers/k8s/resources/gatewayclass.go
+++ b/providers/k8s/resources/gatewayclass.go
@@ -22,7 +22,10 @@ type mqlK8sGatewayclassInternal struct {
 }
 
 func (k *mqlK8s) gatewayClasses() ([]any, error) {
-	return k8sResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("gatewayclasses")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
+	// Gateway API ships as CRDs, so a cluster that never installed them has no
+	// such kind. That is a cluster with no Gateways, not a failed scan, so the
+	// list degrades to empty rather than erroring.
+	return k8sOptionalResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("gatewayclasses")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
 		ts := obj.GetCreationTimestamp()
 
 		gc, ok := resource.(*gatewayv1.GatewayClass)

--- a/providers/k8s/resources/grpcroute.go
+++ b/providers/k8s/resources/grpcroute.go
@@ -22,7 +22,10 @@ type mqlK8sGrpcrouteInternal struct {
 }
 
 func (k *mqlK8s) grpcRoutes() ([]any, error) {
-	return k8sResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("grpcroutes")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
+	// Gateway API ships as CRDs, so a cluster that never installed them has no
+	// such kind. That is a cluster with no Gateways, not a failed scan, so the
+	// list degrades to empty rather than erroring.
+	return k8sOptionalResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("grpcroutes")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
 		ts := obj.GetCreationTimestamp()
 
 		gr, ok := resource.(*gatewayv1.GRPCRoute)

--- a/providers/k8s/resources/httproute.go
+++ b/providers/k8s/resources/httproute.go
@@ -22,7 +22,10 @@ type mqlK8sHttprouteInternal struct {
 }
 
 func (k *mqlK8s) httpRoutes() ([]any, error) {
-	return k8sResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("httproutes")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
+	// Gateway API ships as CRDs, so a cluster that never installed them has no
+	// such kind. That is a cluster with no Gateways, not a failed scan, so the
+	// list degrades to empty rather than erroring.
+	return k8sOptionalResourceToMql(k.MqlRuntime, gvkString(gatewayv1.SchemeGroupVersion.WithKind("httproutes")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
 		ts := obj.GetCreationTimestamp()
 
 		hr, ok := resource.(*gatewayv1.HTTPRoute)

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -141,6 +141,8 @@ k8s {
   resourceClaims() []k8s.resourceclaim
   // Kubernetes dynamic resource allocation ResourceClaimTemplates
   resourceClaimTemplates() []k8s.resourceclaimtemplate
+  // Kubernetes RuntimeClasses
+  runtimeClasses() []k8s.runtimeclass
 }
 
 // Kubernetes API resource type
@@ -381,6 +383,27 @@ private k8s.node @defaults("name labels['kubernetes.io/arch'] labels['kubernetes
   volumesAttached() []dict
   // Names of volumes currently in use by pods on the node
   volumesInUse() []string
+  // Container runtime handlers the kubelet advertises
+  //
+  // One entry per handler the node can run pods with, with keys `name` (the
+  // handler a RuntimeClass selects, empty for the runtime's default) and
+  // `features`, holding `recursiveReadOnlyMounts` and `userNamespaces`. A
+  // kubelet that reports no handlers returns an empty list.
+  runtimeHandlers() []dict
+  // Whether any runtime handler on the node supports user namespaces
+  //
+  // A pod that sets hostUsers to false gets no isolation on a node whose
+  // runtime cannot provide a user namespace, so this is what makes that
+  // mismatch detectable. Null when the kubelet advertises no handler features
+  // at all, which is not the same as reporting that the feature is absent.
+  supportsUserNamespaces() bool
+  // Whether the node's runtime supports SupplementalGroupsPolicy
+  //
+  // Read from the node's reported features. When true the runtime honors a
+  // pod's supplementalGroupsPolicy of Strict, which stops the container image
+  // from adding group memberships the pod spec did not grant. Null when the
+  // kubelet reports no feature block.
+  supportsSupplementalGroupsPolicy() bool
 }
 
 // Kubernetes node taint
@@ -461,6 +484,8 @@ private k8s.pod @defaults("namespace name created") @context("k8s.context") {
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Volumes the pod declares
+  volumes() []k8s.volume
   // Whether any container effectively runs with the Unconfined seccomp profile
   //
   // Resolves the container-level seccomp profile, falling back to the pod-level
@@ -603,6 +628,11 @@ private k8s.pod @defaults("namespace name created") @context("k8s.context") {
   schedulerName() string
   // Name of the RuntimeClass that selects the container runtime
   runtimeClassName() string
+  // The RuntimeClass that selects the container runtime
+  //
+  // Null when the pod names no RuntimeClass, in which case the node's default
+  // runtime handler runs it, or when the named class no longer exists.
+  runtimeClass() k8s.runtimeclass
   // Name of the ServiceAccount used to run the pod
   serviceAccountName() string
   // The ServiceAccount used to run the pod
@@ -621,6 +651,15 @@ private k8s.pod @defaults("namespace name created") @context("k8s.context") {
   hostPID() bool
   // Whether the pod shares the host IPC namespace
   hostIPC() bool
+  // Whether the pod shares the host user namespace
+  //
+  // True when containers run in the node's user namespace, so a process
+  // running as root inside a container is root on the node. False when the pod
+  // requests its own user namespace, which maps container UIDs onto
+  // unprivileged host UIDs. Kubernetes leaves the field unset by default and
+  // treats unset as true, so this reports true for a pod that never asks for
+  // the isolation.
+  hostUsers() bool
   // Whether containers in the pod share a single PID namespace
   shareProcessNamespace() bool
   // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
@@ -711,6 +750,15 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   hostPID() bool
   // Whether the pod shares the host IPC namespace
   hostIPC() bool
+  // Whether the pod template shares the host user namespace
+  //
+  // True when containers run in the node's user namespace, so a process
+  // running as root inside a container is root on the node. False when the
+  // template requests its own user namespace, which maps container UIDs onto
+  // unprivileged host UIDs. Kubernetes leaves the field unset by default and
+  // treats unset as true, so this reports true for a template that never asks
+  // for the isolation.
+  hostUsers() bool
   // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
   securityContext() dict
   // Whether any container runs in privileged mode, across regular, init, and ephemeral containers
@@ -742,6 +790,8 @@ private k8s.deployment @defaults("namespace name desiredReplicas readyReplicas c
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Volumes the pod template declares
+  volumes() []k8s.volume
   // Whether any container effectively runs with the Unconfined seccomp profile
   //
   // Resolves the container-level seccomp profile, falling back to the pod-level
@@ -890,6 +940,15 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   hostPID() bool
   // Whether the pod shares the host IPC namespace
   hostIPC() bool
+  // Whether the pod template shares the host user namespace
+  //
+  // True when containers run in the node's user namespace, so a process
+  // running as root inside a container is root on the node. False when the
+  // template requests its own user namespace, which maps container UIDs onto
+  // unprivileged host UIDs. Kubernetes leaves the field unset by default and
+  // treats unset as true, so this reports true for a template that never asks
+  // for the isolation.
+  hostUsers() bool
   // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
   securityContext() dict
   // Whether any container runs in privileged mode, across regular, init, and ephemeral containers
@@ -921,6 +980,8 @@ private k8s.daemonset @defaults("namespace name desiredNumberScheduled numberRea
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Volumes the pod template declares
+  volumes() []k8s.volume
   // Whether any container effectively runs with the Unconfined seccomp profile
   //
   // Resolves the container-level seccomp profile, falling back to the pod-level
@@ -1059,6 +1120,15 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   hostPID() bool
   // Whether the pod shares the host IPC namespace
   hostIPC() bool
+  // Whether the pod template shares the host user namespace
+  //
+  // True when containers run in the node's user namespace, so a process
+  // running as root inside a container is root on the node. False when the
+  // template requests its own user namespace, which maps container UIDs onto
+  // unprivileged host UIDs. Kubernetes leaves the field unset by default and
+  // treats unset as true, so this reports true for a template that never asks
+  // for the isolation.
+  hostUsers() bool
   // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
   securityContext() dict
   // Whether any container runs in privileged mode, across regular, init, and ephemeral containers
@@ -1090,6 +1160,8 @@ private k8s.statefulset @defaults("namespace name desiredReplicas readyReplicas 
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Volumes the pod template declares
+  volumes() []k8s.volume
   // Whether any container effectively runs with the Unconfined seccomp profile
   //
   // Resolves the container-level seccomp profile, falling back to the pod-level
@@ -1245,6 +1317,15 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   hostPID() bool
   // Whether the pod shares the host IPC namespace
   hostIPC() bool
+  // Whether the pod template shares the host user namespace
+  //
+  // True when containers run in the node's user namespace, so a process
+  // running as root inside a container is root on the node. False when the
+  // template requests its own user namespace, which maps container UIDs onto
+  // unprivileged host UIDs. Kubernetes leaves the field unset by default and
+  // treats unset as true, so this reports true for a template that never asks
+  // for the isolation.
+  hostUsers() bool
   // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
   securityContext() dict
   // Whether any container runs in privileged mode, across regular, init, and ephemeral containers
@@ -1276,6 +1357,8 @@ private k8s.replicaset @defaults("namespace name desiredReplicas readyReplicas c
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Volumes the pod template declares
+  volumes() []k8s.volume
   // Whether any container effectively runs with the Unconfined seccomp profile
   //
   // Resolves the container-level seccomp profile, falling back to the pod-level
@@ -1413,6 +1496,15 @@ private k8s.job @defaults("namespace name succeeded failed created") @context("k
   hostPID() bool
   // Whether the pod shares the host IPC namespace
   hostIPC() bool
+  // Whether the pod template shares the host user namespace
+  //
+  // True when containers run in the node's user namespace, so a process
+  // running as root inside a container is root on the node. False when the
+  // template requests its own user namespace, which maps container UIDs onto
+  // unprivileged host UIDs. Kubernetes leaves the field unset by default and
+  // treats unset as true, so this reports true for a template that never asks
+  // for the isolation.
+  hostUsers() bool
   // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
   securityContext() dict
   // Whether any container runs in privileged mode, across regular, init, and ephemeral containers
@@ -1444,6 +1536,8 @@ private k8s.job @defaults("namespace name succeeded failed created") @context("k
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Volumes the pod template declares
+  volumes() []k8s.volume
   // Whether any container effectively runs with the Unconfined seccomp profile
   //
   // Resolves the container-level seccomp profile, falling back to the pod-level
@@ -1597,6 +1691,15 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") @contex
   hostPID() bool
   // Whether the pod shares the host IPC namespace
   hostIPC() bool
+  // Whether the pod template shares the host user namespace
+  //
+  // True when containers run in the node's user namespace, so a process
+  // running as root inside a container is root on the node. False when the
+  // template requests its own user namespace, which maps container UIDs onto
+  // unprivileged host UIDs. Kubernetes leaves the field unset by default and
+  // treats unset as true, so this reports true for a template that never asks
+  // for the isolation.
+  hostUsers() bool
   // Pod-level security context (runAsUser, runAsGroup, runAsNonRoot, fsGroup, seccompProfile, supplementalGroups, sysctls, windowsOptions)
   securityContext() dict
   // Whether any container runs in privileged mode, across regular, init, and ephemeral containers
@@ -1628,6 +1731,8 @@ private k8s.cronjob @defaults("namespace name schedule suspend created") @contex
   usesHostNamespaces() bool
   // Whether the pod mounts a hostPath volume
   usesHostPath() bool
+  // Volumes the pod template declares
+  volumes() []k8s.volume
   // Whether any container effectively runs with the Unconfined seccomp profile
   //
   // Resolves the container-level seccomp profile, falling back to the pod-level
@@ -1851,6 +1956,34 @@ private k8s.container @defaults("name") {
   // container sets no seccomp profile, in which case the pod-level profile (if
   // any) applies. Parsed from `securityContext.seccompProfile.type`.
   seccompProfileType string
+  // AppArmor profile type applied to the container
+  //
+  // One of `RuntimeDefault`, `Localhost`, or `Unconfined`. Empty when the
+  // container sets no AppArmor profile, in which case the pod-level profile
+  // (if any) applies. `Unconfined` disables AppArmor confinement for the
+  // container. Parsed from `securityContext.appArmorProfile.type`.
+  appArmorProfileType string
+  // How /proc is mounted inside the container
+  //
+  // One of `Default`, which masks and read-only mounts the kernel paths the
+  // runtime considers dangerous, or `Unmasked`, which exposes all of them.
+  // Empty when the container sets no procMount, in which case `Default`
+  // applies. Parsed from `securityContext.procMount`.
+  procMount string
+  // SELinux type label the container runs under
+  //
+  // Empty when the container sets no SELinux type, in which case the pod-level
+  // label or the runtime's default applies. A type such as `spc_t` runs the
+  // container as a super-privileged container with no SELinux confinement.
+  // Parsed from `securityContext.seLinuxOptions.type`.
+  seLinuxType string
+  // SELinux level label the container runs under
+  //
+  // The sensitivity and category set (for example `s0:c123,c456`) that
+  // separates one container's objects from another's. Empty when the container
+  // sets no level, in which case the pod-level label or a runtime-assigned
+  // level applies. Parsed from `securityContext.seLinuxOptions.level`.
+  seLinuxLevel string
   // Container's working directory
   workingDir string
   // Whether this container should allocate a TTY for itself
@@ -2028,6 +2161,34 @@ private k8s.initContainer @defaults("name") {
   // container sets no seccomp profile, in which case the pod-level profile (if
   // any) applies. Parsed from `securityContext.seccompProfile.type`.
   seccompProfileType string
+  // AppArmor profile type applied to the container
+  //
+  // One of `RuntimeDefault`, `Localhost`, or `Unconfined`. Empty when the
+  // container sets no AppArmor profile, in which case the pod-level profile
+  // (if any) applies. `Unconfined` disables AppArmor confinement for the
+  // container. Parsed from `securityContext.appArmorProfile.type`.
+  appArmorProfileType string
+  // How /proc is mounted inside the container
+  //
+  // One of `Default`, which masks and read-only mounts the kernel paths the
+  // runtime considers dangerous, or `Unmasked`, which exposes all of them.
+  // Empty when the container sets no procMount, in which case `Default`
+  // applies. Parsed from `securityContext.procMount`.
+  procMount string
+  // SELinux type label the container runs under
+  //
+  // Empty when the container sets no SELinux type, in which case the pod-level
+  // label or the runtime's default applies. A type such as `spc_t` runs the
+  // container as a super-privileged container with no SELinux confinement.
+  // Parsed from `securityContext.seLinuxOptions.type`.
+  seLinuxType string
+  // SELinux level label the container runs under
+  //
+  // The sensitivity and category set (for example `s0:c123,c456`) that
+  // separates one container's objects from another's. Empty when the container
+  // sets no level, in which case the pod-level label or a runtime-assigned
+  // level applies. Parsed from `securityContext.seLinuxOptions.level`.
+  seLinuxLevel string
   // Container's working directory
   workingDir string
   // Whether this container should allocate a TTY for itself
@@ -2147,6 +2308,34 @@ private k8s.ephemeralContainer @defaults("name") {
   // container sets no seccomp profile, in which case the pod-level profile (if
   // any) applies. Parsed from `securityContext.seccompProfile.type`.
   seccompProfileType string
+  // AppArmor profile type applied to the container
+  //
+  // One of `RuntimeDefault`, `Localhost`, or `Unconfined`. Empty when the
+  // container sets no AppArmor profile, in which case the pod-level profile
+  // (if any) applies. `Unconfined` disables AppArmor confinement for the
+  // container. Parsed from `securityContext.appArmorProfile.type`.
+  appArmorProfileType string
+  // How /proc is mounted inside the container
+  //
+  // One of `Default`, which masks and read-only mounts the kernel paths the
+  // runtime considers dangerous, or `Unmasked`, which exposes all of them.
+  // Empty when the container sets no procMount, in which case `Default`
+  // applies. Parsed from `securityContext.procMount`.
+  procMount string
+  // SELinux type label the container runs under
+  //
+  // Empty when the container sets no SELinux type, in which case the pod-level
+  // label or the runtime's default applies. A type such as `spc_t` runs the
+  // container as a super-privileged container with no SELinux confinement.
+  // Parsed from `securityContext.seLinuxOptions.type`.
+  seLinuxType string
+  // SELinux level label the container runs under
+  //
+  // The sensitivity and category set (for example `s0:c123,c456`) that
+  // separates one container's objects from another's. Empty when the container
+  // sets no level, in which case the pod-level label or a runtime-assigned
+  // level applies. Parsed from `securityContext.seLinuxOptions.level`.
+  seLinuxLevel string
   // Container's working directory
   workingDir string
   // Whether this container should allocate a TTY for itself
@@ -2576,6 +2765,18 @@ private k8s.serviceaccount @defaults("namespace name created") @context("k8s.con
   canReadSecrets() bool
   // Whether any bound role has a wildcard rule (wildcard verbs, API groups, or resources)
   hasWildcardPermissions() bool
+  // Secret objects the service account carries
+  //
+  // Resolves each entry of secrets to the Secret in the account's namespace. A
+  // service account that still carries a Secret here holds a long-lived,
+  // non-expiring API token, unlike the projected tokens the kubelet rotates.
+  // Entries whose Secret no longer exists are omitted.
+  secretRefs() []k8s.secret
+  // Secret objects used to pull private container images
+  //
+  // Resolves each entry of imagePullSecrets to the Secret in the account's
+  // namespace. Entries whose Secret no longer exists are omitted.
+  imagePullSecretRefs() []k8s.secret
 }
 
 // Kubernetes ClusterRole
@@ -3242,6 +3443,147 @@ private k8s.persistentvolume @defaults("name capacity['storage'] phase storageCl
   reason() string
   // Human-readable message about the current phase
   message() string
+}
+
+// Kubernetes RuntimeClass
+//
+// Container runtime configuration a pod selects by name, selected by name.
+// The handler field names the CRI handler the kubelet invokes, which is how a
+// workload is placed on a sandboxed runtime such as gVisor or Kata Containers
+// instead of the node's default runtime. The overhead field reports the fixed
+// resources the runtime itself consumes per pod, scheduling restricts which
+// nodes may run pods of the class, and pods returns the pods currently
+// selecting it.
+private k8s.runtimeclass @defaults("name handler created") @context("k8s.context") {
+  // Mondoo ID for the Kubernetes object
+  id string
+  // Kubernetes object UID
+  uid string
+  // Kubernetes resource version
+  resourceVersion string
+  // Kubernetes labels
+  labels() map[string]string
+  // Kubernetes annotations
+  annotations() map[string]string
+  // Owner references describing the controllers and parent objects that own this object
+  ownerReferences() []k8s.ownerReference
+  // Server-side apply records describing which field managers own which fields
+  managedFields() []k8s.managedField
+  // Kubernetes object name
+  name string
+  // Kubernetes object type
+  kind string
+  // Kubernetes object creation timestamp
+  created time
+  // Full resource manifest
+  manifest() dict
+  // CRI handler the kubelet invokes for pods of this class
+  //
+  // Names a runtime the node has configured, for example `runc` for the
+  // default runtime or `runsc` for gVisor. A node whose kubelet advertises no
+  // matching handler cannot run pods of this class.
+  handler string
+  // Fixed resource overhead the runtime adds to every pod of this class
+  //
+  // Keys are resource names such as cpu and memory; values are Kubernetes
+  // quantity strings. Empty when the class declares no overhead.
+  overhead map[string]string
+  // Node restrictions for pods of this class
+  //
+  // Keys are `nodeSelector`, the labels a node must carry for a pod of this
+  // class to be scheduled on it, and `tolerations`, the taints such a pod
+  // gains automatically. Null when the class places no restriction, in which
+  // case any node may run its pods whether or not the runtime is installed
+  // there.
+  scheduling dict
+  // Pods that select this RuntimeClass
+  pods() []k8s.pod
+}
+
+// Kubernetes pod volume
+//
+// Storage a pod or pod template attaches, selected by the volume name that a
+// container's volumeMounts refer to. The type field names the single populated
+// volume source, and the sources that carry security meaning are read out
+// alongside it: hostPath and hostPathType for a mount of the node's own
+// filesystem, emptyDirMedium and emptyDirSizeLimit for scratch space,
+// csiDriver for an inline CSI volume, and serviceAccountTokens for the
+// projected API tokens the kubelet writes into the pod. The secrets,
+// configMaps, and persistentVolumeClaim fields resolve the objects a source
+// names in the same namespace, and source carries the complete volume source
+// for the types that are not read out into their own fields.
+private k8s.volume @defaults("name type") {
+  // Name of the volume as referenced by container volumeMounts
+  name string
+  // Namespace of the pod or pod template that declares the volume
+  namespace string
+  // Populated volume source type
+  //
+  // One of `hostPath`, `emptyDir`, `secret`, `configMap`, `projected`,
+  // `persistentVolumeClaim`, `csi`, `downwardAPI`, `ephemeral`, `nfs`,
+  // `iscsi`, or another source name the API server accepts. Empty when the
+  // volume declares no source at all.
+  type string
+  // Node filesystem path the volume mounts
+  //
+  // A hostPath volume reaches the node's own filesystem, so this path decides
+  // what a container reads or writes outside its image. Null for every other
+  // volume type.
+  hostPath string
+  // Expected type of the hostPath target
+  //
+  // One of `DirectoryOrCreate`, `Directory`, `FileOrCreate`, `File`, `Socket`,
+  // `CharDevice`, `BlockDevice`, or empty for no check. Null for every volume
+  // type other than hostPath.
+  hostPathType string
+  // Storage medium backing an emptyDir volume
+  //
+  // Empty for the node's default medium, which is disk, and `Memory` for a
+  // tmpfs volume that counts against the pod's memory limit. Null for every
+  // other volume type.
+  emptyDirMedium string
+  // Size limit of an emptyDir volume as a Kubernetes quantity
+  //
+  // Null when the volume is not an emptyDir or sets no limit, in which case it
+  // may grow until the node's ephemeral storage is exhausted.
+  emptyDirSizeLimit string
+  // Name of the CSI driver backing an inline CSI volume
+  //
+  // Null for every volume type other than an inline csi volume.
+  csiDriver string
+  // Projected ServiceAccount tokens the volume delivers
+  //
+  // One entry per serviceAccountToken source in a projected volume, with keys
+  // `audience` (the recipient the token is valid for, empty when the token
+  // targets the API server itself), `expirationSeconds` (the lifetime
+  // requested from the kubelet, which rotates the file), and `path` (the file
+  // the token is written to inside the container). Empty for every other
+  // volume type.
+  serviceAccountTokens() []dict
+  // Secret objects the volume mounts
+  //
+  // Resolves a secret volume source, and every secret source of a projected
+  // volume, to the Secret in the same namespace. Empty when the volume mounts
+  // no Secret; a referenced Secret that no longer exists is omitted.
+  secrets() []k8s.secret
+  // ConfigMap objects the volume mounts
+  //
+  // Resolves a configMap volume source, and every configMap source of a
+  // projected volume, to the ConfigMap in the same namespace. Empty when the
+  // volume mounts no ConfigMap; a referenced ConfigMap that no longer exists
+  // is omitted.
+  configMaps() []k8s.configmap
+  // PersistentVolumeClaim the volume binds
+  //
+  // Null when the volume is not a persistentVolumeClaim volume, or when the
+  // claim it names no longer exists.
+  persistentVolumeClaim() k8s.persistentvolumeclaim
+  // Complete volume source
+  //
+  // The volume source as the API server stores it, keyed by source name. This
+  // carries the sources that are not read out into their own fields, such as
+  // nfs, iscsi, cephfs, downwardAPI, and ephemeral.
+  source dict
 }
 
 // Kubernetes StorageClass

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -3447,13 +3447,13 @@ private k8s.persistentvolume @defaults("name capacity['storage'] phase storageCl
 
 // Kubernetes RuntimeClass
 //
-// Container runtime configuration a pod selects by name, selected by name.
-// The handler field names the CRI handler the kubelet invokes, which is how a
-// workload is placed on a sandboxed runtime such as gVisor or Kata Containers
-// instead of the node's default runtime. The overhead field reports the fixed
-// resources the runtime itself consumes per pod, scheduling restricts which
-// nodes may run pods of the class, and pods returns the pods currently
-// selecting it.
+// Container runtime configuration a pod selects by name. The handler field
+// names the CRI handler the kubelet invokes, which is how a workload is placed
+// on a sandboxed runtime such as gVisor or Kata Containers instead of the
+// node's default runtime. The overhead field reports the fixed resources the
+// runtime itself consumes per pod, scheduling restricts which nodes may run
+// pods of the class, and pods lists the workloads currently running under
+// this class.
 private k8s.runtimeclass @defaults("name handler created") @context("k8s.context") {
   // Mondoo ID for the Kubernetes object
   id string

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -59,6 +59,8 @@ const (
 	ResourceK8sNetworkPolicyCoverage                     string = "k8s.networkPolicyCoverage"
 	ResourceK8sCustomresource                            string = "k8s.customresource"
 	ResourceK8sPersistentvolume                          string = "k8s.persistentvolume"
+	ResourceK8sRuntimeclass                              string = "k8s.runtimeclass"
+	ResourceK8sVolume                                    string = "k8s.volume"
 	ResourceK8sStorageclass                              string = "k8s.storageclass"
 	ResourceK8sPriorityclass                             string = "k8s.priorityclass"
 	ResourceK8sHorizontalpodautoscaler                   string = "k8s.horizontalpodautoscaler"
@@ -272,6 +274,14 @@ func init() {
 		"k8s.persistentvolume": {
 			Init:   initK8sPersistentvolume,
 			Create: createK8sPersistentvolume,
+		},
+		"k8s.runtimeclass": {
+			Init:   initK8sRuntimeclass,
+			Create: createK8sRuntimeclass,
+		},
+		"k8s.volume": {
+			// to override args, implement: initK8sVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createK8sVolume,
 		},
 		"k8s.storageclass": {
 			Init:   initK8sStorageclass,
@@ -659,6 +669,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.resourceClaimTemplates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8s).GetResourceClaimTemplates()).ToDataRes(types.Array(types.Resource("k8s.resourceclaimtemplate")))
 	},
+	"k8s.runtimeClasses": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8s).GetRuntimeClasses()).ToDataRes(types.Array(types.Resource("k8s.runtimeclass")))
+	},
 	"k8s.apiresource.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sApiresource).GetName()).ToDataRes(types.String)
 	},
@@ -893,6 +906,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.node.volumesInUse": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNode).GetVolumesInUse()).ToDataRes(types.Array(types.String))
 	},
+	"k8s.node.runtimeHandlers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNode).GetRuntimeHandlers()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.node.supportsUserNamespaces": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNode).GetSupportsUserNamespaces()).ToDataRes(types.Bool)
+	},
+	"k8s.node.supportsSupplementalGroupsPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sNode).GetSupportsSupplementalGroupsPolicy()).ToDataRes(types.Bool)
+	},
 	"k8s.node.context": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sNode).GetContext()).ToDataRes(types.Resource("k8s.context"))
 	},
@@ -955,6 +977,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.pod.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.volumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetVolumes()).ToDataRes(types.Array(types.Resource("k8s.volume")))
 	},
 	"k8s.pod.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
@@ -1121,6 +1146,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.pod.runtimeClassName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetRuntimeClassName()).ToDataRes(types.String)
 	},
+	"k8s.pod.runtimeClass": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetRuntimeClass()).ToDataRes(types.Resource("k8s.runtimeclass"))
+	},
 	"k8s.pod.serviceAccountName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetServiceAccountName()).ToDataRes(types.String)
 	},
@@ -1141,6 +1169,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.pod.hostIPC": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetHostIPC()).ToDataRes(types.Bool)
+	},
+	"k8s.pod.hostUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sPod).GetHostUsers()).ToDataRes(types.Bool)
 	},
 	"k8s.pod.shareProcessNamespace": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPod).GetShareProcessNamespace()).ToDataRes(types.Bool)
@@ -1247,6 +1278,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.deployment.hostIPC": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetHostIPC()).ToDataRes(types.Bool)
 	},
+	"k8s.deployment.hostUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetHostUsers()).ToDataRes(types.Bool)
+	},
 	"k8s.deployment.securityContext": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetSecurityContext()).ToDataRes(types.Dict)
 	},
@@ -1273,6 +1307,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.deployment.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.deployment.volumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDeployment).GetVolumes()).ToDataRes(types.Array(types.Resource("k8s.volume")))
 	},
 	"k8s.deployment.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDeployment).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
@@ -1451,6 +1488,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.daemonset.hostIPC": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetHostIPC()).ToDataRes(types.Bool)
 	},
+	"k8s.daemonset.hostUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetHostUsers()).ToDataRes(types.Bool)
+	},
 	"k8s.daemonset.securityContext": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetSecurityContext()).ToDataRes(types.Dict)
 	},
@@ -1477,6 +1517,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.daemonset.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.daemonset.volumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sDaemonset).GetVolumes()).ToDataRes(types.Array(types.Resource("k8s.volume")))
 	},
 	"k8s.daemonset.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sDaemonset).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
@@ -1652,6 +1695,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.statefulset.hostIPC": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetHostIPC()).ToDataRes(types.Bool)
 	},
+	"k8s.statefulset.hostUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetHostUsers()).ToDataRes(types.Bool)
+	},
 	"k8s.statefulset.securityContext": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetSecurityContext()).ToDataRes(types.Dict)
 	},
@@ -1678,6 +1724,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.statefulset.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.statefulset.volumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sStatefulset).GetVolumes()).ToDataRes(types.Array(types.Resource("k8s.volume")))
 	},
 	"k8s.statefulset.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStatefulset).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
@@ -1868,6 +1917,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.replicaset.hostIPC": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetHostIPC()).ToDataRes(types.Bool)
 	},
+	"k8s.replicaset.hostUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetHostUsers()).ToDataRes(types.Bool)
+	},
 	"k8s.replicaset.securityContext": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetSecurityContext()).ToDataRes(types.Dict)
 	},
@@ -1894,6 +1946,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.replicaset.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.replicaset.volumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sReplicaset).GetVolumes()).ToDataRes(types.Array(types.Resource("k8s.volume")))
 	},
 	"k8s.replicaset.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sReplicaset).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
@@ -2054,6 +2109,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.job.hostIPC": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetHostIPC()).ToDataRes(types.Bool)
 	},
+	"k8s.job.hostUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetHostUsers()).ToDataRes(types.Bool)
+	},
 	"k8s.job.securityContext": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetSecurityContext()).ToDataRes(types.Dict)
 	},
@@ -2080,6 +2138,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.job.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.job.volumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sJob).GetVolumes()).ToDataRes(types.Array(types.Resource("k8s.volume")))
 	},
 	"k8s.job.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sJob).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
@@ -2273,6 +2334,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.cronjob.hostIPC": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetHostIPC()).ToDataRes(types.Bool)
 	},
+	"k8s.cronjob.hostUsers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetHostUsers()).ToDataRes(types.Bool)
+	},
 	"k8s.cronjob.securityContext": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetSecurityContext()).ToDataRes(types.Dict)
 	},
@@ -2299,6 +2363,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.cronjob.usesHostPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetUsesHostPath()).ToDataRes(types.Bool)
+	},
+	"k8s.cronjob.volumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sCronjob).GetVolumes()).ToDataRes(types.Array(types.Resource("k8s.volume")))
 	},
 	"k8s.cronjob.usesUnconfinedSeccomp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sCronjob).GetUsesUnconfinedSeccomp()).ToDataRes(types.Bool)
@@ -2519,6 +2586,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.container.seccompProfileType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sContainer).GetSeccompProfileType()).ToDataRes(types.String)
 	},
+	"k8s.container.appArmorProfileType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sContainer).GetAppArmorProfileType()).ToDataRes(types.String)
+	},
+	"k8s.container.procMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sContainer).GetProcMount()).ToDataRes(types.String)
+	},
+	"k8s.container.seLinuxType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sContainer).GetSeLinuxType()).ToDataRes(types.String)
+	},
+	"k8s.container.seLinuxLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sContainer).GetSeLinuxLevel()).ToDataRes(types.String)
+	},
 	"k8s.container.workingDir": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sContainer).GetWorkingDir()).ToDataRes(types.String)
 	},
@@ -2654,6 +2733,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"k8s.initContainer.seccompProfileType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sInitContainer).GetSeccompProfileType()).ToDataRes(types.String)
 	},
+	"k8s.initContainer.appArmorProfileType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sInitContainer).GetAppArmorProfileType()).ToDataRes(types.String)
+	},
+	"k8s.initContainer.procMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sInitContainer).GetProcMount()).ToDataRes(types.String)
+	},
+	"k8s.initContainer.seLinuxType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sInitContainer).GetSeLinuxType()).ToDataRes(types.String)
+	},
+	"k8s.initContainer.seLinuxLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sInitContainer).GetSeLinuxLevel()).ToDataRes(types.String)
+	},
 	"k8s.initContainer.workingDir": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sInitContainer).GetWorkingDir()).ToDataRes(types.String)
 	},
@@ -2746,6 +2837,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.ephemeralContainer.seccompProfileType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sEphemeralContainer).GetSeccompProfileType()).ToDataRes(types.String)
+	},
+	"k8s.ephemeralContainer.appArmorProfileType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sEphemeralContainer).GetAppArmorProfileType()).ToDataRes(types.String)
+	},
+	"k8s.ephemeralContainer.procMount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sEphemeralContainer).GetProcMount()).ToDataRes(types.String)
+	},
+	"k8s.ephemeralContainer.seLinuxType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sEphemeralContainer).GetSeLinuxType()).ToDataRes(types.String)
+	},
+	"k8s.ephemeralContainer.seLinuxLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sEphemeralContainer).GetSeLinuxLevel()).ToDataRes(types.String)
 	},
 	"k8s.ephemeralContainer.workingDir": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sEphemeralContainer).GetWorkingDir()).ToDataRes(types.String)
@@ -3184,6 +3287,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.serviceaccount.hasWildcardPermissions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sServiceaccount).GetHasWildcardPermissions()).ToDataRes(types.Bool)
+	},
+	"k8s.serviceaccount.secretRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetSecretRefs()).ToDataRes(types.Array(types.Resource("k8s.secret")))
+	},
+	"k8s.serviceaccount.imagePullSecretRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sServiceaccount).GetImagePullSecretRefs()).ToDataRes(types.Array(types.Resource("k8s.secret")))
 	},
 	"k8s.serviceaccount.context": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sServiceaccount).GetContext()).ToDataRes(types.Resource("k8s.context"))
@@ -3850,6 +3959,93 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"k8s.persistentvolume.context": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sPersistentvolume).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
+	"k8s.runtimeclass.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetId()).ToDataRes(types.String)
+	},
+	"k8s.runtimeclass.uid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetUid()).ToDataRes(types.String)
+	},
+	"k8s.runtimeclass.resourceVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetResourceVersion()).ToDataRes(types.String)
+	},
+	"k8s.runtimeclass.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"k8s.runtimeclass.annotations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetAnnotations()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"k8s.runtimeclass.ownerReferences": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetOwnerReferences()).ToDataRes(types.Array(types.Resource("k8s.ownerReference")))
+	},
+	"k8s.runtimeclass.managedFields": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetManagedFields()).ToDataRes(types.Array(types.Resource("k8s.managedField")))
+	},
+	"k8s.runtimeclass.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetName()).ToDataRes(types.String)
+	},
+	"k8s.runtimeclass.kind": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetKind()).ToDataRes(types.String)
+	},
+	"k8s.runtimeclass.created": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetCreated()).ToDataRes(types.Time)
+	},
+	"k8s.runtimeclass.manifest": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetManifest()).ToDataRes(types.Dict)
+	},
+	"k8s.runtimeclass.handler": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetHandler()).ToDataRes(types.String)
+	},
+	"k8s.runtimeclass.overhead": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetOverhead()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"k8s.runtimeclass.scheduling": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetScheduling()).ToDataRes(types.Dict)
+	},
+	"k8s.runtimeclass.pods": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetPods()).ToDataRes(types.Array(types.Resource("k8s.pod")))
+	},
+	"k8s.runtimeclass.context": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sRuntimeclass).GetContext()).ToDataRes(types.Resource("k8s.context"))
+	},
+	"k8s.volume.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetName()).ToDataRes(types.String)
+	},
+	"k8s.volume.namespace": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetNamespace()).ToDataRes(types.String)
+	},
+	"k8s.volume.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetType()).ToDataRes(types.String)
+	},
+	"k8s.volume.hostPath": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetHostPath()).ToDataRes(types.String)
+	},
+	"k8s.volume.hostPathType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetHostPathType()).ToDataRes(types.String)
+	},
+	"k8s.volume.emptyDirMedium": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetEmptyDirMedium()).ToDataRes(types.String)
+	},
+	"k8s.volume.emptyDirSizeLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetEmptyDirSizeLimit()).ToDataRes(types.String)
+	},
+	"k8s.volume.csiDriver": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetCsiDriver()).ToDataRes(types.String)
+	},
+	"k8s.volume.serviceAccountTokens": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetServiceAccountTokens()).ToDataRes(types.Array(types.Dict))
+	},
+	"k8s.volume.secrets": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetSecrets()).ToDataRes(types.Array(types.Resource("k8s.secret")))
+	},
+	"k8s.volume.configMaps": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetConfigMaps()).ToDataRes(types.Array(types.Resource("k8s.configmap")))
+	},
+	"k8s.volume.persistentVolumeClaim": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetPersistentVolumeClaim()).ToDataRes(types.Resource("k8s.persistentvolumeclaim"))
+	},
+	"k8s.volume.source": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlK8sVolume).GetSource()).ToDataRes(types.Dict)
 	},
 	"k8s.storageclass.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlK8sStorageclass).GetId()).ToDataRes(types.String)
@@ -5796,6 +5992,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8s).ResourceClaimTemplates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.runtimeClasses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8s).RuntimeClasses, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"k8s.apiresource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sApiresource).__id, ok = v.Value.(string)
 		return
@@ -6120,6 +6320,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sNode).VolumesInUse, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"k8s.node.runtimeHandlers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNode).RuntimeHandlers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.node.supportsUserNamespaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNode).SupportsUserNamespaces, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.node.supportsSupplementalGroupsPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sNode).SupportsSupplementalGroupsPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.node.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sNode).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
 		return
@@ -6218,6 +6430,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.pod.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.pod.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6440,6 +6656,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sPod).RuntimeClassName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"k8s.pod.runtimeClass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).RuntimeClass, ok = plugin.RawToTValue[*mqlK8sRuntimeclass](v.Value, v.Error)
+		return
+	},
 	"k8s.pod.serviceAccountName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).ServiceAccountName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -6466,6 +6686,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.pod.hostIPC": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPod).HostIPC, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.pod.hostUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sPod).HostUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"k8s.pod.shareProcessNamespace": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6612,6 +6836,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDeployment).HostIPC, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.deployment.hostUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).HostUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.deployment.securityContext": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).SecurityContext, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -6646,6 +6874,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.deployment.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDeployment).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.deployment.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDeployment).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.deployment.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6888,6 +7120,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sDaemonset).HostIPC, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.daemonset.hostUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).HostUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.daemonset.securityContext": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).SecurityContext, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -6922,6 +7158,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.daemonset.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sDaemonset).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.daemonset.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sDaemonset).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.daemonset.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7160,6 +7400,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sStatefulset).HostIPC, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.statefulset.hostUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).HostUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.statefulset.securityContext": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).SecurityContext, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -7194,6 +7438,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.statefulset.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sStatefulset).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.statefulset.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sStatefulset).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.statefulset.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7452,6 +7700,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sReplicaset).HostIPC, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.replicaset.hostUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).HostUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.replicaset.securityContext": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).SecurityContext, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -7486,6 +7738,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.replicaset.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sReplicaset).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.replicaset.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sReplicaset).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.replicaset.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7704,6 +7960,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sJob).HostIPC, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.job.hostUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).HostUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.job.securityContext": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).SecurityContext, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -7738,6 +7998,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.job.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sJob).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.job.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sJob).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.job.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8000,6 +8264,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sCronjob).HostIPC, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"k8s.cronjob.hostUsers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).HostUsers, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"k8s.cronjob.securityContext": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).SecurityContext, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
@@ -8034,6 +8302,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.cronjob.usesHostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sCronjob).UsesHostPath, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.cronjob.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sCronjob).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.cronjob.usesUnconfinedSeccomp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8332,6 +8604,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sContainer).SeccompProfileType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"k8s.container.appArmorProfileType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContainer).AppArmorProfileType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.container.procMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContainer).ProcMount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.container.seLinuxType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContainer).SeLinuxType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.container.seLinuxLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sContainer).SeLinuxLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"k8s.container.workingDir": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sContainer).WorkingDir, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8520,6 +8808,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlK8sInitContainer).SeccompProfileType, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"k8s.initContainer.appArmorProfileType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sInitContainer).AppArmorProfileType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.initContainer.procMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sInitContainer).ProcMount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.initContainer.seLinuxType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sInitContainer).SeLinuxType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.initContainer.seLinuxLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sInitContainer).SeLinuxLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"k8s.initContainer.workingDir": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sInitContainer).WorkingDir, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -8646,6 +8950,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.ephemeralContainer.seccompProfileType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sEphemeralContainer).SeccompProfileType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.ephemeralContainer.appArmorProfileType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sEphemeralContainer).AppArmorProfileType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.ephemeralContainer.procMount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sEphemeralContainer).ProcMount, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.ephemeralContainer.seLinuxType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sEphemeralContainer).SeLinuxType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.ephemeralContainer.seLinuxLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sEphemeralContainer).SeLinuxLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"k8s.ephemeralContainer.workingDir": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9274,6 +9594,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.serviceaccount.hasWildcardPermissions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sServiceaccount).HasWildcardPermissions, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.secretRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).SecretRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.serviceaccount.imagePullSecretRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sServiceaccount).ImagePullSecretRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"k8s.serviceaccount.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10218,6 +10546,130 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"k8s.persistentvolume.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlK8sPersistentvolume).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).__id, ok = v.Value.(string)
+		return
+	},
+	"k8s.runtimeclass.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.uid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Uid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.resourceVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).ResourceVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.annotations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Annotations, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.ownerReferences": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).OwnerReferences, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.managedFields": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).ManagedFields, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.kind": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Kind, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Created, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.manifest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Manifest, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.handler": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Handler, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.overhead": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Overhead, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.scheduling": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Scheduling, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.pods": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Pods, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.runtimeclass.context": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sRuntimeclass).Context, ok = plugin.RawToTValue[*mqlK8sContext](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).__id, ok = v.Value.(string)
+		return
+	},
+	"k8s.volume.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.namespace": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).Namespace, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.hostPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).HostPath, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.hostPathType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).HostPathType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.emptyDirMedium": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).EmptyDirMedium, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.emptyDirSizeLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).EmptyDirSizeLimit, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.csiDriver": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).CsiDriver, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.serviceAccountTokens": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).ServiceAccountTokens, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.secrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).Secrets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.configMaps": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).ConfigMaps, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.persistentVolumeClaim": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).PersistentVolumeClaim, ok = plugin.RawToTValue[*mqlK8sPersistentvolumeclaim](v.Value, v.Error)
+		return
+	},
+	"k8s.volume.source": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlK8sVolume).Source, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"k8s.storageclass.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -12718,6 +13170,7 @@ type mqlK8s struct {
 	ResourceSlices                    plugin.TValue[[]any]
 	ResourceClaims                    plugin.TValue[[]any]
 	ResourceClaimTemplates            plugin.TValue[[]any]
+	RuntimeClasses                    plugin.TValue[[]any]
 }
 
 // createK8s creates a new instance of this resource
@@ -13654,6 +14107,22 @@ func (c *mqlK8s) GetResourceClaimTemplates() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8s) GetRuntimeClasses() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RuntimeClasses, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s", c.__id, "runtimeClasses")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.runtimeClasses()
+	})
+}
+
 // mqlK8sApiresource for the k8s.apiresource resource
 type mqlK8sApiresource struct {
 	MqlRuntime *plugin.Runtime
@@ -14307,37 +14776,40 @@ type mqlK8sNode struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlK8sNodeInternal
-	Id                      plugin.TValue[string]
-	Uid                     plugin.TValue[string]
-	Labels                  plugin.TValue[map[string]any]
-	Annotations             plugin.TValue[map[string]any]
-	OwnerReferences         plugin.TValue[[]any]
-	ManagedFields           plugin.TValue[[]any]
-	ResourceVersion         plugin.TValue[string]
-	Name                    plugin.TValue[string]
-	Kind                    plugin.TValue[string]
-	Created                 plugin.TValue[*time.Time]
-	NodeInfo                plugin.TValue[any]
-	KubeletPort             plugin.TValue[int64]
-	Taints                  plugin.TValue[[]any]
-	Conditions              plugin.TValue[[]any]
-	Addresses               plugin.TValue[[]any]
-	Capacity                plugin.TValue[any]
-	Allocatable             plugin.TValue[any]
-	ProviderID              plugin.TValue[string]
-	Unschedulable           plugin.TValue[bool]
-	PodCIDR                 plugin.TValue[string]
-	PodCIDRs                plugin.TValue[[]any]
-	OsImage                 plugin.TValue[string]
-	OperatingSystem         plugin.TValue[string]
-	Architecture            plugin.TValue[string]
-	KernelVersion           plugin.TValue[string]
-	KubeletVersion          plugin.TValue[string]
-	ContainerRuntimeVersion plugin.TValue[string]
-	Images                  plugin.TValue[[]any]
-	VolumesAttached         plugin.TValue[[]any]
-	VolumesInUse            plugin.TValue[[]any]
-	Context                 plugin.TValue[*mqlK8sContext]
+	Id                               plugin.TValue[string]
+	Uid                              plugin.TValue[string]
+	Labels                           plugin.TValue[map[string]any]
+	Annotations                      plugin.TValue[map[string]any]
+	OwnerReferences                  plugin.TValue[[]any]
+	ManagedFields                    plugin.TValue[[]any]
+	ResourceVersion                  plugin.TValue[string]
+	Name                             plugin.TValue[string]
+	Kind                             plugin.TValue[string]
+	Created                          plugin.TValue[*time.Time]
+	NodeInfo                         plugin.TValue[any]
+	KubeletPort                      plugin.TValue[int64]
+	Taints                           plugin.TValue[[]any]
+	Conditions                       plugin.TValue[[]any]
+	Addresses                        plugin.TValue[[]any]
+	Capacity                         plugin.TValue[any]
+	Allocatable                      plugin.TValue[any]
+	ProviderID                       plugin.TValue[string]
+	Unschedulable                    plugin.TValue[bool]
+	PodCIDR                          plugin.TValue[string]
+	PodCIDRs                         plugin.TValue[[]any]
+	OsImage                          plugin.TValue[string]
+	OperatingSystem                  plugin.TValue[string]
+	Architecture                     plugin.TValue[string]
+	KernelVersion                    plugin.TValue[string]
+	KubeletVersion                   plugin.TValue[string]
+	ContainerRuntimeVersion          plugin.TValue[string]
+	Images                           plugin.TValue[[]any]
+	VolumesAttached                  plugin.TValue[[]any]
+	VolumesInUse                     plugin.TValue[[]any]
+	RuntimeHandlers                  plugin.TValue[[]any]
+	SupportsUserNamespaces           plugin.TValue[bool]
+	SupportsSupplementalGroupsPolicy plugin.TValue[bool]
+	Context                          plugin.TValue[*mqlK8sContext]
 }
 
 // createK8sNode creates a new instance of this resource
@@ -14593,6 +15065,24 @@ func (c *mqlK8sNode) GetVolumesInUse() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlK8sNode) GetRuntimeHandlers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RuntimeHandlers, func() ([]any, error) {
+		return c.runtimeHandlers()
+	})
+}
+
+func (c *mqlK8sNode) GetSupportsUserNamespaces() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SupportsUserNamespaces, func() (bool, error) {
+		return c.supportsUserNamespaces()
+	})
+}
+
+func (c *mqlK8sNode) GetSupportsSupplementalGroupsPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.SupportsSupplementalGroupsPolicy, func() (bool, error) {
+		return c.supportsSupplementalGroupsPolicy()
+	})
+}
+
 func (c *mqlK8sNode) GetContext() *plugin.TValue[*mqlK8sContext] {
 	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
 		if c.MqlRuntime.HasRecording {
@@ -14799,6 +15289,7 @@ type mqlK8sPod struct {
 	AddedCapabilities             plugin.TValue[[]any]
 	UsesHostNamespaces            plugin.TValue[bool]
 	UsesHostPath                  plugin.TValue[bool]
+	Volumes                       plugin.TValue[[]any]
 	UsesUnconfinedSeccomp         plugin.TValue[bool]
 	HasSeccompProfile             plugin.TValue[bool]
 	UsesUnconfinedAppArmor        plugin.TValue[bool]
@@ -14854,6 +15345,7 @@ type mqlK8sPod struct {
 	PreemptionPolicy              plugin.TValue[string]
 	SchedulerName                 plugin.TValue[string]
 	RuntimeClassName              plugin.TValue[string]
+	RuntimeClass                  plugin.TValue[*mqlK8sRuntimeclass]
 	ServiceAccountName            plugin.TValue[string]
 	ServiceAccount                plugin.TValue[*mqlK8sServiceaccount]
 	AutomountServiceAccountToken  plugin.TValue[bool]
@@ -14861,6 +15353,7 @@ type mqlK8sPod struct {
 	EscapesNetworkPolicy          plugin.TValue[bool]
 	HostPID                       plugin.TValue[bool]
 	HostIPC                       plugin.TValue[bool]
+	HostUsers                     plugin.TValue[bool]
 	ShareProcessNamespace         plugin.TValue[bool]
 	SecurityContext               plugin.TValue[any]
 	DnsPolicy                     plugin.TValue[string]
@@ -14976,6 +15469,22 @@ func (c *mqlK8sPod) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sPod) GetVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Volumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.pod", c.__id, "volumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumes()
 	})
 }
 
@@ -15393,6 +15902,22 @@ func (c *mqlK8sPod) GetRuntimeClassName() *plugin.TValue[string] {
 	})
 }
 
+func (c *mqlK8sPod) GetRuntimeClass() *plugin.TValue[*mqlK8sRuntimeclass] {
+	return plugin.GetOrCompute[*mqlK8sRuntimeclass](&c.RuntimeClass, func() (*mqlK8sRuntimeclass, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.pod", c.__id, "runtimeClass")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sRuntimeclass), nil
+			}
+		}
+
+		return c.runtimeClass()
+	})
+}
+
 func (c *mqlK8sPod) GetServiceAccountName() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.ServiceAccountName, func() (string, error) {
 		return c.serviceAccountName()
@@ -15442,6 +15967,12 @@ func (c *mqlK8sPod) GetHostPID() *plugin.TValue[bool] {
 func (c *mqlK8sPod) GetHostIPC() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HostIPC, func() (bool, error) {
 		return c.hostIPC()
+	})
+}
+
+func (c *mqlK8sPod) GetHostUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HostUsers, func() (bool, error) {
+		return c.hostUsers()
 	})
 }
 
@@ -15700,6 +16231,7 @@ type mqlK8sDeployment struct {
 	HostNetwork                  plugin.TValue[bool]
 	HostPID                      plugin.TValue[bool]
 	HostIPC                      plugin.TValue[bool]
+	HostUsers                    plugin.TValue[bool]
 	SecurityContext              plugin.TValue[any]
 	RunsPrivileged               plugin.TValue[bool]
 	AllowsPrivilegeEscalation    plugin.TValue[bool]
@@ -15709,6 +16241,7 @@ type mqlK8sDeployment struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	Volumes                      plugin.TValue[[]any]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
 	UsesUnconfinedAppArmor       plugin.TValue[bool]
@@ -15827,6 +16360,12 @@ func (c *mqlK8sDeployment) GetHostIPC() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sDeployment) GetHostUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HostUsers, func() (bool, error) {
+		return c.hostUsers()
+	})
+}
+
 func (c *mqlK8sDeployment) GetSecurityContext() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.SecurityContext, func() (any, error) {
 		return c.securityContext()
@@ -15878,6 +16417,22 @@ func (c *mqlK8sDeployment) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sDeployment) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sDeployment) GetVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Volumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.deployment", c.__id, "volumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumes()
 	})
 }
 
@@ -16276,6 +16831,7 @@ type mqlK8sDaemonset struct {
 	HostNetwork                  plugin.TValue[bool]
 	HostPID                      plugin.TValue[bool]
 	HostIPC                      plugin.TValue[bool]
+	HostUsers                    plugin.TValue[bool]
 	SecurityContext              plugin.TValue[any]
 	RunsPrivileged               plugin.TValue[bool]
 	AllowsPrivilegeEscalation    plugin.TValue[bool]
@@ -16285,6 +16841,7 @@ type mqlK8sDaemonset struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	Volumes                      plugin.TValue[[]any]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
 	UsesUnconfinedAppArmor       plugin.TValue[bool]
@@ -16402,6 +16959,12 @@ func (c *mqlK8sDaemonset) GetHostIPC() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sDaemonset) GetHostUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HostUsers, func() (bool, error) {
+		return c.hostUsers()
+	})
+}
+
 func (c *mqlK8sDaemonset) GetSecurityContext() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.SecurityContext, func() (any, error) {
 		return c.securityContext()
@@ -16453,6 +17016,22 @@ func (c *mqlK8sDaemonset) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sDaemonset) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sDaemonset) GetVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Volumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.daemonset", c.__id, "volumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumes()
 	})
 }
 
@@ -16845,6 +17424,7 @@ type mqlK8sStatefulset struct {
 	HostNetwork                          plugin.TValue[bool]
 	HostPID                              plugin.TValue[bool]
 	HostIPC                              plugin.TValue[bool]
+	HostUsers                            plugin.TValue[bool]
 	SecurityContext                      plugin.TValue[any]
 	RunsPrivileged                       plugin.TValue[bool]
 	AllowsPrivilegeEscalation            plugin.TValue[bool]
@@ -16854,6 +17434,7 @@ type mqlK8sStatefulset struct {
 	AddedCapabilities                    plugin.TValue[[]any]
 	UsesHostNamespaces                   plugin.TValue[bool]
 	UsesHostPath                         plugin.TValue[bool]
+	Volumes                              plugin.TValue[[]any]
 	UsesUnconfinedSeccomp                plugin.TValue[bool]
 	HasSeccompProfile                    plugin.TValue[bool]
 	UsesUnconfinedAppArmor               plugin.TValue[bool]
@@ -16976,6 +17557,12 @@ func (c *mqlK8sStatefulset) GetHostIPC() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sStatefulset) GetHostUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HostUsers, func() (bool, error) {
+		return c.hostUsers()
+	})
+}
+
 func (c *mqlK8sStatefulset) GetSecurityContext() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.SecurityContext, func() (any, error) {
 		return c.securityContext()
@@ -17027,6 +17614,22 @@ func (c *mqlK8sStatefulset) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sStatefulset) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sStatefulset) GetVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Volumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.statefulset", c.__id, "volumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumes()
 	})
 }
 
@@ -17449,6 +18052,7 @@ type mqlK8sReplicaset struct {
 	HostNetwork                  plugin.TValue[bool]
 	HostPID                      plugin.TValue[bool]
 	HostIPC                      plugin.TValue[bool]
+	HostUsers                    plugin.TValue[bool]
 	SecurityContext              plugin.TValue[any]
 	RunsPrivileged               plugin.TValue[bool]
 	AllowsPrivilegeEscalation    plugin.TValue[bool]
@@ -17458,6 +18062,7 @@ type mqlK8sReplicaset struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	Volumes                      plugin.TValue[[]any]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
 	UsesUnconfinedAppArmor       plugin.TValue[bool]
@@ -17570,6 +18175,12 @@ func (c *mqlK8sReplicaset) GetHostIPC() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sReplicaset) GetHostUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HostUsers, func() (bool, error) {
+		return c.hostUsers()
+	})
+}
+
 func (c *mqlK8sReplicaset) GetSecurityContext() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.SecurityContext, func() (any, error) {
 		return c.securityContext()
@@ -17621,6 +18232,22 @@ func (c *mqlK8sReplicaset) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sReplicaset) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sReplicaset) GetVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Volumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.replicaset", c.__id, "volumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumes()
 	})
 }
 
@@ -17983,6 +18610,7 @@ type mqlK8sJob struct {
 	HostNetwork                  plugin.TValue[bool]
 	HostPID                      plugin.TValue[bool]
 	HostIPC                      plugin.TValue[bool]
+	HostUsers                    plugin.TValue[bool]
 	SecurityContext              plugin.TValue[any]
 	RunsPrivileged               plugin.TValue[bool]
 	AllowsPrivilegeEscalation    plugin.TValue[bool]
@@ -17992,6 +18620,7 @@ type mqlK8sJob struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	Volumes                      plugin.TValue[[]any]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
 	UsesUnconfinedAppArmor       plugin.TValue[bool]
@@ -18115,6 +18744,12 @@ func (c *mqlK8sJob) GetHostIPC() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sJob) GetHostUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HostUsers, func() (bool, error) {
+		return c.hostUsers()
+	})
+}
+
 func (c *mqlK8sJob) GetSecurityContext() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.SecurityContext, func() (any, error) {
 		return c.securityContext()
@@ -18166,6 +18801,22 @@ func (c *mqlK8sJob) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sJob) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sJob) GetVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Volumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.job", c.__id, "volumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumes()
 	})
 }
 
@@ -18584,6 +19235,7 @@ type mqlK8sCronjob struct {
 	HostNetwork                  plugin.TValue[bool]
 	HostPID                      plugin.TValue[bool]
 	HostIPC                      plugin.TValue[bool]
+	HostUsers                    plugin.TValue[bool]
 	SecurityContext              plugin.TValue[any]
 	RunsPrivileged               plugin.TValue[bool]
 	AllowsPrivilegeEscalation    plugin.TValue[bool]
@@ -18593,6 +19245,7 @@ type mqlK8sCronjob struct {
 	AddedCapabilities            plugin.TValue[[]any]
 	UsesHostNamespaces           plugin.TValue[bool]
 	UsesHostPath                 plugin.TValue[bool]
+	Volumes                      plugin.TValue[[]any]
 	UsesUnconfinedSeccomp        plugin.TValue[bool]
 	HasSeccompProfile            plugin.TValue[bool]
 	UsesUnconfinedAppArmor       plugin.TValue[bool]
@@ -18706,6 +19359,12 @@ func (c *mqlK8sCronjob) GetHostIPC() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlK8sCronjob) GetHostUsers() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HostUsers, func() (bool, error) {
+		return c.hostUsers()
+	})
+}
+
 func (c *mqlK8sCronjob) GetSecurityContext() *plugin.TValue[any] {
 	return plugin.GetOrCompute[any](&c.SecurityContext, func() (any, error) {
 		return c.securityContext()
@@ -18757,6 +19416,22 @@ func (c *mqlK8sCronjob) GetUsesHostNamespaces() *plugin.TValue[bool] {
 func (c *mqlK8sCronjob) GetUsesHostPath() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.UsesHostPath, func() (bool, error) {
 		return c.usesHostPath()
+	})
+}
+
+func (c *mqlK8sCronjob) GetVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Volumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.cronjob", c.__id, "volumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumes()
 	})
 }
 
@@ -19144,6 +19819,10 @@ type mqlK8sContainer struct {
 	AddedCapabilities        plugin.TValue[[]any]
 	DroppedCapabilities      plugin.TValue[[]any]
 	SeccompProfileType       plugin.TValue[string]
+	AppArmorProfileType      plugin.TValue[string]
+	ProcMount                plugin.TValue[string]
+	SeLinuxType              plugin.TValue[string]
+	SeLinuxLevel             plugin.TValue[string]
 	WorkingDir               plugin.TValue[string]
 	Tty                      plugin.TValue[bool]
 	Stdin                    plugin.TValue[bool]
@@ -19297,6 +19976,22 @@ func (c *mqlK8sContainer) GetDroppedCapabilities() *plugin.TValue[[]any] {
 
 func (c *mqlK8sContainer) GetSeccompProfileType() *plugin.TValue[string] {
 	return &c.SeccompProfileType
+}
+
+func (c *mqlK8sContainer) GetAppArmorProfileType() *plugin.TValue[string] {
+	return &c.AppArmorProfileType
+}
+
+func (c *mqlK8sContainer) GetProcMount() *plugin.TValue[string] {
+	return &c.ProcMount
+}
+
+func (c *mqlK8sContainer) GetSeLinuxType() *plugin.TValue[string] {
+	return &c.SeLinuxType
+}
+
+func (c *mqlK8sContainer) GetSeLinuxLevel() *plugin.TValue[string] {
+	return &c.SeLinuxLevel
 }
 
 func (c *mqlK8sContainer) GetWorkingDir() *plugin.TValue[string] {
@@ -19464,6 +20159,10 @@ type mqlK8sInitContainer struct {
 	AddedCapabilities        plugin.TValue[[]any]
 	DroppedCapabilities      plugin.TValue[[]any]
 	SeccompProfileType       plugin.TValue[string]
+	AppArmorProfileType      plugin.TValue[string]
+	ProcMount                plugin.TValue[string]
+	SeLinuxType              plugin.TValue[string]
+	SeLinuxLevel             plugin.TValue[string]
 	WorkingDir               plugin.TValue[string]
 	Tty                      plugin.TValue[bool]
 	Stdin                    plugin.TValue[bool]
@@ -19619,6 +20318,22 @@ func (c *mqlK8sInitContainer) GetSeccompProfileType() *plugin.TValue[string] {
 	return &c.SeccompProfileType
 }
 
+func (c *mqlK8sInitContainer) GetAppArmorProfileType() *plugin.TValue[string] {
+	return &c.AppArmorProfileType
+}
+
+func (c *mqlK8sInitContainer) GetProcMount() *plugin.TValue[string] {
+	return &c.ProcMount
+}
+
+func (c *mqlK8sInitContainer) GetSeLinuxType() *plugin.TValue[string] {
+	return &c.SeLinuxType
+}
+
+func (c *mqlK8sInitContainer) GetSeLinuxLevel() *plugin.TValue[string] {
+	return &c.SeLinuxLevel
+}
+
 func (c *mqlK8sInitContainer) GetWorkingDir() *plugin.TValue[string] {
 	return &c.WorkingDir
 }
@@ -19691,6 +20406,10 @@ type mqlK8sEphemeralContainer struct {
 	AddedCapabilities        plugin.TValue[[]any]
 	DroppedCapabilities      plugin.TValue[[]any]
 	SeccompProfileType       plugin.TValue[string]
+	AppArmorProfileType      plugin.TValue[string]
+	ProcMount                plugin.TValue[string]
+	SeLinuxType              plugin.TValue[string]
+	SeLinuxLevel             plugin.TValue[string]
 	WorkingDir               plugin.TValue[string]
 	Tty                      plugin.TValue[bool]
 	Stdin                    plugin.TValue[bool]
@@ -19825,6 +20544,22 @@ func (c *mqlK8sEphemeralContainer) GetDroppedCapabilities() *plugin.TValue[[]any
 
 func (c *mqlK8sEphemeralContainer) GetSeccompProfileType() *plugin.TValue[string] {
 	return &c.SeccompProfileType
+}
+
+func (c *mqlK8sEphemeralContainer) GetAppArmorProfileType() *plugin.TValue[string] {
+	return &c.AppArmorProfileType
+}
+
+func (c *mqlK8sEphemeralContainer) GetProcMount() *plugin.TValue[string] {
+	return &c.ProcMount
+}
+
+func (c *mqlK8sEphemeralContainer) GetSeLinuxType() *plugin.TValue[string] {
+	return &c.SeLinuxType
+}
+
+func (c *mqlK8sEphemeralContainer) GetSeLinuxLevel() *plugin.TValue[string] {
+	return &c.SeLinuxLevel
 }
 
 func (c *mqlK8sEphemeralContainer) GetWorkingDir() *plugin.TValue[string] {
@@ -21257,6 +21992,8 @@ type mqlK8sServiceaccount struct {
 	CanEscalatePrivileges        plugin.TValue[bool]
 	CanReadSecrets               plugin.TValue[bool]
 	HasWildcardPermissions       plugin.TValue[bool]
+	SecretRefs                   plugin.TValue[[]any]
+	ImagePullSecretRefs          plugin.TValue[[]any]
 	Context                      plugin.TValue[*mqlK8sContext]
 }
 
@@ -21440,6 +22177,38 @@ func (c *mqlK8sServiceaccount) GetCanReadSecrets() *plugin.TValue[bool] {
 func (c *mqlK8sServiceaccount) GetHasWildcardPermissions() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.HasWildcardPermissions, func() (bool, error) {
 		return c.hasWildcardPermissions()
+	})
+}
+
+func (c *mqlK8sServiceaccount) GetSecretRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SecretRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.serviceaccount", c.__id, "secretRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.secretRefs()
+	})
+}
+
+func (c *mqlK8sServiceaccount) GetImagePullSecretRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ImagePullSecretRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.serviceaccount", c.__id, "imagePullSecretRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.imagePullSecretRefs()
 	})
 }
 
@@ -23739,6 +24508,326 @@ func (c *mqlK8sPersistentvolume) GetContext() *plugin.TValue[*mqlK8sContext] {
 
 		return c.context()
 	})
+}
+
+// mqlK8sRuntimeclass for the k8s.runtimeclass resource
+type mqlK8sRuntimeclass struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlK8sRuntimeclassInternal
+	Id              plugin.TValue[string]
+	Uid             plugin.TValue[string]
+	ResourceVersion plugin.TValue[string]
+	Labels          plugin.TValue[map[string]any]
+	Annotations     plugin.TValue[map[string]any]
+	OwnerReferences plugin.TValue[[]any]
+	ManagedFields   plugin.TValue[[]any]
+	Name            plugin.TValue[string]
+	Kind            plugin.TValue[string]
+	Created         plugin.TValue[*time.Time]
+	Manifest        plugin.TValue[any]
+	Handler         plugin.TValue[string]
+	Overhead        plugin.TValue[map[string]any]
+	Scheduling      plugin.TValue[any]
+	Pods            plugin.TValue[[]any]
+	Context         plugin.TValue[*mqlK8sContext]
+}
+
+// createK8sRuntimeclass creates a new instance of this resource
+func createK8sRuntimeclass(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlK8sRuntimeclass{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("k8s.runtimeclass", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlK8sRuntimeclass) MqlName() string {
+	return "k8s.runtimeclass"
+}
+
+func (c *mqlK8sRuntimeclass) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlK8sRuntimeclass) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlK8sRuntimeclass) GetUid() *plugin.TValue[string] {
+	return &c.Uid
+}
+
+func (c *mqlK8sRuntimeclass) GetResourceVersion() *plugin.TValue[string] {
+	return &c.ResourceVersion
+}
+
+func (c *mqlK8sRuntimeclass) GetLabels() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Labels, func() (map[string]any, error) {
+		return c.labels()
+	})
+}
+
+func (c *mqlK8sRuntimeclass) GetAnnotations() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Annotations, func() (map[string]any, error) {
+		return c.annotations()
+	})
+}
+
+func (c *mqlK8sRuntimeclass) GetOwnerReferences() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.OwnerReferences, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.runtimeclass", c.__id, "ownerReferences")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.ownerReferences()
+	})
+}
+
+func (c *mqlK8sRuntimeclass) GetManagedFields() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ManagedFields, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.runtimeclass", c.__id, "managedFields")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.managedFields()
+	})
+}
+
+func (c *mqlK8sRuntimeclass) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlK8sRuntimeclass) GetKind() *plugin.TValue[string] {
+	return &c.Kind
+}
+
+func (c *mqlK8sRuntimeclass) GetCreated() *plugin.TValue[*time.Time] {
+	return &c.Created
+}
+
+func (c *mqlK8sRuntimeclass) GetManifest() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.Manifest, func() (any, error) {
+		return c.manifest()
+	})
+}
+
+func (c *mqlK8sRuntimeclass) GetHandler() *plugin.TValue[string] {
+	return &c.Handler
+}
+
+func (c *mqlK8sRuntimeclass) GetOverhead() *plugin.TValue[map[string]any] {
+	return &c.Overhead
+}
+
+func (c *mqlK8sRuntimeclass) GetScheduling() *plugin.TValue[any] {
+	return &c.Scheduling
+}
+
+func (c *mqlK8sRuntimeclass) GetPods() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Pods, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.runtimeclass", c.__id, "pods")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.pods()
+	})
+}
+
+func (c *mqlK8sRuntimeclass) GetContext() *plugin.TValue[*mqlK8sContext] {
+	return plugin.GetOrCompute[*mqlK8sContext](&c.Context, func() (*mqlK8sContext, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.runtimeclass", c.__id, "context")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sContext), nil
+			}
+		}
+
+		return c.context()
+	})
+}
+
+// mqlK8sVolume for the k8s.volume resource
+type mqlK8sVolume struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlK8sVolumeInternal
+	Name                  plugin.TValue[string]
+	Namespace             plugin.TValue[string]
+	Type                  plugin.TValue[string]
+	HostPath              plugin.TValue[string]
+	HostPathType          plugin.TValue[string]
+	EmptyDirMedium        plugin.TValue[string]
+	EmptyDirSizeLimit     plugin.TValue[string]
+	CsiDriver             plugin.TValue[string]
+	ServiceAccountTokens  plugin.TValue[[]any]
+	Secrets               plugin.TValue[[]any]
+	ConfigMaps            plugin.TValue[[]any]
+	PersistentVolumeClaim plugin.TValue[*mqlK8sPersistentvolumeclaim]
+	Source                plugin.TValue[any]
+}
+
+// createK8sVolume creates a new instance of this resource
+func createK8sVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlK8sVolume{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("k8s.volume", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlK8sVolume) MqlName() string {
+	return "k8s.volume"
+}
+
+func (c *mqlK8sVolume) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlK8sVolume) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlK8sVolume) GetNamespace() *plugin.TValue[string] {
+	return &c.Namespace
+}
+
+func (c *mqlK8sVolume) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlK8sVolume) GetHostPath() *plugin.TValue[string] {
+	return &c.HostPath
+}
+
+func (c *mqlK8sVolume) GetHostPathType() *plugin.TValue[string] {
+	return &c.HostPathType
+}
+
+func (c *mqlK8sVolume) GetEmptyDirMedium() *plugin.TValue[string] {
+	return &c.EmptyDirMedium
+}
+
+func (c *mqlK8sVolume) GetEmptyDirSizeLimit() *plugin.TValue[string] {
+	return &c.EmptyDirSizeLimit
+}
+
+func (c *mqlK8sVolume) GetCsiDriver() *plugin.TValue[string] {
+	return &c.CsiDriver
+}
+
+func (c *mqlK8sVolume) GetServiceAccountTokens() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ServiceAccountTokens, func() ([]any, error) {
+		return c.serviceAccountTokens()
+	})
+}
+
+func (c *mqlK8sVolume) GetSecrets() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Secrets, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.volume", c.__id, "secrets")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.secrets()
+	})
+}
+
+func (c *mqlK8sVolume) GetConfigMaps() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ConfigMaps, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.volume", c.__id, "configMaps")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.configMaps()
+	})
+}
+
+func (c *mqlK8sVolume) GetPersistentVolumeClaim() *plugin.TValue[*mqlK8sPersistentvolumeclaim] {
+	return plugin.GetOrCompute[*mqlK8sPersistentvolumeclaim](&c.PersistentVolumeClaim, func() (*mqlK8sPersistentvolumeclaim, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("k8s.volume", c.__id, "persistentVolumeClaim")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlK8sPersistentvolumeclaim), nil
+			}
+		}
+
+		return c.persistentVolumeClaim()
+	})
+}
+
+func (c *mqlK8sVolume) GetSource() *plugin.TValue[any] {
+	return &c.Source
 }
 
 // mqlK8sStorageclass for the k8s.storageclass resource

--- a/providers/k8s/resources/k8s.lr.versions
+++ b/providers/k8s/resources/k8s.lr.versions
@@ -177,6 +177,7 @@ k8s.configmaps 9.0.0
 k8s.container 9.0.0
 k8s.container.addedCapabilities 13.1.2
 k8s.container.allowPrivilegeEscalation 13.1.2
+k8s.container.appArmorProfileType 13.10.1
 k8s.container.args 9.0.0
 k8s.container.command 9.0.0
 k8s.container.containerImage 9.0.0
@@ -190,6 +191,7 @@ k8s.container.livenessProbe 9.0.0
 k8s.container.name 9.0.0
 k8s.container.ports 13.0.16
 k8s.container.privileged 13.1.2
+k8s.container.procMount 13.10.1
 k8s.container.readOnlyRootFilesystem 13.1.2
 k8s.container.readinessProbe 9.0.0
 k8s.container.resizePolicy 13.0.16
@@ -198,6 +200,8 @@ k8s.container.restartPolicy 13.0.16
 k8s.container.runAsGroup 13.1.2
 k8s.container.runAsNonRoot 13.1.2
 k8s.container.runAsUser 13.1.2
+k8s.container.seLinuxLevel 13.10.1
+k8s.container.seLinuxType 13.10.1
 k8s.container.seccompProfileType 13.1.2
 k8s.container.securityContext 9.0.0
 k8s.container.startupProbe 13.0.16
@@ -250,6 +254,7 @@ k8s.cronjob.hasWritableRootFilesystem 13.2.2
 k8s.cronjob.hostIPC 13.2.2
 k8s.cronjob.hostNetwork 13.2.2
 k8s.cronjob.hostPID 13.2.2
+k8s.cronjob.hostUsers 13.10.1
 k8s.cronjob.id 9.0.0
 k8s.cronjob.imageRegistries 13.3.1
 k8s.cronjob.initContainers 9.0.0
@@ -289,6 +294,7 @@ k8s.cronjob.usesSecretsAsEnv 13.3.1
 k8s.cronjob.usesUnconfinedAppArmor 13.4.1
 k8s.cronjob.usesUnconfinedSeccomp 13.3.1
 k8s.cronjob.usesUnmaskedProcMount 13.4.1
+k8s.cronjob.volumes 13.10.1
 k8s.cronjobs 9.0.0
 k8s.customresource 9.0.0
 k8s.customresource.annotations 9.0.0
@@ -331,6 +337,7 @@ k8s.daemonset.hasWritableRootFilesystem 13.2.2
 k8s.daemonset.hostIPC 13.2.2
 k8s.daemonset.hostNetwork 13.2.2
 k8s.daemonset.hostPID 13.2.2
+k8s.daemonset.hostUsers 13.10.1
 k8s.daemonset.id 9.0.0
 k8s.daemonset.imageRegistries 13.3.1
 k8s.daemonset.initContainers 9.0.0
@@ -373,6 +380,7 @@ k8s.daemonset.usesSecretsAsEnv 13.3.1
 k8s.daemonset.usesUnconfinedAppArmor 13.4.1
 k8s.daemonset.usesUnconfinedSeccomp 13.3.1
 k8s.daemonset.usesUnmaskedProcMount 13.4.1
+k8s.daemonset.volumes 13.10.1
 k8s.daemonsets 9.0.0
 k8s.deployment 9.0.0
 k8s.deployment.addedCapabilities 13.2.2
@@ -400,6 +408,7 @@ k8s.deployment.hasWritableRootFilesystem 13.2.2
 k8s.deployment.hostIPC 13.2.2
 k8s.deployment.hostNetwork 13.2.2
 k8s.deployment.hostPID 13.2.2
+k8s.deployment.hostUsers 13.10.1
 k8s.deployment.id 9.0.0
 k8s.deployment.imageRegistries 13.3.1
 k8s.deployment.initContainers 9.0.0
@@ -443,6 +452,7 @@ k8s.deployment.usesSecretsAsEnv 13.3.1
 k8s.deployment.usesUnconfinedAppArmor 13.4.1
 k8s.deployment.usesUnconfinedSeccomp 13.3.1
 k8s.deployment.usesUnmaskedProcMount 13.4.1
+k8s.deployment.volumes 13.10.1
 k8s.deployments 9.0.0
 k8s.deviceClasses 13.9.2
 k8s.deviceclass 13.9.2
@@ -511,6 +521,7 @@ k8s.endpointslice.uid 11.1.139
 k8s.ephemeralContainer 9.0.0
 k8s.ephemeralContainer.addedCapabilities 13.1.2
 k8s.ephemeralContainer.allowPrivilegeEscalation 13.1.2
+k8s.ephemeralContainer.appArmorProfileType 13.10.1
 k8s.ephemeralContainer.args 9.0.0
 k8s.ephemeralContainer.command 9.0.0
 k8s.ephemeralContainer.containerImage 9.0.0
@@ -522,10 +533,13 @@ k8s.ephemeralContainer.imagePullPolicy 9.0.0
 k8s.ephemeralContainer.name 9.0.0
 k8s.ephemeralContainer.ports 13.0.16
 k8s.ephemeralContainer.privileged 13.1.2
+k8s.ephemeralContainer.procMount 13.10.1
 k8s.ephemeralContainer.readOnlyRootFilesystem 13.1.2
 k8s.ephemeralContainer.runAsGroup 13.1.2
 k8s.ephemeralContainer.runAsNonRoot 13.1.2
 k8s.ephemeralContainer.runAsUser 13.1.2
+k8s.ephemeralContainer.seLinuxLevel 13.10.1
+k8s.ephemeralContainer.seLinuxType 13.10.1
 k8s.ephemeralContainer.seccompProfileType 13.1.2
 k8s.ephemeralContainer.securityContext 9.0.0
 k8s.ephemeralContainer.stdin 13.0.16
@@ -719,6 +733,7 @@ k8s.ingresstls.id 9.0.0
 k8s.initContainer 9.0.0
 k8s.initContainer.addedCapabilities 13.1.2
 k8s.initContainer.allowPrivilegeEscalation 13.1.2
+k8s.initContainer.appArmorProfileType 13.10.1
 k8s.initContainer.args 9.0.0
 k8s.initContainer.command 9.0.0
 k8s.initContainer.containerImage 9.0.0
@@ -732,6 +747,7 @@ k8s.initContainer.livenessProbe 13.0.16
 k8s.initContainer.name 9.0.0
 k8s.initContainer.ports 13.0.16
 k8s.initContainer.privileged 13.1.2
+k8s.initContainer.procMount 13.10.1
 k8s.initContainer.readOnlyRootFilesystem 13.1.2
 k8s.initContainer.readinessProbe 13.0.16
 k8s.initContainer.resizePolicy 13.0.16
@@ -740,6 +756,8 @@ k8s.initContainer.restartPolicy 13.0.16
 k8s.initContainer.runAsGroup 13.1.2
 k8s.initContainer.runAsNonRoot 13.1.2
 k8s.initContainer.runAsUser 13.1.2
+k8s.initContainer.seLinuxLevel 13.10.1
+k8s.initContainer.seLinuxType 13.10.1
 k8s.initContainer.seccompProfileType 13.1.2
 k8s.initContainer.securityContext 9.0.0
 k8s.initContainer.startupProbe 13.0.16
@@ -784,6 +802,7 @@ k8s.job.hasWritableRootFilesystem 13.2.2
 k8s.job.hostIPC 13.2.2
 k8s.job.hostNetwork 13.2.2
 k8s.job.hostPID 13.2.2
+k8s.job.hostUsers 13.10.1
 k8s.job.id 9.0.0
 k8s.job.imageRegistries 13.3.1
 k8s.job.initContainers 9.0.0
@@ -826,6 +845,7 @@ k8s.job.usesSecretsAsEnv 13.3.1
 k8s.job.usesUnconfinedAppArmor 13.4.1
 k8s.job.usesUnconfinedSeccomp 13.3.1
 k8s.job.usesUnmaskedProcMount 13.4.1
+k8s.job.volumes 13.10.1
 k8s.jobs 9.0.0
 k8s.lease 13.0.16
 k8s.lease.acquireTime 13.0.16
@@ -1004,6 +1024,9 @@ k8s.node.podCIDR 13.0.16
 k8s.node.podCIDRs 13.0.16
 k8s.node.providerID 13.0.16
 k8s.node.resourceVersion 9.0.0
+k8s.node.runtimeHandlers 13.10.1
+k8s.node.supportsSupplementalGroupsPolicy 13.10.1
+k8s.node.supportsUserNamespaces 13.10.1
 k8s.node.taints 11.1.138
 k8s.node.uid 9.0.0
 k8s.node.unschedulable 13.0.16
@@ -1130,6 +1153,7 @@ k8s.pod.hostIP 13.0.16
 k8s.pod.hostIPC 13.0.16
 k8s.pod.hostNetwork 13.0.16
 k8s.pod.hostPID 13.0.16
+k8s.pod.hostUsers 13.10.1
 k8s.pod.hostname 13.0.16
 k8s.pod.id 9.0.0
 k8s.pod.imagePullSecrets 13.0.16
@@ -1171,6 +1195,7 @@ k8s.pod.risksStaleImage 13.3.1
 k8s.pod.runningImageDigests 13.3.1
 k8s.pod.runsAsRoot 13.2.2
 k8s.pod.runsPrivileged 13.2.2
+k8s.pod.runtimeClass 13.10.1
 k8s.pod.runtimeClassName 13.0.16
 k8s.pod.schedulerName 13.0.16
 k8s.pod.securityContext 13.0.16
@@ -1195,6 +1220,7 @@ k8s.pod.usesSecretsAsEnv 13.3.1
 k8s.pod.usesUnconfinedAppArmor 13.4.1
 k8s.pod.usesUnconfinedSeccomp 13.3.1
 k8s.pod.usesUnmaskedProcMount 13.4.1
+k8s.pod.volumes 13.10.1
 k8s.podDisruptionBudgets 13.0.16
 k8s.poddisruptionbudget 13.0.16
 k8s.poddisruptionbudget.annotations 13.0.16
@@ -1393,6 +1419,7 @@ k8s.replicaset.hasWritableRootFilesystem 13.2.2
 k8s.replicaset.hostIPC 13.2.2
 k8s.replicaset.hostNetwork 13.2.2
 k8s.replicaset.hostPID 13.2.2
+k8s.replicaset.hostUsers 13.10.1
 k8s.replicaset.id 9.0.0
 k8s.replicaset.imageRegistries 13.3.1
 k8s.replicaset.initContainers 9.0.0
@@ -1430,6 +1457,7 @@ k8s.replicaset.usesSecretsAsEnv 13.3.1
 k8s.replicaset.usesUnconfinedAppArmor 13.4.1
 k8s.replicaset.usesUnconfinedSeccomp 13.3.1
 k8s.replicaset.usesUnmaskedProcMount 13.4.1
+k8s.replicaset.volumes 13.10.1
 k8s.replicasets 9.0.0
 k8s.resourceClaimTemplates 13.9.2
 k8s.resourceClaims 13.9.2
@@ -1525,6 +1553,24 @@ k8s.resourceslice.resourceVersion 13.9.2
 k8s.resourceslice.uid 13.9.2
 k8s.rolebindings 9.0.0
 k8s.roles 9.0.0
+k8s.runtimeClasses 13.10.1
+k8s.runtimeclass 13.10.1
+k8s.runtimeclass.annotations 13.10.1
+k8s.runtimeclass.context 13.10.1
+k8s.runtimeclass.created 13.10.1
+k8s.runtimeclass.handler 13.10.1
+k8s.runtimeclass.id 13.10.1
+k8s.runtimeclass.kind 13.10.1
+k8s.runtimeclass.labels 13.10.1
+k8s.runtimeclass.managedFields 13.10.1
+k8s.runtimeclass.manifest 13.10.1
+k8s.runtimeclass.name 13.10.1
+k8s.runtimeclass.overhead 13.10.1
+k8s.runtimeclass.ownerReferences 13.10.1
+k8s.runtimeclass.pods 13.10.1
+k8s.runtimeclass.resourceVersion 13.10.1
+k8s.runtimeclass.scheduling 13.10.1
+k8s.runtimeclass.uid 13.10.1
 k8s.secret 9.0.0
 k8s.secret.annotations 9.0.0
 k8s.secret.certificateExpiry 13.3.4
@@ -1599,6 +1645,7 @@ k8s.serviceaccount.context 13.6.1
 k8s.serviceaccount.created 9.0.0
 k8s.serviceaccount.hasWildcardPermissions 13.3.1
 k8s.serviceaccount.id 9.0.0
+k8s.serviceaccount.imagePullSecretRefs 13.10.1
 k8s.serviceaccount.imagePullSecrets 9.0.0
 k8s.serviceaccount.isClusterAdmin 13.3.1
 k8s.serviceaccount.kind 9.0.0
@@ -1610,6 +1657,7 @@ k8s.serviceaccount.namespace 9.0.0
 k8s.serviceaccount.ownerReferences 13.2.2
 k8s.serviceaccount.resourceVersion 9.0.0
 k8s.serviceaccount.roleBindings 13.3.1
+k8s.serviceaccount.secretRefs 13.10.1
 k8s.serviceaccount.secrets 9.0.0
 k8s.serviceaccount.uid 9.0.0
 k8s.serviceaccounts 9.0.0
@@ -1642,6 +1690,7 @@ k8s.statefulset.hasWritableRootFilesystem 13.2.2
 k8s.statefulset.hostIPC 13.2.2
 k8s.statefulset.hostNetwork 13.2.2
 k8s.statefulset.hostPID 13.2.2
+k8s.statefulset.hostUsers 13.10.1
 k8s.statefulset.id 9.0.0
 k8s.statefulset.imageRegistries 13.3.1
 k8s.statefulset.initContainers 9.0.0
@@ -1687,6 +1736,7 @@ k8s.statefulset.usesSecretsAsEnv 13.3.1
 k8s.statefulset.usesUnconfinedAppArmor 13.4.1
 k8s.statefulset.usesUnconfinedSeccomp 13.3.1
 k8s.statefulset.usesUnmaskedProcMount 13.4.1
+k8s.statefulset.volumes 13.10.1
 k8s.statefulsets 9.0.0
 k8s.storageClasses 11.1.139
 k8s.storageclass 11.1.139
@@ -1768,3 +1818,17 @@ k8s.userinfo.username 9.0.0
 k8s.validatingAdmissionPolicies 13.2.2
 k8s.validatingAdmissionPolicyBindings 13.2.2
 k8s.validatingWebhookConfigurations 11.1.63
+k8s.volume 13.10.1
+k8s.volume.configMaps 13.10.1
+k8s.volume.csiDriver 13.10.1
+k8s.volume.emptyDirMedium 13.10.1
+k8s.volume.emptyDirSizeLimit 13.10.1
+k8s.volume.hostPath 13.10.1
+k8s.volume.hostPathType 13.10.1
+k8s.volume.name 13.10.1
+k8s.volume.namespace 13.10.1
+k8s.volume.persistentVolumeClaim 13.10.1
+k8s.volume.secrets 13.10.1
+k8s.volume.serviceAccountTokens 13.10.1
+k8s.volume.source 13.10.1
+k8s.volume.type 13.10.1

--- a/providers/k8s/resources/node.go
+++ b/providers/k8s/resources/node.go
@@ -253,3 +253,51 @@ func (k *mqlK8sNode) ownerReferences() ([]any, error) {
 func (k *mqlK8sNode) managedFields() ([]any, error) {
 	return k8sManagedFields(k.MqlRuntime, k.obj)
 }
+
+// nodeRuntimeHandlerFeatures reports whether any advertised runtime handler
+// supports the named feature. It returns (value, true) only when at least one
+// handler carries a features block; a kubelet that advertises no features at
+// all yields (false, false), which the accessors report as null. Reporting
+// false there would claim the node cannot do something it never spoke about.
+func nodeRuntimeHandlerFeatures(handlers []corev1.NodeRuntimeHandler, pick func(*corev1.NodeRuntimeHandlerFeatures) *bool) (bool, bool) {
+	reported := false
+	supported := false
+	for i := range handlers {
+		f := handlers[i].Features
+		if f == nil {
+			continue
+		}
+		v := pick(f)
+		if v == nil {
+			continue
+		}
+		reported = true
+		if *v {
+			supported = true
+		}
+	}
+	return supported, reported
+}
+
+func (k *mqlK8sNode) runtimeHandlers() ([]any, error) {
+	return convert.JsonToDictSlice(k.obj.Status.RuntimeHandlers)
+}
+
+func (k *mqlK8sNode) supportsUserNamespaces() (bool, error) {
+	supported, reported := nodeRuntimeHandlerFeatures(k.obj.Status.RuntimeHandlers,
+		func(f *corev1.NodeRuntimeHandlerFeatures) *bool { return f.UserNamespaces })
+	if !reported {
+		k.SupportsUserNamespaces.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+	return supported, nil
+}
+
+func (k *mqlK8sNode) supportsSupplementalGroupsPolicy() (bool, error) {
+	features := k.obj.Status.Features
+	if features == nil || features.SupplementalGroupsPolicy == nil {
+		k.SupportsSupplementalGroupsPolicy.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+	return *features.SupplementalGroupsPolicy, nil
+}

--- a/providers/k8s/resources/optional_kind_test.go
+++ b/providers/k8s/resources/optional_kind_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/k8s/connection/shared"
+	sharedres "go.mondoo.com/mql/providers/k8s/connection/shared/resources"
+	"go.mondoo.com/mql/utils/syncx"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+// stubConnection answers every Resources call with a fixed error, so the tests
+// below can drive the "the cluster does not serve this kind" branch without a
+// cluster.
+type stubConnection struct {
+	err error
+}
+
+func (c *stubConnection) ID() uint32       { return 0 }
+func (c *stubConnection) ParentID() uint32 { return 0 }
+func (c *stubConnection) Name() string     { return "stub" }
+func (c *stubConnection) Runtime() string  { return "k8s-cluster" }
+func (c *stubConnection) Resources(kind, name, namespace string) (*shared.ResourceResult, error) {
+	return nil, c.err
+}
+func (c *stubConnection) ServerVersion() *version.Info { return &version.Info{} }
+func (c *stubConnection) SupportedResourceTypes() (*sharedres.ApiResourceIndex, error) {
+	return sharedres.NewApiResourceIndex(), nil
+}
+func (c *stubConnection) Platform() *inventory.Platform { return &inventory.Platform{} }
+func (c *stubConnection) Asset() *inventory.Asset       { return &inventory.Asset{} }
+func (c *stubConnection) AssetId() (string, error)      { return "stub", nil }
+func (c *stubConnection) BasePlatformId() (string, error) {
+	return "stub", nil
+}
+func (c *stubConnection) AdmissionReviews() ([]admissionv1.AdmissionReview, error) {
+	return nil, nil
+}
+func (c *stubConnection) Namespace(name string) (*corev1.Namespace, error) { return nil, nil }
+func (c *stubConnection) Namespaces() ([]corev1.Namespace, error)          { return nil, nil }
+func (c *stubConnection) InventoryConfig() *inventory.Config               { return &inventory.Config{} }
+
+func stubRuntime(err error) *plugin.Runtime {
+	rt := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	rt.Connection = &stubConnection{err: err}
+	return rt
+}
+
+// A kind the cluster never installed (Gateway API and the other CRD-backed
+// APIs are the common case) is a cluster with none of those objects, not a
+// failed scan. Returning an error here fails every policy that touches the
+// resource on the majority of clusters.
+func TestOptionalKindDegradesToEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "the CRD was never installed",
+			err:  errors.New(`could not find api kind "gateways.v1.gateway.networking.k8s.io"`),
+		},
+		{
+			name: "RBAC hides the kind",
+			err: apierrors.NewForbidden(
+				schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gateways"},
+				"", errors.New("denied")),
+		},
+		{
+			name: "the object itself is reported missing",
+			err: apierrors.NewNotFound(
+				schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gateways"}, ""),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := k8sOptionalResourceToMql(stubRuntime(test.err), "gateways.v1.gateway.networking.k8s.io", nil)
+			require.NoError(t, err)
+			assert.Equal(t, []any{}, out)
+		})
+	}
+}
+
+// Anything else is a real failure and has to keep propagating. Swallowing a
+// throttled or half-finished list would report "no such objects" for a cluster
+// that has them.
+func TestOptionalKindPropagatesRealErrors(t *testing.T) {
+	wanted := errors.New("etcdserver: request timed out")
+	_, err := k8sOptionalResourceToMql(stubRuntime(wanted), "gateways.v1.gateway.networking.k8s.io", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wanted)
+}

--- a/providers/k8s/resources/pod.go
+++ b/providers/k8s/resources/pod.go
@@ -316,6 +316,45 @@ func (k *mqlK8sPod) runtimeClassName() (string, error) {
 	return *spec.RuntimeClassName, nil
 }
 
+// runtimeClass resolves the pod's runtimeClassName to the RuntimeClass
+// object. It scans the already-fetched class list rather than calling
+// NewResource per pod, which would run the target's init before the runtime
+// cache is consulted and turn one list call into one per pod.
+func (k *mqlK8sPod) runtimeClass() (*mqlK8sRuntimeclass, error) {
+	name := k.GetRuntimeClassName()
+	if name.Error != nil {
+		return nil, name.Error
+	}
+	if name.Data == "" {
+		k.RuntimeClass.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	o, err := CreateResource(k.MqlRuntime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	classes := o.(*mqlK8s).GetRuntimeClasses()
+	if classes.Error != nil {
+		return nil, classes.Error
+	}
+
+	for i := range classes.Data {
+		rc, ok := classes.Data[i].(*mqlK8sRuntimeclass)
+		if !ok {
+			continue
+		}
+		if rc.Name.Data == name.Data {
+			return rc, nil
+		}
+	}
+
+	// The pod names a class the cluster does not have (it was deleted, or the
+	// scan cannot read the kind). That is a real state, not an error.
+	k.RuntimeClass.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}
+
 func (k *mqlK8sPod) serviceAccountName() (string, error) {
 	spec, err := k.podSpecTyped()
 	if err != nil {

--- a/providers/k8s/resources/referencegrant.go
+++ b/providers/k8s/resources/referencegrant.go
@@ -25,7 +25,10 @@ type mqlK8sReferencegrantInternal struct {
 func (k *mqlK8s) referenceGrants() ([]any, error) {
 	// ReferenceGrant is served as v1beta1 on older clusters and v1 on newer ones.
 	// Pass the unqualified plural so the server-preferred version is selected.
-	return k8sResourceToMql(k.MqlRuntime, "referencegrants", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
+	// Gateway API ships as CRDs, so a cluster that never installed them has no
+	// such kind. That is a cluster with no Gateways, not a failed scan, so the
+	// list degrades to empty rather than erroring.
+	return k8sOptionalResourceToMql(k.MqlRuntime, "referencegrants", func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
 		ts := obj.GetCreationTimestamp()
 
 		var rg *gatewayv1.ReferenceGrant

--- a/providers/k8s/resources/runtimeclass.go
+++ b/providers/k8s/resources/runtimeclass.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"sync"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/types"
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type mqlK8sRuntimeclassInternal struct {
+	lock sync.Mutex
+	obj  *nodev1.RuntimeClass
+}
+
+func (k *mqlK8s) runtimeClasses() ([]any, error) {
+	// node.k8s.io/v1 has been GA since 1.20, but a cluster can still hide the
+	// kind behind RBAC, so an unavailable kind degrades to an empty list
+	// rather than failing every query that touches it.
+	return k8sOptionalResourceToMql(k.MqlRuntime, gvkString(nodev1.SchemeGroupVersion.WithKind("runtimeclasses")), func(kind string, resource runtime.Object, obj metav1.Object, objT metav1.Type) (any, error) {
+		ts := obj.GetCreationTimestamp()
+
+		rc, ok := resource.(*nodev1.RuntimeClass)
+		if !ok {
+			return nil, errors.New("not a k8s runtimeclass")
+		}
+
+		overhead := map[string]any{}
+		if rc.Overhead != nil {
+			for name, quantity := range rc.Overhead.PodFixed {
+				overhead[string(name)] = quantity.String()
+			}
+		}
+
+		args := map[string]*llx.RawData{
+			"id":              llx.StringData(objIdFromK8sObj(obj, objT)),
+			"uid":             llx.StringData(string(obj.GetUID())),
+			"resourceVersion": llx.StringData(obj.GetResourceVersion()),
+			"name":            llx.StringData(obj.GetName()),
+			"kind":            llx.StringData(objT.GetKind()),
+			"created":         llx.TimeData(ts.Time),
+			"handler":         llx.StringData(rc.Handler),
+			"overhead":        llx.MapData(overhead, types.String),
+			"scheduling":      llx.NilData,
+		}
+
+		// A RuntimeClass with no scheduling block places no restriction on
+		// which nodes run its pods. Report that as null rather than as an
+		// empty selector, which would read as "restricted to nothing".
+		if rc.Scheduling != nil {
+			scheduling, err := convert.JsonToDict(rc.Scheduling)
+			if err != nil {
+				return nil, err
+			}
+			args["scheduling"] = llx.DictData(scheduling)
+		}
+
+		r, err := CreateResource(k.MqlRuntime, "k8s.runtimeclass", args)
+		if err != nil {
+			return nil, err
+		}
+		r.(*mqlK8sRuntimeclass).obj = rc
+		return r, nil
+	})
+}
+
+func (k *mqlK8sRuntimeclass) id() (string, error) {
+	return k.Id.Data, nil
+}
+
+func initK8sRuntimeclass(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initResource[*mqlK8sRuntimeclass](runtime, args, func(k *mqlK8s) *plugin.TValue[[]any] { return k.GetRuntimeClasses() })
+}
+
+func (k *mqlK8sRuntimeclass) manifest() (map[string]any, error) {
+	return convert.JsonToDict(k.obj)
+}
+
+func (k *mqlK8sRuntimeclass) annotations() (map[string]any, error) {
+	return convert.MapToInterfaceMap(k.obj.GetAnnotations()), nil
+}
+
+func (k *mqlK8sRuntimeclass) labels() (map[string]any, error) {
+	return convert.MapToInterfaceMap(k.obj.GetLabels()), nil
+}
+
+func (k *mqlK8sRuntimeclass) ownerReferences() ([]any, error) {
+	return k8sOwnerReferences(k.MqlRuntime, k.obj)
+}
+
+func (k *mqlK8sRuntimeclass) managedFields() ([]any, error) {
+	return k8sManagedFields(k.MqlRuntime, k.obj)
+}
+
+// pods returns the pods that name this RuntimeClass. This is the edge that
+// answers which workloads actually land on a sandboxed runtime, rather than
+// which classes merely exist.
+func (k *mqlK8sRuntimeclass) pods() ([]any, error) {
+	o, err := CreateResource(k.MqlRuntime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	pods := o.(*mqlK8s).GetPods()
+	if pods.Error != nil {
+		return nil, pods.Error
+	}
+
+	out := []any{}
+	for i := range pods.Data {
+		p, ok := pods.Data[i].(*mqlK8sPod)
+		if !ok {
+			continue
+		}
+		name := p.GetRuntimeClassName()
+		if name.Error != nil || name.Data != k.Name.Data {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}

--- a/providers/k8s/resources/serviceaccount.go
+++ b/providers/k8s/resources/serviceaccount.go
@@ -259,3 +259,29 @@ func (k *mqlK8sServiceaccount) ownerReferences() ([]any, error) {
 func (k *mqlK8sServiceaccount) managedFields() ([]any, error) {
 	return k8sManagedFields(k.MqlRuntime, k.obj)
 }
+
+// secretRefs resolves the ObjectReferences in the account's secrets list to
+// the Secret objects themselves. This is the join a "no static ServiceAccount
+// tokens" audit needs: a service account that still lists a Secret here holds
+// a long-lived token that nothing rotates.
+func (k *mqlK8sServiceaccount) secretRefs() ([]any, error) {
+	names := make([]string, 0, len(k.obj.Secrets))
+	for _, ref := range k.obj.Secrets {
+		names = append(names, ref.Name)
+	}
+	return resolveNamespaced[*mqlK8sSecret](
+		k.MqlRuntime, k.obj.GetNamespace(), names,
+		func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetSecrets() })
+}
+
+// imagePullSecretRefs resolves the LocalObjectReferences in the account's
+// imagePullSecrets list to the Secret objects themselves.
+func (k *mqlK8sServiceaccount) imagePullSecretRefs() ([]any, error) {
+	names := make([]string, 0, len(k.obj.ImagePullSecrets))
+	for _, ref := range k.obj.ImagePullSecrets {
+		names = append(names, ref.Name)
+	}
+	return resolveNamespaced[*mqlK8sSecret](
+		k.MqlRuntime, k.obj.GetNamespace(), names,
+		func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetSecrets() })
+}

--- a/providers/k8s/resources/volume.go
+++ b/providers/k8s/resources/volume.go
@@ -1,0 +1,251 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type mqlK8sVolumeInternal struct {
+	vol       corev1.Volume
+	namespace string
+}
+
+// volumeSourceType names the single populated member of a VolumeSource. A
+// volume carries exactly one source, so the first match wins; an empty string
+// means the volume declares no source at all, which the API server rejects but
+// a hand-written manifest can still contain.
+func volumeSourceType(vs corev1.VolumeSource) string {
+	switch {
+	case vs.HostPath != nil:
+		return "hostPath"
+	case vs.EmptyDir != nil:
+		return "emptyDir"
+	case vs.Secret != nil:
+		return "secret"
+	case vs.ConfigMap != nil:
+		return "configMap"
+	case vs.Projected != nil:
+		return "projected"
+	case vs.PersistentVolumeClaim != nil:
+		return "persistentVolumeClaim"
+	case vs.CSI != nil:
+		return "csi"
+	case vs.DownwardAPI != nil:
+		return "downwardAPI"
+	case vs.Ephemeral != nil:
+		return "ephemeral"
+	case vs.NFS != nil:
+		return "nfs"
+	case vs.ISCSI != nil:
+		return "iscsi"
+	case vs.FC != nil:
+		return "fc"
+	case vs.RBD != nil:
+		return "rbd"
+	case vs.CephFS != nil:
+		return "cephfs"
+	case vs.Cinder != nil:
+		return "cinder"
+	case vs.Glusterfs != nil:
+		return "glusterfs"
+	case vs.AWSElasticBlockStore != nil:
+		return "awsElasticBlockStore"
+	case vs.AzureDisk != nil:
+		return "azureDisk"
+	case vs.AzureFile != nil:
+		return "azureFile"
+	case vs.GCEPersistentDisk != nil:
+		return "gcePersistentDisk"
+	case vs.VsphereVolume != nil:
+		return "vsphereVolume"
+	case vs.PortworxVolume != nil:
+		return "portworxVolume"
+	case vs.Quobyte != nil:
+		return "quobyte"
+	case vs.FlexVolume != nil:
+		return "flexVolume"
+	case vs.Flocker != nil:
+		return "flocker"
+	case vs.PhotonPersistentDisk != nil:
+		return "photonPersistentDisk"
+	case vs.ScaleIO != nil:
+		return "scaleIO"
+	case vs.StorageOS != nil:
+		return "storageos"
+	case vs.GitRepo != nil:
+		return "gitRepo"
+	case vs.Image != nil:
+		return "image"
+	default:
+		return ""
+	}
+}
+
+// volumeSecretNames lists every Secret the volume mounts, covering both a
+// plain secret source and each secret source of a projected volume.
+func volumeSecretNames(vs corev1.VolumeSource) []string {
+	var out []string
+	if vs.Secret != nil && vs.Secret.SecretName != "" {
+		out = append(out, vs.Secret.SecretName)
+	}
+	if vs.Projected != nil {
+		for i := range vs.Projected.Sources {
+			src := vs.Projected.Sources[i]
+			if src.Secret != nil && src.Secret.Name != "" {
+				out = append(out, src.Secret.Name)
+			}
+		}
+	}
+	return out
+}
+
+// volumeConfigMapNames lists every ConfigMap the volume mounts, covering both
+// a plain configMap source and each configMap source of a projected volume.
+func volumeConfigMapNames(vs corev1.VolumeSource) []string {
+	var out []string
+	if vs.ConfigMap != nil && vs.ConfigMap.Name != "" {
+		out = append(out, vs.ConfigMap.Name)
+	}
+	if vs.Projected != nil {
+		for i := range vs.Projected.Sources {
+			src := vs.Projected.Sources[i]
+			if src.ConfigMap != nil && src.ConfigMap.Name != "" {
+				out = append(out, src.ConfigMap.Name)
+			}
+		}
+	}
+	return out
+}
+
+// projectedServiceAccountTokens returns one entry per serviceAccountToken
+// source of a projected volume. expirationSeconds stays null when the pod does
+// not request a lifetime, because the kubelet then picks its own default and
+// reporting a number here would claim the pod asked for one.
+func projectedServiceAccountTokens(vs corev1.VolumeSource) []any {
+	out := []any{}
+	if vs.Projected == nil {
+		return out
+	}
+	for i := range vs.Projected.Sources {
+		sat := vs.Projected.Sources[i].ServiceAccountToken
+		if sat == nil {
+			continue
+		}
+		entry := map[string]any{
+			"audience": sat.Audience,
+			"path":     sat.Path,
+		}
+		if sat.ExpirationSeconds != nil {
+			entry["expirationSeconds"] = *sat.ExpirationSeconds
+		} else {
+			entry["expirationSeconds"] = nil
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// newVolumes builds the k8s.volume resources for a pod spec. ownerID scopes
+// the cache key: volume names are unique within one pod spec but repeat freely
+// across pods and templates, so the key has to carry both dimensions.
+func newVolumes(runtime *plugin.Runtime, ownerID, namespace string, spec *corev1.PodSpec) ([]any, error) {
+	out := []any{}
+	if spec == nil {
+		return out, nil
+	}
+
+	for i := range spec.Volumes {
+		v := spec.Volumes[i]
+
+		source, err := convert.JsonToDict(v.VolumeSource)
+		if err != nil {
+			return nil, err
+		}
+
+		args := map[string]*llx.RawData{
+			"__id":              llx.StringData(ownerID + "/volume/" + v.Name),
+			"name":              llx.StringData(v.Name),
+			"namespace":         llx.StringData(namespace),
+			"type":              llx.StringData(volumeSourceType(v.VolumeSource)),
+			"hostPath":          llx.NilData,
+			"hostPathType":      llx.NilData,
+			"emptyDirMedium":    llx.NilData,
+			"emptyDirSizeLimit": llx.NilData,
+			"csiDriver":         llx.NilData,
+			"source":            llx.DictData(source),
+		}
+
+		if hp := v.HostPath; hp != nil {
+			args["hostPath"] = llx.StringData(hp.Path)
+			args["hostPathType"] = llx.StringDataPtr(stringPtrFromTypedPtr(hp.Type))
+		}
+		if ed := v.EmptyDir; ed != nil {
+			args["emptyDirMedium"] = llx.StringData(string(ed.Medium))
+			if ed.SizeLimit != nil {
+				args["emptyDirSizeLimit"] = llx.StringData(ed.SizeLimit.String())
+			}
+		}
+		if csi := v.CSI; csi != nil {
+			args["csiDriver"] = llx.StringData(csi.Driver)
+		}
+
+		r, err := CreateResource(runtime, "k8s.volume", args)
+		if err != nil {
+			return nil, err
+		}
+		mqlVol := r.(*mqlK8sVolume)
+		mqlVol.vol = v
+		mqlVol.namespace = namespace
+		out = append(out, mqlVol)
+	}
+
+	return out, nil
+}
+
+func (k *mqlK8sVolume) serviceAccountTokens() ([]any, error) {
+	return projectedServiceAccountTokens(k.vol.VolumeSource), nil
+}
+
+func (k *mqlK8sVolume) secrets() ([]any, error) {
+	return resolveNamespaced[*mqlK8sSecret](
+		k.MqlRuntime, k.namespace, volumeSecretNames(k.vol.VolumeSource),
+		func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetSecrets() })
+}
+
+func (k *mqlK8sVolume) configMaps() ([]any, error) {
+	return resolveNamespaced[*mqlK8sConfigmap](
+		k.MqlRuntime, k.namespace, volumeConfigMapNames(k.vol.VolumeSource),
+		func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetConfigmaps() })
+}
+
+func (k *mqlK8sVolume) persistentVolumeClaim() (*mqlK8sPersistentvolumeclaim, error) {
+	pvc := k.vol.VolumeSource.PersistentVolumeClaim
+	if pvc == nil || pvc.ClaimName == "" {
+		k.PersistentVolumeClaim.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	claims, err := resolveNamespaced[*mqlK8sPersistentvolumeclaim](
+		k.MqlRuntime, k.namespace, []string{pvc.ClaimName},
+		func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetPersistentVolumeClaims() })
+	if err != nil {
+		return nil, err
+	}
+	if len(claims) == 0 {
+		k.PersistentVolumeClaim.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	claim, ok := claims[0].(*mqlK8sPersistentvolumeclaim)
+	if !ok {
+		return nil, errors.New("not a k8s persistentvolumeclaim")
+	}
+	return claim, nil
+}

--- a/providers/k8s/resources/volume_id_test.go
+++ b/providers/k8s/resources/volume_id_test.go
@@ -1,0 +1,110 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/k8s/connection/manifest"
+	"go.mondoo.com/mql/providers/k8s/connection/shared"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+func volumeTestRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	conn, err := manifest.NewConnection(0, &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Options: map[string]string{shared.OPTION_NAMESPACE: "default"}},
+		},
+	}, manifest.WithManifestFile("../connection/shared/resources/testdata/pod-volumes.yaml"))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	runtime.Connection = conn
+	return runtime
+}
+
+func podVolumes(t *testing.T, runtime *plugin.Runtime, name string) []any {
+	t.Helper()
+	obj, err := NewResource(runtime, "k8s.pod", map[string]*llx.RawData{
+		"name":      llx.StringData(name),
+		"namespace": llx.StringData("default"),
+	})
+	require.NoError(t, err)
+
+	vols := obj.(*mqlK8sPod).GetVolumes()
+	require.NoError(t, vols.Error)
+	return vols.Data
+}
+
+// A volume name is unique only within one pod spec, so two pods that both
+// declare "shared-name" must not collide in the resource cache. A colliding
+// key would make CreateResource hand back the first pod's volume, silently
+// reporting the second pod's tmpfs as a hostPath mount of /var/log.
+func TestVolumeIdCarriesTheOwningObject(t *testing.T) {
+	runtime := volumeTestRuntime(t)
+
+	first := podVolumes(t, runtime, "first")
+	second := podVolumes(t, runtime, "second")
+	require.Len(t, first, 2)
+	require.Len(t, second, 1)
+
+	firstShared := first[0].(*mqlK8sVolume)
+	secondShared := second[0].(*mqlK8sVolume)
+
+	assert.Equal(t, "shared-name", firstShared.GetName().Data)
+	assert.Equal(t, "shared-name", secondShared.GetName().Data)
+	assert.NotEqual(t, firstShared.MqlID(), secondShared.MqlID())
+
+	// and each one reports its own source, not the other's
+	assert.Equal(t, "hostPath", firstShared.GetType().Data)
+	assert.Equal(t, "/var/log", firstShared.GetHostPath().Data)
+	assert.Equal(t, "emptyDir", secondShared.GetType().Data)
+	assert.Equal(t, "Memory", secondShared.GetEmptyDirMedium().Data)
+	assert.Equal(t, "32Mi", secondShared.GetEmptyDirSizeLimit().Data)
+}
+
+// Fields that belong to another volume source must stay null. An empty string
+// on hostPath would read as a mount of the filesystem root.
+func TestVolumeUnrelatedSourceFieldsStayNull(t *testing.T) {
+	runtime := volumeTestRuntime(t)
+	second := podVolumes(t, runtime, "second")
+	require.Len(t, second, 1)
+
+	v := second[0].(*mqlK8sVolume)
+	assert.NotEqual(t, 0, v.GetHostPath().State&plugin.StateIsNull)
+	assert.NotEqual(t, 0, v.GetHostPathType().State&plugin.StateIsNull)
+	assert.NotEqual(t, 0, v.GetCsiDriver().State&plugin.StateIsNull)
+	assert.Empty(t, v.GetServiceAccountTokens().Data)
+}
+
+func TestVolumeProjectedServiceAccountTokenDetail(t *testing.T) {
+	runtime := volumeTestRuntime(t)
+	first := podVolumes(t, runtime, "first")
+	require.Len(t, first, 2)
+
+	tokens := first[1].(*mqlK8sVolume).GetServiceAccountTokens()
+	require.NoError(t, tokens.Error)
+	require.Len(t, tokens.Data, 2)
+
+	assert.Equal(t, map[string]any{
+		"audience":          "first-audience",
+		"expirationSeconds": int64(600),
+		"path":              "token",
+	}, tokens.Data[0])
+
+	// The manifest never requested a lifetime, so none is reported. On a live
+	// cluster the API server defaults this field, which is exactly why the
+	// manifest path is where the null case is observable.
+	assert.Equal(t, map[string]any{
+		"audience":          "",
+		"expirationSeconds": nil,
+		"path":              "legacy-token",
+	}, tokens.Data[1])
+}

--- a/providers/k8s/resources/volume_test.go
+++ b/providers/k8s/resources/volume_test.go
@@ -1,0 +1,228 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestVolumeSourceType(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   corev1.VolumeSource
+		expected string
+	}{
+		{
+			name:     "no source at all",
+			source:   corev1.VolumeSource{},
+			expected: "",
+		},
+		{
+			name:     "hostPath",
+			source:   corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run"}},
+			expected: "hostPath",
+		},
+		{
+			name:     "emptyDir",
+			source:   corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			expected: "emptyDir",
+		},
+		{
+			name:     "secret",
+			source:   corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "creds"}},
+			expected: "secret",
+		},
+		{
+			name:     "configMap",
+			source:   corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}},
+			expected: "configMap",
+		},
+		{
+			name:     "projected",
+			source:   corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{}},
+			expected: "projected",
+		},
+		{
+			name:     "persistentVolumeClaim",
+			source:   corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data"}},
+			expected: "persistentVolumeClaim",
+		},
+		{
+			name:     "csi",
+			source:   corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{Driver: "secrets-store.csi.k8s.io"}},
+			expected: "csi",
+		},
+		{
+			name:     "downwardAPI",
+			source:   corev1.VolumeSource{DownwardAPI: &corev1.DownwardAPIVolumeSource{}},
+			expected: "downwardAPI",
+		},
+		{
+			name:     "ephemeral",
+			source:   corev1.VolumeSource{Ephemeral: &corev1.EphemeralVolumeSource{}},
+			expected: "ephemeral",
+		},
+		{
+			name:     "nfs",
+			source:   corev1.VolumeSource{NFS: &corev1.NFSVolumeSource{Server: "10.0.0.1"}},
+			expected: "nfs",
+		},
+		{
+			name:     "iscsi",
+			source:   corev1.VolumeSource{ISCSI: &corev1.ISCSIVolumeSource{}},
+			expected: "iscsi",
+		},
+		{
+			name:     "image",
+			source:   corev1.VolumeSource{Image: &corev1.ImageVolumeSource{}},
+			expected: "image",
+		},
+		{
+			// hostPath is checked first, so a spec that somehow carries two
+			// sources still reports the one that decides host reachability.
+			name: "hostPath wins over a second source",
+			source: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: "/"},
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+			expected: "hostPath",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, volumeSourceType(test.source))
+		})
+	}
+}
+
+func TestVolumeSecretNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   corev1.VolumeSource
+		expected []string
+	}{
+		{
+			name:     "no secret",
+			source:   corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			expected: nil,
+		},
+		{
+			name:     "plain secret source",
+			source:   corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "creds"}},
+			expected: []string{"creds"},
+		},
+		{
+			name:     "secret source with an empty name is skipped",
+			source:   corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{}},
+			expected: nil,
+		},
+		{
+			name: "every projected secret source is reported",
+			source: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "one"}}},
+					{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "cm"}}},
+					{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "two"}}},
+					{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "token"}},
+				},
+			}},
+			expected: []string{"one", "two"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, volumeSecretNames(test.source))
+		})
+	}
+}
+
+func TestVolumeConfigMapNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   corev1.VolumeSource
+		expected []string
+	}{
+		{
+			name:     "no configMap",
+			source:   corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "creds"}},
+			expected: nil,
+		},
+		{
+			name:     "plain configMap source",
+			source:   corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "settings"}}},
+			expected: []string{"settings"},
+		},
+		{
+			name: "every projected configMap source is reported",
+			source: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "ca"}}},
+					{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "s"}}},
+					{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "extra"}}},
+				},
+			}},
+			expected: []string{"ca", "extra"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, volumeConfigMapNames(test.source))
+		})
+	}
+}
+
+func TestProjectedServiceAccountTokens(t *testing.T) {
+	expiry := int64(3600)
+
+	t.Run("a non-projected volume carries none", func(t *testing.T) {
+		assert.Equal(t, []any{}, projectedServiceAccountTokens(
+			corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "creds"}}))
+	})
+
+	t.Run("a projected volume with no token source carries none", func(t *testing.T) {
+		assert.Equal(t, []any{}, projectedServiceAccountTokens(
+			corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
+					{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: "ca"}}},
+				},
+			}}))
+	})
+
+	t.Run("audience and expiry are reported per token", func(t *testing.T) {
+		got := projectedServiceAccountTokens(corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+			Sources: []corev1.VolumeProjection{
+				{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+					Audience: "vault", ExpirationSeconds: &expiry, Path: "token",
+				}},
+			},
+		}})
+		assert.Equal(t, []any{map[string]any{
+			"audience":          "vault",
+			"expirationSeconds": int64(3600),
+			"path":              "token",
+		}}, got)
+	})
+
+	t.Run("an unrequested expiry stays null rather than becoming zero", func(t *testing.T) {
+		// A manifest that omits expirationSeconds has not asked for a
+		// lifetime; the kubelet picks one. Reporting 0 would read as "this pod
+		// requested a token that expires immediately".
+		got := projectedServiceAccountTokens(corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+			Sources: []corev1.VolumeProjection{
+				{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "token"}},
+			},
+		}})
+		assert.Equal(t, []any{map[string]any{
+			"audience":          "",
+			"expirationSeconds": nil,
+			"path":              "token",
+		}}, got)
+	})
+}

--- a/providers/k8s/resources/workload_isolation_test.go
+++ b/providers/k8s/resources/workload_isolation_test.go
@@ -1,0 +1,117 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// hostUsers is the field that decides whether root in a container is root on
+// the node, and Kubernetes treats an unset field as true. Getting the
+// direction wrong would report isolation the workload never asked for.
+func TestSpecHostUsers(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     *corev1.PodSpec
+		expected bool
+	}{
+		{
+			name:     "unset means the host user namespace is shared",
+			spec:     &corev1.PodSpec{},
+			expected: true,
+		},
+		{
+			name:     "explicit true shares the host user namespace",
+			spec:     &corev1.PodSpec{HostUsers: boolPtr(true)},
+			expected: true,
+		},
+		{
+			name:     "explicit false requests an isolated user namespace",
+			spec:     &corev1.PodSpec{HostUsers: boolPtr(false)},
+			expected: false,
+		},
+		{
+			name:     "a spec we could not read reports the unsafe direction",
+			spec:     nil,
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, specHostUsers(test.spec))
+		})
+	}
+}
+
+func TestNodeRuntimeHandlerFeatures(t *testing.T) {
+	userNS := func(f *corev1.NodeRuntimeHandlerFeatures) *bool { return f.UserNamespaces }
+
+	tests := []struct {
+		name              string
+		handlers          []corev1.NodeRuntimeHandler
+		expectedSupported bool
+		expectedReported  bool
+	}{
+		{
+			name:             "a kubelet that advertises no handlers reports nothing",
+			handlers:         nil,
+			expectedReported: false,
+		},
+		{
+			name:             "handlers without a features block report nothing",
+			handlers:         []corev1.NodeRuntimeHandler{{Name: "runc"}},
+			expectedReported: false,
+		},
+		{
+			name: "a features block that omits the field reports nothing",
+			handlers: []corev1.NodeRuntimeHandler{
+				{Name: "runc", Features: &corev1.NodeRuntimeHandlerFeatures{
+					RecursiveReadOnlyMounts: boolPtr(true),
+				}},
+			},
+			expectedReported: false,
+		},
+		{
+			name: "every handler reporting false is a real negative answer",
+			handlers: []corev1.NodeRuntimeHandler{
+				{Name: "", Features: &corev1.NodeRuntimeHandlerFeatures{UserNamespaces: boolPtr(false)}},
+				{Name: "runc", Features: &corev1.NodeRuntimeHandlerFeatures{UserNamespaces: boolPtr(false)}},
+			},
+			expectedSupported: false,
+			expectedReported:  true,
+		},
+		{
+			name: "one supporting handler is enough",
+			handlers: []corev1.NodeRuntimeHandler{
+				{Name: "runc", Features: &corev1.NodeRuntimeHandlerFeatures{UserNamespaces: boolPtr(false)}},
+				{Name: "runsc", Features: &corev1.NodeRuntimeHandlerFeatures{UserNamespaces: boolPtr(true)}},
+			},
+			expectedSupported: true,
+			expectedReported:  true,
+		},
+		{
+			name: "a handler with no features does not mask one that has them",
+			handlers: []corev1.NodeRuntimeHandler{
+				{Name: "runc"},
+				{Name: "runsc", Features: &corev1.NodeRuntimeHandlerFeatures{UserNamespaces: boolPtr(true)}},
+			},
+			expectedSupported: true,
+			expectedReported:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			supported, reported := nodeRuntimeHandlerFeatures(test.handlers, userNS)
+			assert.Equal(t, test.expectedReported, reported, "reported")
+			if reported {
+				assert.Equal(t, test.expectedSupported, supported, "supported")
+			}
+		})
+	}
+}

--- a/providers/k8s/resources/workload_security.go
+++ b/providers/k8s/resources/workload_security.go
@@ -18,6 +18,7 @@ package resources
 import (
 	corev1 "k8s.io/api/core/v1"
 
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/providers/k8s/connection/shared/resources"
 )
@@ -246,6 +247,28 @@ func dictFromSpec(spec *corev1.PodSpec, err error) (map[string]any, error) {
 	return convert.JsonToDict(spec.SecurityContext)
 }
 
+// specHostUsers reports whether the pod shares the host user namespace.
+// Kubernetes leaves hostUsers unset by default and treats unset as true, so an
+// absent field reports true: the workload never asked for a user namespace, so
+// root inside its containers is root on the node. A spec we could not read
+// reports the same, which is the direction that fails safe.
+func specHostUsers(spec *corev1.PodSpec) bool {
+	if spec == nil || spec.HostUsers == nil {
+		return true
+	}
+	return *spec.HostUsers
+}
+
+// volumesFromSpec builds the k8s.volume list for a workload. id scopes the
+// volume cache keys to the owning object, since volume names are only unique
+// within one pod spec.
+func volumesFromSpec(runtime *plugin.Runtime, id, namespace string, spec *corev1.PodSpec, err error) ([]any, error) {
+	if err != nil {
+		return nil, err
+	}
+	return newVolumes(runtime, id, namespace, spec)
+}
+
 // ---- k8s.pod ----
 
 func (k *mqlK8sPod) runsPrivileged() (bool, error) {
@@ -286,6 +309,16 @@ func (k *mqlK8sPod) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sPod) usesHostPath() (bool, error) {
 	spec, err := k.podSpecTyped()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sPod) hostUsers() (bool, error) {
+	spec, err := k.podSpecTyped()
+	return boolFromSpec(spec, err, specHostUsers)
+}
+
+func (k *mqlK8sPod) volumes() ([]any, error) {
+	spec, err := k.podSpecTyped()
+	return volumesFromSpec(k.MqlRuntime, k.Id.Data, k.Namespace.Data, spec, err)
 }
 
 func (k *mqlK8sPod) usesUnconfinedSeccomp() (bool, error) {
@@ -372,6 +405,16 @@ func (k *mqlK8sDeployment) usesHostPath() (bool, error) {
 	return boolFromSpec(spec, err, specUsesHostPath)
 }
 
+func (k *mqlK8sDeployment) hostUsers() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHostUsers)
+}
+
+func (k *mqlK8sDeployment) volumes() ([]any, error) {
+	spec, err := k.securitySpec()
+	return volumesFromSpec(k.MqlRuntime, k.Id.Data, k.Namespace.Data, spec, err)
+}
+
 func (k *mqlK8sDeployment) usesUnconfinedSeccomp() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
@@ -454,6 +497,16 @@ func (k *mqlK8sDaemonset) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sDaemonset) usesHostPath() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sDaemonset) hostUsers() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHostUsers)
+}
+
+func (k *mqlK8sDaemonset) volumes() ([]any, error) {
+	spec, err := k.securitySpec()
+	return volumesFromSpec(k.MqlRuntime, k.Id.Data, k.Namespace.Data, spec, err)
 }
 
 func (k *mqlK8sDaemonset) usesUnconfinedSeccomp() (bool, error) {
@@ -540,6 +593,16 @@ func (k *mqlK8sStatefulset) usesHostPath() (bool, error) {
 	return boolFromSpec(spec, err, specUsesHostPath)
 }
 
+func (k *mqlK8sStatefulset) hostUsers() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHostUsers)
+}
+
+func (k *mqlK8sStatefulset) volumes() ([]any, error) {
+	spec, err := k.securitySpec()
+	return volumesFromSpec(k.MqlRuntime, k.Id.Data, k.Namespace.Data, spec, err)
+}
+
 func (k *mqlK8sStatefulset) usesUnconfinedSeccomp() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
@@ -622,6 +685,16 @@ func (k *mqlK8sReplicaset) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sReplicaset) usesHostPath() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sReplicaset) hostUsers() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHostUsers)
+}
+
+func (k *mqlK8sReplicaset) volumes() ([]any, error) {
+	spec, err := k.securitySpec()
+	return volumesFromSpec(k.MqlRuntime, k.Id.Data, k.Namespace.Data, spec, err)
 }
 
 func (k *mqlK8sReplicaset) usesUnconfinedSeccomp() (bool, error) {
@@ -708,6 +781,16 @@ func (k *mqlK8sJob) usesHostPath() (bool, error) {
 	return boolFromSpec(spec, err, specUsesHostPath)
 }
 
+func (k *mqlK8sJob) hostUsers() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHostUsers)
+}
+
+func (k *mqlK8sJob) volumes() ([]any, error) {
+	spec, err := k.securitySpec()
+	return volumesFromSpec(k.MqlRuntime, k.Id.Data, k.Namespace.Data, spec, err)
+}
+
 func (k *mqlK8sJob) usesUnconfinedSeccomp() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesUnconfinedSeccomp)
@@ -790,6 +873,16 @@ func (k *mqlK8sCronjob) usesHostNamespaces() (bool, error) {
 func (k *mqlK8sCronjob) usesHostPath() (bool, error) {
 	spec, err := k.securitySpec()
 	return boolFromSpec(spec, err, specUsesHostPath)
+}
+
+func (k *mqlK8sCronjob) hostUsers() (bool, error) {
+	spec, err := k.securitySpec()
+	return boolFromSpec(spec, err, specHostUsers)
+}
+
+func (k *mqlK8sCronjob) volumes() ([]any, error) {
+	spec, err := k.securitySpec()
+	return volumesFromSpec(k.MqlRuntime, k.Id.Data, k.Namespace.Data, spec, err)
 }
 
 func (k *mqlK8sCronjob) usesUnconfinedSeccomp() (bool, error) {


### PR DESCRIPTION
Coverage expansion for the k8s provider, scoped to one question: **what can a workload reach outside its own container?**

The audit produced 20 k8s findings. This PR ships the six that answer that question together, so the schema addition reads as one change rather than twenty. The other fourteen are listed below with reasons.

## Findings implemented

| # | Finding | What landed |
|---|---|---|
| 7 | `k8s.pod.hostUsers` | `hostUsers` on `k8s.pod` and the six controller kinds. Kubernetes leaves the field unset by default and treats unset as *true*, so an absent field reports `true`: the workload never asked for a user namespace, and root in the container is root on the node. That direction is documented on the field and is the one that fails safe. |
| 9 | Per-container AppArmor, procMount, SELinux | `appArmorProfileType`, `procMount`, `seLinuxType`, `seLinuxLevel` on `k8s.container`, `k8s.initContainer` and `k8s.ephemeralContainer`, flattened next to the existing `seccompProfileType`. Unset stays empty, so "this container asked for nothing, the pod level decides" stays distinguishable from an explicit `Unconfined`. |
| 6 | `k8s.runtimeclass` and the pod edge | New cluster-scoped resource (`handler`, `overhead`, `scheduling`), `k8s.runtimeClasses()`, `pod.runtimeClass()`, and the reverse edge `runtimeclass.pods()` that answers which workloads actually land on a sandboxed runtime. |
| 16 | Node runtime handlers and features | `k8s.node.runtimeHandlers()`, plus `supportsUserNamespaces()` and `supportsSupplementalGroupsPolicy()`. This is the half that makes finding 7 actionable: a `hostUsers: false` pod on a node whose every handler reports `userNamespaces: false` gets no isolation at all. |
| 4 | Typed pod volumes | `k8s.volume` on pods and on all six pod-template kinds: `type`, `hostPath`/`hostPathType`, `emptyDirMedium`/`emptyDirSizeLimit`, `csiDriver`, `serviceAccountTokens` (audience, expirationSeconds, path), and typed refs `secrets()`, `configMaps()`, `persistentVolumeClaim()`. `source` keeps the complete raw source for the types that are not flattened. |
| 19 | ServiceAccount credential edges | `secretRefs()` and `imagePullSecretRefs()` resolving to `k8s.secret`. This is the join a "no static ServiceAccount tokens" audit needs. No Secret *contents* are exposed; the edge is to the object. |

### Bug found while verifying, and fixed here

`k8s.gateways`, `k8s.gatewayClasses`, `k8s.httpRoutes`, `k8s.grpcRoutes` and `k8s.referenceGrants` **errored** on any cluster that has not installed the Gateway API CRDs, which is most clusters:

```
"k8s.gateways.length": { "error": "could not find api kind \"gateways.v1.gateway.networking.k8s.io\"" }
```

A cluster with no Gateway API is a cluster with no Gateways, not a failed scan. They now route through `k8sOptionalResourceToMql`, matching what the L4 routes, the DRA kinds and `k8s.networkExposures` already did. Verified in both directions below.

`node/v1` is also now registered in the manifest client schema, so a `RuntimeClass` in a manifest decodes as itself instead of falling through to `k8s.customresources`.

## Verified against a live cluster

minikube, Kubernetes v1.34.0, containerd runtime, plus a manifest scan of the same fixtures. Provider built from this branch and run through `PROVIDERS_PATH` so the installed provider was never touched.

Two states for every field: a pod that asks for no isolation and a pod that asks for all of it.

| Query | Result |
|---|---|
| `k8s.pods { name hostUsers }` | pod with no `hostUsers` → `true`; pod with `hostUsers: false` → `false` |
| `k8s.nodes { supportsUserNamespaces }` | `false` (every handler reports `userNamespaces: false`) |
| `k8s.nodes { supportsSupplementalGroupsPolicy }` | **`null`** — this kubelet reports no `status.features` block at all, which is not the same as reporting the feature absent |
| `k8s.nodes { runtimeHandlers }` | 3 handlers (`""`, `io.containerd.runc.v2`, `runc`), each with `recursiveReadOnlyMounts: true, userNamespaces: false` |
| `container { appArmorProfileType procMount seLinuxType seLinuxLevel }` | `Unconfined`/`""`/`spc_t`/`s0` on the loose pod; `RuntimeDefault`/`Default`/`""`/`""` on the tight one; `""`/`Unmasked`/`""`/`""` on a third |
| `k8s.runtimeClasses { name handler overhead scheduling pods { name } }` | `runsc` class with overhead `{cpu: 100m, memory: 120Mi}` and a nodeSelector; `runc` class with `overhead: {}` and **`scheduling: null`**; `pods` correctly lists the one pod selecting it |
| `pod.runtimeClass` | resolves to the named class on the cluster asset; `null` for a pod naming none |
| `volumes { type hostPath hostPathType }` | `hostPath` `/var/log` `Directory`; on a template, `/var/run/docker.sock` `Socket` |
| `volumes { emptyDirMedium emptyDirSizeLimit }` | `Memory` / `64Mi`; both **`null`** on every non-emptyDir volume |
| `volumes { serviceAccountTokens }` | explicit source → `{audience: "…", expirationSeconds: 3600, path: "token"}`; the kubelet-injected `kube-api-access-*` volume → `{audience: "", expirationSeconds: 3607, path: "token"}` |
| `volumes { secrets { name } configMaps { name } }` | resolves the mounted Secret and ConfigMap, and both projected sources of a projected volume |
| `serviceaccounts { secretRefs { name type } }` | the account carrying a static token resolves to a Secret of type `kubernetes.io/service-account-token`; the account without one returns `[]` |
| `k8s.pods.where(volumes.any(type == "hostPath"))` | 7 pods cluster-wide, including `kube-proxy`'s `/lib/modules` with `hostPathType: ""` (an unchecked mount) — a distinction that was invisible before |

### Absent-CRD contrast (the important one)

Same cluster, same query, before and after installing the Gateway API CRDs:

| State | `k8s.gateways.length` | `k8s.gatewayClasses.length` | `k8s.runtimeClasses.length` |
|---|---|---|---|
| Stock cluster, before this PR | **error** `could not find api kind` | error | n/a |
| Stock cluster, after this PR | `0` | `0` | `2` |
| Gateway API v1.2.1 CRDs installed | `1`, with `gatewayClass` resolving to its class | `1` | `2` |

`k8s.runtimeClasses` uses the same optional path from the start, so it degrades identically where RBAC hides the kind.

### Manifest mode

Same fixtures scanned as a YAML file with no cluster:

- `k8s.runtimeClasses` decodes both classes with `overhead` and `scheduling`, and `k8s.customresources.length` is `0`, confirming the scheme registration took effect.
- `k8s.pods`, `k8s.deployments`, `volumes`, `hostUsers`, the container fields and `secretRefs` all populate identically.
- `k8s.nodes.length` and `k8s.gateways.length` are `0` — cluster-scoped objects that a manifest simply does not contain are an empty result, not a failure.
- One value differs from the live run and should: a projected token source with no `expirationSeconds` reports **`null`** here, whereas the live API server defaults it to `3600`. The manifest path is the only place that null is observable, and it is covered by a unit test.

### Admission mode

Unchanged and neutral. The bundled AdmissionReview fixture lists nothing for existing kinds either (`k8s.pods.length` and `k8s.deployments.length` are both `0` before and after this PR), so the new fields inherit exactly the current behavior there.

### Cluster-scoped visibility (not a regression)

`pod.runtimeClass` is `null` when read from a *namespace* asset rather than the cluster asset, because cluster-scoped kinds are not listed in a namespace-scoped connection. `k8s.storageClasses` behaves identically in the same scan, so this is the provider's existing scoping rule and not something this PR introduces.

## Tests

`go test ./...` inside `providers/k8s/` is green. New pure-Go coverage:

- `volumeSourceType` over 14 sources including the no-source case and a spec carrying two sources.
- `volumeSecretNames` / `volumeConfigMapNames` including multi-source projected volumes and empty names.
- `projectedServiceAccountTokens` including the non-projected case and the unrequested-expiry case that must stay `null` rather than becoming `0` (a `0` would read as "requested a token that expires immediately").
- `specHostUsers` for unset / true / false / unreadable spec.
- `nodeRuntimeHandlerFeatures` for no handlers, handlers without a features block, a features block omitting the field, all-false, one-true, and a featureless handler not masking one that reports.
- `k8s.volume` `__id` collision: two pods declaring the same volume name resolve to distinct ids and each reports its own source. A colliding key would have made `CreateResource` hand back the first pod's volume and report the second pod's tmpfs as a hostPath mount of `/var/log`.
- Unrelated volume-source fields stay `null` rather than empty string.
- `k8sOptionalResourceToMql` degrading to `[]` for missing-kind / forbidden / not-found, and still propagating a real error (a timed-out list must not read as "no such objects").
- The existing `pod-securitycontext.yaml` fixture is extended with the new confinement fields in both the set and unset directions.

## Deferred, and why

Size, not merit. Each is self-contained and better reviewed on its own.

**Needs a new dependency or new CRD plumbing** — these are the biggest and least like each other:
- **11 · AdminNetworkPolicy / BaselineAdminNetworkPolicy** (L) — needs the `policy.networking.k8s.io` module as a new provider dependency, plus a real model of ANP `Deny`/`Pass` precedence over namespaced NetworkPolicy. That is its own PR, and it should land together with the `k8s.networkPolicyCoverage` reporting that already claims to reason about ANPs.
- **15 · BackendTLSPolicy** and **12 · typed Gateway listener** — both extend the Gateway API surface. They belong in one Gateway-focused PR that also takes the `gatewayv1alpha3` dependency BackendTLSPolicy needs. The absent-CRD fix in this PR is the groundwork they need.
- **18 · VolumeAttributesClass** (S) — `storage/v1` but gated on a feature gate that is off by default, so it needs the availability-detection treatment and a cluster configured to test it.

**Admission cluster** — coherent as its own PR:
- **1 · MutatingAdmissionPolicy** (M) — the API moved across `admissionregistration` alpha/beta/v1 by cluster version, so it needs version detection rather than a fixed GVK.
- **2 · Typed admission-webhook sub-resource** (M) — turning `webhooks()` from a dict dump into typed rows, which pairs naturally with 1.
- **8 · CustomResourceDefinition** (M) — conversion webhooks and `preserveUnknownFields`, admission-adjacent and the same reviewer context.

**RBAC escalation cluster** — needs its own exhaustive test matrix:
- **3 · Escalation predicates beyond escalate/bind/impersonate** (M) and **5 · Aggregated ClusterRole edges** (M). Both change how `rbacAllowsPrivilegeEscalation` and `hasWildcardRule` read, and the wildcard, sub-resource and negative cases need a table test each. Mixing that into a schema-addition PR would bury it.

**Independent, small, no natural home here:**
- **10 · CSIDriver** (S) — `tokenRequests`, `fsGroupPolicy`, `seLinuxMount`.
- **13 · FlowSchema / PriorityLevelConfiguration** (M) — API Priority and Fairness.
- **14 · ClusterTrustBundle** (S) — `certificates/v1beta1`, and should go through `CreateSharedResource("certificates", …)` as `certificates() []network.certificate` rather than hand-parsing PEM.
- **17 · Secret and ConfigMap `immutable`** (S) — a one-field integrity control on two resources; trivially separable.
- **20 · EndpointSlice backing-pod edge** (C, S) — `endpointslice.pods()` from `targetRef`. Belongs with the network-exposure work rather than with workload isolation.

## Where the audit was right, and one place it was incomplete

Finding 7's evidence is exactly correct: `usesHostNamespaces` folds only `hostNetwork`/`hostPID`/`hostIPC`, and `hostUsers` was unreachable. Finding 16 is the necessary complement and the live cluster proved why — a stock containerd node reports `userNamespaces: false` on **every** handler, so a `hostUsers: false` pod there gets nothing.

Two things the findings did not say:

1. **`procMount: Unmasked` is rejected unless `hostUsers` is false.** The API server refuses the combination outright (`spec.containers[0].securityContext.procMount: Invalid value: "Unmasked": hostUsers must be false to use Unmasked`). Findings 7 and 9 are more tightly coupled than they read separately, which is part of why they ship together here.
2. **The Gateway API listers were already broken** on any cluster without the CRDs — the exact failure mode trap 2 describes, present in shipped code rather than in anything the findings proposed. Fixed here.
