### PR TITLE
🟢 os: finish the v14 module-path migration in the Windows ACL files

### DIFF
--- a/providers/os/resources/powershell/scriptlength_test.go
+++ b/providers/os/resources/powershell/scriptlength_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
 )
 
 // knownOverCap records the embedded scripts that already exceed the command-line

--- a/providers/os/resources/windows/acl_test.go
+++ b/providers/os/resources/windows/acl_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
 )
 
 // The fixtures are the verbatim output of AclScript captured from a Windows

--- a/providers/os/resources/windows/scheduledtask_test.go
+++ b/providers/os/resources/windows/scheduledtask_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
 )
 
 // A script that no longer fits on the command line does not fail loudly. The

--- a/providers/os/resources/windows_acl.go
+++ b/providers/os/resources/windows_acl.go
@@ -8,11 +8,11 @@ import (
 	"io"
 	"sync"
 
-	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers/os/connection/shared"
-	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
-	"go.mondoo.com/mql/v13/providers/os/resources/windows"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
+	"go.mondoo.com/mql/providers/os/resources/windows"
 )
 
 // mqlWindowsAclInternal caches the one Get-Acl call behind every field, so a


### PR DESCRIPTION
`main` does not compile.

#10071 (Windows ACLs) landed **after** #10268 had already moved the tree off the versioned module path, and was not rebased across that change. Nine imports still name `go.mondoo.com/mql/v13/...`, which no module provides any more:

```
$ git worktree add /tmp/mainchk origin/main && cd /tmp/mainchk
$ go build ./providers/os/...
providers/os/resources/windows_acl.go:11:2: no required module provides package go.mondoo.com/mql/v13/llx
providers/os/resources/windows_acl.go:12:2: no required module provides package go.mondoo.com/mql/v13/providers-sdk/v1/plugin
providers/os/resources/windows_acl.go:13:2: no required module provides package go.mondoo.com/mql/v13/providers/os/connection/shared
providers/os/resources/windows_acl.go:14:2: no required module provides package go.mondoo.com/mql/v13/providers/os/resources/powershell
providers/os/resources/windows_acl.go:15:2: no required module provides package go.mondoo.com/mql/v13/providers/os/resources/windows
```

## Why this matters beyond one package

Anything that builds a provider fails on it. That is why `go-mod`, `go-test`, `go-test-providers`, `generated-files` and `golangci-lint` are currently red on pull requests that changed none of this — the failure follows `main`, not the branch. It was found from three unrelated PRs whose CI could not be explained by their own diffs.

## The change

Four files rewritten onto the current path:

| file | imports |
|---|---|
| `providers/os/resources/windows_acl.go` | 5 |
| `providers/os/resources/powershell/scriptlength_test.go` | 1 |
| `providers/os/resources/windows/acl_test.go` | 1 |
| `providers/os/resources/windows/scheduledtask_test.go` | 1 |

## What is deliberately left alone

`providers/defaults_shared.go` keeps its `go.mondoo.com/mql/v13/providers/os` entry. It is a **string in `DefaultOsIDs`, not an import**, and the comment above it says why: the ID is retained so a v14 engine still meets os provider binaries released before the ID change. Rewriting it would drop the default local connector for those. `docs/adr/042` keeps its references for the same reason — it is a historical record.

## Verification

Run in a clean worktree off this branch:

| check | result |
|---|---|
| `go build ./providers/os/...` | passes (fails on `main`) |
| `go build ./...` | passes |
| `go test ./providers/os/resources/...` | all packages ok |
| `go mod tidy` | no diff to `go.mod` / `go.sum` |
| `gofmt -l` | clean |

No behavioural change: the packages named are the same packages, reached by the path they now live at.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>